### PR TITLE
[DS-1188] Collection view doesn't show content by default

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -16,7 +16,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.time.DateFormatUtils;
-import org.apache.commons.validator.UrlValidator;
+import org.apache.commons.validator.routines.UrlValidator;
 import org.apache.log4j.Logger;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -97,7 +97,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         {
            String solrService = new DSpace().getConfigurationService().getProperty("discovery.search.server") ;
 
-            UrlValidator urlValidator = new UrlValidator();
+            UrlValidator urlValidator = new UrlValidator(UrlValidator.ALLOW_LOCAL_URLS);
             if(urlValidator.isValid(solrService))
             {
                 try {

--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryRecentSubmissionsConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryRecentSubmissionsConfiguration.java
@@ -18,6 +18,7 @@ public class DiscoveryRecentSubmissionsConfiguration {
     private String type;
 
     private int max = 5;
+    private boolean useAsHomePage;
 
     public String getMetadataSortField() {
         return metadataSortField;
@@ -43,5 +44,13 @@ public class DiscoveryRecentSubmissionsConfiguration {
 
     public void setType(String type) {
         this.type = type;
+    }
+
+    public void setUseAsHomePage(boolean useAsHomePage) {
+        this.useAsHomePage = useAsHomePage;
+    }
+
+    public boolean getUseAsHomePage() {
+        return useAsHomePage;
     }
 }

--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -82,6 +82,16 @@
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-solrj</artifactId>
             <version>${lucene.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jcl-over-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/AbstractRecentSubmissionTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/AbstractRecentSubmissionTransformer.java
@@ -14,6 +14,9 @@ import org.apache.log4j.Logger;
 import org.dspace.app.xmlui.cocoon.AbstractDSpaceTransformer;
 import org.dspace.app.xmlui.utils.DSpaceValidity;
 import org.dspace.app.xmlui.utils.HandleUtil;
+import org.dspace.app.xmlui.wing.Message;
+import org.dspace.app.xmlui.wing.WingException;
+import org.dspace.app.xmlui.wing.element.Division;
 import org.dspace.content.DSpaceObject;
 import org.dspace.core.Constants;
 import org.dspace.discovery.*;
@@ -31,6 +34,7 @@ import java.util.List;
  */
 public abstract class AbstractRecentSubmissionTransformer extends AbstractDSpaceTransformer implements CacheableProcessingComponent {
 
+    private static final Message view_more = message("xmlui.ArtifactBrowser.AbstractRecentSubmissionTransformer.recent_submissions_more");
     private static final Logger log = Logger.getLogger(AbstractRecentSubmissionTransformer.class);
 
     /**
@@ -145,6 +149,22 @@ public abstract class AbstractRecentSubmissionTransformer extends AbstractDSpace
         }catch (SearchServiceException se){
             log.error("Caught SearchServiceException while retrieving recent submission for: " + (dso == null ? "home page" : dso.getHandle()), se);
         }
+    }
+
+    /**
+     * Add a view more link at the bottom of a recent submission view
+     * @param recentSubmissionDiv recent submission div to which we are to add the link
+     * @param dso the site/community/collection on who's home page we are
+     * @throws WingException ...
+     */
+    protected void addViewMoreLink(Division recentSubmissionDiv, DSpaceObject dso) throws WingException {
+        String url = contextPath;
+        if(dso != null)
+        {
+            url += "/handle/" + dso.getHandle();
+        }
+        url += "/recent-submissions";
+        recentSubmissionDiv.addPara("recent-submission-view-more", "recentSubmissionViewMore").addXref(url).addContent(view_more);
     }
 
     @Override

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/CollectionRecentSubmissions.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/CollectionRecentSubmissions.java
@@ -75,6 +75,8 @@ public class CollectionRecentSubmissions extends AbstractRecentSubmissionTransfo
                     lastSubmitted.addReference(resultObj);
                 }
             }
+            addViewMoreLink(lastSubmittedDiv, collection);
+
         }
     }
 }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/CommunityRecentSubmissions.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/CommunityRecentSubmissions.java
@@ -73,6 +73,7 @@ public class CommunityRecentSubmissions extends AbstractRecentSubmissionTransfor
                     lastSubmitted.addReference(resultObject);
                 }
             }
