### PR TITLE
DS-1209 adjust additions pom so that servlet-api is bundled into lib dir...

### DIFF
--- a/dspace/modules/additions/pom.xml
+++ b/dspace/modules/additions/pom.xml
@@ -94,7 +94,6 @@
       <dependency>
          <groupId>javax.servlet</groupId>
          <artifactId>servlet-api</artifactId>
-         <scope>provided</scope>
       </dependency>
       <dependency>
          <groupId>ant-contrib</groupId>


### PR DESCRIPTION
The built lib directory is missing the servlet-api jar, and hence 'ant fresh_install' fails with java.lang.ClassNotFoundException: javax.servlet.ServletRequest 

Bundling the servlet-api jar into the lib directory is the solution for the build to succeed. No impact on the running application and there is no bundling of servlet-api into the webapps.
