### PR TITLE
DS-1873: Minor fixes for Checksum Checker Daily Report Emailer.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/checker/DailyReportEmailer.java
+++ b/dspace-api/src/main/java/org/dspace/checker/DailyReportEmailer.java
@@ -65,12 +65,16 @@ public class DailyReportEmailer
     public void sendReport(File attachment, int numberOfBitstreams) 
             throws IOException, javax.mail.MessagingException 
     { 
-        Email email = new Email(); 
-        email.setSubject("Checksum checker Report - " + numberOfBitstreams + " Bitstreams found with POSSIBLE issues"); 
-        email.setContent("report is attached ..."); 
-        email.addAttachment(attachment, "checksum_checker_report.txt"); 
-        email.addRecipient(ConfigurationManager.getProperty("mail.admin")); 
-        email.send(); 
+        if(numberOfBitstreams > 0)
+        {
+            String hostname = ConfigurationManager.getProperty("dspace.hostname");
+            Email email = new Email();
+            email.setSubject("Checksum checker Report - " + numberOfBitstreams + " Bitstreams found with POSSIBLE issues on " + hostname);
+            email.setContent("report is attached ...");
+            email.addAttachment(attachment, "checksum_checker_report.txt");
+            email.addRecipient(ConfigurationManager.getProperty("mail.admin"));
+            email.send();
+        }
     } 
 
     /**


### PR DESCRIPTION
1. Ensure it only sends an email if there's a possible issue. 
2. Also include "dspace.hostname" in email subject, so you can tell which DSpace site sent the email.

More info at: https://jira.duraspace.org/browse/DS-1873
