### PR TITLE
Revert autocommit configuration (as is in DSpace 3.x)

### DIFF
--- a/dspace/solr/oai/conf/solrconfig.xml
+++ b/dspace/solr/oai/conf/solrconfig.xml
@@ -366,10 +366,11 @@
          have some sort of hard autoCommit to limit the log size.
       -->
      <autoCommit> 
-       <maxTime>${solr.autoCommit.maxTime:15000}</maxTime> 
-       <openSearcher>false</openSearcher> 
+       <maxDocs>10000</maxDocs> <!--Commit every 10.000 documents-->
+       <maxTime>${solr.autoCommit.maxTime:10000}</maxTime> <!--Default commit every 10 seconds-->
+       <openSearcher>true</openSearcher> 
      </autoCommit>
-
+     
     <!-- softAutoCommit is like autoCommit except it causes a
          'soft' commit which only ensures that changes are visible
          but does not ensure that data is synced to disk.  This is

--- a/dspace/solr/search/conf/solrconfig.xml
+++ b/dspace/solr/search/conf/solrconfig.xml
@@ -366,8 +366,9 @@
          have some sort of hard autoCommit to limit the log size.
       -->
      <autoCommit> 
-       <maxTime>${solr.autoCommit.maxTime:15000}</maxTime> 
-       <openSearcher>false</openSearcher> 
+       <maxDocs>10000</maxDocs> <!--Commit every 10.000 documents-->
+       <maxTime>${solr.autoCommit.maxTime:10000}</maxTime> <!--Default commit every 10 seconds-->
+       <openSearcher>true</openSearcher> 
      </autoCommit>
 
     <!-- softAutoCommit is like autoCommit except it causes a

--- a/dspace/solr/statistics/conf/solrconfig.xml
+++ b/dspace/solr/statistics/conf/solrconfig.xml
@@ -366,8 +366,9 @@
          have some sort of hard autoCommit to limit the log size.
       -->
      <autoCommit> 
-       <maxTime>${solr.autoCommit.maxTime:15000}</maxTime> 
-       <openSearcher>false</openSearcher> 
+       <maxDocs>10000</maxDocs> <!--Commit every 10.000 documents-->
+       <maxTime>${solr.autoCommit.maxTime:900000}</maxTime> <!--Default commit every 15 minutes--> 
+       <openSearcher>true</openSearcher> 
      </autoCommit>
 
     <!-- softAutoCommit is like autoCommit except it causes a


### PR DESCRIPTION
This PR revert the DSpace 3.x autocommit settings for each solr core. Now with openSearcher set to true the indexer should be to work as in the past.

From solr documentation: openSearcher => Whether to open a new searcher when performing a commit. If this is false, the default, the commit will flush recent index changes to stable storage, but does not cause a new searcher to be opened to make those changes visible

https://jira.duraspace.org/browse/DS-1715
