### PR TITLE
DS-1689 Create Spatial Index and Spatial Query

### DIFF
--- a/dspace-api/src/main/java/org/dspace/search/DSIndexer.java
+++ b/dspace-api/src/main/java/org/dspace/search/DSIndexer.java
@@ -7,6 +7,10 @@
  */
 package org.dspace.search;
 
+import com.spatial4j.core.context.SpatialContext;
+import com.spatial4j.core.context.jts.JtsSpatialContext;
+import com.spatial4j.core.shape.Rectangle;
+import com.spatial4j.core.shape.impl.RectangleImpl;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -47,6 +51,10 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.MultiFields;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.spatial.SpatialStrategy;
+import org.apache.lucene.spatial.prefix.RecursivePrefixTreeStrategy;
+import org.apache.lucene.spatial.prefix.tree.QuadPrefixTree;
+import org.apache.lucene.spatial.prefix.tree.SpatialPrefixTree;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.util.Bits;
@@ -1073,20 +1081,55 @@ public class DSIndexer
         int j;
         if (indexConfigArr.length > 0)
         {
-            DCValue[] mydc;
+            DCValue[] mydc=null;
+            String eastBound=null;
+            String westBound=null;
+            String southBound=null;
+            String northBound=null;
 
             for (int i = 0; i < indexConfigArr.length; i++)
             {
-                // extract metadata (ANY is wildcard from Item class)
-                if (indexConfigArr[i].qualifier!= null && indexConfigArr[i].qualifier.equals("*"))
+                //Get Geographic Bounding Box indexes
+                //This means that metadata that represent coordinates should have the structure:
+                // [schema].GeographicBoundingBox.EastBoundLongtitude
+                // [schema].GeographicBoundingBox.WestBoundLongtitude
+                // [schema].GeographicBoundingBox.NorthBoundLongtitude
+                // [schema].GeographicBoundingBox.SouthBoundLongtitude
+                // In a more abstract implementation the "spatial" metadata items could be defined in dspace.cfg
+                if (indexConfigArr[i].element.equals("GeographicBoundingBox"))
                 {
-                    mydc = item.getMetadata(indexConfigArr[i].schema, indexConfigArr[i].element, Item.ANY, Item.ANY);
+                    log.info("get Bounding Box");
+                    try{
+                    if (indexConfigArr[i].qualifier.equals("EastBoundLongtitude"))
+                    {
+                        eastBound= item.getMetadata(indexConfigArr[i].schema, indexConfigArr[i].element, indexConfigArr[i].qualifier, Item.ANY)[0].value;     
+                    }
+                    if (indexConfigArr[i].qualifier.equals("WestBoundLongtitude"))
+                    {
+                        westBound= item.getMetadata(indexConfigArr[i].schema, indexConfigArr[i].element, indexConfigArr[i].qualifier, Item.ANY)[0].value;   
+                    }
+                    if (indexConfigArr[i].qualifier.equals("NorthBoundLatitude"))
+                    {
+                        northBound= item.getMetadata(indexConfigArr[i].schema, indexConfigArr[i].element, indexConfigArr[i].qualifier, Item.ANY)[0].value;   
+                    }
+                    if (indexConfigArr[i].qualifier.equals("SouthBoundLatitude"))
+                    {
+                        southBound= item.getMetadata(indexConfigArr[i].schema, indexConfigArr[i].element, indexConfigArr[i].qualifier, Item.ANY)[0].value;
+                    }
+                    }catch (ArrayIndexOutOfBoundsException e){
+                        log.error("Skipping Bounding Box");                    
+                    }
+                }else{
+                    // extract metadata (ANY is wildcard from Item class)
+                    if (indexConfigArr[i].qualifier!= null && indexConfigArr[i].qualifier.equals("*"))
+                    {
+                        mydc = item.getMetadata(indexConfigArr[i].schema, indexConfigArr[i].element, Item.ANY, Item.ANY);
+                    }
+                    else
+                    {
+                        mydc = item.getMetadata(indexConfigArr[i].schema, indexConfigArr[i].element, indexConfigArr[i].qualifier, Item.ANY);
+                    }
                 }
-                else
-                {
-                    mydc = item.getMetadata(indexConfigArr[i].schema, indexConfigArr[i].element, indexConfigArr[i].qualifier, Item.ANY);
-                }
-
 
                 //Index the controlled vocabularies localized display values for all localized input-forms.xml (e.g. input-forms_el.xml)
                 if ("inputform".equalsIgnoreCase(indexConfigArr[i].type)){
@@ -1227,6 +1270,19 @@ public class DSIndexer
                         doc.add( new Field("default", mydc[j].value, Field.Store.NO, Field.Index.ANALYZED));
                     }
                 }
+            }
+            //Create Spatial Index if present
+            if ((eastBound!=null) && (westBound!=null) && (northBound!=null) && (southBound!=null))
+            {
+                log.info("Create Spatial Index");
+                SpatialContext SC=JtsSpatialContext.GEO;
+                SpatialPrefixTree grid=new QuadPrefixTree(SC,10);
+                SpatialStrategy SS=new RecursivePrefixTreeStrategy(grid,"bbox");
+                Rectangle shape=new RectangleImpl(Double.valueOf(eastBound.trim()),Double.valueOf(westBound.trim()),Double.valueOf(southBound.trim()),Double.valueOf(northBound.trim()),SC);
+                for (IndexableField f: SS.createIndexableFields(shape))
+                {
+                    doc.add(f);
+                }         
             }
         }
 

