### PR TITLE
DS-1617 Switch to SOLRBrowseDAOs implementation as default in DSpace 4.0

### DIFF
--- a/dspace-api/src/main/java/org/dspace/browse/BrowseDAOFactory.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseDAOFactory.java
@@ -32,20 +32,8 @@ public class BrowseDAOFactory
 	    String className = ConfigurationManager.getProperty("browseDAO.class");
         if (className == null)
         {
-            // For compatibility with previous versions
-            String db = ConfigurationManager.getProperty("db.name");
-            if ("postgres".equals(db))
-            {
-                return new BrowseDAOPostgres(context);
-            }
-            else if ("oracle".equals(db))
-            {
-                return new BrowseDAOOracle(context);
-            }
-            else
-            {
-                throw new BrowseException("The configuration for db.name is either invalid, or contains an unrecognised database");
-            }    
+            // SOLR implementation is the default since DSpace 4.0        	
+            return new SolrBrowseDAO(context);
         }
         try
         {
@@ -73,20 +61,8 @@ public class BrowseDAOFactory
 	    String className = ConfigurationManager.getProperty("browseCreateDAO.class");
         if (className == null)
         {
-            // For compatibility with previous versions
-            String db = ConfigurationManager.getProperty("db.name");
-            if ("postgres".equals(db))
-            {
-                return new BrowseCreateDAOPostgres(context);
-            }
-            else if ("oracle".equals(db))
-            {
-                return new BrowseCreateDAOOracle(context);
-            }
-            else
-            {
-                throw new BrowseException("The configuration for db.name is either invalid, or contains an unrecognised database");
-            }
+            // SOLR implementation is the default since DSpace 4.0
+			return new SolrBrowseCreateDAO(context);
         }
         try
         {

--- a/dspace-api/src/main/java/org/dspace/browse/BrowseIndex.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseIndex.java
@@ -680,12 +680,10 @@ public final class BrowseIndex
         while ( ((definition = ConfigurationManager.getProperty("webui.browse.index." + idx))) != null)
         {
             BrowseIndex bi = new BrowseIndex(definition, idx);
-            
-            //Load the frequency configuration
-            String freqDefinition = ConfigurationManager.getProperty("webui.browse.metadata.show-freq." + idx);
-            if (freqDefinition!=null)
-            	bi.displayFrequencies = Boolean.valueOf(freqDefinition);
-            
+			bi.displayFrequencies = Boolean.valueOf(ConfigurationManager
+					.getBooleanProperty("webui.browse.metadata.show-freq."
+							+ idx, true));
+
             browseIndices.add(bi);
             idx++;
         }

--- a/dspace-api/src/main/java/org/dspace/browse/SolrBrowseCreateDAO.java
+++ b/dspace-api/src/main/java/org/dspace/browse/SolrBrowseCreateDAO.java
@@ -372,6 +372,9 @@ public class SolrBrowseCreateDAO implements BrowseCreateDAO,
     public void insertIndex(String table, int itemID, Map sortCols)
             throws BrowseException
     {
+		// this is required to be sure that communities2item will be cleaned
+		// after the switch to SOLRBrowseDAOs. See DS-1619
+    	dbCreateDAO.deleteCommunityMappings(itemID);
     }
 
     @Override

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -639,7 +639,12 @@ event.dispatcher.default.class = org.dspace.event.BasicDispatcher
 # uncomment below and comment out original property to enable the legacy lucene indexing
 # event.dispatcher.default.consumers = versioning, search, browse, eperson, harvester
 #
-event.dispatcher.default.consumers = versioning, browse, discovery, eperson, harvester
+# add the browse consumer if you want to switch back to the DBMS Browse DAOs implementation
+# as the SOLR implementation rely on the discovery consumer
+#
+# event.dispatcher.default.consumers = versioning, browse, discovery, eperson, harvester
+
+event.dispatcher.default.consumers = versioning, discovery, eperson, harvester
 
 # The noindex dispatcher will not create search or browse indexes (useful for batch item imports)
 event.dispatcher.noindex.class = org.dspace.event.BasicDispatcher
@@ -878,7 +883,7 @@ webui.strengths.cache = false
 #
 # Define the DAO class to use this must meet your storage choice for 
 # the browse system (RDBMS: PostgreSQL or Oracle, SOLR). 
-# By default the standard RDBMS implementation for your db is used
+# By default, since DSpace 4.0, the SOLR implementation is used
 #
 # PostgreSQL:
 # browseDAO.class = org.dspace.browse.BrowseDAOPostgres


### PR DESCRIPTION
This pull request enable SOLRBrowseDAOs implementation as default in DSpace and turn on by default the show frequencies as with the SOLR implementation no performance penalities are present.
Please note that in the dspace.cfg comments there was an error since DSpace 3.0 that already say that frequencies was shown by default
