### PR TITLE
SSO authentication module - RemoteUser

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/RemoteUserAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/RemoteUserAuthentication.java
@@ -1,0 +1,524 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.authenticate;
+
+import java.sql.SQLException;
+import java.util.Hashtable;
+
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.core.ConfigurationManager;
+import org.dspace.core.Context;
+import org.dspace.core.LogManager;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
+
+/**
+ * Java file based on LDAPHierarchicalAuthentication
+ * Amended by Ian Wellaway 30-11-2012
+ * Adapted to use the username from SSO, available via the request.getRemoteUser() method
+ * User has already been authenticated using SSO so the script doesn't need to authenticate the user
+ *   but merely check if they have a current ePerson record and act accordingly.
+ *
+ * To this end, I have also added code to the dspace-xmlui-api/aspect/ePerson/LDAPAuthenticateAction
+ *   file and an extra parameter to the dspace/config/modules/authentication-LDAP.cfg file
+ *
+ * Original comment:
+ * This LDAP authentication method is more complex than the simple 'LDAPAuthentication'
+ * in that it allows authentication against structured hierarchical LDAP trees of
+ * users. An initial bind is required using a user name and password in order to
+ * search the tree and find the DN of the user. A second bind is then required to
+ * check the credentials of the user by binding directly to their DN.
+ *
+ * @author Stuart Lewis, Chris Yates, Alex Barbieri, Flavio Botelho, Reuben Pasquini
+ * @version $Revision$
+ */
+public class RemoteUserAuthentication
+        implements AuthenticationMethod {
+
+    /** log4j category */
+    private static Logger log = Logger.getLogger(RemoteUserAuthentication.class);
+
+    /**
+     * Let a real auth method return true if it wants.
+     */
+    public boolean canSelfRegister(Context context,
+            HttpServletRequest request,
+            String username)
+            throws SQLException {
+        // Looks to see if autoregister is set or not
+        return ConfigurationManager.getBooleanProperty("authentication-ldap", "autoregister");
+    }
+
+    /**
+     * Nothing here, initialization is done when auto-registering.
+     */
+    public void initEPerson(Context context, HttpServletRequest request,
+            EPerson eperson)
+            throws SQLException {
+        // XXX should we try to initialize netid based on email addr,
+        // XXX for eperson created by some other method??
+    }
+
+    /**
+     * Cannot change LDAP password through dspace, right?
+     */
+    public boolean allowSetPassword(Context context,
+            HttpServletRequest request,
+            String username)
+            throws SQLException {
+        // XXX is this right?
+        return false;
+    }
+
+    /*
+     * This is an explicit method.
+     */
+    public boolean isImplicit() {
+        return false;
+    }
+
+    /*
+     * Add authenticated users to the group defined in dspace.cfg by
+     * the login.specialgroup key.
+     */
+    public int[] getSpecialGroups(Context context, HttpServletRequest request) {
+// Prevents anonymous users from being added to this group, and the second check
+// ensures they are LDAP users
+        try {
+            if (!context.getCurrentUser().getNetid().equals("")) {
+                String groupName = ConfigurationManager.getProperty("authentication-ldap", "login.specialgroup");
+                if ((groupName != null) && (!groupName.trim().equals(""))) {
+                    Group ldapGroup = Group.findByName(context, groupName);
+                    if (ldapGroup == null) {
+// Oops - the group isn't there.
+                        log.warn(LogManager.getHeader(context,
+                                "ldap_specialgroup",
+                                "Group defined in login.specialgroup does not exist"));
+                        return new int[0];
+                    } else {
+                        return new int[]{ldapGroup.getID()};
+                    }
+                }
+            }
+        } catch (Exception npe) {
+// The user is not an LDAP user, so we don't need to worry about them
+        }
+        return new int[0];
+    }
+
+    /*
+     * Authenticate the given credentials.
+     * This is the heart of the authentication method: test the
+     * credentials for authenticity, and if accepted, attempt to match
+     * (or optionally, create) an <code>EPerson</code>. If an <code>EPerson</code> is found it is
+     * set in the <code>Context</code> that was passed.
+     *
+     * @param context
+     * DSpace context, will be modified (ePerson set) upon success.
+     *
+     * @param username
+     * Username (or email address) when method is explicit. Use null for
+     * implicit method.
+     *
+     * @param password
+     * Password for explicit auth, or null for implicit method.
+     *
+     * @param realm
+     * Realm is an extra parameter used by some authentication methods, leave null if
+     * not applicable.
+     *
+     * @param request
+     * The HTTP request that started this operation, or null if not applicable.
+     *
+     * @return One of:
+     * SUCCESS, BAD_CREDENTIALS, CERT_REQUIRED, NO_SUCH_USER, BAD_ARGS
+     * <p>Meaning:
+     * <br>SUCCESS - authenticated OK.
+     * <br>BAD_CREDENTIALS - user exists, but credentials (e.g. passwd) don't match
+     * <br>CERT_REQUIRED - not allowed to login this way without X.509 cert.
+     * <br>NO_SUCH_USER - user not found using this method.
+     * <br>BAD_ARGS - user/pw not appropriate for this method
+     */
+    public int authenticate(Context context,
+            String netid,
+            String password,
+            String realm,
+            HttpServletRequest request)
+            throws SQLException {
+
+        log.info(LogManager.getHeader(context, "auth", "Remote User Start"));
+
+        //Gets userid from the SSO authentication
+        if (request != null)
+        {
+            netid = request.getRemoteUser();
+            password = "test";
+            log.info(LogManager.getHeader(context, "auth", "auth attempt via SSO"));
+        }
+        else
+        {
+            log.info(LogManager.getHeader(context, "auth", "auth attempt via SWORD"));
+        }
+
+        log.info(LogManager.getHeader(context, "auth", "attempting trivial auth of user=" + netid));
+
+        // Locate the eperson
+        EPerson eperson = null;
+        try {
+            eperson = EPerson.findByNetid(context, netid.toLowerCase());
+        } catch (SQLException e) {
+        }
+        SpeakerToLDAP ldap = new SpeakerToLDAP(log);
+
+// Get the DN of the user
+        String adminUser = ConfigurationManager.getProperty("authentication-ldap", "search.user");
+        String adminPassword = ConfigurationManager.getProperty("authentication-ldap", "search.password");
+        String dn = ldap.getDNOfUser(adminUser, adminPassword, context, netid);
+
+// Check a DN was found
+        if ((dn == null) || (dn.trim().equals(""))) {
+            log.info(LogManager.getHeader(context, "failed_login", "no DN found for user " + netid));
+            return BAD_CREDENTIALS;
+        }
+
+// if they entered a netid that matches an eperson
+        if (eperson != null) {
+            // e-mail address corresponds to active account
+            if (eperson.getRequireCertificate()) {
+                return CERT_REQUIRED;
+            } else if (!eperson.canLogIn()) {
+                return BAD_ARGS;
+            }
+
+            if (1==1){
+            //if (ldap.ldapAuthenticate(dn, password, context)) {
+                context.setCurrentUser(eperson);
+                log.info(LogManager.getHeader(context, "authenticate", "type=ldap"));
+                return SUCCESS;
+            } else {
+                return BAD_CREDENTIALS;
+            }
+        } // the user does not already exist so try and authenticate them
+        // with ldap and create an eperson for them
+        else {
+            if (1==1){
+            //if (ldap.ldapAuthenticate(dn, password, context)) {
+                // Register the new user automatically
+                log.info(LogManager.getHeader(context,
+                        "autoregister", "netid=" + netid));
+
+                // If there is no email and the email domain is set, add it to the netid
+                String email = ldap.ldapEmail;
+                if (((email == null) || ("".equals(email))) &&
+                        (!"".equals(ConfigurationManager.getProperty("authentication-ldap", "netid_email_domain")))) {
+                    email = netid + ConfigurationManager.getProperty("authentication-ldap", "netid_email_domain");
+                }
+
+                if ((email != null) && (!"".equals(email))) {
+                    try {
+                        eperson = EPerson.findByEmail(context, email);
+                        if (eperson != null) {
+                            log.info(LogManager.getHeader(context,
+                                    "type=remoteuser-login", "type=ldap_but_already_email"));
+                            context.setIgnoreAuthorization(true);
+                            eperson.setNetid(netid.toLowerCase());
+                            eperson.update();
+                            context.commit();
+                            context.setIgnoreAuthorization(false);
+                            context.setCurrentUser(eperson);
+                            return SUCCESS;
+                        } else {
+                            if (canSelfRegister(context, request, netid)) {
+// TEMPORARILY turn off authorisation
+                                try {
+                                    context.setIgnoreAuthorization(true);
+                                    eperson = EPerson.create(context);
+                                    if ((email != null) && (!"".equals(email))) {
+                                        eperson.setEmail(email);
+                                    }
+                                    if ((ldap.ldapGivenName != null) && (!ldap.ldapGivenName.equals(""))) {
+                                        eperson.setFirstName(ldap.ldapGivenName);
+                                    }
+                                    if ((ldap.ldapSurname != null) && (!ldap.ldapSurname.equals(""))) {
+                                        eperson.setLastName(ldap.ldapSurname);
+                                    }
+                                    if ((ldap.ldapPhone != null) && (!ldap.ldapPhone.equals(""))) {
+                                        eperson.setMetadata("phone", ldap.ldapPhone);
+                                    }
+                                    eperson.setNetid(netid.toLowerCase());
+                                    eperson.setCanLogIn(true);
+                                    AuthenticationManager.initEPerson(context, request, eperson);
+                                    eperson.update();
+                                    context.commit();
+                                    context.setCurrentUser(eperson);
+                                } catch (AuthorizeException e) {
+                                    return NO_SUCH_USER;
+                                } finally {
+                                    context.setIgnoreAuthorization(false);
+                                }
+
+                                log.info(LogManager.getHeader(context, "authenticate",
+                                        "type=remoteuser-login, created ePerson"));
+                                return SUCCESS;
+                            } else {
+// No auto-registration for valid certs
+                                log.info(LogManager.getHeader(context,
+                                        "failed_login", "type=ldap_but_no_record"));
+                                return NO_SUCH_USER;
+                            }
+                        }
+                    } catch (AuthorizeException e) {
+                        eperson = null;
+                    } finally {
+                        context.setIgnoreAuthorization(false);
+                    }
+                }
+            }
+        }
+        return BAD_ARGS;
+    }
+
+    /**
+     * Internal class to manage LDAP query and results, mainly
+     * because there are multiple values to return.
+     */
+    private static class SpeakerToLDAP {
+
+        private Logger log = null;
+        protected String ldapEmail = null;
+        protected String ldapGivenName = null;
+        protected String ldapSurname = null;
+        protected String ldapPhone = null;
+        /** LDAP settings */
+        String ldap_provider_url = ConfigurationManager.getProperty("authentication-ldap", "provider_url");
+        String ldap_id_field = ConfigurationManager.getProperty("authentication-ldap", "id_field");
+        String ldap_search_context = ConfigurationManager.getProperty("authentication-ldap", "search_context");
+        String ldap_search_scope = ConfigurationManager.getProperty("authentication-ldap", "search_scope");
+        String ldap_email_field = ConfigurationManager.getProperty("authentication-ldap", "email_field");
+        String ldap_givenname_field = ConfigurationManager.getProperty("authentication-ldap", "givenname_field");
+        String ldap_surname_field = ConfigurationManager.getProperty("authentication-ldap", "surname_field");
+        String ldap_phone_field = ConfigurationManager.getProperty("authentication-ldap", "phone_field");
+
+        SpeakerToLDAP(Logger thelog) {
+            log = thelog;
+        }
+
+        protected String getDNOfUser(String adminUser, String adminPassword, Context context, String netid) {
+// The resultant DN
+            String resultDN;
+
+// The search scope to use (default to 0)
+            int ldap_search_scope_value = 0;
+            try {
+                ldap_search_scope_value = Integer.parseInt(ldap_search_scope.trim());
+            } catch (NumberFormatException e) {
+// Log the error if it has been set but is invalid
+                if (ldap_search_scope != null) {
+                    log.warn(LogManager.getHeader(context,
+                            "ldap_authentication", "invalid search scope: " + ldap_search_scope));
+                }
+            }
+
+// Set up environment for creating initial context
+            Hashtable env = new Hashtable(11);
+            env.put(javax.naming.Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+            env.put(javax.naming.Context.PROVIDER_URL, ldap_provider_url);
+
+            if ((adminUser != null) && (!adminUser.trim().equals("")) &&
+                    (adminPassword != null) && (!adminPassword.trim().equals(""))) {
+                // Use admin credencials for search// Authenticate
+                env.put(javax.naming.Context.SECURITY_AUTHENTICATION, "simple");
+                env.put(javax.naming.Context.SECURITY_PRINCIPAL, adminUser);
+                env.put(javax.naming.Context.SECURITY_CREDENTIALS, adminPassword);
+            } else {
+                // Use anonymous authentication
+                env.put(javax.naming.Context.SECURITY_AUTHENTICATION, "none");
+            }
+
+            DirContext ctx = null;
+            try {
+// Create initial context
+                ctx = new InitialDirContext(env);
+
+                Attributes matchAttrs = new BasicAttributes(true);
+                matchAttrs.put(new BasicAttribute(ldap_id_field, netid));
+
+// look up attributes
+                try {
+                    SearchControls ctrls = new SearchControls();
+                    ctrls.setSearchScope(ldap_search_scope_value);
+
+                    NamingEnumeration<SearchResult> answer = ctx.search(
+                            ldap_provider_url + ldap_search_context,
+                            "(&({0}={1}))", new Object[]{ldap_id_field,
+                                netid}, ctrls);
+
+                    while (answer.hasMoreElements()) {
+                        SearchResult sr = answer.next();
+                        if (StringUtils.isEmpty(ldap_search_context)) {
+                            resultDN = sr.getName();
+                        } else {
+                            resultDN = (sr.getName() + "," + ldap_search_context);
+                        }
+
+                        String attlist[] = {ldap_email_field, ldap_givenname_field,
+                            ldap_surname_field, ldap_phone_field};
+                        Attributes atts = sr.getAttributes();
+                        Attribute att;
+
+                        if (attlist[0] != null) {
+                            att = atts.get(attlist[0]);
+                            if (att != null) {
+                                ldapEmail = (String) att.get();
+                            }
+                        }
+
+                        if (attlist[1] != null) {
+                            att = atts.get(attlist[1]);
+                            if (att != null) {
+                                ldapGivenName = (String) att.get();
+                            }
+                        }
+
+                        if (attlist[2] != null) {
+                            att = atts.get(attlist[2]);
+                            if (att != null) {
+                                ldapSurname = (String) att.get();
+                            }
+                        }
+
+                        if (attlist[3] != null) {
+                            att = atts.get(attlist[3]);
+                            if (att != null) {
+                                ldapPhone = (String) att.get();
+                            }
+                        }
+
+                        if (answer.hasMoreElements()) {
+// Oh dear - more than one match
+// Ambiguous user, can't continue
+                        } else {
+                            log.debug(LogManager.getHeader(context, "got DN", resultDN));
+                            return resultDN;
+                        }
+                    }
+                } catch (NamingException e) {
+// if the lookup fails go ahead and create a new record for them because the authentication
+// succeeded
+                    log.warn(LogManager.getHeader(context,
+                            "ldap_attribute_lookup", "type=failed_search " + e));
+                }
+            } catch (NamingException e) {
+                log.warn(LogManager.getHeader(context,
+                        "ldap_authentication", "type=failed_auth " + e));
+            } finally {
+// Close the context when we're done
+                try {
+                    if (ctx != null) {
+                        ctx.close();
+                    }
+                } catch (NamingException e) {
+                }
+            }
+
+// No DN match found
+            return null;
+        }
+
+        /**
+         * contact the ldap server and attempt to authenticate
+         */
+        protected boolean ldapAuthenticate(String netid, String password,
+                Context context) {
+            if (!password.equals("")) {
+// Set up environment for creating initial context
+                Hashtable<String, String> env = new Hashtable<String, String>();
+                env.put(javax.naming.Context.INITIAL_CONTEXT_FACTORY,
+                        "com.sun.jndi.ldap.LdapCtxFactory");
+                env.put(javax.naming.Context.PROVIDER_URL, ldap_provider_url);
+
+// Authenticate
+                env.put(javax.naming.Context.SECURITY_AUTHENTICATION, "Simple");
+                env.put(javax.naming.Context.SECURITY_PRINCIPAL, netid);
+                env.put(javax.naming.Context.SECURITY_CREDENTIALS, password);
+                env.put(javax.naming.Context.AUTHORITATIVE, "true");
+                env.put(javax.naming.Context.REFERRAL, "follow");
+
+                DirContext ctx = null;
+                try {
+// Try to bind
+                    ctx = new InitialDirContext(env);
+                } catch (NamingException e) {
+                    log.warn(LogManager.getHeader(context,
+                            "ldap_authentication", "type=failed_auth " + e));
+                    return false;
+                } finally {
+// Close the context when we're done
+                    try {
+                        if (ctx != null) {
+                            ctx.close();
+                        }
+                    } catch (NamingException e) {
+                    }
+                }
+            } else {
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    /*
+     * Returns URL to which to redirect to obtain credentials (either password
+     * prompt or e.g. HTTPS port for client cert.); null means no redirect.
+     *
+     * @param context
+     * DSpace context, will be modified (ePerson set) upon success.
+     *
+     * @param request
+     * The HTTP request that started this operation, or null if not applicable.
+     *
+     * @param response
+     * The HTTP response from the servlet method.
+     *
+     * @return fully-qualified URL
+     */
+    public String loginPageURL(Context context,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        
+         return response.encodeRedirectURL(request.getContextPath() +
+                "/remoteuser-login");
+         
+    }
+
+    /**
+     * Returns message key for title of the "login" page, to use
+     * in a menu showing the choice of multiple login methods.
+     *
+     * @param context
+     * DSpace context, will be modified (ePerson set) upon success.
+     *
+     * @return Message key to look up in i18n message catalog.
+     */
+    public String loginPageTitle(Context context) {
+        return "Remote User Login";
+    }
+}
+
+
+

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/RemoteUserAuthenticateAction.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/RemoteUserAuthenticateAction.java
@@ -1,0 +1,111 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.xmlui.aspect.eperson;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.avalon.framework.parameters.Parameters;
+import org.apache.cocoon.acting.AbstractAction;
+import org.apache.cocoon.environment.ObjectModelHelper;
+import org.apache.cocoon.environment.Redirector;
+import org.apache.cocoon.environment.Request;
+import org.apache.cocoon.environment.SourceResolver;
+import org.apache.cocoon.environment.http.HttpEnvironment;
+import org.apache.cocoon.sitemap.PatternException;
+import org.dspace.app.xmlui.utils.AuthenticationUtil;
+import org.dspace.core.ConfigurationManager;
+import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
+
+/**
+ * Attempt to authenticate the user based upon their presented credentials. This
+ * action uses the http parameters of username, ldap_password, and login_realm
+ * as credentials.
+ * 
+ * If the authentication attempt is successfull then an HTTP redirect will be
+ * sent to the browser redirecting them to their original location in the system
+ * before authenticated or if none is supplied back to the DSpace homepage. The
+ * action will also return true, thus contents of the action will be excuted.
+ * 
+ * If the authentication attempt fails, the action returns false.
+ * 
+ * Example use:
+ * 
+ * <map:act name="LDAPAuthenticate"> <map:serialize type="xml"/> </map:act>
+ * <map:transform type="try-to-login-again-transformer">
+ * 
+ * @author Jay Paz
+ */
+public class RemoteUserAuthenticateAction extends AbstractAction {
+
+    /**
+     * Attempt to authenticate the user.
+     */
+    public Map act(Redirector redirector, SourceResolver resolver,
+            Map objectModel, String source, Parameters parameters)
+            throws Exception {
+        // First check if we are preforming a new login
+        Request request = ObjectModelHelper.getRequest(objectModel);
+
+        String username = request.getParameter("username");
+        String password = request.getParameter("ldap_password");
+        String realm = request.getParameter("login_realm");
+
+        /* IW - Comment out so code attempts to authenticate user immediately
+        if (username == null || password == null) {
+            return null;
+        }
+        */
+
+        try {
+            Context context = AuthenticationUtil.authenticate(objectModel, username, password, realm);
+
+            EPerson eperson = context.getCurrentUser();
+
+            if (eperson != null) {
+                // The user has successfully logged in
+                String redirectURL = request.getContextPath();
+
+                if (AuthenticationUtil.isInterupptedRequest(objectModel)) {
+                    // Resume the request and set the redirect target URL to
+                    // that of the originaly interrupted request.
+                    redirectURL += AuthenticationUtil.resumeInterruptedRequest(objectModel);
+                } else {
+                    // Otherwise direct the user to the specified 'loginredirect' page (or homepage by default)
+                    String loginRedirect = ConfigurationManager.getProperty("xmlui.user.loginredirect");
+                    redirectURL += (loginRedirect != null) ? loginRedirect.trim() : "/";
+                }
+
+                // Authentication successfull send a redirect.
+                final HttpServletResponse httpResponse = (HttpServletResponse) objectModel.get(HttpEnvironment.HTTP_RESPONSE_OBJECT);
+
+                httpResponse.sendRedirect(redirectURL);
+
+                // log the user out for the rest of this current request,
+                // however they will be reauthenticated
+                // fully when they come back from the redirect. This prevents
+                // caching problems where part of the
+                // request is preformed fore the user was authenticated and the
+                // other half after it succedded. This
+                // way the user is fully authenticated from the start of the
+                // request.
+                context.setCurrentUser(null);
+
+                return new HashMap();
+            }
+        } catch (SQLException sqle) {
+            throw new PatternException("Unable to preform authentication", sqle);
+        }
+
+        return null;
+    }
+}

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/RemoteUserLogin.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/RemoteUserLogin.java
@@ -1,0 +1,170 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.xmlui.aspect.eperson;
+
+import java.io.Serializable;
+import java.sql.SQLException;
+
+import javax.servlet.http.HttpSession;
+
+import org.apache.cocoon.caching.CacheableProcessingComponent;
+import org.apache.cocoon.environment.ObjectModelHelper;
+import org.apache.cocoon.environment.Request;
+import org.apache.excalibur.source.SourceValidity;
+import org.apache.excalibur.source.impl.validity.NOPValidity;
+import org.dspace.app.xmlui.cocoon.AbstractDSpaceTransformer;
+import org.dspace.app.xmlui.utils.AuthenticationUtil;
+import org.dspace.app.xmlui.wing.Message;
+import org.dspace.app.xmlui.wing.WingException;
+import org.dspace.app.xmlui.wing.element.Body;
+import org.dspace.app.xmlui.wing.element.Division;
+import org.dspace.app.xmlui.wing.element.Item;
+import org.dspace.app.xmlui.wing.element.List;
+import org.dspace.app.xmlui.wing.element.PageMeta;
+import org.dspace.app.xmlui.wing.element.Password;
+import org.dspace.app.xmlui.wing.element.Text;
+import org.xml.sax.SAXException;
+
+/**
+ * Query the user for their authentication credentials.
+ *
+ * The parameter "return-url" may be passed to give a location where to redirect
+ * the user to after sucessfully authenticating.
+ *
+ * @author Jay Paz
+ */
+public class RemoteUserLogin extends AbstractDSpaceTransformer implements
+        CacheableProcessingComponent {
+
+    /** language strings */
+    public static final Message T_title = message("xmlui.EPerson.LDAPLogin.title");
+    public static final Message T_dspace_home = message("xmlui.general.dspace_home");
+    public static final Message T_trail = message("xmlui.EPerson.LDAPLogin.trail");
+    public static final Message T_head1 = message("xmlui.EPerson.LDAPLogin.head1");
+    public static final Message T_userName = message("xmlui.EPerson.LDAPLogin.username");
+    public static final Message T_error_bad_login = message("xmlui.EPerson.LDAPLogin.error_bad_login");
+    public static final Message T_password = message("xmlui.EPerson.LDAPLogin.password");
+    public static final Message T_submit = message("xmlui.EPerson.LDAPLogin.submit");
+
+    /**
+     * Generate the unique caching key. This key must be unique inside the space
+     * of this component.
+     */
+    public Serializable getKey() {
+        Request request = ObjectModelHelper.getRequest(objectModel);
+        String previous_username = request.getParameter("username");
+
+// Get any message parameters
+        HttpSession session = request.getSession();
+        String header = (String) session.getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_HEADER);
+        String message = (String) session.getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_MESSAGE);
+        String characters = (String) session.getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_CHARACTERS);
+
+// If there is a message or previous email attempt then the page is not
+// cachable
+        if (header == null && message == null && characters == null && previous_username == null) {
+            // cacheable
+            return "1";
+        } else {
+            // Uncachable
+            return "0";
+        }
+    }
+
+    /**
+     * Generate the cache validity object.
+     */
+    public SourceValidity getValidity() {
+        Request request = ObjectModelHelper.getRequest(objectModel);
+        String previous_username = request.getParameter("username");
+
+// Get any message parameters
+        HttpSession session = request.getSession();
+        String header = (String) session.getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_HEADER);
+        String message = (String) session.getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_MESSAGE);
+        String characters = (String) session.getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_CHARACTERS);
+
+// If there is a message or previous email attempt then the page is not
+// cachable
+        if (header == null && message == null && characters == null && previous_username == null) {
+            // Always valid
+            return NOPValidity.SHARED_INSTANCE;
+        } else {
+            // invalid
+            return null;
+        }
+    }
+
+    /**
+     * Set the page title and trail.
+     */
+    public void addPageMeta(PageMeta pageMeta) throws WingException {
+        pageMeta.addMetadata("title").addContent(T_title);
+
+        pageMeta.addTrailLink(contextPath + "/", T_dspace_home);
+        pageMeta.addTrail().addContent(T_trail);
+    }
+
+    /**
+     * Display the login form.
+     */
+    public void addBody(Body body) throws SQLException, SAXException,
+            WingException {
+// Check if the user has previously attempted to login.
+        Request request = ObjectModelHelper.getRequest(objectModel);
+        HttpSession session = request.getSession();
+        String previousUserName = request.getParameter("username");
+
+// Get any message parameters
+        String header = (String) session.getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_HEADER);
+        String message = (String) session.getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_MESSAGE);
+        String characters = (String) session.getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_CHARACTERS);
+
+        if (header != null || message != null || characters != null) {
+            Division reason = body.addDivision("login-reason");
+
+            if (header != null) {
+                reason.setHead(message(header));
+            } else {
+                // Always have a head.
+                reason.setHead("Authentication Required");
+            }
+
+            if (message != null) {
+                reason.addPara(message(message));
+            }
+
+            if (characters != null) {
+                reason.addPara(characters);
+            }
+        }
+
+        Division login = body.addInteractiveDivision("login", contextPath + "/remoteuser-login", Division.METHOD_POST, "primary");
+        login.setHead(T_head1);
+
+        List list = login.addList("remoteuser-login", List.TYPE_FORM);
+
+        Text email = list.addItem().addText("username");
+        email.setRequired();
+        email.setLabel(T_userName);
+        if (previousUserName != null) {
+            email.setValue(previousUserName);
+            email.addError(T_error_bad_login);
+        }
+
+        Item item = list.addItem();
+        Password password = item.addPassword("ldap_password");
+        password.setRequired();
+        password.setLabel(T_password);
+
+        list.addLabel();
+        Item submit = list.addItem("login-in", null);
+        submit.addButton("submit").setValue(T_submit);
+
+    }
+}

