### PR TITLE
DS-1596 fix : Display error messages in your XMLUI theme

### DIFF
--- a/dspace-xmlui/src/main/webapp/exception2dri.xslt
+++ b/dspace-xmlui/src/main/webapp/exception2dri.xslt
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+-->
+
+<!-- 
+
+This stylesheet is used to transform Cocoon XML exceptions into
+valid DRI (Digital Repository Interface) XML. That way the exceptions
+can be displayed within your existing DSpace theme (e.g. Mirage).
+
+Created by Tim Donohue
+
+-->
+
+<xsl:stylesheet version="1.0"
+                xmlns="http://di.tamu.edu/DRI/1.0/"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:ex="http://apache.org/cocoon/exception/1.0"
+                xmlns:i18n="http://apache.org/cocoon/i18n/2.1">
+  
+  <!-- let sitemap override default page title -->
+  <xsl:param name="pageTitle"><xsl:value-of select="/ex:exception-report/ex:message"/></xsl:param>
+
+  <!-- let sitemap override default context path -->
+  <xsl:param name="contextPath">/</xsl:param>
+
+  <xsl:template match="ex:exception-report">
+    <document version="1.1">
+      <body>
+        <div id="exception">
+          <head><xsl:value-of select="$pageTitle"/></head>
+          <p></p>
+          <p>
+            <xref><xsl:attribute name="target"><xsl:value-of select="$contextPath"/></xsl:attribute><i18n:text>xmlui.general.go_home</i18n:text></xref>
+          </p>
+          <p>
+            <!-- TODO: This should be moved to an I18N message key -->
+            Please contact your <xref><xsl:attribute name="target"><xsl:value-of select="$contextPath"/>/contact</xsl:attribute>site administrators</xref> if you have any questions about this error message. 
+          </p>
+          <!-- Include the full stacktrace in the page, but hide it from view. -->
+          <p rend="hidden">
+            <xsl:apply-templates select="ex:full-stacktrace"/>
+          </p>
+        </div>
+      </body>
+      <options/>
+      <meta>
+        <userMeta/>
+        <!-- Add basic error page metadata -->
+        <pageMeta>
+          <metadata element="contextPath"><xsl:value-of select="$contextPath"/></metadata>
+          <metadata element="title"><xsl:value-of select="$pageTitle"/></metadata>
+          <trail>
+            <xsl:attribute name="target"><xsl:value-of select="$contextPath"/></xsl:attribute>
+            <i18n:text>xmlui.general.dspace_home</i18n:text>
+          </trail>
+        </pageMeta>
+        <repositoryMeta/>
+      </meta>
+    </document>
+  </xsl:template>
+
+  <xsl:template match="ex:full-stacktrace">
+       <hi>Java <xsl:value-of select="translate(local-name(), '-', ' ')"/></hi>
+       <br/>
+       <xsl:value-of select="translate(.,'&#13;','')"/>
+  </xsl:template>
+  
+</xsl:stylesheet>

--- a/dspace-xmlui/src/main/webapp/exception2dri.xslt
+++ b/dspace-xmlui/src/main/webapp/exception2dri.xslt
@@ -41,12 +41,19 @@ Created by Tim Donohue
             <xref><xsl:attribute name="target"><xsl:value-of select="$contextPath"/>/</xsl:attribute><i18n:text>xmlui.general.go_home</i18n:text></xref>
           </p>
           <p>
-            <!-- TODO: This should be moved to an I18N message key -->
-            Please contact your <xref><xsl:attribute name="target"><xsl:value-of select="$contextPath"/>/contact</xsl:attribute>site administrators</xref> if you have any questions about this error message. 
+            <i18n:text>xmlui.error.contact_msg</i18n:text>
           </p>
-          <!-- Include the full stacktrace in the page, but hide it from view. -->
-          <p rend="hidden">
-            <xsl:apply-templates select="ex:full-stacktrace"/>
+          <p>
+            <xref><xsl:attribute name="target"><xsl:value-of select="$contextPath"/>/contact</xsl:attribute><i18n:text>xmlui.error.contact</i18n:text></xref> 
+          </p>
+          <p></p>
+          <!-- Create a link which lets users optionally display the error stacktrace (using JQuery) -->
+          <p>
+            <xref target="javascript:jQuery('#errorstack').show().css('visibility','visible');"><i18n:text>xmlui.error.show_stack</i18n:text></xref>
+          </p>
+          <!-- Include the Java stacktrace on the page, but hide it from view by default. -->
+          <p id="errorstack" rend="pre hidden">
+            <xsl:apply-templates select="ex:stacktrace"/>
           </p>
         </div>
       </body>
@@ -67,10 +74,12 @@ Created by Tim Donohue
     </document>
   </xsl:template>
 
-  <xsl:template match="ex:full-stacktrace">
-       <hi>Java <xsl:value-of select="translate(local-name(), '-', ' ')"/></hi>
-       <br/>
-       <xsl:value-of select="translate(.,'&#13;','')"/>
+  <!-- Display Java error stack -->
+  <xsl:template match="ex:stacktrace">
+       <hi rend="bold">Java <xsl:value-of select="translate(local-name(), '-', ' ')"/>:</hi>
+       <hi>
+         <xsl:value-of select="translate(.,'&#13;','')"/>
+       </hi>
   </xsl:template>
-  
+ 
 </xsl:stylesheet>

--- a/dspace-xmlui/src/main/webapp/exception2dri.xslt
+++ b/dspace-xmlui/src/main/webapp/exception2dri.xslt
@@ -38,7 +38,7 @@ Created by Tim Donohue
           <head><xsl:value-of select="$pageTitle"/></head>
           <p></p>
           <p>
-            <xref><xsl:attribute name="target"><xsl:value-of select="$contextPath"/></xsl:attribute><i18n:text>xmlui.general.go_home</i18n:text></xref>
+            <xref><xsl:attribute name="target"><xsl:value-of select="$contextPath"/>/</xsl:attribute><i18n:text>xmlui.general.go_home</i18n:text></xref>
           </p>
           <p>
             <!-- TODO: This should be moved to an I18N message key -->

--- a/dspace-xmlui/src/main/webapp/exception2html.xslt
+++ b/dspace-xmlui/src/main/webapp/exception2html.xslt
@@ -14,6 +14,11 @@
 This stylsheet to handle exception display is a modified version of the
 base apache cocoon stylesheet, this is still under the Apache license.
 
+In DSpace, this stylesheet is ONLY used when major exceptions occur. DSpace will
+first attempt to use 'exception2dri.xsl' in order to display the error within your
+DSpace theme. However, if that fails (or the Theme is not configured properly), then
+DSpace will fallback to using this stylesheet to generate an un-themed exception display.
+
 The original author is unknown.
 Scott Phillips adapted it for Manakin's need.
 

--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -38,6 +38,11 @@
         <message key="xmlui.general.perform">Perform</message>
         <message key="xmlui.general.queue">Queue</message>
 
+        <!-- Keys which are used by exception2dri.xsl on error pages -->
+        <message key="xmlui.error.contact_msg">Please contact the site administrator if you wish to report this error. If possible, please  provide details about what you were doing at the time this error occurred.</message>
+        <message key="xmlui.error.contact">Contact site administrator</message>
+        <message key="xmlui.error.show_stack">Show underlying error stack</message>
+
 	<!--
 		Page not found keys
 

--- a/dspace-xmlui/src/main/webapp/themes/Classic/lib/style.css
+++ b/dspace-xmlui/src/main/webapp/themes/Classic/lib/style.css
@@ -821,6 +821,10 @@ form.discover-sort-box select{
     visibility:hidden;
 }
 
