### PR TITLE
DS-1754 Use canonical not absolute path

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemupdate/ItemUpdate.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemupdate/ItemUpdate.java
@@ -515,7 +515,7 @@ public class ItemUpdate {
 	private File initUndoArchive(File sourceDir)
 	throws FileNotFoundException, IOException
 	{				
-		File parentDir = sourceDir.getAbsoluteFile().getParentFile(); 
+		File parentDir = sourceDir.getCanonicalFile().getParentFile();
 		if (parentDir == null)
 		{
 			throw new FileNotFoundException("Parent directory of archive directory not found; unable to write UndoArchive; no processing performed");    			
@@ -533,8 +533,8 @@ public class ItemUpdate {
 		// create root directory
 		if (!undoDir.mkdir())
 		{
-        	pr("ERROR creating  Undo Archive directory ");
-        	throw new IOException("ERROR creating  Undo Archive directory ");
+			pr("ERROR creating  Undo Archive directory " + undoDir.getCanonicalPath());
+			throw new IOException("ERROR creating  Undo Archive directory " + undoDir.getCanonicalPath());
 		}
 		
         //Undo is suppressed to prevent undo of undo


### PR DESCRIPTION
Using the canonical path when determining the location of the undo information
leads to consistent behaviour when using "." as the source vs using eg an
absolute path. This also adds the name of the directory to the error message in
case the directory cannot be created, to help with troubleshooting.
