### PR TITLE
DS-1936 - Update robots.txt to include a Sitemap entry

### DIFF
--- a/dspace-jspui/src/main/webapp/robots.txt
+++ b/dspace-jspui/src/main/webapp/robots.txt
@@ -1,5 +1,26 @@
 User-agent: *
 
-# Uncomment the following line ONLY if sitemaps.org or HTML sitemaps are used
+# The FULL URL to your DSpace sitemaps
+# The ${dspace.url} will be auto-filled with the value in dspace.cfg
+# XML sitemap is listed first as it is preferred by most search engines
+Sitemap: ${dspace.url}/sitemap
+Sitemap: ${dspace.url}/htmlmap
+
+# Disable access to Discovery search
+Disallow: /simple-search
+
+# Optionally uncomment the following line ONLY if sitemaps are working
 # and you have verified that your site is being indexed correctly.
 # Disallow: /browse
+
+# If you have configured DSpace (Solr-based) Statistics to be publicly
+# accessible, then you may not want this content to be indexed
+# Disallow: /statistics
+
+# You also may wish to disallow access to the following paths, in order
+# to stop web spiders from accessing user-based content:
+# Disallow: /contact
+# Disallow: /feedback
+# Disallow: /forgot
+# Disallow: /login
+# Disallow: /register

--- a/dspace-xmlui/src/main/webapp/static/robots.txt
+++ b/dspace-xmlui/src/main/webapp/static/robots.txt
@@ -1,17 +1,27 @@
 User-agent: *
+
+# The FULL URL to your DSpace sitemaps
+# The ${dspace.url} will be auto-filled with the value in dspace.cfg
+# XML sitemap is listed first as it is preferred by most search engines
+Sitemap: ${dspace.url}/sitemap
+Sitemap: ${dspace.url}/htmlmap
+
+# Disable access to Discovery search and filters
 Disallow: /discover 
 Disallow: /search-filter
 
-# Uncomment the following line ONLY if sitemaps.org or HTML sitemaps are used
+# Optionally uncomment the following line ONLY if sitemaps are working
 # and you have verified that your site is being indexed correctly.
 # Disallow: /browse
 
+# If you have configured DSpace (Solr-based) Statistics to be publicly 
+# accessible, then you may not want this content to be indexed
+# Disallow: /statistics
+
 # You also may wish to disallow access to the following paths, in order
 # to stop web spiders from accessing user-based content:
-# Disallow: /advanced-search
 # Disallow: /contact
 # Disallow: /feedback
 # Disallow: /forgot
 # Disallow: /login
 # Disallow: /register
-# Disallow: /search

--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -655,15 +655,19 @@ Common usage:
 
     <target name="copy_webapps">
 
+        <!-- Copy webapp files to /webapps (excluding any filtered files) -->
         <copy todir="${dspace.dir}/webapps" preservelastmodified="true" failonerror="no">
             <fileset dir="webapps">
                 <exclude name="**/web.xml" />
+                <exclude name="**/robots.txt" />
             </fileset>
         </copy>
 
+        <!-- Ensure specific webapp files (web.xml, robots.txt) are filtered -->
         <copy todir="${dspace.dir}/webapps" preservelastmodified="false" failonerror="no">
             <fileset dir="webapps">
                 <include name="**/web.xml" />
+                <include name="**/robots.txt" />
             </fileset>
             <filterchain>
                 <expandproperties />


### PR DESCRIPTION
This PR does a few things:
1. Updates JSPUI & XMLUI robots.txt to include a "Sitemap" entry
2. Ensures that "Sitemap" entry is autofilled out with [dspace.url]/htmlmap (when 'ant' is run)
3. "Syncs" up the comments in the JSPUI and XMLUI robots.txt. They have gotten vastly out of sync.  For this purpose, I admit to having "borrowed" from the great robots.txt at https://scholarworks.iupui.edu/robots.txt

I've tested the process and it seems to work fine. Comments welcome.
