### PR TITLE
[DS-1065] controlled-vocabulary.xsd says that the 'id' attribute is optional, so make it optional instead of NPE if missing.

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -111,6 +111,7 @@
                 <configuration>
                     <systemPropertyVariables>
                         <dspace.dir>${project.build.directory}/testing/dspace</dspace.dir>
+                        <dspace.dir.static>${basedir}/src/test/data/dspaceFolder</dspace.dir.static>
                         <dspace.configuration>${project.build.directory}/testing/dspace.cfg.woven</dspace.configuration>
                         <db.schema.path>${project.build.directory}/testing/dspace/etc/h2/database_schema.sql</db.schema.path>
                         <dspace.log.init.disable>true</dspace.log.init.disable>

--- a/dspace-api/src/main/java/org/dspace/content/authority/DSpaceControlledVocabulary.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/DSpaceControlledVocabulary.java
@@ -55,7 +55,7 @@ import org.dspace.core.SelfNamedPlugin;
 public class DSpaceControlledVocabulary extends SelfNamedPlugin implements ChoiceAuthority
 {
 
-	private static Logger log = Logger.getLogger(DSpaceControlledVocabulary.class);
+    private static Logger log = Logger.getLogger(DSpaceControlledVocabulary.class);
     private static String xpathTemplate = "//node[contains(translate(@label,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz'),'%s')]";
     private static String idTemplate = "//node[@id = '%s']";
     private static String pluginNames[] = null;
@@ -85,22 +85,24 @@ public class DSpaceControlledVocabulary extends SelfNamedPlugin implements Choic
     {
         if (pluginNames == null)
         {
-        	class xmlFilter implements java.io.FilenameFilter
+            class xmlFilter implements java.io.FilenameFilter
             {
-        		public boolean accept(File dir, String name)
+                @Override
+                public boolean accept(File dir, String name)
                 {
-        			return name.endsWith(".xml");
-        		}
-        	}
-            String vocabulariesPath = ConfigurationManager.getProperty("dspace.dir") + "/config/controlled-vocabularies/";
-        	String[] xmlFiles = (new File(vocabulariesPath)).list(new xmlFilter());
-        	List<String> names = new ArrayList<String>();
-        	for (String filename : xmlFiles)
+                    return name.endsWith(".xml");
+                }
+            }
+            String vocabulariesPath = ConfigurationManager.getProperty("dspace.dir")
+                    + "/config/controlled-vocabularies/";
+            String[] xmlFiles = (new File(vocabulariesPath)).list(new xmlFilter());
+            List<String> names = new ArrayList<String>();
+            for (String filename : xmlFiles)
             {
-        		names.add((new File(filename)).getName().replace(".xml",""));
-        	}
-        	pluginNames = names.toArray(new String[names.size()]);
-            log.info("Got plugin names = "+Arrays.deepToString(pluginNames));
+                names.add((new File(filename)).getName().replace(".xml", ""));
+            }
+            pluginNames = names.toArray(new String[names.size()]);
+            log.info("Got plugin names = " + Arrays.deepToString(pluginNames));
         }
     }
 
@@ -154,6 +156,7 @@ public class DSpaceControlledVocabulary extends SelfNamedPlugin implements Choic
     	}
     }
 
+    @Override
     public Choices getMatches(String field, String text, int collection, int start, int limit, String locale)
     {
     	init();
@@ -162,47 +165,50 @@ public class DSpaceControlledVocabulary extends SelfNamedPlugin implements Choic
     	XPath xpath = XPathFactory.newInstance().newXPath();
     	Choice[] choices;
     	try {
-    		NodeList results = (NodeList)xpath.evaluate(xpathExpression, vocabulary, XPathConstants.NODESET);
-    		String[] authorities  = new String[results.getLength()];
-    		String[] values = new String[results.getLength()];
-    		String[] labels  = new String[results.getLength()];
-        	for (int i=0; i<results.getLength(); i++)
+            NodeList results = (NodeList) xpath.evaluate(xpathExpression,
+                    vocabulary, XPathConstants.NODESET);
+            String[] authorities = new String[results.getLength()];
+            String[] values = new String[results.getLength()];
+            String[] labels = new String[results.getLength()];
+            for (int i = 0; i < results.getLength(); i++)
             {
-        		Node node = results.item(i);
-        		String hierarchy = this.buildString(node);
-        		if (this.suggestHierarchy)
+                Node node = results.item(i);
+                String hierarchy = this.buildString(node);
+                if (this.suggestHierarchy)
                 {
-        			labels[i] = hierarchy;
-        		}
+                    labels[i] = hierarchy;
+                }
                 else
                 {
-        			labels[i] = node.getAttributes().getNamedItem("label").getNodeValue();
-        		}
-        		if (this.storeHierarchy)
+                    labels[i] = node.getAttributes().getNamedItem("label").getNodeValue();
+                }
+                if (this.storeHierarchy)
                 {
-        			values[i] = hierarchy;
-        		}
+                    values[i] = hierarchy;
+                }
                 else
                 {
-        			values[i] = node.getAttributes().getNamedItem("label").getNodeValue();
-        		}
-        		authorities[i] = node.getAttributes().getNamedItem("id").getNodeValue();
-        	}
-        	int resultCount = Math.min(labels.length-start, limit);
-        	choices = new Choice[resultCount];
-        	if (resultCount > 0)
+                    values[i] = node.getAttributes().getNamedItem("label").getNodeValue();
+                }
+                authorities[i] = node.getAttributes().getNamedItem("id").getNodeValue();
+            }
+            int resultCount = Math.min(labels.length - start, limit);
+            choices = new Choice[resultCount];
+            if (resultCount > 0)
             {
-            	for (int i=0; i<resultCount; i++)
+                for (int i = 0; i < resultCount; i++)
                 {
-           			choices[i] = new Choice(authorities[start+i],values[start+i],labels[start+i]);
-            	}
-        	}
+                    choices[i] = new Choice(authorities[start + i], values[start
+                            + i], labels[start + i]);
+                }
+            }
     	} catch(XPathExpressionException e) {
     		choices = new Choice[0];
     	}
     	return new Choices(choices, 0, choices.length, Choices.CF_AMBIGUOUS, false);
     }
 
