### PR TITLE
[DS-1272] Enable Discovery By Default for the XMLUI

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -244,6 +244,10 @@
             <artifactId>commons-pool</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.mail</groupId>
             <artifactId>mail</artifactId>
         </dependency>

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/CollectionViewer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/CollectionViewer.java
@@ -10,8 +10,6 @@ package org.dspace.app.xmlui.aspect.artifactbrowser;
 import java.io.IOException;
 import java.io.Serializable;
 import java.sql.SQLException;
-import java.util.Map;
-import java.util.HashMap;
 
 import org.apache.cocoon.caching.CacheableProcessingComponent;
 import org.apache.cocoon.util.HashUtil;
@@ -25,11 +23,8 @@ import org.dspace.app.xmlui.wing.WingException;
 import org.dspace.app.xmlui.wing.element.Body;
 import org.dspace.app.xmlui.wing.element.Division;
 import org.dspace.app.xmlui.wing.element.ReferenceSet;
-import org.dspace.app.xmlui.wing.element.List;
 import org.dspace.app.xmlui.wing.element.PageMeta;
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.browse.BrowseException;
-import org.dspace.browse.BrowseIndex;
 import org.dspace.content.Collection;
 import org.dspace.content.DSpaceObject;
 import org.dspace.core.ConfigurationManager;
@@ -55,19 +50,6 @@ public class CollectionViewer extends AbstractDSpaceTransformer implements Cache
     public static final Message T_untitled = 
     	message("xmlui.general.untitled");
     
-    private static final Message T_head_browse =
-        message("xmlui.ArtifactBrowser.CollectionViewer.head_browse");
-    
-    private static final Message T_browse_titles =
-        message("xmlui.ArtifactBrowser.CollectionViewer.browse_titles");
-    
-    private static final Message T_browse_authors =
-        message("xmlui.ArtifactBrowser.CollectionViewer.browse_authors");
-    
-    private static final Message T_browse_dates = 
-        message("xmlui.ArtifactBrowser.CollectionViewer.browse_dates");
-    
-
     /** Cached validity object */
     private SourceValidity validity;
     
@@ -218,41 +200,10 @@ public class CollectionViewer extends AbstractDSpaceTransformer implements Cache
             home.setHead(name);
         }
 
