### PR TITLE
[DS-1269] EmailService to encapsulate the sending of mail

### DIFF
--- a/dspace-api/src/main/java/org/dspace/checker/DailyReportEmailer.java
+++ b/dspace-api/src/main/java/org/dspace/checker/DailyReportEmailer.java
@@ -12,21 +12,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Date;
 import java.util.GregorianCalendar;
-import java.util.Properties;
-
-import javax.activation.DataHandler;
-import javax.activation.DataSource;
-import javax.activation.FileDataSource;
-import javax.mail.BodyPart;
-import javax.mail.Message;
 import javax.mail.MessagingException;
-import javax.mail.Multipart;
-import javax.mail.Session;
-import javax.mail.Transport;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeBodyPart;
-import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeMultipart;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;

--- a/dspace-api/src/main/java/org/dspace/core/Email.java
+++ b/dspace-api/src/main/java/org/dspace/core/Email.java
@@ -19,16 +19,14 @@ import java.util.Date;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Properties;
+
 import javax.activation.DataHandler;
 import javax.activation.FileDataSource;
 import javax.mail.Address;
-import javax.mail.Authenticator;
 import javax.mail.BodyPart;
 import javax.mail.Message;
 import javax.mail.MessagingException;
 import javax.mail.Multipart;
-import javax.mail.PasswordAuthentication;
 import javax.mail.Session;
 import javax.mail.Transport;
 import javax.mail.internet.InternetAddress;

--- a/dspace-api/src/main/java/org/dspace/core/Email.java
+++ b/dspace-api/src/main/java/org/dspace/core/Email.java
@@ -19,7 +19,6 @@ import java.util.Date;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.List;
-
 import javax.activation.DataHandler;
 import javax.activation.FileDataSource;
 import javax.mail.Address;
@@ -33,6 +32,9 @@ import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
+import org.apache.log4j.Logger;
+import org.dspace.services.EmailService;
+import org.dspace.utils.DSpace;
 
 /**
  * Class representing an e-mail message, also used to send e-mails.

--- a/dspace-services/pom.xml
+++ b/dspace-services/pom.xml
@@ -47,6 +47,10 @@
             <artifactId>servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.mail</groupId>
+            <artifactId>mail</artifactId>
+        </dependency>
         <!-- SPECIAL CASE - need JUNIT at build time and testing time -->
         <dependency>
             <groupId>junit</groupId>

--- a/dspace-services/src/main/java/org/dspace/services/EmailService.java
+++ b/dspace-services/src/main/java/org/dspace/services/EmailService.java
@@ -1,0 +1,23 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+package org.dspace.services;
+
+import javax.mail.Session;
+
+/**
+ *
+ * @author mwood
+ */
+public interface EmailService
+{
+    /**
+     * Provide a reference to the JavaMail session.
+     */
+    Session getSession();
+}

