### PR TITLE
[DS-1489] SolrJ-3.3.0 dependency in OAI

### DIFF
--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-solrj</artifactId>
-            <version>3.3.0</version>
+            <version>${lucene.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/dspace/modules/oai/pom.xml
+++ b/dspace/modules/oai/pom.xml
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-core</artifactId>
-            <version>3.3.0</version>
+            <version>${lucene.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Added the maven lucene.version to the oai pom's. This will keep solr versions synched across DSpace modules.
