### PR TITLE
DS-1190: Google Analytics support for JSPUI.

### DIFF
--- a/dspace-jspui/dspace-jspui-api/src/main/java/org/dspace/app/webui/jsptag/ItemTag.java
+++ b/dspace-jspui/dspace-jspui-api/src/main/java/org/dspace/app/webui/jsptag/ItemTag.java
@@ -866,7 +866,53 @@ public class ItemTag extends TagSupport
                                 // Work out what the bitstream link should be
                                 // (persistent
                                 // ID if item has Handle)
-                                String bsLink = "<a target=\"_blank\" href=\""
+                               String bsLink = "<a target=\"_blank\"";
+                                
+                                /*
+                                 *  if goggle analytics downloads tracking is turned on 
+                                 * in dspace.cfg we will add async event call.
+                                 * Note: GA tracking code must be put in ga.jspf file                                 * 
+                                 */
+
+                                boolean gaEnabled = ConfigurationManager.getBooleanProperty("google.analytics.enabled");
+                                boolean gaTrackDownloads = ConfigurationManager.getBooleanProperty("google.analytics.trackdownloads");
+                                String gaLabel = ConfigurationManager.getProperty("google.analytics.tracklabel");
+
+                                if (gaEnabled && gaTrackDownloads)
+                                {
+                                    StringBuilder trackLabel = new StringBuilder();
+
+                                    String[] labelParts = gaLabel.split("\\+");
+                                    for (int lpc = 0; lpc < labelParts.length; lpc++)
+                                    {
+                                        if (labelParts[lpc].equalsIgnoreCase("handle"))
+                                        {
+                                            trackLabel.append("handle=").append(item.getHandle()).append(" ");
+                                        }
+                                        if (labelParts[lpc].equalsIgnoreCase("collection"))
+                                        {
+                                            trackLabel.append("collection=").append(item.getOwningCollection().getName()).append(" ");
+                                        }
+                                        if (labelParts[lpc].equalsIgnoreCase("title"))
+                                        {
+                                            DCValue[] dcvs = item.getMetadata("dc.title");
+                                            if (dcvs != null && dcvs.length > 0)
+                                            {
+                                                trackLabel.append("title=").append(dcvs[0].value).append(" ");
+                                            }
+                                        }
+                                        if (labelParts[lpc].equalsIgnoreCase("bitstream"))
+                                        {
+                                            trackLabel.append("bitstream=").append(UIUtil.encodeBitstreamName(bitstreams[k].getName(),
+                                                Constants.DEFAULT_ENCODING)).append(" ");
+                                        }
+                                    }
+                                
+                                    bsLink = bsLink + " onClick=\"javascript: _gaq.push(['_trackEvent', 'Downloads', "
+                                        + "'Download/View', '" + trackLabel.toString() + "']);\"";
+                                }
+
+                                bsLink = bsLink + " href=\""
                                         + request.getContextPath();
 
                                 if ((handle != null)

--- a/dspace-jspui/dspace-jspui-webapp/src/main/webapp/ga.jspf
+++ b/dspace-jspui/dspace-jspui-webapp/src/main/webapp/ga.jspf
@@ -1,0 +1,29 @@
+<%--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+--%>
+<%--
+    This GA tracking code can be obtained at your GA account settings page.
+    It should be the same (untill Google will change the script) and the only difference for 
+    accounts will be in XX-YYYYYYYY-Z code.
+    Put your real account's code here insteand of XX-YYYYYYYY-Z 
+--%>
+
+<script type="text/javascript">
+
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', 'XX-YYYYYYYY-Z']);
+  _gaq.push(['_trackPageview']);
+
+  (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+
+</script>

--- a/dspace-jspui/dspace-jspui-webapp/src/main/webapp/layout/header-default.jsp
+++ b/dspace-jspui/dspace-jspui-webapp/src/main/webapp/layout/header-default.jsp
@@ -38,6 +38,9 @@
     String extraHeadData = (String)request.getAttribute("dspace.layout.head");
     String dsVersion = Util.getSourceVersion();
     String generator = dsVersion == null ? "DSpace" : "DSpace "+dsVersion;
+
+    //check if google analytics enabled
+    boolean gaEnabled = ConfigurationManager.getBooleanProperty("google.analytics.enabled");
 %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
@@ -80,6 +83,10 @@
     <script type="text/javascript" src="<%= request.getContextPath() %>/static/js/scriptaculous/builder.js"> </script>
     <script type="text/javascript" src="<%= request.getContextPath() %>/static/js/scriptaculous/controls.js"> </script>
     <script type="text/javascript" src="<%= request.getContextPath() %>/static/js/choice-support.js"> </script>
+    
+    <% if (gaEnabled) { %>
+        <%@ include file="<%= request.getContextPath() %>/ga.jspf" %>
+    <% } %>
     </head>
 
     <%-- HACK: leftmargin, topmargin: for non-CSS compliant Microsoft IE browser --%>

--- a/dspace-jspui/dspace-jspui-webapp/src/main/webapp/layout/header-popup.jsp
+++ b/dspace-jspui/dspace-jspui-webapp/src/main/webapp/layout/header-popup.jsp
@@ -33,6 +33,9 @@
     String feedRef = (String)request.getAttribute("dspace.layout.feedref");
     List parts = (List)request.getAttribute("dspace.layout.linkparts");
     String extraHeadData = (String)request.getAttribute("dspace.layout.head");
+
+    //check if google analytics enabled
+    boolean gaEnabled = ConfigurationManager.getBooleanProperty("google.analytics.enabled");
 %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
@@ -58,6 +61,10 @@
     <script type="text/javascript" src="<%= request.getContextPath() %>/static/js/scriptaculous/builder.js"> </script>
     <script type="text/javascript" src="<%= request.getContextPath() %>/static/js/scriptaculous/controls.js"> </script>
     <script type="text/javascript" src="<%= request.getContextPath() %>/static/js/choice-support.js"> </script>
+    
+    <% if (gaEnabled) { %>
+        <%@ include file="<%= request.getContextPath() %>/ga.jspf" %>
+    <% } %>
     </head>
 
     <%-- HACK: leftmargin, topmargin: for non-CSS compliant Microsoft IE browser --%>

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1679,3 +1679,18 @@ webui.suggest.enable = false
 # context-switch then you will need to set the paramater to the HTTP parameter that
 # records the original IP address.
 #xmlui.controlpanel.activity.ipheader = X-Forward-For
+
+#-----------------------------------------------------------------------#
+#------------------ Google Analytics configuration ---------------------#
+#-----------------------------------------------------------------------#
+google.analytics.enabled = false
+google.analytics.trackdownloads = false
+
+#how do we want to attribute our download action
+#handle - include item's handle
+#collection - include owning collection name
+#title - include item's title
+#bitstream - include bitstream's name
+# we can concatenate any of them, like: collection+handle+title
+
+google.analytics.tracklabel = collection+title+handle


### PR DESCRIPTION
Tracking code is in ga.jspf file - user MUST replace XX-YYYYYYYY-Z
string with real number from GA account. Or user can completely
replace tracking code copying it from GA account settings (don't forget
about license header to keep).

User can turn on/off GA in dspace.cfg

ItemTag.java was modified to track Download/View events + label them.
Statistics on downloads will be shown in Events section of GA.
