### PR TITLE
Remove actual dependency of dspace-stats on dspace-api

### DIFF
--- a/dspace-stats/pom.xml
+++ b/dspace-stats/pom.xml
@@ -195,7 +195,11 @@
             <type>jar</type>
             <scope>test</scope>
         </dependency>
-    </dependencies>
+	 <dependency>
+	  <groupId>commons-cli</groupId>
+	  <artifactId>commons-cli</artifactId>
+	 </dependency>
+	</dependencies>
    
    <reporting>
       <excludeDefaults>false</excludeDefaults>

--- a/dspace-stats/src/test/java/org/dspace/statistics/util/TestLocationUtils.java
+++ b/dspace-stats/src/test/java/org/dspace/statistics/util/TestLocationUtils.java
@@ -10,7 +10,6 @@ package org.dspace.statistics.util;
 import java.util.Locale;
 import static org.junit.Assert.*;
 
-import org.dspace.AbstractUnitTest;
 import org.dspace.core.I18nUtil;
 import org.junit.Test;
 
@@ -18,7 +17,6 @@ import org.junit.Test;
  * @author mwood
  */
 public class TestLocationUtils
-extends AbstractUnitTest
 {
     private static final String UNKNOWN_CONTINENT = I18nUtil
             .getMessage("org.dspace.statistics.util.LocationUtils.unknown-continent");


### PR DESCRIPTION
TestLocationUtils doesn't need to extend AbstractUnitTest.  Removing the 'extends' clause removes the actual (as opposed to declared) dependency on dspace-api and should allow building both with and without tests enabled.
