### PR TITLE
DS-1981   remove newlines before printing to CSV file in metadata-export

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSVLine.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSVLine.java
@@ -187,7 +187,7 @@ public class DSpaceCSVLine implements Serializable
         }
 
         // Replace newline with ' '
-        s = s.replace("\n", " ");
+        s = s.replaceAll("\n", " ");
         // Replace internal quotes with two sets of quotes
         return "\"" + s.replaceAll("\"", "\"\"") + "\"";
     }

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSVLine.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSVLine.java
@@ -186,6 +186,8 @@ public class DSpaceCSVLine implements Serializable
             s = str.toString();
         }
 
+        // Replace newline with ' '
+        s = s.replace("\n", " ");
         // Replace internal quotes with two sets of quotes
         return "\"" + s.replaceAll("\"", "\"\"") + "\"";
     }


### PR DESCRIPTION
we have dirty data in our repo - aka item names with newlines 

this creates messy CSV output in the metadata exporter 

https://jira.duraspace.org/browse/DS-1981
