### PR TITLE
let Maven filter log4j.properties, added new loglevel properties

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -149,3 +149,13 @@ http.proxy.host =
 
 # port number of proxy server
 http.proxy.port =
+
+#####################
+# LOGLEVEL SETTINGS #
+#####################
+loglevel.other = INFO
+# loglevel.other: Log level for other third-party tools/APIs used by DSpace
+# Possible values (from most to least info): DEBUG, INFO, WARN, ERROR, FATAL
+loglevel.dspace = INFO
+# loglevel.dspace: Log level for all DSpace-specific code (org.dspace.*)
+# Possible values (from most to least info): DEBUG, INFO, WARN, ERROR, FATAL

--- a/dspace/config/log4j.properties
+++ b/dspace/config/log4j.properties
@@ -12,12 +12,22 @@
 # write files that rotate every day or every month.
 #
 # Text surrounded by ${} symbols is replaced with the corresponding
-# property from dspace.cfg.  For example:
+# property from dspace.cfg by Ant when DSpace is deployed.  For example:
 #
-# ${dspace.url}
+# dspace.url
 #
 # would be replaced with the dspace.url property in dspace.cfg.
-
+#
+# Additional properties expanded by Maven during the DSpace assembly
+# process:
+# 
+# loglevel.dspace (currently set to: ${loglevel.dspace})
+#   Log level for all DSpace-specific code (org.dspace.*)
+#   Possible values (from most to least info): DEBUG, INFO, WARN, ERROR, FATAL
+#
+# loglevel.other (currently set to: ${loglevel.other})
+#   Log level for other third-party tools/APIs used by DSpace
+#   Possible values (from most to least info): DEBUG, INFO, WARN, ERROR, FATAL
 
 ###########################################################################
 # A1 is the name of the appender for most DSpace activity.
@@ -25,10 +35,10 @@
 # The root category is the default setting for all non-DSpace code.
 # Change this from INFO to DEBUG to see extra logging created by non-DSpace
 # code.
-log4j.rootCategory=INFO, A1
+log4j.rootCategory=${loglevel.other}, A1
 # This line sets the logging level for DSpace code. Set this to DEBUG to see
 # extra detailed logging for DSpace code.
-log4j.logger.org.dspace=INFO, A1
+log4j.logger.org.dspace=${loglevel.dspace}, A1
 # Do not change this line
 log4j.additivity.org.dspace=false
 # The name of the file appender

--- a/dspace/src/main/assembly/assembly.xml
+++ b/dspace/src/main/assembly/assembly.xml
@@ -56,6 +56,7 @@
          <excludes>
             <exclude>src</exclude>
             <exclude>config/dspace.cfg</exclude>
+            <exclude>config/log4j.properties</exclude>
             <exclude>config/modules/**</exclude>
          </excludes>
       </fileSet>
@@ -69,10 +70,15 @@
       </fileSet>
    </fileSets>
 
-   <!-- Copy over the dspace.cfg & filter it -->
+   <!-- Copy over the dspace.cfg and log4j.properties files & filter them -->
    <files>
       <file>
          <source>config/dspace.cfg</source>
+         <outputDirectory>config</outputDirectory>
+         <filtered>true</filtered>
+      </file>
+      <file>
+         <source>config/log4j.properties</source>
          <outputDirectory>config</outputDirectory>
          <filtered>true</filtered>
       </file>


### PR DESCRIPTION
This PR addresses DS-1565 by creating and using two new loglevel properties in dspace.properties, and lets maven filter log4j.properties, to allow you to set loglevel via ENV.properties files. This will help institutions ensure that debug logging is only turned on where appropriate, either development or staging environments, and not in production.
