### PR TITLE
Improved thumbnail and branded preview filters as discussed in DS-1259

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/BrandedPreviewJPEGFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/BrandedPreviewJPEGFilter.java
@@ -8,7 +8,9 @@
 package org.dspace.app.mediafilter;
 
 import java.awt.Graphics2D;
-import java.awt.image.BufferedImage;
+import java.awt.image.*;
+import java.awt.RenderingHints;
+import java.awt.Transparency;
 import java.awt.Font;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -73,6 +75,10 @@ public class BrandedPreviewJPEGFilter extends MediaFilter
                 .getIntProperty("webui.preview.maxwidth");
         float ymax = (float) ConfigurationManager
                 .getIntProperty("webui.preview.maxheight");
+        boolean blurring = (boolean) ConfigurationManager
+                .getBooleanProperty("webui.preview.blurring");
+        boolean hqscaling = (boolean) ConfigurationManager
+                .getBooleanProperty("webui.preview.hqscaling");
         int brandHeight = ConfigurationManager.getIntProperty("webui.preview.brand.height");
         String brandFont = ConfigurationManager.getProperty("webui.preview.brand.font");
         int brandFontPoint = ConfigurationManager.getIntProperty("webui.preview.brand.fontpoint");
@@ -137,6 +143,23 @@ public class BrandedPreviewJPEGFilter extends MediaFilter
         BufferedImage branded = new BufferedImage((int) xsize, (int) ysize + brandHeight,
                 BufferedImage.TYPE_INT_RGB);
 
+        // Use blurring if selected in config.
+        // a little blur before scaling does wonders for keeping moire in check.
+        if (blurring)
+        {
+                // send the buffered image off to get blurred.
+                buf = getBlurredInstance((BufferedImage) buf);
+        }
+
+        // Use high quality scaling method if selected in config.
+        // this has a definite performance penalty.
+        if (hqscaling)
+        {
+                // send the buffered image off to get an HQ downscale.
+                buf = getScaledInstance((BufferedImage) buf, (int) xsize, (int) ysize,
+                        (Object) RenderingHints.VALUE_INTERPOLATION_BICUBIC, (boolean) true);
+        }
+
         // now render the image into the preview buffer
         Graphics2D g2d = branded.createGraphics();
         g2d.drawImage(buf, 0, 0, (int) xsize, (int) ysize, null);
@@ -158,4 +181,97 @@ public class BrandedPreviewJPEGFilter extends MediaFilter
 
         return bais; // hope this gets written out before its garbage collected!
 	}
