### PR TITLE
[DS-1939] JMockit 0.994 is too old for Java 1.7

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -408,14 +408,14 @@
             <groupId>org.dspace</groupId>
             <artifactId>dspace-services</artifactId>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+        <dependency> <!-- Keep jmockit before junit -->
+            <groupId>com.googlecode.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>mockit</groupId>
-            <artifactId>jmockit</artifactId>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dspace-api/src/test/java/org/dspace/AbstractUnitTest.java
+++ b/dspace-api/src/test/java/org/dspace/AbstractUnitTest.java
@@ -58,7 +58,7 @@ import org.xml.sax.SAXException;
 public class AbstractUnitTest
 {
     /** log4j category */
-    private static Logger log = Logger.getLogger(AbstractUnitTest.class);
+    private static final Logger log = Logger.getLogger(AbstractUnitTest.class);
 
     //Below there are static variables shared by all the instances of the class
     
@@ -119,6 +119,9 @@ public class AbstractUnitTest
             {
                 kernelImpl.start(ConfigurationManager.getProperty("dspace.dir"));
             }
+
+            // Start the mock database
+            new MockDatabaseManager();
 
             // Load the default registries. This assumes the temporary
             // filesystem is working and the in-memory DB in place.

--- a/dspace-api/src/test/java/org/dspace/MockConfigurationManager.java
+++ b/dspace-api/src/test/java/org/dspace/MockConfigurationManager.java
@@ -10,7 +10,7 @@ package org.dspace;
 
 import java.util.Properties;
 import mockit.Mock;
-import mockit.MockClass;
+import mockit.MockUp;
 import org.dspace.core.ConfigurationManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,8 +23,9 @@ import org.slf4j.LoggerFactory;
  *
  * @author mwood
  */
-@MockClass(realClass=ConfigurationManager.class)
-public class MockConfigurationManager {
+public class MockConfigurationManager
+        extends MockUp<ConfigurationManager>
+{
     private static final Properties properties = new Properties();
     private static final Logger log = LoggerFactory.getLogger(MockConfigurationManager.class);
 

--- a/dspace-api/src/test/java/org/dspace/browse/MockBrowseCreateDAOOracle.java
+++ b/dspace-api/src/test/java/org/dspace/browse/MockBrowseCreateDAOOracle.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import java.util.Set;
 
 import mockit.Mock;
-import mockit.MockClass;
+import mockit.MockUp;
 import org.apache.log4j.Logger;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
@@ -30,12 +30,12 @@ import org.dspace.storage.rdbms.TableRowIterator;
  * Mocks some methods of BrowseCreateDAOOracle to enable compatibility with H2
  * @author pvillega
  */
-@MockClass(realClass=BrowseCreateDAOOracle.class)
 public class MockBrowseCreateDAOOracle
+        extends MockUp<BrowseCreateDAOOracle>
 {
 
     /** log4j category */
-    private static Logger log = Logger.getLogger(MockBrowseCreateDAOOracle.class);
+    private static final Logger log = Logger.getLogger(MockBrowseCreateDAOOracle.class);
 
     /**
      * internal copy of the current DSpace context (including the database

--- a/dspace-api/src/test/java/org/dspace/discovery/MockIndexEventConsumer.java
+++ b/dspace-api/src/test/java/org/dspace/discovery/MockIndexEventConsumer.java
@@ -8,7 +8,7 @@
 package org.dspace.discovery;
 
 import mockit.Mock;
-import mockit.MockClass;
+import mockit.MockUp;
 import org.dspace.core.Context;
 import org.dspace.event.Event;
 
@@ -18,8 +18,9 @@ import org.dspace.event.Event;
  *
  * @author tdonohue
  */
-@MockClass(realClass=IndexEventConsumer.class)
-public class MockIndexEventConsumer {
+public class MockIndexEventConsumer
+        extends MockUp<IndexEventConsumer>
+{
    
     //public void initialize() throws Exception {
         //do nothing

--- a/dspace-api/src/test/java/org/dspace/statistics/util/SpiderDetectorTest.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/util/SpiderDetectorTest.java
@@ -8,16 +8,13 @@
 package org.dspace.statistics.util;
 
 import mockit.Mock;
-import mockit.MockClass;
-import mockit.Mockit;
+import mockit.MockUp;
 import org.dspace.statistics.SolrLogger;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * @author mwood
@@ -29,13 +26,7 @@ public class SpiderDetectorTest
     @BeforeClass
     static public void beforeClass()
     {
-        Mockit.setUpMocks(MockSolrLogger.class); // Don't test SolrLogger here
-    }
-    @AfterClass
-
-    static public void afterClass()
-    {
-        Mockit.tearDownMocks(SolrLogger.class);
+        new MockSolrLogger();
     }
 
     /**
@@ -152,8 +143,8 @@ public class SpiderDetectorTest
      * Dummy SolrLogger for testing.
      * @author mwood
      */
-    @MockClass (realClass = org.dspace.statistics.SolrLogger.class)
     static public class MockSolrLogger
+            extends MockUp<SolrLogger>
     {
         @Mock
         public void $init() {}

--- a/dspace-api/src/test/java/org/dspace/storage/rdbms/MockDatabaseManager.java
+++ b/dspace-api/src/test/java/org/dspace/storage/rdbms/MockDatabaseManager.java
@@ -7,16 +7,12 @@
  */
 package org.dspace.storage.rdbms;
 
-import mockit.Mock;
-import mockit.MockClass;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
-import java.net.URL;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.Date;
@@ -31,15 +27,16 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+
+import mockit.Mock;
+import mockit.MockUp;
 
 import org.apache.commons.dbcp.ConnectionFactory;
 import org.apache.commons.dbcp.DriverManagerConnectionFactory;
@@ -61,16 +58,16 @@ import org.dspace.core.Context;
  *
  * @author pvillega
  */
-@MockClass(realClass = DatabaseManager.class)
 public class MockDatabaseManager
+        extends MockUp<DatabaseManager>
 {
     /** log4j category */
-    private static Logger log = Logger.getLogger(DatabaseManager.class);
+    private static final Logger log = Logger.getLogger(DatabaseManager.class);
 
     /** True if initialization has been done */
     private static boolean initialized = false;
 
-    private static Map<String, String> insertSQL = new HashMap<String, String>();
+    private static final Map<String, String> insertSQL = new HashMap<String, String>();
     
     private static boolean isOracle = false;
     private static boolean isPostgres = false;
@@ -108,7 +105,7 @@ public class MockDatabaseManager
      * A map of database column information. The key is the table name, a
      * String; the value is an array of ColumnInfo objects.
      */
-    private static Map<String, Map<String, ColumnInfo>> info = new HashMap<String, Map<String, ColumnInfo>>();
+    private static final Map<String, Map<String, ColumnInfo>> info = new HashMap<String, Map<String, ColumnInfo>>();
 
     /**
      * It allows us to print information on the pool, for debugging purposes

--- a/dspace-services/pom.xml
+++ b/dspace-services/pom.xml
@@ -51,6 +51,11 @@
             <groupId>javax.mail</groupId>
             <artifactId>mail</artifactId>
         </dependency>
+        <dependency> <!-- Keep jmockit before junit -->
+            <groupId>com.googlecode.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- SPECIAL CASE - need JUNIT at build time and testing time -->
         <dependency>
             <groupId>junit</groupId>
@@ -68,11 +73,6 @@
             <groupId>org.mortbay.jetty</groupId>
             <artifactId>jetty-servlet-tester</artifactId>
             <version>6.1.14</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>mockit</groupId>
-            <artifactId>jmockit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -93,8 +93,6 @@
                     Enable to debug Maven Surefire tests in remote proces
                     <debugForkedProcess>true</debugForkedProcess>
                     -->
-                    <!-- required when running JMockit under Java 1.5 -->
-                    <argLine>-javaagent:"${settings.localRepository}"/mockit/jmockit/0.999.4/jmockit-0.999.4.jar</argLine>
                 </configuration>
              </plugin>
              <plugin>
@@ -1021,16 +1019,16 @@
              <artifactId>slf4j-log4j12</artifactId>
              <version>${slf4j.version}</version>
          </dependency>
+         <dependency> <!-- Keep jmockit before junit -->
+            <groupId>com.googlecode.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+            <version>1.1</version>
+            <scope>test</scope>
+         </dependency>
          <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.8.1</version>
-            <scope>test</scope>
-         </dependency>
-         <dependency>
-            <groupId>mockit</groupId>
-            <artifactId>jmockit</artifactId>
-            <version>0.999.4</version>
             <scope>test</scope>
          </dependency>
          <dependency>


### PR DESCRIPTION
Needed by [DS-1935] which upgrades required Java version to 1.7.

https://jira.duraspace.org/browse/DS-1939
