### PR TITLE
[DS-1751] Request a copy of the document page has 'Mensaje:' (should be message?)

### DIFF
--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -1772,7 +1772,7 @@ jsp.version.notice.workflow_version_help = A more recent version of this item is
 itemRequest.all = All files
 itemRequest.response.subject.approve = Request copy of document
 itemRequest.response.body.approve = Dear {0},\n\
-In response to your request I have the pleasure to send you in attachment a copy of the file(s), concerning the document: "{2}" ({1}), which I am author (or co-author) of.\n\n\
+In response to your request I have the pleasure to send you in attachment a copy of the file(s) concerning the document: "{2}" ({1}), of which I am author (or co-author).\n\n\
 Best regards,\n\
 {3} <{4}>
  

--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -1778,7 +1778,7 @@ Best regards,\n\
  
 itemRequest.response.subject.reject = Request copy of document
 itemRequest.response.body.reject = Dear {0},\n\
-In response to your request I regret to inform you that it''s not possible to send you a copy of the file(s) you have requested, concerning the document: "{2}" ({1}), which I am author (or co-author) of.\n\n\
+In response to your request I regret to inform you that it''s not possible to send you a copy of the file(s) you have requested, concerning the document: "{2}" ({1}), of which I am author (or co-author).\n\n\
 Best regards,\n\
 {3} <{4}>
 jsp.request.item.request-form.info2 = Request a document copy: {0} 
@@ -1793,8 +1793,8 @@ jsp.request.item.request-form.yes = all files (of this document) in restricted a
 jsp.request.item.request-form.no = the file(s) you requested 
 jsp.request.item.request-form.title = Request a document copy 
 jsp.request.item.request-information.info1 = Subject: Request a document copy
-jsp.request.item.request-information.info2 = IF YOU ARE THE AUTHOR (OR ONE OF THE) AUTHORS OF THE DOCUMENT, {0}, use the buttons bellow to answer the request for a copy made by the user, {1}.
-jsp.request.item.request-information.note = Accordingly with your answer it will be generated a model answer that you can personalise! 
+jsp.request.item.request-information.info2 = IF YOU ARE AN AUTHOR OF THE DOCUMENT, {0}, use one of the buttons below to answer the request for a copy made by the user, {1}.
+jsp.request.item.request-information.note = This repository will propose an appropriate model reply, which you may edit.
 jsp.request.item.request-information.yes = Send a copy 
 jsp.request.item.request-information.no = Don&#146;t send a copy 
 jsp.request.item.request-information.title = Request a document copy 
@@ -1816,7 +1816,7 @@ jsp.request.item.request-send.info2 = Your request was sent successfully to the 
 jsp.request.item.request-send.title = Request a document copy
 jsp.request.item.request-free-acess.title = Your answer was sent successfully!
 jsp.request.item.request-free-acess.info1 = Your answer was sent successfully to the e-mail indicated by the requester. Thank you.
-jsp.request.item.request-free-acess.info2 = YOU CAN USE THIS OCASION TO ASK CHANGING THE STATUS OF YOUR DOCUMENT TO OPEN ACCESS (AVOIDING TO ANSWER TO THESE REQUESTS), IF THERE AREN'T REASONS TO KEEP IT IN RESTRICTED ACCESS. For this, after inserting your name and e-mail (to authentication reasons), click in the button "Change to Open Access".
+jsp.request.item.request-free-acess.info2 = You may use this occasion to reconsider the access restrictions on the document (to avoid having to respond to these requests), if there is no reason to keep it restricted. To do so, after inserting your name and e-mail (for authentication), click the button "Change to Open Access".
 jsp.request.item.request-free-acess.close = Close.
 jsp.request.item.request-free-acess.free = Change to Open Access
 jsp.request.item.request-free-acess.name = Name:

