### PR TITLE
[DS-1246] Discovery indexer indexes collection license field.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SearchUtils.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SearchUtils.java
@@ -67,6 +67,11 @@ public class SearchUtils {
         return manager.getServiceByName(DiscoveryConfigurationService.class.getName(), DiscoveryConfigurationService.class);
     }
 
+    public static List<String> getIgnoredMetadataFields(int type)
+    {
+        return getConfigurationService().getToIgnoreMetadataFields().get(type);
+    }
+
     /**
      * Method that retrieves a list of all the configuration objects from the given item
      * A configuration object can be returned for each parent community/collection

--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfigurationService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfigurationService.java
@@ -18,6 +18,7 @@ import java.util.Map;
 public class DiscoveryConfigurationService {
 
     private Map<String, DiscoveryConfiguration> map;
+    private Map<Integer, List<String>> toIgnoreMetadataFields;
 
     public Map<String, DiscoveryConfiguration> getMap() {
         return map;
@@ -25,6 +26,14 @@ public class DiscoveryConfigurationService {
 
     public void setMap(Map<String, DiscoveryConfiguration> map) {
         this.map = map;
+    }
+
+    public Map<Integer, List<String>> getToIgnoreMetadataFields() {
+        return toIgnoreMetadataFields;
+    }
+
+    public void setToIgnoreMetadataFields(Map<Integer, List<String>> toIgnoreMetadataFields) {
+        this.toIgnoreMetadataFields = toIgnoreMetadataFields;
     }
 
     public static void main(String[] args) {

--- a/dspace/config/modules/discovery.cfg
+++ b/dspace/config/modules/discovery.cfg
@@ -10,9 +10,6 @@ search.server = http://localhost:8080/solr/search
 #Char used to ensure that the sidebar facets are case insensitive
 #solr.facets.split.char=\n|||\n
 
-#All metadata fields that will not end up in the index, this is a comma separated list
-index.ignore=dc.description.provenance
-
 # index.ignore-variants = false
 # index.ignore-authority = false
 index.projection=dc.title,dc.contributor.*,dc.date.issued

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -9,12 +9,15 @@
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:context="http://www.springframework.org/schema/context"
-    xsi:schemaLocation="http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-2.5.xsd"
+           http://www.springframework.org/schema/context/spring-context-3.0.xsd
+           http://www.springframework.org/schema/util
+           http://www.springframework.org/schema/util/spring-util-3.0.xsd"
     default-autowire-candidates="*Service,*DAO,javax.sql.DataSource">
 
     <context:annotation-config /> <!-- allows us to use spring annotations in beans -->
@@ -42,6 +45,46 @@
                <!--Use site to override the default configuration for the home page & default discovery page-->
                <!--<entry key="site" value-ref="defaultConfiguration" />-->
                <!--<entry key="123456789/7621" value-ref="defaultConfiguration"/>-->
+            </map>
+        </property>
+        <property name="toIgnoreMetadataFields">
+            <map>
+                <entry>
+                    <key><util:constant static-field="org.dspace.core.Constants.COMMUNITY"/></key>
+                    <list>
+                        <!--Introduction text-->
+                        <!--<value>dc.description</value>-->
+                        <!--Short description-->
+                        <!--<value>dc.description.abstract</value>-->
+                        <!--News-->
+                        <!--<value>dc.description.tableofcontents</value>-->
+                        <!--Copyright text-->
+                        <value>dc.rights</value>
+                        <!--Community name-->
+                        <!--<value>dc.title</value>-->
+                    </list>
+                </entry>
+                <entry>
+                    <key><util:constant static-field="org.dspace.core.Constants.COLLECTION"/></key>
+                    <list>
+                        <!--Introduction text-->
+                        <!--<value>dc.description</value>-->
+                        <!--Short description-->
+                        <!--<value>dc.description.abstract</value>-->
+                        <!--News-->
+                        <!--<value>dc.description.tableofcontents</value>-->
+                        <!--Copyright text-->
+                        <value>dc.rights</value>
+                        <!--Collection name-->
+                        <!--<value>dc.title</value>-->
+                    </list>
+                </entry>
+                <entry>
+                    <key><util:constant static-field="org.dspace.core.Constants.ITEM"/></key>
+                    <list>
+                        <value>dc.description.provenance</value>
+                    </list>
+                </entry>
             </map>
         </property>
     </bean>


### PR DESCRIPTION
Added configuration for community/collection/item metadata, by default the license field will not be indexed for communities and collections.
