### PR TITLE
Change jquery url from http://code.jquery.org to https://ajax.googleapis.com

### DIFF
--- a/dspace-oai/src/main/webapp/static/style.xsl
+++ b/dspace-oai/src/main/webapp/static/style.xsl
@@ -27,7 +27,7 @@
 			<head>
 				<title>DSpace OAI-PMH Data Provider</title>
 				<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-				<script src="http://code.jquery.com/jquery-1.7.2.min.js"
+				<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"
 					type="text/javascript"></script>
 				<style type="text/css">
 					a {


### PR DESCRIPTION
Changed from the url at code.jquery.org to one that supports HTTPS. The CDN for jquery, doesn't have a valid ssl certificate for https://code.jquery.org. Google's Host Libraries server does support this. Fixes an issue where if running OAI through https, Internet Explorer 9 will complain about insecure content.
