### PR TITLE
DS-1857 Unhandled exception in BTE batch import when uploading CSV files with misconfiguration options

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -436,12 +436,12 @@
         <dependency>
             <groupId>gr.ekt.bte</groupId>
             <artifactId>bte-core</artifactId>
-            <version>0.9.2.2</version>
+            <version>0.9.3.2</version>
         </dependency>
         <dependency>
             <groupId>gr.ekt.bte</groupId>
             <artifactId>bte-io</artifactId>
-            <version>0.9.2.2</version>
+            <version>0.9.3.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -436,12 +436,12 @@
         <dependency>
             <groupId>gr.ekt.bte</groupId>
             <artifactId>bte-core</artifactId>
-            <version>0.9.3.2</version>
+            <version>0.9.3.3</version>
         </dependency>
         <dependency>
             <groupId>gr.ekt.bte</groupId>
             <artifactId>bte-io</artifactId>
-            <version>0.9.3.2</version>
+            <version>0.9.3.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -715,7 +715,7 @@ public class ItemImport
         	} catch (Exception e) {
         		System.err.println("Exception");
         		e.printStackTrace();
-        		throw e;
+        		//throw e;
         	}
 
         	ItemImport myloader = new ItemImport();
@@ -762,8 +762,7 @@ public class ItemImport
 
         if (d == null || !d.isDirectory())
         {
-            System.out.println("Error, cannot open source directory " + sourceDir);
-            System.exit(1);
+            throw new Exception("Error, cannot open source directory " + sourceDir);
         }
 
         String[] dircontents = d.list(directoryFilter);
@@ -793,9 +792,8 @@ public class ItemImport
 
         if (d == null || !d.isDirectory())
         {
-            System.out.println("Error, cannot open source directory "
+            throw new Exception("Error, cannot open source directory "
                     + sourceDir);
-            System.exit(1);
         }
 
         // read in HashMap first, to get list of handles & source dirs

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -715,6 +715,7 @@ public class ItemImport
         	} catch (Exception e) {
         		System.err.println("Exception");
         		e.printStackTrace();
+        		throw e;
         	}
 
         	ItemImport myloader = new ItemImport();

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -715,7 +715,7 @@ public class ItemImport
         	} catch (Exception e) {
         		System.err.println("Exception");
         		e.printStackTrace();
-        		//throw e;
+        		throw e;
         	}
 
         	ItemImport myloader = new ItemImport();

--- a/dspace/config/spring/api/bte.xml
+++ b/dspace/config/spring/api/bte.xml
@@ -284,13 +284,13 @@
 	<bean id="csvDataLoader" class="gr.ekt.bteio.loaders.CSVDataLoader">
 		<property name="fieldMap">
 			<map>
-				<entry key="1" value="title" />
-				<entry key="0" value="authors" />
+				<entry key="0" value="title" />
+				<entry key="1" value="authors" />
 				<entry key="2" value="issued" />
 				<entry key="3" value="journal" />
-				<entry key="14" value="abstract" />
-				<entry key="31" value="jissn" />
-				<entry key="38" value="subtype" />
+				<entry key="4" value="abstract" />
+				<entry key="5" value="jissn" />
+				<entry key="6" value="subtype" />
 			</map>
 		</property>
 		<property name="skipLines" value="1" />
@@ -302,13 +302,13 @@
 	<bean id="tsvDataLoader" class="gr.ekt.bteio.loaders.CSVDataLoader">
 		<property name="fieldMap">
 			<map>
-				<entry key="7" value="Title" />
-				<entry key="1" value="Author" />
-				<entry key="37" value="Year" />
-				<entry key="8" value="Journal" />
-				<entry key="19" value="Abstract" />
-				<entry key="31" value="ISSN" />
-				<entry key="0" value="Type" />
+				<entry key="0" value="title" />
+				<entry key="1" value="authors" />
+				<entry key="2" value="issued" />
+				<entry key="3" value="journal" />
+				<entry key="4" value="abstract" />
+				<entry key="5" value="jissn" />
+				<entry key="6" value="subtype" />
 			</map>
 		</property>
 		<!-- This makes the CSV data loader able to load TSV data -->


### PR DESCRIPTION
The batch import would terminate the tomcat running DSpace 4.0, if the file the user was trying to upload did not conform to the format defined in the BTE spring configuration. For instance if the configuration expected 5 columns when uploading a CSV, but only 4 existed actually in the file the CSVDataLoader would throw an Exception that would eventually execute a System.exit(1).

This PR, fixes this bug, and updates the dependencies to the latest BTE version.

Relevant jira issue: https://jira.duraspace.org/browse/DS-1857