--- a/dspace-xmlui/src/main/resources/aspects/EPerson/sitemap.xmap
+++ b/dspace-xmlui/src/main/resources/aspects/EPerson/sitemap.xmap
@@ -11,7 +11,7 @@
 
 <!-- 
 
-The EPerson Aspect is responsible for loging in, loging out, new user 
+The EPerson Aspect is responsible for logging in, logging out, new user 
 registration, forgotten passwords, editing profiles, and changing passwords.
 
 -->
@@ -42,6 +42,7 @@ registration, forgotten passwords, editing profiles, and changing passwords.
 			<map:action name="AuthenticateAction" src="org.dspace.app.xmlui.aspect.eperson.AuthenticateAction"/>
 			<map:action name="ShibbolethAction" src="org.dspace.app.xmlui.aspect.eperson.ShibbolethAction"/>
 			<map:action name="LDAPAuthenticateAction" src="org.dspace.app.xmlui.aspect.eperson.LDAPAuthenticateAction"/>
+                        <map:action name="RemoteUserAuthenticateAction" src="org.dspace.app.xmlui.aspect.eperson.RemoteUserAuthenticateAction"/>
 			<map:action name="UnAuthenticateAction" src="org.dspace.app.xmlui.aspect.eperson.UnAuthenticateAction"/>
 			<map:action name="LoginRedirect" src="org.dspace.app.xmlui.aspect.eperson.LoginRedirect" />
 		</map:actions>
