### PR TITLE
Solr indexer improvement

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
@@ -40,10 +40,15 @@ public class IndexEventConsumer implements Consumer {
 
     DSpace dspace = new DSpace();
 
+    private Boolean doCommit = null; 
+    
     IndexingService indexer = dspace.getServiceManager().getServiceByName(IndexingService.class.getName(),IndexingService.class);
 
     public void initialize() throws Exception {
-
+        String stringDoCommit = dspace.getConfigurationService().getProperty("discovery.index.commit");
+        if(stringDoCommit!=null) {
+            doCommit = Boolean.parseBoolean(stringDoCommit);
+        }
     }
 
     /**
@@ -157,7 +162,7 @@ public class IndexEventConsumer implements Consumer {
     public void end(Context ctx) throws Exception {
 
         if (objectsToUpdate != null && handlesToDelete != null) {
-
+            boolean pushCommit = false;
             // update the changed Items not deleted because they were on create list
             for (DSpaceObject iu : objectsToUpdate) {
                 /* we let all types through here and 
@@ -168,10 +173,11 @@ public class IndexEventConsumer implements Consumer {
                 if (hdl != null && !handlesToDelete.contains(hdl)) {
                     try {
                         indexer.indexContent(ctx, iu, true);
+                        pushCommit = true;
                         log.debug("Indexed "
                                 + Constants.typeText[iu.getType()]
                                 + ", id=" + String.valueOf(iu.getID())
-                                + ", handle=" + hdl);
+                                + ", handle=" + hdl);                        
                     }
                     catch (Exception e) {
                         log.error("Failed while indexing object: ", e);
@@ -182,6 +188,7 @@ public class IndexEventConsumer implements Consumer {
             for (String hdl : handlesToDelete) {
                 try {
                     indexer.unIndexContent(ctx, hdl, false);
+                    pushCommit = true;
                     if (log.isDebugEnabled())
                     {
                         log.debug("UN-Indexed Item, handle=" + hdl);
@@ -192,8 +199,10 @@ public class IndexEventConsumer implements Consumer {
                 }
 
             }
-
-            indexer.commit(true);
+            
+            if(pushCommit) {            
+                indexer.commit(doCommit);
+            }
         }
 
         // "free" the resources

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
@@ -176,12 +176,12 @@ public class IndexEventConsumer implements Consumer {
                     catch (Exception e) {
                         log.error("Failed while indexing object: ", e);
                     }
-                }
+                }                
             }
 
             for (String hdl : handlesToDelete) {
                 try {
-                    indexer.unIndexContent(ctx, hdl, true);
+                    indexer.unIndexContent(ctx, hdl, false);
                     if (log.isDebugEnabled())
                     {
                         log.debug("UN-Indexed Item, handle=" + hdl);
@@ -193,6 +193,7 @@ public class IndexEventConsumer implements Consumer {
 
             }
 
+            indexer.commit(true);
         }
 
         // "free" the resources

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
@@ -40,15 +40,12 @@ public class IndexEventConsumer implements Consumer {
 
     DSpace dspace = new DSpace();
 
-    private Boolean doCommit = null; 
+    private Boolean softCommit = null; 
     
     IndexingService indexer = dspace.getServiceManager().getServiceByName(IndexingService.class.getName(),IndexingService.class);
 
     public void initialize() throws Exception {
-        String stringDoCommit = dspace.getConfigurationService().getProperty("discovery.index.commit");
-        if(stringDoCommit!=null) {
-            doCommit = Boolean.parseBoolean(stringDoCommit);
-        }
+        softCommit = dspace.getConfigurationService().getPropertyAsType("discovery.index.nrt", true);        
     }
 
     /**
@@ -201,7 +198,7 @@ public class IndexEventConsumer implements Consumer {
             }
             
             if(pushCommit) {            
-                indexer.commit(doCommit);
+                indexer.commit(softCommit);
             }
         }
 

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
@@ -40,7 +40,7 @@ public class IndexEventConsumer implements Consumer {
 
     DSpace dspace = new DSpace();
 
-    private Boolean softCommit = null; 
+    private boolean softCommit; 
     
     IndexingService indexer = dspace.getServiceManager().getServiceByName(IndexingService.class.getName(),IndexingService.class);
 

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexingService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexingService.java
@@ -57,5 +57,7 @@ public interface IndexingService {
 
     void commit() throws SearchServiceException;
 
+    void commit(Boolean commit) throws SearchServiceException;
+
     void optimize() throws SearchServiceException;
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexingService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexingService.java
@@ -57,7 +57,7 @@ public interface IndexingService {
 
     void commit() throws SearchServiceException;
 
-    void commit(Boolean commit) throws SearchServiceException;
+    void commit(boolean nrt) throws SearchServiceException;
 
     void optimize() throws SearchServiceException;
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -2267,4 +2267,41 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 			throw new SearchServiceException(e.getMessage(), e);
 		}
 	}
+
+	/**
+	 * The method performing an explicit commit unless commit is null; 
+	 * The kind of the commit are soft or hard commit. If true performs
+	 * a soft commit with waitFlush and waitSearcher to false, then if false
+	 * run a default hard commit with waitFlush and waitSearcher to true.
+	 * 
+	 * 
+     * @param commit true softCommit, false hardCommit, null none
+     * @throws SearchServiceException
+     */
+    @Override    
+    public void commit(Boolean commit) throws SearchServiceException
+    {
+        if (commit != null)
+        {
+            if (commit) //softcommit
+            {
+                try
+                {
+                    if (getSolr() != null)
+                    {
+                        getSolr().commit(false, false, true);
+                    }
+                }
+                catch (Exception e)
+                {
+                    throw new SearchServiceException(e.getMessage(), e);
+                }
+            }
+            else
+            {
+                //hard commit
+                commit();
+            }
+        }
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -2279,29 +2279,21 @@ public class SolrServiceImpl implements SearchService, IndexingService {
      * @throws SearchServiceException
      */
     @Override    
-    public void commit(Boolean commit) throws SearchServiceException
+    public void commit(boolean nrt) throws SearchServiceException
     {
-        if (commit != null)
+        if (nrt) // softcommit
         {
-            if (commit) //softcommit
+            try
             {
-                try
+                if (getSolr() != null)
                 {
-                    if (getSolr() != null)
-                    {
-                        getSolr().commit(false, false, true);
-                    }
-                }
-                catch (Exception e)
-                {
-                    throw new SearchServiceException(e.getMessage(), e);
+                    getSolr().commit(false, false, true);
                 }
             }
-            else
+            catch (Exception e)
             {
-                //hard commit
-                commit();
+                throw new SearchServiceException(e.getMessage(), e);
             }
-        }
+        }        
     }
 }

--- a/dspace/config/modules/discovery.cfg
+++ b/dspace/config/modules/discovery.cfg
@@ -14,6 +14,11 @@ search.server = ${solr.server}/search
 # index.ignore-authority = false
 index.projection=dc.title,dc.contributor.*,dc.date.issued
 
+# Used to control the kind of the commit - e.g. For Solr implementation switch from softcommit (true) to hardcommit (false)
+# Comment this line to not perform any commit, pay attention also to tuning on solrconfig.xml the correct maxTime for autocommit
+# or use system substitution for "solr.autoCommit.maxTime" property as you can read at http://wiki.apache.org/solr/SolrConfigXml#System_property_substitution 
+index.commit = true
+
 # ONLY-FOR-JSPUI: 
 # 1) you need to set the DiscoverySearchRequestProcessor in the dspace.cfg 
 # 2) to show facet on Site/Community/etc. you need to add a Site/Community/Collection

--- a/dspace/config/modules/discovery.cfg
+++ b/dspace/config/modules/discovery.cfg
@@ -14,10 +14,10 @@ search.server = ${solr.server}/search
 # index.ignore-authority = false
 index.projection=dc.title,dc.contributor.*,dc.date.issued
 
-# Used to control the kind of the commit - e.g. For Solr implementation switch from softcommit (true) to hardcommit (false)
-# Comment this line to not perform any commit, pay attention also to tuning on solrconfig.xml the correct maxTime for autocommit
+# Used to control the Near Real Time - e.g. For Solr implementation switch from softcommit (true) to none commit (false)
+# Turn to false do not perform any commit, pay attention also to tuning on solrconfig.xml the correct maxTime for autocommit
 # or use system substitution for "solr.autoCommit.maxTime" property as you can read at http://wiki.apache.org/solr/SolrConfigXml#System_property_substitution 
-index.commit = true
+index.nrt = true
 
 # ONLY-FOR-JSPUI: 
 # 1) you need to set the DiscoverySearchRequestProcessor in the dspace.cfg 

--- a/dspace/solr/oai/conf/solrconfig.xml
+++ b/dspace/solr/oai/conf/solrconfig.xml
@@ -367,7 +367,7 @@
       -->
      <autoCommit>
        <maxDocs>10000</maxDocs> <!--Commit every 10.000 documents-->
-       <maxTime>${solr.autoCommit.maxTime:10000}</maxTime> <!--Default commit every 10 seconds-->
+       <maxTime>${solr.autoCommit.maxTime:600000}</maxTime> <!--Default commit every 10 seconds-->
        <openSearcher>true</openSearcher>
      </autoCommit>
 

--- a/dspace/solr/oai/conf/solrconfig.xml
+++ b/dspace/solr/oai/conf/solrconfig.xml
@@ -365,9 +365,10 @@
          If the updateLog is enabled, then it's highly recommended to
          have some sort of hard autoCommit to limit the log size.
       -->
-     <autoCommit> 
-       <maxTime>${solr.autoCommit.maxTime:15000}</maxTime> 
-       <openSearcher>false</openSearcher> 
+     <autoCommit>
+       <maxDocs>10000</maxDocs> <!--Commit every 10.000 documents-->
+       <maxTime>${solr.autoCommit.maxTime:10000}</maxTime> <!--Default commit every 10 seconds-->
+       <openSearcher>true</openSearcher>
      </autoCommit>
 
     <!-- softAutoCommit is like autoCommit except it causes a

--- a/dspace/solr/search/conf/solrconfig.xml
+++ b/dspace/solr/search/conf/solrconfig.xml
@@ -366,8 +366,9 @@
          have some sort of hard autoCommit to limit the log size.
       -->
      <autoCommit> 
-       <maxTime>${solr.autoCommit.maxTime:15000}</maxTime> 
-       <openSearcher>false</openSearcher> 
+       <maxDocs>10000</maxDocs> <!--Commit every 10.000 documents-->
+       <maxTime>${solr.autoCommit.maxTime:600000}</maxTime> <!--Default commit every 10 minutes-->
+       <openSearcher>true</openSearcher> 
      </autoCommit>
 
     <!-- softAutoCommit is like autoCommit except it causes a

--- a/dspace/solr/statistics/conf/solrconfig.xml
+++ b/dspace/solr/statistics/conf/solrconfig.xml
@@ -365,9 +365,10 @@
          If the updateLog is enabled, then it's highly recommended to
          have some sort of hard autoCommit to limit the log size.
       -->
-     <autoCommit> 
-       <maxTime>${solr.autoCommit.maxTime:15000}</maxTime> 
-       <openSearcher>false</openSearcher> 
+     <autoCommit>
+       <maxDocs>10000</maxDocs> <!--Commit every 10.000 documents-->
+       <maxTime>${solr.autoCommit.maxTime:900000}</maxTime> <!--Default commit every 15 minutes-->
+       <openSearcher>true</openSearcher>
      </autoCommit>
 
     <!-- softAutoCommit is like autoCommit except it causes a

--- a/dspace/solr/statistics/conf/solrconfig.xml
+++ b/dspace/solr/statistics/conf/solrconfig.xml
@@ -367,7 +367,7 @@
       -->
      <autoCommit>
        <maxDocs>10000</maxDocs> <!--Commit every 10.000 documents-->
-       <maxTime>${solr.autoCommit.maxTime:900000}</maxTime> <!--Default commit every 15 minutes-->
+       <maxTime>${solr.autoCommit.maxTime:600000}</maxTime> <!--Default commit every 15 minutes-->
        <openSearcher>true</openSearcher>
      </autoCommit>
 


### PR DESCRIPTION
This is an alternative for PR #368 

Use the near real time searching for index consumer means that documents are available for search almost immediately after being indexed.Softcommit is used this will refresh the view of the index faster, but without guarantees that the document is stably stored, use tlog to mantains the history and autoCommit configuration will do the rest every 15 minutes so it will flush recent index changes to stable storage. The behaviour can be modified by turn off the index.commit please see https://github.com/lap82/DSpace/commit/cb4468b85bca3c153a9686ba51ac34f85beb5940#diff-835d88df2862c3e3d90a212f74177f00R20

https://jira.duraspace.org/browse/DS-1715
