### PR TITLE
DS-1028 Implementation of CAS (Single Sign-On) authentication for DSpace

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -482,6 +482,13 @@
             <artifactId>postgresql</artifactId>
         </dependency>
 
+        <!-- CAS: Needed for CAS authentication -->
+	<dependency>
+	    <groupId>cas</groupId>
+            <artifactId>casclient</artifactId>
+            <version>2.1.1</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/dspace-api/src/main/java/org/dspace/authenticate/CASAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/CASAuthentication.java
@@ -1,0 +1,346 @@
+package org.dspace.authenticate;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.net.URL;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.apache.log4j.Logger;
+import org.dspace.core.ConfigurationManager;
+import org.dspace.core.Context;
+import org.dspace.core.LogManager;
+import org.dspace.eperson.EPerson;
+
+import org.jasig.cas.client.validation.Saml11TicketValidator;
+import org.jasig.cas.client.validation.Saml11TicketValidationFilter;
+import org.jasig.cas.client.validation.Cas10TicketValidationFilter;
+import org.jasig.cas.client.validation.Cas10TicketValidator;
+import org.jasig.cas.client.validation.Assertion;
+
+// we use the Java CAS client
+import edu.yale.its.tp.cas.client.*;
+
+/**
+ * Authenticator for Central Authentication Service (CAS).
+ *
+ * @author Naveed Hashmi, University of Bristol
+ * based on code developed by Nordija A/S (www.nordija.com) for Center of Knowledge Technology (www.cvt.dk)
+ * @version $Revision: 1.0 $
+ * @author Nicolás Kovac Neumann, Universidad de La Laguna
+ * CAS authentication has been adapted to DSpace 3.1 (latest stable) and proved functionality with CAS 3.5.0
+ * @version $Revision: 1.1 $
+ */
+
+public class CASAuthentication
+    implements AuthenticationMethod {
+
+    /** log4j category */
+    private static Logger log = Logger.getLogger(CASAuthentication.class);
+
+    private static String casProxyvalidate;   //URL to validate PT tickets
+
+    // (optional) store user's details for self registration, can get this info from LDAP, RDBMS etc
+    private String firstName="University";
+    private String lastName="User";
+
+    /**
+     * Predicate, can new user automatically create EPerson.
+     * Checks configuration value.  You'll probably want this to
+     * be true to take advantage of a Web certificate infrastructure
+     * with many more users than are already known by DSpace.
+     */
+    public boolean canSelfRegister(Context context,
+                                   HttpServletRequest request,
+                                   String username)
+        throws SQLException
+    {
+        return ConfigurationManager.getBooleanProperty(
+        "authentication-cas", "webui.cas.autoregister");
+    }
+
+    /**
+     *  Nothing extra to initialize.
+     */
+    public void initEPerson(Context context, HttpServletRequest request,
+            EPerson eperson)
+        throws SQLException
+    {
+    }
+
+    /**
+     * We don't use EPerson password so there is no reason to change it.
+     */
+    public boolean allowSetPassword(Context context,
+                                    HttpServletRequest request,
+                                    String username)
+        throws SQLException
+    {
+        return false;
+    }
+
+    /**
+     * 
+     * Predicate, is this an implicit authentication method.
+     * An implicit method gets credentials from the environment (such as
+     * an HTTP request or even Java system properties) rather than the
+     * explicit username and password.  For example, a method that reads
+     * the X.509 certificates in an HTTPS request is implicit.
+     * @return true if this method uses implicit authentication.
+     * 
+     * Returns true, CAS is an implicit method
+     */
+    public boolean isImplicit()
+    {
+        return true;
+    }
+
+    /**
+     * No special groups.
+     */
+    public int[] getSpecialGroups(Context context, HttpServletRequest request)
+    {
+        return new int[0];
+    }
+
+
+    /**
+     * CAS authentication.
+     *
+     * @return One of: SUCCESS, BAD_CREDENTIALS, NO_SUCH_USER, BAD_ARGS
+     */
+    public int authenticate(Context context,
+                            String netid,
+                            String password,
+                            String realm,
+                            HttpServletRequest request)
+        throws SQLException
+    {
+        final String ticket = request.getParameter("ticket");
+        final String service = request.getRequestURL().toString();
+        log.info(LogManager.getHeader(context, "login", " ticket: " + ticket));
+        log.info(LogManager.getHeader(context, "login", "service: " + service));
+
+        if (ticket != null)
+        {
+            try
+            {
+                // Determine CAS validation URL
+                String validate = ConfigurationManager.getProperty("authentication-cas", "cas.validate.url");
+                log.info(LogManager.getHeader(context, "login", "CAS ticket: " + ticket));
+                log.info(LogManager.getHeader(context, "login", "CAS service: " + service));
+                if (validate == null)
+                {
+                    throw new ServletException("No CAS validation URL specified. You need to set property 'cas.validate.url'");
+                }
+
+                // Validate ticket (it is assumed that CAS validator returns the user network ID)
+                netid = validate(service, ticket, validate);
+                if (netid == null)
+                {
+                    throw new ServletException("Ticket '" + ticket + "' is not valid");
+                }
+
+                // Locate the eperson in DSpace
+                EPerson eperson = null;
+                try
+                {
+                    eperson = EPerson.findByNetid(context, netid.toLowerCase());
+                }
+                catch (SQLException e)
+                {
+                  log.error("cas findbynetid failed");
+                  log.error(e.getStackTrace());
+                }
+
+                // if they entered a netd that matches an eperson and they are allowed to login
+                if (eperson != null)
+                {
+                  // e-mail address corresponds to active account
+                    if (eperson.getRequireCertificate())
+                    {
+                        // they must use a certificate
+                        return CERT_REQUIRED;
+                    }
+                    else if (!eperson.canLogIn()) {
+                        return BAD_ARGS;
+                    }
+
+                    // Logged in OK.
+                    HttpSession session = request.getSession(false);
+                    if (session!=null) {
+                      session.setAttribute("loginType", "CAS");
+                    }
+
+                    context.setCurrentUser(eperson);
+                    log.info(LogManager.getHeader(context, "authenticate", "type=CAS"));
+
+                    return SUCCESS;
+                }
+
+                // the user does not exist in DSpace so create an eperson
+                else
+                {
+                  if (canSelfRegister(context, request, netid) )
+                    {
+                        // TEMPORARILY turn off authorisation
+                        // Register the new user automatically
+                        context.setIgnoreAuthorization(true);
+                        eperson = EPerson.create(context);
+                        // use netid only but this implies that user has to manually update their profile
+                        eperson.setNetid(netid);
+
+                        // if you wish to automatically extract further user details: email, first_name and last_name
+                        //  enter your method here: e.g. query LDAP or RDBMS etc.
+                        /* e.g.
+                        registerUser(netid);
+                        eperson.setEmail(email);*/
+
+                        eperson.setFirstName(firstName);
+                        eperson.setLastName(lastName);
+                        
+                        eperson.setLanguage("en");
+                        eperson.setEmail(netid);
+                        eperson.setRequireCertificate(false);
+                        eperson.setSelfRegistered(false);
+
+                        eperson.setCanLogIn(true);
+                        AuthenticationManager.initEPerson(context, request, eperson);
+                        eperson.update();
+                        context.commit();
+                        context.setIgnoreAuthorization(false);
+                        context.setCurrentUser(eperson);
+                        log.warn(LogManager.getHeader(context, "authenticate",
+                            netid + "  type=CAS auto-register"));
+                        return SUCCESS;
+                    }
+                    else
+                    {
+                        // No auto-registration for valid netid
+                        log.warn(LogManager.getHeader(context, "authenticate",
+                            netid + "  type=netid_but_no_record, cannot auto-register"));
+                        return NO_SUCH_USER;
+                    }
+                }
+
+            } catch (Exception e)
+            {
+                log.error(e.getStackTrace()[0]);
+                //throw new ServletException(e);
+            }
+        }
+        return BAD_ARGS;
+    }
+
+
+  /**
+   * Returns the NetID of the owner of the given ticket, or null if the
+   * ticket isn't valid.
+   *
+   * @param service the service ID for the application validating the
+   *                ticket
+   * @param ticket  the opaque service ticket (ST) to validate
+   */
+  public static String validate(String service, String ticket, String validateURL)
+      throws IOException, ServletException
+  {
+                ServiceTicketValidator stv = null;
+                String validateUrl = null;
+
+                if (ticket.startsWith("ST")) {
+                        stv = new ServiceTicketValidator();
+                } else {
+                        // uPortal uses this
+                        stv = new ProxyTicketValidator();
+                        validateUrl = casProxyvalidate;
+                }
+
+                stv.setCasValidateUrl(validateURL);
+                stv.setService(java.net.URLEncoder.encode(service));
+                stv.setServiceTicket(ticket);
+
+                try {
+                   stv.validate();
+                } catch (Exception e) {
+                   log.error("Unexpected exception caught", e);
+                   throw new ServletException(e);
+                }
+
+                if (!stv.isAuthenticationSuccesful()) { 
+                     return null;
+                }
+                String netid = stv.getUser();
+                log.info("Authenticated user via CAS: " + netid);
+                return netid;
+
+  }
+
+
+    /**
+    * Add code here to extract user details
+    * email, firstname, lastname
+    * from LDAP or database etc
+    */
+
+   public void registerUser(String netid)
+                          throws ClassNotFoundException, SQLException
+    {
+                // add your code here
+    }
+
+
+    /*
+     * Returns URL to which to redirect to obtain credentials (either password
+     * prompt or e.g. HTTPS port for client cert.); null means no redirect.
+     *
+     * @param context
+     *  DSpace context, will be modified (ePerson set) upon success.
+     *
+     * @param request
+     *  The HTTP request that started this operation, or null if not applicable.
+     *
+     * @param response
+     *  The HTTP response from the servlet method.
+     *
+     * @return fully-qualified URL
+     */
+    public String loginPageURL(Context context,
+                            HttpServletRequest request,
+                            HttpServletResponse response)
+    {
+       // Determine CAS server URL
+       final String authServer = ConfigurationManager.getProperty("authentication-cas", "cas.server.url");
+       StringBuffer url=new StringBuffer(authServer);
+       url.append("?service=").append(request.getScheme()).
+       append("://").append(request.getServerName());
+       //Add the URL callback
+       if(request.getServerPort()!=80)
+         url.append(":").append(request.getServerPort());
+       url.append(request.getContextPath()).append("/cas-login");
+       log.info("CAS server and service:  " + authServer);
+       //System.out.println(url);
+       
+       // Redirect to CAS server
+       return response.encodeRedirectURL(url.toString());
+    }
+
+    /*
+     * Returns message key for title of the "login" page, to use
+     * in a menu showing the choice of multiple login methods.
+     *
+     * @param context
+     *  DSpace context, will be modified (ePerson set) upon success.
+     *
+     * @return Message key to look up in i18n message catalog.
+     */
+    public String loginPageTitle(Context context)
+    {
+        //return null;
+        return "org.dspace.eperson.CASAuthentication.title";
+    }
+
+}
+

