### PR TITLE
[DS-1569] Don't try to emit a password if there is none.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/packager/RoleDisseminator.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/RoleDisseminator.java
@@ -479,19 +479,25 @@ public class RoleDisseminator implements PackageDisseminator
         if (emitPassword)
         {
             PasswordHash password = eperson.getPasswordHash();
+            if (null != password)
+            {
+                writer.writeStartElement(PASSWORD_HASH);
 
-            writer.writeStartElement(PASSWORD_HASH);
+                String algorithm = password.getAlgorithm();
+                if (null != algorithm)
+                {
+                    writer.writeAttribute(PASSWORD_DIGEST, algorithm);
+                }
 
-            String algorithm = password.getAlgorithm();
-            if (null != algorithm)
-                writer.writeAttribute(PASSWORD_DIGEST, algorithm);
+                String salt = password.getSaltString();
+                if (null != salt)
+                {
+                    writer.writeAttribute(PASSWORD_SALT, salt);
+                }
 
-            String salt = password.getSaltString();
-            if (null != salt)
-                writer.writeAttribute(PASSWORD_SALT, salt);
-
-            writer.writeCharacters(password.getHashString());
-            writer.writeEndElement();
+                writer.writeCharacters(password.getHashString());
+                writer.writeEndElement();
+            }
         }
 
         if (eperson.canLogIn())

--- a/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
@@ -905,7 +905,7 @@ public class EPerson extends DSpaceObject
     /**
      * Return the EPerson's password hash.
      *
-     * @return hash of the password
+     * @return hash of the password, or null on failure (such as no password).
      */
     public PasswordHash getPasswordHash()
     {


### PR DESCRIPTION
Issue #DS-1569 - RoleDisseminator fails to check for possible null password
