### PR TITLE
Updated SWORDv2 module

### DIFF
--- a/dspace-swordv2/pom.xml
+++ b/dspace-swordv2/pom.xml
@@ -3,30 +3,33 @@
     <groupId>org.dspace</groupId>
     <artifactId>dspace-swordv2</artifactId>
     <packaging>war</packaging>
-    <name>DSpace SWORD v2</name>
+    <name>DSpace SWORD v2 :: Web Application Resources</name>
     <description>DSpace SWORD v2 Deposit Service Provider Web Application</description>
+    <url>http://projects.dspace.org/dspace-sword-webapp</url>
 
     <!--
        A Parent POM that Maven inherits DSpace Default
-       POM attributes from.
+       POM atrributes from.
     -->
     <parent>
         <groupId>org.dspace</groupId>
         <artifactId>dspace-parent</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>1.8.2</version>
         <relativePath>..</relativePath>
     </parent>
 
-    <properties>
-        <!-- This is the path to the root [dspace-src] directory. -->
-        <root.basedir>${basedir}/..</root.basedir>
-    </properties>
+    <!--
+       The Subversion repository location is used by Continuum to update against
+       when changes have occurred, this spawns a new build cycle and releases snapshots
+       into the snapshot repository below.
+    -->
+    <scm>
+        <connection>scm:svn:http://scm.dspace.org/svn/repo/tags/dspace-1.8.2</connection>
+        <developerConnection>scm:svn:https://scm.dspace.org/svn/repo/tags/dspace-1.8.2</developerConnection>
+        <url>http://scm.dspace.org/svn/repo/tags/dspace-1.8.2</url>
+    </scm>
 
     <build>
-        <filters>
-            <!-- Filter using the properties file defined by dspace-parent POM -->
-            <filter>${filters.file}</filter>
-        </filters>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -57,6 +60,26 @@
 
 
     <profiles>
+        <!--
+           when activated a dspace.config configuration
+           file location passed on the commandline
+           (-Ddspace.config=...) can be passed through
+           to be used as a filter source by projects for
+           tasks such as updating the ${dspace.dir} in
+           web.xml etc.
+        -->
+        <profile>
+            <activation>
+                <property>
+                    <name>dspace.config</name>
+                </property>
+            </activation>
+            <build>
+                <filters>
+                    <filter>${dspace.config}</filter>
+                </filters>
+            </build>
+        </profile>
         <profile>
             <id>oracle-support</id>
             <activation>
@@ -92,19 +115,19 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
-            <scope>provided</scope>
+            <version>2.3</version>
         </dependency>
         <dependency>
             <groupId>org.swordapp</groupId>
-            <artifactId>server</artifactId>
-            <version>2.0</version>
+            <artifactId>sword2-server</artifactId>
+            <version>1.0</version>
             <type>jar</type>
             <classifier>classes</classifier>
         </dependency>
         <dependency>
             <groupId>org.swordapp</groupId>
-            <artifactId>server</artifactId>
-            <version>2.0</version>
+            <artifactId>sword2-server</artifactId>
+            <version>1.0</version>
             <type>war</type>
         </dependency>
         <dependency>
@@ -119,6 +142,7 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
+            <version>1.2.15</version>
             <exclusions>
                 <exclusion>
                     <artifactId>jmxtools</artifactId>

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/AbstractSimpleDC.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/AbstractSimpleDC.java
@@ -1,0 +1,89 @@
+package org.dspace.sword2;
+
+import org.dspace.content.DCValue;
+import org.dspace.content.Item;
+import org.dspace.core.ConfigurationManager;
+
+import java.util.HashMap;
+import java.util.Properties;
+
+public class AbstractSimpleDC
+{
+    protected HashMap<String, String> dcMap = null;
+    protected HashMap<String, String> atomMap = null;
+
+    protected void loadMetadataMaps()
+    {
+        if (this.dcMap == null)
+        {
+            // we should load our DC map from configuration
+            this.dcMap = new HashMap<String, String>();
+            Properties props = ConfigurationManager.getProperties("swordv2-server");
+            for (Object key : props.keySet())
+            {
+                String keyString = (String) key;
+                if (keyString.startsWith("simpledc."))
+                {
+                    String k = keyString.substring("simpledc.".length());
+                    String v = (String) props.get(key);
+                    this.dcMap.put(k, v);
+                }
+            }
+        }
+
+        if (this.atomMap == null)
+        {
+            this.atomMap = new HashMap<String, String>();
+            Properties props = ConfigurationManager.getProperties("swordv2-server");
+                for (Object key : props.keySet())
+                {
+                    String keyString = (String) key;
+                    if (keyString.startsWith("atom."))
+                    {
+                        String k = keyString.substring("atom.".length());
+                        String v = (String) props.get(key);
+                        this.atomMap.put(k, v);
+                    }
+                }
+        }
+    }
+
+    protected SimpleDCMetadata getMetadata(Item item)
+    {
+        this.loadMetadataMaps();
+
+        SimpleDCMetadata md = new SimpleDCMetadata();
+        DCValue[] all = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+
+        for (DCValue dcv : all)
+        {
+            String valueMatch = dcv.schema + "." + dcv.element;
+            if (dcv.qualifier != null)
+            {
+                valueMatch += "." + dcv.qualifier;
+            }
+
+            // look for the metadata in the dublin core map
+            for (String key : this.dcMap.keySet())
+            {
+                String value = this.dcMap.get(key);
+                if (valueMatch.equals(value))
+                {
+                    md.addDublinCore(key, dcv.value);
+                }
+            }
+
+            // look for the metadata in the atom map
+            for (String key : this.atomMap.keySet())
+            {
+                String value = this.atomMap.get(key);
+                if (valueMatch.equals(value))
+                {
+                    md.addAtom(key, dcv.value);
+                }
+            }
+        }
+
+        return md;
+    }
+}

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/AbstractSwordContentIngester.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/AbstractSwordContentIngester.java
@@ -11,6 +11,7 @@ import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bitstream;
 import org.dspace.content.BitstreamFormat;
 import org.dspace.content.Bundle;
+import org.dspace.content.Collection;
 import org.dspace.content.DCDate;
 import org.dspace.content.DCValue;
 import org.dspace.content.DSpaceObject;
