### PR TITLE
DS-1711 DS-1712 DS-1466 Implement consistent definition of Private items

### DIFF
--- a/dspace-api/src/main/java/org/dspace/browse/BrowseDAOOracle.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseDAOOracle.java
@@ -116,6 +116,7 @@ public class BrowseDAOOracle implements BrowseDAO
     /** flags for what the items represent */
     private boolean itemsInArchive = true;
     private boolean itemsWithdrawn = false;
+    private boolean itemsDiscoverable = true;
 
     private boolean enableBrowseFrequencies = true;
     
@@ -360,7 +361,8 @@ public class BrowseDAOOracle implements BrowseDAO
                 TableRow row = tri.next();
                 BrowseItem browseItem = new BrowseItem(context, row.getIntColumn("item_id"),
                                                   itemsInArchive,
-                                                  itemsWithdrawn);
+                                                  itemsWithdrawn,
+                                                  itemsDiscoverable);
                 results.add(browseItem);
             }
 
@@ -682,11 +684,19 @@ public class BrowseDAOOracle implements BrowseDAO
         {
             itemsInArchive = false;
             itemsWithdrawn = true;
+            itemsDiscoverable = true;
         }
-        else
+        else if (table.equals(BrowseIndex.getPrivateBrowseIndex().getTableName()))
+        {
+        	itemsInArchive = true;
+            itemsWithdrawn = false;
+        	itemsDiscoverable = false;
+        }
+        else 
         {
             itemsInArchive = true;
             itemsWithdrawn = false;
+            itemsDiscoverable = true;
         }
 
         this.rebuildQuery = true;

--- a/dspace-api/src/main/java/org/dspace/browse/BrowseDAOPostgres.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseDAOPostgres.java
@@ -116,6 +116,7 @@ public class BrowseDAOPostgres implements BrowseDAO
     /** flags for what the items represent */
     private boolean itemsInArchive = true;
     private boolean itemsWithdrawn = false;
+    private boolean itemsDiscoverable = true;
 
     private boolean enableBrowseFrequencies = true;
     
@@ -367,7 +368,8 @@ public class BrowseDAOPostgres implements BrowseDAO
                 TableRow row = tri.next();
                 BrowseItem browseItem = new BrowseItem(context, row.getIntColumn("item_id"),
                                                   itemsInArchive,
-                                                  itemsWithdrawn);
+                                                  itemsWithdrawn,
+                                                  itemsDiscoverable);
                 results.add(browseItem);
             }
 
@@ -687,12 +689,21 @@ public class BrowseDAOPostgres implements BrowseDAO
         {
             itemsInArchive = false;
             itemsWithdrawn = true;
+            itemsDiscoverable = true;
         }
-        else
+        else if (table.equals(BrowseIndex.getPrivateBrowseIndex().getTableName()))
+        {
+        	itemsInArchive = true;
+            itemsWithdrawn = false;
+        	itemsDiscoverable = false;
+        }
+        else 
         {
             itemsInArchive = true;
             itemsWithdrawn = false;
+            itemsDiscoverable = true;
         }
+
 
         this.rebuildQuery = true;
     }

--- a/dspace-api/src/main/java/org/dspace/browse/BrowseItem.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseItem.java
@@ -55,6 +55,9 @@ public class BrowseItem extends DSpaceObject
     /** is the item withdrawn */
     private boolean withdrawn  = false;
 
+    /** is the item discoverable */
+    private boolean discoverable = true;
+    
     /** item handle */
 	private String handle = null;
 
@@ -66,12 +69,13 @@ public class BrowseItem extends DSpaceObject
      * @param in_archive
      * @param withdrawn
      */
-	public BrowseItem(Context context, int id, boolean in_archive, boolean withdrawn)
+	public BrowseItem(Context context, int id, boolean in_archive, boolean withdrawn, boolean discoverable)
 	{
 		this.context = context;
 		this.id = id;
         this.in_archive = in_archive;
         this.withdrawn = withdrawn;
+        this.discoverable = discoverable;
     }
 
 	/**
@@ -404,4 +408,8 @@ public class BrowseItem extends DSpaceObject
     {
         return withdrawn;
     }
+    
+    public boolean isDiscoverable() {
+    	return discoverable;
+	}
 }

--- a/dspace-api/src/main/java/org/dspace/browse/BrowseItemDAOOracle.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseItemDAOOracle.java
@@ -21,7 +21,7 @@ import java.util.List;
 public class BrowseItemDAOOracle implements BrowseItemDAO
 {
     /** query to obtain all the items from the database */