+.pre {
+    white-space:pre;
+}
+
 .icon-button{
     padding:4px;
     cursor: pointer;

--- a/dspace-xmlui/src/main/webapp/themes/Classic/sitemap.xmap
+++ b/dspace-xmlui/src/main/webapp/themes/Classic/sitemap.xmap
@@ -8,7 +8,100 @@
     http://www.dspace.org/license/
 
 -->
+<!-- HOW A DSPACE THEME IS PROCESSED IN 5 STEPS:
+
+          1: Generate the DRI (XML) page
+
+                The first step is to generate a DRI page for the request;
+                this is handled by the Aspect chain. Once it is generated
+                it is the beginning of a theme's pipeline, the DRI page is
+                ultimately transformed in the resulting XHTML that is
+                given to the user's browser.
+
+          2: Add page metadata (to DRI) - see "transform-to-xhtml" resource
+
+                The next step is to add theme specific metadata to the
+                DRI page. This is metadata about where the theme is
+                located and its name. Typically this metadata is different
+                depending on the users browser, this allows us to give
+                different stylesheets to Internet Explorer than for other browsers.
+
+          3: Transform DRI to XHTML (via XSLT) - see "transform-to-xhtml" resource
+
+                The third step is the main component of a theme. The XSL
+                transformations will turn the DRI page from the aspects
+                into an XHTML page useable by browsers.
+
+          4: Localize the page (by replacing i18n tags) - see "transform-to-xhtml" resource
+
+                The second to last step is to localize the content for the
+                particular user, if they user is requesting a page in a
+                particular language then those language strings are inserted
+                into the resulting XHTML.
+
+          5: Serialize to the browser
+
+                The last step sends the XHTML page to the user's browser.
+-->
 <map:sitemap xmlns:map="http://apache.org/cocoon/sitemap/1.0">
+        <!-- Define global resources that are used in multiple areas of the pipeline. -->
+        <map:resources>
+            <!--
+               This "transform-to-xhtml" resource is in charge of transforming DRI to XHTML.
+               It expects a pre-generated DRI page. It adds needed CSS/JS references to that DRI,
+               and then transforms it to XHTML using the Theme's XSLT(s).
+               Please note: this Sitemap 'resource' can be called from multiple places (almost like a function).
+            -->
+            <map:resource name="transform-to-xhtml">
+                <!-- Add page metadata to DRI -->
+                <!-- This adds all Stylesheets (CSS) and Javascript (js) into the DRI XML,
+                     so that they are accessible to the XSLTs -->
+                <map:select type="browser">
+                    <!-- Internet explorer 6 -->
+                    <map:when test="explorer6">
+                        <map:transform type="IncludePageMeta">
+                            <map:parameter name="stylesheet.screen#1" value="lib/style.css"/>
+                            <map:parameter name="stylesheet.screen#2" value="lib/style-ie6.css"/>
+                            <map:parameter name="stylesheet.screen#3" value="lib/jquery-ui-1.8.15.custom.css"/>
+
+                            <map:parameter name="javascript#1" value="lib/jquery-1.6.2.min.js"/>
+                            <map:parameter name="javascript#2" value="lib/jquery-ui-1.8.15.custom.min.js"/>
+
+                            <map:parameter name="theme.path" value="{global:theme-path}"/>
+                            <map:parameter name="theme.name" value="{global:theme-name}"/>
+                        </map:transform>
+                    </map:when>
+                    <!-- The theme has been tested with firefox 2.0 & i.e. 7.0 -->
+                    <map:otherwise>
+                        <map:transform type="IncludePageMeta">
+                            <map:parameter name="stylesheet.screen" value="lib/style.css"/>
+                            <map:parameter name="stylesheet.screen#2" value="lib/jquery-ui-1.8.15.custom.css"/>
+
+                            <map:parameter name="javascript#1" value="lib/jquery-1.6.2.min.js"/>
+                            <map:parameter name="javascript#2" value="lib/jquery-ui-1.8.15.custom.min.js"/>
+                            <map:parameter name="theme.path" value="{global:theme-path}"/>
+                            <map:parameter name="theme.name" value="{global:theme-name}"/>
+                        </map:transform>
+                    </map:otherwise>
+                </map:select>
+ 
+                <!-- Debugging output (this is only called when ?XML is passed on querystring) -->
+                <!-- It allows developers to view the final DRI XML, in order to build/debug theme XSLTs -->
+                <map:match type="request" pattern="XML">
+                    <map:serialize type="xml"/>
+                </map:match>
+
+                <!-- Transform DRI to XHTML using the Theme's XSLT(s) -->
+                <map:transform src="Classic.xsl"/>
+
+                <!-- Localize the XHTML page (by replacing i18n tags) -->
+                <map:act type="locale">
+                    <map:transform type="i18n">
+                        <map:parameter name="locale" value="{locale}"/>
+                    </map:transform>
+                </map:act>                
+            </map:resource>
+        </map:resources>
 	<map:pipelines>
 		
 		<map:component-configurations>
@@ -38,57 +131,54 @@
 			<map:match pattern="**">
 				
 				<!-- Step 1: Generate the DRI page -->
+                                <!-- This line actually initiates the Aspect chain. The Aspect chain will build
+                                     the DRI (XML) content based on which page the user is accessing. -->
 				<map:generate type="file" src="cocoon://DRI/{1}"/>
 				
-				<!-- Step 2 Add page metadata -->
-				<map:select type="browser">
-					<!-- Internet explorer 6 -->
-					<map:when test="explorer6">
-						<map:transform type="IncludePageMeta">
-							<map:parameter name="stylesheet.screen#1" value="lib/style.css"/>
-							<map:parameter name="stylesheet.screen#2" value="lib/style-ie6.css"/>
-                            <map:parameter name="stylesheet.screen#3" value="lib/jquery-ui-1.8.15.custom.css"/>
-
-                            <map:parameter name="javascript#1" value="lib/jquery-1.6.2.min.js"/>
-                            <map:parameter name="javascript#2" value="lib/jquery-ui-1.8.15.custom.min.js"/>
-
-							<map:parameter name="theme.path" value="{global:theme-path}"/>
-							<map:parameter name="theme.name" value="{global:theme-name}"/>
-						</map:transform>
-					</map:when>
-					<!-- The theme has been tested with firefox 2.0 & i.e. 7.0 -->
-					<map:otherwise>
-						<map:transform type="IncludePageMeta">
-							<map:parameter name="stylesheet.screen" value="lib/style.css"/>
-							<map:parameter name="stylesheet.screen#2" value="lib/jquery-ui-1.8.15.custom.css"/>
-
-							<map:parameter name="javascript#1" value="lib/jquery-1.6.2.min.js"/>
-							<map:parameter name="javascript#2" value="lib/jquery-ui-1.8.15.custom.min.js"/>
-							<map:parameter name="theme.path" value="{global:theme-path}"/>
-							<map:parameter name="theme.name" value="{global:theme-name}"/>
-						</map:transform>
-					</map:otherwise>
-				</map:select>
+                                <!-- Step 2: Transform the DRI page into XHTML -->
+                                <!-- This line calls the resource named 'transform-to-xhtml' (included above). 
+                                     That resource is in charge of tranforming this DRI content into XHTML -->
+                                <map:call resource="transform-to-xhtml"/>
 				
-				<!-- Debuging output -->
-				<map:match type="request" pattern="XML">
-					<map:serialize type="xml"/>
-				</map:match>
-				
-				<!-- Step 3: Transform to XHTML -->
-				<map:transform src="Classic.xsl"/>
-				
-				<!-- Step 4: Localize the page -->
-				<map:act type="locale">
-					<map:transform type="i18n">
-						<map:parameter name="locale" value="{locale}"/>						
-					</map:transform>
-				</map:act>
-				
-				<!-- Step 5: Serialize to the browser -->
+				<!-- Step 3: Serialize to the browser -->
 				<map:serialize type="xhtml"/>
 				
 			</map:match>
 		</map:pipeline>
+
+                <!--
+                    Handle any errors which are thrown during any step in the above pipelines.
+                    This would include simple invalid URL errors (404 page not found), as well as
+                    any errors that may occur from the Aspect chain, or from the Theme itself.
+                -->
+                <map:handle-errors>
+                    <!-- Step 1: Tell Cocoon to generate an XML formatted exception message -->
+                    <map:generate type="exception"/>
+
+                    <!-- Step 2: Transform that Cocoon XML exception into valid DRI (using exception2dri.xslt)-->
+                    <map:transform src="../../exception2dri.xslt">
+                        <map:parameter name="contextPath" value="{request:contextPath}"/>
+                    </map:transform>
+
+                    <!-- Step 3: Transform that DRI formatted exception into XHTML (using our Theme) -->
+                    <map:call resource="transform-to-xhtml"/>
+
+                    <!-- Step 4: Serialize XHTML page to user's brower. Based on the type of error,
+                         provide a different HTTP response code. -->
+                    <map:select type="exception">
+                        <!-- HTTP 400 Bad Request -->
+                        <map:when test="bad-request">
+                            <map:serialize type="xhtml" status-code="400"/>
+                        </map:when>
+                        <!-- HTTP 404 Page Not Found -->
+                        <map:when test="not-found">
+                            <map:serialize type="xhtml" status-code="404"/>
+                        </map:when>
+                        <!-- All other errors (HTTP 500 Internal Server Error) -->
+                        <map:otherwise>
+                            <map:serialize type="xhtml" status-code="500"/>
+                        </map:otherwise>
+                    </map:select>
+                </map:handle-errors>
 	</map:pipelines>
 </map:sitemap>

--- a/dspace-xmlui/src/main/webapp/themes/Kubrick/lib/css/style.css
+++ b/dspace-xmlui/src/main/webapp/themes/Kubrick/lib/css/style.css
@@ -1987,3 +1987,8 @@ margin: 2px 2px 0px 2px;
 #ds-language-selection {
 text-align: right;
 }
+
+.hidden {
+display:none;
+visibility:hidden;
+}

--- a/dspace-xmlui/src/main/webapp/themes/Kubrick/lib/css/style.css
+++ b/dspace-xmlui/src/main/webapp/themes/Kubrick/lib/css/style.css
@@ -1992,3 +1992,7 @@ text-align: right;
 display:none;
 visibility:hidden;
 }
+
+.pre {
+    white-space:pre;
+}

--- a/dspace-xmlui/src/main/webapp/themes/Kubrick/sitemap.xmap
+++ b/dspace-xmlui/src/main/webapp/themes/Kubrick/sitemap.xmap
@@ -8,8 +8,140 @@
     http://www.dspace.org/license/
 
 -->
+<!-- HOW A DSPACE THEME IS PROCESSED IN 5 STEPS:
+
+          1: Generate the DRI (XML) page
+
+                The first step is to generate a DRI page for the request;
+                this is handled by the Aspect chain. Once it is generated
+                it is the beginning of a theme's pipeline, the DRI page is
+                ultimately transformed in the resulting XHTML that is
+                given to the user's browser.
+
+          2: Add page metadata (to DRI) - see "transform-to-xhtml" resource
+
+                The next step is to add theme specific metadata to the
+                DRI page. This is metadata about where the theme is
+                located and its name. Typically this metadata is different
+                depending on the users browser, this allows us to give
+                different stylesheets to Internet Explorer than for other browsers.
+
+          3: Transform DRI to XHTML (via XSLT) - see "transform-to-xhtml" resource
+
+                The third step is the main component of a theme. The XSL
+                transformations will turn the DRI page from the aspects
+                into an XHTML page useable by browsers.
+
+          4: Localize the page (by replacing i18n tags) - see "transform-to-xhtml" resource
+
+                The second to last step is to localize the content for the
+                particular user, if they user is requesting a page in a
+                particular language then those language strings are inserted
+                into the resulting XHTML.
+
+          5: Serialize to the browser
+
+                The last step sends the XHTML page to the user's browser.
+-->
 <map:sitemap xmlns:map="http://apache.org/cocoon/sitemap/1.0">