+            addViewMoreLink(lastSubmittedDiv, dso);
         }
     }
 }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SiteRecentSubmissions.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SiteRecentSubmissions.java
@@ -63,6 +63,7 @@ public class SiteRecentSubmissions extends AbstractRecentSubmissionTransformer {
                     lastSubmitted.addReference(dso);
                 }
             }
+            addViewMoreLink(lastSubmittedDiv, null);
         }
 
     }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/recentSubmissions/RecentSubmissionTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/recentSubmissions/RecentSubmissionTransformer.java
@@ -1,0 +1,210 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.xmlui.aspect.discovery.recentSubmissions;
+
+import org.apache.avalon.framework.parameters.Parameters;
+import org.apache.cocoon.ProcessingException;
+import org.apache.cocoon.environment.ObjectModelHelper;
+import org.apache.cocoon.environment.Request;
+import org.apache.cocoon.environment.SourceResolver;
+import org.dspace.app.util.Util;
+import org.dspace.app.xmlui.cocoon.AbstractDSpaceTransformer;
+import org.dspace.app.xmlui.utils.HandleUtil;
+import org.dspace.app.xmlui.utils.UIException;
+import org.dspace.app.xmlui.wing.Message;
+import org.dspace.app.xmlui.wing.WingException;
+import org.dspace.app.xmlui.wing.element.*;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Site;
+import org.dspace.core.ConfigurationManager;
+import org.dspace.discovery.DiscoverResult;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Map;
+
+/**
+ * Transformer that renders recent submissions with a paging option to traverse them
+ *
+ * @author Kevin Van de Velde (kevin at atmire dot com)
+ */
+public class RecentSubmissionTransformer extends AbstractDSpaceTransformer {
+
+    protected static final Message T_dspace_home = message("xmlui.general.dspace_home");
+    protected static final Message T_untitled = message("xmlui.general.untitled");
+    protected static final Message T_head = message("xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.head");
+    protected static final Message T_recent_submission_head = message("xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.recent.head");
+    protected static final Message T_trail = message("xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.trail");
+
+    protected boolean isHomePage = false;
+
+    @Override
+    public void setup(SourceResolver resolver, Map objectModel, String src, Parameters parameters) throws ProcessingException, SAXException, IOException {
+        super.setup(resolver, objectModel, src, parameters);
+        isHomePage = parameters.getParameterAsBoolean("isHomePage", false);
+    }
+
+    @Override
+    public void addPageMeta(PageMeta pageMeta) throws SAXException, WingException, UIException, SQLException, IOException, AuthorizeException {
+        DSpaceObject dso = getDSpaceObject();
+
+        // Set up the major variables
+        // Set the page title
+        String name = dso.getName();
+        Metadata titlePageMeta = pageMeta.addMetadata("title");
+        if (name == null || name.length() == 0)
+        {
+            if(isHomePage){
+                titlePageMeta.addContent(T_untitled);
+            }else{
+                titlePageMeta.addContent(T_recent_submission_head.parameterize(name));
+            }
+        }
+        else
+        {
+            if(isHomePage){
+                titlePageMeta.addContent(name);
+            }else{
+                titlePageMeta.addContent(T_recent_submission_head.parameterize(name));
+            }
+        }
+
+        // Add the trail back to the repository root.
+        pageMeta.addTrailLink(contextPath + "/",T_dspace_home);
+        HandleUtil.buildHandleTrail(dso, pageMeta,contextPath, !isHomePage);
+        if(!isHomePage)
+        {
+            //Add a trail link indicating that we are on a recent submissions page
+            pageMeta.addTrail().addContent(T_trail);
+        }
+
+        /**
+         * If we are on a home page add the feeds (if enabled)
+         */
+        if(isHomePage)
+        {
+            // Add RSS links if available
+            String formats = ConfigurationManager.getProperty("webui.feed.formats");
+            if ( formats != null )
+            {
+                for (String format : formats.split(","))
+                {
+                    // Remove the protocol number, i.e. just list 'rss' or' atom'
+                    String[] parts = format.split("_");
+                    if (parts.length < 1)
+                    {
+                        continue;
+                    }
+
+                    String feedFormat = parts[0].trim()+"+xml";
+
+                    String feedURL = contextPath+"/feed/"+format.trim()+"/"+dso.getHandle();
+                    pageMeta.addMetadata("feed", feedFormat).addContent(feedURL);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void addBody(Body body) throws SAXException, WingException, SQLException, IOException, AuthorizeException, ProcessingException {
+        Request request = ObjectModelHelper.getRequest(objectModel);
+        DSpaceObject dso = getDSpaceObject();
+
+        Division mainDivision = body.addDivision("main-recent-submissions");
+        setMainTitle(dso, mainDivision);
+        Division recentSubmissionDivision = mainDivision.addDivision("recent-submissions");
+        if(isHomePage){
+            recentSubmissionDivision.setHead(T_recent_submission_head);
+        }
+
+        DiscoverResult recentlySubmittedItems = RecentSubmissionUtils.getRecentlySubmittedItems(context, dso, getOffset(request));
+        setPagination(request, dso, recentSubmissionDivision, recentlySubmittedItems);
+
+        ReferenceSet lastSubmitted = recentSubmissionDivision.addReferenceSet(
+                "last-submitted", ReferenceSet.TYPE_SUMMARY_LIST,
+                null, "recent-submissions");
+
+        for (DSpaceObject resultObject : recentlySubmittedItems.getDspaceObjects()) {
+            if(resultObject != null){
+                lastSubmitted.addReference(resultObject);
+            }
+        }
+    }
+
+    protected void setPagination(Request request, DSpaceObject dso, Division mainDivision, DiscoverResult recentlySubmittedItems) {
+        int offset = getOffset(request);
+        int rpp = RecentSubmissionUtils.getRecentSubmissionConfiguration(dso).getMax();
+        int firstIndex = offset + 1;
+        int lastIndex = offset + recentlySubmittedItems.getDspaceObjects().size();
+        mainDivision.setSimplePagination((int) recentlySubmittedItems.getTotalSearchResults(), firstIndex,
+                lastIndex, getPreviousPageURL(dso, offset, rpp), getNextPageURL(dso, offset, rpp, (int) recentlySubmittedItems.getTotalSearchResults()));
+    }
+
+    protected void setMainTitle(DSpaceObject dso, Division mainDivision) throws WingException {
+        String title = dso.getName();
+        if(isHomePage)
+        {
+            mainDivision.setHead(title);
+        }else{
+            //We are not acting as home page so use a message
+            mainDivision.setHead(T_head.parameterize(title));
+        }
+
+    }
+
+    protected String getNextPageURL(DSpaceObject dso, int currentOffset, int rpp, int total){
+        if((rpp + currentOffset) < total)
+        {
+            return getBaseUrl(dso) + "?offset=" + (rpp + currentOffset);
+        }else{
+            return null;
+        }
+    }
+
+    protected String getPreviousPageURL(DSpaceObject dso, int currentOffset, int rpp) {
+        if((currentOffset - rpp) < 0){
+            return null;
+        }else{
+            return getBaseUrl(dso) + "?offset=" + (currentOffset - rpp);
+        }
+    }
+
+    protected String getBaseUrl(DSpaceObject dso)
+    {
+        String url = contextPath;
+        if(dso != null && dso.getID() != Site.SITE_ID)
+        {
+            url += "/handle/" + dso.getHandle();
+        }
+        if(!isHomePage)
+        {
+            url += "/recent-submissions";
+        }
+        return url;
+    }
+
+    protected int getOffset(Request request) {
+        int start = Util.getIntParameter(request, "offset");
+        if(start == -1){
+            start = 0;
+        }
+        return start;
+    }
+
+    protected DSpaceObject getDSpaceObject() throws SQLException {
+        DSpaceObject dso = HandleUtil.obtainHandle(objectModel);
+        if(dso == null)
+        {
+            return Site.find(context, Site.SITE_ID);
+        }else{
+            return dso;
+        }
+    }
+}

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/recentSubmissions/RecentSubmissionUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/recentSubmissions/RecentSubmissionUtils.java
@@ -1,0 +1,79 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.xmlui.aspect.discovery.recentSubmissions;
+
+import org.apache.log4j.Logger;
+import org.dspace.content.DSpaceObject;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.discovery.*;
+import org.dspace.discovery.configuration.DiscoveryConfiguration;
+import org.dspace.discovery.configuration.DiscoveryRecentSubmissionsConfiguration;
+
+import java.util.List;
+
+/**
+ * Class containing utility methods used to render recent submissions
+ *
+ * @author Kevin Van de Velde (kevin at atmire dot com)
+ */
+public class RecentSubmissionUtils {
+
+    private static final Logger log = Logger.getLogger(RecentSubmissionUtils.class);
+
+    /**
+     * Retrieves the recent submitted items of the given scope
+     *
+     * @param dso the DSpace object can either be null (indicating home page), a collection or a community
+     */
+    public static DiscoverResult getRecentlySubmittedItems(Context context, DSpaceObject dso, int offset) {
+        try {
+            DiscoverQuery queryArgs = new DiscoverQuery();
+
+            //Add the default filter queries
+            DiscoveryConfiguration discoveryConfiguration = getDiscoveryConfiguration(dso);
+            List<String> defaultFilterQueries = discoveryConfiguration.getDefaultFilterQueries();
+            queryArgs.addFilterQueries(defaultFilterQueries.toArray(new String[defaultFilterQueries.size()]));
+            queryArgs.setDSpaceObjectFilter(Constants.ITEM);
+
+            DiscoveryRecentSubmissionsConfiguration recentSubmissionConfiguration = getRecentSubmissionConfiguration(discoveryConfiguration);
+            if(recentSubmissionConfiguration != null){
+                queryArgs.setMaxResults(recentSubmissionConfiguration.getMax());
+                queryArgs.setStart(offset);
+                String sortField = SearchUtils.getSearchService().toSortFieldIndex(recentSubmissionConfiguration.getMetadataSortField(), recentSubmissionConfiguration.getType());
+                if(sortField != null){
+                    queryArgs.setSortField(
+                            sortField,
+                            DiscoverQuery.SORT_ORDER.desc
+                    );
+                }
+                SearchService service = SearchUtils.getSearchService();
+                return service.search(context, dso, queryArgs);
+            }else{
+                //No configuration, no results
+                return null;
+            }
+        }catch (SearchServiceException se){
+            log.error("Caught SearchServiceException while retrieving recent submission for: " + (dso == null ? "home page" : dso.getHandle()), se);
+            return null;
+        }
+    }
+
+    public static DiscoveryRecentSubmissionsConfiguration getRecentSubmissionConfiguration(DSpaceObject dso) {
+        return getRecentSubmissionConfiguration(getDiscoveryConfiguration(dso));
+
+    }
+    public static DiscoveryRecentSubmissionsConfiguration getRecentSubmissionConfiguration(DiscoveryConfiguration discoveryConfiguration) {
+        return discoveryConfiguration.getRecentSubmissionConfiguration();
+    }
+
+    public static DiscoveryConfiguration getDiscoveryConfiguration(DSpaceObject dso) {
+        return SearchUtils.getDiscoveryConfiguration(dso);
+    }
+
+}

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/viewArtifacts/ContainerHomePageMatcher.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/viewArtifacts/ContainerHomePageMatcher.java
@@ -1,0 +1,66 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.xmlui.aspect.viewArtifacts;
+
+import org.apache.avalon.framework.parameters.Parameters;
+import org.apache.cocoon.matching.Matcher;
+import org.apache.cocoon.sitemap.PatternException;
+import org.apache.log4j.Logger;
+import org.dspace.app.xmlui.utils.HandleUtil;
+import org.dspace.discovery.SearchUtils;
+import org.dspace.discovery.configuration.DiscoveryConfiguration;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Matcher used to determine which transformers are used to render the home page for a community/collection
+ *
+ * @author Kevin Van de Velde (kevin at atmire dot com)
+ */
+public class ContainerHomePageMatcher implements Matcher {
+
+    private static final Logger log = Logger.getLogger(ContainerHomePageMatcher.class);
+
+    @Override
+    public Map match(String pattern, Map objectModel, Parameters parameters) throws PatternException {
+        boolean not = false;
+        int action = -1; // the action to check
+
+        if (pattern.startsWith("!"))
+        {
+            not = true;
+            pattern = pattern.substring(1);
+        }
+
+        if(pattern.equals("discoveryRecentSubmissions") || pattern.equals("metadata"))
+        {
+            try {
+                boolean isHomePageActive;
+                DiscoveryConfiguration discoveryConfiguration = SearchUtils.getDiscoveryConfiguration(HandleUtil.obtainHandle(objectModel));
+                if(discoveryConfiguration.getRecentSubmissionConfiguration() != null && discoveryConfiguration.getRecentSubmissionConfiguration().getUseAsHomePage())
+                {
+                    isHomePageActive = !pattern.equals("metadata");
+                } else{
+                    isHomePageActive = pattern.equals("metadata");
+                }
+                if(isHomePageActive ^ not)
+                {
+                    return new HashMap();
+                }else{
+                    return null;
+                }
+            } catch (SQLException e) {
+                log.error("SQL exception while determining home page", e);
+
+            }
+        }
+        throw new IllegalArgumentException();
+    }
+}

--- a/dspace-xmlui/src/main/resources/aspects/BrowseArtifacts/sitemap.xmap
+++ b/dspace-xmlui/src/main/resources/aspects/BrowseArtifacts/sitemap.xmap
@@ -32,6 +32,7 @@ collections / items / and bitstreams.
         <map:matchers default="wildcard">
                 <map:matcher name="HandleTypeMatcher" src="org.dspace.app.xmlui.aspect.general.HandleTypeMatcher"/>
                 <map:matcher name="HandleAuthorizedMatcher" src="org.dspace.app.xmlui.aspect.general.HandleAuthorizedMatcher"/>
+                <map:matcher name="ContainerHomePageSelector" src="org.dspace.app.xmlui.aspect.viewArtifacts.ContainerHomePageMatcher"/>
         </map:matchers>
     </map:components>
 
@@ -90,8 +91,10 @@ collections / items / and bitstreams.
 
                         <map:match type="HandleTypeMatcher" pattern="collection">
                             <map:match pattern="handle/*/*">
-                                <map:transform type="CollectionBrowse"/>
-                                <map:transform type="CollectionRecentSubmissions"/>
+                                <map:match type="ContainerHomePageSelector" pattern="metadata">
+                                    <map:transform type="CollectionBrowse"/>
+                                    <map:transform type="CollectionRecentSubmissions"/>
+                                </map:match>
                             </map:match>
                         </map:match>
 

--- a/dspace-xmlui/src/main/resources/aspects/Discovery/i18n/messages.xml
+++ b/dspace-xmlui/src/main/resources/aspects/Discovery/i18n/messages.xml
@@ -41,6 +41,11 @@
     <!-- Site Leve Recently Added Content -->
     <message key="xmlui.ArtifactBrowser.SiteViewer.head_recent_submissions">Recently Added</message>
 
+    <message key="xmlui.ArtifactBrowser.AbstractRecentSubmissionTransformer.recent_submissions_more">View more</message>
+    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.head">{0}: Recent submissions</message>
+    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.trail">Recent submissions</message>
+    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.recent.head">Recently added</message>
+
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_type_filter">Kind</message>
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_publisher_filter">Publisher</message>
 

--- a/dspace-xmlui/src/main/resources/aspects/Discovery/sitemap.xmap
+++ b/dspace-xmlui/src/main/resources/aspects/Discovery/sitemap.xmap
@@ -42,6 +42,7 @@ and searching the repository.
             <map:transformer name="RelatedItems" src="org.dspace.app.xmlui.aspect.discovery.RelatedItems"/>
 
             <map:transformer name="RestrictedItem" src="org.dspace.app.xmlui.aspect.artifactbrowser.RestrictedItem"/>
+            <map:transformer name="RecentSubmissionTransformer" src="org.dspace.app.xmlui.aspect.discovery.recentSubmissions.RecentSubmissionTransformer"/>
         </map:transformers>
                
         <map:actions>
@@ -51,6 +52,7 @@ and searching the repository.
         <map:matchers default="wildcard">
             <map:matcher name="HandleTypeMatcher" src="org.dspace.app.xmlui.aspect.general.HandleTypeMatcher"/>
             <map:matcher name="HandleAuthorizedMatcher" src="org.dspace.app.xmlui.aspect.general.HandleAuthorizedMatcher"/>
+            <map:matcher name="ContainerHomePageSelector" src="org.dspace.app.xmlui.aspect.viewArtifacts.ContainerHomePageMatcher"/>
         </map:matchers>
     <map:selectors>
         <map:selector name="AuthenticatedSelector" src="org.dspace.app.xmlui.aspect.general.AuthenticatedSelector"/>
@@ -84,6 +86,14 @@ and searching the repository.
                 <map:transform type="FrontPageSearch"/>
 
                 <map:transform type="SiteRecentSubmissions"/>
+
+                <map:serialize type="xml"/>
+            </map:match>
+
+            <map:match pattern="recent-submissions">
+                <map:transform type="RecentSubmissionTransformer">
+                    <map:parameter name="isHomePage" value="false"/>
+                </map:transform>
 
                 <map:serialize type="xml"/>
             </map:match>
@@ -149,10 +159,28 @@ and searching the repository.
                             <map:serialize type="xml"/>
 						</map:match>
 
-
                         <map:match pattern="handle/*/*/search-filter">
                             <map:transform type="SearchFacetFilter"/>
                             <map:serialize type="xml"/>
+                        </map:match>
+
+                        <map:match pattern="handle/*/*/recent-submissions">
+                            <map:transform type="RecentSubmissionTransformer">
+                                <map:parameter name="isHomePage" value="false"/>
+                            </map:transform>
+                            <map:serialize type="xml"/>
+                        </map:match>
+
+                        <map:match pattern="handle/*/*">
+                            <map:match type="HandleTypeMatcher" pattern="collection">
+                                <map:match type="ContainerHomePageSelector" pattern="discoveryRecentSubmissions">
+                                    <map:transform type="SidebarFacetsTransformer"/>
+                                    <map:transform type="RecentSubmissionTransformer">
+                                        <map:parameter name="isHomePage" value="true"/>
+                                    </map:transform>
+                                    <map:serialize type="xml"/>
+                                </map:match>
+                            </map:match>
                         </map:match>
                     </map:match>
                 </map:match>

--- a/dspace-xmlui/src/main/resources/aspects/ViewArtifacts/sitemap.xmap
+++ b/dspace-xmlui/src/main/resources/aspects/ViewArtifacts/sitemap.xmap
@@ -37,6 +37,7 @@ and searching the repository.
                 <map:matchers default="wildcard">
                         <map:matcher name="HandleTypeMatcher" src="org.dspace.app.xmlui.aspect.general.HandleTypeMatcher"/>
                         <map:matcher name="HandleAuthorizedMatcher" src="org.dspace.app.xmlui.aspect.general.HandleAuthorizedMatcher"/>
+                        <map:matcher name="ContainerHomePageSelector" src="org.dspace.app.xmlui.aspect.viewArtifacts.ContainerHomePageMatcher"/>
                 </map:matchers>
 
 
@@ -130,8 +131,10 @@ and searching the repository.
                                                         <map:parameter name="type" value="collection"/>
                                                         <map:parameter name="eventType" value="view"/>
                                                 </map:act>
+                                                    <map:match type="ContainerHomePageSelector" pattern="metadata">
                                                         <map:transform type="CollectionViewer"/>
                                                         <map:serialize type="xml"/>
+                                                    </map:match>
                                                 </map:match>
                                                 <map:match type="HandleTypeMatcher" pattern="item">
                                                   <map:act type="UsageLoggerAction">

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/css/style.css
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/css/style.css
@@ -1373,3 +1373,8 @@ table.discovery-filters th.new-filter-header
 .searchTime{
     color: #999999;
 }
+
+.recentSubmissionViewMore{
+    text-align: right;
+    font-size: 120%;
+}

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -135,14 +135,16 @@
                 <property name="metadataSortField" value="dc.date.accessioned" />
                 <property name="type" value="date"/>
                 <property name="max" value="5"/>
+                <!-- If enabled the collection home page will not display metadata but show a pageable list of recent submissions -->
+                <property name="useAsHomePage" value="true"/>
             </bean>
         </property>
         <!--Default result per page  -->
         <property name="defaultRpp" value="10" />
         <property name="hitHighlightingConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
-        <property name="metadataFields">
-            <list>
+                <property name="metadataFields">
+                    <list>
                         <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
                             <property name="field" value="dc.title"/>
                             <property name="snippets" value="5"/>
@@ -161,29 +163,29 @@
                             <property name="maxSize" value="250"/>
                             <property name="snippets" value="2"/>
                         </bean>
-            </list>
-        </property>
-    </bean>
+                    </list>
+                </property>
+            </bean>
         </property>
         <property name="moreLikeThisConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoveryMoreLikeThisConfiguration">
                 <!--When altering this list also alter the "xmlui.Discovery.RelatedItems.help" key as it describes
                 the metadata fields below-->
                 <property name="similarityMetadataFields">
-            <list>
+                    <list>
                         <value>dc.title</value>
-                <value>dc.contributor.author</value>
-                <value>dc.creator</value>
+                        <value>dc.contributor.author</value>
+                        <value>dc.creator</value>
                         <value>dc.subject</value>
-            </list>
-        </property>
+                    </list>
+                </property>
                 <!--The minimum number of matching terms across the metadata fields above before an item is found as related -->
                 <property name="minTermFrequency" value="5"/>
                 <!--The maximum number of related items displayed-->
                 <property name="max" value="3"/>
                 <!--The minimum word length below which words will be ignored-->
                 <property name="minWordLength" value="5"/>
-    </bean>
+            </bean>
         </property>
     </bean>
 

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -136,7 +136,7 @@
                 <property name="type" value="date"/>
                 <property name="max" value="5"/>
                 <!-- If enabled the collection home page will not display metadata but show a pageable list of recent submissions -->
-                <property name="useAsHomePage" value="true"/>
+                <property name="useAsHomePage" value="false"/>
             </bean>
         </property>
         <!--Default result per page  -->

--- a/pom.xml
+++ b/pom.xml
@@ -703,11 +703,6 @@
               <version>1.4.0</version>
           </dependency>
          <dependency>
-            <groupId>commons-validator</groupId>
-            <artifactId>commons-validator</artifactId>
-            <version>1.3.1</version>
-         </dependency>
-         <dependency>
             <groupId>javax.mail</groupId>
             <artifactId>mail</artifactId>
             <version>1.4</version>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-1188

This is a pull request for the XMLUI version. The configuration on wether or not to use recent submissions on a collection home page was added to the discovery configuration spring file. I choose this route to keep all configuration together instead of spreading it out.
On all pages where recent submissions are shown a link "show more" is displayed, so even if this option isn't enabled people will be able to browse through recent submission easily.

Ps: This solution also required discovery to be enabled, but since it is the default for DSpace 4.0, I don't think this should be an issue (no use in doing double work).
