### PR TITLE
DS-1781 LDAP never uses the specified email_field

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
@@ -249,15 +249,21 @@ public class LDAPAuthentication
                 // Register the new user automatically
                 log.info(LogManager.getHeader(context,
                                 "autoregister", "netid=" + netid));
-
-                // If there is no email and the email domain is set, add it to the netid
+                
                 String email = ldap.ldapEmail;
-                if (((email == null) || ("".equals(email))) &&
-                    (!"".equals(ConfigurationManager.getProperty("authentication-ldap", "netid_email_domain"))))
-                {
-                    email = netid + ConfigurationManager.getProperty("authentication-ldap", "netid_email_domain");
+                if (StringUtils.isEmpty(email))
+                { 
+                    // If there is no email and the email domain is set, add it to the netid
+                    if ((StringUtils.isNotEmpty(ConfigurationManager.getProperty("authentication-ldap", "netid_email_domain"))))
+                    {
+                        email = netid + ConfigurationManager.getProperty("authentication-ldap", "netid_email_domain"); 
+                    }
+                    else
+                    {
+                       email = netid;
+                    }
                 }
-
+                
                 if ((email != null) && (!"".equals(email)))
                 {
                     try


### PR DESCRIPTION
Made a PR for the proposed patch; I haven't tested it yet.
