### PR TITLE
 [DS-1352] - Itemimport replace issue

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/Collection.java
+++ b/dspace-api/src/main/java/org/dspace/content/Collection.java
@@ -1041,6 +1041,30 @@ public class Collection extends DSpaceObject
     }
 
     /**
+     * Remove an item from all collections. If the item is orphaned, it is NOT deleted
+     *
+     * @param item item to remove
+     * @throws SQLException
+     * @throws AuthorizeException
+     * @throws IOException
+     */
+    public void removeItemFromAllCollections(Item item) throws SQLException, AuthorizeException,
+            IOException
+    {
+        // Check authorisation
+        AuthorizeManager.authorizeAction(ourContext, this, Constants.REMOVE);
+
+        DatabaseManager.updateQuery(ourContext,
+                "DELETE FROM collection2item WHERE "+
+                "item_id= ? ",
+                item.getID());
+        DatabaseManager.setConstraintImmediate(ourContext, "coll2item_item_fk");
+
+        ourContext.addEvent(new Event(Event.REMOVE, Constants.COLLECTION, getID(), Constants.ITEM, item.getID(), item.getHandle()));
+    }
+
+
+    /**
      * Update the collection metadata (including logo and workflow groups) to
      * the database. Inserts if this is a new collection.
      *

--- a/dspace-api/src/main/java/org/dspace/content/Item.java
+++ b/dspace-api/src/main/java/org/dspace/content/Item.java
@@ -2843,4 +2843,42 @@ public class Item extends DSpaceObject
             return null;
         }
     }
+
+
+    public void cleanItem() throws SQLException, AuthorizeException, IOException
+    {
+       // Check authorisation here. If we don't, it may happen that we remove the
+       // metadata but when getting to the point of removing the bundles we get an exception
+       // leaving the database in an inconsistent state
+
+       AuthorizeManager.authorizeAction(ourContext, this, Constants.ADD);
+       log.info(LogManager.getHeader(ourContext, "clean_item", "item_id=" + getID()));
+       
+       // Remove from cache
+       ourContext.removeCached(this, getID());
+       
+       try
+       {
+          // Remove from indices and we will index the new data later
+          IndexBrowse ib = new IndexBrowse(ourContext);
+          ib.itemRemoved(this);
+       }
+
+       catch (BrowseException e)
+       {
+          log.error("caught exception: ", e);
+          throw new SQLException(e.getMessage(), e);
+       }
+
+       // Delete the metadata (in memory; will write to db when update is called)
+       List<DCValue> values = new ArrayList<DCValue>();
+       setMetadata(values);
+
+       // Remove bundles
+       Bundle[] bunds = getBundles();
+       for (int i = 0; i < bunds.length; i++)
+       {
+          removeBundle(bunds[i]);
+       }
+    }
 }


### PR DESCRIPTION
This change fixes the JIRA Ticket: https://jira.duraspace.org/browse/DS-1352

When doing a batch import with option replace instead of deleting the item and creating a new one, it replaces all the metadata and bitstreams for the item. This solves statistics issues that use the item_id has reference.

ex:
 -> check item_id for item
./dspace import --replace -c  <col_handle> -s <src_dir> -m mapfile -e <user>
 -> check again item_id for item