-    private String findAll = "SELECT item_id, in_archive, withdrawn FROM item WHERE in_archive = 1 OR withdrawn = 1";
+    private String findAll = "SELECT item_id, in_archive, withdrawn, discoverable FROM item WHERE in_archive = 1 OR withdrawn = 1";
 
     /** query to get the text value of a metadata element only (qualifier is NULL) */
     private String getByMetadataElement = "SELECT authority, confidence, text_value,text_lang,element,qualifier FROM metadatavalue, metadatafieldregistry, metadataschemaregistry " +
@@ -75,7 +75,8 @@ public class BrowseItemDAOOracle implements BrowseItemDAO
                 TableRow row = tri.next();
                 items.add(new BrowseItem(context, row.getIntColumn("item_id"),
                                                   row.getBooleanColumn("in_archive"),
-                                                  row.getBooleanColumn("withdrawn")));
+                                                  row.getBooleanColumn("withdrawn"),
+                                                  row.getBooleanColumn("discoverable")));
             }
         }
         finally

--- a/dspace-api/src/main/java/org/dspace/browse/BrowseItemDAOPostgres.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseItemDAOPostgres.java
@@ -21,7 +21,7 @@ import java.util.List;
 public class BrowseItemDAOPostgres implements BrowseItemDAO
 {
     /** query to obtain all the items from the database */
-    private String findAll = "SELECT item_id, in_archive, withdrawn FROM item WHERE in_archive = true OR withdrawn = true";
+    private String findAll = "SELECT item_id, in_archive, withdrawn, discoverable FROM item WHERE in_archive = true OR withdrawn = true";
 
     /** query to get the text value of a metadata element only (qualifier is NULL) */
     private String getByMetadataElement = "SELECT authority, confidence, text_value,text_lang,element,qualifier FROM metadatavalue, metadatafieldregistry, metadataschemaregistry " +
@@ -74,7 +74,8 @@ public class BrowseItemDAOPostgres implements BrowseItemDAO
                 TableRow row = tri.next();
                 items.add(new BrowseItem(context, row.getIntColumn("item_id"),
                                                   row.getBooleanColumn("in_archive"),
-                                                  row.getBooleanColumn("withdrawn")));
+                                                  row.getBooleanColumn("withdrawn"),
+                                                  row.getBooleanColumn("discoverable")));
             }
         }
         finally

--- a/dspace-api/src/main/java/org/dspace/browse/SolrBrowseDAO.java
+++ b/dspace-api/src/main/java/org/dspace/browse/SolrBrowseDAO.java
@@ -133,7 +133,7 @@ public class SolrBrowseDAO implements BrowseDAO
     private DiscoverResult sResponse = null;
 
     private boolean itemsWithdrawn = false;
-    private boolean itemsPrivate = false;
+    private boolean itemsDiscoverable = true;
 
     private boolean showFrequencies;
     
@@ -186,7 +186,8 @@ public class SolrBrowseDAO implements BrowseDAO
             }
             try
             {
-                sResponse = searcher.search(context, query, itemsWithdrawn);
+				sResponse = searcher.search(context, query, itemsWithdrawn
+						|| !itemsDiscoverable);
             }
             catch (SearchServiceException e)
             {
@@ -201,18 +202,10 @@ public class SolrBrowseDAO implements BrowseDAO
         if (itemsWithdrawn)
         {
             query.addFilterQueries("withdrawn:true");
-            if (itemsPrivate)
-            {
-                query.addFilterQueries("discoverable:false");    
-            }
-            else
-            {
-                query.addFilterQueries("NOT(discoverable:false)");    
-            }
         }
-        else
+        else if (!itemsDiscoverable)
         {
-            query.addFilterQueries("NOT(withdrawn:true)");
+            query.addFilterQueries("discoverable:false");    
         }
     }
 
@@ -301,7 +294,7 @@ public class SolrBrowseDAO implements BrowseDAO
             // processing the query...
             Item item = (Item) solrDoc;
             BrowseItem bitem = new BrowseItem(context, item.getID(),
-                    item.isArchived(), item.isWithdrawn());
+                    item.isArchived(), item.isWithdrawn(), item.isDiscoverable());
             bitems.add(bitem);
         }
         return bitems;
@@ -681,13 +674,10 @@ public class SolrBrowseDAO implements BrowseDAO
         if (table.equals(BrowseIndex.getWithdrawnBrowseIndex().getTableName()))
         {
             itemsWithdrawn = true;
-            itemsPrivate = false;
         }
         else if (table.equals(BrowseIndex.getPrivateBrowseIndex().getTableName()))
         {
-            itemsPrivate = true;
-            // items private are also withdrawn
-            itemsWithdrawn = true;
+            itemsDiscoverable = false;
         }
         facetField = table;
     }

