### PR TITLE
DS-1370 fixes SQL scripts/adds missing tables and sequences to cleanup

### DIFF
--- a/dspace/etc/clean-database.sql
+++ b/dspace/etc/clean-database.sql
@@ -80,6 +80,8 @@ DROP TABLE Group2GroupCache;
 DROP TABLE Group2Group;
 DROP TABLE FileExtension;
 -- Drop main object tables near end as many other tables have dependencies on them
+DROP TABLE versionitem;
+DROP TABLE versionhistory;
 DROP TABLE Community;
 DROP TABLE Collection;
 DROP TABLE Item;
@@ -96,6 +98,7 @@ DROP TABLE EPerson;
 DROP SEQUENCE bitstreamformatregistry_seq;
 DROP SEQUENCE fileextension_seq;
 DROP SEQUENCE bitstream_seq;
+DROP SEQUENCE checksum_history_seq;
 DROP SEQUENCE eperson_seq;
 DROP SEQUENCE epersongroup_seq;
 DROP SEQUENCE item_seq;
@@ -125,6 +128,8 @@ DROP SEQUENCE group2group_seq;
 DROP SEQUENCE group2groupcache_seq;
 DROP SEQUENCE harvested_collection_seq;
 DROP SEQUENCE harvested_item_seq;
+DROP SEQUENCE versionhistory_seq;
+DROP SEQUENCE versionitem_seq;
 
 -- Drop the getnextid() function
 DROP FUNCTION getnextid(VARCHAR(40));

--- a/dspace/etc/oracle/ORACLE_README.txt
+++ b/dspace/etc/oracle/ORACLE_README.txt
@@ -59,3 +59,8 @@ JDBC driver is reporting INTEGERS as type DECIMAL.
 Oracle doesn't like it when you reference table names in lower case when
 getting JDBC metadata for the tables, so they are converted in TableRow
 to upper case.
+
+==UPDATE 27 November 2012==
+Oracle complains with ORA-01408 if you attempt to create an index on a column which
+has already had the UNIQUE contraint added (such an index is implicit in maintaining the uniqueness
+of the column). See DS-1370 for details.

--- a/dspace/etc/oracle/database_schema.sql
+++ b/dspace/etc/oracle/database_schema.sql
@@ -143,12 +143,6 @@ CREATE TABLE EPerson
   language            VARCHAR2(64)
 );
 
--- index by email
-CREATE INDEX eperson_email_idx ON EPerson(email);
-
--- index by netid
-CREATE INDEX eperson_netid_idx ON EPerson(netid);
-
 -------------------------------------------------------
 -- EPersonGroup table
 -------------------------------------------------------


### PR DESCRIPTION
Mostly these are changes to address Oracle warnings from the DB setup script (nothing serious, but Oracle error messages can be alarming). This pull request also adds some missing tables and sequences to the clean database SQL script. Which impacts both Oracle and PostgreSQL. In the process of reviewing the output of the DB setup script, other non-serious Oracle error messages were observed. Another Jira issue will be created to deal with these error messages.
