### PR TITLE
DS-1211 upgrade to Servlet API 2.4 and other compatible dependencies

### DIFF
--- a/dspace-jspui/dspace-jspui-api/pom.xml
+++ b/dspace-jspui/dspace-jspui-api/pom.xml
@@ -62,6 +62,12 @@
          <version>1.1.2</version>
       </dependency>
       <dependency>
+         <groupId>javax.servlet</groupId>
+         <artifactId>jsp-api</artifactId>
+         <version>2.0</version>
+         <scope>provided</scope>
+      </dependency>
+      <dependency>
          <groupId>org.springframework</groupId>
          <artifactId>spring-webmvc</artifactId>
          <type>jar</type>

--- a/dspace-swordv2/pom.xml
+++ b/dspace-swordv2/pom.xml
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
-            <version>2.3</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.swordapp</groupId>

--- a/dspace-xmlui/dspace-xmlui-api/pom.xml
+++ b/dspace-xmlui/dspace-xmlui-api/pom.xml
@@ -50,7 +50,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
-            <version>2.3</version>
             <scope>provided</scope>
         </dependency>
 

--- a/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/cocoon/HttpServletRequestCocoonWrapper.java
+++ b/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/cocoon/HttpServletRequestCocoonWrapper.java
@@ -270,6 +270,22 @@ public class HttpServletRequestCocoonWrapper implements HttpServletRequest{
 			throws UnsupportedEncodingException {
 		this.cocoonRequest.setCharacterEncoding(arg0);
 	}
+
+	public int getRemotePort() {
+		return this.cocoonRequest.getRemotePort();
+	}
+
+	public String getLocalName() {
+		return this.cocoonRequest.getLocalName();
+	}
+
+	public String getLocalAddr() {
+		return this.cocoonRequest.getLocalAddr();
+	}
+
+	public int getLocalPort() {
+		return this.cocoonRequest.getLocalPort();
+	}
 	
 	
 	

--- a/dspace/modules/jspui/pom.xml
+++ b/dspace/modules/jspui/pom.xml
@@ -127,7 +127,6 @@
 		<dependency>
 		   <groupId>javax.servlet</groupId>
 		   <artifactId>servlet-api</artifactId>
-		   <version>2.3</version>
 		   <scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/dspace/modules/lni/pom.xml
+++ b/dspace/modules/lni/pom.xml
@@ -122,7 +122,6 @@
       <dependency>
          <groupId>javax.servlet</groupId>
          <artifactId>servlet-api</artifactId>
-         <version>2.3</version>
          <scope>provided</scope>
       </dependency>
 

--- a/dspace/modules/oai/pom.xml
+++ b/dspace/modules/oai/pom.xml
@@ -115,7 +115,6 @@
       <dependency>
          <groupId>javax.servlet</groupId>
          <artifactId>servlet-api</artifactId>
-         <version>2.3</version>
          <scope>provided</scope>
       </dependency>
    </dependencies>

--- a/dspace/modules/sword/pom.xml
+++ b/dspace/modules/sword/pom.xml
@@ -121,7 +121,6 @@
       <dependency>
          <groupId>javax.servlet</groupId>
          <artifactId>servlet-api</artifactId>
-         <version>2.3</version>
          <scope>provided</scope>
       </dependency>
    </dependencies>

--- a/dspace/modules/swordv2/pom.xml
+++ b/dspace/modules/swordv2/pom.xml
@@ -130,7 +130,6 @@
       <dependency>
          <groupId>javax.servlet</groupId>
          <artifactId>servlet-api</artifactId>
-         <version>2.3</version>
          <scope>provided</scope>
       </dependency>
 

--- a/dspace/modules/xmlui/pom.xml
+++ b/dspace/modules/xmlui/pom.xml
@@ -181,7 +181,6 @@
       <dependency>
          <groupId>javax.servlet</groupId>
          <artifactId>servlet-api</artifactId>
-         <version>2.3</version>
          <scope>provided</scope>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -683,13 +683,13 @@
          <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
-            <version>2.2</version>
+            <version>2.6</version>
             <!-- <version>2.1</version> in xmlui - wing -->
          </dependency>
          <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.0.4</version>
+            <version>1.1.1</version>
          </dependency>
          <dependency>
             <groupId>commons-pool</groupId>
@@ -709,7 +709,7 @@
          <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
-            <version>2.3</version>
+            <version>2.4</version>
          </dependency>
 
          <dependency>


### PR DESCRIPTION
The following is an upgrade to Servlet API 2.4 as well as commons-lang 2.6 and commons-logging 1.1.1.
