### PR TITLE
DS-1733 check to see if item is in archive and valid before trying to add it to the CSV

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSV.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSV.java
@@ -385,6 +385,11 @@ public class DSpaceCSV implements Serializable
      */
     public final void addItem(Item i) throws Exception
     {
+        // If the item is not in the archive, the call to get its handle below will fail
+        if (i.isWithdrawn() || !i.isArchived() || i.getOwningCollection() == null) {
+            return;
+        }
+
         // Create the CSV line
         DSpaceCSVLine line = new DSpaceCSVLine(i.getID());
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-1733

The call below these lines will fail horribly (and silently(:

String owningCollectionHandle = i.getOwningCollection().getHandle();
