### PR TITLE
[DS-1210] NullPointerException on /search-filter without field param

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ConfigurableBrowse.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ConfigurableBrowse.java
@@ -12,21 +12,20 @@ import java.io.Serializable;
 import java.sql.SQLException;
 import java.util.*;
 
+import org.apache.avalon.framework.parameters.Parameters;
+import org.apache.cocoon.ProcessingException;
 import org.apache.cocoon.ResourceNotFoundException;
 import org.apache.cocoon.caching.CacheableProcessingComponent;
 import org.apache.cocoon.environment.ObjectModelHelper;
 import org.apache.cocoon.environment.Request;
+import org.apache.cocoon.environment.SourceResolver;
 import org.apache.cocoon.environment.http.HttpEnvironment;
 import org.apache.cocoon.util.HashUtil;
 import org.apache.commons.lang.StringUtils;
 import org.apache.excalibur.source.SourceValidity;
 import org.apache.log4j.Logger;
 import org.dspace.app.xmlui.cocoon.AbstractDSpaceTransformer;
-import org.dspace.app.xmlui.utils.ContextUtil;
-import org.dspace.app.xmlui.utils.DSpaceValidity;
-import org.dspace.app.xmlui.utils.HandleUtil;
-import org.dspace.app.xmlui.utils.RequestUtils;
-import org.dspace.app.xmlui.utils.UIException;
+import org.dspace.app.xmlui.utils.*;
 import org.dspace.app.xmlui.wing.Message;
 import org.dspace.app.xmlui.wing.WingException;
 import org.dspace.app.xmlui.wing.element.Body;
@@ -133,6 +132,22 @@ public class ConfigurableBrowse extends AbstractDSpaceTransformer implements
 
     private Message titleMessage = null;
     private Message trailMessage = null;
+
+    @Override
+    public void setup(SourceResolver resolver, Map objectModel, String src, Parameters parameters) throws ProcessingException, SAXException, IOException {
+        super.setup(resolver, objectModel, src, parameters);
+
+        //Verify if we have received valid parameters
+        try {
+            getUserParams();
+        } catch (ResourceNotFoundException e) {
+            throw new BadRequestException("Invalid parameters");
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        } catch (UIException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     public Serializable getKey()
     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SearchFacetFilter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SearchFacetFilter.java
@@ -7,18 +7,19 @@
  */
 package org.dspace.app.xmlui.aspect.discovery;
 
+import org.apache.avalon.framework.parameters.Parameters;
+import org.apache.cocoon.ProcessingException;
 import org.apache.cocoon.caching.CacheableProcessingComponent;
 import org.apache.cocoon.environment.ObjectModelHelper;
 import org.apache.cocoon.environment.Request;
+import org.apache.cocoon.environment.SourceResolver;
 import org.apache.cocoon.util.HashUtil;
+import org.apache.commons.lang.StringUtils;
 import org.apache.excalibur.source.SourceValidity;
 import org.apache.log4j.Logger;
 import org.dspace.app.util.Util;
 import org.dspace.app.xmlui.cocoon.AbstractDSpaceTransformer;
-import org.dspace.app.xmlui.utils.DSpaceValidity;
-import org.dspace.app.xmlui.utils.HandleUtil;
-import org.dspace.app.xmlui.utils.RequestUtils;
-import org.dspace.app.xmlui.utils.UIException;
+import org.dspace.app.xmlui.utils.*;
 import org.dspace.app.xmlui.wing.Message;
 import org.dspace.app.xmlui.wing.WingException;
 import org.dspace.app.xmlui.wing.element.*;
@@ -82,6 +83,19 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
         DSpace dspace = new DSpace();
         searchService = dspace.getServiceManager().getServiceByName(SearchService.class.getName(),SearchService.class);
 
+    }
+
+    @Override
+    public void setup(SourceResolver resolver, Map objectModel, String src, Parameters parameters) throws ProcessingException, SAXException, IOException {
+        super.setup(resolver, objectModel, src, parameters);
+
+        Request request = ObjectModelHelper.getRequest(objectModel);
+        String facetField = request.getParameter(SearchFilterParam.FACET_FIELD);
+
+        if(StringUtils.isBlank(facetField))
+        {
+            throw new BadRequestException("Invalid " + SearchFilterParam.FACET_FIELD + " parameter");
+        }
     }
 
     /**

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/BadRequestException.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/BadRequestException.java
@@ -1,0 +1,32 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.xmlui.utils;
+
+import java.io.IOException;
+
+/**
+ * Exception thrown in case of bad request syntax
+ *
+ * Example: invalid/missing parameters, ...
+ *
+ * @author Kevin Van de Velde (kevin at atmire dot com)
+ */
+public class BadRequestException extends IOException {
+
+    public BadRequestException(String message) {
+        super(message);
+    }
+
+    public BadRequestException(Throwable t) {
+        super(t);
+    }
+
+    public BadRequestException(String message, Throwable t) {
+        super(message, t);
+    }
+}

--- a/dspace-xmlui/src/main/webapp/sitemap.xmap
+++ b/dspace-xmlui/src/main/webapp/sitemap.xmap
@@ -176,6 +176,7 @@
                         <map:selector logger="sitemap.selector.exception" name="exception" src="org.apache.cocoon.selection.ExceptionSelector">
                                 <exception name="not-found" class="org.apache.cocoon.ResourceNotFoundException"/>
                                 <exception name="invalid-continuation" class="org.apache.cocoon.components.flow.InvalidContinuationException"/>
+                                <exception name="bad-request" class="org.dspace.app.xmlui.utils.BadRequestException"/>
                                 <!-- The statement below tells the selector to unroll as much exceptions as possible -->
                                 <exception class="java.lang.Throwable" unroll="true"/>
                         </map:selector>
@@ -654,6 +655,20 @@
 
                 <map:handle-errors>
                         <map:select type="exception">
+
+                                <map:when test="bad-request">
+                                        <map:generate type="exception"/>
+                                        <map:transform src="exception2html.xslt">
+                                                <map:parameter name="contextPath" value="{request:contextPath}"/>
+                                                <map:parameter name="pageTitle" value="Bad request"/>
+                                        </map:transform>
+                                        <map:act type="locale">
+                                            <map:transform type="i18n">
+                                                    <map:parameter name="locale" value="{locale}"/>
+                                            </map:transform>
+                                        </map:act>
+                                        <map:serialize type="xhtml" status-code="400"/>
+                                </map:when>
 
                                 <map:when test="not-found">
                                         <map:generate type="exception"/>


### PR DESCRIPTION
When the field parameter is absent a new **BadRequestException** will be thrown. This exception will result in a 400 (Bad request) status.

Since the same issue occurred in the old configurable browse, I also fixed it there.
