### PR TITLE
Fix README to make GitHub the official source repository

### DIFF
--- a/README
+++ b/README
@@ -20,8 +20,11 @@ are encouraged to obtain the appropriate version of the Documentation
 
 To obtain files from the repository and build, please see:
 
- - git://github.com/DSpace/DSpace.git
+ - https://github.com/DSpace/DSpace/
 
+or just:
+
+ - git clone git://github.com/DSpace/DSpace.git
 
 Please refer any further problems to the dspace-tech@lists.sourceforge.net
 mailing list.

--- a/README
+++ b/README
@@ -16,11 +16,11 @@ https://wiki.duraspace.org/display/DSPACE/DSpaceContributors
 
 Installation instructions for other versions may be different, so you
 are encouraged to obtain the appropriate version of the Documentation
-(from the links above or from SVN).
+(from the links above or from the source repository).
 
-To obtain files from the SVN repository and build, please see:
+To obtain files from the repository and build, please see:
 
- - https://scm.dspace.org/svn/repo/dspace/tags/
+ - git://github.com/DSpace/DSpace.git
 
 
 Please refer any further problems to the dspace-tech@lists.sourceforge.net


### PR DESCRIPTION
As discussed on IRC yesterday, I took out the references to SVN and replaced them with some more generic language and links to GitHub.
