### PR TITLE
DS-1648 1) DSpace enhancement, mapping author names to registered users with UI options 2) Keeping UI option to choose autor-user wise Collections where the item can be mapped.

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -22,7 +22,7 @@
 # to install DSpace. NOTE: this value will be copied over to the
 # "dspace.dir" setting in the final "dspace.cfg" file. It can be
 # modified later on in your "dspace.cfg", if needed.
-dspace.install.dir=/dspace
+dspace.install.dir=/home/bahata/Desktop/DspaceBean
 
 # DSpace host name - should match base URL.  Do not include port number
 dspace.hostname = localhost

--- a/build.properties
+++ b/build.properties
@@ -22,7 +22,7 @@
 # to install DSpace. NOTE: this value will be copied over to the
 # "dspace.dir" setting in the final "dspace.cfg" file. It can be
 # modified later on in your "dspace.cfg", if needed.
-dspace.install.dir=/home/bahata/Desktop/DspaceBean
+dspace.install.dir=/dspace
 
 # DSpace host name - should match base URL.  Do not include port number
 dspace.hostname = localhost

--- a/dspace-api/src/main/java/org/dspace/content/InstallItem.java
+++ b/dspace-api/src/main/java/org/dspace/content/InstallItem.java
@@ -190,6 +190,7 @@ public class InstallItem
         // create collection2item mapping
         is.getCollection().addItem(item);
         
+       //Here the collections chosen to map the item are going to add the item . 
        DCValue[] collIds=item.getMetadata("dc", "collectionChosen", "authorWise", LANGUAGE_QUALIFIER);    
        
        if(collIds!=null&&collIds.length>0)

--- a/dspace-api/src/main/java/org/dspace/content/InstallItem.java
+++ b/dspace-api/src/main/java/org/dspace/content/InstallItem.java
@@ -17,6 +17,7 @@ import org.dspace.embargo.EmbargoManager;
 import org.dspace.event.Event;
 import org.dspace.identifier.IdentifierException;
 import org.dspace.identifier.IdentifierService;
