### PR TITLE
DS-1971 Updated bte dependency to v0.9.2.4

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -436,12 +436,12 @@
         <dependency>
             <groupId>gr.ekt.bte</groupId>
             <artifactId>bte-core</artifactId>
-            <version>0.9.2.3</version>
+            <version>0.9.2.4</version>
         </dependency>
         <dependency>
             <groupId>gr.ekt.bte</groupId>
             <artifactId>bte-io</artifactId>
-            <version>0.9.2.3</version>
+            <version>0.9.2.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
By mistake bte-io version 0.9.2.3 had a dependency on bte-core 0.9.2.3-SNAPSHOT (http://search.maven.org/remotecontent?filepath=gr/ekt/bte/bte-io/0.9.2.3/bte-io-0.9.2.3.pom), which was producing a warning when building dspace-api. 

A new version of BTE (0.9.2.4) has been published in maven central and this pull request updates the dspace-api dependency information on BTE, so that building it does not produce this warning.