@@ -30,11 +31,31 @@ import java.util.StringTokenizer;
 
 public abstract class AbstractSwordContentIngester implements SwordContentIngester
 {
-	public abstract DepositResult ingest(Context context, Deposit deposit, DSpaceObject dso, VerboseDescription verboseDescription)
-			throws DSpaceSwordException, SwordError, SwordAuthException, SwordServerException;
+    public DepositResult ingest(Context context, Deposit deposit, DSpaceObject dso, VerboseDescription verboseDescription)
+            throws DSpaceSwordException, SwordError, SwordAuthException, SwordServerException
+    {
+        return this.ingest(context, deposit, dso, verboseDescription, null);
+    }
 
-    public abstract DepositResult ingest(Context context, Deposit deposit, DSpaceObject dso, VerboseDescription verboseDescription, DepositResult result)
-			throws DSpaceSwordException, SwordError, SwordAuthException, SwordServerException;
+    public DepositResult ingest(Context context, Deposit deposit, DSpaceObject dso, VerboseDescription verboseDescription, DepositResult result)
+            throws DSpaceSwordException, SwordError, SwordAuthException, SwordServerException
+    {
+        if (dso instanceof Collection)
+        {
+            return this.ingestToCollection(context, deposit, (Collection) dso, verboseDescription, result);
+        }
+        else if (dso instanceof Item)
+        {
+            return this.ingestToItem(context, deposit, (Item) dso, verboseDescription, result);
+        }
+        return null;
+    }
+
+    public abstract DepositResult ingestToCollection(Context context, Deposit deposit, Collection collection, VerboseDescription verboseDescription, DepositResult result)
+    			throws DSpaceSwordException, SwordError, SwordAuthException, SwordServerException;
+
+    public abstract DepositResult ingestToItem(Context context, Deposit deposit, Item item, VerboseDescription verboseDescription, DepositResult result)
+    			throws DSpaceSwordException, SwordError, SwordAuthException, SwordServerException;
 
 	protected BitstreamFormat getFormat(Context context, String fileName)
 			throws SQLException
@@ -124,15 +145,16 @@ public abstract class AbstractSwordContentIngester implements SwordContentIngest
 	}
 
 	/**
-	 * Utility method to turn given metadata fields of the form
+	 * utility method to turn given metadata fields of the form
 	 * schema.element.qualifier into DCValue objects which can be
 	 * used to access metadata in items.
 	 *
 	 * The def parameter should be null, * or "" depending on how
-	 * you intend to use the DCValue object.
+	 * you intend to use the DCValue object
 	 *
 	 * @param config
 	 * @param def
+	 * @return
 	 */
 	protected DCValue configToDC(String config, String def)
 	{

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/AtomCollectionGenerator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/AtomCollectionGenerator.java
@@ -20,9 +20,10 @@ import org.swordapp.server.SwordCollection;
 public interface AtomCollectionGenerator
 {
 	/**
-	 * Build the ATOM Collection which represents the given DSpace Object.
+	 * Build the ATOM Collection which represents the given DSpace Object
 	 * 
 	 * @param dso
+	 * @return
 	 * @throws DSpaceSwordException
 	 */
 	public SwordCollection buildCollection(Context context, DSpaceObject dso, SwordConfigurationDSpace config) throws DSpaceSwordException;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/AtomStatementDisseminator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/AtomStatementDisseminator.java
@@ -44,7 +44,7 @@ public class AtomStatementDisseminator extends GenericStatementDisseminator impl
 		}
 
 		DCValue[] dcvs = item.getMetadata(field);
-		if (dcvs == null)
+		if (dcvs == null || dcvs.length == 0)
 		{
 			return null;
 		}

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/BinaryContentIngester.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/BinaryContentIngester.java
@@ -28,26 +28,6 @@ import java.util.List;
 
 public class BinaryContentIngester extends AbstractSwordContentIngester
 {
-	public DepositResult ingest(Context context, Deposit deposit, DSpaceObject dso, VerboseDescription verboseDescription)
-			throws DSpaceSwordException, SwordError, SwordAuthException, SwordServerException
-	{
-		return this.ingest(context, deposit, dso, verboseDescription, null);
-	}
-
-	public DepositResult ingest(Context context, Deposit deposit, DSpaceObject dso, VerboseDescription verboseDescription, DepositResult result)
-			throws DSpaceSwordException, SwordError, SwordAuthException, SwordServerException
-	{
-		if (dso instanceof Collection)
-		{
-			return this.ingestToCollection(context, deposit, (Collection) dso, verboseDescription, result);
-		}
-		else if (dso instanceof Item)
-		{
-			return this.ingestToItem(context, deposit, (Item) dso, verboseDescription, result);
-		}
-		return null;
-	}
-
 	public DepositResult ingestToCollection(Context context, Deposit deposit, Collection collection, VerboseDescription verboseDescription, DepositResult result)
 			throws DSpaceSwordException, SwordError, SwordAuthException, SwordServerException
 	{
@@ -79,7 +59,7 @@ public class BinaryContentIngester extends AbstractSwordContentIngester
 
 			// now we have an item in the workspace, and we need to consider adding some metadata to it,
 			// but since the binary file didn't contain anything, what do we do?
-			item.addMetadata("dc", "title", null, null, "Unititled: " + deposit.getFilename());
+			item.addMetadata("dc", "title", null, null, "Untitled: " + deposit.getFilename());
 			item.addMetadata("dc", "description", null, null, "Zip file deposted by SWORD without accompanying metadata");
 
 			// update the item metadata to inclue the current time as
@@ -145,7 +125,9 @@ public class BinaryContentIngester extends AbstractSwordContentIngester
 				original = item.createBundle("ORIGINAL");
 			}
 
-			Bitstream bs = item.createSingleBitstream(deposit.getInputStream());
+            Bitstream bs = original.createBitstream(deposit.getInputStream());
+            BitstreamFormat format = this.getFormat(context, deposit.getFilename());
+            bs.setFormat(format);
 			bs.setName(deposit.getFilename());
 			bs.update();
 

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/CollectionCollectionGenerator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/CollectionCollectionGenerator.java
@@ -28,10 +28,10 @@ public class CollectionCollectionGenerator implements AtomCollectionGenerator
 	private static Logger log = Logger.getLogger(CommunityCollectionGenerator.class);
 
 	/**
-	 * Build the collection for the given DSpaceObject.  In this
-	 * implementation, if the object is not a DSpace Collection, it will
-	 * throw an exception.
+	 * Build the collection for the given DSpaceObject.  In this implementation,
+	 * if the object is not a DSpace COllection, it will throw an exception
 	 * @param dso
+	 * @return
 	 * @throws DSpaceSwordException
 	 */
 	public SwordCollection buildCollection(Context context, DSpaceObject dso, SwordConfigurationDSpace swordConfig)

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/CollectionDepositManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/CollectionDepositManagerDSpace.java
@@ -76,6 +76,10 @@ public class CollectionDepositManagerDSpace extends DSpaceSwordAPI implements Co
 
 			// get the deposit target
 			Collection collection = this.getDepositTarget(context, collectionUri, config);
+            if (collection == null)
+            {
+                throw new SwordError(404);
+            }
 
 			// Ensure that this method is allowed
 			WorkflowManager wfm = WorkflowManagerFactory.getInstance();
@@ -185,7 +189,7 @@ public class CollectionDepositManagerDSpace extends DSpaceSwordAPI implements Co
 			long delta = finish.getTime() - start.getTime();
 
 			this.verboseDescription.append("Total time for deposit processing: " + delta + " ms");
-			receipt.setVerboseDescription(this.verboseDescription.toString());
+            this.addVerboseDescription(receipt, this.verboseDescription);
 
 			// if something hasn't killed it already (allowed), then complete the transaction
 			sc.commit();
@@ -303,6 +307,10 @@ public class CollectionDepositManagerDSpace extends DSpaceSwordAPI implements Co
 
 		// get the target collection
 		Collection collection = urlManager.getCollection(context, depositUrl);
+        if (collection == null)
+        {
+            throw new SwordError(404);
+        }
 
 		this.verboseDescription.append("Performing deposit using deposit URL: " + depositUrl);
 

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/CollectionListManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/CollectionListManagerDSpace.java
@@ -46,6 +46,10 @@ public class CollectionListManagerDSpace extends DSpaceSwordAPI implements Colle
 			SwordUrlManager urlManager = config.getUrlManager(context, config);
 
 			Collection collection = urlManager.getCollection(context, colIRI.toString());
+            if (collection == null)
+            {
+                throw new SwordError(404);
+            }
 
 			List<Item> items = this.listItems(sc, collection, swordConfig);
 			Feed feed = this.itemListToFeed(sc, items, swordConfig);

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/ContainerManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/ContainerManagerDSpace.java
@@ -9,12 +9,14 @@ package org.dspace.sword2;
 
 import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.AuthorizeManager;
 import org.dspace.content.Collection;
-import org.dspace.content.InProgressSubmission;
 import org.dspace.content.Item;
 import org.dspace.content.WorkspaceItem;
+import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.LogManager;
+import org.dspace.workflow.WorkflowItem;
 import org.swordapp.server.AuthCredentials;
 import org.swordapp.server.ContainerManager;
 import org.swordapp.server.Deposit;
@@ -92,11 +94,27 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI implements ContainerM
 			SwordUrlManager urlManager = config.getUrlManager(context, config);
 
 			Item item = urlManager.getItem(context, editIRI);
+            if (item == null)
+            {
+                throw new SwordError(404);
+            }
+
+            // we can't give back an entry unless the user is authorised to retrieve it
+            AuthorizeManager.authorizeAction(context, item, Constants.READ);
 
 			ReceiptGenerator genny = new ReceiptGenerator();
 			DepositReceipt receipt = genny.createReceipt(context, item, config);
+			sc.abort();
 			return receipt;
 		}
+        catch (AuthorizeException e)
+        {
+            throw new SwordAuthException();
+        }
+        catch (SQLException e)
+        {
+            throw new SwordServerException(e);
+        }
 		catch (DSpaceSwordException e)
 		{
 			throw new SwordServerException(e);
@@ -135,6 +153,10 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI implements ContainerM
 
             // get the deposit target
             Item item = this.getDSpaceTarget(context, editIRI, config);
+            if (item == null)
+            {
+                throw new SwordError(404);
+            }
 
 			// now we have the deposit target, we can determine whether this operation is allowed
 			// at all
@@ -210,7 +232,7 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI implements ContainerM
             long delta = finish.getTime() - start.getTime();
 
             this.verboseDescription.append("Total time for deposit processing: " + delta + " ms");
-            receipt.setVerboseDescription(this.verboseDescription.toString());
+            this.addVerboseDescription(receipt, this.verboseDescription);
 
             // if something hasn't killed it already (allowed), then complete the transaction
             sc.commit();
@@ -258,6 +280,10 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI implements ContainerM
 
 			// get the deposit target
             Item item = this.getDSpaceTarget(context, editIRI, config);
+            if (item == null)
+            {
+                throw new SwordError(404);
+            }
 
 			// Ensure that this method is allowed
 			WorkflowManager wfm = WorkflowManagerFactory.getInstance();
@@ -334,7 +360,7 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI implements ContainerM
 			long delta = finish.getTime() - start.getTime();
 
 			this.verboseDescription.append("Total time for deposit processing: " + delta + " ms");
-			receipt.setVerboseDescription(this.verboseDescription.toString());
+            this.addVerboseDescription(receipt, this.verboseDescription);
 
 			// if something hasn't killed it already (allowed), then complete the transaction
 			sc.commit();
@@ -359,7 +385,7 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI implements ContainerM
 	public DepositReceipt addMetadataAndResources(String s, Deposit deposit, AuthCredentials authCredentials, SwordConfiguration config)
 			throws SwordError, SwordServerException
 	{
-		return null;  //To change body of implemented methods use File | Settings | File Templates.
+		return null;
 	}
 
 	public DepositReceipt addMetadata(String editIRI, Deposit deposit, AuthCredentials authCredentials, SwordConfiguration swordConfig)
@@ -386,6 +412,10 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI implements ContainerM
 
             // get the deposit target
             Item item = this.getDSpaceTarget(context, editIRI, config);
+            if (item == null)
+            {
+                throw new SwordError(404);
+            }
 
 			// now we have the deposit target, we can determine whether this operation is allowed
 			// at all
@@ -461,7 +491,7 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI implements ContainerM
             long delta = finish.getTime() - start.getTime();
 
             this.verboseDescription.append("Total time for deposit processing: " + delta + " ms");
-            receipt.setVerboseDescription(this.verboseDescription.toString());
+            this.addVerboseDescription(receipt, this.verboseDescription);
 
             // if something hasn't killed it already (allowed), then complete the transaction
             sc.commit();
@@ -486,7 +516,7 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI implements ContainerM
 	public DepositReceipt addResources(String s, Deposit deposit, AuthCredentials authCredentials, SwordConfiguration config)
 			throws SwordError, SwordServerException
 	{
-		return null;  //To change body of implemented methods use File | Settings | File Templates.
+		return null;
 	}
 
 	public void deleteContainer(String editIRI, AuthCredentials authCredentials, SwordConfiguration swordConfig)
@@ -513,6 +543,10 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI implements ContainerM
 
             // get the deposit target
             Item item = this.getDSpaceTarget(context, editIRI, config);
+            if (item == null)
+            {
+                throw new SwordError(404);
+            }
 
 			// now we have the deposit target, we can determine whether this operation is allowed
 			// at all
@@ -591,6 +625,10 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI implements ContainerM
 
             // get the deposit target
             Item item = this.getDSpaceTarget(context, editIRI, config);
+            if (item == null)
+            {
+                throw new SwordError(404);
+            }
 
 			// now we have the deposit target, we can determine whether this operation is allowed
 			// at all
@@ -634,7 +672,7 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI implements ContainerM
             long delta = finish.getTime() - start.getTime();
 
             this.verboseDescription.append("Total time for modify processing: " + delta + " ms");
-            receipt.setVerboseDescription(this.verboseDescription.toString());
+            this.addVerboseDescription(receipt, this.verboseDescription);
 
             // if something hasn't killed it already (allowed), then complete the transaction
             sc.commit();
@@ -679,7 +717,7 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI implements ContainerM
 			// delegate the to the version manager to get rid of any existing content and to version
 			// if if necessary
 			VersionManager vm = new VersionManager();
-			vm.emptyBundle(item, "ORIGINAL");
+			vm.removeBundle(item, "ORIGINAL");
 		}
 		catch (SQLException e)
 		{
@@ -790,7 +828,7 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI implements ContainerM
 			}
 			else if (wft.isItemInWorkflow(context, item))
 			{
-				InProgressSubmission wfi = wft.getWorkflowItem(context, item);
+				WorkflowItem wfi = wft.getWorkflowItem(context, item);
 				wfi.deleteWrapper();
 			}
 
@@ -822,6 +860,10 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI implements ContainerM
 
 		// get the target collection
 		Item item = urlManager.getItem(context, editUrl);
+        if (item == null)
+        {
+            throw new SwordError(404);
+        }
 
 		this.verboseDescription.append("Performing replace using edit-media URL: " + editUrl);
         this.verboseDescription.append("Location resolves to item with handle: " + item.getHandle());

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/DSpaceUriRegistry.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/DSpaceUriRegistry.java
@@ -12,30 +12,32 @@ public class DSpaceUriRegistry
 	public static final String DSPACE_SWORD_NS = "http://www.dspace.org/ns/sword/2.0/";
 
 	/** if unpackaging the package fails */
-	public static final String UNPACKAGE_FAIL = DSPACE_SWORD_NS + "/errors/UnpackageFail";
+	public static final String UNPACKAGE_FAIL = DSPACE_SWORD_NS + "errors/UnpackageFail";
 
 	/** if the url of the request does not resolve to something meaningful */
-	public static final String BAD_URL = DSPACE_SWORD_NS + "/errors/BadUrl";
+	public static final String BAD_URL = DSPACE_SWORD_NS + "errors/BadUrl";
 
 	/** if the media requested is unavailable */
-	public static final String MEDIA_UNAVAILABLE = DSPACE_SWORD_NS + "/errors/MediaUnavailable";
+	public static final String MEDIA_UNAVAILABLE = DSPACE_SWORD_NS + "errors/MediaUnavailable";
 
     /* additional codes */
 
     /** Invalid package */
-	public static final String PACKAGE_ERROR = DSPACE_SWORD_NS + "/errors/PackageError";
+	public static final String PACKAGE_ERROR = DSPACE_SWORD_NS + "errors/PackageError";
 
     /** Missing resources in package */
-	public static final String PACKAGE_VALIDATION_ERROR = DSPACE_SWORD_NS + "/errors/PackageValidationError";
+	public static final String PACKAGE_VALIDATION_ERROR = DSPACE_SWORD_NS + "errors/PackageValidationError";
 
     /** Crosswalk error */
-	public static final String CROSSWALK_ERROR = DSPACE_SWORD_NS + "/errors/CrosswalkError";
+	public static final String CROSSWALK_ERROR = DSPACE_SWORD_NS + "errors/CrosswalkError";
 
     /** Invalid collection for linking */
-	public static final String COLLECTION_LINK_ERROR = DSPACE_SWORD_NS + "/errors/CollectionLinkError";
+	public static final String COLLECTION_LINK_ERROR = DSPACE_SWORD_NS + "errors/CollectionLinkError";
 
     /** Database or IO Error when installing new item */
-	public static final String REPOSITORY_ERROR = DSPACE_SWORD_NS + "/errors/RepositoryError";
+	public static final String REPOSITORY_ERROR = DSPACE_SWORD_NS + "errors/RepositoryError";
 
-    public static final String NOT_ACCEPTABLE = DSPACE_SWORD_NS + "/errors/NotAcceptable";
+    // FIXME: this is being withdrawn from all 406 responses for the time being, in preference
+    // for ErrorContent as per the spec (whether that is right or wrong)
+    public static final String NOT_ACCEPTABLE = DSPACE_SWORD_NS + "errors/NotAcceptable";
 }

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/MediaResourceManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/MediaResourceManagerDSpace.java
@@ -9,9 +9,13 @@ package org.dspace.sword2;
 
 import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.AuthorizeManager;
+import org.dspace.authorize.ResourcePolicy;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.Item;
+import org.dspace.core.ConfigurationManager;
+import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.LogManager;
 import org.swordapp.server.AuthCredentials;
@@ -41,22 +45,241 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI implements MediaR
 
     private VerboseDescription verboseDescription = new VerboseDescription();
 
-    public MediaResource getMediaResourceRepresentation(String uri, Map<String, String> accept, AuthCredentials authCredentials, SwordConfiguration swordConfig)
-            throws SwordError, SwordServerException, SwordAuthException
+    private boolean isAccessible(Context context, Bitstream bitstream)
+            throws DSpaceSwordException
     {
         try
         {
-            SwordContext sc = null;
-            SwordConfigurationDSpace config = (SwordConfigurationDSpace) swordConfig;
+            return AuthorizeManager.authorizeActionBoolean(context, bitstream, Constants.READ);
+        }
+        catch (SQLException e)
+        {
+            throw new DSpaceSwordException(e);
+        }
+    }
 
