### PR TITLE
[DS-1212] Export all collections of a community recursively in ItemExport

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/Community.java
+++ b/dspace-api/src/main/java/org/dspace/content/Community.java
@@ -794,6 +794,48 @@ public class Community extends DSpaceObject
     }
 
     /**
+     * Return an array of collections of this community and its subcommunities
+     * 
+     * @return an array of colections
+     */
+
+    public Collection[] getAllCollections() throws SQLException
+    {
+        List<Collection> collectionList = new ArrayList<Collection>();
+        for (Community subcommunity : getSubcommunities())
+        {
+            addCollectionList(subcommunity, collectionList);
+        }
+
+        for (Collection collection : getCollections())
+        {
+            collectionList.add(collection);
+        }
+
+        // Put them in an array
+        Collection[] collectionArray = new Collection[collectionList.size()];
+        collectionArray = (Collection[]) collectionList.toArray(collectionArray);
+
+        return collectionArray;
+
+    }
+    /**
+     * Internal method to process subcommunities recursively
+     */
+    private void addCollectionList(Community community, List<Collection> collectionList) throws SQLException
+    {
+        for (Community subcommunity : community.getSubcommunities())
+        {
+            addCollectionList(subcommunity, collectionList);
+        }
+
+        for (Collection collection : community.getCollections())
+        {
+            collectionList.add(collection);
+        }
+    }
+
+    /**
      * Create a new collection within this community. The collection is created
      * without any workflow groups or default submitter group.
      * 

--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -1350,6 +1350,7 @@ news-side.html = news-side.html
 
 news-top.html = news-top.html
 
+org.dspace.app.itemexport.no-result = The DSpaceObject that you specified has no items.
 org.dspace.app.webui.jsptag.CollectionListTag.collectionName                    = Collection Name
 org.dspace.app.webui.jsptag.CommunityListTag.communityName                      = Community Name
 org.dspace.app.webui.jsptag.ItemListTag.authors                                 = Authors

--- a/dspace-api/src/test/java/org/dspace/content/CommunityTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/CommunityTest.java
@@ -767,6 +767,37 @@ public class CommunityTest extends AbstractDSpaceObjectTest
     }
 
     /**
+     * Test of getAllCollections method, of class Community.
+     */
+    @Test
+    public void testGetAllCollections() throws Exception
+    {
+        new NonStrictExpectations()
+        {
+            AuthorizeManager authManager;
+            {
+                AuthorizeManager.authorizeAction((Context) any, (Community) any,
+                        Constants.ADD); result = null;
+                AuthorizeManager.authorizeActionBoolean((Context) any, (Community) any,
+                        Constants.ADD); result = true;
+            }
+        };
+
+        //empty by default
+        assertThat("testGetAllCollections 0",c.getAllCollections(), notNullValue());
+        assertTrue("testGetAllCollections 1", c.getAllCollections().length == 0);
+
+        //community has a collection and a subcommunity, subcommunity has a collection
+        Collection collOfC = c.createCollection();
+        Community sub = Community.create(c, context);
+        Collection collOfSub = sub.createCollection();
+        assertThat("testGetAllCollections 2",c.getAllCollections(), notNullValue());
+        assertTrue("testGetAllCollections 3", c.getAllCollections().length == 2);
+        assertThat("testGetAllCollections 4", c.getAllCollections()[0], equalTo(collOfSub));
+        assertThat("testGetAllCollections 5", c.getAllCollections()[1], equalTo(collOfC));
+    }
+
+    /**
      * Test of createCollection method, of class Community.
      */
     @Test


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-1212

These patches resolve the problems that reported in DS-1212 with adding the following two functions.
1. Export collections of the subcommuniteis of the specific community recursively.
2. Send a email that notify "no collections are export" if the specified community has no collections.
