### PR TITLE
DS-1391 build should check for ant version 1.8.0+

### DIFF
--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -34,6 +34,15 @@ Common usage:
 
 ========================================================================
   </description>
+  
+  	<!-- DS-1391: Ant 1.8.0+ is required, fail if not available. -->
+	<fail message="Ant 1.8.0+ is required, ${ant.version} is not supported">
+        <condition>
+			<not>
+				<antversion atleast="1.8.0"/>
+			</not>
+        </condition>
+    </fail>
 
     <!-- ============================================================= -->
     <!-- Will be using various environment variables                   -->


### PR DESCRIPTION
This adds a check to the Ant version used for the build, and fails the build if its too low.

The install docs already say that Ant 1.8 is required, this enforces it.

The reason for this is outlined in https://jira.duraspace.org/browse/DS-1391

Basically, if using Ant <1.8.0, the 'overwrite' function for the config dir doesn't work due to property expansion only being added in Ant 1.8.