-	<map:pipelines>
+        <!-- Define global resources that are used in multiple areas of the pipeline. -->
+        <map:resources>
+            <!--
+               This "transform-to-xhtml" resource is in charge of transforming DRI to XHTML.
+               It expects a pre-generated DRI page. It adds needed CSS/JS references to that DRI,
+               and then transforms it to XHTML using the Theme's XSLT(s).
+               Please note: this Sitemap 'resource' can be called from multiple places (almost like a function).
+            -->
+            <map:resource name="transform-to-xhtml">
+                <!-- Add page metadata to DRI -->
+                <!-- This adds all Stylesheets (CSS) and Javascript (js) into the DRI XML,
+                     so that they are accessible to the XSLTs -->
+                <!-- Step 2 Add page metadata -->
+                <map:select type="browser">
+                    <map:when test="explorer6">
+                        <map:transform type="IncludePageMeta">
+                            <map:parameter name="stylesheet.screen#1" value="lib/css/style.css"/>
+                            <map:parameter name="stylesheet.screen#2" value="lib/css/style-ie6.css"/>
+                            <map:parameter name="stylesheet.screen#3" value="lib/jquery-ui-1.8.15.custom.css"/>
+
+                            <map:parameter name="javascript#1" value="lib/jquery-1.2.min.js"/>
+                            <map:parameter name="javascript#2" value="lib/kubrick-jquery.js"/>
+                            <map:parameter name="javascript#3" value="lib/jquery-ui-1.8.15.custom.min.js"/>
+                            <map:parameter name="theme.path" value="{global:theme-path}"/>
+                            <map:parameter name="theme.name" value="{global:theme-name}"/>
+                        </map:transform>
+                    </map:when>
+                    <map:when test="explorer7">
+                        <map:transform type="IncludePageMeta">
+                            <map:parameter name="stylesheet.screen#1" value="lib/css/style.css"/>
+                            <map:parameter name="stylesheet.screen#2" value="lib/css/style-ie7.css"/>
+                            <map:parameter name="stylesheet.screen#3" value="lib/jquery-ui-1.8.15.custom.css"/>
+
+                            <map:parameter name="javascript#1" value="lib/jquery-1.2.min.js"/>
+                            <map:parameter name="javascript#2" value="lib/kubrick-jquery.js"/>
+                            <map:parameter name="javascript#3" value="lib/jquery-ui-1.8.15.custom.min.js"/>
+                            <map:parameter name="theme.path" value="{global:theme-path}"/>
+                            <map:parameter name="theme.name" value="{global:theme-name}"/>
+                        </map:transform>
+                    </map:when>
+                    <map:when test="safari2">
+                        <map:transform type="IncludePageMeta">
+                            <map:parameter name="stylesheet.screen#1" value="lib/css/style.css"/>
+                            <map:parameter name="stylesheet.screen#3" value="lib/css/style-safari2.css"/>
+                            <map:parameter name="stylesheet.screen#4" value="lib/jquery-ui-1.8.15.custom.css"/>
+
+                            <map:parameter name="javascript#1" value="lib/jquery-1.2.min.js"/>
+                            <map:parameter name="javascript#2" value="lib/kubrick-jquery.js"/>
+                            <map:parameter name="javascript#3" value="lib/jquery-ui-1.8.15.custom.min.js"/>
+                            <map:parameter name="theme.path" value="{global:theme-path}"/>
+                            <map:parameter name="theme.name" value="{global:theme-name}"/>
+                        </map:transform>
+                    </map:when>
+                    <map:when test="safari3">
+                        <map:transform type="IncludePageMeta">
+                            <map:parameter name="stylesheet.screen#1" value="lib/css/style.css"/>
+                            <map:parameter name="stylesheet.screen#3" value="lib/css/style-safari3.css"/>
+                            <map:parameter name="stylesheet.screen#4" value="lib/jquery-ui-1.8.15.custom.css"/>
+
+                            <map:parameter name="javascript#1" value="lib/jquery-1.2.min.js"/>
+                            <map:parameter name="javascript#2" value="lib/kubrick-jquery.js"/>
+                            <map:parameter name="javascript#3" value="lib/jquery-ui-1.8.15.custom.min.js"/>
+                            <map:parameter name="theme.path" value="{global:theme-path}"/>
+                            <map:parameter name="theme.name" value="{global:theme-name}"/>
+                        </map:transform>
+                    </map:when>
+                    <map:otherwise>
+                        <map:transform type="IncludePageMeta">
+                            <map:parameter name="stylesheet.screen" value="lib/css/style.css"/>
+                            <map:parameter name="stylesheet.screen#2" value="lib/jquery-ui-1.8.15.custom.css"/>
+
+                            <map:parameter name="javascript#1" value="lib/jquery-1.2.min.js"/>
+                            <map:parameter name="javascript#2" value="lib/kubrick-jquery.js"/>
+                            <map:parameter name="javascript#3" value="lib/jquery-ui-1.8.15.custom.min.js"/>
+                            <map:parameter name="theme.path" value="{global:theme-path}"/>
+                            <map:parameter name="theme.name" value="{global:theme-name}"/>
+                        </map:transform>
+                    </map:otherwise>
+                </map:select>
+
+                <!-- Debugging output (this is only called when ?XML is passed on querystring) -->
+                <!-- It allows developers to view the final DRI XML, in order to build/debug theme XSLTs -->
+                <map:match type="request" pattern="XML">
+                    <map:serialize type="xml"/>
+                </map:match>
+
+                <!-- Transform DRI to XHTML using the Theme's XSLT(s) -->
+                <map:transform src="{global:theme-name}.xsl"/>
+
+                <!-- Localize the XHTML page (by replacing i18n tags) -->
+                <map:act type="locale">
+                    <map:transform type="i18n">
+                        <map:parameter name="locale" value="{locale}"/>
+                    </map:transform>
+                </map:act>
+            </map:resource>
+	</map:resources>
+        <map:pipelines>
 		
 		<!-- 
 			Define global theme variables that are used later in this 
@@ -52,140 +184,56 @@
 			<!-- Never allow the browser to cache dynamic content -->
 			<map:parameter name="expires" value="now"/>
 			
-			<!-- Aspect content 
-			
-			There are five steps to processing aspect content:
-				
-			1: Generate the DRI page
-				
-				The first step is to generate a DRI page for the request; 
-				this is handled by the aspect chain. Once it is generated 
-				it is the beginning of a theme's pipeline, the DRI page is 
-				ultimately transformed in the resulting XHTML that is 
-				given to the user's browser.
-				
-			2: Add page metadata
-				
-				The next step is to add theme specific metadata to the 
-				DRI page. This is metadata about where the theme is 
-				located and its name. Typically this metadata is different 
-				depending on the users browser, this allows us to give 
-				different stylesheets to Internet Explorer than for other 
-				browsers.
-				
-			3: Transform to XHTML
-				
-				The third step is the main component of a theme the XSL 
-				transformations will turn the DRI page from the aspects 
-				into an XHTML page useable by browsers. 
-				
-			4: Localize the page
-				
-				The second to last step is to localize the content for the 
-				particular user, if they user is requesting a page in a 
-				particular language then those language strings are inserted 
-				into the resulting XHTML.  
-				
-			5: Serialize to the browser
-				
-				The last step sends the page to the user's browser. 
-				
-			-->
 			<map:match pattern="**">
 				
 				<!-- Step 1: Generate the DRI page -->
+                                <!-- This line actually initiates the Aspect chain. The Aspect chain will build
+                                     the DRI (XML) content based on which page the user is accessing. -->
 				<map:generate type="file" src="cocoon://DRI/{1}"/>
 				
-				<!-- Step 2 Add page metadata -->
-				<map:select type="browser">
-					<map:when test="explorer6">
-						<map:transform type="IncludePageMeta">
-							<map:parameter name="stylesheet.screen#1" value="lib/css/style.css"/>
-							<map:parameter name="stylesheet.screen#2" value="lib/css/style-ie6.css"/>
-							<map:parameter name="stylesheet.screen#3" value="lib/jquery-ui-1.8.15.custom.css"/>
-
-							<map:parameter name="javascript#1" value="lib/jquery-1.2.min.js"/>
-							<map:parameter name="javascript#2" value="lib/kubrick-jquery.js"/>
-							<map:parameter name="javascript#3" value="lib/jquery-ui-1.8.15.custom.min.js"/>
-							<map:parameter name="theme.path" value="{global:theme-path}"/>
-							<map:parameter name="theme.name" value="{global:theme-name}"/>
-						</map:transform>
-
-
-					</map:when>
-					<map:when test="explorer7">
-						<map:transform type="IncludePageMeta">
-							<map:parameter name="stylesheet.screen#1" value="lib/css/style.css"/>
-							<map:parameter name="stylesheet.screen#2" value="lib/css/style-ie7.css"/>
-							<map:parameter name="stylesheet.screen#3" value="lib/jquery-ui-1.8.15.custom.css"/>
-
-							<map:parameter name="javascript#1" value="lib/jquery-1.2.min.js"/>
-							<map:parameter name="javascript#2" value="lib/kubrick-jquery.js"/>
-							<map:parameter name="javascript#3" value="lib/jquery-ui-1.8.15.custom.min.js"/>
-							<map:parameter name="theme.path" value="{global:theme-path}"/>
-							<map:parameter name="theme.name" value="{global:theme-name}"/>
-						</map:transform>
-					</map:when>
-					<map:when test="safari2">
-						<map:transform type="IncludePageMeta">
-							<map:parameter name="stylesheet.screen#1" value="lib/css/style.css"/>
-							<map:parameter name="stylesheet.screen#3" value="lib/css/style-safari2.css"/>
-							<map:parameter name="stylesheet.screen#4" value="lib/jquery-ui-1.8.15.custom.css"/>
-
-							<map:parameter name="javascript#1" value="lib/jquery-1.2.min.js"/>
-							<map:parameter name="javascript#2" value="lib/kubrick-jquery.js"/>
-							<map:parameter name="javascript#3" value="lib/jquery-ui-1.8.15.custom.min.js"/>
-							<map:parameter name="theme.path" value="{global:theme-path}"/>
-							<map:parameter name="theme.name" value="{global:theme-name}"/>
-						</map:transform>
-					</map:when>
-					<map:when test="safari3">
-						<map:transform type="IncludePageMeta">
-							<map:parameter name="stylesheet.screen#1" value="lib/css/style.css"/>
-							<map:parameter name="stylesheet.screen#3" value="lib/css/style-safari3.css"/>
-							<map:parameter name="stylesheet.screen#4" value="lib/jquery-ui-1.8.15.custom.css"/>
-
-							<map:parameter name="javascript#1" value="lib/jquery-1.2.min.js"/>
-							<map:parameter name="javascript#2" value="lib/kubrick-jquery.js"/>
-							<map:parameter name="javascript#3" value="lib/jquery-ui-1.8.15.custom.min.js"/>
-							<map:parameter name="theme.path" value="{global:theme-path}"/>
-							<map:parameter name="theme.name" value="{global:theme-name}"/>
-						</map:transform>
-					</map:when>
-					<map:otherwise>
-						<map:transform type="IncludePageMeta">
-							<map:parameter name="stylesheet.screen" value="lib/css/style.css"/>
-							<map:parameter name="stylesheet.screen#2" value="lib/jquery-ui-1.8.15.custom.css"/>
-
-							<map:parameter name="javascript#1" value="lib/jquery-1.2.min.js"/>
-							<map:parameter name="javascript#2" value="lib/kubrick-jquery.js"/>
-							<map:parameter name="javascript#3" value="lib/jquery-ui-1.8.15.custom.min.js"/>
-							<map:parameter name="theme.path" value="{global:theme-path}"/>
-							<map:parameter name="theme.name" value="{global:theme-name}"/>
-						</map:transform>
-					</map:otherwise>
-				</map:select>
+                                <!-- Step 2: Transform the DRI page into XHTML -->
+                                <!-- This line calls the resource named 'transform-to-xhtml' (included above). 
+                                     That resource is in charge of tranforming this DRI content into XHTML -->
+                                <map:call resource="transform-to-xhtml"/>
 				
