### PR TITLE
[DS-1180] build the DN manually instead of attempting to search with the...

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/LDAPHierarchicalAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/LDAPHierarchicalAuthentication.java
@@ -182,7 +182,19 @@ public class LDAPHierarchicalAuthentication
 		// Get the DN of the user
 		String adminUser = ConfigurationManager.getProperty("authentication-ldap", "search.user");
 		String adminPassword = ConfigurationManager.getProperty("authentication-ldap", "search.password");
-		String dn = ldap.getDNOfUser(adminUser, adminPassword, context, netid);
+		String objectContext = ConfigurationManager.getProperty("authentication-ldap", "object_context");
+		String idField = ConfigurationManager.getProperty("authentication-ldap", "id_field");
+		String dn = "";
+
+		// If adminUser is blank, then we can't search so assume the DN
+		if (StringUtils.isBlank(adminUser) || StringUtils.isBlank(adminPassword))
+		{
+			dn = idField + "=" + netid + "," + objectContext;
+		}
+		else
+		{
+			dn = ldap.getDNOfUser(adminUser, adminPassword, context, netid);
+		}
 
 		// Check a DN was found
 		if ((dn == null) || (dn.trim().equals("")))


### PR DESCRIPTION
Before attempting a user authentication, LDAPHierarchicalAuthentication attempts to lookup the user's DN using an adminUser and adminPassword. This is unnecessary if all users from an institution are in the same LDAP container, e.g.,: 

  uid=sam,ou=Users,dc=example,dc=edu 

The necessary variables for building the DN manually are already in authentication-ldap.cfg. This patch attempts to build the DN manually _if_ the adminUser is empty.
