### PR TITLE
DS-1208 "Fix" to add in a "-Denv" flag to allow users to specify a different *.properties file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ nbdist/
 nbactions.xml
 nb-configuration.xml
 META-INF/
+
+## Ignore all *.properties file, EXCEPT build.properties (the default)
+*.properties
+!build.properties

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,6 @@
     <!--Force UTF-8 encoding during build on all platforms-->
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <filters.file>build.properties</filters.file>
         <lucene.version>3.5.0</lucene.version>
     </properties>
 
@@ -172,6 +171,38 @@
    </build>
    
    <profiles>
+
+       <!-- By default the main dspace.cfg file will be filtered during the build
+            using the "build.properties" file. This profile takes effect, unless
+            "-Denv" is passed in (see 'environment' profile below for more info). -->
+       <profile>
+           <id>default</id>
+           <activation>
+               <property>
+                    <name>!env</name>
+                </property>
+           </activation>
+           <properties>
+               <filters.file>build.properties</filters.file>
+           </properties>
+       </profile>
+
+       <!-- Users can pass in an environment flag "-Denv" to tell DSpace to use
+            a different properties file during its build process. 
+            For example: "mvn package -Denv=test" would build DSpace using the
+            settings in "test.properties" instead of those in "build.properties" -->
+       <profile>
+           <id>environment</id>
+           <activation>
+                <property>
+                    <name>env</name>
+                </property>
+           </activation>
+           <properties>
+                <filters.file>${env}.properties</filters.file>
+           </properties>
+       </profile>
+
 
         <!-- This profile ensures that we ONLY generate the Unit Test Environment
              if the testEnvironment.xml file is found. That way the Test Environment
@@ -383,10 +414,14 @@
       <profile>
         <id>skiptests</id>
         <activation>
-            <activeByDefault>true</activeByDefault>
-         </activation>
+            <!-- This profile should be active at all times, unless the user
+                 specifies a different value for "maven.test.skip" -->
+            <property>
+                <name>!maven.test.skip</name>
+            </property>
+        </activation>
         <properties>
-         <maven.test.skip>true</maven.test.skip>
+            <maven.test.skip>true</maven.test.skip>
         </properties>
       </profile>
    </profiles>


### PR DESCRIPTION
DS-1208 (Addition of "build.properties") initially claimed that it was a providing an option for developers to have their own local environment settings which were _NOT_ in source control (or at least not by default).

https://jira.duraspace.org/browse/DS-1208

Although "build.properties" allows for local developer settings, the file itself is stored in source control. So, if you change it locally, Git will keep bugging you to commit your local changes.

This pull request makes a small tweak to our 'dspace-parent' POM & .gitignore which allows developers to create their own custom "*.properties" file which is not under source control (they can also still choose to use "build.properties" if they want).

Essentially an "env" (environment) flag is added that takes any value, and loads up the *.properties file of that name.  Here's some examples:
- mvn package       (still builds using "build.properties", the default)
- mvn package -Denv=test      (builds using a "test.properties" file instead of "build.properties")
- mvn package -Denv=tim       (builds using a "tim.properties" file)
- mvn package -Denv=awesome  (builds using an "awesome.properties" file)

You get the idea :)

Finally, it should be noted that the .gitignore settings are tweaked such that all *.properties files are ignored EXCEPT for "build.properties" (which is our default build settings).

I'll readily admit this change is in a bit of a gray area between "bug fix" and "small improvement".  I'll leave it up to someone else whether we add this small tweak to 3.0 or wait until a future release.  (However, I have tested this, and it seems to work perfectly fine.)
