### PR TITLE
[DS-1819] Discovery filters encoding

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/AbstractSearch.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/AbstractSearch.java
@@ -401,7 +401,7 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
         //}// Empty query
     }
 
-    protected String addFilterQueriesToUrl(String pageURLMask) {
+    protected String addFilterQueriesToUrl(String pageURLMask) throws UIException {
         Map<String, String[]> filterQueryParams = getParameterFilterQueries();
         if(filterQueryParams != null)
         {
@@ -413,7 +413,7 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
                 {
                     for (String filterQueryValue : filterQueryValues)
                     {
-                        maskBuilder.append("&").append(filterQueryParam).append("=").append(filterQueryValue);
+                        maskBuilder.append("&").append(filterQueryParam).append("=").append(encodeForURL(filterQueryValue));
                     }
                 }
             }


### PR DESCRIPTION
The filters aren't always properly encoded on the discovery pages, take the following url for example: 
http://demo.dspace.org/xmlui/discover?filtertype_0=title&filter_relational_operator_0=contains&filter_0=test++%26+test&filtertype_4=title&filter_relational_operator_4=contains&filter_4=&submit_apply_filter=Apply&query=test&rpp=5&sort_by=dc.title_sort&order=asc 

When navigating to the next page the "test & test" filter loses the ampersand.
