### PR TITLE
[DS-1281] XMLWorkflow throws NullPointerException on "Assign Roles" when not enabled

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/collection/AssignCollectionRoles.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/collection/AssignCollectionRoles.java
@@ -114,15 +114,6 @@ public class AssignCollectionRoles extends AbstractDSpaceTransformer
 		Group admins = thisCollection.getAdministrators();
 		Group submitters = thisCollection.getSubmitters();
 
-        HashMap<String, Role> roles = null;
-
-        try {
-            roles = WorkflowUtils.getAllExternalRoles(thisCollection);
-        } catch (WorkflowConfigurationException e) {
-            log.error(LogManager.getHeader(context, "error while getting collection roles", "Collection id: " + thisCollection.getID()));
-        } catch (IOException e) {
-            log.error(LogManager.getHeader(context, "error while getting collection roles", "Collection id: " + thisCollection.getID()));
-        }
 		Group defaultRead = null;
 		int defaultReadID = FlowContainerUtils.getCollectionDefaultRead(context, collectionID);
 		if (defaultReadID >= 0)
@@ -256,7 +247,14 @@ public class AssignCollectionRoles extends AbstractDSpaceTransformer
 
 
          if(ConfigurationManager.getProperty("workflow","workflow.framework").equals("xmlworkflow")){
-             addXMLWorkflowRoles(thisCollection, baseURL, roles, rolesTable);
+             try{
+                 HashMap<String, Role> roles = WorkflowUtils.getAllExternalRoles(thisCollection);
+                 addXMLWorkflowRoles(thisCollection, baseURL, roles, rolesTable);
+             } catch (WorkflowConfigurationException e) {
+                log.error(LogManager.getHeader(context, "error while getting collection roles", "Collection id: " + thisCollection.getID()));
+             } catch (IOException e) {
+                 log.error(LogManager.getHeader(context, "error while getting collection roles", "Collection id: " + thisCollection.getID()));
+             }
          }else{
              addOriginalWorkflowRoles(thisCollection, baseURL, rolesTable);
          }


### PR DESCRIPTION
This pull request will not fix the nullpointer (which is caused by old spring version & java 7). It will fix the issue that the XmlWorkflow code is called regardless if it has been enabled.
