### PR TITLE
DS-1208 Build time filtering to allow multi developer/environment builds

### DIFF
--- a/build.properties.sample
+++ b/build.properties.sample
@@ -1,0 +1,137 @@
+# DSpace build.properties
+# This file should be customised to suit your build environment.
+# Note that not all configuration is handled here, only the most common properties that tend to differ between build environments. 
+# For adjusting global settings or more complex settings, edit the relevant config file.
+
+##########################
+# SERVER CONFIGURATION #
+##########################
+
+# DSpace installation directory. Data will be stored within this directory
+dspace.dir=/dspace
+
+# DSpace host name - should match base URL.  Do not include port number
+dspace.hostname = localhost
+
+# DSpace base host URL.  Include port number etc.
+dspace.baseUrl = http://localhost:8080
+
+# Name of the site
+dspace.name = DSpace at My University
+
+# Solr server
+solr.server=http://localhost:8080/solr
+
+# Default language for metadata values
+default.language = en_US
+
+##########################
+# DATABASE CONFIGURATION #
+##########################
+
+# Database name ("oracle", or "postgres")
+db.name=postgres
+
+# Uncomment the appropriate block below for your database.
+# postgres
+db.driver=org.postgresql.Driver
+db.url=jdbc:postgresql://localhost:5432/dspace
+db.username=dspace
+db.password=dspace
+
+# oracle
+#db.driver= oracle.jdbc.OracleDriver
+#db.url=jdbc:oracle:thin:@//localhost:1521/xe
+#db.username=dspace
+#db.password=dspace
+
+# Schema name - if your database contains multiple schemas, you can avoid problems with
+# retrieving the definitions of duplicate object names by specifying
+# the schema name here that is used for DSpace by uncommenting the following entry
+db.schema = 
+
+# Maximum number of DB connections in pool
+db.maxconnections = 30
+
+# Maximum time to wait before giving up if all connections in pool are busy (milliseconds)
+db.maxwait = 5000
+
+# Maximum number of idle connections in pool (-1 = unlimited)
+db.maxidle = -1
+
+# Determine if prepared statement should be cached. (default is true)
+db.statementpool = true
+
+# Specify a name for the connection pool (useful if you have multiple applications sharing Tomcat's dbcp)
+# If not specified, defaults to 'dspacepool'
+db.poolname = dspacepool
+
+#######################
+# EMAIL CONFIGURATION #
+#######################
+
+# SMTP mail server
+mail.server = smtp.example.com
+
+# SMTP mail server authentication username and password (if required)
+# mail.server.username = myusername
+# mail.server.password = mypassword
+mail.server.username=
+mail.server.password=
+
+# SMTP mail server alternate port (defaults to 25)
+mail.server.port = 25
+
+# From address for mail
+mail.from.address = dspace-noreply@myu.edu
+
+# Currently limited to one recipient!
+mail.feedback.recipient = dspace-help@myu.edu
+
+# General site administration (Webmaster) e-mail
+mail.admin = dspace-help@myu.edu
+
+# Recipient for server errors and alerts
+#mail.alert.recipient = email-address-here
+mail.alert.recipient=
+
+# Recipient for new user registration emails
+#mail.registration.notify = email-address-here
+mail.registration.notify=
+
+
+########################
+# HANDLE CONFIGURATION #
+########################
+
+# Canonical Handle URL prefix
+#
+# By default, DSpace is configured to use http://hdl.handle.net/
+# as the canonical URL prefix when generating dc.identifier.uri
+# during submission, and in the 'identifier' displayed in JSPUI
+# item record pages.
+#
+# If you do not subscribe to CNRI's handle service, you can change this
+# to match the persistent URL service you use, or you can force DSpace
+# to use your site's URL, eg.
+#handle.canonical.prefix = ${dspace.url}/handle/
+#
+# Note that this will not alter dc.identifer.uri metadata for existing
+# items (only for subsequent submissions), but it will alter the URL 
+# in JSPUI's 'identifier' message on item record pages for existing items.
+#
+# If omitted, the canonical URL prefix will be http://hdl.handle.net/
+handle.canonical.prefix = http://hdl.handle.net/
+
+# CNRI Handle prefix
+handle.prefix = 123456789
+
+#######################
+# PROXY CONFIGURATION #
+#######################
+# uncomment and specify both properties if proxy server required
+# proxy server for external http requests - use regular hostname without port number
+http.proxy.host =
+
+# port number of proxy server
+http.proxy.port =

--- a/dspace-jspui/dspace-jspui-webapp/pom.xml
+++ b/dspace-jspui/dspace-jspui-webapp/pom.xml
@@ -18,6 +18,28 @@
    </parent>
 
    <build>
