### PR TITLE
DS-1294 Autocomplete in discovery filter doesn't work

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1127,7 +1127,7 @@ plugin.single.org.dspace.app.webui.search.SearchRequestProcessor = \
 # define here any json handler
 #
 # comment this line if you disable discovery
-plugin.named.org.dspace.app.webui.json,JSONRequest = \
+plugin.named.org.dspace.app.webui.json.JSONRequest = \
 	org.dspace.app.webui.discovery.DiscoveryJSONRequest = discovery
 
 


### PR DESCRIPTION
The JSON discovery plugin was misconfigured in the dspace.cfg
