### PR TITLE
Cleanup & fixing of several release process POM issues.

### DIFF
--- a/dspace/modules/pom.xml
+++ b/dspace/modules/pom.xml
@@ -12,28 +12,25 @@
 		<version>3.0-rc2-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
-    
+
+    <!-- The 'additions' module must *always* be built, as it is included
+         as a dependency in most other modules in [src]/dspace/modules -->
+    <modules>
+        <module>additions</module>
+    </modules>
+
     <!-- 
-         List of enabled DSpace Modules to build/install.
+         List of enabled DSpace "addon" / local customization Modules to build/install.
          To disable building of modules, you can use the Maven '-P' commandline 
          option along with the profile's id.  For example, the following tells
          Maven to *disable* building of 'dspace-oai' and 'dspace-lni' modules:
          'mvn package -P !dspace-oai,!dspace-lni'
          
          Also note that the profile IDs below match the profile IDs of the source
-         modules in /dspace/pom.xml, so the above command will also disable the
+         modules in [dspace-src]/pom.xml, so the above command will also disable the
          compiling of the corresponding source module.
     -->
     <profiles>
-       <profile>
-          <id>dspace-additions</id>
-          <activation>
-             <activeByDefault>true</activeByDefault>
-          </activation>
-          <modules>
-             <module>additions</module>
-          </modules>
-       </profile>
         <profile>
             <id>dspace-xmlui</id>
             <activation>
@@ -89,7 +86,7 @@
             </modules>
         </profile>
         <profile>
-            <id>dspace-xoai</id>
+            <id>dspace-oai</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>

--- a/pom.xml
+++ b/pom.xml
@@ -108,8 +108,8 @@
             <artifactId>maven-release-plugin</artifactId>
             <version>2.3.2</version>
             <configuration>
-                <!-- During release:perform, enable the "addons" profile -->
-                <releaseProfiles>addons</releaseProfiles>
+                <!-- During release:perform, enable the "release" profile (see below) -->
+                <releaseProfiles>release</releaseProfiles>
                 <goals>deploy</goals>
                 <!-- Suggest tagging the release in SCM as "dspace-[version]" -->
                 <tagNameFormat>dspace-@{project.version}</tagNameFormat>
@@ -321,14 +321,16 @@
 
 
       <!--
-         Use 'mvn deploy -Paddons' while doing Continuous Integration
-         and deploying addons to the Maven repository.
+         The 'release' profile is used by the 'maven-release-plugin' (see above)
+         to actually perform a DSpace software release to Maven central.
        -->
       <profile>
-         <id>addons</id>
+         <id>release</id>
          <activation>
             <activeByDefault>false</activeByDefault>
          </activation>
+         <!-- Activate all modules *except* for the 'dspace' module,
+              as it does not include any Java source code to release. -->
          <modules>
             <module>dspace-api</module>
             <module>dspace-jspui</module>
@@ -341,8 +343,8 @@
       </profile>
 
       <!--
-         Use 'mvn package -Pdistributions' to create distributions
-         to upload to S.F.
+         Run this profile (e.g. 'mvn package -Pdistributions') to create
+         zip / tarball distributions to upload to SourceForge or similar.
        -->
       <profile>
          <id>distributions</id>


### PR DESCRIPTION
This pull request fixes some current issues when running "mvn release:prepare".  Currently, if you run that, you'll get dependency errors since the release process does NOT build the "additions" module by default.  This commit fixes that issue and does a few other minor cleanup tasks in POMs, including:

Renamed the "addons" profile to "release" as it is really for maven releases.  Ensured the "additions" module (under [src]/dspace/modules/) is ALWAYS enabled, as several other modules under [src]/dspace/modules/ have it as a dependency.  Cleaned up some comments in POMs.
