### PR TITLE
DS-1389- removing all lines that mention the admin URL

### DIFF
--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -968,9 +968,6 @@ Common usage:
 
    ${dspace.url}
 
- You should also be able to access the administrator UI:
-
-   ${dspace.url}/dspace-admin
 ====================================================================
         </echo>
 


### PR DESCRIPTION
as per a suggestion by Andrea Schweer, this pull request removes the line that mentions a non-existent admin URL from the DSpace Ant build.xml script. This should address the concern raised by DS-1389
