### PR TITLE
[DS-1322] Item without Title inaccessible via the UI unless for the admin via ID or Handle

### DIFF
--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -78,6 +78,8 @@ itemlist.dc.type.degree        = Degree
 itemlist.et-al                 = et al
 itemlist.thumbnail             = Preview
 
+itemlist.title.undefined	   = Undefined
+
 jsp.adminhelp                                                   = <span class="glyphicon glyphicon-question-sign"></span>
 jsp.administer                                                  = Administer
 jsp.admintools                                                  = Admin Tools

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/BrowseListTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/BrowseListTag.java
@@ -570,7 +570,24 @@ public class BrowseListTag extends TagSupport
                             metadata = "<em>" + sb.toString() + "</em>";
                         }
                     }
-
+                    else {
+                    	//In case title has no value, replace it with "undefined" so as the user has something to
+                    	//click in order to access the item page
+                    	String undefined = LocaleSupport.getLocalizedMessage(pageContext, "itemlist.title.undefined");
+                    	if (field.equals(titleField) && (items[i].isWithdrawn() || !isDiscoverable(hrq, items[i])))
+                        {
+                            metadata = "<span style=\"font-style:italic\">("+undefined+")</span>";
+                        }
+                        // format the title field correctly (as long as the item isn't withdrawn, link to it)
+                        else if (field.equals(titleField))
+                        {
+                            metadata = "<a href=\"" + hrq.getContextPath() + "/handle/"
+                            + items[i].getHandle() + "\">"
+                            + "<span style=\"font-style:italic\">("+undefined+")</span>"
+                            + "</a>";
+                        }
+                    }
+                    
                     // prepare extra special layout requirements for dates
                     String extras = "";
                     if (isDate[colIdx])

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/BrowseListTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/BrowseListTag.java
@@ -570,16 +570,16 @@ public class BrowseListTag extends TagSupport
                             metadata = "<em>" + sb.toString() + "</em>";
                         }
                     }
-                    else {
-                    	//In case title has no value, replace it with "undefined" so as the user has something to
-                    	//click in order to access the item page
+                    //In case title has no value, replace it with "undefined" so as the user has something to
+                	//click in order to access the item page
+                    else if (field.equals(titleField)){
                     	String undefined = LocaleSupport.getLocalizedMessage(pageContext, "itemlist.title.undefined");
-                    	if (field.equals(titleField) && items[i].isWithdrawn())
+                    	if (items[i].isWithdrawn())
                         {
                             metadata = "<span style=\"font-style:italic\">("+undefined+")</span>";
                         }
                         // format the title field correctly (as long as the item isn't withdrawn, link to it)
-                        else if (field.equals(titleField))
+                        else
                         {
                             metadata = "<a href=\"" + hrq.getContextPath() + "/handle/"
                             + items[i].getHandle() + "\">"

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/BrowseListTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/BrowseListTag.java
@@ -483,7 +483,7 @@ public class BrowseListTag extends TagSupport
                             metadata = UIUtil.displayDate(dd, false, false, hrq);
                         }
                         // format the title field correctly for withdrawn and private items (ie. don't link)
-                        else if (field.equals(titleField) && (items[i].isWithdrawn() || !isDiscoverable(hrq, items[i])))
+                        else if (field.equals(titleField) && items[i].isWithdrawn())
                         {
                             metadata = Utils.addEntities(metadataArray[0].value);
                         }
@@ -574,7 +574,7 @@ public class BrowseListTag extends TagSupport
                     	//In case title has no value, replace it with "undefined" so as the user has something to
                     	//click in order to access the item page
                     	String undefined = LocaleSupport.getLocalizedMessage(pageContext, "itemlist.title.undefined");
-                    	if (field.equals(titleField) && (items[i].isWithdrawn() || !isDiscoverable(hrq, items[i])))
+                    	if (field.equals(titleField) && items[i].isWithdrawn())
                         {
                             metadata = "<span style=\"font-style:italic\">("+undefined+")</span>";
                         }
@@ -902,23 +902,6 @@ public class BrowseListTag extends TagSupport
         catch (UnsupportedEncodingException e)
         {
             throw new JspException("Server does not support DSpace's default encoding. ", e);
-        }
-    }
-
-    /* whether the embedded item of the bitem is discoverable or not? */
-    private boolean isDiscoverable(HttpServletRequest hrq, BrowseItem bitem)
-            throws JspException
-    {
-    	try
-    	{
-            Context c = UIUtil.obtainContext(hrq);
-            Item item = Item.find(c, bitem.getID());
-
-            return item.isDiscoverable();
-        }
-        catch (SQLException sqle)
-        {
-        	throw new JspException(sqle.getMessage(), sqle);
         }
     }
 }

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemListTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemListTag.java
@@ -535,16 +535,16 @@ public class ItemListTag extends TagSupport
                             metadata = "<em>" + sb.toString() + "</em>";
                         }
                     }
-                    else {
-                    	//In case title has no value, replace it with "undefined" so as the user has something to
-                    	//click in order to access the item page
+                    //In case title has no value, replace it with "undefined" so as the user has something to
+                	//click in order to access the item page
+                    else if (field.equals(titleField)){
                     	String undefined = LocaleSupport.getLocalizedMessage(pageContext, "itemlist.title.undefined");
-                    	if (field.equals(titleField) && items[i].isWithdrawn())
+                    	if (items[i].isWithdrawn())
                         {
                             metadata = "<span style=\"font-style:italic\">("+undefined+")</span>";
                         }
                         // format the title field correctly (as long as the item isn't withdrawn, link to it)
-                        else if (field.equals(titleField))
+                        else
                         {
                             metadata = "<a href=\"" + hrq.getContextPath() + "/handle/"
                             + items[i].getHandle() + "\">"
@@ -552,7 +552,7 @@ public class ItemListTag extends TagSupport
                             + "</a>";
                         }
                     }
-                    
+
                     // prepare extra special layout requirements for dates
                     String extras = "";
                     if (isDate[colIdx])

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemListTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemListTag.java
@@ -535,7 +535,24 @@ public class ItemListTag extends TagSupport
                             metadata = "<em>" + sb.toString() + "</em>";
                         }
                     }
-
+                    else {
+                    	//In case title has no value, replace it with "undefined" so as the user has something to
+                    	//click in order to access the item page
+                    	String undefined = LocaleSupport.getLocalizedMessage(pageContext, "itemlist.title.undefined");
+                    	if (field.equals(titleField) && items[i].isWithdrawn())
+                        {
+                            metadata = "<span style=\"font-style:italic\">("+undefined+")</span>";
+                        }
+                        // format the title field correctly (as long as the item isn't withdrawn, link to it)
+                        else if (field.equals(titleField))
+                        {
+                            metadata = "<a href=\"" + hrq.getContextPath() + "/handle/"
+                            + items[i].getHandle() + "\">"
+                            + "<span style=\"font-style:italic\">("+undefined+")</span>"
+                            + "</a>";
+                        }
+                    }
+                    
                     // prepare extra special layout requirements for dates
                     String extras = "";
                     if (isDate[colIdx])


### PR DESCRIPTION
Corresponding JIRA issue: https://jira.duraspace.org/browse/DS-1322

Item without Title inaccessible via the UI unless for the admin via ID or Handle.

This PR adds the ability in JSPUI to display the localized phrase "Undefined" in the item list (browse or search) for items that have no title, so as the user can access the item via the title link.
