### PR TITLE
DS-1576: call correct getProperty() function

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
@@ -657,7 +657,7 @@ public class LDAPAuthentication
                     }
                 }
 
-                groupMap = ConfigurationManager.getProperty("ldap.login.groupmap." + ++i);
+                groupMap = ConfigurationManager.getProperty("authentication-ldap", "login.groupmap." + ++i);
             }
         }
     }


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-1576

getProperty("ldap.login.groupmap") no longer works since DSpace separated the configuration settings of each module