--- a/dspace-api/src/main/java/org/dspace/search/DSQuery.java
+++ b/dspace-api/src/main/java/org/dspace/search/DSQuery.java
@@ -7,6 +7,9 @@
  */
 package org.dspace.search;
 
+import com.spatial4j.core.context.SpatialContext;
+import com.spatial4j.core.context.jts.JtsSpatialContext;
+import com.spatial4j.core.shape.impl.RectangleImpl;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -21,12 +24,13 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.queryparser.classic.TokenMgrError;
-import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.Sort;
-import org.apache.lucene.search.SortField;
-import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.*;
+import org.apache.lucene.spatial.SpatialStrategy;
+import org.apache.lucene.spatial.prefix.RecursivePrefixTreeStrategy;
+import org.apache.lucene.spatial.prefix.tree.QuadPrefixTree;
+import org.apache.lucene.spatial.prefix.tree.SpatialPrefixTree;
+import org.apache.lucene.spatial.query.SpatialArgs;
+import org.apache.lucene.spatial.query.SpatialOperation;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.util.Version;
@@ -83,6 +87,7 @@ public class DSQuery
         operator = ConfigurationManager.getProperty("search.operator");   
     }
 
+    
     /**
      * Do a query, returning a QueryResults object
      *
@@ -92,6 +97,22 @@ public class DSQuery
      * @return query results QueryResults
      */
     public static QueryResults doQuery(Context c, QueryArgs args)
+            throws IOException
+    {
+        return doQuery(c, args, null ,null);
+    }
+    
+    /**
+     * Do a query, returning a QueryResults object
+     *
+     * @param c  context
+     * @param args query arguments in QueryArgs object
+     * @param spatialFilter spatial bounding box passed as parameter e.g "25.1742,27.5031,37.5952,39.5727"
+     * @param spatialOperation e.g "IsWithin" or "Intesects"
+     * 
+     * @return query results QueryResults
+     */
+    public static QueryResults doQuery(Context c, QueryArgs args,  String spatialFilter, String spatialOperation)
             throws IOException
     {
         String querystring = args.getQuery();
@@ -137,7 +158,7 @@ public class DSQuery
 
             Query myquery = qp.parse(querystring);
             //Retrieve enough docs to get all the results we need !
-            TopDocs  hits = performQuery(args, searcher, myquery, args.getPageSize() * (args.getStart() + 1));
+            TopDocs  hits = performQuery(args, searcher, myquery, args.getPageSize() * (args.getStart() + 1), spatialFilter, spatialOperation);
             
             Date endTime = new Date();
             
@@ -215,8 +236,39 @@ public class DSQuery
         return qr;
     }
 