@@ -97,26 +98,26 @@ registration, forgotten passwords, editing profiles, and changing passwords.
 			
 			
 			<!-- 
-					Add the basic navigation content to every page. This includes:
+					Add the basic navigation content to everypage. This includes:
 					
 					1) Metadata about the authenticated user.
-					   - This includes language information, whether the user is authenticated or not.
-					2) Navigation links for logging in and logging out.
+					   - This includes language information whether the user is authenticated or not.
+					2) Navigation links for loging in and logging out.
 					3) User contextual navigation items such as editing your profile, registering etc.
 					-->
 			<map:transform type="Navigation"/>
 			
 			
 			<!--
-					Perform a DSpace login. If the user's credentials are valid then the 
+					Preform a DSpace login. If the user's credentials are valid then the 
 					AuthenticateAction will succeed and a HTTP redirect will be sent to 
 					another page. If the credentials are not valid then a form will be 
 					displayed requesting new credentials.
 					
-					There are typically two methods by which the user arrives at this url, 
+					There are typicaly two methods by which the user arives at this url, 
 					one the user type in or followed a link straight to /login. The other 
 					is that they were trying to access a part of the system that required 
-					authentication. When this happens they will receive a redirect to the 
+					authentication. When this happens they will recieve a redirect to the 
 					/login form, as such they will not be presenting any credentials and 
 					will display the login form.  
 				 	-->
