### PR TITLE
[DS-1622] Porting of the Login As feature to JSPUI 

### DIFF
--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -1556,13 +1556,7 @@ jsp.tools.lookup.field.dc_contributor_author.nonauthority = Local value '@1@' (n
 # reset password
 jsp.dspace-admin.eperson-main.ResetPassword.title = Reset password
 jsp.dspace-admin.eperson-main.ResetPassword.head = Reset password
-jsp.dspace-admin.eperson-main.ResetPassword.para1 = Please enter a new password into the box below, and confirm it by typing it again into the second box. It should be at least six characters long.
-jsp.dspace-admin.eperson-main.ResetPassword.email_address = Email Address
-jsp.dspace-admin.eperson-main.ResetPassword.new_password = New password
-jsp.dspace-admin.eperson-main.ResetPassword.confirm_password = Retype to Confirm
 jsp.dspace-admin.eperson-main.ResetPassword.submit = Reset password
-jsp.dspace-admin.eperson-main.ResetPassword.error_invalid_password = Choose a password at least 6 characters long
-jsp.dspace-admin.eperson-main.ResetPassword.error_unconfirmed_password = Please retype your password to confirm
 jsp.dspace-admin.eperson-main.ResetPassword.success_notice = An email message has been sent to the user containing a token that may be used to choose a new password.
 jsp.dspace-admin.eperson-main.ResetPassword-error.errormsg = Sorry, an error has occurred when the system try to send email with instructions.
 jsp.dspace-admin.eperson-main.ResetPassword.returntoedit = Return to the Administer EPeople page

--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -1560,3 +1560,9 @@ jsp.dspace-admin.eperson-main.ResetPassword.submit = Reset password
 jsp.dspace-admin.eperson-main.ResetPassword.success_notice = An email message has been sent to the user containing a token that may be used to choose a new password.
 jsp.dspace-admin.eperson-main.ResetPassword-error.errormsg = Sorry, an error has occurred when the system try to send email with instructions.
 jsp.dspace-admin.eperson-main.ResetPassword.returntoedit = Return to the Administer EPeople page
+
+# login as
+jsp.dspace-admin.eperson-main.LoginAs.submit = Login As
+jsp.dspace-admin.eperson-main.LoginAs.onlyAdmins = Only site administrators may assume login as another user.
+jsp.dspace-admin.eperson-main.LoginAs.onlyAuthenticatedAdmins = Only authenticated users who are administrators may assume the login as another user.
+jsp.dspace-admin.eperson-main.LoginAs.notAnotherAdmin = You may not assume the login as another administrator.

--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -1552,3 +1552,17 @@ jsp.tools.lookup.field.dc_contributor_author.help.last = Last name, e.g. "Smith"
 jsp.tools.lookup.field.dc_contributor_author.help.first = First name(s) e.g. "Fred"
 jsp.tools.lookup.field.dc_contributor_author.title = LC Name Authority author lookup
 jsp.tools.lookup.field.dc_contributor_author.nonauthority = Local value '@1@' (not in Naming Authority)
+
+# reset password
+jsp.dspace-admin.eperson-main.ResetPassword.title = Reset password
+jsp.dspace-admin.eperson-main.ResetPassword.head = Reset password
+jsp.dspace-admin.eperson-main.ResetPassword.para1 = Please enter a new password into the box below, and confirm it by typing it again into the second box. It should be at least six characters long.
+jsp.dspace-admin.eperson-main.ResetPassword.email_address = Email Address
+jsp.dspace-admin.eperson-main.ResetPassword.new_password = New password
+jsp.dspace-admin.eperson-main.ResetPassword.confirm_password = Retype to Confirm
+jsp.dspace-admin.eperson-main.ResetPassword.submit = Reset password
+jsp.dspace-admin.eperson-main.ResetPassword.error_invalid_password = Choose a password at least 6 characters long
+jsp.dspace-admin.eperson-main.ResetPassword.error_unconfirmed_password = Please retype your password to confirm
+jsp.dspace-admin.eperson-main.ResetPassword.success_notice = An email message has been sent to the user containing a token that may be used to choose a new password.
+jsp.dspace-admin.eperson-main.ResetPassword-error.errormsg = Sorry, an error has occurred when the system try to send email with instructions.
+jsp.dspace-admin.eperson-main.ResetPassword.returntoedit = Return to the Administer EPeople page

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EPersonAdminServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EPersonAdminServlet.java
@@ -264,6 +264,8 @@ public class EPersonAdminServlet extends DSpaceServlet
 							.sendForgotPasswordInfo(context, e.getEmail());
 					request.setAttribute("reset_password", Boolean.TRUE);
 					showMain(context, request, response);
+                    // Context needs completing to write registration data
+                    context.complete();
 				} 
 				catch (MessagingException e1) 
 				{

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EPersonAdminServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EPersonAdminServlet.java
@@ -9,21 +9,31 @@ package org.dspace.app.webui.servlet.admin;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.Locale;
 
 import javax.mail.MessagingException;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import javax.servlet.jsp.jstl.core.Config;
 
+import org.apache.log4j.Logger;
 import org.dspace.app.webui.servlet.DSpaceServlet;
+import org.dspace.app.webui.util.Authenticate;
 import org.dspace.app.webui.util.JSPManager;
 import org.dspace.app.webui.util.UIUtil;
+import org.dspace.authenticate.AuthenticationManager;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.AuthorizeManager;
+import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
+import org.dspace.core.I18nUtil;
+import org.dspace.core.LogManager;
 import org.dspace.eperson.AccountManager;
 import org.dspace.eperson.EPerson;
-import org.dspace.eperson.Group;
 import org.dspace.eperson.EPersonDeletionException;
+import org.dspace.eperson.Group;
 
 /**
  * Servlet for editing and creating e-people
@@ -33,6 +43,10 @@ import org.dspace.eperson.EPersonDeletionException;
  */
 public class EPersonAdminServlet extends DSpaceServlet
 {
+    
+    /** Logger */
+    private static Logger log = Logger.getLogger(EPersonAdminServlet.class);
+    
     protected void doDSGet(Context context, HttpServletRequest request,
             HttpServletResponse response) throws ServletException, IOException,
             SQLException, AuthorizeException
@@ -272,6 +286,74 @@ public class EPersonAdminServlet extends DSpaceServlet
 					JSPManager.showJSP(request, response,
 							"/dspace-admin/eperson-resetpassword-error.jsp");
 				}
+            }
+        }
+        else if (button.equals("submit_login_as"))
+        {
+            if (!ConfigurationManager.getBooleanProperty("jspui.user.assumelogin", false))
+            {
+                throw new AuthorizeException(I18nUtil.getMessage("jsp.dspace-admin.eperson-main.LoginAs.submit"));                
+            }
+            EPerson e = EPerson.find(context, UIUtil.getIntParameter(request,
+                    "eperson_id"));
+            // Check the EPerson exists
+            if (e == null)
+            {
+                request.setAttribute("no_eperson_selected", new Boolean(true));
+                showMain(context, request, response);
+            }
+            // Only super administrators can login as someone else.
+            else if (!AuthorizeManager.isAdmin(context))
+            {
+                JSPManager.showAuthorizeError(request, response, new AuthorizeException(I18nUtil.getMessage("jsp.dspace-admin.eperson-main.LoginAs.onlyAdmins")));
+            }
+            else
+            {
+                log.info(LogManager.getHeader(context, "login-as",
+                        "current_eperson="
+                                + context.getCurrentUser().getFullName()
+                                + ", id=" + context.getCurrentUser().getID()
+                                + ", as_eperson=" + e.getFullName() + ", id="
+                                + e.getID()));
+                
+                // Just to be double be sure, make sure the administrator
+                // is the one who actually authenticated himself.
+                HttpSession session = request.getSession(false);
+                Integer authenticatedID = (Integer) session.getAttribute("dspace.current.user.id"); 
+                if (context.getCurrentUser().getID() != authenticatedID)
+                {
+                    throw new AuthorizeException(I18nUtil.getMessage("jsp.dspace-admin.eperson-main.LoginAs.onlyAuthenticatedAdmins"));
+                }
+                
+                // You may not assume the login of another super administrator
+                Group administrators = Group.find(context,1);
+                if (administrators.isMember(e))
+                {
+                    throw new AuthorizeException(I18nUtil.getMessage("jsp.dspace-admin.eperson-main.LoginAs.notAnotherAdmin"));
+                }
+                                
+                // Logged in OK.
+                Authenticate.loggedIn(context, request, e);
+
+                // Set the Locale according to user preferences
+                Locale epersonLocale = I18nUtil.getEPersonLocale(context
+                        .getCurrentUser());
+                context.setCurrentLocale(epersonLocale);
+                Config.set(request.getSession(), Config.FMT_LOCALE,
+                        epersonLocale);
+
+                // Set any special groups - invoke the authentication mgr.
+                int[] groupIDs = AuthenticationManager.getSpecialGroups(
+                        context, request);
+
+                for (int i = 0; i < groupIDs.length; i++)
+                {
+                    context.setSpecialGroup(groupIDs[i]);
+                    log.debug("Adding Special Group id="
+                            + String.valueOf(groupIDs[i]));
+                }
+
+                response.sendRedirect(request.getContextPath() + "/mydspace");
             }
         }
         else

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EPersonAdminServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EPersonAdminServlet.java
@@ -291,6 +291,7 @@ public class EPersonAdminServlet extends DSpaceServlet
             }
             else
             {
+                
                 log.info(LogManager.getHeader(context, "login-as",
                         "current_eperson="
                                 + context.getCurrentUser().getFullName()

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EPersonAdminServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EPersonAdminServlet.java
@@ -10,6 +10,7 @@ package org.dspace.app.webui.servlet.admin;
 import java.io.IOException;
 import java.sql.SQLException;
 
+import javax.mail.MessagingException;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -19,6 +20,7 @@ import org.dspace.app.webui.util.JSPManager;
 import org.dspace.app.webui.util.UIUtil;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.core.Context;
+import org.dspace.eperson.AccountManager;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.EPersonDeletionException;
@@ -241,6 +243,34 @@ public class EPersonAdminServlet extends DSpaceServlet
 
             showMain(context, request, response);
             context.complete();
+        }
+        else if (button.equals("submit_resetpassword"))
+        {
+        	EPerson e = EPerson.find(context, UIUtil.getIntParameter(request,
+                    "eperson_id"));
+
+            // Check the EPerson exists
+            if (e == null)
+            {
+            	request.setAttribute("no_eperson_selected", Boolean.TRUE);            	
+            	showMain(context, request, response);
+            }
+            else 
+            {
+            	// Note, this may throw an error is the email is bad.
+				try 
+				{
+					AccountManager
+							.sendForgotPasswordInfo(context, e.getEmail());
+					request.setAttribute("reset_password", Boolean.TRUE);
+					showMain(context, request, response);
+				} 
+				catch (MessagingException e1) 
+				{
+					JSPManager.showJSP(request, response,
+							"/dspace-admin/eperson-resetpassword-error.jsp");
+				}
+            }
         }
         else
         {

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EPersonAdminServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EPersonAdminServlet.java
@@ -88,7 +88,7 @@ public class EPersonAdminServlet extends DSpaceServlet
 	            context.complete();
             }
         }
-        else if (button.equals("submit_save"))
+        else if (button.equals("submit_save") || button.equals("submit_resetpassword"))
         {
             // Update the metadata for an e-person
             EPerson e = EPerson.find(context, UIUtil.getIntParameter(request,
@@ -145,6 +145,10 @@ public class EPersonAdminServlet extends DSpaceServlet
 
                     e.update();
 
+                    if (button.equals("submit_resetpassword"))
+                    {
+                        resetPassword(context, request, response, e);
+                    }
                     showMain(context, request, response);
                     context.complete();
                 }
@@ -199,9 +203,17 @@ public class EPersonAdminServlet extends DSpaceServlet
 
                 e.update();
 
+                if (button.equals("submit_resetpassword"))
+                {
+                    resetPassword(context, request, response, e);
+                }
+                
                 showMain(context, request, response);
                 context.complete();
             }
+            
+
+
         }
         else if (button.equals("submit_delete"))
         {
@@ -244,40 +256,29 @@ public class EPersonAdminServlet extends DSpaceServlet
             showMain(context, request, response);
             context.complete();
         }
-        else if (button.equals("submit_resetpassword"))
-        {
-        	EPerson e = EPerson.find(context, UIUtil.getIntParameter(request,
-                    "eperson_id"));
-
-            // Check the EPerson exists
-            if (e == null)
-            {
-            	request.setAttribute("no_eperson_selected", Boolean.TRUE);            	
-            	showMain(context, request, response);
-            }
-            else 
-            {
-            	// Note, this may throw an error is the email is bad.
-				try 
-				{
-					AccountManager
-							.sendForgotPasswordInfo(context, e.getEmail());
-					request.setAttribute("reset_password", Boolean.TRUE);
-					showMain(context, request, response);
-                    // Context needs completing to write registration data
-                    context.complete();
-				} 
-				catch (MessagingException e1) 
-				{
-					JSPManager.showJSP(request, response,
-							"/dspace-admin/eperson-resetpassword-error.jsp");
-				}
-            }
-        }
         else
         {
             // Cancel etc. pressed - show list again
             showMain(context, request, response);
+        }
+    }
+
+    private void resetPassword(Context context, HttpServletRequest request,
+            HttpServletResponse response, EPerson e) throws SQLException,
+            IOException, AuthorizeException, ServletException
+    {
+        // Note, this may throw an error is the email is bad.
+        try
+        {
+            AccountManager
+                    .sendForgotPasswordInfo(context, e.getEmail());
+            request.setAttribute("reset_password", Boolean.TRUE);
+          
+        }
+        catch (MessagingException e1)
+        {
+            JSPManager.showJSP(request, response,
+                    "/dspace-admin/eperson-resetpassword-error.jsp");
         }
     }
 

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EPersonAdminServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EPersonAdminServlet.java
@@ -146,8 +146,18 @@ public class EPersonAdminServlet extends DSpaceServlet
                     e.update();
 
                     if (button.equals("submit_resetpassword"))