+
+    public BufferedImage getBlurredInstance(BufferedImage buf)
+    {
+    /**
+     * Convenience method that returns a blurred instance of the
+     * provided {@code BufferedImage}.
+     *
+     */
+
+     // kernel for blur op
+     float[] matrix = {
+        0.111f, 0.111f, 0.111f,
+        0.111f, 0.111f, 0.111f,
+        0.111f, 0.111f, 0.111f,
+      };
+
+     // perform the blur and return the blurred version.
+     BufferedImageOp blur = new ConvolveOp( new Kernel(3, 3, matrix) );
+     BufferedImage blurbuf = blur.filter(buf, null);
+     return blurbuf;
+    }
+
+    /**
+     * Convenience method that returns a scaled instance of the
+     * provided {@code BufferedImage}.
+     *
+     * @param buf the original image to be scaled
+     * @param targetWidth the desired width of the scaled instance,
+     *    in pixels
+     * @param targetHeight the desired height of the scaled instance,
+     *    in pixels
+     * @param hint one of the rendering hints that corresponds to
+     *    {@code RenderingHints.KEY_INTERPOLATION} (e.g.
+     *    {@code RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR},
+     *    {@code RenderingHints.VALUE_INTERPOLATION_BILINEAR},
+     *    {@code RenderingHints.VALUE_INTERPOLATION_BICUBIC})
+     * @param higherQuality if true, this method will use a multi-step
+     *    scaling technique that provides higher quality than the usual
+     *    one-step technique (only useful in downscaling cases, where
+     *    {@code targetWidth} or {@code targetHeight} is
+     *    smaller than the original dimensions, and generally only when
+     *    the {@code BILINEAR} hint is specified)
+     * @return a scaled version of the original {@code BufferedImage}
+     */
+    public BufferedImage getScaledInstance(BufferedImage buf,
+                                           int targetWidth,
+                                           int targetHeight,
+                                           Object hint,
+                                           boolean higherQuality)
+    {
+        int type = (buf.getTransparency() == Transparency.OPAQUE) ?
+            BufferedImage.TYPE_INT_RGB : BufferedImage.TYPE_INT_ARGB;
+        BufferedImage blurbuf = (BufferedImage)buf;
+        int w, h;
+        if (higherQuality) {
+            // Use multi-step technique: start with original size, then
+            // scale down in multiple passes with drawImage()
+            // until the target size is reached
+            w = buf.getWidth();
+            h = buf.getHeight();
+        } else {
+            // Use one-step technique: scale directly from original
+            // size to target size with a single drawImage() call
+            w = targetWidth;
+            h = targetHeight;
+        }
+
+        do {
+            if (higherQuality && w > targetWidth) {
+                w /= 2;
+                if (w < targetWidth) {
+                    w = targetWidth;
+                }
+            }
+
+            if (higherQuality && h > targetHeight) {
+                h /= 2;
+                if (h < targetHeight) {
+                    h = targetHeight;
+                }
+            }
+
+            BufferedImage tmp = new BufferedImage(w, h, type);
+            Graphics2D g2d = tmp.createGraphics();
+            g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, hint);
+            g2d.drawImage(blurbuf, 0, 0, w, h, null);
+            g2d.dispose();
+
+            blurbuf = tmp;
+        } while (w != targetWidth || h != targetHeight);
+
+        return blurbuf;
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/BrandedPreviewJPEGFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/BrandedPreviewJPEGFilter.java
@@ -8,6 +8,7 @@
 package org.dspace.app.mediafilter;
 
 import java.awt.Graphics2D;
+import java.awt.Color;
 import java.awt.image.*;
 import java.awt.RenderingHints;
 import java.awt.Transparency;
@@ -268,7 +269,7 @@ public class BrandedPreviewJPEGFilter extends MediaFilter
             BufferedImage tmp = new BufferedImage(w, h, type);
             Graphics2D g2d = tmp.createGraphics();
             g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, hint);
-            g2d.drawImage(scalebuf, 0, 0, w, h, null);
+            g2d.drawImage(scalebuf, 0, 0, w, h, Color.WHITE, null);
             g2d.dispose();
 
             scalebuf = tmp;

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/BrandedPreviewJPEGFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/BrandedPreviewJPEGFilter.java
@@ -24,6 +24,8 @@ import org.dspace.core.ConfigurationManager;
  * Filter image bitstreams, scaling the image to be within the bounds of
  * thumbnail.maxwidth, thumbnail.maxheight, the size we want our thumbnail to be
  * no bigger than. Creates only JPEGs.
+ *
+ * @author Jason Sherman <jsherman@usao.edu>
  */
 public class BrandedPreviewJPEGFilter extends MediaFilter
 {

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/BrandedPreviewJPEGFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/BrandedPreviewJPEGFilter.java
@@ -185,6 +185,20 @@ public class BrandedPreviewJPEGFilter extends MediaFilter
         return bais; // hope this gets written out before its garbage collected!
 	}
 
