### PR TITLE
[DS-831] Recent items addon : Listing of most recently added items to DSpace

### DIFF
--- a/dspace-jspui/src/main/webapp/styles.css
+++ b/dspace-jspui/src/main/webapp/styles.css
@@ -702,3 +702,12 @@ input.ds-authority-lock.is-locked
   { background-image: url(image/lock24.png); }
 input.ds-authority-lock.is-unlocked
   { background-image: url(image/unlock24.png); }
+
+.standard10 {
+    margin-left: 10px;
+    margin-right: 10px;
+    font-family: "verdana", "Arial", "Helvetica", sans-serif;
+    font-size: 10pt; 
+    padding-left: 10px;
+ }
+

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1103,6 +1103,12 @@ recent.submissions.sort-option = dateaccessioned
 # how many recent submissions should be displayed at any one time
 recent.submissions.count = 5
 
+# Shows at the homepage the most recent submissions
+#recent.submissions.show = true
+
+# Hides from the homepage the list of communities (cleaner homepage)
+#recent.submissions.hideCommunities = false
+
 # tell the community and collection pages that we are using the Recent
 # Submissions code
 plugin.sequence.org.dspace.plugin.CommunityHomeProcessor = \


### PR DESCRIPTION
This pull request is modified version of the patch made by Joao in DS-831. 

I made the following changes.

1) remake patches for version 3.1
2) change property names from "recentsubmission._" to "recent.submission._"
3) change default value of "recent.submission.hideCommunities" from true to false
4) set default value to "recent.submissions.sort-option" and "recent.submissions.count"
5) use resultItems directly