@@ -139,11 +140,11 @@ registration, forgotten passwords, editing profiles, and changing passwords.
 			
 			<!-- 
 				The following are matches to the URL returned by the stackable authentication
-				methods defined in the dspace.cnf file
+			     methods defined in the dspace.cnf file
 			-->
 			<map:match pattern="password-login">
 				<map:act type="AuthenticateAction">
-					<!-- Login succeeded, request will be forwarded. -->
+					<!-- Loggin succeeded, request will be forwarded. -->
 					<map:serialize type="xml"/>
 				</map:act>
 				
@@ -152,20 +153,20 @@ registration, forgotten passwords, editing profiles, and changing passwords.
 				<map:serialize type="xml"/>
 			</map:match>
 			
-         <map:match pattern="certificate-login">
-            <map:act type="AuthenticateAction">
-               <!-- Loggin succeeded, request will be forwarded. -->
-               <map:serialize type="xml"/>
-            </map:act>
-            
-            <!-- Login failed, try again. Show them static content from xml file --> 
-            <map:transform type="FailedAuthentication" />  
-            <map:serialize type="xml"/>
-         </map:match>
+                         <map:match pattern="certificate-login">
+                            <map:act type="AuthenticateAction">
+                               <!-- Loggin succeeded, request will be forwarded. -->
+                               <map:serialize type="xml"/>
+                            </map:act>
+
+                            <!-- Login failed, try again. Show them static content from xml file -->
+                            <map:transform type="FailedAuthentication" />
+                            <map:serialize type="xml"/>
+                         </map:match>
          
 			<map:match pattern="shibboleth-login">
 				<map:act type="ShibbolethAction">
