### PR TITLE
DS-1928 use the oai-identifier schema in <description>

### DIFF
--- a/dspace-oai/src/main/webapp/static/style.xsl
+++ b/dspace-oai/src/main/webapp/static/style.xsl
@@ -729,10 +729,18 @@
 									<td class="clear"></td>
 								</tr>
 								<tr class="info">
-									<td class="name">Description</td>
+									<td class="name">Repository identifier</td>
 									<td class="value">
 										<xsl:value-of
-											select="oai:OAI-PMH/oai:Identify/oai:description/node()/text()" />
+											select="oai:description/oai:oai-identifier/oai:repositoryIdentifier/text()" />
+									</td>
+									<td class="clear"></td>
+								</tr>
+								<tr class="info">
+									<td class="name">Sample identifier</td>
+									<td class="value">
+										<xsl:value-of
+											select="oai:description/oai:oai-identifier/oai:sampleIdentifier/text()" />
 									</td>
 									<td class="clear"></td>
 								</tr>

--- a/dspace/config/crosswalks/oai/description.xml
+++ b/dspace/config/crosswalks/oai/description.xml
@@ -1,1 +1,6 @@
-<XOAIDescription xmlns="http://www.lyncode.com/XOAIConfiguration">XOAI: OAI-PMH Java Toolkit</XOAIDescription>
+<oai-identifier xmlns="http://www.openarchives.org/OAI/2.0/oai-identifier" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai-identifier http://www.openarchives.org/OAI/2.0/oai-identifier.xsd">
+<scheme>oai</scheme>
+<repositoryIdentifier>${dspace.hostname}</repositoryIdentifier>
+<delimiter>:</delimiter>
+<sampleIdentifier>oai:${dspace.hostname}:${handle.prefix}/1234</sampleIdentifier>
+</oai-identifier>

--- a/dspace/src/main/assembly/assembly.xml
+++ b/dspace/src/main/assembly/assembly.xml
@@ -82,6 +82,11 @@
          <outputDirectory>config</outputDirectory>
          <filtered>true</filtered>
       </file>
+      <file>
+         <source>config/crosswalks/oai/description.xml</source>
+         <outputDirectory>config</outputDirectory>
+         <filtered>true</filtered>
+      </file>
    </files>
 
    <!--


### PR DESCRIPTION
This is a backport of #493 to dspace-4_x.

It doesn't work yet because unlike in master, in dspace-4_x there is a default namespace (xmlns="http://www.openarchives.org/OAI/2.0/oai-identifier") defined on <oai-identifier> and I couldn't figure out how to address the nodes under <oai-identifier>.
