### PR TITLE
DS-1174: added e.printStackTrace to exception handler in itemUpdate.java

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemupdate/ItemUpdate.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemupdate/ItemUpdate.java
@@ -454,6 +454,7 @@ public class ItemUpdate {
     		catch(Exception e)
     		{
     			pr("Exception processing item " + dirname + ": " + e.toString());
+                e.printStackTrace();
     		}
         }  
         


### PR DESCRIPTION
This pull request should help with troubleshooting errors that might crop up during an item update batch run... a stack trace should now appear in the dspace logs, if an error occurs.