-					<!-- Login succeeded, request will be forwarded. -->
+					<!-- Loggin succeeded, request will be forwarded. -->
 					<map:serialize type="xml"/>
 				</map:act>
 				
@@ -176,7 +177,7 @@ registration, forgotten passwords, editing profiles, and changing passwords.
 			
 			<map:match pattern="ldap-login">
 				<map:act type="LDAPAuthenticateAction">
-					<!-- Login succeeded, request will be forwarded. -->
+					<!-- Loggin succeeded, request will be forwarded. -->
 					<map:serialize type="xml"/>
 				</map:act>
 				
@@ -184,11 +185,22 @@ registration, forgotten passwords, editing profiles, and changing passwords.
 				<map:transform type="LDAPLogin"/>
 				<map:serialize type="xml"/>
 			</map:match>
+
+			<map:match pattern="remoteuser-login">
+				<map:act type="RemoteUserAuthenticateAction">
+					<!-- Loggin succeeded, request will be forwarded. -->
+					<map:serialize type="xml"/>
+				</map:act>
+
+				<!-- Login failed, try again. -->
+				<map:transform type="RemoteUserLogin"/>
+				<map:serialize type="xml"/>
+			</map:match>
 			
 			<!--
-					Log the user out. The UnAuthenticateAction can not fail and will 
-					always redirect the user to the DSpace homepage.
-					-->
+                        Log the user out. The UnAuthenticateAction can not fail and will
+                        always redirect the user to the DSpace homepage.
+                        -->
 			<map:match pattern="logout">
 				<map:act type="UnAuthenticateAction">
 					<!-- logout succeeded, request will be forwarded to the homepage. -->