-        // The search / browse box.
+        // The search / browse box placeholder, this division will be populated either in the browse or discovery aspect
         {
-//            TODO: move browse stuff out of here
-            Division search = home.addDivision("collection-search-browse",
+            home.addDivision("collection-search-browse",
                     "secondary search-browse");
-
-            // Browse by list
-            Division browseDiv = search.addDivision("collection-browse","secondary browse");
-            List browse = browseDiv.addList("collection-browse", List.TYPE_SIMPLE,
-                    "collection-browse");
-            browse.setHead(T_head_browse);
-            String url = contextPath + "/handle/" + collection.getHandle();
-
-            try
-            {
-                // Get a Map of all the browse tables
-                BrowseIndex[] bis = BrowseIndex.getBrowseIndices();
-                for (BrowseIndex bix : bis)
-                {
-                    // Create a Map of the query parameters for this link
-                    Map<String, String> queryParams = new HashMap<String, String>();
-
-                    queryParams.put("type", bix.getName());
-
-                    // Add a link to this browse
-                    browse.addItemXref(super.generateURL(url + "/browse", queryParams),
-                            message("xmlui.ArtifactBrowser.Navigation.browse_" + bix.getName()));
-                }
-            }
-            catch (BrowseException bex)
-            {
-                browse.addItemXref(url + "/browse?type=title",T_browse_titles);
-                browse.addItemXref(url + "/browse?type=author",T_browse_authors);
-                browse.addItemXref(url + "/browse?type=dateissued",T_browse_dates);
-            }
         }
 
         // Add the reference

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/CommunityViewer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/CommunityViewer.java
@@ -10,8 +10,6 @@ package org.dspace.app.xmlui.aspect.artifactbrowser;
 import java.io.IOException;
 import java.io.Serializable;
 import java.sql.SQLException;
-import java.util.Map;
-import java.util.HashMap;
 
 import org.apache.cocoon.caching.CacheableProcessingComponent;
 import org.apache.cocoon.util.HashUtil;
@@ -25,12 +23,9 @@ import org.dspace.app.xmlui.wing.WingException;
 import org.dspace.app.xmlui.wing.element.Body;
 import org.dspace.app.xmlui.wing.element.Division;
 import org.dspace.app.xmlui.wing.element.ReferenceSet;
-import org.dspace.app.xmlui.wing.element.List;
 import org.dspace.app.xmlui.wing.element.Reference;
 import org.dspace.app.xmlui.wing.element.PageMeta;
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.browse.BrowseException;
-import org.dspace.browse.BrowseIndex;
 import org.dspace.browse.ItemCountException;
 import org.dspace.browse.ItemCounter;
 import org.dspace.content.Collection;
@@ -59,20 +54,7 @@ public class CommunityViewer extends AbstractDSpaceTransformer implements Cachea
     public static final Message T_untitled = 
     	message("xmlui.general.untitled");
 
-    private static final Message T_head_browse =
-        message("xmlui.ArtifactBrowser.CommunityViewer.head_browse");
-    
-    private static final Message T_browse_titles = 
-        message("xmlui.ArtifactBrowser.CommunityViewer.browse_titles");
-    
-    private static final Message T_browse_authors =
-        message("xmlui.ArtifactBrowser.CommunityViewer.browse_authors");
-    
-    private static final Message T_browse_dates =
-        message("xmlui.ArtifactBrowser.CommunityViewer.browse_dates");
-    
-
-    private static final Message T_head_sub_communities = 
+    private static final Message T_head_sub_communities =
         message("xmlui.ArtifactBrowser.CommunityViewer.head_sub_communities");
     
     private static final Message T_head_sub_collections =
@@ -261,42 +243,10 @@ public class CommunityViewer extends AbstractDSpaceTransformer implements Cachea
             home.setHead(name);
         }
 
