### PR TITLE
DS-1733: Improvements to changes made in PR#364. 

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSV.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSV.java
@@ -385,8 +385,9 @@ public class DSpaceCSV implements Serializable
      */
     public final void addItem(Item i) throws Exception
     {
-        // If the item is not in the archive, the call to get its handle below will fail
-        if (i.isWithdrawn() || !i.isArchived() || i.getOwningCollection() == null) {
+        // If the item does not have an "owningCollection" the the below "getHandle()" call will fail
+        // This should not happen but is here for safety.
+        if (i.getOwningCollection() == null) {
             return;
         }
 

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExport.java
@@ -137,6 +137,9 @@ public class MetadataExport
         }
         catch (Exception e)
         {
+            // Something went wrong...
+            System.err.println("Error exporting to CSV:");
+            e.printStackTrace();
             return null;
         }
     }


### PR DESCRIPTION
- Ensure withdrawn items are still exported to CSV, since this is a feature of Bulk Metadata Editing.
- Improve error logging on export.

Relates to https://jira.duraspace.org/browse/DS-1733 and #364 (merged).

I've done some light testing this afternoon. Did some metadata exports of both in_archive and withdrawn content (in_archive=false). No errors appear in the logs, and CSV is generated successfully.

I think this is ready to merge