--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -315,34 +315,34 @@
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.title">Request a copy of the document</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.trail">Request a copy of the document</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.head">Request a copy of the document</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Enter the following information to request a copy of the document to the responsible</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail">E-mail</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Enter the following information to request a copy of the document from the responsible person</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail">Your e-mail address</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail_help">This email address is used for sending the document.</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail.error">E-mail is mandatory</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message">Mensaje</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message.error">Mensaje is mandatory</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail.error">Address is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message.error">Message is required</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.files">Files</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.allFiles">All files (of this document) in restricted access.</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.notAllFiles">Only The requested file.</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName">Name</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName.error">Name is mandatory</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName.error">Name is required</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.submit">Request copy</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestSent.java -->
 	<message key="xmlui.ArtifactBrowser.ItemRequestSent.title">Your request has been sent.</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestSent.trail">Your request has been sent.</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestSent.head">Your request has been sent.</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestSent.para1">Your request has been sent to the author or responsible.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.para1">Your request has been sent to the author or responsible person.</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseDecisionForm.java -->
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.title">Document copy request</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.trail">Document copy request</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.head">Document copy request</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para1">IF YOU ARE THE AUTHOR (OR ONE AUTHOR) DOCUMENT "{0}" uses the buttons to answer the user's request.</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para2">According to your choice will be generated a model answer customizable.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para1">IF YOU ARE THE AUTHOR (OR AN AUTHOR) OF DOCUMENT "{0}" use the buttons to answer the user's request.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para2">This repository will propose an appropriate model reply, which you may edit.</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Send copy</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.dontSend">Don't send copy</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseTrueForm.java -->
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.title">Document copy request</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.trail">Document copy request</message>
@@ -357,7 +357,7 @@
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.title">Document copy request</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.trail">Document copy request</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.head">Document copy request</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.para1">This is the text that will send the applicant (together with the document).</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.para1">This is the text to be sent to the applicant (together with the document).</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.message">Message</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.subject">Subject</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.mail">Send</message>
@@ -367,11 +367,11 @@
 	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.title">Change permissions request</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.trail">Change permissions request</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.head">Change permissions request</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.para1">You can take advantage of the occasion to reconsider the free disposition of the document (to avoid having to respond to these requests), if there is no reason to keep it restricted. This may apply inserting your data below and press the button</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.para1">You may use this occasion to reconsider the access restrictions on the document (to avoid having to respond to these requests), if there is no reason to keep it restricted. To do so, after inserting your name and e-mail (for authentication), click the button "Change to Open Access".</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name">Name</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email">E-mail</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name.error">The name is mandatory</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email.error">The e-mail is mandatory</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name.error">The name is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email.error">The e-mail address is required</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.changeToOpen">Change to open access</message>
 	        
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
@@ -2154,6 +2154,8 @@
 
 	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">Dublin Core elements</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-terms">Dublin Core terms</message>
+
+        <message key="xmlui.dri2xhtml.METS-1.0.blocked">Blocked</message>
 
 
 	<!-- Special pioneer model related text, wherever it might end up -->

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -408,15 +408,14 @@
                         </xsl:otherwise>
                     </xsl:choose>
                     <xsl:if test="contains(mets:FLocat[@LOCTYPE='URL']/@xlink:href,'isAllowed=n')">
- 	                    <img>
- 	                     <xsl:attribute name="src">
- 	                        <xsl:value-of select="$context-path"/>
- 	                        <xsl:text>/static/icons/lock24.png</xsl:text>
- 	                     </xsl:attribute>
- 	                      <xsl:attribute name="alt">
- 	                        <i18n:text>xmlui.dri2xhtml.METS-1.0.blocked</i18n:text>
- 	                      </xsl:attribute>               
- 	                    </img>
+                        <img>
+                            <xsl:attribute name="src">
+                                <xsl:value-of select="$context-path"/>
+                                <xsl:text>/static/icons/lock24.png</xsl:text>
+                            </xsl:attribute>
+                           <xsl:attribute name="alt">xmlui.dri2xhtml.METS-1.0.blocked</xsl:attribute>
+                           <xsl:attribute name="attr" namespace="http://apache.org/cocoon/i18n/2.1">alt</xsl:attribute>
+                        </img>
                      </xsl:if>
                 </a>
             </div>

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -414,7 +414,7 @@
  	                        <xsl:text>/static/icons/lock24.png</xsl:text>
  	                     </xsl:attribute>
  	                      <xsl:attribute name="alt">
