### PR TITLE
[DS-1590] Mirage: thumbnail dimensions are not enforced in listings

### DIFF
--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/aspect/artifactbrowser/item-list.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/aspect/artifactbrowser/item-list.xsl
@@ -243,7 +243,7 @@
 
     <xsl:template match="mets:fileSec" mode="artifact-preview">
         <xsl:param name="href"/>
-        <div class="thumbnail-wrapper">
+        <div class="thumbnail-wrapper" style="width: {$thumbnail.maxwidth}px;">
             <div class="artifact-preview">
                 <a class="image-link" href="{$href}">
                     <xsl:choose>

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -388,7 +388,7 @@
     <xsl:template match="mets:file">
         <xsl:param name="context" select="."/>
         <div class="file-wrapper clearfix">
-            <div class="thumbnail-wrapper">
+            <div class="thumbnail-wrapper" style="width: {$thumbnail.maxwidth}px;">
                 <a class="image-link">
                     <xsl:attribute name="href">
                         <xsl:value-of select="mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>


### PR DESCRIPTION
adding the max thumbnail width from cfg to thumbnail-wrapper divs
