### PR TITLE
DS-1191 provide a warning in the logs if resumeLogin fails because of ip mismatch

### DIFF
--- a/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/utils/AuthenticationUtil.java
+++ b/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/utils/AuthenticationUtil.java
@@ -280,7 +280,7 @@ public class AuthenticationUtil
                 else
                 {
                     // Possible hack attempt or maybe your setup is not providing a consistent end-user IP address.
-                    log.info(LogManager.getHeader(context, "ip_mismatch", "id=" + id + ", request ip=" +
+                    log.warn(LogManager.getHeader(context, "ip_mismatch", "id=" + id + ", request ip=" +
                         request.getRemoteAddr() + ", session ip=" + address));
                 }
             } // if id

--- a/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/utils/AuthenticationUtil.java
+++ b/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/utils/AuthenticationUtil.java
@@ -279,7 +279,9 @@ public class AuthenticationUtil
                 }
                 else
                 {
-                    // Possible hack attempt.
+                    // Possible hack attempt or maybe your setup is not providing a consistent end-user IP address.
+                    log.info(LogManager.getHeader(context, "ip_mismatch", "id=" + id + ", request ip=" +
+                        request.getRemoteAddr() + ", session ip=" + address));
                 }
             } // if id
         } // if session


### PR DESCRIPTION
Simple patch to provide warning in logs instead of silent error.