-				<!-- Debuging output -->
-				<map:match type="request" pattern="XML">
-					<map:serialize type="xml"/>
-				</map:match>
-				
-				<!-- Step 3: Transform to XHTML -->
-				<map:transform src="{global:theme-name}.xsl"/>
-			    <!-- <map:transform src="template.xsl"/> -->
-				
-				<!-- Step 4: Localize the page -->
-				<map:act type="locale">
-					<map:transform type="i18n">
-						<map:parameter name="locale" value="{locale}"/>						
-					</map:transform>
-				</map:act>
-				
-				<!-- Step 5: Serialize to the browser -->
+				<!-- Step 3: Serialize to the browser -->
 				<map:serialize type="xhtml"/>
-				
 			</map:match>
 		</map:pipeline>
+
+                <!--
+                    Handle any errors which are thrown during any step in the above pipelines.
+                    This would include simple invalid URL errors (404 page not found), as well as
+                    any errors that may occur from the Aspect chain, or from the Theme itself.
+                -->
+                <map:handle-errors>
+                    <!-- Step 1: Tell Cocoon to generate an XML formatted exception message -->
+                    <map:generate type="exception"/>
+
+                    <!-- Step 2: Transform that Cocoon XML exception into valid DRI (using exception2dri.xslt)-->
+                    <map:transform src="../../exception2dri.xslt">
+                        <map:parameter name="contextPath" value="{request:contextPath}"/>
+                    </map:transform>
+
+                    <!-- Step 3: Transform that DRI formatted exception into XHTML (using our Theme) -->
+                    <map:call resource="transform-to-xhtml"/>
+
+                    <!-- Step 4: Serialize XHTML page to user's brower. Based on the type of error,
+                         provide a different HTTP response code. -->
+                    <map:select type="exception">
+                        <!-- HTTP 400 Bad Request -->
+                        <map:when test="bad-request">
+                            <map:serialize type="xhtml" status-code="400"/>
+                        </map:when>
+                        <!-- HTTP 404 Page Not Found -->
+                        <map:when test="not-found">
+                            <map:serialize type="xhtml" status-code="404"/>
+                        </map:when>
+                        <!-- All other errors (HTTP 500 Internal Server Error) -->
+                        <map:otherwise>
+                            <map:serialize type="xhtml" status-code="500"/>
+                        </map:otherwise>
+                    </map:select>
+                </map:handle-errors>
 	</map:pipelines>
 </map:sitemap>

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/css/style.css
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/css/style.css
@@ -1109,6 +1109,10 @@ form.discover-sort-box select{
     visibility:hidden;
 }
 
