### PR TITLE
[DS-1600] Variable "style" is defined twice in ItemTag.java and are used by error in its render() method

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemTag.java
@@ -472,7 +472,7 @@ public class ItemTag extends TagSupport
                 try
                 {
                     label = I18nUtil.getMessage("metadata."
-                            + (style != null ? style + "." : "") + field,
+                            + ("default".equals(this.style) ? "" : this.style + ".") + field,
                             context);
                 }
                 catch (MissingResourceException e)


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-1600
