### PR TITLE
DS-1469 Read configuration files (dspace.cfg + emails templates) in UTF-8 as default

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/ConfigurationManager.java
+++ b/dspace-api/src/main/java/org/dspace/core/ConfigurationManager.java
@@ -597,7 +597,7 @@ public class ConfigurationManager
         BufferedReader reader = null;
         try
         {
-            reader = new BufferedReader(new FileReader(emailFile));
+            reader = new BufferedReader(new InputStreamReader(new FileInputStream(emailFile), "UTF-8"));
 
             boolean more = true;
 
@@ -921,7 +921,7 @@ public class ConfigurationManager
             {
                 properties = new Properties();
                 is = url.openStream();
-                properties.load(is);
+                properties.load(new InputStreamReader(is, "UTF-8"));
 
                 // walk values, interpolating any embedded references.
                 for (Enumeration<?> pe = properties.propertyNames(); pe.hasMoreElements(); )


### PR DESCRIPTION
Filereader assumes default charset of ISO-8859-1. Since everything else in Dspace is UTF-8 as default this is a bit confusing.

https://jira.duraspace.org/browse/DS-1469
