### PR TITLE
DS-1745: DSpace should no longer assign "dc.date.issued=[today]" when date field is missing

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/InstallItem.java
+++ b/dspace-api/src/main/java/org/dspace/content/InstallItem.java
@@ -113,28 +113,38 @@ public class InstallItem
         }
 
         // Even though we are restoring an item it may not have the proper dates. So let's
-        // double check that it has a date accessioned and date issued, and if either of those dates
-        // are not set then set them to today.
+        // double check its associated date(s)
         DCDate now = DCDate.getCurrent();
         
-        // If the item doesn't have a date.accessioned, create one.
+        // If the item doesn't have a date.accessioned, set it to today
         DCValue[] dateAccessioned = item.getDC("date", "accessioned", Item.ANY);
         if (dateAccessioned.length == 0)
         {
 	        item.addDC("date", "accessioned", null, now.toString());
         }
         
-        // create issue date if not present
+        // If issue date is set as "today" (literal string), then set it to current date
+        // In the below loop, we temporarily clear all issued dates and re-add, one-by-one,
+        // replacing "today" with today's date.
+        // NOTE: As of DSpace 4.0, DSpace no longer sets an issue date by default
         DCValue[] currentDateIssued = item.getDC("date", "issued", Item.ANY);
-        if (currentDateIssued.length == 0)
+        item.clearDC("date", "issued", Item.ANY);
+        for (DCValue dcv : currentDateIssued)
         {
-            DCDate issued = new DCDate(now.getYear(),now.getMonth(),now.getDay(),-1,-1,-1);
-            item.addDC("date", "issued", null, issued.toString());
+            if(dcv.value!=null && dcv.value.equalsIgnoreCase("today"))
+            {
+                DCDate issued = new DCDate(now.getYear(),now.getMonth(),now.getDay(),-1,-1,-1);
+                item.addDC(dcv.element, dcv.qualifier, dcv.language, issued.toString());
+            }
+            else if(dcv.value!=null)
+            {
+                item.addDC(dcv.element, dcv.qualifier, dcv.language, dcv.value);
+            }
         }
         
         // Record that the item was restored
-		String provDescription = "Restored into DSpace on "+ now + " (GMT).";
-		item.addDC("description", "provenance", "en", provDescription);
+        String provDescription = "Restored into DSpace on "+ now + " (GMT).";
+        item.addDC("description", "provenance", "en", provDescription);
 
         return finishItem(c, item, is);
     }
@@ -156,23 +166,39 @@ public class InstallItem
              item.addDC("date", "available", null, now.toString());
         }
 
-        // create issue date if not present
+        // If issue date is set as "today" (literal string), then set it to current date
+        // In the below loop, we temporarily clear all issued dates and re-add, one-by-one,
+        // replacing "today" with today's date.
+        // NOTE: As of DSpace 4.0, DSpace no longer sets an issue date by default
         DCValue[] currentDateIssued = item.getDC("date", "issued", Item.ANY);
-
-        if (currentDateIssued.length == 0)
+        item.clearDC("date", "issued", Item.ANY);
+        for (DCValue dcv : currentDateIssued)
         {
-            DCDate issued = new DCDate(now.getYear(),now.getMonth(),now.getDay(),-1,-1,-1);
-            item.addDC("date", "issued", null, issued.toString());
+            if(dcv.value!=null && dcv.value.equalsIgnoreCase("today"))
+            {
+                DCDate issued = new DCDate(now.getYear(),now.getMonth(),now.getDay(),-1,-1,-1);
+                item.addDC(dcv.element, dcv.qualifier, dcv.language, issued.toString());
+            }
+            else if(dcv.value!=null)
+            {
+                item.addDC(dcv.element, dcv.qualifier, dcv.language, dcv.value);
+            }
         }
 
          String provDescription = "Made available in DSpace on " + now
                 + " (GMT). " + getBitstreamProvenanceMessage(item);
 
