### PR TITLE
DS-1372: Change OAI2.0 DSpaceMetadataExistsFilter to check for one or more fields 

### DIFF
--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -111,5 +111,11 @@
             <name>Ivan Másar</name>
             <email>helix84@centrum.sk</email>
         </developer>
+        <developer>
+            <name>Ariel J. Lira</name>
+            <email>arieljlira@gmail.com</email>
+            <organization>SeDiCI</organization>
+            <organizationUrl>http://sedici.unlp.edu.ar</organizationUrl>
+        </developer>
     </developers>
 </project>

--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceMetadataExistsFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceMetadataExistsFilter.java
@@ -8,16 +8,21 @@
 package org.dspace.xoai.filter;
 
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.dspace.core.Context;
 import org.dspace.xoai.data.DSpaceItem;
 import org.dspace.xoai.exceptions.InvalidMetadataFieldException;
+import org.dspace.xoai.filter.DSpaceFilter;
+import org.dspace.xoai.filter.DatabaseFilterResult;
+import org.dspace.xoai.filter.SolrFilterResult;
 import org.dspace.xoai.util.MetadataFieldManager;
 
 /**
- * 
+ * 	
  * @author Lyncode Development Team <dspace@lyncode.com>
  */
 public class DSpaceMetadataExistsFilter extends DSpaceFilter
@@ -25,15 +30,20 @@ public class DSpaceMetadataExistsFilter extends DSpaceFilter
     private static Logger log = LogManager
             .getLogger(DSpaceMetadataExistsFilter.class);
 
-    private String _field;
+    private List<String> _fields;
 
-    private String getField()
+    private List<String> getFields()
     {
-        if (this._field == null)
+        if (this._fields == null)
         {
-            _field = super.getParameter("field");
+            this._fields = super.getParameters("fields");
+
+            //backwards compatibility check for field parameter
+            if (this._fields == null)
+                this._fields = super.getParameters("field");
+
         }
-        return _field;
+        return _fields;
     }
 
     @Override
@@ -41,9 +51,20 @@ public class DSpaceMetadataExistsFilter extends DSpaceFilter
     {
         try
         {
-            return new DatabaseFilterResult(
-                    "EXISTS (SELECT tmp.* FROM metadatavalue tmp WHERE tmp.item_id=i.item_id AND tmp.metadata_field_id=?)",
-                    MetadataFieldManager.getFieldID(context, this.getField()));
+        	List<String> fields = this.getFields();
+        	StringBuilder where = new StringBuilder();
+        	List<Object> args = new ArrayList<Object>(fields.size());
+        	where.append("(");
+        	for (int i = 0; i < fields.size(); i++) {
+        		where.append("EXISTS (SELECT tmp.* FROM metadatavalue tmp WHERE tmp.item_id=i.item_id AND tmp.metadata_field_id=?)");
+        		args.add(MetadataFieldManager.getFieldID(context, fields.get(i)));
+        		
+        		if (i < fields.size() -1 )
+					where.append(" OR ") ;
+        	}
+        	where.append(")");
+        	
+        	return new DatabaseFilterResult(where.toString(), args);
         }
         catch (InvalidMetadataFieldException e)
         {
@@ -59,16 +80,27 @@ public class DSpaceMetadataExistsFilter extends DSpaceFilter
     @Override
     public boolean isShown(DSpaceItem item)
     {
-        if (item.getMetadata(this.getField()).size() > 0)
-            return true;
-
+    	for (String field : this.getFields()) {
+		    //do we have a match? if yes, our job is done
+    		if (item.getMetadata(field).size() > 0)
+		    	return true;
+		}
         return false;
     }
 
     @Override
     public SolrFilterResult getQuery()
     {
-        return new SolrFilterResult("metadata." + this.getField() + ":[* TO *]");
+    	StringBuilder cond = new StringBuilder("(");
+    	List<String> fields = this.getFields();
+    	for (int i = 0; i < fields.size(); i++) {
+    		cond.append("metadata.").append(fields.get(i)).append(":[* TO *]");
+			if (i < fields.size() -1 )
+				cond.append(" OR ") ;
+		}
+    	cond.append(")");
+    	
+    	return new SolrFilterResult(cond.toString());
     }
 
 }

--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceMetadataExistsFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceMetadataExistsFilter.java
@@ -22,7 +22,13 @@ import org.dspace.xoai.filter.SolrFilterResult;
 import org.dspace.xoai.util.MetadataFieldManager;
 
 /**
- * 	
+ * This filter allows one to retrieve (from the data source) those items 
+ * which contains at least one metadata field value defined, it allows
+ * one to define multiple metadata fields to check against.
+ *
+ * One line summary: At least one metadata field defined
+ *
+ * @author Ariel J. Lira <arieljlira@gmail.com>
  * @author Lyncode Development Team <dspace@lyncode.com>
  */
 public class DSpaceMetadataExistsFilter extends DSpaceFilter


### PR DESCRIPTION
Change to org.dspace.xoai.filter.DSpaceMetadataExistsFilter to accept multiple fields instead of just one.
It could be used as follows:

&lt;Filter id="authorexistsFilter"> 
   &lt;Class>org.dspace.xoai.filter.DSpaceMetadataExistsFilter&lt;/Class> 
   &lt;Parameter key="fields">  
      &lt;Value>dc.contributor.author&lt;/Value> 
      &lt;Value>dc.creator&lt;/Value> 
   &lt;/Parameter> 
&lt;/Filter> 