--- a/dspace-api/src/main/java/org/dspace/content/InstallItem.java
+++ b/dspace-api/src/main/java/org/dspace/content/InstallItem.java
@@ -190,14 +190,9 @@ public class InstallItem
         // set owning collection
         item.setOwningCollection(is.getCollection());
 
-        // set in_archive=true only if the user didn't specify that it is a private item
-        if(item.isDiscoverable()){
-            item.setArchived(true);
-        }
-        else{ // private item is withdrawn as well
-            item.withdraw();
-        }
-
+        // set in_archive=true
+        item.setArchived(true);
+        
         // save changes ;-)
         item.update();
 

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -1526,7 +1526,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         return search(context, dso, query, false);
     }
 
-    public DiscoverResult search(Context context, DSpaceObject dso, DiscoverQuery discoveryQuery, boolean includeWithdrawn) throws SearchServiceException {
+    public DiscoverResult search(Context context, DSpaceObject dso, DiscoverQuery discoveryQuery, boolean includeUnDiscoverable) throws SearchServiceException {
         if(dso != null)
         {
             if (dso instanceof Community)
@@ -1540,17 +1540,17 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                 discoveryQuery.addFilterQueries("handle:" + dso.getHandle());
             }
         }
-        return search(context, discoveryQuery, includeWithdrawn);
+        return search(context, discoveryQuery, includeUnDiscoverable);
 
     }
 
 