+    private boolean isAccessible(Context context, Item item)
+            throws DSpaceSwordException
+    {
+        try
+        {
+            return AuthorizeManager.authorizeActionBoolean(context, item, Constants.READ);
+        }
+        catch (SQLException e)
+        {
+            throw new DSpaceSwordException(e);
+        }
+    }
+
+    private MediaResource getBitstreamResource(Context context, Bitstream bitstream)
+            throws SwordServerException, SwordAuthException
+    {
+        try
+        {
+            InputStream stream = bitstream.retrieve();
+            MediaResource mr = new MediaResource(stream, bitstream.getFormat().getMIMEType(), null, true);
+            mr.setContentMD5(bitstream.getChecksum());
+            mr.setLastModified(this.getLastModified(context, bitstream));
+            return mr;
+        }
+        catch (IOException e)
+        {
+            throw new SwordServerException(e);
+        }
+        catch (SQLException e)
+        {
+            throw new SwordServerException(e);
+        }
+        catch (AuthorizeException e)
+        {
+            throw new SwordAuthException(e);
+        }
+    }
+
+    private MediaResource getItemResource(Context context, Item item, SwordUrlManager urlManager, String uri, Map<String, String> accept)
+            throws SwordError, DSpaceSwordException, SwordServerException
+    {
+        boolean feedRequest = urlManager.isFeedRequest(context, uri);
+        SwordContentDisseminator disseminator = null;
+
+        // first off, consider the accept headers.  The accept argument is a map
+        // from accept header to value.
+        // we only care about Accept and Accept-Packaging
+        if (!feedRequest)
+        {
+            String acceptContentType = this.getHeader(accept, "Accept", null);
+            String acceptPackaging = this.getHeader(accept, "Accept-Packaging", UriRegistry.PACKAGE_SIMPLE_ZIP);
+
+            // we know that only one Accept-Packaging value is allowed, so we don't need
+            // to do any further work on it.
+
+            // we extract from the Accept header the ordered list of content types
+            TreeMap<Float, List<String>> analysed = this.analyseAccept(acceptContentType);
+
+            // the meat of this is done by the package disseminator
+            disseminator = SwordDisseminatorFactory.getContentInstance(analysed, acceptPackaging);
+        }
+        else
+        {
+            // we just want to ask for the atom version, so we bypass the main content
+            // negotiation place
+            Map<Float, List<String>> analysed = new HashMap<Float, List<String>>();
+            List<String> list = new ArrayList<String>();
+            list.add("application/atom+xml");
+            analysed.put((float) 1.0, list);
+            disseminator = SwordDisseminatorFactory.getContentInstance(analysed, null);
+        }
+
+        // Note that at this stage, if we don't have a desiredContentType, it will
+        // be null, and the disseminator is free to choose the format
+        InputStream stream = disseminator.disseminate(context, item);
+        MediaResource mr = new MediaResource(stream, disseminator.getContentType(), disseminator.getPackaging());
+        return mr;
+    }
+
+    public MediaResource getMediaResourceRepresentation(String uri, Map<String, String> accept, AuthCredentials authCredentials, SwordConfiguration swordConfig)
+                throws SwordError, SwordServerException, SwordAuthException
+    {
+        log.info("Retrieving Media Resource Representation from " + uri);
+
+        // all the bits we need to make this method function
+        SwordContext sc = null;
+        SwordConfigurationDSpace config = (SwordConfigurationDSpace) swordConfig;
+        Context ctx = null;
+
+        try
+        {
+            // create an unauthenticated context for our initial explorations
+            ctx = new Context();
+            SwordUrlManager urlManager = config.getUrlManager(ctx, config);
+
+            // is this a request for a bitstream or an item (which is the full media resource)?
+            if (urlManager.isActionableBitstreamUrl(ctx, uri))
+            {
+                log.debug("Requested media resource is an actionable bistream: " + uri);
+
+                // request for a bitstream
+                Bitstream bitstream = urlManager.getBitstream(ctx, uri);
+                if (bitstream == null)
+                {
+                    // bitstream not found in the database, so 404 the client.
+                    // Arguably, we should try to authenticate first, but it's not so important
+                    log.error("Requested bitstream does not exist: " + uri);
+                    throw new SwordError(404);
+                }
+
+                // find out, now we know what we're being asked for, whether this is allowed
+                log.debug("checking whether bitstream retrieves are allowed");
+                WorkflowManagerFactory.getInstance().retrieveBitstream(ctx, bitstream);
+                log.debug("bitstream retrieves are allowed");
+
+                // we can do this in principle, but now find out whether the bitstream is accessible without credentials
+                boolean accessible = this.isAccessible(ctx, bitstream);
+
+                if (!accessible)
+                {
+                    log.debug("bitstream is not accessible without authentication: " + uri);
+
+                    // try to authenticate, and if successful switch the contexts around
+                    sc = this.doAuth(authCredentials);
+                    ctx.abort();
+                    ctx = sc.getContext();
+
+                    // re-retrieve the bitstream using the new context
+                    bitstream = Bitstream.find(ctx, bitstream.getID());
+
+                    // and re-verify its accessibility
+                    accessible = this.isAccessible(ctx, bitstream);
+                    if (!accessible)
+                    {
+                        log.info("unable to successfully retrieve bitstream with authentication credentials provided: " + uri);
+                        throw new SwordAuthException();
+                    }
+                }
+
+                // if we get to here we are either allowed to access the bitstream without credentials,
+                // or we have been authenticated with acceptable credentials
+                MediaResource mr = this.getBitstreamResource(ctx, bitstream);
+                if (sc != null)
+                {
+                    sc.abort();
+                }
+                if (ctx.isValid())
+                {
+                    ctx.abort();
+                }
+                return mr;
+            }
+            else
+            {
+                log.debug("Media resource requested is for a representation of the whole item: " + uri);
+                // request for an item
+                Item item = urlManager.getItem(ctx, uri);
+                if (item == null)
+                {
+                    // item now found in the database, so 404 the client
+                    // Arguably, we should try to authenticate first, but it's not so important
+                    throw new SwordError(404);
+                }
+
+                // find out, now we know what we're being asked for, whether this is allowed
+                WorkflowManagerFactory.getInstance().retrieveContent(ctx, item);
+
+                // we can do this in principle but now find out whether the item is accessible without credentials
+                boolean accessible = this.isAccessible(ctx, item);
+
+                if (!accessible)
+                {
+                    // try to authenticate, and if successful switch the contexts around
+                    sc = this.doAuth(authCredentials);
+                    ctx.abort();
+                    ctx = sc.getContext();
+                }
+
+                // if we get to here we are either allowed to access the bitstream without credentials,
+                // or we have been authenticated
+                MediaResource mr = this.getItemResource(ctx, item, urlManager, uri, accept);
+                // sc.abort();
+                ctx.abort();
+                return mr;
+            }
+        }
+        catch (SQLException e)
+        {
+            throw new SwordServerException(e);
+        }
+        catch (DSpaceSwordException e)
+        {
+            throw new SwordServerException(e);
+        }
+        finally
+        {
+            // if there is a sword context, abort it (this will abort the inner dspace context as well)
+            if (sc != null)
+            {
+                sc.abort();
+            }
+            if (ctx != null && ctx.isValid())
+            {
+                ctx.abort();
+            }
+        }
+    }
+
+    /* This was the previous implementation which did not properly deal with authorisation and
+        access without credentials (which is allowed if the bitstream/item permissions are
+        set to allow it ...
+
+    public MediaResource getMediaResourceRepresentation(String uri, Map<String, String> accept, AuthCredentials authCredentials, SwordConfiguration swordConfig)
+            throws SwordError, SwordServerException, SwordAuthException
+    {
+		SwordContext sc = null;
+        try
+        {
+            SwordConfigurationDSpace config = (SwordConfigurationDSpace) swordConfig;
             SwordAuthenticator auth = new SwordAuthenticator();
             sc = auth.authenticate(authCredentials);
             Context context = sc.getContext();
-
-            if (log.isDebugEnabled())
-            {
-                log.debug(LogManager.getHeader(context, "sword_get_media_resource", ""));
-            }
 
             // log the request
             String un = authCredentials.getUsername() != null ? authCredentials.getUsername() : "NONE";
@@ -69,6 +292,10 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI implements MediaR
 			{
 				// we're being asked for the bitstream itself
 				Bitstream bitstream = urlManager.getBitstream(context, uri);
+                if (bitstream == null)
+                {
+                    throw new SwordError(404);
+                }
 
 				// find out, now we know what we're being asked for, whether this is allowed
 				WorkflowManagerFactory.getInstance().retrieveBitstream(context, bitstream);
@@ -83,6 +310,10 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI implements MediaR
 			{
 				// we're dealing with a request for a representation of the item as a media resource
 				Item item = urlManager.getItem(context, uri);
+                if (item == null)
+                {
+                    throw new SwordError(404);
+                }
 				boolean feedRequest = urlManager.isFeedRequest(context, uri);
 
 				// find out, now we know what we're being asked for, whether this is allowed
@@ -122,6 +353,7 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI implements MediaR
 				// be null, and the disseminator is free to choose the format
 				InputStream stream = disseminator.disseminate(context, item);
 				MediaResource mr = new MediaResource(stream, disseminator.getContentType(), disseminator.getPackaging());
+				sc.abort();
 				return mr;
 			}
         }
@@ -141,7 +373,15 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI implements MediaR
 		{
 			throw new SwordServerException(e);
 		}
+		finally
+        {
+            if (sc != null)
+            {
+                sc.abort();
+            }
+        }
     }
+    */
 
     private Date getLastModified(Context context, Bitstream bitstream)
             throws SQLException