-    private static TopDocs performQuery(QueryArgs args, IndexSearcher searcher, Query myquery, int max) throws IOException {
+    private static TopDocs performQuery(QueryArgs args, IndexSearcher searcher, Query myquery, int max,  String spatialFilter,String spatialOperation) throws IOException {
         TopDocs hits;
+        
+         Filter spatial=null;
+         if ((spatialFilter!=null) && !(spatialFilter.equals(""))){
+         try{ 
+            Double[] bbox=getBoundingBox(spatialFilter); 
+            SpatialContext SC=JtsSpatialContext.GEO;
+            SpatialArgs sa=null;
+            //In this implemantation 2 spatial Operations are supported
+            if (spatialOperation.equals("intersect"))
+            {
+              sa = new SpatialArgs(SpatialOperation.Intersects,new RectangleImpl(bbox[0],bbox[1],bbox[2],bbox[3],SC)); 
+            } else {
+              sa = new SpatialArgs(SpatialOperation.IsWithin,new RectangleImpl(bbox[0],bbox[1],bbox[2],bbox[3],SC));  
+            }
+            SpatialPrefixTree grid=new QuadPrefixTree(SC,10);
+            SpatialStrategy SS=new RecursivePrefixTreeStrategy(grid,"bbox");
+            log.info("Query"+myquery.toString());
+            //Create the Filter
+            spatial=SS.makeFilter(sa);
+            // In case text search is empty all docs are returned 
+            // So, the results are limited only by the spatial Filter
+             if (myquery.toString().contains("+(default:empti default:queri default:string)"))
+             {
+                 myquery=new MatchAllDocsQuery();
+             }
+         }catch(NumberFormatException e){
+             log.error("Cannot parse Bounding Box");
+             spatial=null;
+         }
+         }
+         
         try
         {
             if (args.getSortOption() == null)
@@ -225,7 +277,7 @@ public class DSQuery
                         new SortField("search.resourcetype", SortField.Type.INT, true),
                         new SortField(null, SortField.FIELD_SCORE.getType(), SortOption.ASCENDING.equals(args.getSortOrder()))
                     };
-                hits = searcher.search(myquery, max, new Sort(sortFields));
+                hits = searcher.search(myquery, spatial, max, new Sort(sortFields));
             }
             else
             {
@@ -234,7 +286,7 @@ public class DSQuery
                         new SortField("sort_" + args.getSortOption().getName(), SortField.Type.STRING, SortOption.DESCENDING.equals(args.getSortOrder())),
                         SortField.FIELD_SCORE
                     };
-                hits = searcher.search(myquery, max, new Sort(sortFields));
+                hits = searcher.search(myquery, spatial, max, new Sort(sortFields));
             }
         }
         catch (Exception e)
@@ -242,7 +294,7 @@ public class DSQuery
             // Lucene can throw an exception if it is unable to determine a sort time from the specified field
             // Provide a fall back that just works on relevancy.
             log.error("Unable to use speficied sort option: " + (args.getSortOption() == null ? "type/relevance": args.getSortOption().getName()));
-            hits = searcher.search(myquery, max, new Sort(SortField.FIELD_SCORE));
+            hits = searcher.search(myquery, spatial, max, new Sort(SortField.FIELD_SCORE));
         }
         return hits;
     }
@@ -293,8 +345,23 @@ public class DSQuery
                       .replaceAll("\\(\\*", "(")
                       .replaceAll(":\\*", ":");
     }
+    
+    
+     static Double[] getBoundingBox(String bbox) {
+        
+        String[] strCoords=bbox.split(",");
+        Double[] coords=new Double[4];
+        
+        coords[0]=Double.valueOf(strCoords[0].trim());//get westBound
+        coords[1]=Double.valueOf(strCoords[1].trim());//get eastBound
+        coords[2]=Double.valueOf(strCoords[2].trim());//get southBound
+        coords[3]=Double.valueOf(strCoords[3].trim());//get northBound
+        
+        return coords;
+    }
 
