### PR TITLE
[DS-1912] Discovery facets do not always use the authority identifier

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SearchFacetFilter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SearchFacetFilter.java
@@ -425,7 +425,7 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
             //Last add the current filter query
             url += "&filtertype=" + facetField;
             url += "&filter_relational_operator="+value.getFilterType();
-            url += "&filter=" + URLEncoder.encode(displayedValue, "UTF-8");
+            url += "&filter=" + URLEncoder.encode(value.getAsFilterQuery(), "UTF-8");
             cell.addXref(url, displayedValue + " (" + value.getCount() + ")"
             );
         }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SidebarFacetsTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SidebarFacetsTransformer.java
@@ -232,7 +232,7 @@ public class SidebarFacetsTransformer extends AbstractDSpaceTransformer implemen
                                 String displayedValue = value.getDisplayedValue();
                                 String filterQuery = value.getAsFilterQuery();
                                 String filterType = value.getFilterType();
-                                if (fqs.contains(getSearchService().toFilterQuery(context, field.getIndexFieldName(), "equals", value.getDisplayedValue()).getFilterQuery())) {
+                                if (fqs.contains(getSearchService().toFilterQuery(context, field.getIndexFieldName(), value.getFilterType(), value.getAsFilterQuery()).getFilterQuery())) {
                                     filterValsList.addItem(Math.random() + "", "selected").addContent(displayedValue + " (" + value.getCount() + ")");
                                 } else {
                                     String paramsQuery = retrieveParameters(request);


### PR DESCRIPTION
The code currently always uses the displayedValue as a filter parameter, but this is not always correct. Due to the following change in the backend: https://github.com/DSpace/DSpace/blob/master/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java#L1820-1825 . The displayedValue is sometimes overwritten by the authority (if present) so the UI should also takes this into account.

You can test this pull request by setting a sidebar facet to an authority controlled metadata field and selecting a field that has an authority linked to it (but with a similar displayed value in a non authority related field).
