### PR TITLE
Fix for DS-1867 - Maven build issues from [src]/dspace/

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,19 +112,20 @@
       <!-- These plugin settings only apply to this single POM and are not inherited
            to any submodules. -->
       <plugins>
+         <!-- Ensure that any *.properties files have UTF-8 chars encoded (e.g. "\u00e9") *before* using them to filter dspace.cfg and other configs -->
          <plugin>
            <artifactId>maven-antrun-plugin</artifactId>
            <version>1.7</version>
-           <configuration>
-             <target>
-	       <!-- Run 'native2ascii' to encode UTF-8 characters in properties files. Place the resulting file(s) in /target -->
-               <native2ascii encoding="UTF8" src="${basedir}" dest="${basedir}/target" includes="*.properties" />
-             </target>
-           </configuration>
            <executions>
              <execution>
                <id>native2ascii-utf8</id>
                <phase>generate-resources</phase>
+               <configuration>
+                 <target name="Encode any UTF-8 chars in [src]/*.properties">
+                   <!-- Run 'native2ascii' to encode UTF-8 characters in properties files. Place the resulting file(s) in /target -->
+                   <native2ascii encoding="UTF8" src="${root.basedir}" dest="${root.basedir}/target" includes="*.properties" />
+                 </target>
+               </configuration>
                <goals>
                  <goal>run</goal>
                </goals>


### PR DESCRIPTION
This DS-1867 fix ensures the 'native2ascii' call uses 'root.basedir' and not 'basedir' (whose value changes based on which submodule you are running 'mvn' from).  This will ensure 'native2ascii' will also work properly when 'mvn' is called  [src]/dspace/.

https://jira.duraspace.org/browse/DS-1867

This PR also some minor cleanup of the POM, based on the best practice docs for using 'maven-antrun-plugin':
https://maven.apache.org/plugins/maven-antrun-plugin/usage.html

I've tested this, and running "mvn clean" followed by "mvn package" now seems to work fine from _both_ [src] and [src]/dspace/.  However, we may wish to have others also verify it is working, just to ensure I haven't overlooked anything.