@@ -199,7 +211,7 @@ registration, forgotten passwords, editing profiles, and changing passwords.
 			
 			
 			<!--
-					Registration multi-part form. The controller for this form is the 
+					Registration multi-part form. The controler for this form is the 
 					register flow script defined above.
 					-->
 			<map:match pattern="register/**">
@@ -244,7 +256,7 @@ registration, forgotten passwords, editing profiles, and changing passwords.
 			
 			
 			<!--
-					Registration multi-part form. The controller for this form is the 
+					Registration multi-part form. The controler for this form is the 
 					register flow script defined above.
 					-->
 			<map:match pattern="forgot/**">

--- a/dspace-xmlui/src/main/webapp/sitemap.xmap
+++ b/dspace-xmlui/src/main/webapp/sitemap.xmap
@@ -18,9 +18,7 @@
                         <map:generator name="DSpaceFeedGenerator" src="org.dspace.app.xmlui.cocoon.DSpaceFeedGenerator"/>
                         <map:generator name="DSpaceMETSGenerator" src="org.dspace.app.xmlui.cocoon.DSpaceMETSGenerator"/>
                         <map:generator name="DSpaceOREGenerator" src="org.dspace.app.xmlui.cocoon.DSpaceOREGenerator"/>
-                        <map:generator name="DescriptionOpenSearchGenerator" src="org.dspace.app.xmlui.opensearch.DescriptionOpenSearchGenerator"/>
-                        <map:generator name="StandardOpenSearchGenerator" src="org.dspace.app.xmlui.opensearch.StandardOpenSearchGenerator"/>
-                        <map:generator name="DiscoveryOpenSearchGenerator" src="org.dspace.app.xmlui.opensearch.DiscoveryOpenSearchGenerator"/>
+                        <map:generator name="OpenSearchGenerator" src="org.dspace.app.xmlui.cocoon.OpenSearchGenerator"/>
                         <map:generator name="notifying" src="org.apache.cocoon.sitemap.NotifyingGenerator"/>
                         <map:generator name="exception" src="org.apache.cocoon.generation.ExceptionGenerator"/>
                         <map:generator name="AJAXMenuGenerator"
