### PR TITLE
[DS-1328] Subject keyword box breaks layout for long taxonomy values.

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1367,6 +1367,7 @@ authority.minconfidence = ambiguous
 
 ## demo: subject code autocomplete, using srsc as authority
 ## (DSpaceControlledVocabulary plugin must be enabled)
+## Warning: when enabling this feature any controlled vocabulary configuration in the input-forms.xml for the metadata field will be overridden.
 #choices.plugin.dc.subject = srsc
 #choices.presentation.dc.subject = select
 #vocabulary.plugin.srsc.hierarchy.store = true


### PR DESCRIPTION
Added some documentation clarifying that the configuration from the input-forms.xml will be overridden by the authority control settings.
