### PR TITLE
Build fixes

### DIFF
--- a/dspace-lni/dspace-lni-client/src/main/resources/dspace-lni.wsdl
+++ b/dspace-lni/dspace-lni-client/src/main/resources/dspace-lni.wsdl
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+-->
 <wsdl:definitions targetNamespace="http://dspace.org/xmlns/lni" xmlns:apachesoap="http://xml.apache.org/xml-soap" xmlns:impl="http://dspace.org/xmlns/lni" xmlns:intf="http://dspace.org/xmlns/lni" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tns1="http://lang.java" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsdlsoap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
 <!--WSDL created by Apache Axis version: 1.3
 Built on Oct 05, 2005 (05:23:37 EDT)-->

--- a/dspace-lni/dspace-lni-webapp/src/main/config/lni-deploy.wsdd
+++ b/dspace-lni/dspace-lni-webapp/src/main/config/lni-deploy.wsdd
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+-->
+<!--
      Description of DSpace Lightweight Network Interface (LNI) API
      This is the WSDD (Web Services Deployment Descriptor) for
      the parts of the LNI which are available through SOAP.

--- a/dspace-lni/dspace-lni-webapp/src/main/webapp/WEB-INF/server-config.wsdd
+++ b/dspace-lni/dspace-lni-webapp/src/main/webapp/WEB-INF/server-config.wsdd
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+-->
 <deployment xmlns="http://xml.apache.org/axis/wsdd/" xmlns:java="http://xml.apache.org/axis/wsdd/providers/java">
 
  <!-- Server Deployment Descriptor for DSpace LNI, on Axis 1.2

--- a/dspace/modules/solr/pom.xml
+++ b/dspace/modules/solr/pom.xml
@@ -9,15 +9,11 @@
       DSpace SOLR Service Provider Web Application
    </description>
 
-   <!--
-      Solr uses DSpace POM to avoid limitations forced
-      in dependencies found in dspace-parent pom. Solr is
-      a standalone webapplication.
-   -->
    <parent>
       <groupId>org.dspace</groupId>
-      <artifactId>dspace-pom</artifactId>
-      <version>12</version>
+      <artifactId>modules</artifactId>
+      <version>3.0-SNAPSHOT</version>
+      <relativePath>..</relativePath>
    </parent>
 
    <build>

--- a/pom.xml
+++ b/pom.xml
@@ -368,7 +368,7 @@
                               <descriptor>src/main/assembly/src-release.xml</descriptor>
                            </descriptors>
                            <tarLongFileMode>gnu</tarLongFileMode>
-                           <finalName>dspace-${pom.version}</finalName>
+                           <finalName>dspace-${project.version}</finalName>
                         </configuration>
                         <phase>package</phase>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -132,18 +132,22 @@
                          Individual Maven projects may choose to override these defaults. -->
                     <excludes>
                         <exclude>**/src/test/resources/**</exclude>
+                        <exclude>**/src/test/data/**</exclude>
                         <exclude>**/META-INF/**</exclude>
                         <exclude>**/robots.txt</exclude>
                         <exclude>**/*.LICENSE</exclude>
                         <exclude>**/LICENSE*</exclude>
                         <exclude>**/README*</exclude>
                         <exclude>**/readme*</exclude>
+                        <exclude>**/.gitignore</exclude>
                     </excludes>
                     <mapping> 
                         <!-- Custom DSpace file extensions which are not recognized by maven-release-plugin: 
-                             *.xmap, *.xslt, *.LICENSE -->
+                             *.xmap, *.xslt, *.wsdd, *.wsdl, *.LICENSE -->
                         <xmap>XML_STYLE</xmap>
                         <xslt>XML_STYLE</xslt>
+                        <wsdd>XML_STYLE</wsdd>
+                        <wsdl>XML_STYLE</wsdl>
                         <LICENSE>TEXT</LICENSE>
                     </mapping>  
                     <encoding>UTF-8</encoding>


### PR DESCRIPTION
Various minor build fixes, based on the changes made in DS-1150 (Migrate to GitHub). Corrects some POM settings based on Maven build warnings, and added some new exclusions & file extensions to our License Header checker settings.

(This also serves as a test "pull request" from a custom branch, 'build-fixes',  that I've created in my forked repo)
