### PR TITLE
DS-1392 fix: Add a new "root.basedir" property to every POM.  

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -16,6 +16,11 @@
         <relativePath>..</relativePath>
     </parent>
 
+    <properties>
+        <!-- This is the path to the root [dspace-src] directory. -->
+        <root.basedir>${basedir}/..</root.basedir>
+    </properties>
+
     <!--
        Runtime and Compile Time dependencies for DSpace.
     -->

--- a/dspace-jspui/pom.xml
+++ b/dspace-jspui/pom.xml
@@ -17,9 +17,15 @@
       <relativePath>..</relativePath>
    </parent>
 
+    <properties>
+        <!-- This is the path to the root [dspace-src] directory. -->
+        <root.basedir>${basedir}/..</root.basedir>
+    </properties>
+
     <build>
         <filters>
-            <filter>${basedir}/../${filters.file}</filter>
+            <!-- Filter using the properties file defined by dspace-parent POM -->
+            <filter>${filters.file}</filter>
         </filters>
         <plugins>
             <plugin>

--- a/dspace-lni/pom.xml
+++ b/dspace-lni/pom.xml
@@ -15,9 +15,15 @@
       <relativePath>..</relativePath>
    </parent>
 
+    <properties>
+        <!-- This is the path to the root [dspace-src] directory. -->
+        <root.basedir>${basedir}/..</root.basedir>
+    </properties>
+
     <build>
         <filters>
-            <filter>${basedir}/../${filters.file}</filter>
+            <!-- Filter using the properties file defined by dspace-parent POM -->
+            <filter>${filters.file}</filter>
         </filters>
         <plugins>
             <plugin>

--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -12,9 +12,15 @@
         <relativePath>..</relativePath>
     </parent>
 
+    <properties>
+        <!-- This is the path to the root [dspace-src] directory. -->
+        <root.basedir>${basedir}/..</root.basedir>
+    </properties>
+
     <build>
         <filters>
-            <filter>${basedir}/../${filters.file}</filter>
+            <!-- Filter using the properties file defined by dspace-parent POM -->
+            <filter>${filters.file}</filter>
         </filters>
         <plugins>
             <plugin>

--- a/dspace-services/pom.xml
+++ b/dspace-services/pom.xml
@@ -12,6 +12,11 @@
         <version>3.0-rc4-SNAPSHOT</version>
     </parent>
 
+    <properties>
+        <!-- This is the path to the root [dspace-src] directory. -->
+        <root.basedir>${basedir}/..</root.basedir>
+    </properties>
+
     <dependencies>
         <!-- logging -->
         <dependency>

--- a/dspace-sword/pom.xml
+++ b/dspace-sword/pom.xml
@@ -19,9 +19,15 @@
       <relativePath>..</relativePath>
    </parent>
 
+    <properties>
+        <!-- This is the path to the root [dspace-src] directory. -->
+        <root.basedir>${basedir}/..</root.basedir>
+    </properties>
+
     <build>
         <filters>
-            <filter>${basedir}/../${filters.file}</filter>
+            <!-- Filter using the properties file defined by dspace-parent POM -->
+            <filter>${filters.file}</filter>
         </filters>
         <plugins>
             <plugin>

--- a/dspace-swordv2/pom.xml
+++ b/dspace-swordv2/pom.xml
@@ -17,9 +17,15 @@
         <relativePath>..</relativePath>
     </parent>
 
+    <properties>
+        <!-- This is the path to the root [dspace-src] directory. -->
+        <root.basedir>${basedir}/..</root.basedir>
+    </properties>
+
     <build>
         <filters>
-            <filter>${basedir}/../${filters.file}</filter>
+            <!-- Filter using the properties file defined by dspace-parent POM -->
+            <filter>${filters.file}</filter>
         </filters>
         <plugins>
             <plugin>

--- a/dspace-xmlui/pom.xml
+++ b/dspace-xmlui/pom.xml
@@ -15,9 +15,15 @@
       <relativePath>..</relativePath>
    </parent>
 
+    <properties>
+        <!-- This is the path to the root [dspace-src] directory. -->
+        <root.basedir>${basedir}/..</root.basedir>
+    </properties>
+
     <build>
         <filters>