@@ -196,6 +436,10 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI implements MediaR
 			if (urlManager.isActionableBitstreamUrl(context, emUri))
 			{
                 Bitstream bitstream = urlManager.getBitstream(context, emUri);
+                if (bitstream == null)
+                {
+                    throw new SwordError(404);
+                }
 
                 // now we have the deposit target, we can determine whether this operation is allowed
                 // at all
@@ -266,6 +510,10 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI implements MediaR
             {
                 // get the deposit target
                 Item item = this.getDSpaceTarget(context, emUri, config);
+                if (item == null)
+                {
+                    throw new SwordError(404);
+                }
 
                 // now we have the deposit target, we can determine whether this operation is allowed
                 // at all
@@ -333,8 +581,8 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI implements MediaR
                 // now we've produced a deposit, we need to decide on its workflow state
                 wfm.resolveState(context, deposit, null, this.verboseDescription, false);
 
-                // ReceiptGenerator genny = new ReceiptGenerator();
-                // DepositReceipt receipt = genny.createReceipt(context, result, config);
+                ReceiptGenerator genny = new ReceiptGenerator();
+                receipt = genny.createMediaResourceReceipt(context, item, config);
             }
 
             Date finish = new Date();
@@ -397,6 +645,10 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI implements MediaR
 			if (urlManager.isActionableBitstreamUrl(context, emUri))
 			{
 				Bitstream bitstream = urlManager.getBitstream(context, emUri);
+                if (bitstream == null)
+                {
+                    throw new SwordError(404);
+                }
 
 				// now we have the deposit target, we can determine whether this operation is allowed
 				// at all
@@ -425,6 +677,10 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI implements MediaR
 			else
 			{
 				Item item = this.getDSpaceTarget(context, emUri, config);
+                if (item == null)
+                {
+                    throw new SwordError(404);
+                }
 
 				// now we have the deposit target, we can determine whether this operation is allowed
 				// at all
@@ -518,6 +774,10 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI implements MediaR
 
             // get the deposit target
             Item item = this.getDSpaceTarget(context, emUri, config);
+            if (item == null)
+            {
+                throw new SwordError(404);
+            }
 
 			// now we have the deposit target, we can determine whether this operation is allowed
 			// at all
@@ -620,7 +880,7 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI implements MediaR
             long delta = finish.getTime() - start.getTime();
 
             this.verboseDescription.append("Total time for add processing: " + delta + " ms");
-            receipt.setVerboseDescription(this.verboseDescription.toString());
+            this.addVerboseDescription(receipt, this.verboseDescription);
 
             // if something hasn't killed it already (allowed), then complete the transaction
             sc.commit();
@@ -652,7 +912,7 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI implements MediaR
 			Bundle[] originals = item.getBundles("ORIGINAL");
 			for (Bundle original : originals)
 			{
-				vm.emptyBundle(item, original);
+				vm.removeBundle(item, original);
 			}
 		}
 		catch (SQLException e)
@@ -714,7 +974,7 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI implements MediaR
 			// delegate the to the version manager to get rid of any existing content and to version
 			// if if necessary
 			VersionManager vm = new VersionManager();
-			vm.emptyBundle(item, "ORIGINAL");
+			vm.removeBundle(item, "ORIGINAL");
 		}
 		catch (SQLException e)
 		{
@@ -741,8 +1001,11 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI implements MediaR
 			throws DSpaceSwordException, SwordError, SwordAuthException, SwordServerException
     {
 		// FIXME: this is basically not possible with the existing DSpace API.
-        // we are going to hack around the problem, by deleting the old bitstream and
-        // adding the new one and returning it
+
+        // We hack around it by deleting the old bitstream and
+        // adding the new one and returning it,
+        // but this isn't in line with the REST approach of SWORD, so the caller should really
+        // 405 the client
 
         // get the things out of the service that we need
 		Context context = swordContext.getContext();

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/ReceiptGenerator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/ReceiptGenerator.java
@@ -50,6 +50,15 @@ public class ReceiptGenerator
 		return receipt;
 	}
 
+    protected DepositReceipt createMediaResourceReceipt(Context context, Item item, SwordConfigurationDSpace config)
+            throws DSpaceSwordException, SwordError, SwordServerException
+    {
+        SwordUrlManager urlManager = config.getUrlManager(context, config);
+        DepositReceipt receipt = new DepositReceipt();
+        receipt.setLocation(urlManager.getContentUrl(item));
+        return receipt;
+    }
+
 	protected DepositReceipt createReceipt(Context context, DepositResult result, SwordConfigurationDSpace config)
 			throws DSpaceSwordException, SwordError, SwordServerException
 	{
@@ -61,7 +70,7 @@ public class ReceiptGenerator
 	 *
 	 * @throws DSpaceSwordException
 	 */
-	protected DepositReceipt createReceipt(Context context, DepositResult result, SwordConfigurationDSpace config, boolean mediaResource)
+	protected DepositReceipt createReceipt(Context context, DepositResult result, SwordConfigurationDSpace config, boolean mediaResourceLocation)
 			throws DSpaceSwordException, SwordError, SwordServerException
 	{
 		SwordUrlManager urlManager = config.getUrlManager(context, config);
@@ -78,7 +87,7 @@ public class ReceiptGenerator
         receipt.setMediaFeedIRI(urlManager.getMediaFeedUrl(result.getItem()));
         receipt.setLastModified(result.getItem().getLastModified());
 
-		if (mediaResource)
+		if (mediaResourceLocation)
 		{
 			receipt.setLocation(urlManager.getContentUrl(result.getItem()));
 		}
@@ -204,11 +213,6 @@ public class ReceiptGenerator
 		receipt.setPackaging(config.getDisseminatePackaging());
 
 		return receipt;
-	}
-
-	private void addMetadata(DepositResult result, DepositReceipt receipt)
-	{
-
 	}
 
 	/**

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/ServiceDocumentManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/ServiceDocumentManagerDSpace.java
@@ -140,6 +140,10 @@ public class ServiceDocumentManagerDSpace implements ServiceDocumentManager
 		{
 			// we are dealing with a partial or sub-service document
 			DSpaceObject dso = urlManager.extractDSpaceObject(url);
+            if (dso == null)
+            {
+                throw new SwordError(404);
+            }
 
 			if (dso instanceof Community)
 			{

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleDCEntryDisseminator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleDCEntryDisseminator.java
@@ -7,67 +7,67 @@
  */
 package org.dspace.sword2;
 
-import org.dspace.content.DCValue;
 import org.dspace.content.Item;
-import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 import org.swordapp.server.DepositReceipt;
 import org.swordapp.server.SwordError;
 import org.swordapp.server.SwordServerException;
 
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
-public class SimpleDCEntryDisseminator implements SwordEntryDisseminator
+public class SimpleDCEntryDisseminator extends AbstractSimpleDC implements SwordEntryDisseminator
 {
-    private Map<String, String> dcMap;
-
-    public SimpleDCEntryDisseminator()
-    {
-        // we should load our DC map from configuration
-        this.dcMap = new HashMap<String, String>();
-        Properties props = ConfigurationManager.getProperties();
-        for (Object key : props.keySet())
-        {
-            String keyString = (String) key;
-            if (keyString.startsWith("sword2.simpledc."))
-            {
-                String k = keyString.substring("sword2.simpledc.".length());
-                String v = (String) props.get(key);
-                this.dcMap.put(k, v);
-            }
-        }
-    }
+    public SimpleDCEntryDisseminator() { }
 
     public DepositReceipt disseminate(Context context, Item item, DepositReceipt receipt)
             throws DSpaceSwordException, SwordError, SwordServerException
     {
-        DCValue[] all = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+        SimpleDCMetadata md = this.getMetadata(item);
 
-        for (DCValue dcv : all)
+        Map<String, String> dc = md.getDublinCore();
+        for (String element : dc.keySet())
         {
-            String valueMatch = dcv.schema + "." + dcv.element;
-            if (dcv.qualifier != null)
+            String value = dc.get(element);
+            receipt.addDublinCore(element, value);
+        }
+
+        /*
+        atom.author = dc.contributor.author
+        atom.published = dc.date.created
+        atom.rights = dc.rights
+        atom.summary = dc.description.abstract
+        atom.title = dc.title
+        atom.updated = dc.date.created
+        */
+
+        Map<String, String> atom = md.getAtom();
+        for (String element : atom.keySet())
+        {
+            String value = atom.get(element);
+            if ("author".equals(element))
             {
-                valueMatch += "." + dcv.qualifier;
+               receipt.getWrappedEntry().addAuthor(value);
             }
-             for (String key : this.dcMap.keySet())
-             {
-                 String value = this.dcMap.get(key);
-                 if (valueMatch.equals(value))
-                 {
-                     receipt.addDublinCore(key, dcv.value);
-                     if (key.equals("title"))
-                     {
-                         receipt.getWrappedEntry().setTitle(dcv.value);
-                     }
-                     if (key.equals("abstract"))
-                     {
-                         receipt.getWrappedEntry().setSummary(dcv.value);
-                     }
-                 }
-             }
+            else if ("published".equals(element))
+            {
+                receipt.getWrappedEntry().setPublished(value);
+            }
+            else if ("rights".equals(element))
+            {
+                receipt.getWrappedEntry().setRights(value);
+            }
+            else if ("summary".equals(element))
+            {
+                receipt.getWrappedEntry().setSummary(value);
+            }
+            else if ("title".equals(element))
+            {
+                receipt.getWrappedEntry().setTitle(value);
+            }
+            else if ("updated".equals(element))
+            {
+                receipt.getWrappedEntry().setUpdated(value);
+            }
         }
 
         return receipt;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleDCEntryIngester.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleDCEntryIngester.java
@@ -24,31 +24,18 @@ import org.swordapp.server.SwordServerException;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-public class SimpleDCEntryIngester implements SwordEntryIngester
+public class SimpleDCEntryIngester extends AbstractSimpleDC implements SwordEntryIngester
 {
-    private Map<String, String> dcMap;
-
 	public SimpleDCEntryIngester()
     {
-        // we should load our DC map from configuration
-        this.dcMap = new HashMap<String, String>();
-        Properties props = ConfigurationManager.getProperties("swordv2-server");
-        for (Object key : props.keySet())
-        {
-            String keyString = (String) key;
-            if (keyString.startsWith("simpledc."))
-            {
-                String k = keyString.substring("simpledc.".length());
-                String v = (String) props.get(key);
-                this.dcMap.put(k, v);
-            }
-        }
+        this.loadMetadataMaps();
     }
 
 	public DepositResult ingest(Context context, Deposit deposit, DSpaceObject dso, VerboseDescription verboseDescription)
@@ -82,9 +69,11 @@ public class SimpleDCEntryIngester implements SwordEntryIngester
 			}
 			result.setItem(item);
 
-			// NOTE: this implementation does not remove pre-existing metadata, as that is actually
-			// rather hard to handle in DSpace (what do you do about provenance and other administrator
-			// added metadata?).  Instead "replace" does nothing different to "create new" or "add".
+			// clean out any existing item metadata which is allowed to be replaced
+            if (replace)
+            {
+                this.removeMetadata(item);
+            }
 
 			// add the metadata to the item
 			this.addMetadataToItem(deposit, item);
@@ -119,6 +108,47 @@ public class SimpleDCEntryIngester implements SwordEntryIngester
 		}
 	}
 
+    private void removeMetadata(Item item)
+            throws DSpaceSwordException
+    {
+        String raw = ConfigurationManager.getProperty("swordv2-server", "metadata.replaceable");
+        String[] parts = raw.split(",");
+        for (String part : parts)
+        {
+            DCValue dcv = this.makeDCValue(part.trim(), null);
+            item.clearMetadata(dcv.schema, dcv.element, dcv.qualifier, Item.ANY);
+        }
+    }
+
+    private void addUniqueMetadata(DCValue dcv, Item item)
+    {
+        String qual = dcv.qualifier;
+        if (dcv.qualifier == null)
+        {
+            qual = Item.ANY;
+        }
+
+        String lang = dcv.language;
+        if (dcv.language == null)
+        {
+            lang = Item.ANY;
+        }
+        DCValue[] existing = item.getMetadata(dcv.schema, dcv.element, qual, lang);
+        for (DCValue dcValue : existing)
+        {
+            // FIXME: probably we want to be slightly more careful about qualifiers and languages
+            //
+            // if the submitted value is already attached to the item, just skip it
+            if (dcValue.value.equals(dcv.value))
+            {
+                return;
+            }
+        }
+
+        // if we get to here, go on and add the metadata
+        item.addMetadata(dcv.schema, dcv.element, dcv.qualifier, dcv.language, dcv.value);
+    }
+
 	private void addMetadataToItem(Deposit deposit, Item item)
 			throws DSpaceSwordException
 	{
@@ -134,7 +164,7 @@ public class SimpleDCEntryIngester implements SwordEntryIngester
 			if (titleField != null)
 			{
 				DCValue dcv = this.makeDCValue(titleField, title);
-				item.addMetadata(dcv.schema, dcv.element, dcv.qualifier, dcv.language, dcv.value);
+                this.addUniqueMetadata(dcv, item);
 			}
 		}
 		if (summary != null)
@@ -143,7 +173,7 @@ public class SimpleDCEntryIngester implements SwordEntryIngester
 			if (abstractField != null)
 			{
 				DCValue dcv = this.makeDCValue(abstractField, summary);
-				item.addMetadata(dcv.schema, dcv.element, dcv.qualifier, dcv.language, dcv.value);
+                this.addUniqueMetadata(dcv, item);
 			}
 		}
 
@@ -157,21 +187,12 @@ public class SimpleDCEntryIngester implements SwordEntryIngester
 				continue;
 			}
 
-			// clear any pre-existing metadata
-			DCValue dcv = this.makeDCValue(dsTerm, null);
-			if (dcv.qualifier == null)
-			{
-				item.clearMetadata(dcv.schema, dcv.element, Item.ANY, Item.ANY);
-			}
-			else
-			{
-				item.clearMetadata(dcv.schema, dcv.element, dcv.qualifier, Item.ANY);
-			}
-
 			// now add all the metadata terms
+            DCValue dcv = this.makeDCValue(dsTerm, null);
 			for (String value : dc.get(term))
 			{
-				item.addMetadata(dcv.schema, dcv.element, dcv.qualifier, dcv.language, value);
+                dcv.value = value;
+                this.addUniqueMetadata(dcv, item);
 			}
 		}
 	}
@@ -240,9 +261,6 @@ public class SimpleDCEntryIngester implements SwordEntryIngester
 			throw new DSpaceSwordException(e);
 		}
     }
-
-	
-
 
     public DCValue makeDCValue(String field, String value)
             throws DSpaceSwordException

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleDCMetadata.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleDCMetadata.java
@@ -1,0 +1,30 @@
+package org.dspace.sword2;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SimpleDCMetadata
+{
+    private Map<String, String> dublinCore = new HashMap<String, String>();
+    private Map<String, String> atom = new HashMap<String, String>();
+
+    public void addDublinCore(String element, String value)
+    {
+        this.dublinCore.put(element, value);
+    }
+
+    public void addAtom(String element, String value)
+    {
+        this.atom.put(element, value);
+    }
+
+    public Map<String, String> getDublinCore()
+    {
+        return dublinCore;
+    }
+
+    public Map<String, String> getAtom()
+    {
+        return atom;
+    }
+}

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleZipContentIngester.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleZipContentIngester.java
@@ -20,41 +20,21 @@ import org.swordapp.server.Deposit;
 import org.swordapp.server.SwordAuthException;
 import org.swordapp.server.SwordError;
 import org.swordapp.server.SwordServerException;
