### PR TITLE
DS-1379 revised 18-3 update SQL script with correct Oracle syntax

### DIFF
--- a/dspace/etc/oracle/database_schema_18-3.sql
+++ b/dspace/etc/oracle/database_schema_18-3.sql
@@ -23,8 +23,8 @@
 
 ALTER TABLE resourcepolicy
   ADD (
-        rpname VARCHAR2(30);
-        rptype VARCHAR2(30);
+        rpname VARCHAR2(30),
+        rptype VARCHAR2(30),
         rpdescription VARCHAR2(100)
       );
 
@@ -54,6 +54,6 @@ CREATE SEQUENCE versionhistory_seq;
 -------------------------------------------
 -- New columns and longer hash for salted password hashing DS-861 --
 -------------------------------------------
-ALTER TABLE EPerson ALTER COLUMN password TYPE VARCHAR(128);
+ALTER TABLE EPerson modify( password VARCHAR(128));
 ALTER TABLE EPerson ADD salt VARCHAR(32);
 ALTER TABLE EPerson ADD digest_algorithm VARCHAR(16);


### PR DESCRIPTION
as suggested by Artur Konczak, reviewed and blessed by our Oracle DBA--however it's as yet untested, the logistics of getting a DSpace 1.8 DB for testing is proving time consuming, and I've run out of time today, so I wanted to at least get this patch out, in case anyone else can test readily. I will test tonight or tomorrow morning, as soon as I have a copy of a version 1.8 Oracle DB to play with
