### PR TITLE
[DS-1519] Workflow and submission process selection based on community hierarchy

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/SubmissionConfigReader.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SubmissionConfigReader.java
@@ -16,6 +16,7 @@ import javax.xml.parsers.*;
 
 import org.apache.log4j.Logger;
 
+import org.dspace.content.Collection;
 import org.dspace.core.ConfigurationManager;
 
 /**
@@ -150,12 +151,20 @@ public class SubmissionConfigReader
      * @throws ServletException
      *             if no default submission process configuration defined
      */
-    public SubmissionConfig getSubmissionConfig(String collectionHandle,
+    public SubmissionConfig getSubmissionConfig(Collection collection,
             boolean isWorkflow) throws ServletException
     {
         // get the name of the submission process config for this collection
-        String submitName = collectionToSubmissionConfig
-                .get(collectionHandle);
+    	String submitName;
+    	try 
+    	{
+    		submitName = Util.findDefinitionInMap(collection, collectionToSubmissionConfig);
+    	} 
+    	catch(Exception e) 
+    	{
+    		throw new ServletException("Error getting submission process definition", e);
+    	}
+    	
         if (submitName == null)
         {
             submitName = collectionToSubmissionConfig
@@ -308,13 +317,15 @@ public class SubmissionConfigReader
             Node nd = nl.item(i);
             if (nd.getNodeName().equals("name-map"))
             {
+            	// preserves the collection-handle attribute for backward compatibility
                 String id = getAttribute(nd, "collection-handle");
+                String handle = getAttribute(nd, "handle");
                 String value = getAttribute(nd, "submission-name");
                 String content = getValue(nd);
-                if (id == null)
+                if (id == null && handle == null)
                 {
                     throw new SAXException(
-                            "name-map element is missing collection-handle attribute in 'item-submission.xml'");
+                            "name-map element is missing handle attribute in 'item-submission.xml'");
                 }
                 if (value == null)
                 {
@@ -326,7 +337,7 @@ public class SubmissionConfigReader
                     throw new SAXException(
                             "name-map element has content in 'item-submission.xml', it should be empty.");
                 }
-                collectionToSubmissionConfig.put(id, value);
+                collectionToSubmissionConfig.put( handle != null ? handle : id , value);
             } // ignore any child node that isn't a "name-map"
         }
     }

--- a/dspace-api/src/main/java/org/dspace/app/util/SubmissionInfo.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SubmissionInfo.java
@@ -611,7 +611,7 @@ public class SubmissionInfo extends HashMap
             // reload the proper Submission process config
             // (by reading the XML config file)
             subInfo.submissionConfig = submissionConfigReader
-                    .getSubmissionConfig(subInfo.getCollectionHandle(), subInfo
+                    .getSubmissionConfig(subInfo.getSubmissionItem().getCollection(), subInfo
                             .isInWorkflow());
 
             // cache this new submission process configuration

--- a/dspace-api/src/main/java/org/dspace/ctask/general/RequiredMetadata.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/RequiredMetadata.java
@@ -18,6 +18,7 @@ import org.dspace.app.util.DCInput;
 import org.dspace.app.util.DCInputSet;
 import org.dspace.app.util.DCInputsReader;
 import org.dspace.app.util.DCInputsReaderException;
+import org.dspace.content.Collection;
 import org.dspace.content.DCValue;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
@@ -79,7 +80,7 @@ public class RequiredMetadata extends AbstractCurationTask
                     handle = "in workflow";
                 }
                 sb.append("Item: ").append(handle);
-                for (String req : getReqList(item.getOwningCollection().getHandle()))
+                for (String req : getReqList(item.getOwningCollection()))
                 {
                     DCValue[] vals = item.getMetadata(req);
                     if (vals.length == 0)
@@ -112,17 +113,13 @@ public class RequiredMetadata extends AbstractCurationTask
         }
     }
     
-    private List<String> getReqList(String handle) throws DCInputsReaderException
+    private List<String> getReqList(Collection collection) throws DCInputsReaderException
     {
-        List<String> reqList = reqMap.get(handle);
-        if (reqList == null)
-        {
-            reqList = reqMap.get("default");
-        }
+        List<String> reqList = reqMap.get(collection.getHandle());
         if (reqList == null)
         {
             reqList = new ArrayList<String>();
-            DCInputSet inputs = reader.getInputs(handle);
+            DCInputSet inputs = reader.getInputs(collection);
             for (int i = 0; i < inputs.getNumberPages(); i++)
             {
                 for (DCInput input : inputs.getPageRows(i, true, true))
@@ -142,7 +139,7 @@ public class RequiredMetadata extends AbstractCurationTask
                     }
                 }
             }