-    /**
+     
+       /**
      * Do a query, restricted to a collection
      * 
      * @param c
@@ -309,6 +376,13 @@ public class DSQuery
     public static QueryResults doQuery(Context c, QueryArgs args,
             Collection coll) throws IOException
     {
+        return doQuery(c, args, coll, null, null);
+    }
+    
+     
+    public static QueryResults doQuery(Context c, QueryArgs args,
+            Collection coll, String spatialFilter, String spatialOperation) throws IOException
+    {
         String querystring = args.getQuery();
 
         querystring = checkEmptyQuery(querystring);
@@ -319,7 +393,7 @@ public class DSQuery
 
         args.setQuery(newquery);
 
-        return doQuery(c, args);
+        return doQuery(c, args, spatialFilter, spatialOperation);
     }
 
     /**
@@ -337,6 +411,12 @@ public class DSQuery
     public static QueryResults doQuery(Context c, QueryArgs args, Community comm)
             throws IOException
     {
+        return doQuery(c, args, comm, null, null);
+    }
+    
+     public static QueryResults doQuery(Context c, QueryArgs args, Community comm, String spatialFilter, String spatialOperation)
+            throws IOException
+    {
         String querystring = args.getQuery();
 
         querystring = checkEmptyQuery(querystring);
@@ -347,7 +427,7 @@ public class DSQuery
 
         args.setQuery(newquery);
 
-        return doQuery(c, args);
+        return doQuery(c, args, spatialFilter, spatialOperation);
     }
 
 

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/AbstractSearch.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/AbstractSearch.java
@@ -217,7 +217,7 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer
     protected void buildSearchResultsDivision(Division search)
             throws IOException, SQLException, WingException
     {
-        if (getQuery().length() > 0)
+        if ((getQuery().length() > 0) || (getSpatialQuery().length()>0))
         {
 
             // Perform the actual search
@@ -406,6 +406,7 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer
         
         Context context = ContextUtil.obtainContext(objectModel);
         String query = getQuery();
+        String spatialQuery=getSpatialQuery();
         DSpaceObject scope = getScope();
         int page = getParameterPage();
 
@@ -434,15 +435,15 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer
         QueryResults qResults = null;
         if (scope instanceof Community)
         {
-            qResults = DSQuery.doQuery(context, queryArgs, (Community) scope);
+            qResults = DSQuery.doQuery(context, queryArgs, (Community) scope, spatialQuery, "intersect");
         }
         else if (scope instanceof Collection)
         {
-            qResults = DSQuery.doQuery(context, queryArgs, (Collection) scope);
+            qResults = DSQuery.doQuery(context, queryArgs, (Collection) scope, spatialQuery, "intesect");
         }
         else
         {
-            qResults = DSQuery.doQuery(context, queryArgs);
+            qResults = DSQuery.doQuery(context, queryArgs, spatialQuery, "intersect");
         }
 
         this.queryResults = qResults;
@@ -555,6 +556,14 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer
      * @return The query string.
      */
     protected abstract String getQuery() throws UIException;