- 	                        <xsl:text>Bloqueado</xsl:text>
+ 	                        <i18n:text>xmlui.dri2xhtml.METS-1.0.blocked</i18n:text>
  	                      </xsl:attribute>               
  	                    </img>
                      </xsl:if>

--- a/dspace-xmlui/src/main/webapp/themes/dri2xhtml-alt/aspect/artifactbrowser/item-view.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/dri2xhtml-alt/aspect/artifactbrowser/item-view.xsl
@@ -471,7 +471,7 @@
  	                        <xsl:text>/static/icons/lock24.png</xsl:text>
  	                     </xsl:attribute>
  	                      <xsl:attribute name="alt">
- 	                        <xsl:text>Bloqueado</xsl:text>
+ 	                        <i18n:text>xmlui.dri2xhtml.METS-1.0.blocked</i18n:text>
  	                      </xsl:attribute>               
  	                    </img>
                      </xsl:if>

--- a/dspace-xmlui/src/main/webapp/themes/dri2xhtml-alt/aspect/artifactbrowser/item-view.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/dri2xhtml-alt/aspect/artifactbrowser/item-view.xsl
@@ -465,15 +465,14 @@
                         </xsl:otherwise>
                     </xsl:choose>
                     <xsl:if test="contains(mets:FLocat[@LOCTYPE='URL']/@xlink:href,'isAllowed=n')">
- 	                    <img>
- 	                     <xsl:attribute name="src">
- 	                        <xsl:value-of select="$context-path"/>
- 	                        <xsl:text>/static/icons/lock24.png</xsl:text>
- 	                     </xsl:attribute>
- 	                      <xsl:attribute name="alt">
- 	                        <i18n:text>xmlui.dri2xhtml.METS-1.0.blocked</i18n:text>
- 	                      </xsl:attribute>               
- 	                    </img>
+                        <img>
+                            <xsl:attribute name="src">
+                                <xsl:value-of select="$context-path"/>
+                                <xsl:text>/static/icons/lock24.png</xsl:text>
+                            </xsl:attribute>
+                            <xsl:attribute name="alt">xmlui.dri2xhtml.METS-1.0.blocked</xsl:attribute>
+                            <xsl:attribute name="attr" namespace="http://apache.org/cocoon/i18n/2.1">alt</xsl:attribute>
+                            </img>
                      </xsl:if>
                 </a>
             </td>

--- a/dspace-xmlui/src/main/webapp/themes/dri2xhtml/General-Handler.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/dri2xhtml/General-Handler.xsl
@@ -118,7 +118,7 @@
  	                        <xsl:text>/static/icons/lock24.png</xsl:text>
  	                     </xsl:attribute>
  	                      <xsl:attribute name="alt">
- 	                        <xsl:text>Bloqueado</xsl:text>
+ 	                        <i18n:text>xmlui.dri2xhtml.METS-1.0.blocked</i18n:text>
  	                      </xsl:attribute>               
  	                    </img>
                      </xsl:if>

--- a/dspace-xmlui/src/main/webapp/themes/dri2xhtml/General-Handler.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/dri2xhtml/General-Handler.xsl
@@ -112,15 +112,14 @@
                         </xsl:otherwise>
                     </xsl:choose>
                     <xsl:if test="contains(mets:FLocat[@LOCTYPE='URL']/@xlink:href,'isAllowed=n')">
- 	                    <img>
- 	                     <xsl:attribute name="src">
- 	                        <xsl:value-of select="$context-path"/>
- 	                        <xsl:text>/static/icons/lock24.png</xsl:text>
- 	                     </xsl:attribute>
- 	                      <xsl:attribute name="alt">
- 	                        <i18n:text>xmlui.dri2xhtml.METS-1.0.blocked</i18n:text>
- 	                      </xsl:attribute>               
- 	                    </img>
+                        <img>
+                            <xsl:attribute name="src">
+                                <xsl:value-of select="$context-path"/>
+                                <xsl:text>/static/icons/lock24.png</xsl:text>
+                            </xsl:attribute>
+                            <xsl:attribute name="alt">xmlui.dri2xhtml.METS-1.0.blocked</xsl:attribute>
+                            <xsl:attribute name="attr" namespace="http://apache.org/cocoon/i18n/2.1">alt</xsl:attribute>
+                        </img>
                      </xsl:if>
                 </a>
             </td>