+		<filters>
+            <filter>${basedir}/../../${filters.file}</filter>
+        </filters>
+		<resources>
+			<!-- Enumerate filtered files explicitly to avoid issues with other config tech. -->
+			<resource>
+				<directory>${basedir}</directory>
+				<filtering>true</filtering>
+				<includes>
+					<include>src/main/webapp/WEB-INF/web.xml</include>
+				</includes>
+			</resource>
+			<!-- Declare a mutually exclusive resource set for non-filtered files. -->
+			<resource>
+				<directory>${basedir}</directory>
+				<filtering>false</filtering>
+				<excludes>
+					<exclude>src/main/webapp/WEB-INF/web.xml</exclude>
+				</excludes>
+			</resource>
+		</resources>
+   
       <plugins>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -27,15 +49,6 @@
                <!-- In version 2.1-alpha-1, this was incorrectly named warSourceExcludes -->
                <packagingExcludes>WEB-INF/lib/*.jar</packagingExcludes>
                <warSourceExcludes>WEB-INF/lib/*.jar</warSourceExcludes>
-               <webResources>
-                  <resource>
-                     <filtering>true</filtering>
-                     <directory>${basedir}/src/main/webapp</directory>
-                     <includes>
-                        <include>WEB-INF/web.xml</include>
-                     </includes>
-                  </resource>
-               </webResources>
             </configuration>
             <executions>
                <execution>
@@ -62,26 +75,6 @@
    </build>
 
    <profiles>
-      <!--
-         when activated a dspace.config configuration
-         file location passed on the commandline
-         (-Ddspace.config=...) can be passed through
-         to be used as a filter source by projects for
-         tasks such as updating the ${dspace.dir} in
-         web.xml etc.
-      -->
-      <profile>
-         <activation>
-            <property>
-               <name>dspace.config</name>
-            </property>
-         </activation>
-         <build>
-            <filters>
-               <filter>${dspace.config}</filter>
-            </filters>
-         </build>
-      </profile>
       <profile>
          <id>oracle-support</id>
          <activation>

--- a/dspace-lni/dspace-lni-webapp/pom.xml
+++ b/dspace-lni/dspace-lni-webapp/pom.xml
@@ -16,6 +16,28 @@
    </parent>
 
    <build>
+		<filters>
+            <filter>${basedir}/../../${filters.file}</filter>
+        </filters>
+		<resources>
+			<!-- Enumerate filtered files explicitly to avoid issues with other config tech. -->
+			<resource>
+				<directory>${basedir}</directory>
+				<filtering>true</filtering>
+				<includes>
+					<include>src/main/webapp/WEB-INF/web.xml</include>
+				</includes>
+			</resource>
+			<!-- Declare a mutually exclusive resource set for non-filtered files. -->
+			<resource>
+				<directory>${basedir}</directory>
+				<filtering>false</filtering>
+				<excludes>
+					<exclude>src/main/webapp/WEB-INF/web.xml</exclude>
+				</excludes>
+			</resource>
+		</resources>
+      
       <plugins>   
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -25,15 +47,6 @@
                <!-- In version 2.1-alpha-1, this was incorrectly named warSourceExcludes -->
                <packagingExcludes>WEB-INF/lib/*.jar</packagingExcludes>
                <warSourceExcludes>WEB-INF/lib/*.jar</warSourceExcludes>
-               <webResources>
-                  <resource>
-                     <filtering>true</filtering>
-                     <directory>${basedir}/src/main/webapp</directory>
-                     <includes>
-                        <include>WEB-INF/web.xml</include>
-                     </includes>
-                  </resource>
-               </webResources>
             </configuration>
             <executions>
                <execution>
@@ -45,26 +58,6 @@
    </build>
 
    <profiles>
-      <!-- 
-         when activated a dspace.config configuration
-         file location passed on the commandline 
-         (-Ddspace.config=...) can be passed through 
-         to be used as a filter source by projects for 
-         tasks such as updating the ${dspace.dir} in
-         web.xml etc.
-      -->
-      <profile>
-         <activation>
-            <property>
-               <name>dspace.config</name>
-            </property>
-         </activation>
-         <build>
-            <filters>
-               <filter>${dspace.config}</filter>
-            </filters>
-         </build>
-      </profile>
       <profile>
          <id>oracle-support</id>
          <activation>

--- a/dspace-oai/dspace-oai-webapp/pom.xml
+++ b/dspace-oai/dspace-oai-webapp/pom.xml
@@ -18,6 +18,28 @@
    </parent>
    
    <build>
+		<filters>
+            <filter>${basedir}/../../${filters.file}</filter>
+        </filters>
+		<resources>
+			<!-- Enumerate filtered files explicitly to avoid issues with other config tech. -->
+			<resource>
+				<directory>${basedir}</directory>
+				<filtering>true</filtering>
+				<includes>
+					<include>src/main/webapp/WEB-INF/web.xml</include>
+				</includes>
+			</resource>
+			<!-- Declare a mutually exclusive resource set for non-filtered files. -->
+			<resource>
+				<directory>${basedir}</directory>
+				<filtering>false</filtering>
+				<excludes>
+					<exclude>src/main/webapp/WEB-INF/web.xml</exclude>
+				</excludes>
+			</resource>
+		</resources>      
+      
       <plugins>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -27,15 +49,6 @@
                <!-- In version 2.1-alpha-1, this was incorrectly named warSourceExcludes -->
                <packagingExcludes>WEB-INF/lib/*.jar</packagingExcludes>
                <warSourceExcludes>WEB-INF/lib/*.jar</warSourceExcludes>
-               <webResources>
-                  <resource>
-                     <filtering>true</filtering>
-                     <directory>${basedir}/src/main/webapp</directory>
-                     <includes>
-                        <include>WEB-INF/web.xml</include>
-                     </includes>
-                  </resource>
-               </webResources>
             </configuration>
             <executions>
                <execution>
@@ -57,26 +70,6 @@
    </build>
 
    <profiles>
-      <!-- 
-         when activated a dspace.config configuration
-         file location passed on the commandline 
-         (-Ddspace.config=...) can be passed through 
-         to be used as a filter source by projects for 
-         tasks such as updating the ${dspace.dir} in
-         web.xml etc.
-      -->
-      <profile>
-         <activation>
-            <property>
-               <name>dspace.config</name>
-            </property>
-         </activation>
-         <build>
-            <filters>
-               <filter>${dspace.config}</filter>
-            </filters>
-         </build>
-      </profile>
       <profile>
          <id>oracle-support</id>
          <activation>

--- a/dspace-sword/dspace-sword-webapp/pom.xml
+++ b/dspace-sword/dspace-sword-webapp/pom.xml
@@ -18,6 +18,28 @@
    </parent>
 
    <build>
+		<filters>
+            <filter>${basedir}/../../${filters.file}</filter>
+        </filters>
+		<resources>
+			<!-- Enumerate filtered files explicitly to avoid issues with other config tech. -->
+			<resource>
+				<directory>${basedir}</directory>
+				<filtering>true</filtering>
+				<includes>
+					<include>src/main/webapp/WEB-INF/web.xml</include>
+				</includes>
+			</resource>
+			<!-- Declare a mutually exclusive resource set for non-filtered files. -->
+			<resource>
+				<directory>${basedir}</directory>
+				<filtering>false</filtering>
+				<excludes>
+					<exclude>src/main/webapp/WEB-INF/web.xml</exclude>
+				</excludes>
+			</resource>
+		</resources>
+      
       <plugins>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -27,15 +49,6 @@
                <!-- In version 2.1-alpha-1, this was incorrectly named warSourceExcludes -->
                <packagingExcludes>WEB-INF/lib/*.jar</packagingExcludes>
                <warSourceExcludes>WEB-INF/lib/*.jar</warSourceExcludes>
-               <webResources>
-                  <resource>
-                     <filtering>true</filtering>
-                     <directory>${basedir}/src/main/webapp</directory>
-                     <includes>
-                        <include>WEB-INF/web.xml</include>
-                     </includes>
-                  </resource>
-               </webResources>
             </configuration>
             <executions>
                <execution>
@@ -47,26 +60,6 @@
    </build>
 
    <profiles>
-      <!--
-         when activated a dspace.config configuration
-         file location passed on the commandline
-         (-Ddspace.config=...) can be passed through
-         to be used as a filter source by projects for
-         tasks such as updating the ${dspace.dir} in
-         web.xml etc.
-      -->
-      <profile>
-         <activation>
-            <property>
-               <name>dspace.config</name>
-            </property>
-         </activation>
-         <build>
-            <filters>
-               <filter>${dspace.config}</filter>
-            </filters>
-         </build>
-      </profile>
       <profile>
          <id>oracle-support</id>
          <activation>

--- a/dspace-swordv2/pom.xml
+++ b/dspace-swordv2/pom.xml
@@ -18,6 +18,28 @@
     </parent>
 
     <build>
+        <filters>
+            <filter>${basedir}/../${filters.file}</filter>
+        </filters>
+		<resources>
+			<!-- Enumerate filtered files explicitly to avoid issues with other config tech. -->
+			<resource>
+				<directory>${basedir}</directory>
+				<filtering>true</filtering>
+				<includes>
+					<include>src/main/webapp/WEB-INF/web.xml</include>
+				</includes>
+			</resource>
+			<!-- Declare a mutually exclusive resource set for non-filtered files. -->
+			<resource>
+				<directory>${basedir}</directory>
+				<filtering>false</filtering>
+				<excludes>
+					<exclude>src/main/webapp/WEB-INF/web.xml</exclude>
+				</excludes>
+			</resource>
+		</resources>
+        
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -27,15 +49,6 @@
                     <!-- In version 2.1-alpha-1, this was incorrectly named warSourceExcludes -->
                     <packagingExcludes>WEB-INF/lib/*.jar</packagingExcludes>
                     <warSourceExcludes>WEB-INF/lib/*.jar</warSourceExcludes>
-                    <webResources>
-                        <resource>
-                            <filtering>true</filtering>
-                            <directory>${basedir}/src/main/webapp</directory>
-                            <includes>
-                                <include>WEB-INF/web.xml</include>
-                            </includes>
-                        </resource>
-                    </webResources>
                 </configuration>
                 <executions>
                     <execution>
@@ -48,26 +61,6 @@
 
 
     <profiles>
-        <!--
-           when activated a dspace.config configuration
-           file location passed on the commandline
-           (-Ddspace.config=...) can be passed through
-           to be used as a filter source by projects for
-           tasks such as updating the ${dspace.dir} in
-           web.xml etc.
-        -->
-        <profile>
-            <activation>
-                <property>
-                    <name>dspace.config</name>
-                </property>
-            </activation>
-            <build>
-                <filters>
-                    <filter>${dspace.config}</filter>
-                </filters>
-            </build>
-        </profile>
         <profile>
             <id>oracle-support</id>
             <activation>

--- a/dspace-xmlui/dspace-xmlui-webapp/pom.xml
+++ b/dspace-xmlui/dspace-xmlui-webapp/pom.xml
@@ -17,6 +17,28 @@
     </parent>
 
     <build>
+        <filters>
+            <filter>${basedir}/../../${filters.file}</filter>
+        </filters>
+		<resources>
+			<!-- Enumerate filtered files explicitly to avoid issues with other config tech. -->
+			<resource>
+				<directory>${basedir}</directory>
+				<filtering>true</filtering>
+				<includes>
+					<include>src/main/webapp/WEB-INF/web.xml</include>
+				</includes>
+			</resource>
+			<!-- Declare a mutually exclusive resource set for non-filtered files. -->
+			<resource>
+				<directory>${basedir}</directory>
+				<filtering>false</filtering>
+				<excludes>
+					<exclude>src/main/webapp/WEB-INF/web.xml</exclude>
+				</excludes>
+			</resource>
+		</resources>
+        
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -26,15 +48,6 @@
                     <!-- In version 2.1-alpha-1, this was incorrectly named warSourceExcludes -->
                     <packagingExcludes>WEB-INF/lib/*.jar</packagingExcludes>
                     <warSourceExcludes>WEB-INF/lib/*.jar</warSourceExcludes>
-                    <webResources>
-                        <resource>
-                            <filtering>true</filtering>
-                            <directory>${basedir}/src/main/webapp</directory>
-                            <includes>
-                                <include>WEB-INF/web.xml</include>
-                            </includes>
-                        </resource>
-                    </webResources>
                 </configuration>
                 <executions>
                     <execution>
@@ -64,26 +77,6 @@
     </build>
 
     <profiles>
-        <!--
-           when activated a dspace.config configuration
-           file location passed on the commandline
-           (-Ddspace.config=...) can be passed through
-           to be used as a filter source by projects for
-           tasks such as updating the ${dspace.dir} in
-           web.xml etc.
-        -->
-        <profile>
-            <activation>
-                <property>
-                    <name>dspace.config</name>
-                </property>
-            </activation>
-            <build>
-                <filters>
-                    <filter>${dspace.config}</filter>
-                </filters>
-            </build>
-        </profile>
         <profile>
             <id>oracle-support</id>
             <activation>

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -13,113 +13,59 @@
 #
 
 
-#---------------------------------------------------------------#
-#------------------GENERAL CONFIGURATIONS-----------------------#
-#---------------------------------------------------------------#
-# These configs are used by underlying DSpace API, and are      #
-# therefore applicable to all interfaces                        #
-#---------------------------------------------------------------#
+#------------------------------------------------------------------#
+#------------------GENERAL CONFIGURATIONS--------------------------#
+#------------------------------------------------------------------#
+# These configs are used by underlying DSpace API, and are         #
+# therefore applicable to all interfaces                           #
+# Local, simple configuration should be made in build.properties   #
+# Global or more complex configuration can be hardcoded here       #
+#------------------------------------------------------------------#
 ##### Basic information ######
 
-# DSpace installation directory
-dspace.dir = ${default.dspace.dir}
-
-# DSpace host name - should match base URL.  Do not include port number
-dspace.hostname = localhost
-
-# DSpace base host URL.  Include port number etc.
-dspace.baseUrl = http://localhost:8080
-
-# DSpace base URL.  Include port number etc., but NOT trailing slash
-# Change to xmlui if you wish to use the xmlui as the default, or remove
-# "/jspui" and set webapp of your choice as the "ROOT" webapp in
-# the servlet engine.
+dspace.dir = ${dspace.dir}
+dspace.hostname = ${dspace.hostname}
+dspace.baseUrl = ${dspace.baseUrl}
 dspace.url = ${dspace.baseUrl}/xmlui
-
-# Name of the site
-dspace.name = DSpace at My University
+dspace.name = ${dspace.name}
+default.language = ${default.language}
 
 ##### Database settings #####
 
-# Database name ("oracle", or "postgres")
-db.name = ${default.db.name}
-#db.name = postgres
-#db.name = oracle
-
-# URL for connecting to database
-db.url = ${default.db.url}
-#db.url = jdbc:postgresql://localhost:5432/dspace
-
-# JDBC Driver
-db.driver = ${default.db.driver}
-#db.driver = org.postgresql.Driver
-
-# Database username and password
-db.username = ${default.db.username}
-db.password = ${default.db.password}
-#db.username = dspace
-#db.password = dspace
-
-# Schema name - if your database contains multiple schemas, you can avoid problems with
-# retrieving the definitions of duplicate object names by specifying
-# the schema name here that is used for DSpace by uncommenting the following entry
-# db.schema =
-
-# Connection pool parameters
-
-# Maximum number of DB connections in pool
-db.maxconnections = 30
-
-# Maximum time to wait before giving up if all connections in pool are busy (milliseconds)
-db.maxwait = 5000
-
-# Maximum number of idle connections in pool (-1 = unlimited)
-db.maxidle = -1
-
-# Determine if prepared statement should be cached. (default is true)
-db.statementpool = true
-
-# Specify a name for the connection pool (useful if you have multiple applications sharing Tomcat's dbcp)
-# If not specified, defaults to 'dspacepool'
-# db.poolname = dspacepool
+db.name = ${db.name}
+db.url = ${db.url}
+db.driver = ${db.driver}
+db.username = ${db.username}
+db.password = ${db.password}
+db.schema = ${db.schema}
+db.maxconnections = ${db.maxconnections}
+db.maxwait = ${db.maxwait}
+db.maxidle = ${db.maxidle}
+db.statementpool = ${db.statementpool}
+db.poolname = ${db.poolname}
 
 ##### Email settings ######
 
-# SMTP mail server
-mail.server = ${default.mail.server}
-
-# SMTP mail server authentication username and password (if required)
-# mail.server.username = myusername
-# mail.server.password = mypassword
-
-# SMTP mail server alternate port (defaults to 25)
-# mail.server.port = 25
-
-# From address for mail
-mail.from.address = dspace-noreply@myu.edu
-
-# Currently limited to one recipient!
-feedback.recipient = dspace-help@myu.edu
-
-# General site administration (Webmaster) e-mail
-mail.admin = dspace-help@myu.edu
-
-# Recipient for server errors and alerts
-# alert.recipient = email-address-here
-
-# Recipient for new user registration emails
-# registration.notify = email-address-here
+mail.server = ${mail.server}
+mail.server.username = ${mail.server.username}
+mail.server.password = ${mail.server.password}
+mail.server.port = ${mail.server.port}
+mail.from.address = ${mail.from.address}
+feedback.recipient = ${mail.feedback.recipient}
+mail.admin = ${mail.admin}
+alert.recipient = ${mail.alert.recipient}
+registration.notify = ${mail.registration.notify}
 
 # Set the default mail character set. This may be overridden by providing a line
 # inside the email template "charset: <encoding>", otherwise this default is used.
-#mail.charset = UTF-8
+mail.charset = UTF-8
 
 # A comma-separated list of hostnames that are allowed to refer browsers to email forms.
 # Default behaviour is to accept referrals only from dspace.hostname
-#mail.allowed.referrers = localhost
+mail.allowed.referrers = ${dspace.hostname}
 
 # Pass extra settings to the Java mail library. Comma-separated, equals sign between
-# the key and the value.
+# the key and the value. For example:
 #mail.extraproperties = mail.smtp.socketFactory.port=465, \
 #                       mail.smtp.socketFactory.class=javax.net.ssl.SSLSocketFactory, \
 #                       mail.smtp.socketFactory.fallback=false
@@ -130,14 +76,11 @@ mail.admin = dspace-help@myu.edu
 # This is especially useful for development and test environments where production data is used when testing functionality.
 #mail.server.disabled = false
 
-# Default language for metadata values
-default.language = en_US
-
-
 ##### File Storage ######
 
 # Asset (bitstream) store number 0 (zero)
 assetstore.dir = ${dspace.dir}/assetstore
+
 
 # Specify extra asset stores like this, counting from 1 upwards:
 # assetstore.dir.1 = /second/assetstore
@@ -210,11 +153,9 @@ assetstore.dir = ${dspace.dir}/assetstore
 ##### Logging configuration #####
 
 # Override default log4j configuration
-# you may provide your own configuration here, existing
-# alternatives are:
+# You may provide your own configuration here, existing alternatives are:
 # log.init.config = ${dspace.dir}/config/log4j.xml
 # log.init.config = ${dspace.dir}/config/log4j-console.properties
-
 log.init.config = ${dspace.dir}/config/log4j.properties
 
 # Where to put the logs (used in configuration only)
@@ -222,8 +163,7 @@ log.dir = ${dspace.dir}/log
 
 # If enabled, the logging and the solr statistics system will look for
 # an X-Forward header. If it finds it, it will use this for the user IP address
-# useProxies = true
-
+#log.useProxies = true
 
 ##### Search settings #####
 
@@ -232,12 +172,11 @@ search.dir = ${dspace.dir}/search
 
 # Higher values of search.max-clauses will enable prefix searches to work on
 # large repositories
-# search.max-clauses = 2048
+search.max-clauses = 2048
 
 # Which Lucene Analyzer implementation to use.  If this is omitted or
 # commented out, the standard DSpace analyzer (designed for English)
 # is used by default.
-# search.analyzer = org.dspace.search.DSAnalyzer
 
 # Non-Stemming analyzer.  Does not "stem" words/terms. When using this analyzer,
 # a search for "wellness" will always return items matching "wellness" and not "well".
@@ -248,14 +187,13 @@ search.dir = ${dspace.dir}/search
 # Chinese analyzer
 # search.analyzer = org.apache.lucene.analysis.cn.ChineseAnalyzer
 
+search.analyzer = org.dspace.search.DSAnalyzer
+
 # Boolean search operator to use, current supported values are OR and AND
 # If this config item is missing or commented out, OR is used
 # AND requires all search terms to be present
 # OR requires one or more search terms to be present
 search.operator = OR
-
-
-##### Search indexing settings #####
 
 # Maximum number of terms indexed for a single field in Lucene.
 # Default is 10,000 words - often not enough for full-text indexing.
@@ -263,7 +201,6 @@ search.operator = OR
 # to take effect on previously added items.
 # -1 = unlimited (Integer.MAX_VALUE)
 search.maxfieldlength = 10000
-
 
 ##### Fields to Index for Search #####
 
@@ -287,31 +224,10 @@ search.index.10 = sponsor:dc.description.sponsorship
 search.index.11 = identifier:dc.identifier.*
 search.index.12 = language:dc.language.iso
 
-
-
 ##### Handle settings ######
 
-# Canonical Handle URL prefix
-#
-# By default, DSpace is configured to use http://hdl.handle.net/
-# as the canonical URL prefix when generating dc.identifier.uri
-# during submission, and in the 'identifier' displayed in JSPUI
-# item record pages.
-#
-# If you do not subscribe to CNRI's handle service, you can change this
-# to match the persistent URL service you use, or you can force DSpace
-# to use your site's URL, eg.
-#handle.canonical.prefix = ${dspace.url}/handle/
-#
-# Note that this will not alter dc.identifer.uri metadata for existing
-# items (only for subsequent submissions), but it will alter the URL 
-# in JSPUI's 'identifier' message on item record pages for existing items.
-#
-# If omitted, the canonical URL prefix will be http://hdl.handle.net/
-handle.canonical.prefix = http://hdl.handle.net/
-
-# CNRI Handle prefix
-handle.prefix = 123456789
+handle.canonical.prefix = ${handle.canonical.prefix}
+handle.prefix = ${handle.prefix}
 
 # Directory for installing Handle server files
 handle.dir = ${dspace.dir}/handle-server
@@ -383,12 +299,8 @@ handle.dir = ${dspace.dir}/handle-server
 
 
 #### Proxy Settings ######
-# uncomment and specify both properties if proxy server required
-# proxy server for external http requests - use regular hostname without port number
-#http.proxy.host =
-
-# port number of proxy server
-#http.proxy.port =
+http.proxy.host = ${http.proxy.host}
+http.proxy.port = ${http.proxy.port}
 
 
 #### Media Filter / Format Filter plugins (through PluginManager) ####

--- a/dspace/config/modules/solr-statistics.cfg
+++ b/dspace/config/modules/solr-statistics.cfg
@@ -9,7 +9,7 @@
 # set this to be the port you run the dspace "solr" webapp
 # on, by default, we are assuming a test configuration with
 # tomcat still running on port 8080
-server = ${default.solr.server}/statistics
+server = ${solr.server}/statistics
 
 # The location for the Geo Database retrieved on update/installation
 dbfile = ${dspace.dir}/config/GeoLiteCity.dat

--- a/dspace/modules/jspui/pom.xml
+++ b/dspace/modules/jspui/pom.xml
@@ -15,32 +15,6 @@
 
 	<profiles>
 
-		<!-- 
-			This profile is used by all children such that
-			when activated a dspace.config configuration
-			file location passed on the commandline 
-			(-Ddspace.config=...) can be passed through 
-			to be used as a filter source by projects for 
-			tasks such as updating the ${dspace.dir} in
-			web.xml etc.
-			
-			When activated, the child project will inherit
-			the configuration.
-		-->
-		<profile>
-            <id>dspace-config</id>
-			<activation>
-				<property>
-					<name>dspace.config</name>
-				</property>
-			</activation>
-			<build>
-				<filters>
-					<filter>${dspace.config}</filter>
-				</filters>
-			</build>
-		</profile>
-
 		<profile>
 			<id>postgres-support</id>
 			<activation>

--- a/dspace/modules/lni/pom.xml
+++ b/dspace/modules/lni/pom.xml
@@ -44,27 +44,6 @@
    </build>
 
    <profiles>
-      <!-- 
-         when activated a dspace.config configuration
-         file location passed on the commandline 
-         (-Ddspace.config=...) can be passed through 
-         to be used as a filter source by projects for 
-         tasks such as updating the ${dspace.dir} in
-         web.xml etc.
-      -->
-      <profile>
-         <id>dspace-config</id>
-         <activation>
-            <property>
-               <name>dspace.config</name>
-            </property>
-         </activation>
-         <build>
-            <filters>
-               <filter>${dspace.config}</filter>
-            </filters>
-         </build>
-      </profile>
       <profile>
          <id>postgres-support</id>
          <activation>

--- a/dspace/modules/oai/pom.xml
+++ b/dspace/modules/oai/pom.xml
@@ -46,27 +46,6 @@
    </build>
 
    <profiles>
-      <!-- 
-         when activated a dspace.config configuration
-         file location passed on the commandline 
-         (-Ddspace.config=...) can be passed through 
-         to be used as a filter source by projects for 
-         tasks such as updating the ${dspace.dir} in
-         web.xml etc.
-      -->
-      <profile>
-         <id>dspace-config</id>
-         <activation>
-            <property>
-               <name>dspace.config</name>
-            </property>
-         </activation>
-         <build>
-            <filters>
-               <filter>${dspace.config}</filter>
-            </filters>
-         </build>
-      </profile>
       <profile>
          <id>postgres-support</id>
          <activation>

--- a/dspace/modules/sword/pom.xml
+++ b/dspace/modules/sword/pom.xml
@@ -48,27 +48,6 @@
    </build>
 
    <profiles>
-      <!--
-         when activated a dspace.config configuration
-         file location passed on the commandline
-         (-Ddspace.config=...) can be passed through
-         to be used as a filter source by projects for
-         tasks such as updating the ${dspace.dir} in
-         web.xml etc.
-      -->
-      <profile>
-         <id>dspace-config</id>
-         <activation>
-            <property>
-               <name>dspace.config</name>
-            </property>
-         </activation>
-         <build>
-            <filters>
-               <filter>${dspace.config}</filter>
-            </filters>
-         </build>
-      </profile>
       <profile>
          <id>oracle-support</id>
          <activation>

--- a/dspace/modules/swordv2/pom.xml
+++ b/dspace/modules/swordv2/pom.xml
@@ -48,27 +48,6 @@
    </build>
 
    <profiles>
-      <!--
-         when activated a dspace.config configuration
-         file location passed on the commandline
-         (-Ddspace.config=...) can be passed through
-         to be used as a filter source by projects for
-         tasks such as updating the ${dspace.dir} in
-         web.xml etc.
-      -->
-      <profile>
-         <id>dspace-config</id>
-         <activation>
-            <property>
-               <name>dspace.config</name>
-            </property>
-         </activation>
-         <build>
-            <filters>
-               <filter>${dspace.config}</filter>
-            </filters>
-         </build>
-      </profile>
       <profile>
          <id>oracle-support</id>
          <activation>

--- a/dspace/modules/xmlui/pom.xml
+++ b/dspace/modules/xmlui/pom.xml
@@ -67,27 +67,6 @@
    </build>
 
    <profiles>
-      <!-- 
-         when activated a dspace.config configuration
-         file location passed on the commandline 
-         (-Ddspace.config=...) can be passed through 
-         to be used as a filter source by projects for 
-         tasks such as updating the ${dspace.dir} in
-         web.xml etc.
-      -->
-      <profile>
-         <id>dspace-config</id>
-         <activation>
-            <property>
-               <name>dspace.config</name>
-            </property>
-         </activation>
-         <build>
-            <filters>
-               <filter>${dspace.config}</filter>
-            </filters>
-         </build>
-      </profile>
       <profile>
          <id>postgres-support</id>
          <activation>

--- a/dspace/pom.xml
+++ b/dspace/pom.xml
@@ -18,99 +18,7 @@
         <version>3.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
-
-    <properties>
-        <default.dspace.dir>/dspace</default.dspace.dir>
-        <default.mail.server>smtp.example.com</default.mail.server>
-        <default.solr.server>http://localhost:8080/solr</default.solr.server>
-    </properties>
-
-    <profiles>
-
-        <!--
-           This profile is used by all children such that
-           when activated a dspace.config configuration
-           file location passed on the commandline
-           (-Ddspace.config=...) can be passed through
-           to be used as a filter source by projects for
-           tasks such as updating the ${dspace.dir} in
-           web.xml etc.
-
-           When activated, the child project will inherit
-           the configuration.
-        -->
-        <profile>
-            <id>dspace-config</id>
-            <activation>
-                <property>
-                    <name>dspace.config</name>
-                </property>
-            </activation>
-            <build>
-                <filters>
-                    <filter>${dspace.config}</filter>
-                </filters>
-            </build>
-        </profile>
-
-        <!--
-           These profiles setup properties and build configuration
-           appropriate to the database that DSpace will be installed
-           against.
-
-           They are activated by using the profile id - ie. -Ppostgres,
-           or defining db.name - ie. -Ddb.name=oracle
-        -->
-        <!--
-           Default profile for Postgres database configuration
-           Use -Ppostgres to activate.
-        -->
-
-        <profile>
-            <id>postgres</id>
-            <activation>
-                <property>
-                    <name>!db.name</name>
-                </property>
-            </activation>
-            <properties>
-                <default.db.name>postgres</default.db.name>
-                <default.db.driver>org.postgresql.Driver</default.db.driver>
-                <default.db.url>
-                    jdbc:postgresql://localhost:5432/dspace
-                </default.db.url>
-                <default.db.username>dspace</default.db.username>
-                <default.db.password>dspace</default.db.password>
-            </properties>
-        </profile>
-
-        <!--
-           Default profile for Oracle database configuration
-           Use -Poracle or -Ddb.name=oracle to activate.
-        -->
-        <profile>
-            <id>oracle</id>
-            <activation>
-                <property>
-                    <name>db.name</name>
-                    <value>oracle</value>
-                </property>
-            </activation>
-            <properties>
-                <default.db.name>oracle</default.db.name>
-                <default.db.driver>
-                    oracle.jdbc.OracleDriver
-                </default.db.driver>
-                <default.db.url>
-                    jdbc:oracle:thin:@//localhost:1521/xe
-                </default.db.url>
-                <default.db.username>dspace</default.db.username>
-                <default.db.password>dspace</default.db.password>
-            </properties>
-        </profile>
-
-    </profiles>
-
+    
     <!--
        Builds Overlay Modules for DSpace
     -->
@@ -119,6 +27,41 @@
     </modules>
 
     <build>
+		<filters>
+            <filter>${basedir}/../${filters.file}</filter>
+        </filters>
+         <resources>
+			<!-- Enumerate filtered files explicitly to avoid issues with other config tech. -->
+            <resource>
+                <directory>${basedir}</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>config/default.context.xml</include>
+                    <include>config/dspace.cfg</include>
+                    <include>config/log4j-handle-plugin.properties</include>
+                    <include>config/log4j.properties</include>
+                    <include>config/modules/curate.cfg</include>
+                    <include>config/modules/oai.cfg</include>
+                    <include>config/modules/solr-statistics.cfg</include>
+
+                </includes>
+            </resource>
+            <!-- Declare a mutually exclusive resource set for non-filtered files. -->
+			<resource>
+                <directory>${basedir}</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>config/default.context.xml</exclude>
+                    <exclude>config/dspace.cfg</exclude>
+                    <exclude>config/log4j-handle-plugin.properties</exclude>
+                    <exclude>config/log4j.properties</exclude>
+                    <exclude>config/modules/curate.cfg</exclude>
+                    <exclude>config/modules/oai.cfg</exclude>
+                    <exclude>config/modules/solr-statistics.cfg</exclude>
+                </excludes>
+            </resource>
+        </resources>
+    
         <plugins>
             <!--  overall project assembly -->
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
     <!--Force UTF-8 encoding during build on all platforms-->
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <filters.file>build.properties</filters.file>
     </properties>
 
     <build>
@@ -140,6 +141,7 @@
                         <exclude>**/README*</exclude>
                         <exclude>**/readme*</exclude>
                         <exclude>**/.gitignore</exclude>
