### PR TITLE
[DS-1803] Configurable workflow migration script fails if collection workflow group has been renamed

### DIFF
--- a/dspace/etc/oracle/xmlworkflow/workflow_migration.sql
+++ b/dspace/etc/oracle/xmlworkflow/workflow_migration.sql
@@ -5,28 +5,28 @@ INSERT INTO cwf_collectionrole (collectionrole_id, role_id, group_id, collection
 SELECT
 cwf_collectionrole_seq.nextval as collectionrole_id,
 'reviewer' AS role_id,
-eperson_group_id AS group_id,
-to_number(replace(replace(name, 'COLLECTION_', ''), '_WORKFLOW_STEP_1', '')) AS collection_id
-FROM epersongroup
-WHERE name LIKE 'COLLECTION_%_WORKFLOW_STEP_1';
+collection.workflow_step_1 AS group_id,
+collection.collection_id AS collection_id
+FROM collection
+WHERE collection.workflow_step_1 IS NOT NULL;
 
 INSERT INTO cwf_collectionrole  (collectionrole_id, role_id, group_id, collection_id)
 SELECT
 cwf_collectionrole_seq.nextval as collectionrole_id,
 'editor' AS role_id,
-eperson_group_id AS group_id,
-to_number(replace(replace(name, 'COLLECTION_', ''), '_WORKFLOW_STEP_2', '')) AS collection_id
-FROM epersongroup
-WHERE name LIKE 'COLLECTION_%_WORKFLOW_STEP_2';
+collection.workflow_step_2 AS group_id,
+collection.collection_id AS collection_id
+FROM collection
+WHERE collection.workflow_step_2 IS NOT NULL;
 
 INSERT INTO cwf_collectionrole  (collectionrole_id, role_id, group_id, collection_id)
 SELECT
 cwf_collectionrole_seq.nextval as collectionrole_id,
 'finaleditor' AS role_id,
-eperson_group_id AS group_id,
-to_number(replace(replace(name, 'COLLECTION_', ''), '_WORKFLOW_STEP_3', '')) AS collection_id
-FROM epersongroup
-WHERE name LIKE 'COLLECTION_%_WORKFLOW_STEP_3';
+collection.workflow_step_3 AS group_id,
+collection.collection_id AS collection_id
+FROM collection
+WHERE collection.workflow_step_3 IS NOT NULL;
 
 
 -- Migrate workflow items

--- a/dspace/etc/postgres/xmlworkflow/workflow_migration.sql
+++ b/dspace/etc/postgres/xmlworkflow/workflow_migration.sql
@@ -2,26 +2,26 @@
 INSERT INTO cwf_collectionrole (role_id, group_id, collection_id)
 SELECT
 'reviewer' AS role_id,
-eperson_group_id AS group_id,
-replace(replace(name, 'COLLECTION_', ''), '_WORKFLOW_STEP_1', '')::INTEGER AS collection_id
-FROM epersongroup
-WHERE name LIKE 'COLLECTION_%_WORKFLOW_STEP_1';
+collection.workflow_step_1 AS group_id,
+collection.collection_id AS collection_id
+FROM collection
+WHERE collection.workflow_step_1 IS NOT NULL;
 
 INSERT INTO cwf_collectionrole  (role_id, group_id, collection_id)
 SELECT
 'editor' AS role_id,
-eperson_group_id AS group_id,
-replace(replace(name, 'COLLECTION_', ''), '_WORKFLOW_STEP_2', '')::INTEGER AS collection_id
-FROM epersongroup
-WHERE name LIKE 'COLLECTION_%_WORKFLOW_STEP_2';
+collection.workflow_step_2 AS group_id,
+collection.collection_id AS collection_id
+FROM collection
+WHERE collection.workflow_step_2 IS NOT NULL;
 
 INSERT INTO cwf_collectionrole  (role_id, group_id, collection_id)
 SELECT
 'finaleditor' AS role_id,
-eperson_group_id AS group_id,
-replace(replace(name, 'COLLECTION_', ''), '_WORKFLOW_STEP_3', '')::INTEGER AS collection_id
-FROM epersongroup
-WHERE name LIKE 'COLLECTION_%_WORKFLOW_STEP_3';
+collection.workflow_step_3 AS group_id,
+collection.collection_id AS collection_id
+FROM collection
+WHERE collection.workflow_step_3 IS NOT NULL;
 
 
 -- Migrate workflow items


### PR DESCRIPTION
If a workflow group has been renamed from the standard "COLLECTION_{collection.id}_WORKFLOW_STEP_{workflow.step}" to something more sensible the configurable workflow migration script fails. 

This is because the migration script uses the name of the group to perform the migration (instead of using the stored identifier)
