### PR TITLE
Revert "[DS-1502] Don't let XSL-T decode entities that we wrote inside <...

### DIFF
--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
@@ -263,7 +263,7 @@
 
                                 FnArray.prototype.execute = function()
                                 {
-                                    for( var i=0; i &lt; this.funcs.length; i++ )
+                                    for( var i=0; i <xsl:text disable-output-escaping="yes">&lt;</xsl:text> this.funcs.length; i++ )
                                     {
                                         this.funcs[i]();
                                     }


### PR DESCRIPTION
...script> tags"

This reverts commit 1d8838baa0572ca3038544aaa11820537086a65a.

That commit produces invalid Javascript.  Multiple layers of XML
processing makes it extremely difficult to shepherd a left broket
through the entire pipeline.  Give up on XHTML correctness for now and
revisit some other day.