+.pre {
+    white-space:pre;
+}
+
 .icon-button{
     padding:4px;
     cursor: pointer;

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/sitemap.xmap
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/sitemap.xmap
@@ -8,8 +8,7 @@
     http://www.dspace.org/license/
 
 -->
-<!-- 
-HOW A DSPACE THEME IS PROCESSED IN 5 STEPS:
+<!-- HOW A DSPACE THEME IS PROCESSED IN 5 STEPS:
           
           1: Generate the DRI (XML) page
 

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/sitemap.xmap
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/sitemap.xmap
@@ -8,6 +8,42 @@
     http://www.dspace.org/license/
 
 -->
+<!-- 
+HOW A DSPACE THEME IS PROCESSED IN 5 STEPS:
+          
+          1: Generate the DRI (XML) page
+
+                The first step is to generate a DRI page for the request;
+                this is handled by the Aspect chain. Once it is generated
+                it is the beginning of a theme's pipeline, the DRI page is
+                ultimately transformed in the resulting XHTML that is
+                given to the user's browser.
+
+          2: Add page metadata (to DRI) - see "transform-to-xhtml" resource
+
+                The next step is to add theme specific metadata to the
+                DRI page. This is metadata about where the theme is
+                located and its name. Typically this metadata is different
+                depending on the users browser, this allows us to give
+                different stylesheets to Internet Explorer than for other browsers.
+
+          3: Transform DRI to XHTML (via XSLT) - see "transform-to-xhtml" resource
+
+                The third step is the main component of a theme. The XSL
+                transformations will turn the DRI page from the aspects
+                into an XHTML page useable by browsers.
+
+          4: Localize the page (by replacing i18n tags) - see "transform-to-xhtml" resource
+
+                The second to last step is to localize the content for the
+                particular user, if they user is requesting a page in a
+                particular language then those language strings are inserted
+                into the resulting XHTML.
+
+          5: Serialize to the browser
+
+                The last step sends the XHTML page to the user's browser.
+-->
 <map:sitemap xmlns:map="http://apache.org/cocoon/sitemap/1.0">
 
     <map:components>
@@ -16,154 +52,167 @@
         </map:readers>
     </map:components>
 
+    <!-- Define global resources that are used in multiple areas of the pipeline. -->
+    <map:resources>
+
+        <!-- 
+             This "transform-to-xhtml" resource is in charge of transforming DRI to XHTML.
+             It expects a pre-generated DRI page. It adds needed CSS/JS references to that DRI,
+             and then transforms it to XHTML using the Theme's XSLT(s).
+             Please note: this Sitemap 'resource' can be called from multiple places (almost like a function).
+        -->
+        <map:resource name="transform-to-xhtml">
+
+            <!-- Add page metadata to DRI -->
+            <!-- This adds all Stylesheets (CSS) and Javascript (js) into the DRI XML, 
+                 so that they are accessible to the XSLTs -->
+            <!-- 3 different IncludePageMeta transformers to ensure that the
+                 stylesheets end up in the correct order-->
+            <map:transform type="IncludePageMeta">
+                <map:parameter name="stylesheet.screen#1" value="lib/css/reset.css"/>
+                <map:parameter name="stylesheet.screen#2" value="lib/css/base.css"/>
+                <map:parameter name="stylesheet.screen#3" value="lib/css/helper.css"/>
+                <map:parameter name="stylesheet.screen#4" value="lib/css/jquery-ui-1.8.15.custom.css"/>
+                <map:parameter name="stylesheet.screen#5" value="lib/css/style.css"/>
+                <map:parameter name="stylesheet.screen#6" value="lib/css/authority-control.css"/>
+            </map:transform>
+            <map:transform type="IncludePageMeta">
+                <map:parameter name="stylesheet.handheld" value="lib/css/handheld.css"/>
+                <map:parameter name="stylesheet.print" value="lib/css/print.css"/>
+            </map:transform>
+            <map:transform type="IncludePageMeta">
+                <map:parameter name="stylesheet.all" value="lib/css/media.css"/>
+                <map:parameter name="javascript" value="lib/js/jquery-ui-1.8.15.custom.min.js"/>
+                <map:parameter name="theme.path" value="{global:theme-path}"/>
+                <map:parameter name="theme.name" value="{global:theme-path}"/>
+            </map:transform>
+
+            <!-- Debugging output (this is only called when ?XML is passed on querystring) -->
+            <!-- It allows developers to view the final DRI XML, in order to build/debug theme XSLTs -->
+            <map:match type="request" pattern="XML">
+                <map:serialize type="xml"/>
+            </map:match>
+                      
+            <!-- Transform DRI to XHTML using the Theme's XSLT(s) -->
+            <map:transform src="{global:theme-path}.xsl"/>
+
+            <!-- Localize the XHTML page (by replacing i18n tags) -->
+            <map:act type="locale">
+                <map:transform type="i18n">
+                    <map:parameter name="locale" value="{locale}"/>
+                </map:transform>
+            </map:act>
+        </map:resource>
+    </map:resources>
+
     <map:pipelines>
 
-		<!--
-			Define global theme variables that are used later in this
-			sitemap. Two variables are typically defined here, the theme's
-			path and name. The path is the directory name where this theme
-			is located, such as "Reference" for the reference theme. The
-			theme's name is used only for descriptive purposes to describe
-			the theme.
-		-->
-		<map:component-configurations>
-			<global-variables>
-				<theme-path>Mirage</theme-path>
-				<theme-name>Mirage</theme-name>
-			</global-variables>
+        <!--
+             Define global theme variables that are used later in this
+             sitemap. Two variables are typically defined here, the theme's
+             path and name. The path is the directory name where this theme
+             is located, such as "Reference" for the reference theme. The
+             theme's name is used only for descriptive purposes to describe
+             the theme.
+        -->
+        <map:component-configurations>
+            <global-variables>
+                <theme-path>Mirage</theme-path>
+                <theme-name>Mirage</theme-name>
+            </global-variables>
         </map:component-configurations>
 
-
-		<map:pipeline>
-			<!-- Allow the browser to cache static content for an hour -->
-			<map:parameter name="expires" value="access plus 1 hours"/>
-
+        <!-- 
+             Caching Pipeline: This caching pipeline handles access to static content (css, js, etc)
+             which is used by this Theme. These static files are simply passed directly to
+             the user's browser without any proccesing.  
+        -->
+        <map:pipeline>
+            <!-- Allow the browser to cache static content for an hour -->
+            <map:parameter name="expires" value="access plus 1 hours"/>
 
             <!-- handle static js and css -->
             <map:match pattern="themes/*/**.js">
-                    <map:read type="ConcatenationReader" src="{2}.js">
-                        <map:parameter name="requestQueryString" value="{request:queryString}"/>
-                    </map:read>
+                <map:read type="ConcatenationReader" src="{2}.js">
+                    <map:parameter name="requestQueryString" value="{request:queryString}"/>
+                </map:read>
             </map:match>
             <map:match pattern="themes/*/**.css">
-                    <map:read type="ConcatenationReader" src="{2}.css">
-                        <map:parameter name="requestQueryString" value="{request:queryString}"/>
-                    </map:read>
+                <map:read type="ConcatenationReader" src="{2}.css">
+                    <map:parameter name="requestQueryString" value="{request:queryString}"/>
+                </map:read>
             </map:match>
             <map:match pattern="themes/*/**.json">
-                    <map:read type="ConcatenationReader" src="{2}.json">
-                        <map:parameter name="requestQueryString" value="{request:queryString}"/>
-                    </map:read>
+                <map:read type="ConcatenationReader" src="{2}.json">
+                    <map:parameter name="requestQueryString" value="{request:queryString}"/>
+                </map:read>
             </map:match>
 
-			<!-- Static content -->
-			<map:match pattern="themes/*/**">
-				<map:read src="{2}"/>
-			</map:match>
-		</map:pipeline>
+            <!-- Static content -->
+            <map:match pattern="themes/*/**">
+                <map:read src="{2}"/>
+            </map:match>
+        </map:pipeline>
 
-		<!--
-			The theme's pipeline is used to process all requests handled
-			by the theme. It is broken up into two parts, the first part
-			handles all static theme content while the second part handle
-			all dynamic aspect generated content. The static content is
-			such things as stylesheets, images, or static pages. Typically
-			these are just stored on disk and passed directly to the
-			browser without any processing.
-		-->
-		<map:pipeline>
-			<!-- Never allow the browser to cache dynamic content -->
-			<map:parameter name="expires" value="now"/>
+        <!--
+             Primary (non-caching) Pipeline: 
+             This pipeline is the one that generates *dynamic* content. It first creates
+             the DRI (XML) by calling the Aspect chain. Then it transforms that DRI
+             into the XHTML page which is passed to the user.
+        -->
+        <map:pipeline>
+            <!-- Never allow the browser to cache dynamic content -->
+            <map:parameter name="expires" value="now"/>
 
-			<!-- Aspect content
+            <map:match pattern="**">
+                <!-- Step 1: Generate the DRI page -->
+                <!-- This line actually initiates the Aspect chain. The Aspect chain will build
+                     the DRI (XML) content based on which page the user is accessing. -->
+                <map:generate type="file" src="cocoon://DRI/{1}"/>
 
-			There are five steps to processing aspect content:
+                <!-- Step 2: Transform the DRI page into XHTML -->
+                <!-- This line calls the resource named 'transform-to-xhtml' (included above). 
+                     That resource is in charge of tranforming this DRI content into XHTML -->
+                <map:call resource="transform-to-xhtml"/>
 
-			1: Generate the DRI page
+                <!-- Step 3: Serialize to the browser (sends final XHTML to user's browser) -->
+                <map:serialize type="xhtml"/>
+            </map:match>
+        </map:pipeline>
+        
+        <!--
+            Handle any errors which are thrown during any step in the above pipelines.
+            This would include simple invalid URL errors (404 page not found), as well as
+            any errors that may occur from the Aspect chain, or from the Theme itself.
+        -->
+        <map:handle-errors>
+            <!-- Step 1: Tell Cocoon to generate an XML formatted exception message -->
+            <map:generate type="exception"/>
 
-				The first step is to generate a DRI page for the request;
-				this is handled by the aspect chain. Once it is generated
-				it is the beginning of a theme's pipeline, the DRI page is
-				ultimately transformed in the resulting XHTML that is
-				given to the user's browser.
+            <!-- Step 2: Transform that Cocoon XML exception into valid DRI (using exception2dri.xslt)-->
+            <map:transform src="../../exception2dri.xslt">
+                <map:parameter name="contextPath" value="{request:contextPath}"/>
+            </map:transform>
 
-			2: Add page metadata
+            <!-- Step 3: Transform that DRI formatted exception into XHTML (using our Theme) -->
+            <map:call resource="transform-to-xhtml"/>
 
-				The next step is to add theme specific metadata to the
-				DRI page. This is metadata about where the theme is
-				located and its name. Typically this metadata is different
-				depending on the users browser, this allows us to give
-				different stylesheets to Internet Explorer than for other
-				browsers.
-
-			3: Transform to XHTML
-
-				The third step is the main component of a theme the XSL
-				transformations will turn the DRI page from the aspects
-				into an XHTML page useable by browsers.
-
-			4: Localize the page
-
-				The second to last step is to localize the content for the
-				particular user, if they user is requesting a page in a
-				particular language then those language strings are inserted
-				into the resulting XHTML.
-
-			5: Serialize to the browser
-
-				The last step sends the page to the user's browser.
-
-			-->
-			<map:match pattern="**">
-
-				<!-- Step 1: Generate the DRI page -->
-				<map:generate type="file" src="cocoon://DRI/{1}"/>
-
-				<!-- Step 2 Add page metadata -->
-
-                <!--3 different IncludePageMeta transformers to ensure that the
-                stylesheets end up in the correct order-->
-                <map:transform type="IncludePageMeta">
-                    <map:parameter name="stylesheet.screen#1" value="lib/css/reset.css"/>
-                    <map:parameter name="stylesheet.screen#2" value="lib/css/base.css"/>
-                    <map:parameter name="stylesheet.screen#3" value="lib/css/helper.css"/>
-                    <map:parameter name="stylesheet.screen#4" value="lib/css/jquery-ui-1.8.15.custom.css"/>
-                    <map:parameter name="stylesheet.screen#5" value="lib/css/style.css"/>
-                    <map:parameter name="stylesheet.screen#6" value="lib/css/authority-control.css"/>
-                </map:transform>
-
-                <map:transform type="IncludePageMeta">
-                    <map:parameter name="stylesheet.handheld" value="lib/css/handheld.css"/>
-                    <map:parameter name="stylesheet.print" value="lib/css/print.css"/>
-                </map:transform>
-
-                <map:transform type="IncludePageMeta">
-                    <map:parameter name="stylesheet.all" value="lib/css/media.css"/>
-                    <map:parameter name="javascript" value="lib/js/jquery-ui-1.8.15.custom.min.js"/>
-                    <map:parameter name="theme.path" value="{global:theme-path}"/>
-                    <map:parameter name="theme.name" value="{global:theme-name}"/>
-                </map:transform>
-
-				<!-- Debuging output -->
-				<map:match type="request" pattern="XML">
-					<map:serialize type="xml"/>
-				</map:match>
-
-				<!-- Step 3: Transform to XHTML -->
-				<map:transform src="{global:theme-name}.xsl"/>
-			    <!-- <map:transform src="Mirage.xsl"/> -->
-
-				<!-- Step 4: Localize the page -->
-				<map:act type="locale">
-					<map:transform type="i18n">
-						<map:parameter name="locale" value="{locale}"/>
-					</map:transform>
-				</map:act>
-
-				<!-- Step 5: Serialize to the browser -->
-				<map:serialize type="xhtml"/>
-
-			</map:match>
-		</map:pipeline>
-	</map:pipelines>
+            <!-- Step 4: Serialize XHTML page to user's brower. Based on the type of error, 
+                         provide a different HTTP response code. -->
+            <map:select type="exception">
+                <!-- HTTP 400 Bad Request -->
+                <map:when test="bad-request">
+                    <map:serialize type="xhtml" status-code="400"/>
+                </map:when>
+                <!-- HTTP 404 Page Not Found -->
+                <map:when test="not-found">
+		    <map:serialize type="xhtml" status-code="404"/>
+                </map:when>
+                <!-- All other errors (HTTP 500 Internal Server Error) -->
+                <map:otherwise>
+                    <map:serialize type="xhtml" status-code="500"/>
+                </map:otherwise>
+            </map:select>
+        </map:handle-errors>
+    </map:pipelines>
 </map:sitemap>

--- a/dspace-xmlui/src/main/webapp/themes/Reference/lib/style.css
+++ b/dspace-xmlui/src/main/webapp/themes/Reference/lib/style.css
@@ -1262,6 +1262,10 @@ form.discover-sort-box select{
     visibility:hidden;
 }
 
+.pre {
+    white-space:pre;
+}
+
 .icon-button{
     padding:4px;
     cursor: pointer;

--- a/dspace-xmlui/src/main/webapp/themes/Reference/sitemap.xmap
+++ b/dspace-xmlui/src/main/webapp/themes/Reference/sitemap.xmap
@@ -8,7 +8,117 @@
     http://www.dspace.org/license/
 
 -->
+<!-- HOW A DSPACE THEME IS PROCESSED IN 5 STEPS:
+
+          1: Generate the DRI (XML) page
+
+                The first step is to generate a DRI page for the request;
+                this is handled by the Aspect chain. Once it is generated
+                it is the beginning of a theme's pipeline, the DRI page is
+                ultimately transformed in the resulting XHTML that is
+                given to the user's browser.
+
+          2: Add page metadata (to DRI) - see "transform-to-xhtml" resource
+
+                The next step is to add theme specific metadata to the
+                DRI page. This is metadata about where the theme is
+                located and its name. Typically this metadata is different
+                depending on the users browser, this allows us to give
+                different stylesheets to Internet Explorer than for other browsers.
+
+          3: Transform DRI to XHTML (via XSLT) - see "transform-to-xhtml" resource
+
+                The third step is the main component of a theme. The XSL
+                transformations will turn the DRI page from the aspects
+                into an XHTML page useable by browsers.
+
+          4: Localize the page (by replacing i18n tags) - see "transform-to-xhtml" resource
+
+                The second to last step is to localize the content for the
+                particular user, if they user is requesting a page in a
+                particular language then those language strings are inserted
+                into the resulting XHTML.
+
+          5: Serialize to the browser
+
+                The last step sends the XHTML page to the user's browser.
+-->
 <map:sitemap xmlns:map="http://apache.org/cocoon/sitemap/1.0">
+        <!-- Define global resources that are used in multiple areas of the pipeline. -->
+        <map:resources>
+            <!-- 
+               This "transform-to-xhtml" resource is in charge of transforming DRI to XHTML.
+               It expects a pre-generated DRI page. It adds needed CSS/JS references to that DRI,
+               and then transforms it to XHTML using the Theme's XSLT(s).
+               Please note: this Sitemap 'resource' can be called from multiple places (almost like a function).
+            -->
+            <map:resource name="transform-to-xhtml">
+                <!-- Add page metadata to DRI -->
+                <!-- This adds all Stylesheets (CSS) and Javascript (js) into the DRI XML, 
+                     so that they are accessible to the XSLTs -->
+                <map:select type="browser">
+                    <map:when test="explorer6">
+                        <map:transform type="IncludePageMeta">
+                            <map:parameter name="stylesheet.screen#1" value="lib/style.css"/>
+                            <map:parameter name="stylesheet.screen#2" value="lib/style-ie.css"/>
+                            <map:parameter name="stylesheet.screen#3" value="lib/style-ie6.css"/>
+                            <map:parameter name="stylesheet.screen#4" value="lib/css/jquery-ui-1.8.15.custom.css"/>
+
+                            <map:parameter name="javascript#1" value="lib/js/jquery-ui-1.8.15.custom.min.js"/>
+
+                            <map:parameter name="theme.path" value="{global:theme-path}"/>
+                            <map:parameter name="theme.name" value="{global:theme-name}"/>
+                        </map:transform>
+                    </map:when>
+                    <map:when test="explorer">
+                        <map:transform type="IncludePageMeta">
+                            <map:parameter name="stylesheet.screen#1" value="lib/style.css"/>
+                            <map:parameter name="stylesheet.screen#2" value="lib/style-ie.css"/>
+                            <map:parameter name="stylesheet.screen#3" value="lib/jquery-ui-1.8.15.custom.css"/>
+
+                            <map:parameter name="javascript#1" value="lib/jquery-1.6.2.min.js"/>
+                            <map:parameter name="javascript#2" value="lib/jquery-ui-1.8.15.custom.min.js"/>
+
+                            <map:parameter name="theme.path" value="{global:theme-path}"/>
+                            <map:parameter name="theme.name" value="{global:theme-name}"/>
+                        </map:transform>
+                    </map:when>
+                    <map:otherwise>
+                        <map:transform type="IncludePageMeta">
+                            <map:parameter name="stylesheet.screen" value="lib/style.css"/>
+                            <map:parameter name="stylesheet.screen#2" value="lib/jquery-ui-1.8.15.custom.css"/>
+
+                            <map:parameter name="javascript#1" value="lib/jquery-1.6.2.min.js"/>
+                            <map:parameter name="javascript#2" value="lib/jquery-ui-1.8.15.custom.min.js"/>
+
+                            <map:parameter name="theme.path" value="{global:theme-path}"/>
+                            <map:parameter name="theme.name" value="{global:theme-name}"/>
+                        </map:transform>
+                    </map:otherwise>
+                </map:select>
+
+                <!-- Debugging output (this is only called when ?XML is passed on querystring) -->
+                <!-- It allows developers to view the final DRI XML, in order to build/debug theme XSLTs -->
+                <map:match type="request" pattern="XML">
+                    <map:serialize type="xml"/>
+                </map:match>
+
+                <!-- Transform DRI to XHTML using the Theme's XSLT(s) -->
+                <map:transform src="../dri2xhtml.xsl"/>
+
+                <!-- Localize the XHTML page (by replacing i18n tags) -->
+                <map:act type="locale">
+                    <map:transform type="i18n">
+                        <map:parameter name="locale" value="{locale}"/>
+                    </map:transform>
+                </map:act>
+
+                <!-- Remove any leftover i18n or dri namespaces from the final document -->
+                <map:transform type="NamespaceFilter" src="http://di.tamu.edu/DRI/1.0/"/>
+                <map:transform type="NamespaceFilter" src="http://apache.org/cocoon/i18n/2.1"/>
+            </map:resource>
+        </map:resources>
+
         <map:pipelines>
                 
                 <!--
@@ -56,115 +166,58 @@
                                 <map:read src="{2}"/>
                         </map:match>
                         
-                        <!-- Aspect content
-                        
-                        There are five steps to processing aspect content:
-                                
-                        1: Generate the DRI page
-                                
-                                The first step is to generate a DRI page for the request;
-                                this is handled by the aspect chain. Once it is generated
-                                it is the beginning of a theme's pipeline, the DRI page is
-                                ultimately transformed in the resulting XHTML that is
-                                given to the user's browser.
-                                
-                        2: Add page metadata
-                                
-                                The next step is to add theme specific metadata to the
-                                DRI page. This is metadata about where the theme is
-                                located and its name. Typically this metadata is different
-                                depending on the users browser, this allows us to give
-                                different stylesheets to Internet Explorer than for other
-                                browsers.
-                                
-                        3: Transform to XHTML
-                                
-                                The third step is the main component of a theme the XSL
-                                transformations will turn the DRI page from the aspects
-                                into an XHTML page useable by browsers.
-                                
-                        4: Localize the page
-                                
-                                The second to last step is to localize the content for the
-                                particular user, if they user is requesting a page in a
-                                particular language then those language strings are inserted
-                                into the resulting XHTML.
-                                
-                        5: Serialize to the browser
-                                
-                                The last step sends the page to the user's browser.
-                                
-                        -->
                         <map:match pattern="**">
                                 
                                 <!-- Step 1: Generate the DRI page -->
+                                <!-- This line actually initiates the Aspect chain. The Aspect chain will build
+                                     the DRI (XML) content based on which page the user is accessing. -->
                                 <map:generate type="file" src="cocoon://DRI/{1}"/>
-                                
-                                <!-- Step 2 Add page metadata -->
-                                <map:select type="browser">
-                                        <map:when test="explorer6">
-                                                <map:transform type="IncludePageMeta">
-                                                        <map:parameter name="stylesheet.screen#1" value="lib/style.css"/>
-                                                        <map:parameter name="stylesheet.screen#2" value="lib/style-ie.css"/>
-                                                        <map:parameter name="stylesheet.screen#3" value="lib/style-ie6.css"/>
-                                                        <map:parameter name="stylesheet.screen#4" value="lib/css/jquery-ui-1.8.15.custom.css"/>
 
-                                                        <map:parameter name="javascript#1" value="lib/js/jquery-ui-1.8.15.custom.min.js"/>
 
-                                                        <map:parameter name="theme.path" value="{global:theme-path}"/>
-                                                        <map:parameter name="theme.name" value="{global:theme-name}"/>
-                                                </map:transform>
-                                        </map:when>
-                                        <map:when test="explorer">
-                                                <map:transform type="IncludePageMeta">
-                                                        <map:parameter name="stylesheet.screen#1" value="lib/style.css"/>
-                                                        <map:parameter name="stylesheet.screen#2" value="lib/style-ie.css"/>
-                                                        <map:parameter name="stylesheet.screen#3" value="lib/jquery-ui-1.8.15.custom.css"/>
-
-                                                        <map:parameter name="javascript#1" value="lib/jquery-1.6.2.min.js"/>
-                                                        <map:parameter name="javascript#2" value="lib/jquery-ui-1.8.15.custom.min.js"/>
-
-                                                        <map:parameter name="theme.path" value="{global:theme-path}"/>
-                                                        <map:parameter name="theme.name" value="{global:theme-name}"/>
-                                                </map:transform>
-                                        </map:when>
-                                        <map:otherwise>
-                                                <map:transform type="IncludePageMeta">
-                                                        <map:parameter name="stylesheet.screen" value="lib/style.css"/>
-                                                        <map:parameter name="stylesheet.screen#2" value="lib/jquery-ui-1.8.15.custom.css"/>
-
-                                                        <map:parameter name="javascript#1" value="lib/jquery-1.6.2.min.js"/>
-                                                        <map:parameter name="javascript#2" value="lib/jquery-ui-1.8.15.custom.min.js"/>
-
-                                                        <map:parameter name="theme.path" value="{global:theme-path}"/>
-                                                        <map:parameter name="theme.name" value="{global:theme-name}"/>
-                                                </map:transform>
-                                        </map:otherwise>
-                                </map:select>
+                                <!-- Step 2: Transform the DRI page into XHTML -->
+                                <!-- This line calls the resource named 'transform-to-xhtml' (included above). 
+                                     That resource is in charge of tranforming this DRI content into XHTML -->
+                                <map:call resource="transform-to-xhtml"/>
                                 
-                                <!-- Debuging output -->
-                                <map:match type="request" pattern="XML">
-                                        <map:serialize type="xml"/>
-                                </map:match>
-                                
-                                <!-- Step 3: Transform to XHTML -->
-                                <map:transform src="../dri2xhtml.xsl"/>
-                                
-                                <!-- Step 4: Localize the page -->
-                                <map:act type="locale">
-                                        <map:transform type="i18n">
-                                                <map:parameter name="locale" value="{locale}"/>
-                                        </map:transform>
-                                </map:act>
-                                
-                                <!-- Remove any leftover i18n or dri namespaces from the final document -->
-                                <map:transform type="NamespaceFilter" src="http://di.tamu.edu/DRI/1.0/"/>
-                                <map:transform type="NamespaceFilter" src="http://apache.org/cocoon/i18n/2.1"/>
-                                
-                                <!-- Step 5: Serialize to the browser -->
+                                <!-- Step 3: Serialize to the browser -->
                                 <map:serialize type="xhtml"/>
                                 
                         </map:match>
                 </map:pipeline>
+
+                <!--
+                    Handle any errors which are thrown during any step in the above pipelines.
+                    This would include simple invalid URL errors (404 page not found), as well as
+                    any errors that may occur from the Aspect chain, or from the Theme itself.
+                -->
+                <map:handle-errors>
+                    <!-- Step 1: Tell Cocoon to generate an XML formatted exception message -->
+                    <map:generate type="exception"/>
+
+                    <!-- Step 2: Transform that Cocoon XML exception into valid DRI (using exception2dri.xslt)-->
+                    <map:transform src="../../exception2dri.xslt">
+                        <map:parameter name="contextPath" value="{request:contextPath}"/>
+                    </map:transform>
+
+                    <!-- Step 3: Transform that DRI formatted exception into XHTML (using our Theme) -->
+                    <map:call resource="transform-to-xhtml"/>
+
+                    <!-- Step 4: Serialize XHTML page to user's brower. Based on the type of error,
+                         provide a different HTTP response code. -->
+                    <map:select type="exception">
+                        <!-- HTTP 400 Bad Request -->
+                        <map:when test="bad-request">
+                            <map:serialize type="xhtml" status-code="400"/>
+                        </map:when>
+                        <!-- HTTP 404 Page Not Found -->
+                        <map:when test="not-found">
+                            <map:serialize type="xhtml" status-code="404"/>
+                        </map:when>
+                        <!-- All other errors (HTTP 500 Internal Server Error) -->
+                        <map:otherwise>
+                            <map:serialize type="xhtml" status-code="500"/>
+                        </map:otherwise>
+                    </map:select>
+                </map:handle-errors>
         </map:pipelines>
 </map:sitemap>

--- a/dspace-xmlui/src/main/webapp/themes/mobile/lib/m-tweaks.css
+++ b/dspace-xmlui/src/main/webapp/themes/mobile/lib/m-tweaks.css
@@ -345,3 +345,13 @@ font-size: 18px;
 margin-bottom: 1px;
 }
 
+/* Hide a tag from visibility. Used in exception2dri.xslt to hide error stack by default. */
+.hidden {
+    display:none;
+    visibility:hidden;
+}
+
+/* Preserve whitespace. Used in exception2dri.xslt to display error messages in themes. */
+.pre {
+    white-space:pre;
+}

--- a/dspace-xmlui/src/main/webapp/themes/mobile/mobile.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/mobile/mobile.xsl
@@ -694,7 +694,7 @@
                            </xsl:attribute>
                             <img alt="Thumbnail">
                                 <xsl:attribute name="src">
-                                <xsl:variable name="request-uri" select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='contextPath'])"/>
+                                <xsl:variable name="request-uri" select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='contextPath']"/>
                                 <xsl:text>/themes/mobile/lib/images/default-thumbnail.png</xsl:text>
                                 </xsl:attribute>
                             </img>