+    
+     /**
+     * Extract the spatial query string. Under most implementations this will be derived
+     * from the url parameters.
+     * 
+     * @return The spatial query string.
+     */
+    protected abstract String getSpatialQuery() throws UIException;
 
     /**
      * Generate a url to the given search implementation with the associated

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/AdvancedSearch.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/AdvancedSearch.java
@@ -129,6 +129,7 @@ public class AdvancedSearch extends AbstractSearch implements CacheableProcessin
         {
             numSearchField = "3";
         }
+        String spatialQueryString = getSpatialQuery();
     	
         // Build the DRI Body
         Division search = body.addDivision("advanced-search","primary");
@@ -178,6 +179,19 @@ public class AdvancedSearch extends AbstractSearch implements CacheableProcessin
         	query.addHidden("query"+i).setValue(field.getQuery());
         }
 
+        //Spatial query passes as filter in Lucene search so it has no value to be added as conjuction field
+        //Element for spatial searching
+        //User can enter a bounding box in the form e.g. "25.1742,27.5031,37.5952,39.5727"
+        Text bbox = queryList.addItem().addText("bbox");
+        //It should be an new entry in messages.xml
+        bbox.setLabel("Spatial Search");
+        bbox.setValue(spatialQueryString);
+        
+        //An alternative implemnentation could be the following so the bbox element to be activated by Theme
+        //Hidden bbox=queryList.addItem().addHidden("bbox");
+        //bbox.setValue(spatialQueryString);
+        
+        
         buildSearchControls(query);
         query.addPara(null, "button-list").addButton("submit").setValue(T_go);
         
@@ -324,6 +338,12 @@ public class AdvancedSearch extends AbstractSearch implements CacheableProcessin
             parameters.put("query" + index, query);
         }
         
+        String spatialquery = getSpatialQuery();
+        if (!"".equals(spatialquery))
+        {
+            parameters.put("bbox", encodeForURL(spatialquery));
+        }
+        
         if (parameters.get("page") == null)
         {
             parameters.put("page", String.valueOf(getParameterPage()));
@@ -362,6 +382,18 @@ public class AdvancedSearch extends AbstractSearch implements CacheableProcessin
         Request request = ObjectModelHelper.getRequest(objectModel);   
         return AdvancedSearchUtils.buildQuery(getSearchFields(request));
     }
+    
+     protected String getSpatialQuery() throws UIException
+    {
+        Request request = ObjectModelHelper.getRequest(objectModel);
+        String query = decodeFromURL(request.getParameter("bbox"));
+        if (query == null)
+        {
+            return "";
+        }
+        return query;
+    }
+
 
     private java.util.List<AdvancedSearchUtils.SearchField> getSearchFields(Request request) throws UIException {
         if (fields == null){

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/SimpleSearch.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/SimpleSearch.java
@@ -86,6 +86,8 @@ public class SimpleSearch extends AbstractSearch implements CacheableProcessingC
             UIException, SQLException, IOException, AuthorizeException
     {
         String queryString = getQuery();
+        //Hold the spatial query
+        String spatialQueryString = getSpatialQuery();
 
         // Build the DRI Body
         Division search = body.addDivision("search","primary");
@@ -106,6 +108,17 @@ public class SimpleSearch extends AbstractSearch implements CacheableProcessingC
         text.setLabel(T_full_text_search);
         text.setValue(queryString);
         
+        //Element for spatial searching
+        //User can enter a bounding box in the form e.g. "25.1742,27.5031,37.5952,39.5727"
+        Text bbox = queryList.addItem().addText("bbox");
+        //It should be an new entry in messages.xml
+        bbox.setLabel("Spatial Search");
+        bbox.setValue(spatialQueryString);
+        
+        //An alternative implemnentation could be the following so the bbox element to be activated by Theme
+        //Hidden bbox=queryList.addItem().addHidden("bbox");
+        //bbox.setValue(spatialQueryString);
+        
         buildSearchControls(query);
         query.addPara(null, "button-list").addButton("submit").setValue(T_go);
 
@@ -122,6 +135,22 @@ public class SimpleSearch extends AbstractSearch implements CacheableProcessingC
     {
         Request request = ObjectModelHelper.getRequest(objectModel);
         String query = decodeFromURL(request.getParameter("query"));
+        if (query == null)
+        {
+            return "";
+        }
+        return query;
+    }
+    
+    
+       /**
+     * Get the spatial search query from the URL parameter, if none is found the empty
+     * string is returned.
+     */
+    public String getSpatialQuery() throws UIException
+    {
+        Request request = ObjectModelHelper.getRequest(objectModel);
+        String query = decodeFromURL(request.getParameter("bbox"));
         if (query == null)
         {
             return "";
@@ -148,6 +177,13 @@ public class SimpleSearch extends AbstractSearch implements CacheableProcessingC
         {
             parameters.put("query", encodeForURL(query));
         }
+        
+        String spatialquery = getSpatialQuery();
+        if (!"".equals(spatialquery))
+        {
+            parameters.put("bbox", encodeForURL(spatialquery));
+        }
+        
         
         if (parameters.get("page") == null)
         {


### PR DESCRIPTION
The following code allows the indexing and querying on "spatial" metadata

A resource may refer to a geographic area and this area can be defined in metadata as geographic bounding box (west edge , east edge , north edge , south edge )   

![image](https://f.cloud.github.com/assets/2056790/1269750/6b16e2f4-2cfe-11e3-9a49-dd0470a0a0ed.png)

If an item's bounding box is present in metadata then it can be indexed and users can perform spatial queries (propably by selecting a geographic area on a map) to get results that refers to a specific geographic area. An implementation of this functionality can be found at the following link:
http://geo-dspace.aegean.gr/xmlui/handle/123456789/4

How this works:
User should create 4 custom metadata fields:
[schema].GeographicBoundingBox.EastBoundLongtitude
[schema].GeographicBoundingBox.WestBoundLongtitude
[schema].GeographicBoundingBox.NorthBoundLongtitude
[schema].GeographicBoundingBox.SouthBoundLongtitude

 (In a more abstract implementation the "spatial" metadata fields could be defined in dspace.cfg.)

After an item is submitted Lucene creates Quadtree spatial index for this item.  
When the user perform a spatial search, he passes a bounding box to lucene which compares this with spatial indexes based on a spatial Operation . For example, if the spatial operation used is "intersect" then Lucene will return all items that their's bounding box intersects with user's passed bounding box.

This requests contains modification only in dspace Kernel API. But there is a need for modifications in XMLUI API and stylesheets in order for this functionality to be fully operational

Notes:
Lucene supports spatial searches from 4 version
This code was tested in Lucene 4.3.0 version
The coordination System is WGS84
