### PR TITLE
Corrected LDAP enabling issue.

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/LDAPServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/LDAPServlet.java
@@ -46,7 +46,7 @@ public class LDAPServlet extends DSpaceServlet
         throws ServletException, IOException, SQLException, AuthorizeException
     {
         // check if ldap is enables and forward to the correct login form
-        boolean ldap_enabled = ConfigurationManager.getBooleanProperty("ldap.enable");
+        boolean ldap_enabled = ConfigurationManager.getBooleanProperty("authentication-ldap", "enable", false);
         if (ldap_enabled)
         {
             JSPManager.showJSP(request, response, "/login/ldap.jsp");

--- a/dspace/config/modules/authentication-ldap.cfg
+++ b/dspace/config/modules/authentication-ldap.cfg
@@ -47,9 +47,9 @@ enable = false
 autoregister = true
 
 
-# This is the url to the institution's ldap server. The /o=myu.edu
-# may or may not be required depending on the LDAP server setup.
-# A server may also require the ldaps:// protocol.
+# This is the url to the institution's ldap server. The "o=myu.edu"
+# part may or may not be required depending on the LDAP server setup,
+# but make sure to include the slash after domain name.  
 #provider_url = ldap://ldap.myu.edu/o=myu.edu
 
 # This is the unique identifier field in the LDAP directory

--- a/dspace/config/modules/authentication-ldap.cfg
+++ b/dspace/config/modules/authentication-ldap.cfg
@@ -50,6 +50,7 @@ autoregister = true
 # This is the url to the institution's ldap server. The "o=myu.edu"
 # part may or may not be required depending on the LDAP server setup,
 # but make sure to include the slash after domain name.  
+# A server may also require the ldaps:// protocol. 
 #provider_url = ldap://ldap.myu.edu/o=myu.edu
 
 # This is the unique identifier field in the LDAP directory

--- a/dspace/config/modules/authentication-ldap.cfg
+++ b/dspace/config/modules/authentication-ldap.cfg
@@ -47,7 +47,7 @@ enable = false
 autoregister = true
 
 
-# This is the url to the institution's ldap server. The o=myu.edu
+# This is the url to the institution's ldap server. The /o=myu.edu
 # may or may not be required depending on the LDAP server setup.
 # A server may also require the ldaps:// protocol.
 #provider_url = ldap://ldap.myu.edu/o=myu.edu

--- a/dspace/config/modules/authentication-ldap.cfg
+++ b/dspace/config/modules/authentication-ldap.cfg
@@ -47,7 +47,7 @@ enable = false
 autoregister = true
 
 
-# This is the url to the institution's ldap server. The /o=myu.edu
+# This is the url to the institution's ldap server. The o=myu.edu
 # may or may not be required depending on the LDAP server setup.
 # A server may also require the ldaps:// protocol.
 #provider_url = ldap://ldap.myu.edu/o=myu.edu


### PR DESCRIPTION
Called the correct overloaded function which will search for "enable" in properties loaded from authentication-ldap.cfg
Function with single parameter was searching in properties loaded from "dspace.cfg"

This issue is discussed here http://dspace.2283337.n4.nabble.com/LDAP-is-not-enabling-td4662146.html