--- a/dspace-xmlui/src/main/webapp/themes/mobile/sitemap.xmap
+++ b/dspace-xmlui/src/main/webapp/themes/mobile/sitemap.xmap
@@ -16,8 +16,95 @@
     September 12, 2012
 	
 -->
+<!-- HOW A DSPACE THEME IS PROCESSED IN 5 STEPS:
 
+          1: Generate the DRI (XML) page
+
+                The first step is to generate a DRI page for the request;
+                this is handled by the Aspect chain. Once it is generated
+                it is the beginning of a theme's pipeline, the DRI page is
+                ultimately transformed in the resulting XHTML that is
+                given to the user's browser.
+
+          2: Add page metadata (to DRI) - see "transform-to-xhtml" resource
+
+                The next step is to add theme specific metadata to the
+                DRI page. This is metadata about where the theme is
+                located and its name. Typically this metadata is different
+                depending on the users browser, this allows us to give
+                different stylesheets to Internet Explorer than for other browsers.
+
+          3: Transform DRI to XHTML (via XSLT) - see "transform-to-xhtml" resource
+
+                The third step is the main component of a theme. The XSL
+                transformations will turn the DRI page from the aspects
+                into an XHTML page useable by browsers.
+
+          4: Localize the page (by replacing i18n tags) - see "transform-to-xhtml" resource
+
+                The second to last step is to localize the content for the
+                particular user, if they user is requesting a page in a
+                particular language then those language strings are inserted
+                into the resulting XHTML.
+
+          5: Serialize to the browser
+
+                The last step sends the XHTML page to the user's browser.
+-->
 <map:sitemap xmlns:map="http://apache.org/cocoon/sitemap/1.0">