+import org.swordapp.server.UriRegistry;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 
 public class SimpleZipContentIngester extends AbstractSwordContentIngester
 {
-    public DepositResult ingest(Context context, Deposit deposit, DSpaceObject dso, VerboseDescription verboseDescription)
-            throws DSpaceSwordException, SwordError, SwordAuthException, SwordServerException
-    {
-        return this.ingest(context, deposit, dso, verboseDescription, null);
-    }
-
-	public DepositResult ingest(Context context, Deposit deposit, DSpaceObject dso, VerboseDescription verboseDescription, DepositResult result)
-			throws DSpaceSwordException, SwordError, SwordAuthException
-	{
-        if (dso instanceof Collection)
-        {
-            return this.ingestToCollection(context, deposit, (Collection) dso, verboseDescription, result);
-        }
-		else if (dso instanceof Item)
-        {
-            return this.ingestToItem(context, deposit, (Item) dso, verboseDescription, result);
-        }
-		return null;
-	}
-
 	public DepositResult ingestToCollection(Context context, Deposit deposit, Collection collection, VerboseDescription verboseDescription, DepositResult result)
 			throws DSpaceSwordException, SwordError, SwordAuthException
     {
@@ -142,7 +122,7 @@ public class SimpleZipContentIngester extends AbstractSwordContentIngester
     }
 
 	private List<Bitstream> unzipToBundle(Context context, File depositFile, Bundle target)
-			throws DSpaceSwordException, SwordAuthException
+			throws DSpaceSwordException, SwordError, SwordAuthException
 	{
 		try
 		{
@@ -164,6 +144,10 @@ public class SimpleZipContentIngester extends AbstractSwordContentIngester
 			}
 
 			return derivedResources;
+		}
+		catch (ZipException e)
+		{
+			throw new SwordError(UriRegistry.ERROR_BAD_REQUEST, "unable to unzip provided package", e);
 		}
 		catch (IOException e)
 		{

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordAuthenticator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordAuthenticator.java
@@ -86,11 +86,12 @@ public class SwordAuthenticator
 	}
 
 	/**
-	 * Authenticate the given service document request.  This extracts the
-	 * appropriate information from the request and forwards to the
-	 * appropriate authentication method.
+	 * Authenticate the given service document request.  This extracts the appropriate
+	 * information from the request and forwards to the appropriate authentication
+	 * method
 	 *
 	 * @param auth
+	 * @return
 	 * @throws DSpaceSwordException
 	 * @throws SwordError
 	 * @throws SwordAuthException
@@ -138,115 +139,6 @@ public class SwordAuthenticator
         }
 		return sc; 
 	}
-
-	/**
-	 * Authenticate the given atom document request.  This extracts the appropriate information
-	 * from the request, and forwards to the appropriate authentication method
-	 *
-	 * @param request
-	 * @return
-	 * @throws SWORDException
-	 * @throws SWORDErrorException
-	 * @throws SWORDAuthenticationException
-	 */
-//	public SwordContext authenticate(AtomDocumentRequest request)
-//			throws SWORDException, SWORDErrorException, SWORDAuthenticationException
-//	{
-//		Context context = this.constructContext(request.getIPAddress());
-//		SwordContext sc = null;
-//		try
-//        {
-//            sc = this.authenticate(context, request);
-//        }
-//        catch (SWORDException e)
-//        {
-//            if (context != null && context.isValid())
-//            {
-//                context.abort();
-//            }
-//            throw e;
-//        }
-//        catch (SWORDErrorException e)
-//        {
-//            if (context != null && context.isValid())
-//            {
-//                context.abort();
-//            }
-//            throw e;
-//        }
-//        catch (SWORDAuthenticationException e)
-//        {
-//            if (context != null && context.isValid())
-//            {
-//                context.abort();
-//            }
-//            throw e;
-//        }
-//        catch (RuntimeException e)
-//        {
-//            if (context != null && context.isValid())
-//            {
-//                context.abort();
-//            }
-//            throw e;
-//        }
-//        return sc;
-//    }
-
-
-	/**
-	 * Authenticate the deposit request.
-	 *
-	 * @param deposit
-	 * @return
-	 * @throws SWORDException
-	 * @throws SWORDErrorException
-	 * @throws SWORDAuthenticationException
-	 */
-//	public SwordContext authenticate(Deposit deposit)
-//			throws SWORDException, SWORDErrorException, SWORDAuthenticationException
-//	{
-//		Context context = this.constructContext(deposit.getIPAddress());
-//		SwordContext sc = null;
-//		try
-//		{
-//		    sc = this.authenticate(context, deposit);
-//		}
-//        catch (SWORDException e)
-//        {
-//            if (context != null && context.isValid())
-//            {
-//                context.abort();
-//            }
-//            throw e;
-//        }
-//        catch (SWORDErrorException e)
-//        {
-//            if (context != null && context.isValid())
-//            {
-//                context.abort();
-//            }
-//            throw e;
-//        }
-//        catch (SWORDAuthenticationException e)
-//        {
-//            if (context != null && context.isValid())
-//            {
-//                context.abort();
-//            }
-//            throw e;
-//        }
-//        catch (RuntimeException e)
-//        {
-//            if (context != null && context.isValid())
-//            {
-//                context.abort();
-//            }
-//            throw e;
-//        }
-//        return sc;
-//	}
-
 
 	/**
 	 * Authenticate the given username/password pair, in conjunction with
@@ -355,7 +247,7 @@ public class SwordAuthenticator
 				if (ep != null)
 				{
 					log.info(LogManager.getHeader(context, "sword_unable_to_set_user", "username=" + un));
-					throw new SwordAuthException("Unable to authenticate the supplied used");
+					throw new SwordAuthException("Unable to authenticate with the supplied credentials");
 				}
 				else
 				{
@@ -469,6 +361,7 @@ public class SwordAuthenticator
 	 * or one of its sub groups?
 	 *
 	 * @param group
+	 * @return
 	 */
 	public boolean isUserInGroup(SwordContext swordContext, Group group)
 	{
@@ -482,9 +375,10 @@ public class SwordAuthenticator
 
 	/**
 	 * Is the onBehalfOf user a member of the given group or
-	 * one of its sub groups?
+	 * one of its sub groups
 	 *
 	 * @param group
+	 * @return
 	 */
 	public boolean isOnBehalfOfInGroup(SwordContext swordContext, Group group)
 	{
@@ -917,7 +811,7 @@ public class SwordAuthenticator
 
 	/**
 	 * Can the current SWORD Context permit deposit into the given
-	 * collection in the given DSpace Context?
+	 * collection in the given DSpace Context
 	 *
 	 * IF: the authenticated user is an administrator
 	 *   AND:
@@ -932,6 +826,7 @@ public class SwordAuthenticator
 	 *
 	 * @param swordContext
 	 * @param collection
+	 * @return
 	 * @throws DSpaceSwordException
 	 */
 	public boolean canSubmitTo(SwordContext swordContext, org.dspace.content.Collection collection)
@@ -984,6 +879,105 @@ public class SwordAuthenticator
 		}
 	}
 
+    public boolean canSubmitTo(SwordContext swordContext, Item item)
+            throws DSpaceSwordException
+    {
+        // a context can submit to an item if the following are satisfied
+        //
+        // 1/ the primary authenticating user is authenticated (which is implicit
+        //      in there being a context in the first place)
+        // 2/ If an On-Behalf-Of request, the On-Behalf-Of user is authorised to
+        //      carry out the action and the authenticating user is in the list
+        //      of allowed mediaters
+        // 3/ If not an On-Behalf-Of request, the authenticating user is authorised
+        //      to carry out the action
+
+        try
+        {
+            boolean isObo = swordContext.getOnBehalfOf() != null;
+            Context allowContext = null;
+            if (isObo)
+            {
+                // we need to find out if the authenticated user is permitted to mediate
+                if (!this.allowedToMediate(swordContext.getAuthenticatorContext()))
+                {
+                    return false;
+                }
+                allowContext = swordContext.getOnBehalfOfContext();
+            }
+            else
+            {
+                allowContext = swordContext.getAuthenticatorContext();
+            }
+
+            // we now need to check whether the selected context that we are authorising
+            // has the appropriate permissions
+            boolean write = AuthorizeManager.authorizeActionBoolean(allowContext, item, Constants.WRITE);
+
+            Bundle[] bundles = item.getBundles("ORIGINAL");
+            boolean add = false;
+            if (bundles.length == 0)
+            {
+                add = AuthorizeManager.authorizeActionBoolean(allowContext, item, Constants.ADD);
+            }
+            else
+            {
+                for (int i = 0; i < bundles.length; i++)
+                {
+                    add = AuthorizeManager.authorizeActionBoolean(allowContext, bundles[i], Constants.ADD);
+                    if (!add)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            boolean allowed = write && add;
+            return allowed;
+        }
+        catch (SQLException e)
+        {
+            log.error("Caught exception: ", e);
+            throw new DSpaceSwordException(e);
+        }
+    }
+
+    private boolean allowedToMediate(Context context)
+    {
+        // get the configuration
+        String mediatorCfg = ConfigurationManager.getProperty("swordv2-server", "on-behalf-of.update.mediators");
+        if (mediatorCfg == null)
+        {
+            // if there's no explicit list of mediators, then anyone can mediate
+            return true;
+        }
+
+        // get the email and netid of the mediator
+        EPerson eperson = context.getCurrentUser();
+        if (eperson == null)
+        {
+            return false;
+        }
+        String email = eperson.getEmail();
+        String netid = eperson.getNetid();
+
+        String[] mediators = mediatorCfg.split(",");
+        for (String mediator : mediators)
+        {
+            String m = mediator.trim();
+            if (email != null && m.equals(email.trim()))
+            {
+                return true;
+            }
+            if (netid != null && m.equals(netid.trim()))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
 	/**
 	 * Does the given context have the authority to submit to the given item.
 	 *
@@ -1004,6 +998,7 @@ public class SwordAuthenticator
 	 * @return	the array of allowed collections
 	 * @throws DSpaceSwordException
 	 */
+    /*
 	public boolean canSubmitTo(SwordContext swordContext, Item item)
 			throws DSpaceSwordException
 	{
@@ -1094,15 +1089,17 @@ public class SwordAuthenticator
 			throw new DSpaceSwordException(e);
 		}
 	}
+	*/
 
 	/**
-	 * Can the given context submit to the specified DSpace object?
+	 * Can the given context submit to the specified dspace object.
 	 *
-	 * This forwards to the individual methods for different object types;
-	 * see their documentation for details of the conditions.
+	 * This forwards to the individual methods for different object types; see
+	 * their documentation for details of the conditions.
 	 *
 	 * @param context
 	 * @param dso
+	 * @return
 	 * @throws DSpaceSwordException
 	 */
 	public boolean canSubmitTo(SwordContext context, DSpaceObject dso)

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordConfigurationDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordConfigurationDSpace.java
@@ -14,8 +14,8 @@ import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
-import org.jaxen.function.FalseFunction;
 import org.swordapp.server.SwordConfiguration;
+import org.swordapp.server.SwordConfigurationDefault;
 import org.swordapp.server.SwordError;
 
 import java.sql.SQLException;
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
-public class SwordConfigurationDSpace implements SwordConfiguration
+public class SwordConfigurationDSpace extends SwordConfigurationDefault implements SwordConfiguration
 {
 	/** logger */
  	public static final Logger log = Logger.getLogger(SwordConfigurationDSpace.class);
@@ -168,7 +168,7 @@ public class SwordConfigurationDSpace implements SwordConfiguration
 
 	public boolean returnStackTraceInError()
 	{
-		return true;
+		return ConfigurationManager.getBooleanProperty("swordv2-server", "verbose-description.error.enable");
 	}
 
 	public boolean returnErrorBody()
@@ -206,7 +206,17 @@ public class SwordConfigurationDSpace implements SwordConfiguration
 		return this.getStringProperty("swordv2-server", "upload.tempdir", null);
 	}
 
-	///////////////////////////////////////////////////////////////////////////////////
+    public String getAlternateUrl()
+    {
+        return ConfigurationManager.getProperty("swordv2-server", "error.alternate.url");
+    }
+
+    public String getAlternateUrlContentType()
+    {
+        return ConfigurationManager.getProperty("swordv2-server", "error.alternate.content-type");
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////
 	// Required by DSpace-side implementation
 	///////////////////////////////////////////////////////////////////////////////////
 
@@ -216,6 +226,7 @@ public class SwordConfigurationDSpace implements SwordConfiguration
 	}
 
 	public List<String> getDisseminatePackaging()
+            throws DSpaceSwordException, SwordError
 	{
 		List<String> dps = new ArrayList<String>();
 		Properties props = ConfigurationManager.getProperties("swordv2-server");
@@ -237,7 +248,23 @@ public class SwordConfigurationDSpace implements SwordConfiguration
             }
 
 			String value = props.getProperty((key));
-			dps.add(value);
+
+            // now we want to ensure that the packaging format we offer has a disseminator
+            // associated with it
+            boolean disseminable = true;
+            try
+            {
+                SwordContentDisseminator disseminator = SwordDisseminatorFactory.getContentInstance(null, value);
+            }
+            catch (SwordError e)
+            {
+                disseminable = false;
+            }
+
+            if (disseminable)
+            {
+			    dps.add(value);
+            }
 		}
 		return dps;
 	}
@@ -253,8 +280,9 @@ public class SwordConfigurationDSpace implements SwordConfiguration
 	}
 
 	/**
-	 * Get the bundle name that SWORD will store its original deposit
-	 * packages in, when storing them inside an item.
+	 * Get the bundle name that sword will store its original deposit packages in, when
+	 * storing them inside an item
+	 * @return
 	 */
 	public String getSwordBundle()
 	{
@@ -272,7 +300,8 @@ public class SwordConfigurationDSpace implements SwordConfiguration
 	}
 
 	/**
-	 * Is this a verbose deposit?
+	 * is this a verbose deposit
+	 * @return
 	 */
 	public boolean isVerbose()
 	{
@@ -280,7 +309,7 @@ public class SwordConfigurationDSpace implements SwordConfiguration
 	}
 
 	/**
-	 * Set whether this is a verbose deposit.
+	 * set whether this is a verbose deposit
 	 * @param verbose
 	 */
 	public void setVerbose(boolean verbose)
@@ -289,7 +318,8 @@ public class SwordConfigurationDSpace implements SwordConfiguration
 	}
 
 	/**
-	 * What is the max upload size (in bytes) for the SWORD interface?
+	 * what is the max upload size (in bytes) for the sword interface
+	 * @return
 	 */
 	public int getMaxUploadSize()
 	{
@@ -297,7 +327,7 @@ public class SwordConfigurationDSpace implements SwordConfiguration
 	}
 
 	/**
-	 * Set the max uplaod size (in bytes) for the SWORD interface.
+	 * set the max uplaod size (in bytes) for the sword interface
 	 * @param maxUploadSize
 	 */
 	public void setMaxUploadSize(int maxUploadSize)
@@ -306,7 +336,8 @@ public class SwordConfigurationDSpace implements SwordConfiguration
 	}
 
 	/**
-	 * Does the server support mediated deposit (aka on-behalf-of)?
+	 * does the server support mediated deposit (aka on-behalf-of)
+	 * @return
 	 */
 	public boolean isMediated()
 	{
@@ -314,7 +345,7 @@ public class SwordConfigurationDSpace implements SwordConfiguration
 	}
 
 	/**
-	 * Set whether the server supports mediated deposit (aka on-behalf-of).
+	 * set whether the server supports mediated deposit (aka on-behalf-of)
 	 * @param mediated
 	 */
 	public void setMediated(boolean mediated)
@@ -323,7 +354,8 @@ public class SwordConfigurationDSpace implements SwordConfiguration
 	}
 
 	/**
-	 * Should the repository keep the original package?
+	 * should the repository keep the original package
+	 * @return
 	 */
 	public boolean isKeepOriginal()
 	{
@@ -377,11 +409,12 @@ public class SwordConfigurationDSpace implements SwordConfiguration
  	}
 
 	/**
-	 * Get the list of MIME types that the given DSpace object will
-	 * accept as packages.
+	 * Get the list of mime types that the given dspace object will
+	 * accept as packages
 	 *
 	 * @param context
 	 * @param dso
+	 * @return
 	 * @throws DSpaceSwordException
 	 */
 	public List<String> getAccepts(Context context, DSpaceObject dso)
@@ -449,9 +482,10 @@ public class SwordConfigurationDSpace implements SwordConfiguration
 	 * http://purl.org/net/sword-types/METSDSpaceSIP
 	 *
 	 * and the Q value is a floating point between 0 and 1 which defines
-	 * how much  the server "likes" this packaging type.
+	 * how much  the server "likes" this packaging type
 	 *
 	 * @param col
+	 * @return
 	 */
 	public List<String> getAcceptPackaging(Collection col)
     {
@@ -541,11 +575,11 @@ public class SwordConfigurationDSpace implements SwordConfiguration
 	}
 
 	/**
-	 * Is the given packaging/media type supported by the given DSpace
-	 * object?
+	 * is the given packaging/media type supported by the given dspace object
 	 *
 	 * @param packageFormat
 	 * @param dso
+	 * @return
 	 * @throws DSpaceSwordException
 	 * @throws SwordError
 	 */
@@ -584,18 +618,59 @@ public class SwordConfigurationDSpace implements SwordConfiguration
 	}
 
 	/**
-	 * Is the given content MIME type acceptable to the given DSpace object.
+	 * is the given content mimetype acceptable to the given dspace object
 	 * @param context
 	 * @param type
 	 * @param dso
+	 * @return
 	 * @throws DSpaceSwordException
 	 */
 	public boolean isAcceptableContentType(Context context, String type, DSpaceObject dso)
 			throws DSpaceSwordException
 	{
 		List<String> accepts = this.getAccepts(context, dso);
+        for (String acc : accepts)
+        {
+            if (this.contentTypeMatches(type, acc))
+            {
+                return true;
+            }
+        }
 		return accepts.contains(type);
 	}
