### PR TITLE
[DS-1225] Show display values (input-forms) for controlled vocabularies in ItemTag

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1443,6 +1443,8 @@ report.dir = ${dspace.dir}/reports/
 #    dc.date.issued(date)   = DC date.issued, render as a date
 #    dc.subject(nobreakline)   = DC subject.keyword, rendered as separated values 
 #                               (see also webui.itemdisplay.inclusespace and webui.itemdisplay.separator options)
+#    dc.language(inputform)   = If the dc.language is in a controlled vocabulary, then the displayed value will be shown based on the stored value from the value-pairs-name in input forms.
+#			      The input-forms will be loaded based on the session locale. If the displayed value is not found, then the value will be shown as is. 	
 #    "link/date" options can be combined with "nobreakline" option using a space among them i.e "dc.identifier.uri(link nobreakline)"
 #
 # If an item has no value for a particular field, it won't be displayed.


### PR DESCRIPTION
EKT's extension to show the display values (input-forms) for controlled vocabularies in ItemTag

https://jira.duraspace.org/browse/DS-1225