@@ -93,9 +91,9 @@
                         <map:transformer name="stylesheet" src="org.dspace.app.xmlui.cocoon.StylesheetInstructionTransformer"/>
                         <map:transformer name="PasswordLogin" src="org.dspace.app.xmlui.aspect.eperson.PasswordLogin"/>
                         <map:transformer name="LDAPLogin" src="org.dspace.app.xmlui.aspect.eperson.LDAPLogin"/>
+                        <map:transformer name="RemoteUserLogin" src="org.dspace.app.xmlui.aspect.eperson.RemoteUserLogin"/>
                         <map:transformer name="notice" src="org.dspace.app.xmlui.aspect.general.NoticeTransformer"/>
                         <map:transformer name="NamespaceFilter" src="org.dspace.app.xmlui.cocoon.NamespaceFilterTransformer"/>
-                        <map:transformer name="RestrictedItem" src="org.dspace.app.xmlui.aspect.artifactbrowser.RestrictedItem"/>
                 </map:transformers>
                 <map:matchers default="wildcard">
                         <map:matcher logger="sitemap.matcher.wildcard" name="wildcard"
@@ -123,7 +121,6 @@
                                 <map:parameter name="ignore-missing-tables" value="true"/>
                         </map:matcher>
                         <map:matcher name="request" src="org.apache.cocoon.matching.RequestParameterMatcher"/>
-                        <map:matcher name="StatisticsAuthorizedMatcher" src="org.dspace.app.xmlui.aspect.statistics.StatisticsAuthorizedMatcher"/>
                 </map:matchers>
                 <map:selectors>
                         <map:selector name="browser" src="org.apache.cocoon.selection.BrowserSelector"
@@ -176,12 +173,9 @@
                         <map:selector logger="sitemap.selector.exception" name="exception" src="org.apache.cocoon.selection.ExceptionSelector">
                                 <exception name="not-found" class="org.apache.cocoon.ResourceNotFoundException"/>
                                 <exception name="invalid-continuation" class="org.apache.cocoon.components.flow.InvalidContinuationException"/>
-                                <exception name="bad-request" class="org.dspace.app.xmlui.utils.BadRequestException"/>
                                 <!-- The statement below tells the selector to unroll as much exceptions as possible -->
                                 <exception class="java.lang.Throwable" unroll="true"/>
                         </map:selector>
-                        <!-- AuthenticatedSelector for forcing user to login if not authorized - PMD -->
-                        <map:selector name="AuthenticatedSelector" src="org.dspace.app.xmlui.aspect.general.AuthenticatedSelector"/>
                 </map:selectors>
                 <map:readers default="resource">
                     <map:reader name="resource" src="org.apache.cocoon.reading.ResourceReader"
@@ -191,14 +185,10 @@
                     <map:reader name="BitstreamReader" src="org.dspace.app.xmlui.cocoon.BitstreamReader"/>
                     <map:reader name="ExportReader" src="org.dspace.app.xmlui.cocoon.ItemExportDownloadReader"/>
                     <map:reader name="MetadataExportReader" src="org.dspace.app.xmlui.cocoon.MetadataExportReader"/>
-
-                    <map:reader name="CSVOutputter" src="org.dspace.app.xmlui.aspect.statisticsElasticSearch.CSVOutputter"/>
-
                     <map:reader name="OpenURLReader" src="org.dspace.app.xmlui.cocoon.OpenURLReader"/>
                     <map:reader name="SitemapReader" src="org.dspace.app.xmlui.cocoon.SitemapReader"/>
                     <map:reader name="ConcatenationReader" src="org.dspace.app.xmlui.cocoon.ConcatenationReader"/>
                     <map:reader name="JQueryLoaderReader" src="org.dspace.app.xmlui.utils.JQueryLoaderReader"/>
-                    <map:reader name="JSONControlledVocabularyReader" src="org.dspace.app.xmlui.cocoon.JSONControlledVocabularyReader"/>
                 </map:readers>
                 <map:actions>
                         <map:action name="locale" src="org.dspace.app.xmlui.cocoon.DSpaceLocaleAction"/>
@@ -353,7 +343,7 @@
 
 
                         <!--
-                                For URL compatibility with the JSPUI, redirect these old url to their new locations.
+                                For URL compatability with the JSPUI, redirect these old url to their new locations.
 
                                 /bitstream/[handlePrefix]/[handlePostfix]/[sequence]/[name]
                                 /html/[handlePrefix]/[handePostfix]/[name]
@@ -387,57 +377,10 @@
                                 </map:read>
                         </map:match>
 
