### PR TITLE
[DS-1268] Fixed wrong URL for OpenSearch description.xml document

### DIFF
--- a/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/aspect/viewArtifacts/Navigation.java
+++ b/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/aspect/viewArtifacts/Navigation.java
@@ -121,10 +121,8 @@ public class Navigation extends AbstractDSpaceTransformer implements CacheablePr
         // add metadata for OpenSearch auto-discovery links if enabled
         if (ConfigurationManager.getBooleanProperty("websvc.opensearch.autolink"))
         {
-            pageMeta.addMetadata("opensearch", "shortName").addContent(
-                                ConfigurationManager.getProperty("websvc.opensearch.shortname"));
-            pageMeta.addMetadata("opensearch", "context").addContent(
-                        ConfigurationManager.getProperty("websvc.opensearch.svccontext"));
+            pageMeta.addMetadata("opensearch", "shortName").addContent( ConfigurationManager.getProperty("websvc.opensearch.shortname") );
+            pageMeta.addMetadata("opensearch", "autolink").addContent( "open-search/description.xml" );
         }
 
         pageMeta.addMetadata("page","contactURL").addContent(contextPath + "/contact");

--- a/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
+++ b/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
@@ -207,8 +207,7 @@
                         <xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverPort']"/>
                         <xsl:value-of select="$context-path"/>
                         <xsl:text>/</xsl:text>
-                        <xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='opensearch'][@qualifier='context']"/>
-                        <xsl:text>description.xml</xsl:text>
+                        <xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='opensearch'][@qualifier='autolink']"/>
                     </xsl:attribute>
                     <xsl:attribute name="title" >
                         <xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='opensearch'][@qualifier='shortName']"/>

--- a/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/themes/dri2xhtml-alt/core/page-structure.xsl
+++ b/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/themes/dri2xhtml-alt/core/page-structure.xsl
@@ -153,8 +153,7 @@
                         <xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverPort']"/>
                         <xsl:value-of select="$context-path"/>
                         <xsl:text>/</xsl:text>
-                        <xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='opensearch'][@qualifier='context']"/>
-                        <xsl:text>description.xml</xsl:text>
+                        <xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='opensearch'][@qualifier='autolink']"/>
                     </xsl:attribute>
                     <xsl:attribute name="title" >
                         <xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='opensearch'][@qualifier='shortName']"/>

--- a/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/themes/dri2xhtml/structural.xsl
+++ b/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/themes/dri2xhtml/structural.xsl
@@ -188,8 +188,7 @@
                         <xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverPort']"/>
                         <xsl:value-of select="$context-path"/>
                         <xsl:text>/</xsl:text>
-                        <xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='opensearch'][@qualifier='context']"/>
-                        <xsl:text>description.xml</xsl:text>
+                        <xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='opensearch'][@qualifier='autolink']"/>
                     </xsl:attribute>
                     <xsl:attribute name="title" >
                         <xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='opensearch'][@qualifier='shortName']"/>


### PR DESCRIPTION
Modified class org.dspace.app.xmlui.aspect.viewArtifacts.Navigation to create a DRI PageMeta metadata element as follows:
<metadata element="opensearch" qualifier="autolink">open-search/description.xml</metadata>

Also [Mirage]/lib/xsl/core/page-structure.xsl file was modified in order to render that element.

Before this patch, the DRI PageMeta element was: <metadata element="opensearch" qualifier="context">, which content was obtained from the property "websvc.opensearch.svccontext", and the page-structure.xsl used to add the "description.xml" string to that value.

More info on: https://jira.duraspace.org/browse/DS-1268

Any comment will be very welcome.