+        // If an issue date was passed in and it wasn't set to "today" (literal string)
+        // then note this previous issue date in provenance message
         if (currentDateIssued.length != 0)
         {
-            DCDate d = new DCDate(currentDateIssued[0].value);
-            provDescription = provDescription + "  Previous issue date: "
-                    + d.toString();
+            String previousDateIssued = currentDateIssued[0].value;
+            if(previousDateIssued!=null && !previousDateIssued.equalsIgnoreCase("today"))
+            {
+                DCDate d = new DCDate(previousDateIssued);
+                provDescription = provDescription + "  Previous issue date: "
+                        + d.toString();
+            }
         }
 
         // Add provenance description

--- a/dspace-api/src/main/java/org/dspace/submit/step/InitialQuestionsStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/InitialQuestionsStep.java
@@ -199,7 +199,7 @@ public class InitialQuestionsStep extends AbstractProcessingStep
                 request.setAttribute("will.remove.titles", Boolean.valueOf(willRemoveTitles));
                 request.setAttribute("will.remove.date", Boolean.valueOf(willRemoveDate));
                 request.setAttribute("will.remove.files", Boolean.valueOf(willRemoveFiles));
-                
+
                 return STATUS_VERIFY_PRUNE; // we will need to do pruning!
             }
         }
@@ -212,6 +212,20 @@ public class InitialQuestionsStep extends AbstractProcessingStep
         if (!subInfo.isInWorkflow())
         {
             subInfo.getSubmissionItem().setMultipleFiles(multipleFiles);
+        }
+
+        // If this work has not been published before & no issued date is set,
+        // then the assumption is that TODAY is the issued date.
+        // (This logic is necessary since the date field is hidden on DescribeStep when publishedBefore==false)
+        if(!publishedBefore)
+        {
+            DCValue[] dateIssued = subInfo.getSubmissionItem().getItem()
+                            .getDC("date", "issued", Item.ANY);
+            if(dateIssued.length==0)
+            {
+                //Set issued date to "today" (NOTE: InstallItem will determine the actual date for us)
+                subInfo.getSubmissionItem().getItem().addDC("date", "issued", null, "today");
+            }
         }
 
         // commit all changes to DB

--- a/dspace-api/src/test/java/org/dspace/content/InstallItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/InstallItemTest.java
@@ -198,4 +198,87 @@ public class InstallItemTest extends AbstractUnitTest
         assertThat("testGetBitstreamProvenanceMessage 0", InstallItem.getBitstreamProvenanceMessage(item), equalTo(testMessage));
     }
 
