### PR TITLE
DS-1757 Missing images in mobile theme

### DIFF
--- a/dspace-xmlui/src/main/webapp/themes/mobile/mobile.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/mobile/mobile.xsl
@@ -694,7 +694,8 @@
                            </xsl:attribute>
                             <img alt="Thumbnail">
                                 <xsl:attribute name="src">
-                                <xsl:text>themes/mobile/lib/images/default-thumbnail.png</xsl:text>
+                                <xsl:variable name="request-uri" select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='contextPath'])"/>
+                                <xsl:text>/themes/mobile/lib/images/default-thumbnail.png</xsl:text>
                                 </xsl:attribute>
                             </img>
                         </a>

--- a/dspace-xmlui/src/main/webapp/themes/mobile/mobile.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/mobile/mobile.xsl
@@ -694,7 +694,7 @@
                            </xsl:attribute>
                             <img alt="Thumbnail">
                                 <xsl:attribute name="src">
-                                <xsl:text>themes/mobile/lib/images/mobile-default-thumbnail.png</xsl:text>
+                                <xsl:text>themes/mobile/lib/images/default-thumbnail.png</xsl:text>
                                 </xsl:attribute>
                             </img>
                         </a>


### PR DESCRIPTION
Removed link to mobile-default-thumbnail.png and changed to default-thumbnail.png which already existed.

http://jira.duraspace.org/browse/DS-1757
