### PR TITLE
DS-1559 Empty dc fields causes page layout issues

### DIFF
--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/aspect/artifactbrowser/item-list.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/aspect/artifactbrowser/item-list.xsl
@@ -84,7 +84,7 @@
                         <xsl:value-of select="$href"/>
                     </xsl:attribute>
                     <xsl:choose>
-                        <xsl:when test="dim:field[@element='title']">
+                        <xsl:when test="dim:field[@element='title' and descendant::text()]">
                             <xsl:value-of select="dim:field[@element='title'][1]/node()"/>
                         </xsl:when>
                         <xsl:otherwise>
@@ -158,7 +158,7 @@
                         <xsl:value-of select="$href"/>
                     </xsl:attribute>
                     <xsl:choose>
-                        <xsl:when test="dim:field[@element='title']">
+                        <xsl:when test="dim:field[@element='title' and descendant::text()]">
                             <xsl:value-of select="dim:field[@element='title'][1]/node()"/>
                         </xsl:when>
                         <xsl:otherwise>

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -104,7 +104,7 @@
           <xsl:when test="$clause = 1">
 
               <xsl:choose>
-                  <xsl:when test="count(dim:field[@element='title'][not(@qualifier)]) &gt; 1">
+                  <xsl:when test="descendant::text() and (count(dim:field[@element='title'][not(@qualifier)]) &gt; 1)">
                       <!-- display first title as h1 -->
                       <h1>
                           <xsl:value-of select="dim:field[@element='title'][not(@qualifier)][1]/node()"/>
@@ -122,7 +122,7 @@
                           </span>
                       </div>
                   </xsl:when>
-                  <xsl:when test="count(dim:field[@element='title'][not(@qualifier)]) = 1">
+                  <xsl:when test="dim:field[@element='title'][descendant::text()] and count(dim:field[@element='title'][not(@qualifier)]) = 1">
                       <h1>
                           <xsl:value-of select="dim:field[@element='title'][not(@qualifier)][1]/node()"/>
                       </h1>
@@ -140,7 +140,7 @@
           </xsl:when>
 
           <!-- Author(s) row -->
-          <xsl:when test="$clause = 2 and (dim:field[@element='contributor'][@qualifier='author'] or dim:field[@element='creator'] or dim:field[@element='contributor'])">
+          <xsl:when test="$clause = 2 and (dim:field[@element='contributor'][@qualifier='author' and descendant::text()] or dim:field[@element='creator' and descendant::text()] or dim:field[@element='contributor' and descendant::text()])">
                     <div class="simple-item-view-authors">
 	                    <xsl:choose>
 	                        <xsl:when test="dim:field[@element='contributor'][@qualifier='author']">
@@ -184,7 +184,7 @@
           </xsl:when>
 
           <!-- identifier.uri row -->
-          <xsl:when test="$clause = 3 and (dim:field[@element='identifier' and @qualifier='uri'])">
+          <xsl:when test="$clause = 3 and (dim:field[@element='identifier' and @qualifier='uri' and descendant::text()])">
                     <div class="simple-item-view-other">
 	                <span class="bold"><i18n:text>xmlui.dri2xhtml.METS-1.0.item-uri</i18n:text>:</span>
 	                <span>
@@ -208,7 +208,7 @@
           </xsl:when>
 
           <!-- date.issued row -->
-          <xsl:when test="$clause = 4 and (dim:field[@element='date' and @qualifier='issued'])">
+          <xsl:when test="$clause = 4 and (dim:field[@element='date' and @qualifier='issued' and descendant::text()])">
                     <div class="simple-item-view-other">
 	                <span class="bold"><i18n:text>xmlui.dri2xhtml.METS-1.0.item-date</i18n:text>:</span>
 	                <span>
@@ -259,7 +259,7 @@
           </xsl:when>
 
           <!-- Description row -->
-          <xsl:when test="$clause = 6 and (dim:field[@element='description' and not(@qualifier)])">
+          <xsl:when test="$clause = 6 and (dim:field[@element='description' and not(@qualifier) and descendant::text()])">
                 <div class="simple-item-view-description">
 	                <h3 class="bold"><i18n:text>xmlui.dri2xhtml.METS-1.0.item-description</i18n:text>:</h3>
 	                <div>

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
@@ -289,7 +289,10 @@
                                 <xsl:text>About This Repository</xsl:text>
                         </xsl:when>
                         <xsl:when test="not($page_title)">
-                                <xsl:text>  </xsl:text>
+                            <i18n:text>xmlui.dri2xhtml.METS-1.0.no-title</i18n:text>
+                        </xsl:when>
+                        <xsl:when test="$page_title = ''">
+                            <i18n:text>xmlui.dri2xhtml.METS-1.0.no-title</i18n:text>
                         </xsl:when>
                         <xsl:otherwise>
                                 <xsl:copy-of select="$page_title/node()" />

--- a/dspace-xmlui/src/main/webapp/themes/dri2xhtml-alt/aspect/artifactbrowser/discovery.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/dri2xhtml-alt/aspect/artifactbrowser/discovery.xsl
@@ -119,7 +119,7 @@
         <div class="artifact-title">
             <a href="{$metsDoc/mets:METS/@OBJID}">
                 <xsl:choose>
-                    <xsl:when test="dri:list[@n=(concat($handle, ':dc.title'))]">
+                    <xsl:when test="dri:list[@n=(concat($handle, ':dc.title')) and descendant::text()]">
                         <xsl:apply-templates select="dri:list[@n=(concat($handle, ':dc.title'))]/dri:item"/>
                     </xsl:when>
                     <xsl:otherwise>
@@ -146,7 +146,7 @@
         <div class="artifact-title">
             <a href="{$metsDoc/mets:METS/@OBJID}">
                 <xsl:choose>
-                    <xsl:when test="dri:list[@n=(concat($handle, ':dc.title'))]">
+                    <xsl:when test="dri:list[@n=(concat($handle, ':dc.title')) and descendant::text()]">
                         <xsl:apply-templates select="dri:list[@n=(concat($handle, ':dc.title'))]/dri:item"/>
                     </xsl:when>
                     <xsl:otherwise>
@@ -191,7 +191,7 @@
                         </xsl:choose>
                     </xsl:attribute>
                     <xsl:choose>
-                        <xsl:when test="dri:list[@n=(concat($handle, ':dc.title'))]">
+                        <xsl:when test="dri:list[@n=(concat($handle, ':dc.title')) and descendant::text()]">
                             <xsl:apply-templates select="dri:list[@n=(concat($handle, ':dc.title'))]/dri:item"/>
                         </xsl:when>
                         <xsl:otherwise>


### PR DESCRIPTION
Fixing a number of issues caused by empty metadata fields in Mirage
