### PR TITLE
DS-1598 Authority Control values show up in red

### DIFF
--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/css/authority-control.css
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/css/authority-control.css
@@ -80,9 +80,4 @@ input.ds-authority-lock.is-locked
 input.ds-authority-lock.is-unlocked
   { background-image: url(../../images/authority_control/unlock24.png); }
 
-
-/* Example of authority display: this makes authors with an authority
-   value show up as red in the item summary view: */
-span.ds-dc_contributor_author-authority { color: #982521; }
-
 #aspect_general_ChoiceLookupTransformer_div_lookup select {height: auto;}

--- a/dspace-xmlui/src/main/webapp/themes/Reference/lib/style.css
+++ b/dspace-xmlui/src/main/webapp/themes/Reference/lib/style.css
@@ -1235,11 +1235,6 @@ input.ds-authority-lock.is-locked
 input.ds-authority-lock.is-unlocked
   { background-image: url(../images/unlock24.png); }
 
-
-/* Example of authority display: this makes authors with an authority
-   value show up as red in the item summary view: */
-span.ds-dc_contributor_author-authority { color: #982521; }
-
 /* Prevent display of COinS span - nonspacing break in span to fix closing tag
 also causes a newline in some browsers */
 span.Z3988 {


### PR DESCRIPTION
Removing specific color for authority controlled authors. Approved by hpottinger, aschweer, rscherle, helix84, tdonohue, bram-atmire
