### PR TITLE
Fix the bug DS-1780

### DIFF
--- a/dspace-api/src/main/java/org/dspace/submit/lookup/ArXivFileDataLoader.java
+++ b/dspace-api/src/main/java/org/dspace/submit/lookup/ArXivFileDataLoader.java
@@ -130,7 +130,10 @@ public class ArXivFileDataLoader extends FileDataLoader
     public RecordSet getRecords(DataLoadingSpec spec)
             throws MalformedSourceException
     {
-
+        if (spec.getOffset() > 0) 
+        {
+            return new RecordSet();
+        }
         return getRecords();
     }
 

--- a/dspace-api/src/main/java/org/dspace/submit/lookup/CrossRefFileDataLoader.java
+++ b/dspace-api/src/main/java/org/dspace/submit/lookup/CrossRefFileDataLoader.java
@@ -122,7 +122,10 @@ public class CrossRefFileDataLoader extends FileDataLoader
     public RecordSet getRecords(DataLoadingSpec spec)
             throws MalformedSourceException
     {
-
+        if (spec.getOffset() > 0) 
+        {
+            return new RecordSet();
+        }
         return getRecords();
     }
 

--- a/dspace-api/src/main/java/org/dspace/submit/lookup/PubmedFileDataLoader.java
+++ b/dspace-api/src/main/java/org/dspace/submit/lookup/PubmedFileDataLoader.java
@@ -133,7 +133,10 @@ public class PubmedFileDataLoader extends FileDataLoader
     public RecordSet getRecords(DataLoadingSpec spec)
             throws MalformedSourceException
     {
-
+        if (spec.getOffset() > 0) 
+        {
+            return new RecordSet();
+        }
         return getRecords();
     }
 


### PR DESCRIPTION
The batch import would go into an infinite loop when loading from a
pubmed, arxiv or crossref XML file. This was due to the fact that the
respective data loaders open the file each time getRecords() is called
coupled with the complicated logic of TransformationEngine.

The bug was fixed by checking if offset is greater than zero in
getRecords(DataLoadingSpec) (which is equivalent to the condition that
the file has already been read) and if so the method returns an empty
RecordSet signaling the TransformationEngine that the input has ended.

Relevant jira issue: https://jira.duraspace.org/browse/DS-1780
