### PR TITLE
[DS-1898] OAI not always closing contexts

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/DSpaceOAIDataProvider.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/DSpaceOAIDataProvider.java
@@ -158,6 +158,11 @@ public class DSpaceOAIDataProvider extends HttpServlet
                     "Requested OAI context \""
                     + request.getPathInfo().replace("/", "")
                     + "\" does not exist");
+        } finally {
+            if(context != null && context.isValid())
+            {
+                context.abort();
+            }
         }
 
     }


### PR DESCRIPTION
Added a finally with a context.abort(), this way the context will always be closed.