--- a/dspace-xmlui/pom.xml
+++ b/dspace-xmlui/pom.xml
@@ -229,6 +229,12 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- CAS: Needed for CAS authentication -->
+        <dependency>
+            <groupId>cas</groupId>
+            <artifactId>casclient</artifactId>
+            <version>2.1.1</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowEPersonUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowEPersonUtils.java
@@ -20,6 +20,7 @@ import org.apache.cocoon.environment.Request;
 import org.apache.cocoon.environment.http.HttpEnvironment;
 import org.apache.commons.lang.StringUtils;
 import org.dspace.app.xmlui.utils.AuthenticationUtil;
+import org.dspace.core.ConfigurationManager;
 import org.dspace.app.xmlui.wing.Message;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.core.Context;
@@ -72,6 +73,8 @@ public class FlowEPersonUtils {
 		String first = request.getParameter("first_name").trim();
 		String last  = request.getParameter("last_name").trim();
 		String phone = request.getParameter("phone").trim();
+		//Single Sign-On 
+		String netid = request.getParameter("netid");
 		boolean login = (request.getParameter("can_log_in") != null) ? true : false;
 		boolean certificate = (request.getParameter("certificate") != null) ? true : false;
 		
@@ -98,6 +101,16 @@ public class FlowEPersonUtils {
     		result.addError("eperson_email_key");
     	}
 		
+    	// check if the netid is already being used
+	if ("true".equals(ConfigurationManager.getProperty("webui.cas.enable"))) {
+		potentialDupicate = EPerson.findByNetid(context, netid);
+	    	if (potentialDupicate != null)
+	    	{
+	    		// special error that the front end knows about.
+	    		result.addError("eperson_netid_key");
+	    	}
+	}
+
 	    // No errors, so we try to create the EPerson from the data provided
 	    if (result.getErrors() == null)
 	    {
@@ -106,6 +119,7 @@ public class FlowEPersonUtils {
     		newPerson.setFirstName(first);
             newPerson.setLastName(last);
             newPerson.setMetadata("phone", phone);
+            newPerson.setNetid(netid);
             newPerson.setCanLogIn(login);
             newPerson.setRequireCertificate(certificate);
             newPerson.setSelfRegistered(false);
@@ -147,6 +161,8 @@ public class FlowEPersonUtils {
 		String first = request.getParameter("first_name");
 		String last  = request.getParameter("last_name");
 		String phone = request.getParameter("phone");
+		//Single Sign-On 
+		String netid=request.getParameter("netid");
 		boolean login = (request.getParameter("can_log_in") != null) ? true : false;
 		boolean certificate = (request.getParameter("certificate") != null) ? true : false;
 		
@@ -189,6 +205,22 @@ public class FlowEPersonUtils {
         			return result;
         		}
         	}
+
+    		// check if the netid is already being used
+    		if ("true".equals(ConfigurationManager.getProperty("webui.cas.enable"))) {
+    			EPerson potentialDupicate = EPerson.findByNetid(context, netid);
+	            	if (potentialDupicate == null) 
+        		{
+        			personModified.setNetid(netid);
+        		} 
+        		else if (!potentialDupicate.equals(personModified)) 
+        		{	       
+        			// set a special field in error so that the transformer can display a pretty error.
+        			result.addError("eperson_netid_key");
+        			return result;
+        		}
+    		} 	
+
         	String originalFirstName = personModified.getFirstName();
             if (originalFirstName == null || !originalFirstName.equals(first)) {
         		personModified.setFirstName(first);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/eperson/AddEPersonForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/eperson/AddEPersonForm.java
@@ -99,6 +99,9 @@ public class AddEPersonForm extends AbstractDSpaceTransformer
     private static final Message T_telephone =
         message("xmlui.EPerson.EditProfile.telephone");
     
+    // netid allows to handle automatic Single Sign-On login (CAS)
+    private static final Message T_netid =
+    	message("xmlui.EPerson.EditProfile.netid");
     	
 	public void addPageMeta(PageMeta pageMeta) throws WingException
     {
@@ -128,6 +131,8 @@ public class AddEPersonForm extends AbstractDSpaceTransformer
 		String firstValue = request.getParameter("first_name");
 		String lastValue  = request.getParameter("last_name");
 		String phoneValue = request.getParameter("phone");
+		// netid allows to handle automatic Single Sign-On login (CAS)
+		String netidValue = request.getParameter("netid");
 		boolean canLogInValue    = (request.getParameter("can_log_in") == null)  ? false : true;
 		boolean certificateValue = (request.getParameter("certificate") == null) ? false : true;
 	    		 
@@ -174,6 +179,13 @@ public class AddEPersonForm extends AbstractDSpaceTransformer
         	lastName.addError(T_error_lname);
         }
         
+        if ("true".equals(ConfigurationManager.getProperty("webui.cas.enable"))){
+	        Text netid = identity.addItem().addText("netid");
+	        netid.setLabel(T_netid);
+	        netid.setValue(netidValue);
+        }
+        
+
         Text phone = identity.addItem().addText("phone");
         phone.setLabel(T_telephone);
         phone.setValue(phoneValue);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/eperson/EditEPersonForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/eperson/EditEPersonForm.java
@@ -140,7 +140,9 @@ public class EditEPersonForm extends AbstractDSpaceTransformer
     private static final Message T_telephone =
     	message("xmlui.EPerson.EditProfile.telephone");
     
-    
+    // netid allows to handle automatic Single Sign-On login (CAS)
+    private static final Message T_netid =
+  	message("xmlui.EPerson.EditProfile.netid");   
     
 
     	
@@ -184,6 +186,7 @@ public class EditEPersonForm extends AbstractDSpaceTransformer
 		String firstValue = eperson.getFirstName();
 		String lastValue  = eperson.getLastName();
 		String phoneValue = eperson.getMetadata("phone");
+                String netidValue = eperson.getNetid();
 		boolean canLogInValue = eperson.canLogIn();
 		boolean certificatValue = eperson.getRequireCertificate();
 		java.util.List<String> deleteConstraints = eperson.getDeleteConstraints();
@@ -203,8 +206,11 @@ public class EditEPersonForm extends AbstractDSpaceTransformer
 		if (request.getParameter("phone") != null)
         {
             phoneValue = request.getParameter("phone");
-        }
-		
+        }		
+		if (request.getParameter("netid") != null)
+	{
+	    netidValue = request.getParameter("netid");
+	}
 		
 		
 		// DIVISION: eperson-edit
@@ -274,6 +280,20 @@ public class EditEPersonForm extends AbstractDSpaceTransformer
         {
         	identity.addLabel(T_last_name);
         	identity.addItem(lastValue);
+        }
+        
+        if ("true".equals(ConfigurationManager.getProperty("webui.cas.enable")))
+        {
+			if (admin) {
+				Text netid = identity.addItem().addText("netid");
+				netid.setLabel(T_netid);
+				netid.setValue(netidValue);
+			}
+			else
+	        {
+	        	identity.addLabel(T_netid);
+	        	identity.addItem(netidValue);
+	        }
         }
         
         if (admin)

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/CASAuthenticateAction.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/CASAuthenticateAction.java
@@ -1,0 +1,114 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.xmlui.aspect.eperson;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.avalon.framework.parameters.Parameters;
+import org.apache.cocoon.acting.AbstractAction;
+import org.apache.cocoon.environment.ObjectModelHelper;
+import org.apache.cocoon.environment.Redirector;
+import org.apache.cocoon.environment.Request;
+import org.apache.cocoon.environment.SourceResolver;
+import org.apache.cocoon.environment.http.HttpEnvironment;
+import org.apache.cocoon.sitemap.PatternException;
+import org.dspace.app.xmlui.utils.AuthenticationUtil;
+import org.dspace.core.ConfigurationManager;
+import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
+/* 
+ * @author Kaboré Wendin-Malegdé Patrick at Paris-Dauphine University
+ * * @version $Revision: 1.0 $
+ */
+/**
+ * Attempt to authenticate the user based upon their presented CAS credentials. 
+ * This action uses the http parameters as supplied by CAS server.
+ * Read dspace.cfg for configuration detail.
+ * 
+ * If the authentication attempt is successfull then an HTTP redirect will be
+ * sent to the browser redirecting them to their original location in the 
+ * system before authenticated or if none is supplied back to the DSpace 
+ * homepage. The action will also return true, thus contents of the action will
+ * be excuted.
+ * 
+ * If the authentication attempt fails, the action returns false.
+ * 
+ * Example use:
+ * 
+ * <map:act name="Authenticate">
+ *   <map:serialize type="xml"/>
+ * </map:act>
+ * <map:transform type="try-to-login-again-transformer">
+ *
+ * @author Scott Phillips
+ */
+
+public class CASAuthenticateAction extends AbstractAction
+{
+
+    /**
+     * Attempt to authenticate the user. 
+     */
+    public Map act(Redirector redirector, SourceResolver resolver, Map objectModel,
+            String source, Parameters parameters) throws Exception
+    {
+        // First check if we are preforming a new login
+        Request request = ObjectModelHelper.getRequest(objectModel);
+        
+        try
+        {
+            Context context = AuthenticationUtil.authenticate(objectModel, null,null, null);
+
+            EPerson eperson = context.getCurrentUser();
+
+            if (eperson != null)
+            {
+            	// The user has successfully logged in
+            	String redirectURL = request.getContextPath();
+            	
+            	if (AuthenticationUtil.isInterupptedRequest(objectModel))
+            	{
+            		// Resume the request and set the redirect target URL to
+            		// that of the originaly interrupted request.
+            		redirectURL += AuthenticationUtil.resumeInterruptedRequest(objectModel);
+            	}
+            	else
+            	{
+            		// Otherwise direct the user to the login page
+            		String loginRedirect = ConfigurationManager.getProperty("xmlui.user.loginredirect");
+            		redirectURL += (loginRedirect != null) ? loginRedirect.trim() : "";	
+            	}
+            	
+                // Authentication successfull send a redirect.
+                final HttpServletResponse httpResponse = (HttpServletResponse) objectModel.get(HttpEnvironment.HTTP_RESPONSE_OBJECT);
+                
+                httpResponse.sendRedirect(redirectURL);
+                
+                // log the user out for the rest of this current request, however they will be reauthenticated
+                // fully when they come back from the redirect. This prevents caching problems where part of the
+                // request is preformed fore the user was authenticated and the other half after it succedded. This
+                // way the user is fully authenticated from the start of the request.
+                context.setCurrentUser(null);
+                
+                return new HashMap();
+            }
+        }
+        catch (SQLException sqle)
+        {
+            throw new PatternException("Unable to preform authentication",
+                    sqle);
+        }
+        
+        return null;
+    }
+
+}

--- a/dspace-xmlui/src/main/resources/aspects/EPerson/sitemap.xmap
+++ b/dspace-xmlui/src/main/resources/aspects/EPerson/sitemap.xmap
@@ -42,6 +42,7 @@ registration, forgotten passwords, editing profiles, and changing passwords.
 			<map:action name="AuthenticateAction" src="org.dspace.app.xmlui.aspect.eperson.AuthenticateAction"/>
 			<map:action name="ShibbolethAction" src="org.dspace.app.xmlui.aspect.eperson.ShibbolethAction"/>
 			<map:action name="LDAPAuthenticateAction" src="org.dspace.app.xmlui.aspect.eperson.LDAPAuthenticateAction"/>
+                        <map:action name="CASAuthenticateAction" src="org.dspace.app.xmlui.aspect.eperson.CASAuthenticateAction"/>
 			<map:action name="UnAuthenticateAction" src="org.dspace.app.xmlui.aspect.eperson.UnAuthenticateAction"/>
 			<map:action name="LoginRedirect" src="org.dspace.app.xmlui.aspect.eperson.LoginRedirect" />
 		</map:actions>
@@ -185,6 +186,17 @@ registration, forgotten passwords, editing profiles, and changing passwords.
 				<map:serialize type="xml"/>
 			</map:match>
 			
+			<map:match pattern="cas-login">
+				<map:act type="CASAuthenticateAction">
+					<!-- Loggin succeeded, request will be forwarded. -->
+					<map:serialize type="xml"/>
+				</map:act>
+				
+				<!-- Login failed, try again. --> 
+				<map:transform type="FailedAuthentication"/>
+				<map:serialize type="xml"/>
+			</map:match>
+
 			<!--
 					Log the user out. The UnAuthenticateAction can not fail and will 
 					always redirect the user to the DSpace homepage.

--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -344,6 +344,7 @@
 	<message key="xmlui.EPerson.EditProfile.first_name">First Name</message>
 	<message key="xmlui.EPerson.EditProfile.last_name">Last Name</message>
 	<message key="xmlui.EPerson.EditProfile.telephone">Contact Telephone</message>
+        <message key="xmlui.EPerson.EditProfile.netid">Single Sign-On Username</message>
         <message key="xmlui.EPerson.EditProfile.Language">Language</message>
 	<message key="xmlui.EPerson.EditProfile.subscriptions">Subscriptions</message>
 	<message key="xmlui.EPerson.EditProfile.subscriptions_help">You may subscribe to collections to receive daily e-mail alerts of new items added. You can subscribe to as many or as few collections as you wish. Another alternative to daily e-mail alerts is to use the RSS feeds available for all collections.</message>
@@ -420,6 +421,7 @@
 	<message key="xmlui.EPerson.LoginChooser.para1">Log in via:</message>
 	<message key="org.dspace.authenticate.ShibAuthentication.title">Shibboleth Authentication</message>
 	<message key="org.dspace.eperson.LDAPAuthentication.title">LDAP Authentication</message>
+        <message key="org.dspace.eperson.CASAuthentication.title">Single Sign-On CAS Authentication</message>
 	<message key="org.dspace.eperson.PasswordAuthentication.title">Password Authentication</message>
 	<message key="org.dspace.eperson.X509Authentication.title">Web Certificate Authentication</message>
 

--- a/dspace/config/modules/authentication-cas.cfg
+++ b/dspace/config/modules/authentication-cas.cfg
@@ -1,0 +1,10 @@
+# CAS options
+cas.server.url=https://yourcasserver/cas/login
+cas.validate.url=https://yourcasserver/cas/serviceValidate
+cas.logout.url=https://yourcasserver/cas/logout
+## Create e-persons for no matching user in dspace
+# If set to false, no new users will be allowed to create account on first authentication!
+webui.cas.autoregister = true
+# if webui.cas.enable= true, you can edit the CAS username
+# on the EPerson page.
+webui.cas.enable = false

--- a/dspace/config/modules/authentication.cfg
+++ b/dspace/config/modules/authentication.cfg
@@ -35,4 +35,5 @@
 #         org.dspace.authenticate.PasswordAuthentication
 
 plugin.sequence.org.dspace.authenticate.AuthenticationMethod = \
-        org.dspace.authenticate.PasswordAuthentication
+        org.dspace.authenticate.CASAuthentication, \
+    org.dspace.authenticate.PasswordAuthentication


### PR DESCRIPTION
The first patch was formerly implemented by Kaboré Wendin-Malegdé Patrick at JIRA (https://jira.duraspace.org/browse/DS-1028).
This first version was done for DSpace 1.7.2, afterwards user kgunn at JIRA did some arrangements to make it work with DSpace 1.8.2 and CAS 3.1.x
and now I've been able to make a 'remix' of both solutions to make it work with DSpace 3.1 and CAS 3.5.x.

Hopefully, this patch will be officially implemented in subsequent DSpace versions as an additional authentication method.