+import static org.dspace.submit.step.DescribeStep.LANGUAGE_QUALIFIER;
 import org.dspace.utils.DSpace;
 
 /**
@@ -188,6 +189,21 @@ public class InstallItem
     {
         // create collection2item mapping
         is.getCollection().addItem(item);
+        
+       DCValue[] collIds=item.getMetadata("dc", "collectionChosen", "authorWise", LANGUAGE_QUALIFIER);    
+       
+       if(collIds!=null&&collIds.length>0)
+       {
+           for(int i=0;i<collIds.length;i++)
+           {
+               Collection coll=Collection.find(c, Integer.parseInt(collIds[i].value));
+               if(coll!=null && coll.getID()!=is.getCollection().getID())
+               {
+                   coll.addItem(item);
+               }
+           }
+       }
+                  
 
         // set owning collection
         item.setOwningCollection(is.getCollection());

--- a/dspace-api/src/main/java/org/dspace/eperson/Group.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/Group.java
@@ -378,6 +378,28 @@ public class Group extends DSpaceObject
 
         return epersonInGroup(c, groupid, currentuser);
     }
+    
+    /**
+     * fast check to see if an eperson is a member called with eperson id, does
+     * database lookup without instantiating all of the epeople objects and is
+     * thus a static method
+     * 
+     * @param c
+     *            context
+     * @param groupid
+     *            group ID to check
+     */
+    public static boolean isMemberGivenUser(Context c, int groupid,EPerson givenUser) throws SQLException
+    {
+        // special, everyone is member of group 0 (anonymous)
+        if (groupid == 0)
+        {
+            return true;
+        }
+
+        
+        return epersonInGroup(c, groupid, givenUser);
+    }
 
     /**
      * Get all of the groups that an eperson is a member of.

--- a/dspace-xmlui/pom.xml
+++ b/dspace-xmlui/pom.xml
@@ -18,6 +18,7 @@
     <properties>
         <!-- This is the path to the root [dspace-src] directory. -->
         <root.basedir>${basedir}/..</root.basedir>
+        <netbeans.hint.deploy.server>Tomcat</netbeans.hint.deploy.server>
     </properties>
 
     <build>

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -48,6 +48,49 @@
          <hint>Enter the names of the authors of this item below.</hint>
          <required></required>
        </field>
+       
+       <field>
+         <dc-schema>dc</dc-schema>
+         <dc-element>author</dc-element>
+         <dc-qualifier>epersonIdentified</dc-qualifier>
+         <repeatable>true</repeatable>
+         <label>Authors Registered as Users</label>
+         <input-type>author</input-type>
+         <hint>The authors matching with registered .</hint>
+         <required></required>
+       </field> 
+       
+       <field>
+         <dc-schema>dc</dc-schema>
+         <dc-element>chosenAuthor</dc-element>
+         <dc-qualifier>epersonIdentified</dc-qualifier>
+         <repeatable>true</repeatable>
+         <label>Authors Registered as Users</label>
+         <input-type>authorChosen</input-type>
+         <hint>The authors matching with registered .</hint>
+         <required></required>
+       </field> 
+       <field>
+         <dc-schema>dc</dc-schema>
+         <dc-element>collectionAvailable</dc-element>
+         <dc-qualifier>authorWise</dc-qualifier>
+         <repeatable>true</repeatable>
+         <label>Available collections</label>
+         <input-type>collectionAvailable</input-type>
+         <hint>Author wise collections </hint>
+         <required></required>
+       </field> 
+       
+       <field>
+         <dc-schema>dc</dc-schema>
+         <dc-element>collectionChosen</dc-element>
+         <dc-qualifier>authorWise</dc-qualifier>
+         <repeatable>true</repeatable>
+         <label>Chosen collections</label>
+         <input-type>collectionChosen</input-type>
+         <hint>Author wise collections </hint>
+         <required></required>
+       </field> 
 
        <field>
          <dc-schema>dc</dc-schema>
@@ -119,19 +162,6 @@
 
        <field>
          <dc-schema>dc</dc-schema>
-         <dc-element>identifier</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <!-- An input-type of qualdrop_value MUST be marked as repeatable -->
-         <repeatable>true</repeatable>
-         <label>Identifiers</label>
-         <input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
-         <hint>If the item has any identification numbers or codes associated with
-it, please enter the types and the actual numbers or codes below.</hint>
-         <required></required>
-       </field>
-
-       <field>
-         <dc-schema>dc</dc-schema>
          <dc-element>type</dc-element>
          <dc-qualifier></dc-qualifier>
          <repeatable>true</repeatable>
@@ -165,6 +195,28 @@ it, please enter the types and the actual numbers or codes below.</hint>
          <hint>Enter appropriate subject keywords or phrases below. </hint>
          <required></required>
          <vocabulary>srsc</vocabulary>
+       </field>
+       
+       <field>
+         <dc-schema>dc</dc-schema>
+         <dc-element>identifier</dc-element>
+         <dc-qualifier></dc-qualifier>
+         <!-- An input-type of qualdrop_value MUST be marked as repeatable -->
+         <repeatable>true</repeatable>
+         <label>Identifiers</label>
+         <input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
+         <hint>If the item has any identification numbers or codes associated with
+it, please enter the types and the actual numbers or codes below.</hint>
+         <required></required>
+       </field>
+       
+       <field>
+         <dc-schema>dc</dc-schema>
+         <dc-element>identifier</dc-element>
+         <dc-qualifier>DOI</dc-qualifier>
+          <label>DOI</label>
+          <input-type>onebox</input-type>
+          <type-bind>Article</type-bind>
        </field>
 
        <field>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-1648

This commit tries to achieve following things:
1)Currently in DSpace, authors are present as just names. They are not mapped to the users registered to DSpace. If an organization wants to track which authors are which users  for a submitted item where multiple authors are there or the submitter is not the author, there is no provision for that. This code would map the authors to the users with name matching. Now basic , first name, last name matching is done. Later it can be extended to add heuristic matchings and or plugging in Authorization control.

The mapped users would be shown in submission work flow DescribeStep by checkboxes. The checked ones would be saved in item metadata as chosen-authors.
All authors mapped as users would be kept as available-authors in item metadata.
2)The collections where the author-mapped-users have got submit authorization, would then be shown in the submission workflow with check boxes. Say AuthorName1 matched User1 and AuthorName2 mapped User2 and User1 has 3 collections where she can submit, 
and User2 has 1 collection where he can submit. The collections would then be shown in DescribeStep as
User1: Col1 [], Col2 [], Col3 [] .
User2: Col4[]. 
Now submitter can chose Col2 and Col4 as the collections where the Item should be mapped.
So those two collection ids would be saved as chosen-collections in Item Metadata.
Upon finishing the item submission , in InstallItem step the item would get mapped to chosen collection. The owning collection logic remains intact.

To achieve this , new dublin core metadata fields are added and they are used in input-form with specific input-types.