-    public DiscoverResult search(Context context, DiscoverQuery discoveryQuery, boolean includeWithdrawn) throws SearchServiceException {
+    public DiscoverResult search(Context context, DiscoverQuery discoveryQuery, boolean includeUnDiscoverable) throws SearchServiceException {
         try {
             if(getSolr() == null){
                 return new DiscoverResult();
             }
-            SolrQuery solrQuery = resolveToSolrQuery(context, discoveryQuery, includeWithdrawn);
+            SolrQuery solrQuery = resolveToSolrQuery(context, discoveryQuery, includeUnDiscoverable);
 
 
             QueryResponse queryResponse = getSolr().query(solrQuery);
@@ -1562,7 +1562,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         }
     }
 
-    protected SolrQuery resolveToSolrQuery(Context context, DiscoverQuery discoveryQuery, boolean includeWithdrawn)
+    protected SolrQuery resolveToSolrQuery(Context context, DiscoverQuery discoveryQuery, boolean includeUnDiscoverable)
     {
         SolrQuery solrQuery = new SolrQuery();
 
@@ -1580,9 +1580,10 @@ public class SolrServiceImpl implements SearchService, IndexingService {
             solrQuery.setParam("spellcheck", Boolean.TRUE);
         }
 
-        if (!includeWithdrawn)
+        if (!includeUnDiscoverable)
         {
         	solrQuery.addFilterQuery("NOT(withdrawn:true)");
+        	solrQuery.addFilterQuery("NOT(discoverable:false)");
 		}
 
         for (int i = 0; i < discoveryQuery.getFilterQueries().size(); i++)

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceResourceRestrictionPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceResourceRestrictionPlugin.java
@@ -59,32 +59,26 @@ public class SolrServiceResourceRestrictionPlugin implements SolrServiceIndexPlu
 
     @Override
     public void additionalSearchParameters(Context context, DiscoverQuery discoveryQuery, SolrQuery solrQuery) {
-        StringBuilder resourceQuery = new StringBuilder();
-        //Always add the anonymous group id to the query
-        resourceQuery.append("read:(g0");
-        EPerson currentUser = context.getCurrentUser();
-        if(currentUser != null){
-            try {
-                resourceQuery.append(" OR e").append(currentUser.getID());
-                //Retrieve all the groups the current user is a member of !
-                Set<Integer> groupIds = Group.allMemberGroupIDs(context, currentUser);
-                for (Integer groupId : groupIds) {
-                    resourceQuery.append(" OR g").append(groupId);
+    	try {
+            if(!AuthorizeManager.isAdmin(context)){
+            	StringBuilder resourceQuery = new StringBuilder();
+                //Always add the anonymous group id to the query
+                resourceQuery.append("read:(g0");
+                EPerson currentUser = context.getCurrentUser();
+                if(currentUser != null){
+                    resourceQuery.append(" OR e").append(currentUser.getID());
+                    //Retrieve all the groups the current user is a member of !
+                    Set<Integer> groupIds = Group.allMemberGroupIDs(context, currentUser);
+                    for (Integer groupId : groupIds) {
+                        resourceQuery.append(" OR g").append(groupId);
+                    }
                 }
-            } catch (SQLException e) {
-                log.error(LogManager.getHeader(context, "Error while adding resource policy information to query", "") ,e);
-            }
-        }
-        resourceQuery.append(")");
-        try {
-            if(AuthorizeManager.isAdmin(context)){
-                //Admins always have read access even if no policies are present !
-                resourceQuery.append(" OR (!read:[* TO *])");
-
+                resourceQuery.append(")");
+                
+                solrQuery.addFilterQuery(resourceQuery.toString());
             }
         } catch (SQLException e) {
-            log.error(LogManager.getHeader(context, "Error while verifying if current user is admin !", ""), e);
+            log.error(LogManager.getHeader(context, "Error while adding resource policy information to query", ""), e);
         }
-        solrQuery.addFilterQuery(resourceQuery.toString());
     }
 }

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EditItemServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EditItemServlet.java
@@ -339,7 +339,6 @@ public class EditItemServlet extends DSpaceServlet
 
             // Withdraw the item
             item.setDiscoverable(false);
-            item.withdraw();
             JSPManager.showJSP(request, response, "/tools/get-item-id.jsp");
             context.complete();
 
@@ -347,7 +346,6 @@ public class EditItemServlet extends DSpaceServlet
 
         case PUBLICIZE:
             item.setDiscoverable(true);
-            item.reinstate();
             JSPManager.showJSP(request, response, "/tools/get-item-id.jsp");
             context.complete();
 
@@ -534,33 +532,16 @@ public class EditItemServlet extends DSpaceServlet
             }
         }
 
-        if (item.isDiscoverable())
-        {
-            try
-            {
-                // who can Withdraw can also Make It Private
-                AuthorizeUtil.authorizeWithdrawItem(context, item);
-                request.setAttribute("privating_button", Boolean.TRUE);
-            }
-            catch (AuthorizeException authex)
-            {
-                request.setAttribute("privating_button", Boolean.FALSE);
-            }
-        }
-        else
-        {
-            try
-            {
-                // who can Reinstate can also Make It Public
-                AuthorizeUtil.authorizeReinstateItem(context, item);
-                request.setAttribute("publicize_button", Boolean.TRUE);
-            }
-            catch (AuthorizeException authex)
-            {
-                request.setAttribute("publicize_button", Boolean.FALSE);
-            }
-        }
-        
+		if (item.isDiscoverable()) 
+		{
+			request.setAttribute("privating_button", AuthorizeManager
+					.authorizeActionBoolean(context, item, Constants.WRITE));
+		} 
+		else 
+		{
+			request.setAttribute("publicize_button", AuthorizeManager
+					.authorizeActionBoolean(context, item, Constants.WRITE));
+		}
         
         request.setAttribute("item", item);
         request.setAttribute("handle", handle);

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EditItemServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EditItemServlet.java
@@ -339,6 +339,7 @@ public class EditItemServlet extends DSpaceServlet
 
             // Withdraw the item
             item.setDiscoverable(false);
+            item.update();
             JSPManager.showJSP(request, response, "/tools/get-item-id.jsp");
             context.complete();
 
@@ -346,6 +347,7 @@ public class EditItemServlet extends DSpaceServlet
 
         case PUBLICIZE:
             item.setDiscoverable(true);
+            item.update();
             JSPManager.showJSP(request, response, "/tools/get-item-id.jsp");
             context.complete();
 

--- a/dspace-jspui/src/main/webapp/layout/navbar-admin.jsp
+++ b/dspace-jspui/src/main/webapp/layout/navbar-admin.jsp
@@ -68,6 +68,7 @@
                <li><a href="<%= request.getContextPath() %>/dspace-admin/supervise"><fmt:message key="jsp.layout.navbar-admin.supervisors"/></a></li>
                <li><a href="<%= request.getContextPath() %>/dspace-admin/curate"><fmt:message key="jsp.layout.navbar-admin.curate"/></a></li>
                <li><a href="<%= request.getContextPath() %>/dspace-admin/withdrawn"><fmt:message key="jsp.layout.navbar-admin.withdrawn"/></a></li>
+               <li><a href="<%= request.getContextPath() %>/dspace-admin/privateitems"><fmt:message key="jsp.layout.navbar-admin.privateitems"/></a></li>
                <li><a href="<%= request.getContextPath() %>/dspace-admin/metadataimport"><fmt:message key="jsp.layout.navbar-admin.metadataimport"/></a></li>
                <li><a href="<%= request.getContextPath() %>/dspace-admin/batchmetadataimport"><fmt:message key="jsp.layout.navbar-admin.batchmetadataimport"/></a></li>               
             </ul>

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -175,9 +175,9 @@ public class XOAI
                 .println("Incremental import. Searching for documents modified after: "
                         + last.toString());
 
-        String sqlQuery = "SELECT item_id FROM item WHERE in_archive=TRUE AND last_modified > ?";
+        String sqlQuery = "SELECT item_id FROM item WHERE in_archive=TRUE AND discoverable=TRUE AND last_modified > ?";
         if(DatabaseManager.isOracle()){
-                sqlQuery = "SELECT item_id FROM item WHERE in_archive=1 AND last_modified > ?";
+                sqlQuery = "SELECT item_id FROM item WHERE in_archive=1 AND discoverable=1 AND last_modified > ?";
         }
 
         try
@@ -200,9 +200,9 @@ public class XOAI
         try
         {
 
-            String sqlQuery = "SELECT item_id FROM item WHERE in_archive=TRUE";
+            String sqlQuery = "SELECT item_id FROM item WHERE in_archive=TRUE AND discoverable=TRUE";
             if(DatabaseManager.isOracle()){
-                sqlQuery = "SELECT item_id FROM item WHERE in_archive=1";
+                sqlQuery = "SELECT item_id FROM item WHERE in_archive=1 AND discoverable=1";
             }
 
             TableRowIterator iterator = DatabaseManager.query(_context,

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowItemUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowItemUtils.java
@@ -333,8 +333,6 @@ public class FlowItemUtils
 
         Item item = Item.find(context, itemID);
         item.setDiscoverable(false);
-        // private item is withdrawn as well
-        item.withdraw();
         item.update();
         context.commit();
 
@@ -359,8 +357,6 @@ public class FlowItemUtils
 
         Item item = Item.find(context, itemID);
         item.setDiscoverable(true);
-        // since private Items are withdrawn they are reinstated during "make it public" process
-        item.reinstate();
         item.update();
         context.commit();
 

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/EditItemStatusForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/EditItemStatusForm.java
@@ -216,27 +216,26 @@ public class EditItemStatusForm extends AbstractDSpaceTransformer {
         if(item.isDiscoverable())
         {
             itemInfo.addLabel(T_label_private);
-            try
-            {
-                // who can Withdraw can also Make It Private
-                AuthorizeUtil.authorizeWithdrawItem(context, item);
-                itemInfo.addItem().addButton("submit_private").setValue(T_submit_private);
-            }
-            catch (AuthorizeException authex)
-            {
-                addNotAllowedButton(itemInfo.addItem(), "submit_private", T_submit_private);
-            }
+			if (AuthorizeManager.authorizeActionBoolean(context, item,
+					Constants.WRITE)) 
+			{
+				itemInfo.addItem().addButton("submit_private")
+						.setValue(T_submit_private);
+			} 
+			else 
+			{
+				addNotAllowedButton(itemInfo.addItem(), "submit_private",
+						T_submit_private);
+			}
         }
         else
         {
             itemInfo.addLabel(T_label_public);
-            try
+            if (AuthorizeManager.authorizeActionBoolean(context, item, Constants.WRITE))
             {
-                // who can Reinstate can also Make It Public
-                AuthorizeUtil.authorizeReinstateItem(context, item);
                 itemInfo.addItem().addButton("submit_public").setValue(T_submit_public);
             }
-            catch (AuthorizeException authex)
+            else
             {
                 addNotAllowedButton(itemInfo.addItem(), "submit_public", T_submit_public);
             }


### PR DESCRIPTION
I have opened a feature branch on DSpace to allow easy review and improvement of the proposed patch to fix our lacking definition of private item.
https://wiki.duraspace.org/display/~bollini/DSpace+Item+state+definitions

The initial PR has been tested using both SOLR Browse DAO and PostgreSQL DAO (the Oracle porting has been done and it was very trivial so probably no need to test it...).
The following tests have been performed:
- item submission as a generic submitter without workflow enabled using both XMLUI and JSPUI marking the item as private
- make an existent item as private
- make public an existent private item
- widthdrawn and reinstantiate an item

What is missing?
We need to agree about the upgrade path for users that could have private items in their database. My first idea is to wirte a simple sql update statement to set withdrawn=false, in_archive= true for all the discoverable=false item that are not in workflow/workspace.
With this change the item will be unsearcheable and unaccessible to all, as in the previous version make an item private also withdrawn the item so no resoucepolicy are present for such items
