### PR TITLE
DS-1200 add styling to statistics tables

### DIFF
--- a/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/StatisticsViewer.java
+++ b/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/StatisticsViewer.java
@@ -415,7 +415,7 @@ public class StatisticsViewer extends AbstractDSpaceTransformer implements Cache
                     rows++;
                 }
 
-                Table block = currDiv.addTable("reportBlock", rows, 2);
+                Table block = currDiv.addTable("reportBlock", rows, 2, "detailtable");
 
                 // prepare the table headers
                 if (content.getStatName() != null || content.getResultName() != null)

--- a/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/aspect/statistics/StatisticsTransformer.java
+++ b/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/aspect/statistics/StatisticsTransformer.java
@@ -297,7 +297,7 @@ public class StatisticsTransformer extends AbstractDSpaceTransformer {
 			/** Generate Table */
 			Division wrapper = mainDiv.addDivision("tablewrapper");
 			Table table = wrapper.addTable("list-table", 1, 1,
-					title == null ? "" : "tableWithTitle");
+					title == null ? "detailtable" : "tableWithTitle detailtable");
 			if (title != null)
             {
                 table.setHead(message(title));
@@ -353,7 +353,7 @@ public class StatisticsTransformer extends AbstractDSpaceTransformer {
 			// String[] rLabels = dataset.getRowLabels().toArray(new String[0]);
 
 			Table table = mainDiv.addTable("list-table", matrix.length, 2,
-					title == null ? "" : "tableWithTitle");
+					title == null ? "detailtable" : "tableWithTitle detailtable");
 			if (title != null)
             {
                 table.setHead(message(title));


### PR DESCRIPTION
The statistics tables in XMLUI have no styling. Simply adding the "detailtable" class provides a lot of good styling to make these pages a lot more readable.