+    public BufferedImage getNormalizedInstance(BufferedImage buf)
+    {
+     int type = (buf.getTransparency() == Transparency.OPAQUE) ?
+            BufferedImage.TYPE_INT_RGB : BufferedImage.TYPE_INT_ARGB_PRE;
+     int w, h;
+     w = buf.getWidth();
+     h = buf.getHeight();
+     BufferedImage normal = new BufferedImage(w, h, type);
+     Graphics2D g2d = normal.createGraphics();
+     g2d.drawImage(buf, 0, 0, w, h, Color.WHITE, null);
+     g2d.dispose();
+     return normal;
+    }
+
     public BufferedImage getBlurredInstance(BufferedImage buf)
     {
     /**
@@ -192,6 +206,8 @@ public class BrandedPreviewJPEGFilter extends MediaFilter
      * provided {@code BufferedImage}.
      *
      */
+
+     buf = getNormalizedInstance(buf);
 
      // kernel for blur op
      float[] matrix = {

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/BrandedPreviewJPEGFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/BrandedPreviewJPEGFilter.java
@@ -235,7 +235,7 @@ public class BrandedPreviewJPEGFilter extends MediaFilter
     {
         int type = (buf.getTransparency() == Transparency.OPAQUE) ?
             BufferedImage.TYPE_INT_RGB : BufferedImage.TYPE_INT_ARGB;
-        BufferedImage blurbuf = (BufferedImage)buf;
+        BufferedImage scalebuf = (BufferedImage)buf;
         int w, h;
         if (higherQuality) {
             // Use multi-step technique: start with original size, then
@@ -268,12 +268,12 @@ public class BrandedPreviewJPEGFilter extends MediaFilter
             BufferedImage tmp = new BufferedImage(w, h, type);
             Graphics2D g2d = tmp.createGraphics();
             g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, hint);
-            g2d.drawImage(blurbuf, 0, 0, w, h, null);
+            g2d.drawImage(scalebuf, 0, 0, w, h, null);
             g2d.dispose();
 
-            blurbuf = tmp;
+            scalebuf = tmp;
         } while (w != targetWidth || h != targetHeight);
 
-        return blurbuf;
+        return scalebuf;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/JPEGFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/JPEGFilter.java
@@ -23,6 +23,8 @@ import org.dspace.core.ConfigurationManager;
  * Filter image bitstreams, scaling the image to be within the bounds of
  * thumbnail.maxwidth, thumbnail.maxheight, the size we want our thumbnail to be
  * no bigger than. Creates only JPEGs.
+ *
+ * @author Jason Sherman <jsherman@usao.edu>
  */
 public class JPEGFilter extends MediaFilter implements SelfRegisterInputFormats
 {

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/JPEGFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/JPEGFilter.java
@@ -8,6 +8,7 @@
 package org.dspace.app.mediafilter;
 
 import java.awt.Graphics2D;
+import java.awt.Color;
 import java.awt.image.*;
 import java.awt.RenderingHints;
 import java.awt.Transparency;
@@ -273,7 +274,7 @@ public class JPEGFilter extends MediaFilter implements SelfRegisterInputFormats
             BufferedImage tmp = new BufferedImage(w, h, type);
             Graphics2D g2d = tmp.createGraphics();
             g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, hint);
-            g2d.drawImage(scalebuf, 0, 0, w, h, null);
+            g2d.drawImage(scalebuf, 0, 0, w, h, Color.WHITE, null);
             g2d.dispose();
 
             scalebuf = tmp;

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/JPEGFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/JPEGFilter.java
@@ -8,7 +8,9 @@
 package org.dspace.app.mediafilter;
 
 import java.awt.Graphics2D;
-import java.awt.image.BufferedImage;
+import java.awt.image.*;
+import java.awt.RenderingHints;
+import java.awt.Transparency;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
@@ -71,6 +73,10 @@ public class JPEGFilter extends MediaFilter implements SelfRegisterInputFormats
                 .getIntProperty("thumbnail.maxwidth");
         float ymax = (float) ConfigurationManager
                 .getIntProperty("thumbnail.maxheight");
+        boolean blurring = (boolean) ConfigurationManager
+                .getBooleanProperty("thumbnail.blurring");
+        boolean hqscaling = (boolean) ConfigurationManager
+                .getBooleanProperty("thumbnail.hqscaling");
 
         // now get the image dimensions
         float xsize = (float) buf.getWidth(null);
@@ -131,6 +137,23 @@ public class JPEGFilter extends MediaFilter implements SelfRegisterInputFormats
         BufferedImage thumbnail = new BufferedImage((int) xsize, (int) ysize,
                 BufferedImage.TYPE_INT_RGB);
 
+        // Use blurring if selected in config.
+        // a little blur before scaling does wonders for keeping moire in check.
+        if (blurring)
+        {
+                // send the buffered image off to get blurred.
+                buf = getBlurredInstance((BufferedImage) buf);
+        }
+
+        // Use high quality scaling method if selected in config.
+        // this has a definite performance penalty.
+        if (hqscaling)
+        {
+                // send the buffered image off to get an HQ downscale.
+                buf = getScaledInstance((BufferedImage) buf, (int) xsize, (int) ysize,
+                        (Object) RenderingHints.VALUE_INTERPOLATION_BICUBIC, (boolean) true);
+        }
+
         // now render the image into the thumbnail buffer
         Graphics2D g2d = thumbnail.createGraphics();
         g2d.drawImage(buf, 0, 0, (int) xsize, (int) ysize, null);
@@ -162,5 +185,98 @@ public class JPEGFilter extends MediaFilter implements SelfRegisterInputFormats
         // Temporarily disabled as JDK 1.6 only
         // return ImageIO.getReaderFileSuffixes();
         return null;
+    }
+
+    public BufferedImage getBlurredInstance(BufferedImage buf)
+    {
+    /**
+     * Convenience method that returns a blurred instance of the
+     * provided {@code BufferedImage}.
+     *
+     */
+
+     // kernel for blur op
+     float[] matrix = {
+        0.111f, 0.111f, 0.111f,
+        0.111f, 0.111f, 0.111f,
+        0.111f, 0.111f, 0.111f,
+      };
+
+     // perform the blur and return the blurred version.
+     BufferedImageOp blur = new ConvolveOp( new Kernel(3, 3, matrix) );
+     BufferedImage blurbuf = blur.filter(buf, null);
+     return blurbuf;
+    }
+
+    /**
+     * Convenience method that returns a scaled instance of the
+     * provided {@code BufferedImage}.
+     *
+     * @param buf the original image to be scaled
+     * @param targetWidth the desired width of the scaled instance,
+     *    in pixels
+     * @param targetHeight the desired height of the scaled instance,
+     *    in pixels
+     * @param hint one of the rendering hints that corresponds to
+     *    {@code RenderingHints.KEY_INTERPOLATION} (e.g.
+     *    {@code RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR},
+     *    {@code RenderingHints.VALUE_INTERPOLATION_BILINEAR},
+     *    {@code RenderingHints.VALUE_INTERPOLATION_BICUBIC})
+     * @param higherQuality if true, this method will use a multi-step
+     *    scaling technique that provides higher quality than the usual
+     *    one-step technique (only useful in downscaling cases, where
+     *    {@code targetWidth} or {@code targetHeight} is
+     *    smaller than the original dimensions, and generally only when
+     *    the {@code BILINEAR} hint is specified)
+     * @return a scaled version of the original {@code BufferedImage}
+     */
+    public BufferedImage getScaledInstance(BufferedImage buf,
+                                           int targetWidth,
+                                           int targetHeight,
+                                           Object hint,
+                                           boolean higherQuality)
+    {
+        int type = (buf.getTransparency() == Transparency.OPAQUE) ?
+            BufferedImage.TYPE_INT_RGB : BufferedImage.TYPE_INT_ARGB;
+        BufferedImage scalebuf = (BufferedImage)buf;
+        int w, h;
+        if (higherQuality) {
+            // Use multi-step technique: start with original size, then
+            // scale down in multiple passes with drawImage()
+            // until the target size is reached
+            w = buf.getWidth();
+            h = buf.getHeight();
+        } else {
+            // Use one-step technique: scale directly from original
+            // size to target size with a single drawImage() call
+            w = targetWidth;
+            h = targetHeight;
+        }
+
+        do {
+            if (higherQuality && w > targetWidth) {
+                w /= 2;
+                if (w < targetWidth) {
+                    w = targetWidth;
+                }
+            }
+
+            if (higherQuality && h > targetHeight) {
+                h /= 2;
+                if (h < targetHeight) {
+                    h = targetHeight;
+                }
+            }
+
+            BufferedImage tmp = new BufferedImage(w, h, type);
+            Graphics2D g2d = tmp.createGraphics();
+            g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, hint);
+            g2d.drawImage(scalebuf, 0, 0, w, h, null);
+            g2d.dispose();
+
+            scalebuf = tmp;
+        } while (w != targetWidth || h != targetHeight);
+
+        return scalebuf;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/JPEGFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/JPEGFilter.java
@@ -190,6 +190,20 @@ public class JPEGFilter extends MediaFilter implements SelfRegisterInputFormats
         return null;
     }
 
