### PR TITLE
DS-1887 assembly descriptor namespace

### DIFF
--- a/dspace/src/main/assembly/assembly.xml
+++ b/dspace/src/main/assembly/assembly.xml
@@ -12,9 +12,9 @@
     This assembly creates the 'target/dspace-[version]-build/' which can
     then be installed via Apache Ant.
 -->
-<assembly xmlns="http://maven.apache.org/POM/4.0.0"
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/assembly-1.1.0-SNAPSHOT.xsd">
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
    <id>build</id>
    <formats>
       <format>dir</format>


### PR DESCRIPTION
assembly descriptor uses the wrong namespace
updated namespace

https://jira.duraspace.org/browse/DS-1887
