### PR TITLE
DS-1192 new property to skip XMLUI ip checks during login

### DIFF
--- a/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/utils/AuthenticationUtil.java
+++ b/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/utils/AuthenticationUtil.java
@@ -247,8 +247,11 @@ public class AuthenticationUtil
             
             if (id != null)
             {
+                // Should we check for an ip match from the start of the request to now?
+                boolean ipcheck = ConfigurationManager.getBooleanProperty("xmlui.session.ipcheck", true);
+
                 String address = (String)session.getAttribute(CURRENT_IP_ADDRESS);
-                if (address != null && address.equals(request.getRemoteAddr()))
+                if (!ipcheck || (address != null && address.equals(request.getRemoteAddr())))
                 {
                     EPerson eperson = EPerson.find(context, id);
                     context.setCurrentUser(eperson);

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1589,6 +1589,14 @@ webui.suggest.enable = false
 # process. The default value is false, i.e. no one may assume the login of another user.
 #xmlui.user.assumelogin = true
 
+# Check if the user has a consistent ip address from the start of the login process
+# to the end of the login process. Disabling this check is not recommended unless
+# absolutely necessary as the ip check can be helpful for preventing session 
+# hijacking. Possible reasons to set this to false: many-to-many wireless networks
+# that prevent consistent ip addresses or complex proxying of requests.
+# The default value is set to true.
+#xmlui.session.ipcheck = true
+
 # After a user has logged into the system, which url should they be directed too?
 # Leave this parameter blank or undefined to direct users to the homepage, or
 # "/profile" for the user's profile, or another reasonable choice is "/submissions"


### PR DESCRIPTION
Allow an override to skip IP checks during the resumeLogin process if an institution can't guarantee a consistent IP 
