### PR TITLE
DS-1756 Wrongly aligned text on mobile theme

### DIFF
--- a/dspace-xmlui/src/main/webapp/themes/mobile/lib/m-tweaks.css
+++ b/dspace-xmlui/src/main/webapp/themes/mobile/lib/m-tweaks.css
@@ -172,7 +172,6 @@ table {
 clear: both;
 width: 100%;
 text-align: left;
-margin-left: -35px;
 padding: 5px;
 }
 


### PR DESCRIPTION
http://jira.duraspace.org/browse/DS-1756

Removed margin-left: -35px; which pushes "There are no files associated with this item." over to the right. I tested this in firebug.