-            <filter>${basedir}/../${filters.file}</filter>
+            <!-- Filter using the properties file defined by dspace-parent POM -->
+            <filter>${filters.file}</filter>
         </filters>
         <plugins>
             <plugin>

--- a/dspace/modules/additions/pom.xml
+++ b/dspace/modules/additions/pom.xml
@@ -21,6 +21,11 @@
       <relativePath>..</relativePath>
    </parent>
 
+   <properties>
+       <!-- This is the path to the root [dspace-src] directory. -->
+       <root.basedir>${basedir}/../../..</root.basedir>
+   </properties>
+
    <profiles>
       <profile>
          <id>oracle-support</id>

--- a/dspace/modules/jspui/pom.xml
+++ b/dspace/modules/jspui/pom.xml
@@ -16,6 +16,11 @@
         <relativePath>..</relativePath>
     </parent>
 
+    <properties>
+        <!-- This is the path to the root [dspace-src] directory. -->
+        <root.basedir>${basedir}/../../..</root.basedir>
+    </properties>
+
     <profiles>
         <profile>
             <id>oracle-support</id>
@@ -36,7 +41,8 @@
     
     <build>
         <filters>
-            <filter>${basedir}/../../../${filters.file}</filter>
+            <!-- Filter using the properties file defined by dspace-parent POM -->
+            <filter>${filters.file}</filter>
         </filters>
         <plugins>
             <plugin>

--- a/dspace/modules/lni/pom.xml
+++ b/dspace/modules/lni/pom.xml
@@ -17,9 +17,15 @@
       <relativePath>..</relativePath>
    </parent>
 
+   <properties>
+       <!-- This is the path to the root [dspace-src] directory. -->
+       <root.basedir>${basedir}/../../..</root.basedir>
+   </properties>
+
    <build>
        <filters>
-           <filter>${basedir}/../../../${filters.file}</filter>
+           <!-- Filter using the properties file defined by dspace-parent POM -->
+           <filter>${filters.file}</filter>
        </filters>
       <plugins>
 

--- a/dspace/modules/oai/pom.xml
+++ b/dspace/modules/oai/pom.xml
@@ -16,9 +16,15 @@
         <relativePath>..</relativePath>
     </parent>
 
+    <properties>
+       <!-- This is the path to the root [dspace-src] directory. -->
+       <root.basedir>${basedir}/../../..</root.basedir>
+    </properties>
+
     <build>
         <filters>
-            <filter>${basedir}/../../../${filters.file}</filter>
+            <!-- Filter using the properties file defined by dspace-parent POM -->
+            <filter>${filters.file}</filter>
         </filters>
         <plugins>
             <plugin>

--- a/dspace/modules/pom.xml
+++ b/dspace/modules/pom.xml
@@ -13,6 +13,11 @@
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
+    <properties>
+        <!-- This is the path to the root [dspace-src] directory. -->
+        <root.basedir>${basedir}/../..</root.basedir>
+    </properties>
+
     <!-- The 'additions' module must *always* be built, as it is included
          as a dependency in most other modules in [src]/dspace/modules -->
     <modules>

--- a/dspace/modules/solr/pom.xml
+++ b/dspace/modules/solr/pom.xml
@@ -17,6 +17,11 @@
       <relativePath>..</relativePath>
    </parent>
 
+   <properties>
+       <!-- This is the path to the root [dspace-src] directory. -->
+       <root.basedir>${basedir}/../../..</root.basedir>
+   </properties>
+
    <build>
       <plugins>
          <plugin>

--- a/dspace/modules/sword/pom.xml
+++ b/dspace/modules/sword/pom.xml
@@ -20,9 +20,15 @@
       <relativePath>..</relativePath>
    </parent>
 
+   <properties>
+       <!-- This is the path to the root [dspace-src] directory. -->
+       <root.basedir>${basedir}/../../..</root.basedir>
+   </properties>
+
    <build>
        <filters>
-           <filter>${basedir}/../../../${filters.file}</filter>
+           <!-- Filter using the properties file defined by dspace-parent POM -->
+           <filter>${filters.file}</filter>
        </filters>
       <plugins>
 

