### PR TITLE
[DS-1750] Remove DSpace manual PDF from the source kit.

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,9 @@
-Installation instructions are included in this release package under
+Installation instructions may be found in DSpace-Manual.pdf, offered 
+with the source archives in the SourceForge project:
 
- - dspace/docs/DSpace-Manual.pdf
+  http://sourceforge.net/projects/dspace/files/DSpace%20Stable/VERSION/
+
+(Replace "VERSION" with the version you are installing, such as "4.0".)
 
 DSpace version information can be viewed online at
  - https://wiki.duraspace.org/display/DSDOC/

--- a/dspace/src/main/assembly/assembly.xml
+++ b/dspace/src/main/assembly/assembly.xml
@@ -48,7 +48,6 @@
          <includes>
             <include>bin/**</include>
             <include>config/**</include>
-            <include>docs/**</include>
             <include>etc/**</include>
             <include>solr/**</include>
          </includes>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-1750

This change just removes the PDF so that it's no longer included in checkouts and doesn't tempt us to update it in the source kit.  Old revisions will still be carried along during cloning.
