### PR TITLE
[DS-1893] Get page refresh after adding a value in the submission forms clears all metadata in XMLUI

### DIFF
--- a/dspace-api/src/main/java/org/dspace/submit/step/DescribeStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/DescribeStep.java
@@ -117,6 +117,10 @@ public class DescribeStep extends AbstractProcessingStep
             throws ServletException, IOException, SQLException,
             AuthorizeException
     {
+        if(!request.getParameterNames().hasMoreElements()){
+            //In case of an empty request do NOT just remove all metadata, just return to the submission page
+            return STATUS_MORE_INPUT_REQUESTED;
+        }
         // check what submit button was pressed in User Interface
         String buttonPressed = Util.getSubmitButton(request, NEXT_BUTTON);
 


### PR DESCRIPTION
This commit will fix this issue by checking if there is at least a single parameter present in the request and if not, it will send in back to the original page (without clearing all the metadata).

https://jira.duraspace.org/browse/DS-1893