+        <!-- Define global resources that are used in multiple areas of the pipeline. -->
+        <map:resources>
+            <!--
+               This "transform-to-xhtml" resource is in charge of transforming DRI to XHTML.
+               It expects a pre-generated DRI page. It adds needed CSS/JS references to that DRI,
+               and then transforms it to XHTML using the Theme's XSLT(s).
+               Please note: this Sitemap 'resource' can be called from multiple places (almost like a function).
+            -->
+            <map:resource name="transform-to-xhtml">
+                <!-- Add page metadata to DRI -->
+                <!-- This adds all Stylesheets (CSS) and Javascript (js) into the DRI XML,
+                     so that they are accessible to the XSLTs -->
+                <map:select type="browser">
+                    <!-- Internet explorer 6 -->
+                    <map:when test="explorer6">
+                        <map:transform type="IncludePageMeta">
+                            <map:parameter name="stylesheet.screen#1" value="lib/style.css"/>
+                            <map:parameter name="stylesheet.screen#2" value="lib/style-ie6.css"/>
+
+                            <map:parameter name="theme.path" value="{global:theme-path}"/>
+                            <map:parameter name="theme.name" value="{global:theme-name}"/>
+                        </map:transform>
+                    </map:when>
+                    <!-- The theme has been tested with firefox 2.0 & i.e. 7.0 -->
+                    <map:otherwise>
+                        <map:transform type="IncludePageMeta">
+                            <map:parameter name="stylesheet.screen" value="lib/style.css"/>
+
+                            <map:parameter name="theme.path" value="{global:theme-path}"/>
+                            <map:parameter name="theme.name" value="{global:theme-name}"/>
+                        </map:transform>
+                    </map:otherwise>
+                </map:select>
+
+                <!-- Debugging output (this is only called when ?XML is passed on querystring) -->
+                <!-- It allows developers to view the final DRI XML, in order to build/debug theme XSLTs -->
+                <map:match type="request" pattern="XML">
+                    <map:serialize type="xml"/>
+                </map:match>
+
+                <!-- Transform DRI to XHTML using the Theme's XSLT(s) -->
+                <map:transform src="mobile.xsl"/>
+
+                <!-- Localize the XHTML page (by replacing i18n tags) -->
+                <!-- Mobile theme should only use the messages_mobile.xml to display short and mobile-friendly labels  -->
+                <map:act type="locale">
+                    <map:transform type="i18n">
+                        <map:parameter name="locale" value="mobile"/>
+                    </map:transform>
+                </map:act>
+
+            </map:resource>
+        </map:resources>
 	<map:pipelines>
 		
 		<map:component-configurations>
@@ -46,51 +133,54 @@
 			<map:match pattern="**">
 				
 				<!-- Step 1: Generate the DRI page -->
-				<map:generate type="file" src="cocoon://DRI/{1}"/>
+				<!-- This line actually initiates the Aspect chain. The Aspect chain will build
+                                     the DRI (XML) content based on which page the user is accessing. -->
+                                <map:generate type="file" src="cocoon://DRI/{1}"/>
 				
-				<!-- Step 2 Add page metadata -->
-				<map:select type="browser">
-					<!-- Internet explorer 6 -->
-					<map:when test="explorer6">
-						<map:transform type="IncludePageMeta">
-							<map:parameter name="stylesheet.screen#1" value="lib/style.css"/>
-							<map:parameter name="stylesheet.screen#2" value="lib/style-ie6.css"/>
-							
-							<map:parameter name="theme.path" value="{global:theme-path}"/>
-							<map:parameter name="theme.name" value="{global:theme-name}"/>
-						</map:transform>
-					</map:when>
-					<!-- The theme has been tested with firefox 2.0 & i.e. 7.0 -->
-					<map:otherwise>
-						<map:transform type="IncludePageMeta">
-							<map:parameter name="stylesheet.screen" value="lib/style.css"/>
-							
-							<map:parameter name="theme.path" value="{global:theme-path}"/>
-							<map:parameter name="theme.name" value="{global:theme-name}"/>
-						</map:transform>
-					</map:otherwise>
-				</map:select>
-				
-				<!-- Debuging output -->
-				<map:match type="request" pattern="XML">
-					<map:serialize type="xml"/>
-				</map:match>
-				
-				<!-- Step 3: Transform to XHTML -->
-				<map:transform src="mobile.xsl"/>
-				
-				<!-- Step 4: Localize the page -->
-				<!-- Mobile theme should only use the messages_mobile.xml to display short and mobile-friendly labels  -->
-				<map:act type="locale">
-					<map:transform type="i18n">
-						<map:parameter name="locale" value="mobile"/>
-					</map:transform>
-				</map:act>
-				
-				<!-- Step 5: Serialize to the browser -->
+                                <!-- Step 2: Transform the DRI page into XHTML -->
+                                <!-- This line calls the resource named 'transform-to-xhtml' (included above). 
+                                     That resource is in charge of tranforming this DRI content into XHTML -->
+                                <map:call resource="transform-to-xhtml"/>                                
+
+				<!-- Step 3: Serialize to the browser -->
 				<map:serialize type="xhtml"/>
 				
 			</map:match>
 		</map:pipeline>
+            
+                <!--
+                    Handle any errors which are thrown during any step in the above pipelines.
+                    This would include simple invalid URL errors (404 page not found), as well as
+                    any errors that may occur from the Aspect chain, or from the Theme itself.
+                -->
+                <map:handle-errors>
+                    <!-- Step 1: Tell Cocoon to generate an XML formatted exception message -->
+                    <map:generate type="exception"/>
+
+                    <!-- Step 2: Transform that Cocoon XML exception into valid DRI (using exception2dri.xslt)-->
+                    <map:transform src="../../exception2dri.xslt">
+                        <map:parameter name="contextPath" value="{request:contextPath}"/>
+                    </map:transform>
+
+                    <!-- Step 3: Transform that DRI formatted exception into XHTML (using our Theme) -->
+                    <map:call resource="transform-to-xhtml"/>
+
+                    <!-- Step 4: Serialize XHTML page to user's brower. Based on the type of error,
+                         provide a different HTTP response code. -->
+                    <map:select type="exception">
+                        <!-- HTTP 400 Bad Request -->
+                        <map:when test="bad-request">
+                            <map:serialize type="xhtml" status-code="400"/>
+                        </map:when>
+                        <!-- HTTP 404 Page Not Found -->
+                        <map:when test="not-found">
+                            <map:serialize type="xhtml" status-code="404"/>
+                        </map:when>
+                        <!-- All other errors (HTTP 500 Internal Server Error) -->
+                        <map:otherwise>
+                            <map:serialize type="xhtml" status-code="500"/>
+                        </map:otherwise>
+                    </map:select>
+                </map:handle-errors>
 	</map:pipelines>
 </map:sitemap>

--- a/dspace-xmlui/src/main/webapp/themes/template/lib/style.css
+++ b/dspace-xmlui/src/main/webapp/themes/template/lib/style.css
@@ -6,8 +6,16 @@
  * http://www.dspace.org/license/
  */
 
+/* Hide a tag from visibility. Used in exception2dri.xslt to hide error stack by default. */
+.hidden {
+    display:none;
+    visibility:hidden;
+}
 
-
+/* Preserve whitespace. Used in exception2dri.xslt to display error messages in themes. */
+.pre {
+    white-space:pre;
+}
 
 
 

--- a/dspace-xmlui/src/main/webapp/themes/template/sitemap.xmap
+++ b/dspace-xmlui/src/main/webapp/themes/template/sitemap.xmap
@@ -8,7 +8,102 @@
     http://www.dspace.org/license/
 
 -->
+<!-- HOW A DSPACE THEME IS PROCESSED IN 5 STEPS:
+
+          1: Generate the DRI (XML) page
+
+                The first step is to generate a DRI page for the request;
+                this is handled by the Aspect chain. Once it is generated
+                it is the beginning of a theme's pipeline, the DRI page is
+                ultimately transformed in the resulting XHTML that is
+                given to the user's browser.
+
+          2: Add page metadata (to DRI) - see "transform-to-xhtml" resource
+
+                The next step is to add theme specific metadata to the
+                DRI page. This is metadata about where the theme is
+                located and its name. Typically this metadata is different
+                depending on the users browser, this allows us to give
+                different stylesheets to Internet Explorer than for other browsers.
+
+          3: Transform DRI to XHTML (via XSLT) - see "transform-to-xhtml" resource
+
+                The third step is the main component of a theme. The XSL
+                transformations will turn the DRI page from the aspects
+                into an XHTML page useable by browsers.
+
+          4: Localize the page (by replacing i18n tags) - see "transform-to-xhtml" resource
+
+                The second to last step is to localize the content for the
+                particular user, if they user is requesting a page in a
+                particular language then those language strings are inserted
+                into the resulting XHTML.
+
+          5: Serialize to the browser
+
+                The last step sends the XHTML page to the user's browser.
+-->
 <map:sitemap xmlns:map="http://apache.org/cocoon/sitemap/1.0">
