### PR TITLE
DS-1201 fix /submissions page missing period and break after first

### DIFF
--- a/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/aspect/submission/Submissions.java
+++ b/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/aspect/submission/Submissions.java
@@ -181,7 +181,8 @@ public class Submissions extends AbstractDSpaceTransformer
                 Para p = start.addPara();
                 p.addContent(T_s_info1a);
                 p.addXref(contextPath+"/submit",T_s_info1b);
-                p.addContent(T_s_info1c);
+                Para secondP = start.addPara();
+                secondP.addContent(T_s_info1c);
                 return;
             }
     	}

--- a/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/i18n/messages.xml
@@ -551,7 +551,7 @@
 	<!-- Same transformer, submissions section -->
 	<message key="xmlui.Submission.Submissions.submit_head1">Submissions</message>
 	<message key="xmlui.Submission.Submissions.submit_info1a">You may </message>
-	<message key="xmlui.Submission.Submissions.submit_info1b">start a new submission</message>
+	<message key="xmlui.Submission.Submissions.submit_info1b">start a new submission.</message>
 	<message key="xmlui.Submission.Submissions.submit_info1c">The submission process includes describing the item and uploading the file(s) comprising it. Each community or collection may set its own submission policy.</message>
 	<message key="xmlui.Submission.Submissions.submit_head2">Unfinished submissions</message>
 	<message key="xmlui.Submission.Submissions.submit_info2a">These are incomplete item submissions. You may also </message>


### PR DESCRIPTION
Submission page in XMLUI currently missing a period after first sentence:

You may start a new submission The submission process includes describing the item and uploading the file(s) comprising it. Each community or collection may set its own submission policy.
