### PR TITLE
[DS-1023] Patch to allow linebreaks in <textarea> boxes

### DIFF
--- a/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/themes/dri2xhtml-alt/core/forms.xsl
+++ b/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/themes/dri2xhtml-alt/core/forms.xsl
@@ -837,6 +837,7 @@
             <xsl:when test="@type= 'textarea'">
                                 <textarea>
                                     <xsl:call-template name="fieldAttributes"/>
+                                    <xsl:attribute name="onkeydown">event.cancelBubble=true;</xsl:attribute>
 
                                     <!--
                                         if the cols and rows attributes are not defined we need to call


### PR DESCRIPTION
This is a very simple patch to fix the linebreaks problem. It is based on adding an "onKeyDown" attribute with value "event.cancelBubble=true;".
More info on https://jira.duraspace.org/browse/DS-1023
Any comment will be very welcome.