+        <!-- Define global resources that are used in multiple areas of the pipeline. -->
+        <map:resources>
+            <!--
+               This "transform-to-xhtml" resource is in charge of transforming DRI to XHTML.
+               It expects a pre-generated DRI page. It adds needed CSS/JS references to that DRI,
+               and then transforms it to XHTML using the Theme's XSLT(s).
+               Please note: this Sitemap 'resource' can be called from multiple places (almost like a function).
+            -->
+            <map:resource name="transform-to-xhtml">
+                <!-- Add page metadata to DRI -->
+                <!-- This adds all Stylesheets (CSS) and Javascript (js) into the DRI XML,
+                     so that they are accessible to the XSLTs -->
+                <map:select type="browser">
+                    <map:when test="explorer">
+                        <map:transform type="IncludePageMeta">
+                            <map:parameter name="stylesheet.screen#1" value="lib/style.css"/>
+                            <map:parameter name="stylesheet.screen#2" value="lib/style-ie.css"/>
+                            <map:parameter name="stylesheet.screen#3" value="lib/css/jquery-ui-1.8.15.custom.css"/>
+
+                            <map:parameter name="javascript#1" value="lib/js/jquery-1.6.2.min.js"/>
+                            <map:parameter name="javascript#2" value="lib/js/jquery-ui-1.8.15.custom.min.js"/>
+
+                            <map:parameter name="theme.path" value="{global:theme-path}"/>
+                            <map:parameter name="theme.name" value="{global:theme-name}"/>
+                        </map:transform>
+                    </map:when>
+                    <map:otherwise>
+                        <map:transform type="IncludePageMeta">
+                            <map:parameter name="stylesheet.screen" value="lib/style.css"/>
+                            <map:parameter name="stylesheet.screen#2" value="lib/jquery-ui-1.8.15.custom.css"/>
+
+                            <map:parameter name="javascript#1" value="lib/jquery-1.6.2.min.js"/>
+                            <map:parameter name="javascript#2" value="lib/jquery-ui-1.8.15.custom.min.js"/>
+
+                            <map:parameter name="theme.path" value="{global:theme-path}"/>
+                            <map:parameter name="theme.name" value="{global:theme-name}"/>
+                        </map:transform>
+                    </map:otherwise>
+                </map:select>
+
+                <!-- Debugging output (this is only called when ?XML is passed on querystring) -->
+                <!-- It allows developers to view the final DRI XML, in order to build/debug theme XSLTs -->
+                <map:match type="request" pattern="XML">
+                    <map:serialize type="xml"/>
+                </map:match>
+
+                <!-- Transform DRI to XHTML using the Theme's XSLT(s) -->
+                <map:transform src="template.xsl"/>
+
+                <!-- Localize the XHTML page (by replacing i18n tags) -->
+                <map:act type="locale">
+                    <map:transform type="i18n">
+                        <map:parameter name="locale" value="{locale}"/>
+                    </map:transform>
+                </map:act>
+
+            </map:resource>
+
+
+        </map:resources>
 	<map:pipelines>
 		
 		<!-- 
@@ -50,101 +145,57 @@
 			<!-- Never allow the browser to cache dynamic content -->
 			<map:parameter name="expires" value="now"/>
 			
-			<!-- Aspect content 
-			
-			There are five steps to processing aspect content:
-				
-			1: Generate the DRI page
-				
-				The first step is to generate a DRI page for the request; 
-				this is handled by the aspect chain. Once it is generated 
-				it is the beginning of a theme's pipeline, the DRI page is 
-				ultimately transformed in the resulting XHTML that is 
-				given to the user's browser.
-				
-			2: Add page metadata
-				
-				The next step is to add theme specific metadata to the 
-				DRI page. This is metadata about where the theme is 
-				located and its name. Typically this metadata is different 
-				depending on the users browser, this allows us to give 
-				different stylesheets to Internet Explorer than for other 
-				browsers.
-				
-			3: Transform to XHTML
-				
-				The third step is the main component of a theme the XSL 
-				transformations will turn the DRI page from the aspects 
-				into an XHTML page useable by browsers. 
-				
-			4: Localize the page
-				
-				The second to last step is to localize the content for the 
-				particular user, if they user is requesting a page in a 
-				particular language then those language strings are inserted 
-				into the resulting XHTML.  
-				
-			5: Serialize to the browser
-				
-				The last step sends the page to the user's browser. 
-				
-			-->
 			<map:match pattern="**">
 				
 				<!-- Step 1: Generate the DRI page -->
+                                <!-- This line actually initiates the Aspect chain. The Aspect chain will build
+                                     the DRI (XML) content based on which page the user is accessing. -->
 				<map:generate type="file" src="cocoon://DRI/{1}"/>
 				
-				<!-- Step 2 Add page metadata -->
-				<map:select type="browser">
-					<map:when test="explorer">
-						<map:transform type="IncludePageMeta">
-							<map:parameter name="stylesheet.screen#1" value="lib/style.css"/>
-							<map:parameter name="stylesheet.screen#2" value="lib/style-ie.css"/>
-							<map:parameter name="stylesheet.screen#3" value="lib/css/jquery-ui-1.8.15.custom.css"/>
-
-                            <map:parameter name="javascript#1" value="lib/js/jquery-1.6.2.min.js"/>
-							<map:parameter name="javascript#2" value="lib/js/jquery-ui-1.8.15.custom.min.js"/>
-
-							
-							<map:parameter name="theme.path" value="{global:theme-path}"/>
-							<map:parameter name="theme.name" value="{global:theme-name}"/>
-						</map:transform>
-					</map:when>
-					<map:otherwise>
-						<map:transform type="IncludePageMeta">
-							<map:parameter name="stylesheet.screen" value="lib/style.css"/>
-							<map:parameter name="stylesheet.screen#2" value="lib/jquery-ui-1.8.15.custom.css"/>
-
-                            <map:parameter name="javascript#1" value="lib/jquery-1.6.2.min.js"/>
-							<map:parameter name="javascript#2" value="lib/jquery-ui-1.8.15.custom.min.js"/>
-
-							
-							<map:parameter name="theme.path" value="{global:theme-path}"/>
-							<map:parameter name="theme.name" value="{global:theme-name}"/>
-						</map:transform>
-					</map:otherwise>
-				</map:select>
+                                <!-- Step 2: Transform the DRI page into XHTML -->
+                                <!-- This line calls the resource named 'transform-to-xhtml' (included above). 
+                                     That resource is in charge of tranforming this DRI content into XHTML -->
+                                <map:call resource="transform-to-xhtml"/>
 				
-				<!-- Debuging output -->
-				<map:match type="request" pattern="XML">
-					<map:serialize type="xml"/>
-				</map:match>
-				
-				<!-- Step 3: Transform to XHTML -->
-				<map:transform src="template.xsl"/>
-			    <!-- <map:transform src="template.xsl"/> -->
-				
-				<!-- Step 4: Localize the page -->
-				<map:act type="locale">
-					<map:transform type="i18n">
-						<map:parameter name="locale" value="{locale}"/>						
-					</map:transform>
-				</map:act>
-				
-				<!-- Step 5: Serialize to the browser -->
+				<!-- Step 3: Serialize to the browser -->
 				<map:serialize type="xhtml"/>
 				
 			</map:match>
 		</map:pipeline>
+
+                <!--
+                    Handle any errors which are thrown during any step in the above pipelines.
+                    This would include simple invalid URL errors (404 page not found), as well as
+                    any errors that may occur from the Aspect chain, or from the Theme itself.
+                -->
+                <map:handle-errors>
+                    <!-- Step 1: Tell Cocoon to generate an XML formatted exception message -->
+                    <map:generate type="exception"/>
+
+                    <!-- Step 2: Transform that Cocoon XML exception into valid DRI (using exception2dri.xslt)-->
+                    <map:transform src="../../exception2dri.xslt">
+                        <map:parameter name="contextPath" value="{request:contextPath}"/>
+                    </map:transform>
+
+                    <!-- Step 3: Transform that DRI formatted exception into XHTML (using our Theme) -->
+                    <map:call resource="transform-to-xhtml"/>
+
+                    <!-- Step 4: Serialize XHTML page to user's brower. Based on the type of error,
+                         provide a different HTTP response code. -->
+                    <map:select type="exception">
+                        <!-- HTTP 400 Bad Request -->
+                        <map:when test="bad-request">
+                            <map:serialize type="xhtml" status-code="400"/>
+                        </map:when>
+                        <!-- HTTP 404 Page Not Found -->
+                        <map:when test="not-found">
+                            <map:serialize type="xhtml" status-code="404"/>
+                        </map:when>
+                        <!-- All other errors (HTTP 500 Internal Server Error) -->
+                        <map:otherwise>
+                            <map:serialize type="xhtml" status-code="500"/>
+                        </map:otherwise>
+                    </map:select>
+                </map:handle-errors>
 	</map:pipelines>
 </map:sitemap>


### PR DESCRIPTION
This is now ready for review for possible merger, as it fixes all themes (see below).

https://jira.duraspace.org/browse/DS-1596

A basic overview of the fix:
- Adds a new "map:handle-errors" section to the Theme's 'sitemap.xmap'.  This section _overrides_ the default ugly DSpace error page, and applies the selected theme to the error message.
- Creates a new "exception2dri.xslt" stylesheet. This stylesheet transforms a Cocoon XML error message into a valid DRI document, so that your Theme can then be used to display the error. This file is shared by all themes.

Some Notes on the Fix:
- Not all errors are guaranteed to be displayed within your Theme.  Most will be (e.g. 404 Page Not Found). However, if a significant internal error occurs or a Theme error occurs, you still may see the ugly default DSpace error page.
- Also note, I've also made some formatting/refactoring changes to the Mirage sitemap.xmap (which is why the diff is so huge). These changes make the file much more human readable (and I've added addition comments to help explain what is going on).
- The Themed error page has I18N. By default, it just displays the primary error message (and returns the proper HTTP code).  But, there is also a link to display the entire Java stacktrace (which is in the HTML source but is hidden by default)

In order to fully fix DS-1596, we will need to make similar changes to _every_ XMLUI Theme's sitemap.xmap

Currently there are fixes for the following Themes:
- Mirage
- Reference
- Classic
- Kubrick
- template
- mobile

This has been tested with all the above Themes and is ready to go. A separate PR will be created for Mirage2 once this one is merged.
