### PR TITLE
Fix for Metadata Schema lookup by long namespace and not short name.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/Item.java
+++ b/dspace-api/src/main/java/org/dspace/content/Item.java
@@ -1842,17 +1842,15 @@ public class Item extends DSpaceObject
 
     private int getMetadataSchemaID(DCValue dcv) throws SQLException
     {
-        int schemaID;
         MetadataSchema schema = MetadataSchema.find(ourContext,dcv.schema);
         if (schema == null)
         {
-            schemaID = MetadataSchema.DC_SCHEMA_ID;
+            schema = MetadataSchema.findByNamespace(ourContext,dcv.schema);
+            if (schema == null) {
+                throw new RuntimeException("Metadata Schema does not exist: " + dcv.schema);
+            }
         }
-        else
-        {
-            schemaID = schema.getSchemaID();
-        }
-        return schemaID;
+        return schema.getSchemaID();
     }
 
     /**


### PR DESCRIPTION
Sometimes DSpace looks up a schema by the long namespace, and not the short name while serializing metadata for an Item. This causes metadata registered in DSpace through the UI metadata registry and present within an atom+xml document submitted via the Sword2 protocol, unable to be added. This patch fixes this issue. It also throws a RuntimeException (I didn't want to change the signature, so there could be a much better way to express this) when the schema is not available via either method. This alleviates the mystery of why DSpace cant' find a defined symbol when parsing the metadata for an Item, as an Item with a bad reference to internal metadata should be recorded as an error. Sword2 protocol users will then know that something is wrong with the metadata in their document and be able to debug.