+    /**
+     * Test passing in "today" as an issued date to InstallItem.
+     */
+    @Test
+    public void testInstallItem_todayAsIssuedDate() throws Exception
+    {
+        //create a dummy WorkspaceItem
+        context.turnOffAuthorisationSystem();
+        String handle = "1345/567";
+        Collection col = Collection.create(context);
+        WorkspaceItem is = WorkspaceItem.create(context, col, false);
+
+        // Set "today" as "dc.date.issued"
+        is.getItem().addMetadata("dc", "date", "issued", Item.ANY, "today");
+        is.getItem().addMetadata("dc", "date", "issued", Item.ANY, "2011-01-01");
+
+        //get current date
+        DCDate now = DCDate.getCurrent();
+        String dayAndTime = now.toString();
+        //parse out just the date, remove the time (format: yyyy-mm-ddT00:00:00Z)
+        String date = dayAndTime.substring(0, dayAndTime.indexOf("T"));
+
+        Item result = InstallItem.installItem(context, is, handle);
+        context.restoreAuthSystemState();
+
+        //Make sure the string "today" was replaced with today's date
+        DCValue[] issuedDates = result.getMetadata("dc", "date", "issued", Item.ANY);
+
+        assertThat("testInstallItem_todayAsIssuedDate 0", issuedDates[0].value, equalTo(date));
+        assertThat("testInstallItem_todayAsIssuedDate 1", issuedDates[1].value, equalTo("2011-01-01"));
+    }
+
+    /**
+     * Test null issue date (when none set) in InstallItem
+     */
+    @Test
+    public void testInstallItem_nullIssuedDate() throws Exception
+    {
+        //create a dummy WorkspaceItem with no dc.date.issued
+        context.turnOffAuthorisationSystem();
+        String handle = "1345/567";
+        Collection col = Collection.create(context);
+        WorkspaceItem is = WorkspaceItem.create(context, col, false);
+
+        Item result = InstallItem.installItem(context, is, handle);
+        context.restoreAuthSystemState();
+
+        //Make sure dc.date.issued is NOT set
+        DCValue[] issuedDates = result.getMetadata("dc", "date", "issued", Item.ANY);
+        assertThat("testInstallItem_nullIssuedDate 0", issuedDates.length, equalTo(0));
+    }
+
+    /**
+     * Test passing in "today" as an issued date to restoreItem.
+     */
+    @Test
+    public void testRestoreItem_todayAsIssuedDate() throws Exception
+    {
+        //create a dummy WorkspaceItem
+        context.turnOffAuthorisationSystem();
+        String handle = "1345/567";
+        Collection col = Collection.create(context);
+        WorkspaceItem is = WorkspaceItem.create(context, col, false);
+
+        // Set "today" as "dc.date.issued"
+        is.getItem().addMetadata("dc", "date", "issued", Item.ANY, "today");
+        is.getItem().addMetadata("dc", "date", "issued", Item.ANY, "2011-01-01");
+
+        //get current date
+        DCDate now = DCDate.getCurrent();
+        String dayAndTime = now.toString();
+        //parse out just the date, remove the time (format: yyyy-mm-ddT00:00:00Z)
+        String date = dayAndTime.substring(0, dayAndTime.indexOf("T"));
+
+        Item result = InstallItem.restoreItem(context, is, handle);
+        context.restoreAuthSystemState();
+
+        //Make sure the string "today" was replaced with today's date
+        DCValue[] issuedDates = result.getMetadata("dc", "date", "issued", Item.ANY);
+
+        assertThat("testRestoreItem_todayAsIssuedDate 0", issuedDates[0].value, equalTo(date));
+        assertThat("testRestoreItem_todayAsIssuedDate 1", issuedDates[1].value, equalTo("2011-01-01"));
+    }
 }


### PR DESCRIPTION
This PR makes several changes to the logic around how DSpace assigns "dc.date.issued":
1. DSpace no longer auto-assigns a "dc.date.issued=[today]" when missing (except as described below)
2. However, when "Initial Questions" are enabled from the UI, DSpace will still assume "dc.date.issued=[today]" when a user says a work is "unpublished". This allows some form of backwards compatibility. Institutions who have a lot of gray literature in DSpace can enable "Initial Questions" for one or more Collections to have DSpace auto-assign issued dates again. (Please note that "Initial Questions" are disabled by default in 4.0, see DS-1655)
3. Also adds a new option (for SWORD or Bulk Ingest tools, etc) to pass in the literal value dc.date.issued="today" to tell DSpace to set 'dc.date.issued=dc.date.accessioned". This means that you can now decide (in your import metadata) whether you want DSpace to auto-assign issued dates when performing a bulk import. 
4. Added new ItemInstall Unit Tests to support this new logic

Finally, I've tested this for all these scenarios:
- Issued date is not specified - Item will still be accepted into DSpace but appears last in "Browse by Issue Date" 
- Issued date is literal "today" - DSpace will auto-assign today's date
- Issued date is set via UI (no initial questions) - User is required to fill out an Issued Date
- Issued date is not set via UI (initial questions enabled + "unpublished") - DSpace will still auto-assign today's date (for backwards compatibility)

This logic all seems to be working right. I'd recommend adding this to 4.0/master immediately, assuming no immediate objections.