-            reqMap.put(inputs.getFormName(), reqList);
+            reqMap.put(collection.getHandle(), reqList);
         }
         return reqList;
     }

--- a/dspace-api/src/main/java/org/dspace/submit/step/DescribeStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/DescribeStep.java
@@ -129,7 +129,7 @@ public class DescribeStep extends AbstractProcessingStep
         DCInput[] inputs = null;
         try
         {
-            inputs = inputsReader.getInputs(c.getHandle()).getPageRows(
+            inputs = inputsReader.getInputs(c).getPageRows(
                     currentPage - 1,
                     subInfo.getSubmissionItem().hasMultipleTitles(),
                     subInfo.getSubmissionItem().isPublishedBefore());
@@ -374,19 +374,18 @@ public class DescribeStep extends AbstractProcessingStep
     public int getNumberOfPages(HttpServletRequest request,
             SubmissionInfo subInfo) throws ServletException
     {
-        // by default, use the "default" collection handle
-        String collectionHandle = DCInputsReader.DEFAULT_COLLECTION;
+        // by default, prepare to use the "default" form definition
+        Collection collection = null;
 
         if (subInfo.getSubmissionItem() != null)
         {
-            collectionHandle = subInfo.getSubmissionItem().getCollection()
-                    .getHandle();
+            collection = subInfo.getSubmissionItem().getCollection();
         }
 
         // get number of input pages (i.e. "Describe" pages)
         try
         {
-            return getInputsReader().getNumberInputPages(collectionHandle);
+            return getInputsReader().getNumberInputPages(collection);
         }
         catch (DCInputsReaderException e)
         {

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/MyDSpaceServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/MyDSpaceServlet.java
@@ -541,8 +541,7 @@ public class MyDSpaceServlet extends DSpaceServlet
             // associated with
             Collection c = wsi.getCollection();
             SubmissionConfigReader subConfigReader = new SubmissionConfigReader();
-            SubmissionConfig subConfig = subConfigReader.getSubmissionConfig(c
-                    .getHandle(), false);
+            SubmissionConfig subConfig = subConfigReader.getSubmissionConfig(c, false);
 
             // Set the "stage_reached" column on the workspace item
             // to the LAST page of the LAST step in the submission process

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/submit/step/JSPDescribeStep.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/submit/step/JSPDescribeStep.java
@@ -209,8 +209,7 @@ public class JSPDescribeStep extends JSPStep
         // requires configurable form info per collection
         try
         {
-            request.setAttribute("submission.inputs", DescribeStep.getInputsReader(formFileName).getInputs(c
-                    .getHandle()));
+            request.setAttribute("submission.inputs", DescribeStep.getInputsReader(formFileName).getInputs(c));
         }
         catch (DCInputsReaderException e)
         {

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/submit/step/JSPInitialQuestionsStep.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/submit/step/JSPInitialQuestionsStep.java
@@ -203,8 +203,7 @@ public class JSPInitialQuestionsStep extends JSPStep
             DCInputsReader inputsReader = new DCInputsReader();
              
             // load the proper submission inputs to be used by the JSP
-            request.setAttribute("submission.inputs", inputsReader.getInputs(c
-                    .getHandle()));
+            request.setAttribute("submission.inputs", inputsReader.getInputs(c));
         }
         catch (DCInputsReaderException e)
         {

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/submit/step/JSPUploadStep.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/submit/step/JSPUploadStep.java
@@ -131,8 +131,7 @@ public class JSPUploadStep extends JSPStep
             try
             {
                 DCInputsReader inputsReader = new DCInputsReader();
-                request.setAttribute("submission.inputs", inputsReader.getInputs(c
-                        .getHandle()));
+                request.setAttribute("submission.inputs", inputsReader.getInputs(c));
             }
             catch (DCInputsReaderException e)
             {
@@ -247,8 +246,7 @@ public class JSPUploadStep extends JSPStep
                         {
                             Collection c = subInfo.getSubmissionItem().getCollection();
                             DCInputsReader inputsReader = new DCInputsReader();
-                            request.setAttribute("submission.inputs", inputsReader
-                                    .getInputs(c.getHandle()));
+                            request.setAttribute("submission.inputs", inputsReader.getInputs(c));
                         }
                         catch (DCInputsReaderException e)
                         {
@@ -268,8 +266,7 @@ public class JSPUploadStep extends JSPStep
                     {
                         Collection c = subInfo.getSubmissionItem().getCollection();
                         DCInputsReader inputsReader = new DCInputsReader();
-                        request.setAttribute("submission.inputs", inputsReader
-                                .getInputs(c.getHandle()));
+                        request.setAttribute("submission.inputs", inputsReader.getInputs(c));
                     }
                     catch (DCInputsReaderException e)
                     {
@@ -288,8 +285,7 @@ public class JSPUploadStep extends JSPStep
                     {
                         Collection c = subInfo.getSubmissionItem().getCollection();
                         DCInputsReader inputsReader = new DCInputsReader();
-                        request.setAttribute("submission.inputs", inputsReader
-                                .getInputs(c.getHandle()));
+                        request.setAttribute("submission.inputs", inputsReader.getInputs(c));
                     }
                     catch (DCInputsReaderException e)
                     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/DescribeStep.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/DescribeStep.java
@@ -164,7 +164,7 @@ public class DescribeStep extends AbstractSubmissionStep
                 DCInput[] inputs;
                 try
                 {
-                        inputSet = getInputsReader().getInputs(submission.getCollection().getHandle());
+                        inputSet = getInputsReader().getInputs(submission.getCollection());
                         inputs = inputSet.getPageRows(getPage()-1, submission.hasMultipleTitles(), submission.isPublishedBefore());
                 }
                 catch (DCInputsReaderException se)
@@ -317,7 +317,7 @@ public class DescribeStep extends AbstractSubmissionStep
         DCInputSet inputSet = null;
         try
         {
-            inputSet = getInputsReader().getInputs(submission.getCollection().getHandle());
+            inputSet = getInputsReader().getInputs(submission.getCollection());
         }
         catch (DCInputsReaderException se)
         {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/workflow/FlowUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/workflow/FlowUtils.java
@@ -189,7 +189,7 @@ public class FlowUtils {
             // Load the Submission Process for the collection this WSI is associated with
             Collection c = wsi.getCollection();
             SubmissionConfigReader subConfigReader = new SubmissionConfigReader();
-            SubmissionConfig subConfig = subConfigReader.getSubmissionConfig(c.getHandle(), false);
+            SubmissionConfig subConfig = subConfigReader.getSubmissionConfig(c, false);
 
             // Set the "stage_reached" column on the workspace item
             // to the LAST page of the LAST step in the submission process

--- a/dspace/config/input-forms.dtd
+++ b/dspace/config/input-forms.dtd
@@ -6,7 +6,8 @@
  <!ELEMENT form-map (name-map)* >
  <!ELEMENT name-map EMPTY >
  <!ATTLIST name-map 
-           collection-handle CDATA #REQUIRED
+           handle CDATA #IMPLIED
+           collection-handle CDATA #IMPLIED
            form-name NMTOKEN #REQUIRED>
 
  <!ELEMENT form-definitions (form)+ >

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -14,7 +14,7 @@
  <!-- the mapping for handle "default".                                    -->
 
  <form-map>
-   <name-map collection-handle="default" form-name="traditional" />
+   <name-map handle="default" form-name="traditional" />
  </form-map>
 
 

--- a/dspace/config/item-submission.dtd
+++ b/dspace/config/item-submission.dtd
@@ -10,8 +10,9 @@
  <!ELEMENT submission-map (name-map+) >
  
  <!ELEMENT name-map EMPTY >
- <!ATTLIST name-map 
-           collection-handle CDATA #REQUIRED
+ <!ATTLIST name-map
+           handle CDATA #IMPLIED
+           collection-handle CDATA #IMPLIED
            submission-name NMTOKEN #REQUIRED>
 
  <!-- 'step-definitions' must contain at least one 'step' node -->

--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -17,7 +17,7 @@
  <!-- which does not appear in this map will be associated with the mapping-->
  <!-- for handle "default".                                                -->
  <submission-map>
-   <name-map collection-handle="default" submission-name="traditional" />
+   <name-map handle="default" submission-name="traditional" />
  </submission-map>
 
 


### PR DESCRIPTION
The main goal of this patch is to be able to define a submission process, a form definition, or a workflow process, based also on community's handles, allowing subcommunities and collections to inherit those definitions.
This patch changes the lookup process in order to check for collection's handle first, and then for its parent community's handle if the first didn't match any definition. This is the same for form definitions (input-forms.xml), submission processes (item-submission.xml) and workflow processes (workflow.xml).
According to this, it was also modified the attribute's name used to bound a definition to a handle: before it was "collection" or "collection-handle", now it's just "handle" (old attribute names are still supported for compatibility). This would need to be documented properly.

I'd like to hear your thoughts on this