--- a/dspace/modules/swordv2/pom.xml
+++ b/dspace/modules/swordv2/pom.xml
@@ -20,9 +20,15 @@
       <relativePath>..</relativePath>
    </parent>
 
+   <properties>
+       <!-- This is the path to the root [dspace-src] directory. -->
+       <root.basedir>${basedir}/../../..</root.basedir>
+   </properties>
+
    <build>
        <filters>
-           <filter>${basedir}/../../../${filters.file}</filter>
+           <!-- Filter using the properties file defined by dspace-parent POM -->
+           <filter>${filters.file}</filter>
        </filters>
       <plugins>
 

--- a/dspace/modules/xmlui/pom.xml
+++ b/dspace/modules/xmlui/pom.xml
@@ -16,9 +16,15 @@
       <relativePath>..</relativePath>
    </parent>
 
+   <properties>
+       <!-- This is the path to the root [dspace-src] directory. -->
+       <root.basedir>${basedir}/../../..</root.basedir>
+   </properties>
+
    <build>
        <filters>
-           <filter>${basedir}/../../../${filters.file}</filter>
+           <!-- Filter using the properties file defined by dspace-parent POM -->
+           <filter>${filters.file}</filter>
        </filters>
       <plugins>
          <plugin>

--- a/dspace/pom.xml
+++ b/dspace/pom.xml
@@ -19,9 +19,15 @@
         <relativePath>..</relativePath>
     </parent>
 
+    <properties>
+        <!-- This is the path to the root [dspace-src] directory. -->
+        <root.basedir>${basedir}/..</root.basedir>
+    </properties>
+
     <build>
         <filters>
-            <filter>${basedir}/../${filters.file}</filter>
+            <!-- Filter using the properties file defined by dspace-parent POM -->
+            <filter>${filters.file}</filter>
         </filters>
          <resources>
             <!-- Enumerate filtered files explicitly to avoid issues with other config tech. -->

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <lucene.version>3.5.0</lucene.version>
+        <!-- 'root.basedir' is the path to the root [dspace-src] dir. It must be redefined by each child POM,
+             as it is used to reference the LICENSE_HEADER and *.properties file(s) in that directory. -->
+        <root.basedir>${basedir}</root.basedir>
     </properties>
 
     <build>
@@ -121,7 +124,7 @@
                 <artifactId>maven-license-plugin</artifactId>
                 <configuration>
                     <!-- License header file (can be a URL, but that's less stable if external site is down on occasion) -->
-                    <header>LICENSE_HEADER</header>
+                    <header>${root.basedir}/LICENSE_HEADER</header>
                     <!--Just check headers of everything in the /src directory -->
                     <includes>
                         <include>src/**</include>
@@ -183,7 +186,8 @@
                 </property>
            </activation>
            <properties>
-               <filters.file>build.properties</filters.file>
+               <!-- 'root.basedir' is the relative path to the [dspace-src] root folder -->
+               <filters.file>${root.basedir}/build.properties</filters.file>
            </properties>
        </profile>
 
@@ -199,7 +203,8 @@
                 </property>
            </activation>
            <properties>
-                <filters.file>${env}.properties</filters.file>
+                <!-- 'root.basedir' is the relative path to the [dspace-src] root folder -->
+                <filters.file>${root.basedir}/${env}.properties</filters.file>
            </properties>
        </profile>
 


### PR DESCRIPTION
This 'root.basedir' property always specifies the relative path to the root [dspace-src] directory.  It is used to reference the path to the LICENSE_HEADER & build.properties file from each submodule.

It's a sort of "fancy" trick that ensures that each submodule has the correct path to files that they ALL need to reference in the [dspace-src] directory.  From what I've seen online, it seems to be the "standard" way of doing this in Maven.

PLEASE NOTE -- you will notice that this does tweak how the build.properties (${filters.file}) is referenced from each submodule.  I chose to do this in order to keep the LICENSE_HEADER reference & build.properties references in sync.

I've run several rebuild tests from both [dspace-src] and submodules, and this seems to all work perfectly. 
