### PR TITLE
DS-1820 Introduction of URL validators in SolrServiceImpl breaks .local urls

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -141,7 +141,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
             String solrService = new DSpace().getConfigurationService().getProperty("discovery.search.server");
 
             UrlValidator urlValidator = new UrlValidator(UrlValidator.ALLOW_LOCAL_URLS);
-            if (urlValidator.isValid(solrService))
+            if (urlValidator.isValid(solrService)||ConfigurationManager.getBooleanProperty("discovery","solr.url.validation.disabled",false))
             {
                 try {
                     log.debug("Solr URL: " + solrService);

--- a/dspace/config/modules/discovery.cfg
+++ b/dspace/config/modules/discovery.cfg
@@ -7,6 +7,10 @@
 ##### Search Indexing #####
 search.server = ${solr.server}/search
 
+#Disable the url validation of the search.server setting above.
+#Defaults to false: validation is enabled
+#solr.url.validation.disabled = false
+
 #Char used to ensure that the sidebar facets are case insensitive
 #solr.facets.split.char=\n|||\n
 


### PR DESCRIPTION
http://jira.duraspace.org/browse/DS-1820

When a URL like http://mypc.local/solr/search is entered as a search.server the URL validation fails. This is default behaviour of the Apache Commons URL validator but potentially unwanted.

I suggest creating an option toggling the URL validation. Default to true. (i.e. validationenabled) 