+    @Override
     public Choices getBestMatch(String field, String text, int collection, String locale)
     {
     	init();
@@ -210,6 +216,7 @@ public class DSpaceControlledVocabulary extends SelfNamedPlugin implements Choic
         return getMatches(field, text, collection, 0, 2, locale);
     }
 
+    @Override
     public String getLabel(String field, String key, String locale)
     {
     	init();

--- a/dspace-api/src/main/java/org/dspace/content/authority/DSpaceControlledVocabulary.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/DSpaceControlledVocabulary.java
@@ -190,7 +190,9 @@ public class DSpaceControlledVocabulary extends SelfNamedPlugin implements Choic
                 {
                     values[i] = node.getAttributes().getNamedItem("label").getNodeValue();
                 }
-                authorities[i] = node.getAttributes().getNamedItem("id").getNodeValue();
+                Node idAttr = node.getAttributes().getNamedItem("id");
+                if (null != idAttr) // 'id' is optional
+                    authorities[i] = idAttr.getNodeValue();
             }
             int resultCount = Math.min(labels.length - start, limit);
             choices = new Choice[resultCount];

--- a/dspace-api/src/main/java/org/dspace/content/authority/DSpaceControlledVocabulary.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/DSpaceControlledVocabulary.java
@@ -194,7 +194,9 @@ public class DSpaceControlledVocabulary extends SelfNamedPlugin implements Choic
                 if (null != idAttr) // 'id' is optional
                     authorities[i] = idAttr.getNodeValue();
             }
