### PR TITLE
DS-1561 build.properties breaks no-auth SMTP

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Email.java
+++ b/dspace-api/src/main/java/org/dspace/core/Email.java
@@ -265,7 +265,7 @@ public class Email
         String username = ConfigurationManager.getProperty("mail.server.username");
         String password = ConfigurationManager.getProperty("mail.server.password");
         
-        if (username != null)
+        if (username != null || username == "")
         {
             props.put("mail.smtp.auth", "true");
             SMTPAuthenticator smtpAuthenticator = new SMTPAuthenticator(


### PR DESCRIPTION
A limitation in build.properties filtering requires us to specify empty values of properties instead of commenting them out, as documented below:

https://wiki.duraspace.org/display/DSDOC3x/Configuration#Configuration-Thebuild.propertiesConfigurationPropertiesFile

This caused a problem with the mail.server.username and mail.server.password properties, which behaved differently when they were empty and when they were not present (commented out).

This commit fixes them by making the case of empty mail.server.username behave the same as if it was missing.
