### PR TITLE
[DS-1380] XOAI: DSpaceAtLeastOneMetadataFilter with operator STARTS_WITH always fails

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceAtLeastOneMetadataFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceAtLeastOneMetadataFilter.java
@@ -116,6 +116,10 @@ public class DSpaceAtLeastOneMetadataFilter extends DSpaceFilter
                     if (praticalValue.contains(theoreticValue))
                         return true;
                     break;
+                case STARTS_WITH:
+                    if (praticalValue.startsWith(theoreticValue))
+                        return true;
+                    break;
                 case ENDS_WITH:
                     if (praticalValue.endsWith(theoreticValue))
                         return true;


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-1380
