### PR TITLE
DS-1722 Fix filtering of all DSpace configs in test environment (In progress)

### DIFF
--- a/src/main/assembly/testEnvironment.xml
+++ b/src/main/assembly/testEnvironment.xml
@@ -29,20 +29,25 @@
                     <fileSet> <!-- installable DSpace files -->
                         <directory />
                         <outputDirectory />
+                        <!-- Copy necessary DSpace subdirectories into Test environment -->
+                        <includes>
+                            <include>bin/**</include>
+                            <include>config/**</include>
+                            <include>etc/**</include>
+                            <include>solr/**</include>
+                        </includes>
+                        <!-- Exclude specific configs (which require filtering) -->
                         <excludes>
                             <exclude>config/dspace.cfg</exclude>
-                        </excludes>
-                        <includes>
-                            <include>bin/**/*</include>
-                            <include>config/**/*</include>
-                            <include>etc/**/*</include>
-                            <include>modules/**/*</include>
-                            <include>solr/**/*</include>
-                        </includes>
+                            <exclude>config/log4j.properties</exclude>
+                            <exclude>config/modules/**</exclude>
+                        </excludes> 
                     </fileSet>
-                    <fileSet> <!-- installable DSpace files needing filtering -->
+                    <fileSet> <!-- Copy specific configs (filtering their content) also into Test environment -->
                         <includes>
+                            <include>config/modules/**</include>
                             <include>config/dspace.cfg</include>
+                            <include>config/log4j.properties</include>
                         </includes>
                         <filtered>true</filtered>
                     </fileSet>


### PR DESCRIPTION
This fixes the filtering of DSpace config files in our Maven testing environment.
https://jira.duraspace.org/browse/DS-1722

HOWEVER, PLEASE DO NOT MERGE THIS IMMEDIATELY.

Although the filtering is fixed, you now will receive errors from Solr, since Solr does not actually run during "mvn test".  This actually slows down the Maven test considerably

2013-10-22 15:58:43,765 ERROR org.dspace.discovery.SolrServiceImpl @ Server refused connection at: http://localhost:8080/solr/search

So, although this PR resolves one problem, another is introduced.  We should fix Solr so that either it is not called during "maven test" or it should be "stubbed" out.

I created this PR as a DS-1722 branch in the main DSpace/DSpace repo, so others are welcome to help out.
