### PR TITLE
Change BTE version to 0.9.2.3 for DS-1857

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -436,12 +436,12 @@
         <dependency>
             <groupId>gr.ekt.bte</groupId>
             <artifactId>bte-core</artifactId>
-            <version>0.9.3.3</version>
+            <version>0.9.2.3</version>
         </dependency>
         <dependency>
             <groupId>gr.ekt.bte</groupId>
             <artifactId>bte-io</artifactId>
-            <version>0.9.3.3</version>
+            <version>0.9.2.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
We released version 0.9.2.3 of BTE that only fixes bugs and is compiled with java 1.6. This PR updates the dspace-api/pom.xml to this version of BTE.

It does fix the bug in DS-1857 and compiles/passes the tests of DSpace with java 1.6.

Thank you,
Panagiotis

http://jira.duraspace.org/browse/DS-1857
