### PR TITLE
[DS-1805] Maven filtering broken for SOLR artifact.

### DIFF
--- a/dspace-solr/pom.xml
+++ b/dspace-solr/pom.xml
@@ -39,6 +39,10 @@
     </properties>
 
     <build>
+        <filters>
+            <!-- Filter using the properties file defined by dspace-parent POM -->
+            <filter>${filters.file}</filter>
+        </filters>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -60,6 +64,15 @@
                             </excludes>
                         </overlay>
                     </overlays>
+                    <webResources>
+                        <resource>
+                            <filtering>true</filtering>
+                            <directory>${basedir}/src/main/webapp</directory>
+                            <includes>
+                                <include>WEB-INF/web.xml</include>
+                            </includes>
+                        </resource>
+                    </webResources>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Enable filtering of dspace-solr's web.xml.

Fixes https://jira.duraspace.org/browse/DS-1805
