### PR TITLE
[DS-1833] Collection content source harvesting test does not work with ORE

### DIFF
--- a/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
@@ -139,13 +139,9 @@ public class OAIHarvester {
         // Set the ORE options
 		Namespace ORESerializationNamespace = OAIHarvester.getORENamespace();
 
-        if (ORESerializationNamespace == null) {
-        	log.error("No ORE serialization namespace declared; see dspace.cfg option \"harvester.oai.oreSerializationFormat.{ORESerialKey} = {ORESerialNS}\"");
-        	throw new HarvestingException("No ORE serialization namespace specified");
-        } else {
-        	ORESerialNS = Namespace.getNamespace(ORESerializationNamespace.getURI());
-        	ORESerialKey = ORESerializationNamespace.getPrefix();
-        }
+        //No need to worry about ORESerializationNamespace, this can never be null
+        ORESerialNS = Namespace.getNamespace(ORESerializationNamespace.getURI());
+        ORESerialKey = ORESerializationNamespace.getPrefix();
 
         // Set the metadata options
         metadataKey = harvestRow.getHarvestMetadataConfig();
@@ -932,7 +928,7 @@ public class OAIHarvester {
         String DMDOAIPrefix = null;
 
         try {
-            OREOAIPrefix = OAIHarvester.oaiResolveNamespaceToPrefix(oaiSource, ORE_NS.getURI());
+            OREOAIPrefix = OAIHarvester.oaiResolveNamespaceToPrefix(oaiSource, getORENamespace().getURI());
             DMDOAIPrefix = OAIHarvester.oaiResolveNamespaceToPrefix(oaiSource, DMD_NS.getURI());
     	}
     	catch (Exception ex) {


### PR DESCRIPTION
The harvesting feature on collections does not resolve the ORE namespace properly when testing. 
For the test the ORE namespace is hardcoded to "http://www.openarchives.org/ore/terms/" while the actual import has a method that will determine the ORE namespace based on configuration (with a fallback on Atom). 

The default namespace for ORE in DSpace OAI is "http://www.w3.org/2005/Atom" so even though the test says that the OAI repo doesn't support ORE the import will work. 

You can test this issue by attempting to harvest demo.dspace.org (this offers ORE by default) (http://demo.dspace.org/oai/request?verb=ListMetadataFormats)

This pull request ensures consistency when it comes down to the ORE metadataFormat.

http://jira.duraspace.org/browse/DS-1833
