### PR TITLE
Fix for DS-1682 - Mirage theme header is hardcoded into XSLT.

### DIFF
--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -1992,7 +1992,7 @@
 	<message key="xmlui.dri2xhtml.structural.contact-link">Contact Us</message>
 	<message key="xmlui.dri2xhtml.structural.feedback-link">Send Feedback</message>
 
-	<message key="xmlui.dri2xhtml.structural.head-subtitle">DSpace/Manakin Repository</message>
+	<message key="xmlui.dri2xhtml.structural.head-subtitle">DSpace Repository</message>
 
 	<message key="xmlui.dri2xhtml.structural.profile">Profile: </message>
 	<message key="xmlui.dri2xhtml.structural.logout">Logout</message>

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
@@ -324,7 +324,9 @@
                         <xsl:text>/</xsl:text>
                     </xsl:attribute>
                     <span id="ds-header-logo">&#160;</span>
-                    <span id="ds-header-logo-text">mirage</span>
+                    <span id="ds-header-logo-text">
+                       <i18n:text>xmlui.dri2xhtml.structural.head-subtitle</i18n:text>
+                    </span>
                 </a>
                 <h1 class="pagetitle visuallyhidden">
                     <xsl:choose>
@@ -339,10 +341,6 @@
                     </xsl:choose>
 
                 </h1>
-                <h2 class="static-pagetitle visuallyhidden">
-                    <i18n:text>xmlui.dri2xhtml.structural.head-subtitle</i18n:text>
-                </h2>
-
 
                 <xsl:choose>
                     <xsl:when test="/dri:document/dri:meta/dri:userMeta/@authenticated = 'yes'">


### PR DESCRIPTION
Both fixes DS-1682 and also changes the default header text (in messages.xml) to be "DSpace Repository" instead of "DSpace/Manakin Repository"

https://jira.duraspace.org/browse/DS-1682

I believe these changes should be non-controversial, but I'll leave this PR open for a few days for comment.