--- a/dspace-services/src/main/java/org/dspace/services/email/EmailServiceImpl.java
+++ b/dspace-services/src/main/java/org/dspace/services/email/EmailServiceImpl.java
@@ -1,0 +1,137 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.services.email;
+
+import java.util.Properties;
+import javax.mail.Authenticator;
+import javax.mail.PasswordAuthentication;
+import javax.mail.Session;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.EmailService;
+import org.dspace.utils.DSpace;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provides mail sending services through JavaMail.  If a {@link javax.mail.Session}
+ * instance is provided through JNDI, it will be used.  If not, then a session
+ * will be created from DSpace configuration data ({@code mail.server} etc.)
+ *
+ * @author mwood
+ */
+public class EmailServiceImpl
+        extends Authenticator
+        implements EmailService
+{
+    private Session session = null;
+
+    /** Lazy initialized since the service manager won't be running yet. */
+    private static ConfigurationService cfg = null;
+
+    private static final Logger logger = (Logger) LoggerFactory.getLogger(EmailServiceImpl.class);
+
+    /**
+     * Provide a reference to the JavaMail session.
+     *
+     * @return the managed Session, or null if none could be created.
+     */
+    @Override
+    public Session getSession()
+    {
+        init();
+        return session;
+    }
+
+    private void init()
+    {
+        if (null != session)
+        {
+            return;
+        }
+
+        if (null == cfg)
+        {
+            cfg = new DSpace().getConfigurationService();
+        }
+
+        // See if there is already a Session in our environment
+        String sessionName = cfg.getProperty("mail.session.name");
+        if (null == sessionName)
+        {
+            sessionName = "Session";
+        }
+        try
+        {
+            InitialContext ctx = new InitialContext(null);
+            session = (Session) ctx.lookup("java:comp/env/mail/" + sessionName);
+        } catch (NamingException ex)
+        {
+            logger.warn("Couldn't get an email session from environment:  {}",
+                    ex.getMessage());
+        }
+
+        if (null != session)
+        {
+            logger.info("Email session retrieved from environment.");
+        }
+        else
+        { // No Session provided, so create one
+            logger.info("Initializing an email session from configuration.");
+            Properties props = new Properties();
+            props.put("mail.transport.protocol", "smtp");
+            String host = cfg.getProperty("mail.server");
+            if (null != host)
+            {
+                props.put("mail.host", cfg.getProperty("mail.server"));
+            }
+            String port = cfg.getProperty("mail.server.port");
+            if (null != port)
+            {
+                props.put("mail.smtp.port", port);
+            }
+
+            if (null == cfg.getProperty("mail.server.username"))
+            {
+                session = Session.getInstance(props);
+            }
+            else
+            {
+                session = Session.getInstance(null, this);
+            }
+
+            // Set extra configuration properties
+            String extras = cfg.getProperty("mail.extraproperties");
+            if ((extras != null) && (!"".equals(extras.trim())))
+            {
+                String arguments[] = extras.split(",");
+                String key, value;
+                for (String argument : arguments)
+                {
+                    key = argument.substring(0, argument.indexOf('=')).trim();
+                    value = argument.substring(argument.indexOf('=') + 1).trim();
+                    props.put(key, value);
+                }
+            }
+        }
+    }
+
+    @Override
+    protected PasswordAuthentication getPasswordAuthentication()
+    {
+        if (null == cfg)
+        {
+            cfg = new DSpace().getConfigurationService();
+        }
+
+        return new PasswordAuthentication(
+                cfg.getProperty("mail.server.username"),
+                cfg.getProperty("mail.server.password"));
+    }
+}

--- a/dspace-services/src/main/java/org/dspace/services/email/EmailServiceImpl.java
+++ b/dspace-services/src/main/java/org/dspace/services/email/EmailServiceImpl.java
@@ -103,7 +103,8 @@ public class EmailServiceImpl
             }
             else
             {
-                session = Session.getInstance(null, this);
+                props.put("mail.smtp.auth", "true");
+                session = Session.getInstance(props, this);
             }
 
             // Set extra configuration properties

--- a/dspace-services/src/main/java/org/dspace/services/email/package-info.java
+++ b/dspace-services/src/main/java/org/dspace/services/email/package-info.java
@@ -1,0 +1,13 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+/**
+ * Manages a JavaMail session for code which wants to send email.
+ */
+
+package org.dspace.services.email;

--- a/dspace-services/src/main/resources/spring/spring-dspace-core-services.xml
+++ b/dspace-services/src/main/resources/spring/spring-dspace-core-services.xml
@@ -45,4 +45,11 @@
 	<!-- EVENTS -->
     <bean id="org.dspace.services.EventService" class="org.dspace.services.events.SystemEventService" />
 
+    <!-- EMAIL -->
+    <bean id="org.dspace.services.email.EmailServiceImpl"
+        class="org.dspace.services.email.EmailServiceImpl">
+        <property name="cfg"
+                  ref="org.dspace.services.ConfigurationService" />
+    </bean>
+
 </beans>

