### PR TITLE
DS-1550: Reattach dspace-lni-client so that it is built whenever dspace-lni gets built

### DIFF
--- a/dspace-lni/dspace-lni-client/pom.xml
+++ b/dspace-lni/dspace-lni-client/pom.xml
@@ -10,10 +10,15 @@
 
    <parent>
       <groupId>org.dspace</groupId>
-      <artifactId>dspace-lni</artifactId>
-      <version>3.0-SNAPSHOT</version>
+      <artifactId>dspace-parent</artifactId>
+      <version>4.0-SNAPSHOT</version>
       <relativePath>..</relativePath>
    </parent>
+   
+   <properties>
+       <!-- This is the path to the root [dspace-src] directory. -->
+       <root.basedir>${basedir}/../..</root.basedir>
+   </properties>
 
    <profiles>
       <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,7 @@
         </profile>
 
         <!--
-           Builds LNI WAR for DSpace
+           Builds LNI WAR & Client for DSpace
         -->
         <profile>
             <id>dspace-lni</id>
@@ -388,6 +388,7 @@
             </activation>
             <modules>
                 <module>dspace-lni</module>
+                <module>dspace-lni/dspace-lni-client</module>
             </modules>
         </profile>
 


### PR DESCRIPTION
This is an alternative to PR #215.  It keeps the 'dspace-lni-client' code where it is.