-            int resultCount = Math.min(labels.length - start, limit);
+            int resultCount = labels.length - start;
+            if ((limit > 0) && (resultCount > limit)) // limit = 0 means no limit
+                resultCount = limit;
             choices = new Choice[resultCount];
             if (resultCount > 0)
             {

--- a/dspace-api/src/test/data/dspaceFolder/config/controlled-vocabularies/farm.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/controlled-vocabularies/farm.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<node label='the farm'>
+ <isComposedBy>
+  <node label='north 40'/>
+  <node id='s40' label='south 40'/>
+ </isComposedBy>
+</node>

--- a/dspace-api/src/test/java/org/dspace/MockConfigurationManager.java
+++ b/dspace-api/src/test/java/org/dspace/MockConfigurationManager.java
@@ -5,10 +5,6 @@
  *
  * http://www.dspace.org/license/
  */
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
 
 package org.dspace;
 
@@ -20,6 +16,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
+ * Dummy ConfigurationManager with a setter instead of external storage for
+ * values.  Call {@link setProperty} to create configuration.
+ *
+ * <p>Please note that this implementation is incomplete!</p>
  *
  * @author mwood
  */
@@ -28,12 +28,24 @@ public class MockConfigurationManager {
     private static final Properties properties = new Properties();
     private static final Logger log = LoggerFactory.getLogger(MockConfigurationManager.class);
 
+    /**
+     * Set a value in the configuration map.
+     *
+     * @param key name of the configuration datum.
+     * @param value value to be assigned to the name.
+     */
     public static void setProperty(String key, String value)
     {
         log.info("setProperty({}, {});", key, value);
         properties.setProperty(key, value);
     }
 
+    /**
+     * Fetch a value from the map.
+     *
+     * @param key name of the configuration property desired.
+     * @return value bound to that name, or null if not set.
+     */
     @Mock
     public static String getProperty(String key)
     {

--- a/dspace-api/src/test/java/org/dspace/MockConfigurationManager.java
+++ b/dspace-api/src/test/java/org/dspace/MockConfigurationManager.java
@@ -1,0 +1,43 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+package org.dspace;
+
+import java.util.Properties;
+import mockit.Mock;
+import mockit.MockClass;
+import org.dspace.core.ConfigurationManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * @author mwood
+ */
+@MockClass(realClass=ConfigurationManager.class)
+public class MockConfigurationManager {
+    private static final Properties properties = new Properties();
+    private static final Logger log = LoggerFactory.getLogger(MockConfigurationManager.class);
+
+    public static void setProperty(String key, String value)
+    {
+        log.info("setProperty({}, {});", key, value);
+        properties.setProperty(key, value);
+    }
+
+    @Mock
+    public static String getProperty(String key)
+    {
+        log.info("getProperty({});", key);
+        return properties.getProperty(key);
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/content/authority/DSpaceControlledVocabularyTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/authority/DSpaceControlledVocabularyTest.java
@@ -87,7 +87,7 @@ public class DSpaceControlledVocabularyTest
         String text = "north 40";
         int collection = 0;
         int start = 0;
-        int limit = 1; // FIXME 0 should mean "no limit" but code under test is busted
+        int limit = 0;
         String locale = null;
         DSpaceControlledVocabulary instance = (DSpaceControlledVocabulary)
                 PluginManager.getNamedPlugin(Class.forName(PLUGIN_INTERFACE), "farm");

--- a/dspace-api/src/test/java/org/dspace/content/authority/DSpaceControlledVocabularyTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/authority/DSpaceControlledVocabularyTest.java
@@ -1,0 +1,140 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.authority;
+
+import java.io.IOException;
+import mockit.UsingMocksAndStubs;
+import org.dspace.MockConfigurationManager;
+import org.dspace.core.PluginManager;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import org.junit.*;
+
+/**
+ * Unit tests for DSpaceControlledVocabulary.
+ *
+ * @author mwood
+ */
+@UsingMocksAndStubs(value=MockConfigurationManager.class)
+public class DSpaceControlledVocabularyTest
+{
+    public DSpaceControlledVocabularyTest()
+    {
+    }
+
+    @BeforeClass
+    public static void setUpClass()
+            throws Exception
+    {
+    }
+
+    @AfterClass
+    public static void tearDownClass()
+            throws Exception
+    {
+    }
+
+    @Before
+    public void setUp()
+    {
+    }
+
+    @After
+    public void tearDown()
+    {
+    }
+
+    /**
+     * Test of getPluginNames method, of class DSpaceControlledVocabulary.
+     */
+/*
+    @Test
+    public void testGetPluginNames()
+    {
+        System.out.println("getPluginNames");
+        String[] expResult = null;
+        String[] result = DSpaceControlledVocabulary.getPluginNames();
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of getMatches method, of class DSpaceControlledVocabulary.
+     */
+    @Test
+    public void testGetMatches() throws IOException, ClassNotFoundException
+    {
+        System.out.println("getMatches");
+
+        // Set up the PluginManager
+        final String PLUGIN_INTERFACE = "org.dspace.content.authority.ChoiceAuthority";
+        final String PLUGIN_NAME = "org.dspace.content.authority.DSpaceControlledVocabulary";
+
+        MockConfigurationManager.setProperty("dspace.dir",
+                System.getProperty("dspace.dir.static"));
+        MockConfigurationManager.setProperty(
+                "plugin.selfnamed." + PLUGIN_INTERFACE, PLUGIN_NAME);
+
+        // Ensure that 'id' attribute is optional
+        String field = null; // not used
+        String text = "north 40";
+        int collection = 0;
+        int start = 0;
+        int limit = 1; // FIXME 0 should mean "no limit" but code under test is busted
+        String locale = null;
+        DSpaceControlledVocabulary instance = (DSpaceControlledVocabulary)
+                PluginManager.getNamedPlugin(Class.forName(PLUGIN_INTERFACE), "farm");
+        assertNotNull(instance);
+        Choices result = instance.getMatches(field, text, collection, start,
+                limit, locale);
+        assertEquals("the farm::north 40", result.values[0].value);
+    }
+
+    /**
+     * Test of getBestMatch method, of class DSpaceControlledVocabulary.
+     */
+/*
+    @Test
+    public void testGetBestMatch()
+    {
+        System.out.println("getBestMatch");
+        String field = "";
+        String text = "";
+        int collection = 0;
+        String locale = "";
+        DSpaceControlledVocabulary instance = new DSpaceControlledVocabulary();
+        Choices expResult = null;
+        Choices result = instance.getBestMatch(field, text, collection, locale);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of getLabel method, of class DSpaceControlledVocabulary.
+     */
+/*
+    @Test
+    public void testGetLabel()
+    {
+        System.out.println("getLabel");
+        String field = "";
+        String key = "";
+        String locale = "";
+        DSpaceControlledVocabulary instance = new DSpaceControlledVocabulary();
+        String expResult = "";
+        String result = instance.getLabel(field, key, locale);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+}


### PR DESCRIPTION
This consists of four commits:
1.  I had to reformat some hard tabs to be able to read the code.
2.  The actual fix.
3.  A simple mock ConfigurationManager so I can test.
4.  The actual unit test and some scaffolding.