--- a/dspace-services/src/test/java/org/dspace/services/email/EmailServiceImplTest.java
+++ b/dspace-services/src/test/java/org/dspace/services/email/EmailServiceImplTest.java
@@ -61,7 +61,7 @@ public class EmailServiceImplTest
     {
         System.out.println("getSession");
         Session session;
-        EmailService instance = getService(EmailService.class);
+        EmailService instance = getService(EmailServiceImpl.class);
 
         // Try to get a Session
         session = instance.getSession();
@@ -88,7 +88,7 @@ public class EmailServiceImplTest
         cfg.setProperty(CFG_USERNAME, USERNAME);
         cfg.setProperty(CFG_PASSWORD, PASSWORD);
 
-        EmailServiceImpl instance = (EmailServiceImpl) getService(EmailService.class);
+        EmailServiceImpl instance = (EmailServiceImpl) getService(EmailServiceImpl.class);
 
         PasswordAuthentication result = instance.getPasswordAuthentication();
         assertNotNull(" null returned", result);

--- a/dspace-services/src/test/java/org/dspace/services/email/EmailServiceImplTest.java
+++ b/dspace-services/src/test/java/org/dspace/services/email/EmailServiceImplTest.java
@@ -1,0 +1,102 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+package org.dspace.services.email;
+
+import javax.mail.MessagingException;
+import javax.mail.PasswordAuthentication;
+import javax.mail.Session;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.EmailService;
+import org.dspace.test.DSpaceAbstractKernelTest;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
+
+/**
+ *
+ * @author mwood
+ */
+public class EmailServiceImplTest
+        extends DSpaceAbstractKernelTest
+{
+    private static final String USERNAME = "auser";
+    private static final String PASSWORD = "apassword";
+
+    /*
+    @BeforeClass
+    public static void setUpClass()
+            throws Exception
+    {
+    }
+
+    @AfterClass
+    public static void tearDownClass()
+            throws Exception
+    {
+    }
+
+    @Before
+    public void setUp()
+    {
+    }
+
+    @After
+    public void tearDown()
+    {
+    }
+    */
+
+    /**
+     * Test of getSession method, of class EmailService.
+     */
+    @Test
+    public void testGetSession()
+            throws MessagingException
+    {
+        System.out.println("getSession");
+        Session session;
+        EmailService instance = getService(EmailService.class);
+
+        // Try to get a Session
+        session = instance.getSession();
+        assertNotNull(" getSession returned null", session);
+    }
+
+    private static final String CFG_USERNAME = "mail.server.username";
+    private static final String CFG_PASSWORD = "mail.server.password";
+
+    /**
+     * Test of getPasswordAuthentication method, of class EmailServiceImpl.
+     */
+    @Test
+    public void testGetPasswordAuthentication()
+    {
+        System.out.println("getPasswordAuthentication");
+        ConfigurationService cfg = getKernel().getConfigurationService();
+
+        // Save existing values.
+        String oldUsername = cfg.getProperty(CFG_USERNAME);
+        String oldPassword = cfg.getProperty(CFG_PASSWORD);
+
+        // Set known values.
+        cfg.setProperty(CFG_USERNAME, USERNAME);
+        cfg.setProperty(CFG_PASSWORD, PASSWORD);
+
+        EmailServiceImpl instance = (EmailServiceImpl) getService(EmailService.class);
+
+        PasswordAuthentication result = instance.getPasswordAuthentication();
+        assertNotNull(" null returned", result);
+        assertEquals(" username does not match configuration", result.getUserName(), USERNAME);
+        assertEquals(" password does not match configuration", result.getPassword(), PASSWORD);
+
+        // Restore old values, if any.
+        cfg.setProperty(CFG_USERNAME, oldUsername);
+        cfg.setProperty(CFG_PASSWORD, oldPassword);
+    }
+}

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -107,6 +107,11 @@ mail.server.port = ${mail.server.port}
 # From address for mail
 mail.from.address = ${mail.from.address}
 
+# Name of a pre-configured Session object to be fetched from a directory.
+# This overrides the Session settings above.  If none can be found, then DSpace
+# will use the above settings to create a Session.
+#mail.session.name = Session
+
 # Currently limited to one recipient!
 feedback.recipient = ${mail.feedback.recipient}
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-1269

This revives the EmailService that was cut out of DS-1182 to separate a new feature from a bug fix.  At the moment, the service exists just to return a configured javax.mail.Session.  I also want to move the email template methods out of ConfigurationManager into this service.

The service uses the familiar dspace.cfg:email.\* values to configure the Session.  However, it first does a JNDI lookup on java:comp/env/mail/Session and, if found, fetches that preconfigured Session object from the directory and returns it instead.  This lets you use e.g. Tomcat's &lt;Resource&gt; feature to separate this bit of environmental knowledge from DSpace altogether.  If you don't like mail/Session, there is a new configuration value to change it to mail/${your choice}.