+
+    private boolean contentTypeMatches(String type, String pattern)
+    {
+        if ("*/*".equals(pattern.trim()))
+        {
+            return true;
+        }
+
+        // get the prefix and suffix match patterns
+        String[] bits = pattern.trim().split("/");
+        String prefixPattern = bits.length > 0 ? bits[0] : "*";
+        String suffixPattern = bits.length > 1 ? bits[1] : "*";
+
+        // get the incoming type prefix and suffix
+        String[] tbits = type.trim().split("/");
+        String typePrefix = tbits.length > 0 ? tbits[0] : "*";
+        String typeSuffix = tbits.length > 1 ? tbits[1] : "*";
+
+        boolean prefixMatch = false;
+        boolean suffixMatch = false;
+
+        if ("*".equals(prefixPattern) || prefixPattern.equals(typePrefix))
+        {
+            prefixMatch = true;
+        }
+
+        if ("*".equals(suffixPattern) || suffixPattern.equals(typeSuffix))
+        {
+            suffixMatch = true;
+        }
+
+        return prefixMatch && suffixMatch;
+    }
 
 	public String getStateUri(String state)
 	{

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordContext.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordContext.java
@@ -84,7 +84,9 @@ public class SwordContext
 	/**
 	 * Returns the most appropriate context for operations on the
 	 * database.  This is the on-behalf-of user's context if the
-	 * user exists, or the authenticated user's context otherwise.
+	 * user exists, or the authenticated user's context otherwise
+	 *
+	 * @return
 	 */
 	public Context getContext()
 	{
@@ -104,6 +106,8 @@ public class SwordContext
 	 * getContext()
 	 *
 	 * on this class instead.
+	 *
+	 * @return
 	 */
 	public Context getAuthenticatorContext()
 	{
@@ -123,6 +127,8 @@ public class SwordContext
 	 *
 	 * on this class instead.  If there is no on-behalf-of user, this
 	 * method will return null.
+	 *
+	 * @return
 	 */
 	public Context getOnBehalfOfContext()
 	{

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordDisseminatorFactory.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordDisseminatorFactory.java
@@ -10,6 +10,7 @@ package org.dspace.sword2;
 import org.dspace.core.PluginManager;
 import org.swordapp.server.SwordError;
 import org.swordapp.server.SwordServerException;
+import org.swordapp.server.UriRegistry;
 
 import java.util.List;
 import java.util.Map;
@@ -89,7 +90,7 @@ public class SwordDisseminatorFactory
 
             if (disseminator == null)
             {
-                throw new SwordError(DSpaceUriRegistry.NOT_ACCEPTABLE, 406, "No plugin can disseminate the requested formats");
+                throw new SwordError(UriRegistry.ERROR_CONTENT, 406, "No plugin can disseminate the requested formats");
             }
 
             disseminator.setPackaging(acceptPackaging);
@@ -126,7 +127,7 @@ public class SwordDisseminatorFactory
 
 		if (disseminator == null)
 		{
-			throw new SwordError(DSpaceUriRegistry.NOT_ACCEPTABLE, 406, "No plugin can disseminate the requested formats");
+			throw new SwordError(UriRegistry.ERROR_CONTENT, 406, "No plugin can disseminate the requested formats");
 		}
 
 		return disseminator;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordIngesterFactory.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordIngesterFactory.java
@@ -32,11 +32,12 @@ public class SwordIngesterFactory
 	 * of the interface to return.
 	 * 
 	 * To configure how this method will respond, configure the package ingester
-	 * for the appropriate media types and defaults.  See the SWORD configuration
+	 * for the appropriate media types and defaults.  See the sword configuration
 	 * documentation for more details.
 	 * 
 	 * @param context
 	 * @param deposit
+	 * @return
 	 * @throws DSpaceSwordException
 	 */
 	public static SwordContentIngester getContentInstance(Context context, Deposit deposit, DSpaceObject dso)

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordMETSContentIngester.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordMETSContentIngester.java
@@ -7,15 +7,21 @@
  */
 package org.dspace.sword2;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 
 import org.apache.log4j.Logger;
 
+import org.dspace.content.Bitstream;
+import org.dspace.content.BitstreamFormat;
+import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
+import org.dspace.content.WorkspaceItem;
 import org.dspace.content.packager.PackageIngester;
 import org.dspace.content.packager.PackageParameters;
+import org.dspace.content.packager.PackageUtils;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 import org.dspace.core.PluginManager;
@@ -38,71 +44,87 @@ public class SwordMETSContentIngester extends AbstractSwordContentIngester
         return this.ingest(context, deposit, dso, verboseDescription, null);
     }
 
-	/* (non-Javadoc)
-	 * @see org.dspace.sword.SWORDIngester#ingest(org.dspace.core.Context, org.purl.sword.base.Deposit)
-	 */
-	public DepositResult ingest(Context context, Deposit deposit, DSpaceObject dso, VerboseDescription verboseDescription, DepositResult result)
-			throws DSpaceSwordException, SwordError
-	{
-        // FIXME: it's not clear how to make the METS ingester work over an existing item
-        
-		try
+    @Override
+    public DepositResult ingestToCollection(Context context, Deposit deposit, Collection collection, VerboseDescription verboseDescription, DepositResult result)
+            throws DSpaceSwordException, SwordError, SwordAuthException, SwordServerException
+    {
+        try
 		{
-			// first, make sure this is the right kind of ingester, and set the collection
-			if (!(dso instanceof Collection))
-			{
-				throw new DSpaceSwordException("Tried to run an ingester on wrong target type");
-			}
-			Collection collection = (Collection) dso;
+            // if we are actuall given an item in the deposit result of a previous operation
+            // then we do an ingestToItem
+            if (result != null)
+            {
+                Item item = result.getItem();
+                return this.ingestToItem(context, deposit, item, verboseDescription, result);
+            }
 
+            // otherwise, go on and do a create ...
+
+            // create the an item in the workspace.  This is necessary, because later
+            // we are going to ask a package ingester to /replace/ this item, which gives
+            // us finer control over the workflow state of the item, whereas asking
+            // the ingester to /create/ this item causes it to be injected into the workflow,
+            // irrespective of the In-Progress header provided by the depositor
+            WorkspaceItem wsi = WorkspaceItem.create(context, collection, true);
+            Item item = wsi.getItem();
+
+            // need to add a licence file, otherwise the METS replace function raises a NullPointerException
+            String licence = collection.getLicense();
+            if (PackageUtils.findDepositLicense(context, item) == null)
+            {
+                PackageUtils.addDepositLicense(context, licence, item, collection);
+            }
+            
 			// get deposited file as InputStream
 			File depositFile = deposit.getFile();
 
 			// load the plugin manager for the required configuration
-			String cfg = ConfigurationManager.getProperty("swordv2-server", "mets-ingester.package-ingester");
+			String cfg = ConfigurationManager.getProperty("sword-server", "mets-ingester.package-ingester");
 			if (cfg == null || "".equals(cfg))
 			{
 				cfg = "METS";  // default to METS
 			}
 			verboseDescription.append("Using package manifest format: " + cfg);
 
-			PackageIngester pi = (PackageIngester)PluginManager.getNamedPlugin("swordv2-server", PackageIngester.class, cfg);
+			PackageIngester pi = (PackageIngester) PluginManager.getNamedPlugin(PackageIngester.class, cfg);
 			verboseDescription.append("Loaded package ingester: " + pi.getClass().getName());
-
-			// the licence is either in the zip or the mets manifest.  Either way
-			// it's none of our business here
-			String licence = null;
 
 			// Initialize parameters to packager
 			PackageParameters params = new PackageParameters();
-			// Force package ingester to respect Collection workflows
-			params.setWorkflowEnabled(true);
 
-			// Should restore mode be enabled, i.e. keep existing handle?
-			if (ConfigurationManager.getBooleanProperty("swordv2-server", "restore-mode.enable",false))
-				params.setRestoreModeEnabled(true);
+            // Force package ingester to respect Collection workflows
+            params.setWorkflowEnabled(true);
+
+            // Should restore mode be enabled, i.e. keep existing handle?
+            if (ConfigurationManager.getBooleanProperty("sword-server", "restore-mode.enable",false))
+            {
+                params.setRestoreModeEnabled(true);
+            }
+
+            // Whether or not to use the collection template
+            params.setUseCollectionTemplate(ConfigurationManager.getBooleanProperty("mets.default.ingest.useCollectionTemplate", false));
 
 			// ingest the item from the temp file
-			DSpaceObject ingestedObject = pi.ingest(context, collection, depositFile, params, licence);
+			DSpaceObject ingestedObject = pi.replace(context, item, depositFile, params);
 			if (ingestedObject == null)
 			{
 				verboseDescription.append("Failed to ingest the package; throwing exception");
-				throw new SwordError(DSpaceUriRegistry.UNPACKAGE_FAIL, "METS package ingester failed to unpack package");
+                throw new SwordError(DSpaceUriRegistry.UNPACKAGE_FAIL, "METS package ingester failed to unpack package");
 			}
 
-			//Verify we have an Item as a result -- SWORD can only ingest Items
-			if (!(ingestedObject instanceof Item))
+            // Verify we have an Item as a result
+            if (!(ingestedObject instanceof Item))
 			{
-				throw new DSpaceSwordException("DSpace Ingester returned wrong object type -- not an Item result.");
+                throw new DSpaceSwordException("DSpace Ingester returned wrong object type -- not an Item result.");
 			}
-			else
-			{
-				//otherwise, we have an item, and a workflow should have already been started for it.
-				verboseDescription.append("Workflow process started");
-			}
+            else
+            {
+                //otherwise, we have an item, and a workflow should have already been started for it.
+                verboseDescription.append("Workflow process started");
+            }
 
 			// get reference to item so that we can report on it
-			Item installedItem = (Item)ingestedObject;
+			Item installedItem = (Item) ingestedObject;
 
 			// update the item metadata to inclue the current time as
 			// the updated date
@@ -142,19 +164,112 @@ public class SwordMETSContentIngester extends AbstractSwordContentIngester
 
 			return dr;
 		}
-		catch (RuntimeException re)
-		{
-			log.error("caught exception: ", re);
-			throw re;
-		}
-		catch (Exception e)
-		{
-			log.error("caught exception: ", e);
-			throw new DSpaceSwordException(e);
-		}
-	}
+        catch (RuntimeException re)
+        {
+            log.error("caught exception: ", re);
+            throw re;
+        }
+        catch (Exception e)
+        {
+            log.error("caught exception: ", e);
+            throw new DSpaceSwordException(e);
+        }
+    }
 
-	/**
+    @Override
+    public DepositResult ingestToItem(Context context, Deposit deposit, Item item, VerboseDescription verboseDescription, DepositResult result)
+            throws DSpaceSwordException, SwordError, SwordAuthException, SwordServerException
+    {
+        if (result == null)
+        {
+            result = new DepositResult();
+        }
+
+        try
+		{
+            // get deposited file as InputStream
+            File depositFile = deposit.getFile();
+
+            // load the plugin manager for the required configuration
+			String cfg = ConfigurationManager.getProperty("sword-server", "mets-ingester.package-ingester");
+			if (cfg == null || "".equals(cfg))
+			{
+				cfg = "METS";  // default to METS
+			}
+			verboseDescription.append("Using package manifest format: " + cfg);
+
+			PackageIngester pi = (PackageIngester) PluginManager.getNamedPlugin(PackageIngester.class, cfg);
+			verboseDescription.append("Loaded package ingester: " + pi.getClass().getName());
+
+			// Initialize parameters to packager
+			PackageParameters params = new PackageParameters();
+
+            // Force package ingester to respect Collection workflows
+            params.setWorkflowEnabled(true);
+
+            // Should restore mode be enabled, i.e. keep existing handle?
+            if (ConfigurationManager.getBooleanProperty("sword-server", "restore-mode.enable",false))
+            {
+                params.setRestoreModeEnabled(true);
+            }
+
+            // Whether or not to use the collection template
+            params.setUseCollectionTemplate(ConfigurationManager.getBooleanProperty("mets.default.ingest.useCollectionTemplate", false));
+
+			// ingest the item from the temp file
+			DSpaceObject ingestedObject = pi.replace(context, item, depositFile, params);
+			if (ingestedObject == null)
+			{
+				verboseDescription.append("Failed to replace the package; throwing exception");
+                throw new SwordError(DSpaceUriRegistry.UNPACKAGE_FAIL, "METS package ingester failed to unpack package");
+			}
+
+            // Verify we have an Item as a result
+            if (!(ingestedObject instanceof Item))
+			{
+                throw new DSpaceSwordException("DSpace Ingester returned wrong object type -- not an Item result.");
+			}
+
+			// get reference to item so that we can report on it
+			Item installedItem = (Item) ingestedObject;
+
+			// update the item metadata to inclue the current time as
+			// the updated date
+			this.setUpdatedDate(installedItem, verboseDescription);
+
+			// in order to write these changes, we need to bypass the
+			// authorisation briefly, because although the user may be
+			// able to add stuff to the repository, they may not have
+			// WRITE permissions on the archive.
+			boolean ignore = context.ignoreAuthorization();
+			context.setIgnoreAuthorization(true);
+			installedItem.update();
+			context.setIgnoreAuthorization(ignore);
+
+			// for some reason, DSpace will not give you the handle automatically,
+			// so we have to look it up
+			String handle = HandleManager.findHandle(context, installedItem);
+
+			verboseDescription.append("Replace successful");
+
+			result.setItem(installedItem);
+			result.setTreatment(this.getTreatment());
+
+			return result;
+		}
+        catch (RuntimeException re)
+        {
+            log.error("caught exception: ", re);
+            throw re;
+        }
+        catch (Exception e)
+        {
+            log.error("caught exception: ", e);
+            throw new DSpaceSwordException(e);
+        }
+    }
+
+    /**
 	 * The human readable description of the treatment this ingester has
 	 * put the deposit through
 	 *

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordMETSPackageIngester.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordMETSPackageIngester.java
@@ -1,0 +1,40 @@
+package org.dspace.sword2;
+
+
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.content.packager.DSpaceMETSIngester;
+import org.dspace.content.packager.PackageParameters;
+import org.dspace.content.packager.PackageUtils;
+import org.dspace.content.packager.PackageValidationException;
+import org.dspace.core.Context;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+public class SwordMETSPackageIngester extends DSpaceMETSIngester
+{
+    /**
+     * Policy:  For DSpace deposit license, take deposit license
+     * supplied by explicit argument first, else use collection's
+     * default deposit license.
+     * For Creative Commons, look for a rightsMd containing a CC license.
+     *
+     * This override basically fixes a bug in the DSpaceMETSIngester which
+     * allows (in fact enforces) a null licence during replace, but which
+     * then requires it to be not-null here.
+     *
+     */
+    @Override
+    public void addLicense(Context context, Item item, String license,
+                                    Collection collection, PackageParameters params)
+        throws PackageValidationException,
+            AuthorizeException, SQLException, IOException
+    {
+        if (PackageUtils.findDepositLicense(context, item) == null && license != null)
+        {
+            PackageUtils.addDepositLicense(context, license, item, collection);
+        }
+    }
+}

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/WorkflowManagerDefault.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/WorkflowManagerDefault.java
@@ -11,6 +11,7 @@ import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
+import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 import org.swordapp.server.Deposit;
 import org.swordapp.server.SwordError;
@@ -60,6 +61,14 @@ public class WorkflowManagerDefault implements WorkflowManager
 
 	public void replaceMetadata(Context context, Item item) throws SwordError, DSpaceSwordException
 	{
+        boolean allowUpdate = ConfigurationManager.getBooleanProperty("swordv2-server", "workflowmanagerdefault.always-update-metadata");
+        if (allowUpdate)
+        {
+            // all updates are allowed
+            return;
+        }
+
+        // otherwise, go ahead and figure out the state
 		WorkflowTools wft = new WorkflowTools();
 		if (item.isArchived() || item.isWithdrawn())
 		{
@@ -118,6 +127,15 @@ public class WorkflowManagerDefault implements WorkflowManager
     public void replaceBitstream(Context context, Bitstream bitstream)
             throws SwordError, DSpaceSwordException
     {
+        // File replace with DSpace actually violates the RESTful environment, so it is
+        // turned off by default, and strongly advised against.  Nonetheless, it is used
+        // by some DepositMO aware extensions, so must be supported (as shown below)
+        boolean fileReplace = ConfigurationManager.getBooleanProperty("swordv2-server", "workflowmanagerdefault.file-replace.enable");
+        if (!fileReplace)
+        {
+            throw new SwordError(UriRegistry.ERROR_METHOD_NOT_ALLOWED, "DSpace does not support file replace; you should DELETE the original file and PUT the new one");
+        }
+
         // this is equivalent to asking whether the media resource in the item can be deleted
 		try
 		{
@@ -156,6 +174,14 @@ public class WorkflowManagerDefault implements WorkflowManager
 
 	public void addMetadata(Context context, Item item) throws SwordError, DSpaceSwordException
 	{
+        boolean allowUpdate = ConfigurationManager.getBooleanProperty("swordv2-server", "workflowmanagerdefault.always-update-metadata");
+        if (allowUpdate)
+        {
+            // all updates are allowed
+            return;
+        }
+
+        // otherwise, lookup the state of the item
 		WorkflowTools wft = new WorkflowTools();
 		if (item.isArchived() || item.isWithdrawn())
 		{
@@ -227,17 +253,17 @@ public class WorkflowManagerDefault implements WorkflowManager
         boolean inarch = item.isArchived() || item.isWithdrawn();
 
         // in progress      inws    inwf    inarch      action      description
-        // 0                0       0       1           ERROR       the deposit finished, and the item is in the archive; this should never be allowed to arise
+        // 0                0       0       1           NOTHING     the deposit finished, and the item is in the archive;
         // 0                0       1       0           NOTHING     the deposit finished, and the item is in the workflow.  Carry on as normal
         // 0                1       0       0           START WF    the deposit is finished, and the item is in the workflow, so we start it
-        // 1                0       0       1           ERROR       the deposit is not finished, and the item is in the archive; this should never be allowed to arise
+        // 1                0       0       1           NOTHING     the deposit is not finished, and the item is in the archive;
         // 1                0       1       0           STOP WF     the deposit is not finished, and it is in the workflow.  Pull it out into the workspace
         // 1                1       0       0           NOTHING     the deposit is not finished, and is in the workspace; leave it there
 
         if (!deposit.isInProgress() && inarch)
         {
-            verboseDescription.append("The deposit is finished, but the item is already in the archive");
-            throw new DSpaceSwordException("Invalid workflow state");
+            verboseDescription.append("The deposit is finished, and the item is already in the archive");
+            // throw new DSpaceSwordException("Invalid workflow state");
         }
 
         if (!deposit.isInProgress() && inws)
@@ -248,8 +274,8 @@ public class WorkflowManagerDefault implements WorkflowManager
 
         if (deposit.isInProgress() && inarch)
         {
-            verboseDescription.append("The deposit is not finished, but the item is already in the archive");
-            throw new DSpaceSwordException("Invalid workflow state");
+            verboseDescription.append("The deposit is not finished, and the item is already in the archive");
+            // throw new DSpaceSwordException("Invalid workflow state");
         }
 
         if (deposit.isInProgress() && inwf)

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/WorkflowTools.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/WorkflowTools.java
@@ -8,32 +8,30 @@
 package org.dspace.sword2;
 
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.content.InProgressSubmission;
 import org.dspace.content.Item;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
+import org.dspace.storage.rdbms.DatabaseManager;
+import org.dspace.storage.rdbms.TableRow;
+import org.dspace.storage.rdbms.TableRowIterator;
 import org.dspace.workflow.WorkflowItem;
 import org.dspace.workflow.WorkflowManager;
-import org.dspace.xmlworkflow.WorkflowConfigurationException;
-import org.dspace.xmlworkflow.WorkflowException;
-import org.dspace.xmlworkflow.XmlWorkflowManager;
-import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 
-import javax.mail.MessagingException;
 import java.io.IOException;
 import java.sql.SQLException;
 
 public class WorkflowTools
 {
     /**
-     * Is the given item in the DSpace workflow?
+     * Is the given item in the DSpace workflow
      *
      * This method queries the database directly to determine if this is the
-     * case rather than using the DSpace API (which is very slow).
+     * case rather than using the DSpace API (which is very slow)
      *
      * @param context
      * @param item
+     * @return
      * @throws DSpaceSwordException
      */
     public boolean isItemInWorkflow(Context context, Item item)
@@ -41,11 +39,15 @@ public class WorkflowTools
     {
         try
         {
-            if(ConfigurationManager.getProperty("workflow","workflow.framework").equals("xmlworkflow")){
-                return XmlWorkflowItem.findByItem(context, item) != null;
-            }else{
-                return WorkflowItem.findByItem(context, item) != null;
+            String query = "SELECT workflow_id FROM workflowitem WHERE item_id = ?";
+            Object[] params = { item.getID() };
+            TableRowIterator tri = DatabaseManager.query(context, query, params);
+            if (tri.hasNext())
+            {
+                tri.close();
+                return true;
             }
+            return false;
         }
         catch (SQLException e)
         {
@@ -57,10 +59,11 @@ public class WorkflowTools
      * Is the given item in a DSpace workspace?
      *
      * This method queries the database directly to determine if this is the
-     * case rather than using the DSpace API (which is very slow).
+     * case rather than using the DSpace API (which is very slow)
      *
      * @param context
      * @param item
+     * @return
      * @throws DSpaceSwordException
      */
     public boolean isItemInWorkspace(Context context, Item item)
@@ -68,7 +71,15 @@ public class WorkflowTools
     {
         try
         {
-            return WorkspaceItem.findByItem(context, item) != null;
+            String query = "SELECT workspace_item_id FROM workspaceitem WHERE item_id = ?";
+            Object[] params = { item.getID() };
+            TableRowIterator tri = DatabaseManager.query(context, query, params);
+            if (tri.hasNext())
+            {
+                tri.close();
+                return true;
+            }
+            return false;
         }
         catch (SQLException e)
         {
@@ -77,25 +88,33 @@ public class WorkflowTools
     }
 
     /**
-     * Obtain the WorkflowItem object which wraps the given Item.
+     * Obtain the WorkflowItem object which wraps the given Item
      *
      * This method queries the database directly to determine if this is the
-     * case rather than using the DSpace API (which is very slow).
+     * case rather than using the DSpace API (which is very slow)
      *
      * @param context
      * @param item
+     * @return
      * @throws DSpaceSwordException
      */
-    public InProgressSubmission getWorkflowItem(Context context, Item item)
+    public WorkflowItem getWorkflowItem(Context context, Item item)
             throws DSpaceSwordException
     {
         try
         {
-            if(ConfigurationManager.getProperty("workflow","workflow.framework").equals("xmlworkflow")){
-                return XmlWorkflowItem.findByItem(context, item);
-            }else{
-                return WorkflowItem.findByItem(context, item);
+            String query = "SELECT workflow_id FROM workflowitem WHERE item_id = ?";
+            Object[] params = { item.getID() };
+            TableRowIterator tri = DatabaseManager.query(context, query, params);
+            if (tri.hasNext())
+            {
+                TableRow row = tri.next();
+                int wfid = row.getIntColumn("workflow_id");
+                WorkflowItem wfi = WorkflowItem.find(context, wfid);
+                tri.close();
+                return wfi;
             }
+            return null;
         }
         catch (SQLException e)
         {
@@ -104,13 +123,14 @@ public class WorkflowTools
     }
 
     /**
-     * Obtain the WorkspaceItem object which wraps the given Item.
+     * Obtain the WorkspaceItem object which wraps the given Item
      *
      * This method queries the database directly to determine if this is the
-     * case rather than using the DSpace API (which is very slow).
+     * case rather than using the DSpace API (which is very slow)
      *
      * @param context
      * @param item
+     * @return
      * @throws DSpaceSwordException
      */
     public WorkspaceItem getWorkspaceItem(Context context, Item item)
@@ -118,7 +138,18 @@ public class WorkflowTools
     {
         try
         {
-            return WorkspaceItem.findByItem(context, item);
+            String query = "SELECT workspace_item_id FROM workspaceitem WHERE item_id = ?";
+            Object[] params = { item.getID() };
+            TableRowIterator tri = DatabaseManager.query(context, query, params);
+            if (tri.hasNext())
+            {
+                TableRow row = tri.next();
+                int wsid = row.getIntColumn("workspace_item_id");
+                WorkspaceItem wsi = WorkspaceItem.find(context, wsid);
+                tri.close();
+                return wsi;
+            }
+            return null;
         }
         catch (SQLException e)
         {
@@ -142,18 +173,13 @@ public class WorkflowTools
 
             // kick off the workflow
             boolean notify = ConfigurationManager.getBooleanProperty("swordv2-server", "workflow.notify");
-            if (ConfigurationManager.getProperty("workflow", "workflow.framework").equals("xmlworkflow")) {
-                if (notify) {
-                    XmlWorkflowManager.start(context, wsi);
-                } else {
-                    XmlWorkflowManager.startWithoutNotify(context, wsi);
-                }
-            } else {
-                if (notify) {
-                    WorkflowManager.start(context, wsi);
-                } else {
-                    WorkflowManager.startWithoutNotify(context, wsi);
-                }
+            if (notify)
+            {
+                WorkflowManager.start(context, wsi);
+            }
+            else
+            {
+                WorkflowManager.startWithoutNotify(context, wsi);
             }
         }
         catch (SQLException e)
@@ -166,12 +192,6 @@ public class WorkflowTools
         }
         catch (IOException e)
         {
-            throw new DSpaceSwordException(e);
-        } catch (WorkflowException e) {
-            throw new DSpaceSwordException(e);
-        } catch (WorkflowConfigurationException e) {
-            throw new DSpaceSwordException(e);
-        } catch (MessagingException e) {
             throw new DSpaceSwordException(e);
         }
     }
@@ -188,17 +208,12 @@ public class WorkflowTools
         try
         {
             // find the item in the workflow if it exists
-            InProgressSubmission wfi = this.getWorkflowItem(context, item);
+            WorkflowItem wfi = this.getWorkflowItem(context, item);
 
             // abort the workflow
             if (wfi != null)
             {
-                if(wfi instanceof WorkflowItem)
-                {
-                    WorkflowManager.abort(context, (WorkflowItem) wfi, context.getCurrentUser());
-                }else{
-                    XmlWorkflowManager.abort(context, (XmlWorkflowItem) wfi, context.getCurrentUser());
-                }
+                WorkflowManager.abort(context, wfi, context.getCurrentUser());
             }
         }
         catch (SQLException e)

--- a/dspace/config/modules/swordv2-server.cfg
+++ b/dspace/config/modules/swordv2-server.cfg
@@ -43,7 +43,7 @@
 #
 # Global settings; these will be used on all DSpace collections
 #
-accept-packaging.collection.METSDSpaceSIP = http://purl.org/net/sword/package/METSDSpaceSIP
+#accept-packaging.collection.METSDSpaceSIP = http://purl.org/net/sword/package/METSDSpaceSIP
 accept-packaging.collection.SimpleZip = http://purl.org/net/sword/package/SimpleZip
 accept-packaging.collection.Binary = http://purl.org/net/sword/package/Binary
 
@@ -51,12 +51,12 @@ accept-packaging.collection.Binary = http://purl.org/net/sword/package/Binary
 # which package types are acceptable to deposit into an existing item,
 # either adding to or replacing the media resource
 #
-accept-packaging.item.METSDSpaceSIP = http://purl.org/net/sword/package/METSDSpaceSIP
+#accept-packaging.item.METSDSpaceSIP = http://purl.org/net/sword/package/METSDSpaceSIP
 accept-packaging.item.SimpleZip = http://purl.org/net/sword/package/SimpleZip
 accept-packaging.item.Binary = http://purl.org/net/sword/package/Binary
 
 # A comma separated list of MIME types that SWORD will accept
-accepts = application/zip, image/jpeg
+accepts = */*
 
 # Collection Specific settings: these will be used on the collections
 # with the given handles
@@ -91,7 +91,12 @@ max-upload-size = 0
 # and will accelerate the rate at which the repository consumes disk
 # space.  BUT, it will also mean that the deposited packages are
 # recoverable in their original form.  It is strongly recommended,
-# therefore, to leave this option turned on
+# therefore, to leave this option turned on.
+#
+# NOTE: this affects all incoming deposits, whether they are package
+# deposits or not.  That is, if individual files are uploaded to the
+# Media Resource, a copy of that file will be stored in the SWORD
+# bundle AND into the ORIGINAL bundle.
 #
 keep-original-package = true
 
@@ -99,7 +104,15 @@ keep-original-package = true
 # keep-original-package is set to true.  The default is "SWORD"
 # if not value is set
 #
-# bundle.name = SWORD
+bundle.name = SWORD
+
+# The bundle name that SWORD should use to store deleted bitstreams
+# if versions.keep is set to true.  This will be used in the case
+# that individual files are updated or removed via SWORD.  If
+# the entire Media Resource (files in the ORIGINAL bundle) is removed
+# this will be backed up in its entirity in a bundle of its own
+#
+# bundle.deleted = DELETED
 
 # In the event of package ingest failure, provide an option to store
 # the package on the file system. The default is false.
@@ -109,10 +122,54 @@ keep-original-package = true
 # Should we support mediated deposit via sword?  Enabled, this will
 # allow users to deposit content packages on behalf of other users.
 #
+# WARNING: enabling mediated deposit is not intrinsically secure,
+# it places a trust relationship between the authenticating user
+# and the On-Behalf-Of user account within DSpace.  For example,
+# ANY authenticated user may make changes to an existing item
+# which belongs to the On-Behalf-Of user, which represents a significant
+# security risk.  It is therefore recommended to either disable
+# mediated deposit, or to expressly set a list of accounts which
+# are allowed to mediate on behalf of other users (see on-behalf-of.update.mediators)
+#
 # See the SWORD specification for a detailed explanation of deposit
 # On-Behalf-Of another user
 #
 on-behalf-of.enable = true
+#
+# Which user accounts are allowed to do updates on items which already
+# exist in DSpace, on-behalf-of other users?
+#
+# If this is left blank, or omitted, then all accounts can mediate
+# updates to items, which could be a security risk, as there is no
+# implicit checking that the authenticated user is a "legitimate"
+# mediator
+#
+# FIXME: this would be best maintained in the database with a nice UI
+# ... so if you feel the urge to build one please don't hesitate!
+#
+#on-behalf-of.update.mediators = user1@myu.edu, user2@myu.edu
+on-behalf-of.update.mediators = test
+
+# Should the deposit receipt include a verbose description of the deposit?
+#
+verbose-description.receipt.enable = false
+
+# should the error document include a verbose description of the error
+#
+verbose-description.error.enable = true
+
+# The error document can contain an alternate url, which the client
+# can use to follow up any issues.
+#
+# This is the Contact-Us page on the XMLUI (localise the url space
+# first)
+#
+error.alternate.url = http://localhost:8080/xmlui/contact
+
+# The URL may have an associated content type; if you know what it
+# is, you can enter it here
+#
+error.alternate.content-type = text/html
 
 # The URL which identifies the sword software which provides
 # the sword interface.  This is the URL which DSpace will use
@@ -138,7 +195,7 @@ auth-type = Basic
 
 # The location where uploaded files and packages are
 # stored while being processed
-upload.tempdir = /dspace/upload
+upload.tempdir = ${upload.temp.dir}
 
 # The metadata field in which to store the updated date for
 # items deposited via SWORD.
@@ -157,7 +214,8 @@ author.field = dc.contributor.author
 title.field = dc.title
 
 # Supported packaging formats for the dissemination of packages
-disseminate-packaging.METSDSpaceSIP = http://purl.org/net/sword/package/METSDSpaceSIP
+# FIXME: this format is not supported ...
+#disseminate-packaging.METSDSpaceSIP = http://purl.org/net/sword/package/METSDSpaceSIP
 disseminate-packaging.SimpleZip = http://purl.org/net/sword/package/SimpleZip
 
 # Configure the plugins to process incoming packages.  The form of this
@@ -179,10 +237,11 @@ disseminate-packaging.SimpleZip = http://purl.org/net/sword/package/SimpleZip
 #
 plugin.named.org.dspace.sword2.SwordContentIngester = \
   org.dspace.sword2.SimpleZipContentIngester = http://purl.org/net/sword/package/SimpleZip, \
-  org.dspace.sword2.SwordMETSIngester = http://purl.org/net/sword/package/METSDSpaceSIP, \
-  org.dspace.sword2.BinaryContentIngester = http://purl.org/net/sword/package/Binary, \
-  org.dspace.swordpackagers.SwordDocXIngester = application/vnd.openxmlformats-officedocument.wordprocessingml.document, \
-  org.dspace.swordpackagers.SwordXifIngester = image/jpeg
+  org.dspace.sword2.SwordMETSContentIngester = http://purl.org/net/sword/package/METSDSpaceSIP, \
+  org.dspace.sword2.BinaryContentIngester = http://purl.org/net/sword/package/Binary
+#, \
+#  org.dspace.swordpackagers.SwordDocXIngester = application/vnd.openxmlformats-officedocument.wordprocessingml.document, \
+#  org.dspace.swordpackagers.SwordXifIngester = image/jpeg
 
 plugin.single.org.dspace.sword2.SwordEntryIngester = \
   org.dspace.sword2.SimpleDCEntryIngester
@@ -203,8 +262,38 @@ plugin.named.org.dspace.sword2.SwordStatementDisseminator = \
   org.dspace.sword2.AtomStatementDisseminator = application/atom+xml_type_feed, \
   org.dspace.sword2.OreStatementDisseminator = application/rdf+xml
 
+# Which bundles should the Statement include in its list of aggregated resources
+#
+# The Statement will automatically mark any bitstreams which are in the bundle
+# identified by the ${bundle.name} property, provided that bundle is also
+# listed here (i.e. if you want Original Deposits to be listed in the Statement
+# then you should add the SWORD bundle to this list)
+#
+statement.bundles = ORIGINAL, SWORD, SECONDARY, SECONDARY_CLOSED, LICENSE
+
+# Workflow manager implementation - tells us what we are allowed to do
+# via the SWORDv2 interface
 plugin.single.org.dspace.sword2.WorkflowManager = \
   org.dspace.sword2.WorkflowManagerDefault
+
+# Should the WorkflowManagerDefault allow updates to the item's metadata
+# to take place on items which are in states other than the workspace
+# (e.g. in the workflow, archive, or withdrawn) ?
+#
+workflowmanagerdefault.always-update-metadata = true
+
+# Should the server allow PUT to individual files?
+#
+# If this is enabled, then DSpace may be used with the DepositMO SWORD
+# extensions, BUT the caveat is that DSpace does not formally support
+# Bitstream replace, so this is equivalent to a DELETE and then a POST,
+# which violates the RESTfulness of the server.  The resulting file
+# DOES NOT have the same identifier as the file it was replacing.  As such
+# it is STRONGLY RECOMMENDED to leave this option turned off unless working
+# explicitly with DepositMO enabled client environments
+#
+workflowmanagerdefault.file-replace.enable = false
+
 
 # tell the SWORD METS implementation which package ingester to use
 # to install deposited content.  This should refer to one of the
@@ -227,7 +316,7 @@ plugin.single.org.dspace.sword2.WorkflowManager = \
 # restored to activity.
 restore-mode.enable = false
 
-# metadata field mapping for SimpleDCEntryIngester
+# metadata field mapping for SimpleDCEntryIngester, SimpleDCEntryDisseminator and FeedContentDisseminator,
 #
 simpledc.abstract = dc.description.abstract
 simpledc.accessRights = dc.rights
@@ -245,7 +334,7 @@ simpledc.created = dc.date.created
 simpledc.creator = dc.contributor.author
 simpledc.date = dc.date
 simpledc.dateAccepted = dc.date.accepted
-simpledc.dateCopyrighted = dc.date.???
+# simpledc.dateCopyrighted = dc.date.???
 simpledc.dateSubmitted = dc.date.submitted
 simpledc.description = dc.description
 #simpledc.educationLevel = dc.???
@@ -285,6 +374,50 @@ simpledc.title = dc.title
 simpledc.type = dc.type
 #simpledc.valid = dc.????
 
+atom.author = dc.contributor.author
+atom.published = dc.date.created
+atom.rights = dc.rights
+atom.summary = dc.description.abstract
+atom.title = dc.title
+atom.updated = dc.date.created
+
+# Used by SimpleDCEntryIngester:
+#
+# Which metadata fields can be replaced during a PUT to the Item of an
+# Atom Entry document?  Fields listed here are the ones which will be
+# removed when a new PUT comes through (irrespective of whether there
+# is a new incoming value to replace them)
+#
+metadata.replaceable = dc.description.abstract, \
+  						dc.rights, \
+  						dc.title.alternative, \
+  						dc.identifier.citation, \
+  						dc.contributor, \
+  						dc.coverage, \
+  						dc.contributor.author, \
+  						dc.date, \
+  						dc.description, \
+  						dc.format.extent, \
+  						dc.format, dc.identifier, \
+  						dc.relation.ispartof, \
+  						dc.relation.isreferencedby, \
+  						dc.relation.isreplacedby, \
+  						dc.relation.isrequiredby, \
+  						dc.language, \
+  						dc.format.medium, \
+  						dc.date.modified, \
+  						dc.publisher, \
+  						dc.relation.references, \
+  						dc.relation, \
+  						dc.relation.replaces, \
+  						dc.relation.requires, \
+  						dc.source, \
+  						dc.coverage.spatial, \
+  						dc.subject, \
+  						dc.coverage.temporal, \
+  						dc.title, \
+  						dc.type
+
 
 # order of precedence for importing multipart content.  if entry-first then
 # metadata in the package will override metadata in the entry, otherwise
@@ -306,11 +439,22 @@ workflow.notify = true
 #
 versions.keep = true
 
-state.workspace.uri = http://localhost:8080/xmlui/state/inprogress
+state.workspace.uri = http://dspace.org/state/inprogress
 state.workspace.description = The item is in the user workspace
-state.workflow.uri = http://localhost:8080/xmlui/state/inreview
+state.workflow.uri = http://dspace.org/state/inreview
 state.workflow.description = The item is undergoing review prior to acceptance to the archive
-state.archive.uri = http://localhost:8080/xmlui/state/archived
+state.archive.uri = http://dspace.org/state/archived
 state.archive.description = The item has been archived
-state.withdrawn.uri = http://localhost:8080/xmlui/state/withdrawn
-state.withdrawn.description = The item has been withdrawn from the item and is no longer available
+state.withdrawn.uri = http://dspace.org/state/withdrawn
+state.withdrawn.description = The item has been withdrawn from the archive and is no longer available
+
+# URL template for items in the workspace (items in the archive will use
+# the handle)
+#
+# JSPUI
+# workspace.url-template = http://localhost:8080/jspui/view-workspaceitem?submit_view=Yes&workspace_id=#wsid#
+
+# XMLUI
+workspace.url-template = http://localhost:8080/xmlui/submit?workspaceID=#wsid#
+
+

--- a/dspace/config/registries/bitstream-formats.xml
+++ b/dspace/config/registries/bitstream-formats.xml
@@ -733,5 +733,32 @@
       <extension>rdf</extension>
     </bitstream-type>
 
+	<bitstream-type>
+        <mimetype>application/zip</mimetype>
+        <short_description>Zip File</short_description>
+        <description>A Zipped archive file</description>
+        <support_level>1</support_level>
+        <internal>false</internal>
+        <extension>zip</extension>
+      </bitstream-type>
+
+    <bitstream-type>
+        <mimetype>application/atom+xml; type=entry</mimetype>
+        <short_description>Atom Entry Document (1)</short_description>
+        <description>An Atom Entry Document</description>
+        <support_level>1</support_level>
+        <internal>false</internal>
+    	<extension>xml</extension>
+      </bitstream-type>
+
+    <bitstream-type>
+        <mimetype>application/atom+xml;type=entry</mimetype>
+        <short_description>Atom Entry Document (2)</short_description>
+        <description>An Atom Entry Document</description>
+        <support_level>1</support_level>
+        <internal>false</internal>
+        <extension>xml</extension>
+      </bitstream-type>
+
 
 </dspace-bitstream-types>


### PR DESCRIPTION
This contribution provides major enhancements to the dspace-swordv2 module:
- some general bug fixes including: bitstream url construction, config options, context management and connection pool, ORIGINAL bundle problem
- proper METSDSpaceSIP support in both deposit and update proper authentication for accessing actionable bitstreams (i.e. those that can be replaced via sword), tightened security options around mediated actions, and add extra security to the access of descriptive documents (deposit receipts, statements)
- more configuration options: bundles to expose in Statements, DepositMO extensions (for individual files), and many more
- some general refactoring
- addition of 404 responses where necessary
- better support for add/replace of metadata, and how metadata updates are handled on archived items
- update to latest version of Java Server library
- new bitstream formats in the bitstream registry

In order to use this module, we also need to push a new version of the Java Server library for SWORDv2 into the central maven repo (https://github.com/swordapp/JavaServer2.0).
