### PR TITLE
[DS-1741] Batch import UI - only the File DataLoaders should appear in the drop down

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/BTEBatchImportService.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/BTEBatchImportService.java
@@ -9,8 +9,11 @@ package org.dspace.app.itemimport;
 
 import gr.ekt.bte.core.DataLoader;
 import gr.ekt.bte.core.TransformationEngine;
+import gr.ekt.bte.dataloader.FileDataLoader;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 
@@ -74,5 +77,17 @@ public class BTEBatchImportService
 
 	public void setTransformationEngine(TransformationEngine transformationEngine) {
 		this.transformationEngine = transformationEngine;
+	}
+	
+	public List<String> getFileDataLoaders(){
+		List<String> result = new ArrayList<String>();
+				
+		for (String key : dataLoaders.keySet()){
+			DataLoader dl = dataLoaders.get(key);
+			if (dl instanceof FileDataLoader){
+				result.add(key);
+			}
+		}
+		return result;
 	}
 }

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/BatchMetadataImportServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/BatchMetadataImportServlet.java
@@ -96,7 +96,7 @@ public class BatchMetadataImportServlet extends DSpaceServlet
         	
         	//Get all the possible data loaders from the Spring configuration
         	BTEBatchImportService dls  = new DSpace().getSingletonService(BTEBatchImportService.class);
-        	List<String> inputTypes = Lists.newArrayList(dls.getDataLoaders().keySet());
+        	List<String> inputTypes =dls.getFileDataLoaders();
         	
         	request.setAttribute("input-types", inputTypes);
         	
@@ -150,8 +150,7 @@ public class BatchMetadataImportServlet extends DSpaceServlet
     {
     	//Get all the possible data loaders from the Spring configuration
     	BTEBatchImportService dls  = new DSpace().getSingletonService(BTEBatchImportService.class);
-    	List<String> inputTypes = Lists.newArrayList(dls.getDataLoaders().keySet());
-    	
+    	List<String> inputTypes = dls.getFileDataLoaders();
     	request.setAttribute("input-types", inputTypes);
     	
     	//Get all collections


### PR DESCRIPTION
Related Jira issue: https://jira.duraspace.org/browse/DS-1741

Resolves the problem in which in the administrative batch import UI, the data loader drop down menu included non-applicable for file upload BTE data loaders.