-        // The search / browse box.
+        // The search / browse box placeholder, this division will be populated either in the browse or discovery aspect
         {
-            Division search = home.addDivision("community-search-browse",
+            home.addDivision("community-search-browse",
                     "secondary search-browse");
-
-
-//            TODO: move browse stuff out of here
-            // Browse by list
-            Division browseDiv = search.addDivision("community-browse","secondary browse");
-            List browse = browseDiv.addList("community-browse", List.TYPE_SIMPLE,
-                    "community-browse");
-            browse.setHead(T_head_browse);
-            String url = contextPath + "/handle/" + community.getHandle();
-
-            try
-            {
-                // Get a Map of all the browse tables
-                BrowseIndex[] bis = BrowseIndex.getBrowseIndices();
-                for (BrowseIndex bix : bis)
-                {
-                    // Create a Map of the query parameters for this link
-                    Map<String, String> queryParams = new HashMap<String, String>();
-
-                    queryParams.put("type", bix.getName());
-
-                    // Add a link to this browse
-                    browse.addItemXref(super.generateURL(url + "/browse", queryParams),
-                            message("xmlui.ArtifactBrowser.Navigation.browse_" + bix.getName()));
-                }
-            }
-            catch (BrowseException bex)
-            {
-                browse.addItemXref(url + "/browse?type=title",T_browse_titles);
-                browse.addItemXref(url + "/browse?type=author",T_browse_authors);
-                browse.addItemXref(url + "/browse?type=dateissued",T_browse_dates);
-            }
         }
 
         // Add main reference:

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/browseArtifacts/CollectionBrowse.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/browseArtifacts/CollectionBrowse.java
@@ -1,0 +1,93 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.xmlui.aspect.browseArtifacts;
+
+import org.apache.cocoon.ProcessingException;
+import org.dspace.app.xmlui.cocoon.AbstractDSpaceTransformer;
+import org.dspace.app.xmlui.utils.HandleUtil;
+import org.dspace.app.xmlui.wing.Message;
+import org.dspace.app.xmlui.wing.WingException;
+import org.dspace.app.xmlui.wing.element.Body;
+import org.dspace.app.xmlui.wing.element.Division;
+import org.dspace.app.xmlui.wing.element.List;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.browse.BrowseException;
+import org.dspace.browse.BrowseIndex;
+import org.dspace.content.Collection;
+import org.dspace.content.DSpaceObject;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Renders the browse links for a collection
+ *
+ * @author Kevin Van de Velde (kevin at atmire dot com)
+ * @author Mark Diggory (markd at atmire dot com)
+ * @author Ben Bosman (ben at atmire dot com)
+ */
+public class CollectionBrowse extends AbstractDSpaceTransformer {
+
+    private static final Message T_head_browse =
+        message("xmlui.ArtifactBrowser.CollectionViewer.head_browse");
+
+    private static final Message T_browse_titles =
+        message("xmlui.ArtifactBrowser.CollectionViewer.browse_titles");
+
+    private static final Message T_browse_authors =
+        message("xmlui.ArtifactBrowser.CollectionViewer.browse_authors");
+
+    private static final Message T_browse_dates =
+        message("xmlui.ArtifactBrowser.CollectionViewer.browse_dates");
+
+    @Override
+    public void addBody(Body body) throws SAXException, WingException, SQLException, IOException, AuthorizeException, ProcessingException {
+        DSpaceObject dso = HandleUtil.obtainHandle(objectModel);
+        if (!(dso instanceof Collection))
+        {
+            return;
+        }
+
+        // Set up the major variables
+        Collection collection = (Collection) dso;
+
+        Division home = body.addDivision("collection-home", "primary repository collection");
+
+        Division search = home.addDivision("collection-search-browse",
+                "secondary search-browse");
+
+        // Browse by list
+        Division browseDiv = search.addDivision("collection-browse", "secondary browse");
+        List browse = browseDiv.addList("collection-browse", List.TYPE_SIMPLE,
+                "collection-browse");
+        browse.setHead(T_head_browse);
+        String url = contextPath + "/handle/" + collection.getHandle();
+
+        try {
+            // Get a Map of all the browse tables
+            BrowseIndex[] bis = BrowseIndex.getBrowseIndices();
+            for (BrowseIndex bix : bis) {
+                // Create a Map of the query parameters for this link
+                Map<String, String> queryParams = new HashMap<String, String>();
+
+                queryParams.put("type", bix.getName());
+
+                // Add a link to this browse
+                browse.addItemXref(generateURL(url + "/browse", queryParams),
+                        message("xmlui.ArtifactBrowser.Navigation.browse_" + bix.getName()));
+            }
+        } catch (BrowseException bex) {
+            browse.addItemXref(url + "/browse?type=title", T_browse_titles);
+            browse.addItemXref(url + "/browse?type=author", T_browse_authors);
+            browse.addItemXref(url + "/browse?type=dateissued", T_browse_dates);
+        }
+    }
+}

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/browseArtifacts/CommunityBrowse.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/browseArtifacts/CommunityBrowse.java
@@ -1,0 +1,93 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.xmlui.aspect.browseArtifacts;
+
+import org.apache.cocoon.ProcessingException;
+import org.dspace.app.xmlui.cocoon.AbstractDSpaceTransformer;
+import org.dspace.app.xmlui.utils.HandleUtil;
+import org.dspace.app.xmlui.wing.Message;
+import org.dspace.app.xmlui.wing.WingException;
+import org.dspace.app.xmlui.wing.element.Body;
+import org.dspace.app.xmlui.wing.element.Division;
+import org.dspace.app.xmlui.wing.element.List;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.browse.BrowseException;
+import org.dspace.browse.BrowseIndex;
+import org.dspace.content.Community;
+import org.dspace.content.DSpaceObject;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Renders the browse links for a community
+ *
+ * @author Kevin Van de Velde (kevin at atmire dot com)
+ * @author Mark Diggory (markd at atmire dot com)
+ * @author Ben Bosman (ben at atmire dot com)
+ */
+public class CommunityBrowse extends AbstractDSpaceTransformer {
+
+    private static final Message T_head_browse =
+        message("xmlui.ArtifactBrowser.CommunityViewer.head_browse");
+
+    private static final Message T_browse_titles =
+        message("xmlui.ArtifactBrowser.CommunityViewer.browse_titles");
+
+    private static final Message T_browse_authors =
+        message("xmlui.ArtifactBrowser.CommunityViewer.browse_authors");
+
+    private static final Message T_browse_dates =
+        message("xmlui.ArtifactBrowser.CommunityViewer.browse_dates");
+
+    @Override
+    public void addBody(Body body) throws SAXException, WingException, SQLException, IOException, AuthorizeException, ProcessingException {
+        DSpaceObject dso = HandleUtil.obtainHandle(objectModel);
+        if (!(dso instanceof Community))
+        {
+            return;
+        }
+
+        // Set up the major variables
+        Community community = (Community) dso;
+
+        Division home = body.addDivision("community-home", "primary repository community");
+
+        Division search = home.addDivision("community-search-browse",
+                "secondary search-browse");
+
+        // Browse by list
+        Division browseDiv = search.addDivision("community-browse", "secondary browse");
+        List browse = browseDiv.addList("community-browse", List.TYPE_SIMPLE,
+                "community-browse");
+        browse.setHead(T_head_browse);
+        String url = contextPath + "/handle/" + community.getHandle();
+
+        try {
+            // Get a Map of all the browse tables
+            BrowseIndex[] bis = BrowseIndex.getBrowseIndices();
+            for (BrowseIndex bix : bis) {
+                // Create a Map of the query parameters for this link
+                Map<String, String> queryParams = new HashMap<String, String>();
+
+                queryParams.put("type", bix.getName());
+
+                // Add a link to this browse
+                browse.addItemXref(generateURL(url + "/browse", queryParams),
+                        message("xmlui.ArtifactBrowser.Navigation.browse_" + bix.getName()));
+            }
+        } catch (BrowseException bex) {
+            browse.addItemXref(url + "/browse?type=title", T_browse_titles);
+            browse.addItemXref(url + "/browse?type=author", T_browse_authors);
+            browse.addItemXref(url + "/browse?type=dateissued", T_browse_dates);
+        }
+    }
+}

--- a/dspace-xmlui/src/main/resources/aspects/BrowseArtifacts/sitemap.xmap
+++ b/dspace-xmlui/src/main/resources/aspects/BrowseArtifacts/sitemap.xmap
@@ -23,6 +23,8 @@ collections / items / and bitstreams.
             <map:transformer name="CommunityBrowser" src="org.dspace.app.xmlui.aspect.artifactbrowser.CommunityBrowser"/>
             <map:transformer name="CommunityRecentSubmissions" src="org.dspace.app.xmlui.aspect.artifactbrowser.CommunityRecentSubmissions"/>
             <map:transformer name="CollectionRecentSubmissions" src="org.dspace.app.xmlui.aspect.artifactbrowser.CollectionRecentSubmissions"/>
+            <map:transformer name="CommunityBrowse" src="org.dspace.app.xmlui.aspect.browseArtifacts.CommunityBrowse"/>
+            <map:transformer name="CollectionBrowse" src="org.dspace.app.xmlui.aspect.browseArtifacts.CollectionBrowse"/>
             <map:transformer name="ConfigurableBrowse" src="org.dspace.app.xmlui.aspect.artifactbrowser.ConfigurableBrowse"/>
             <map:transformer name="StaticPage" src="org.dspace.app.xmlui.aspect.browseArtifacts.StaticPage"/>
         </map:transformers>
@@ -81,12 +83,14 @@ collections / items / and bitstreams.
 
                         <map:match type="HandleTypeMatcher" pattern="community">
                             <map:match pattern="handle/*/*">
+                                <map:transform type="CommunityBrowse"/>
                                 <map:transform type="CommunityRecentSubmissions"/>
                             </map:match>
                         </map:match>
 
                         <map:match type="HandleTypeMatcher" pattern="collection">
                             <map:match pattern="handle/*/*">
+                                <map:transform type="CollectionBrowse"/>
                                 <map:transform type="CollectionRecentSubmissions"/>
                             </map:match>
                         </map:match>

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -639,7 +639,7 @@ event.dispatcher.default.class = org.dspace.event.BasicDispatcher
 # uncomment below and comment out original property to enable discovery indexing
 # event.dispatcher.default.consumers = versioning, search, browse, discovery, eperson, harvester
 #
-event.dispatcher.default.consumers = versioning, search, browse, eperson, harvester
+event.dispatcher.default.consumers = versioning, search, browse, discovery, eperson, harvester
 
 # The noindex dispatcher will not create search or browse indexes (useful for batch item imports)
 event.dispatcher.noindex.class = org.dspace.event.BasicDispatcher
@@ -1101,7 +1101,8 @@ webui.browse.link.1 = author:dc.contributor.*
 recent.submissions.sort-option = dateaccessioned
 
 # how many recent submissions should be displayed at any one time
-recent.submissions.count = 5
+# Set to 0 since discovery uses a separate configuration for this
+recent.submissions.count = 0
 
 # tell the community and collection pages that we are using the Recent
 # Submissions code

--- a/dspace/config/modules/discovery.cfg
+++ b/dspace/config/modules/discovery.cfg
@@ -5,7 +5,7 @@
 # faceted-search system.                                        #
 #---------------------------------------------------------------#
 ##### Search Indexing #####
-search.server = http://localhost:8080/solr/search
+search.server = ${solr.server}/search
 
 #Char used to ensure that the sidebar facets are case insensitive
 #solr.facets.split.char=\n|||\n

--- a/dspace/config/xmlui.xconf
+++ b/dspace/config/xmlui.xconf
@@ -82,7 +82,7 @@
         <!-- Base DSpace XMLUI Aspects for Display, Browse, Search, Admin, Login and Submission -->
         <aspect name="Displaying Artifacts" path="resource://aspects/ViewArtifacts/" />
         <aspect name="Browsing Artifacts" path="resource://aspects/BrowseArtifacts/" />
-        <aspect name="Searching Artifacts" path="resource://aspects/SearchArtifacts/" />
+        <aspect name="Discovery" path="resource://aspects/Discovery/" />
         <aspect name="Administration" path="resource://aspects/Administrative/" />
         <aspect name="E-Person" path="resource://aspects/EPerson/" />
         <aspect name="Submission and Workflow" path="resource://aspects/Submission/" />
@@ -115,14 +115,14 @@
         <!-- ==============
              Search Engines
              ============== -->
-        <!-- By default, DSpace uses a basic (Lucene based) search engine (see SearchArtifacts aspect above) -->
         <!--
-            To enable Discovery (faceted/filtered search), uncomment this aspect.
-            Also make sure to comment out the above 'SearchArtifacts' aspect 
+            To enable the old lucene based search (no facets, filters), uncomment this aspect.
+            Also make sure to comment out the above 'Discovery' aspect
             (in the "Basic Features/Aspects" group) as leaving it on together
-            with Discovery will cause UI overlap issues
+            with Searching Artifacts aspect will cause UI overlap issues
         -->
-        <!-- <aspect name="Discovery" path="resource://aspects/Discovery/" /> -->
+        <!--<aspect name="Searching Artifacts" path="resource://aspects/SearchArtifacts/" />-->
+
 
         <!-- ==============
              SWORDv1 Client

--- a/pom.xml
+++ b/pom.xml
@@ -696,6 +696,11 @@
             <artifactId>commons-pool</artifactId>
             <version>1.4</version>
          </dependency>
+          <dependency>
+              <groupId>commons-validator</groupId>
+              <artifactId>commons-validator</artifactId>
+              <version>1.4.0</version>
+          </dependency>
          <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>


### PR DESCRIPTION
This pull request will enable discovery by default.

Some remarks about the pull request:
- The discovery solr impl has been altered so that if no valid solr url is provided it will not start throwing exceptions, it will graciously skip all discovery methods (this is the case for the api tests)
- I also moved the "browse" links out of the CommunityViewer & CollectionViewer classes, so if you turn off the browse aspect all the browse links are now gone from the user interface (as one would expect)

Work not included in this pull request:
- The browse aspect is still enabled (since this serves a different use case than discovery)
- Enabling discovery for the jspui
- Adding update-discovery-index to index-init & index-update, although if this requested I will alter it