--- a/dspace/config/emails/request_item.admin
+++ b/dspace/config/emails/request_item.admin
@@ -1,6 +1,6 @@
 Subject: Request for Open Access
 
-{3} with address {4}, 
+{3}, with address {4},
 requested the following document/file to be in Open Access: 
 
 Document Handle:{1} 

--- a/dspace/config/emails/request_item.author
+++ b/dspace/config/emails/request_item.author
@@ -2,7 +2,7 @@ Subject: Request copy of document
 
 Dear {7},
 
-A user of {9}, named {0} and using the email {1} requested a copy of the file(s), associated with the document: "{4}" ({3}) submitted by you.
+A user of {9}, named {0} and using the email {1}, requested a copy of the file(s) associated with the document: "{4}" ({3}) submitted by you.
 
 This request came along with the following message:
 
@@ -10,8 +10,8 @@ This request came along with the following message:
 
 To answer, click {6}. Whether you choose to grant or deny the request, we think that it''s in your best interest to respond.
 
-IF YOU ARE NOT AN AUTHOR OF THIS DOCUMENT, and only submitted the document on the author's behalf, PLEASE REDIRECT THIS MESSAGE TO THE AUTHOR(S).  Only the author(s) should answer the request to send a copy.
+IF YOU ARE NOT AN AUTHOR OF THIS DOCUMENT, and only submitted the document on the author''s behalf, PLEASE REDIRECT THIS MESSAGE TO THE AUTHOR(S).  Only the author(s) should answer the request to send a copy.
 
 IF YOU ARE AN AUTHOR OF THE REQUESTED DOCUMENT, thank you for your cooperation!
 
-If you have any questions concerning this request, please contact {10}
+If you have any questions concerning this request, please contact {10}.

--- a/dspace/config/emails/request_item.author
+++ b/dspace/config/emails/request_item.author
@@ -2,16 +2,16 @@ Subject: Request copy of document
 
 Dear {7},
 
-A user of {9}, named {0} and using the email {1} requested a copy of the file(s), concerning to the document: "{4}" ({3}) submitted by you.
+A user of {9}, named {0} and using the email {1} requested a copy of the file(s), associated with the document: "{4}" ({3}) submitted by you.
 
 This request came along with the following message:
 
 "{5}"
 
-to answer click {6} In both cases, we think that it''s in your best interest to answer this request.
+To answer, click {6}. Whether you choose to grant or deny the request, we think that it''s in your best interest to respond.
 
-IF YOU AREN''T THE AUTHOR OR ONE OF THE AUTHORS OF THIS DOCUMENT, and only submitted the document on his behalf, PLEASE REDIRECT THIS MESSAGE TO THE AUTHOR(S), only the author(s) should answer the request to send a copy.
-IF YOU ARE THE AUTHOR OR ONE OF THE AUTHOR(S) OF THE REQUESTED DOCUMENT, 
+IF YOU ARE NOT AN AUTHOR OF THIS DOCUMENT, and only submitted the document on the author's behalf, PLEASE REDIRECT THIS MESSAGE TO THE AUTHOR(S).  Only the author(s) should answer the request to send a copy.
 
-Thank you for your collaboration!
-If you have any doubt concerning this request, please contact {10}
+IF YOU ARE AN AUTHOR OF THE REQUESTED DOCUMENT, thank you for your cooperation!
+
+If you have any questions concerning this request, please contact {10}


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-1751

I would particularly appreciate other eyes on the places where I replaced hardcoded Portugese "Bloqueado" with an i18n:text element.  I _think_ I did this properly but should be double-checked by someone with more experience in this area.

There is a very fine distinction between "mandatory" and "required", but I made the change because I thought it seemed just as firm but less commanding.

Comments on any of my changes would be welcome.