-                        <map:match pattern="handle/*/*/stats/csv">
-                            <map:match type="StatisticsAuthorizedMatcher" pattern="READ">
-                                <map:read type="CSVOutputter"/>
-                            </map:match>
-
-                            <map:match type="StatisticsAuthorizedMatcher" pattern="!READ">
-                                <map:select type="AuthenticatedSelector">
-                                    <map:when test="eperson">
-                                        <map:transform type="RestrictedItem"/>
-                                        <map:serialize/>
-                                    </map:when>
-                                    <map:otherwise>
-                                        <map:act type="StartAuthentication">
-                                            <map:parameter name="header" value="xmlui.ArtifactBrowser.RestrictedItem.auth_header"/>
-                                            <map:parameter name="message" value="xmlui.ArtifactBrowser.RestrictedItem.auth_message"/>
-                                        </map:act>
-                                        <map:serialize/>
-                                    </map:otherwise>
-                                </map:select>
-                            </map:match>
-                        </map:match>
-
-                        <map:match pattern="handle/*/*/stats/csv/*">
-                            <map:match type="StatisticsAuthorizedMatcher" pattern="READ">
-                                <map:read type="CSVOutputter"/>
-                            </map:match>
-
-                            <map:match type="StatisticsAuthorizedMatcher" pattern="!READ">
-                                <map:select type="AuthenticatedSelector">
-                                    <map:when test="eperson">
-                                        <map:transform type="RestrictedItem"/>
-                                        <map:serialize/>
-                                    </map:when>
-                                    <map:otherwise>
-                                        <map:act type="StartAuthentication">
-                                            <map:parameter name="header" value="xmlui.ArtifactBrowser.RestrictedItem.auth_header"/>
-                                            <map:parameter name="message" value="xmlui.ArtifactBrowser.RestrictedItem.auth_message"/>
-                                        </map:act>
-                                        <map:serialize/>
-                                    </map:otherwise>
-                                </map:select>
-                            </map:match>
-                        </map:match>
-
                         <map:match pattern="JSON/discovery/**">
                             <map:mount check-reload="no" src="aspects/json-solr.xmap" uri-prefix="JSON/discovery/"/>
                         </map:match>
 
-                        <map:match pattern="JSON/controlled-vocabulary">
-                            <map:read type="JSONControlledVocabularyReader"/>
-                        </map:match>
                 </map:pipeline>
 
                 <!-- new AJAX menu (choices) responses for metadata authority control -->
@@ -532,40 +475,36 @@
                         <map:serialize type="xml"/>
                     </map:match>
 
-                    <!-- OpenSearch description document for whole repo or community/collection -->
-                    <map:match pattern="open-search/description.xml">
-                        <map:generate type="DescriptionOpenSearchGenerator"/>
-                        <map:serialize type="opensearch"/>
-                    </map:match>
-
-                    <!-- OpenSearch results document for whole repo or community/collection -->
+                    <!-- OpenSearch results for whole repo or community/collection -->
                     <map:match pattern="open-search/**">
-                        <map:match pattern="open-search/">
-                            <map:generate type="StandardOpenSearchGenerator"/>
+
+                        <map:match pattern="open-search/description.xml">
+                            <map:generate type="OpenSearchGenerator">
+                                <map:parameter name="type" value="description"/>
+                            </map:generate>
+                            <map:serialize type="opensearch"/>
                         </map:match>
 
-                        <map:match pattern="open-search/discover">
-                            <map:generate type="DiscoveryOpenSearchGenerator"/>
+                        <map:match pattern="open-search/**">
+                            <map:generate type="OpenSearchGenerator"/>
+                            <map:act type="locale">
+                                  <map:transform type="i18n">
+                                          <map:parameter name="locale" value="{locale}"/>
+                                  </map:transform>
+                            </map:act>
+                            <map:select type="request-parameter">
+                                <map:parameter name="parameter-name" value="format"/>
+                                <map:when test="rss">
+                                    <map:serialize type="rss"/>
+                                </map:when>
+                                <map:when test="atom">
+                                    <map:serialize type="atom"/>
+                                </map:when>
+                                <map:otherwise>
+                                    <map:serialize type="html"/>
+                                </map:otherwise>
+                            </map:select>
                         </map:match>
-
-                        <map:act type="locale">
-                            <map:transform type="i18n">
-                                <map:parameter name="locale" value="{locale}"/>
-                            </map:transform>
-                        </map:act>
-
-                        <map:select type="request-parameter">
-                            <map:parameter name="parameter-name" value="format"/>
-                            <map:when test="rss">
-                                <map:serialize type="rss"/>
-                            </map:when>
-                            <map:when test="atom">
-                                <map:serialize type="atom"/>
-                            </map:when>
-                            <map:otherwise>
-                                <map:serialize type="xml"/>
-                            </map:otherwise>
-                        </map:select>
                     </map:match>
 
                     <!-- HTML Sitemaps and Sitemaps.org Sitemaps for whole repo -->
@@ -655,20 +594,6 @@
 
                 <map:handle-errors>
                         <map:select type="exception">
-
-                                <map:when test="bad-request">
-                                        <map:generate type="exception"/>
-                                        <map:transform src="exception2html.xslt">
-                                                <map:parameter name="contextPath" value="{request:contextPath}"/>
-                                                <map:parameter name="pageTitle" value="Bad request"/>
-                                        </map:transform>
-                                        <map:act type="locale">
-                                            <map:transform type="i18n">
-                                                    <map:parameter name="locale" value="{locale}"/>
-                                            </map:transform>
-                                        </map:act>
-                                        <map:serialize type="xhtml" status-code="400"/>
-                                </map:when>
 
                                 <map:when test="not-found">
                                         <map:generate type="exception"/>


### PR DESCRIPTION
Bespoke authentication module 'RemoteUser' uses HTTPServletRequest.getRemoteUser() to acquire username from tomcat after user has been authenticated by SSO. 

Point your SSO at /repository/remoteuser-login

Added files: 
dspace-api/src/main/java/org/dspace/authenticate/RemoteUserAuthentication.java
dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/aspect/eperson/RemoteUserAuthenticateAction.java
dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/aspect/eperson/RemoteUserLogin.java

Modified files:
dspace-xmlui-api/src/main/resources/aspects/EPerson/sitemap.xmap
dspace-xmlui-webapp/src/main/webapp/sitemap.xmap

System changes: add the parameter tomcatAuthentication="false" to the ajp connector in /opt/tomcat6/conf/server.xml 

Tested and working in Dspace 1.8.2
