### PR TITLE
[DS-1832] Proxy configuration set in system properties if empty

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
+++ b/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
@@ -25,6 +25,7 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PosixParser;
+import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
@@ -316,8 +317,8 @@ public class GenerateSitemaps
             throws MalformedURLException, UnsupportedEncodingException
     {
         // Set up HTTP proxy
-        if ((ConfigurationManager.getProperty("http.proxy.host") != null)
-                && (ConfigurationManager.getProperty("http.proxy.port") != null))
+        if ((StringUtils.isNotBlank(ConfigurationManager.getProperty("http.proxy.host")))
+                && (StringUtils.isNotBlank(ConfigurationManager.getProperty("http.proxy.port"))))
         {
             System.setProperty("proxySet", "true");
             System.setProperty("proxyHost", ConfigurationManager

--- a/dspace-api/src/main/java/org/dspace/license/CreativeCommons.java
+++ b/dspace-api/src/main/java/org/dspace/license/CreativeCommons.java
@@ -20,6 +20,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bitstream;
@@ -61,7 +62,7 @@ public class CreativeCommons
         String proxyHost = ConfigurationManager.getProperty("http.proxy.host");
         String proxyPort = ConfigurationManager.getProperty("http.proxy.port");
 
-        if ((proxyHost != null) && (proxyPort != null))
+        if (StringUtils.isNotBlank(proxyHost) && StringUtils.isNotBlank(proxyPort))
         {
             System.setProperty("http.proxyHost", proxyHost);
             System.setProperty("http.proxyPort", proxyPort);


### PR DESCRIPTION
The proxy configuration is always set in the system properties even if the property is empty (there is a null check but by default the property is empty so it will pass the null test). 
This pull request will not only check if the value isn't null but also if the value contains a value.