+                        <exclude>**/build.properties*</exclude>
                     </excludes>
                     <mapping> 
                         <!-- Custom DSpace file extensions which are not recognized by maven-release-plugin: 
@@ -1157,6 +1159,16 @@
             <role>developer</role>
          </roles>
          <timezone>-5</timezone>
+      </contributor>
+      <contributor>
+         <name>Steve Swinsburg</name>
+         <email>steve.swinsburg@anu.edu.au</email>
+         <organization>The Australian National University</organization>
+         <organizationUrl>http://www.anu.edu.au</organizationUrl>
+         <roles>
+            <role>developer</role>
+         </roles>
+         <timezone>+10</timezone>
       </contributor>
    </contributors>
 


### PR DESCRIPTION
The addition of properly placeholders in dspace.cfg goes some of the way to allowing multiple developers/environments to use the same source tree, however not enough properties have been externalised. 

For example,if I had 5 developers, how would I customise this property for each of them? 
dspace.baseUrl = http://localhost:8080 

In addition, the current setup requires the build to activate a maven profile, and supply properties either at build time or from a pom.xml, which are then hardcoded. 

This isn't as flexible as it could be, for example by putting all configurable properties into a build.properties/filter.properties file and keeping that out of source control. 
Then each developer simply customises the properties file with the values for their environment, and the build inserts the properties into the relevant source files at build time. 

This is a standard maven filtering approach in use by many other projects. Note that any number of files can be filtered using this approach. 

Using this approach, one simple copies build.properties.sample to build.properties, fills out the params and away they go. No other file needs to be modified. Not all properties have been externalised, just the ones that would typically differ between environments, e.g. dspace dir, server addresses, database, email etc. For more complex configuration that is unlikely to change between developer.build environments, the config still happens within the source code itself.

For properties that were externalised, their documentation was moved to build.properties. The rest has been left behind so that people can still be guided as to the configuration.

References: 
http://maven.apache.org/plugins/maven-resources-plugin/examples/filter.html

Note that this pull request contains two single line commits from my previous pull request for DS-1209. Sorry about that. Please ignore those. I've been unable to remove them from the commit range here.
