### PR TITLE
Fix for DS-972 - get the "More Results" button to work for Authority Control in XMLUI

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/general/ChoiceLookupTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/general/ChoiceLookupTransformer.java
@@ -242,7 +242,6 @@ public class ChoiceLookupTransformer extends AbstractDSpaceTransformer
         Button accept = buttItem.addButton("accept", "choices-lookup");
         accept.setValue(isRepeating ? T_add : T_accept);
         Button more = buttItem.addButton("more", "choices-lookup");
-        more.setDisabled();
         more.setValue(T_more);
         Button cancel = buttItem.addButton("cancel", "choices-lookup");
         cancel.setValue(T_cancel);


### PR DESCRIPTION
Had to avoid disabling button via DRI (for some reason jQuery can never re-enable it, if it is disabled via DRI).  

Also cleaned up code in choice-support.js to ensure that "More Results" button works properly now. It didn't work at all previously.

I've tested this heavily with LC Author Authority & it seems to work well now. So, I think this is ready for 3.0.
