### PR TITLE
DS-1457 In OAI src for jquery uses an http only 

### DIFF
--- a/dspace-oai/src/main/webapp/static/style.xsl
+++ b/dspace-oai/src/main/webapp/static/style.xsl
@@ -27,7 +27,7 @@
 			<head>
 				<title>DSpace OAI-PMH Data Provider</title>
 				<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-				<script src="http://code.jquery.com/jquery-1.7.2.min.js"
+				<script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"
 					type="text/javascript"></script>
 				<style type="text/css">
 					a {


### PR DESCRIPTION
Change the source to ajax.googleapis.com, which allows either http or https source.

URL Syntax is from: https://developers.google.com/speed/libraries/devguide#jquery

Works in IE9/FF17 (Windows/Linux)/FF7 Windows