+    public BufferedImage getNormalizedInstance(BufferedImage buf)
+    {
+     int type = (buf.getTransparency() == Transparency.OPAQUE) ?
+            BufferedImage.TYPE_INT_RGB : BufferedImage.TYPE_INT_ARGB_PRE;
+     int w, h;
+     w = buf.getWidth();
+     h = buf.getHeight();
+     BufferedImage normal = new BufferedImage(w, h, type);
+     Graphics2D g2d = normal.createGraphics();
+     g2d.drawImage(buf, 0, 0, w, h, Color.WHITE, null);
+     g2d.dispose();
+     return normal;
+    }
+
     public BufferedImage getBlurredInstance(BufferedImage buf)
     {
     /**
@@ -197,6 +211,8 @@ public class JPEGFilter extends MediaFilter implements SelfRegisterInputFormats
      * provided {@code BufferedImage}.
      *
      */
+
+     buf = getNormalizedInstance(buf);
 
      // kernel for blur op
      float[] matrix = {

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -826,6 +826,14 @@ webui.item.thumbnail.show = true
 thumbnail.maxwidth  = 80
 thumbnail.maxheight = 80
 
+# Blur before scaling.  A little blur before scaling does wonders for keeping
+# moire in check.
+thumbnail.blurring = true
+
+# High quality scaling option.  Setting to true can dramatically increase
+# image quality, but it takes longer to create thumbnails.
+thumbnail.hqscaling = true
+
 
 #### Settings for Item Preview ####
 
@@ -833,13 +841,25 @@ webui.preview.enabled = false
 # max dimensions of the preview image
 webui.preview.maxwidth = 600
 webui.preview.maxheight = 600
+
+# Blur before scaling.  A little blur before scaling does wonders for keeping
+# moire in check.
+webui.preview.blurring = true
+
+# High quality scaling option.  Setting to true can dramatically increase
+# image quality, but it will take much longer to create previews.
+webui.preview.hqscaling = true
+
 # the brand text
 webui.preview.brand = My Institution Name
+
 # an abbreviated form of the above text, this will be used
 # when the preview image cannot fit the normal text
 webui.preview.brand.abbrev = MyOrg
+
 # the height of the brand
 webui.preview.brand.height = 20
+
 # font settings for the brand text
 webui.preview.brand.font = SansSerif
 webui.preview.brand.fontpoint = 12


### PR DESCRIPTION
Adds high quality scaling option which causes filter to use bicubic scaliing and to scale in multiple steps for images with an x or y scale factor under 0.5.

Adds blur option which prevents high frequency interference (like moire patterns) from getting extremely prominent after scaling.

Both options set to enabled in dspace.cfg
