### PR TITLE
Fix for DS-1593 : Ensure discovery.cfg uses 'solr.server' setting instead of hardcoding its own URL

### DIFF
--- a/dspace/config/modules/discovery.cfg
+++ b/dspace/config/modules/discovery.cfg
@@ -5,7 +5,7 @@
 # faceted-search system.                                        #
 #---------------------------------------------------------------#
 ##### Search Indexing #####
-search.server = http://localhost:8080/solr/search
+search.server = ${solr.server}/search
 
 #Char used to ensure that the sidebar facets are case insensitive
 #solr.facets.split.char=\n|||\n


### PR DESCRIPTION
I believe this change should be non-controversial in nature. It's a minor bug fix to the build.properties functionality added in DSpace 3.

If no one objects, I'd like to fix this bug for both 3.2 (dspace-3_x branch) and 4.0 (master branch).

It's worth noting that this same usage of "solr.server" is already in the solr-statistics.cfg file:
https://github.com/DSpace/DSpace/blob/master/dspace/config/modules/solr-statistics.cfg#L12
