### PR TITLE
Build dspace kernel with Lucene 4.3.0

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -200,10 +200,7 @@
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-analyzers</artifactId>
+            <version>4.3.1</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>
@@ -421,6 +418,12 @@
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
             <version>0.18.6</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>lucene-analyzers</artifactId>
+                    <groupId>org.apache.lucene</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -441,7 +444,21 @@
             <groupId>postgresql</groupId>
             <artifactId>postgresql</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-queries</artifactId>
+            <version>4.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-analyzers-common</artifactId>
+            <version>4.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-queryparser</artifactId>
+            <version>4.3.1</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/dspace-api/src/main/java/org/dspace/search/DSAnalyzer.java
+++ b/dspace-api/src/main/java/org/dspace/search/DSAnalyzer.java
@@ -10,10 +10,12 @@ package org.dspace.search;
 import java.io.Reader;
 import java.util.Set;
 
-import org.apache.lucene.analysis.LowerCaseFilter;
-import org.apache.lucene.analysis.PorterStemFilter;
-import org.apache.lucene.analysis.StopFilter;
-import org.apache.lucene.analysis.StopwordAnalyzerBase;
+
+import org.apache.lucene.analysis.core.LowerCaseFilter;
+import org.apache.lucene.analysis.en.PorterStemFilter;
+import org.apache.lucene.analysis.core.StopFilter;
+import org.apache.lucene.analysis.util.StopwordAnalyzerBase;
+import org.apache.lucene.analysis.util.CharArraySet;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.standard.StandardFilter;
@@ -50,7 +52,7 @@ public class DSAnalyzer extends StopwordAnalyzerBase
     /*
      * Stop table
      */
-    protected final Set stopSet;
+    protected final CharArraySet stopSet;
 
     /**
      * Builds an analyzer

--- a/dspace-api/src/main/java/org/dspace/search/DSNonStemmingAnalyzer.java
+++ b/dspace-api/src/main/java/org/dspace/search/DSNonStemmingAnalyzer.java
@@ -9,8 +9,8 @@ package org.dspace.search;
 
 import java.io.Reader;
 
-import org.apache.lucene.analysis.LowerCaseFilter;
-import org.apache.lucene.analysis.StopFilter;
+import org.apache.lucene.analysis.core.LowerCaseFilter;
+import org.apache.lucene.analysis.core.StopFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.standard.StandardFilter;

--- a/dspace-api/src/main/java/org/dspace/search/DSQuery.java
+++ b/dspace-api/src/main/java/org/dspace/search/DSQuery.java
@@ -16,10 +16,11 @@ import java.util.List;
 
 import org.apache.log4j.Logger;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.queryParser.ParseException;
-import org.apache.lucene.queryParser.QueryParser;
-import org.apache.lucene.queryParser.TokenMgrError;
+import org.apache.lucene.queryparser.classic.ParseException;
+import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.queryparser.classic.TokenMgrError;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
@@ -221,16 +222,16 @@ public class DSQuery
             if (args.getSortOption() == null)
             {
                 SortField[] sortFields = new SortField[] {
-                        new SortField("search.resourcetype", SortField.INT, true),
-                        new SortField(null, SortField.SCORE, SortOption.ASCENDING.equals(args.getSortOrder()))
+                        new SortField("search.resourcetype", SortField.Type.INT, true),
+                        new SortField(null, SortField.Type.SCORE, SortOption.ASCENDING.equals(args.getSortOrder()))
                     };
                 hits = searcher.search(myquery, max, new Sort(sortFields));
             }
             else
             {
                 SortField[] sortFields = new SortField[] {
-                        new SortField("search.resourcetype", SortField.INT, true),
-                        new SortField("sort_" + args.getSortOption().getName(), SortField.STRING, SortOption.DESCENDING.equals(args.getSortOrder())),
+                        new SortField("search.resourcetype", SortField.Type.INT, true),
+                        new SortField("sort_" + args.getSortOption().getName(), SortField.Type.STRING, SortOption.DESCENDING.equals(args.getSortOrder())),
                         SortField.FIELD_SCORE
                     };
                 hits = searcher.search(myquery, max, new Sort(sortFields));
@@ -396,7 +397,8 @@ public class DSQuery
         {
             try
             {
-                searcher.close();
+                // Searcher close is not used. So propably we must close Reader
+                searcher.getIndexReader().close();
                 searcher = null;
             }
             catch (IOException ioe)
@@ -416,14 +418,16 @@ public class DSQuery
 
     /*---------  protected methods ----------*/
 
-    /**	
+/**	
      * get an IndexReader.
      * @throws IOException 
      */
-    protected static IndexReader getIndexReader() 
+    protected static DirectoryReader getIndexReader() 
     	throws IOException
     {
-    	return getSearcher(null).getIndexReader();
+    	Directory searchDir = FSDirectory.open(new File(indexDir));
+    	return DirectoryReader.open(searchDir);
+        
     }
     
     /**
@@ -438,14 +442,15 @@ public class DSQuery
         // If we have already opened a searcher, check to see if the index has been updated
         // If it has, we need to close the existing searcher - we will open a new one later
 
-        Directory searchDir = FSDirectory.open(new File(indexDir));
+        
+        DirectoryReader dr=getIndexReader();
 
-        if (searcher != null && lastModified != IndexReader.getCurrentVersion(searchDir))
+        if (searcher != null && lastModified != dr.getVersion())
         {
             try
             {
                 // Close the cached IndexSearcher
-                searcher.close();
+                searcher.getIndexReader().close();
             }
             catch (IOException ioe)
             {
@@ -464,11 +469,11 @@ public class DSQuery
         if (searcher == null)
         {
             // So, open a new searcher
-            lastModified = IndexReader.getCurrentVersion(searchDir);
+            lastModified = dr.getVersion();
             String osName = System.getProperty("os.name");
             if (osName != null && osName.toLowerCase().contains("windows"))
             {
-                searcher = new IndexSearcher(searchDir){
+                searcher = new IndexSearcher(dr){
                     /*
                      * TODO: Has Lucene fixed this bug yet?
                      * Lucene doesn't release read locks in
@@ -477,14 +482,14 @@ public class DSQuery
                      */
                     @Override
                     protected void finalize() throws Throwable {
-                        this.close();
+                        this.getIndexReader().close();
                         super.finalize();
                     }
                 };
             }
             else
             {
-                searcher = new IndexSearcher(searchDir);
+                searcher = new IndexSearcher(dr);
             }
         }
 

--- a/dspace-api/src/main/java/org/dspace/search/DSTokenizer.java
+++ b/dspace-api/src/main/java/org/dspace/search/DSTokenizer.java
@@ -9,7 +9,7 @@ package org.dspace.search;
 
 import java.io.Reader;
 
-import org.apache.lucene.analysis.CharTokenizer;
+import org.apache.lucene.analysis.util.CharTokenizer;
 import org.apache.lucene.util.Version;
 
 /**


### PR DESCRIPTION
Currently, dspace is based on Lucene 3.5.
Lucene 4.3.0 support spatial search which can be useful.

The migration was based on the following pages:
http://lucene.apache.org/core/4_3_0/MIGRATE.html
http://lucene.apache.org/core/4_3_0/core/index.html