-                    {
-                        resetPassword(context, request, response, e);
+                    {                        
+                        try
+                        {
+                            resetPassword(context, request, response, e);
+                        }
+                        catch (MessagingException e1)
+                        {
+                            JSPManager
+                                    .showJSP(request, response,
+                                            "/dspace-admin/eperson-resetpassword-error.jsp");
+                            return;
+                        }
                     }
                     showMain(context, request, response);
                     context.complete();
@@ -205,7 +215,17 @@ public class EPersonAdminServlet extends DSpaceServlet
 
                 if (button.equals("submit_resetpassword"))
                 {
-                    resetPassword(context, request, response, e);
+                    try
+                    {
+                        resetPassword(context, request, response, e);
+                    }
+                    catch (MessagingException e1)
+                    {
+                        JSPManager
+                                .showJSP(request, response,
+                                        "/dspace-admin/eperson-resetpassword-error.jsp");
+                        return;
+                    }                   
                 }
                 
                 showMain(context, request, response);
@@ -265,21 +285,12 @@ public class EPersonAdminServlet extends DSpaceServlet
 
     private void resetPassword(Context context, HttpServletRequest request,
             HttpServletResponse response, EPerson e) throws SQLException,
-            IOException, AuthorizeException, ServletException
+            IOException, AuthorizeException, ServletException,
+            MessagingException
     {
         // Note, this may throw an error is the email is bad.
-        try
-        {
-            AccountManager
-                    .sendForgotPasswordInfo(context, e.getEmail());
-            request.setAttribute("reset_password", Boolean.TRUE);
-          
-        }
-        catch (MessagingException e1)
-        {
-            JSPManager.showJSP(request, response,
-                    "/dspace-admin/eperson-resetpassword-error.jsp");
-        }
+        AccountManager.sendForgotPasswordInfo(context, e.getEmail());
+        request.setAttribute("reset_password", Boolean.TRUE);
     }
 
     private void showMain(Context c, HttpServletRequest request,

--- a/dspace-jspui/src/main/webapp/dspace-admin/eperson-edit.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/eperson-edit.jsp
@@ -193,7 +193,8 @@
                 <td align="left">
                     <%-- <input type="submit" name="submit_save" value="Save Edits"> --%>
                     <input type="submit" name="submit_save" value="<fmt:message key="jsp.dspace-admin.general.save"/>" />
-                </td>
+                    &nbsp;<input type="submit" name="submit_resetpassword" value="<fmt:message key="jsp.dspace-admin.eperson-main.ResetPassword.submit"/>"/>
+                </td>                
                 <td align="right">
                     <%-- <input type="submit" name="submit_delete" value="Delete EPerson..."> --%>
                     <input type="submit" name="submit_delete" value="<fmt:message key="jsp.dspace-admin.general.delete"/>" />

--- a/dspace-jspui/src/main/webapp/dspace-admin/eperson-main.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/eperson-main.jsp
@@ -14,6 +14,8 @@
   - Attributes:
   -   no_eperson_selected - if a user tries to edit or delete an EPerson without
   -                         first selecting one
+  -   reset_password - if a user tries to reset password of an EPerson and the email with token is
+  -                    send successfull 
   -
   - Returns:
   -   submit_add    - admin wants to add an eperson
@@ -32,6 +34,7 @@
 
 <%
    boolean noEPersonSelected = (request.getAttribute("no_eperson_selected") != null);
+   boolean resetPassword = (request.getAttribute("reset_password") != null);
 %>
 
 <dspace:layout titlekey="jsp.dspace-admin.eperson-main.title"
@@ -59,7 +62,11 @@
 	     <fmt:message key="jsp.dspace-admin.eperson-main.noepersonselected"/>
 	   </strong></p>
 <%  } %>
-    
+<% if (resetPassword)
+	{ %><p><strong>
+	     <fmt:message key="jsp.dspace-admin.eperson-main.ResetPassword.success_notice"/>
+	   </strong></p>
+<%  } %>    
     <form name="epersongroup" method="post" action="">    
 
     <center>
@@ -81,6 +88,7 @@
                 <td>
                 	<%-- then&nbsp;<input type="submit" name="submit_edit" value="Edit..." onclick="javascript:finishEPerson();"> --%>
                 	<fmt:message key="jsp.dspace-admin.eperson-main.then"/>&nbsp;<input type="submit" name="submit_edit" value="<fmt:message key="jsp.dspace-admin.general.edit"/>" onclick="javascript:finishEPerson();"/>
+                	&nbsp;<input type="submit" name="submit_resetpassword" value="<fmt:message key="jsp.dspace-admin.eperson-main.ResetPassword.submit"/>" onclick="javascript:finishEPerson();"/>
                 </td>
                 <td>
                 	<%-- <input type="submit" name="submit_delete" value="Delete..." onclick="javascript:finishEPerson();"> --%>

--- a/dspace-jspui/src/main/webapp/dspace-admin/eperson-main.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/eperson-main.jsp
@@ -87,8 +87,7 @@
                 </td>
                 <td>
                 	<%-- then&nbsp;<input type="submit" name="submit_edit" value="Edit..." onclick="javascript:finishEPerson();"> --%>
-                	<fmt:message key="jsp.dspace-admin.eperson-main.then"/>&nbsp;<input type="submit" name="submit_edit" value="<fmt:message key="jsp.dspace-admin.general.edit"/>" onclick="javascript:finishEPerson();"/>
-                	&nbsp;<input type="submit" name="submit_resetpassword" value="<fmt:message key="jsp.dspace-admin.eperson-main.ResetPassword.submit"/>" onclick="javascript:finishEPerson();"/>
+                	<fmt:message key="jsp.dspace-admin.eperson-main.then"/>&nbsp;<input type="submit" name="submit_edit" value="<fmt:message key="jsp.dspace-admin.general.edit"/>" onclick="javascript:finishEPerson();"/>                	
                 </td>
                 <td>
                 	<%-- <input type="submit" name="submit_delete" value="Delete..." onclick="javascript:finishEPerson();"> --%>

--- a/dspace-jspui/src/main/webapp/dspace-admin/eperson-main.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/eperson-main.jsp
@@ -29,12 +29,14 @@
     prefix="fmt" %>
 
 <%@ page import="javax.servlet.jsp.jstl.fmt.LocaleSupport" %>
+<%@ page import="org.dspace.core.ConfigurationManager" %>
 	
 <%@ taglib uri="http://www.dspace.org/dspace-tags.tld" prefix="dspace" %>
 
 <%
    boolean noEPersonSelected = (request.getAttribute("no_eperson_selected") != null);
    boolean resetPassword = (request.getAttribute("reset_password") != null);
+   boolean loginAs = ConfigurationManager.getBooleanProperty("jspui.user.assumelogin", false);
 %>
 
 <dspace:layout titlekey="jsp.dspace-admin.eperson-main.title"
@@ -89,6 +91,7 @@
                 	<%-- then&nbsp;<input type="submit" name="submit_edit" value="Edit..." onclick="javascript:finishEPerson();"> --%>
                 	<fmt:message key="jsp.dspace-admin.eperson-main.then"/>&nbsp;<input type="submit" name="submit_edit" value="<fmt:message key="jsp.dspace-admin.general.edit"/>" onclick="javascript:finishEPerson();"/>
                 	&nbsp;<input type="submit" name="submit_resetpassword" value="<fmt:message key="jsp.dspace-admin.eperson-main.ResetPassword.submit"/>" onclick="javascript:finishEPerson();"/>
+                	<% if(loginAs) { %>&nbsp;<input type="submit" name="submit_login_as" value="<fmt:message key="jsp.dspace-admin.eperson-main.LoginAs.submit"/>" onclick="javascript:finishEPerson();"/> <% } %>
                 </td>
                 <td>
                 	<%-- <input type="submit" name="submit_delete" value="Delete..." onclick="javascript:finishEPerson();"> --%>

--- a/dspace-jspui/src/main/webapp/dspace-admin/eperson-resetpassword-error.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/eperson-resetpassword-error.jsp
@@ -1,0 +1,40 @@
+<%--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+--%>
+<%--
+  - Page representing an eperson reset password error
+  
+  --%>
+
+<%@ page contentType="text/html;charset=UTF-8" %>
+
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt"
+    prefix="fmt" %>
+
+<%@ page isErrorPage="true" %>
+<%@ taglib uri="http://www.dspace.org/dspace-tags.tld" prefix="dspace" %>
+
+<dspace:layout titlekey="jsp.dspace-admin.eperson-main.ResetPassword.title"
+               navbar="admin"
+               locbar="link"
+               parenttitlekey="jsp.administer"
+               parentlink="/dspace-admin">
+
+    <h1><fmt:message key="jsp.dspace-admin.eperson-main.ResetPassword.head" /></h1>
+
+    
+    <p><fmt:message key="jsp.dspace-admin.eperson-main.ResetPassword-error.errormsg"/></p>
+
+     
+    <p align="center">
+        <a href="<%= request.getContextPath() %>/dspace-admin/edit-epeople"><fmt:message key="jsp.dspace-admin.eperson-main.ResetPassword.returntoedit" /></a>
+    </p>
+
+</dspace:layout>
+

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1696,7 +1696,12 @@ webui.suggest.enable = false
 # _uacct = "UA-XXXXXXX-X"
 # Take this key (just the UA-XXXXXX-X part) and place it here in this parameter.
 # jspui.google.analytics.key=UA-XXXXXX-X
-
+ 
+# Determine if super administrators (those whom are in the Administrators group)
+# can login as another user from the "edit eperson" page. This is useful for
+# debugging problems in a running dspace instance, especially in the workflow
+# process. The default value is false, i.e. no one may assume the login of another user.
+#jspui.user.assumelogin = true
 
 #---------------------------------------------------------------#
 #--------------XMLUI SPECIFIC CONFIGURATIONS--------------------#


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-1622

Porting of the administrative loginAs feature to the JSPUI. The code is not a copy and paste from XMLUI for the different behaviour to manage the same attribute in the session, but it mantains the same rules:
- Turn the feature on/off in dspace.cfg (jspui.user.assumelogin vs xmlui.user.assumelogin)
- Only super administrator can login as someone else (not himself)
- Can't log in as another super administrator
- Set any special groups - invoke the authentication mgr.

The authentication logic is does into loggedIn method on JSPUI Authenticate.java class.

Take care that this code is built on top of the PR282 (reset password feature)
