### PR TITLE
DS-1951  Global Setting to stop Explicit Authentication Trigger for GET-DSObject requests (JSPUI only)

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/DSpaceServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/DSpaceServlet.java
@@ -20,6 +20,7 @@ import org.dspace.app.webui.util.Authenticate;
 import org.dspace.app.webui.util.JSPManager;
 import org.dspace.app.webui.util.UIUtil;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 import org.dspace.core.LogManager;
 
@@ -134,19 +135,28 @@ public class DSpaceServlet extends HttpServlet
         catch (AuthorizeException ae)
         {
             /*
-             * If no user is logged in, we will start authentication, since if
-             * they authenticate, they might be allowed to do what they tried to
-             * do. If someone IS logged in, and we got this exception, we know
-             * they tried to do something they aren't allowed to, so we display
-             * an error in that case.
+             * somebody logged in
+             * ==> we know user not allowed to do whatever she tried
              */
-            if (context.getCurrentUser() != null ||
-                Authenticate.startAuthentication(context, request, response))
-            {
+            /* nobody logged in && auto.explicit == true
+             * ==> start explicit authentication
+             *  account owners can login and might get their request through
+             *  others get login prompt instead of 403
+             */
+            /* nobody logged in && auto.explicit == false
+             * ==> authenticate error
+             * account owners can try to login in by clicking the 'My DSpace' and ty again
+             * others will get error page
+             */
+            Boolean doexplicit = ConfigurationManager.getBooleanProperty("authentication", "auto.explicit", true);
+            Boolean noAccess = true;
+            if (doexplicit && null == context.getCurrentUser() ) {
+                noAccess = Authenticate.startAuthentication(context, request, response);
+            }
+            if (noAccess) {
                 // FIXME: Log the right info?
                 // Log the error
-                log.info(LogManager.getHeader(context, "authorize_error", ae
-                        .toString()));
+                log.info(LogManager.getHeader(context, "authorize_error", ae.toString()));
 
                 JSPManager.showAuthorizeError(request, response, ae);
             }

--- a/dspace-jspui/src/main/webapp/error/authorize.jsp
+++ b/dspace-jspui/src/main/webapp/error/authorize.jsp
@@ -18,7 +18,9 @@
 	
 <%@ page isErrorPage="true" %>
 
-<%@ taglib uri="http://www.dspace.org/dspace-tags.tld" prefix="dspace" %>
+<%@ taglib uri="/WEB-INF/dspace-tags.tld" prefix="dspace" %>
+
+<%@ page import="org.dspace.eperson.EPerson" %>
 
 <dspace:layout titlekey="jsp.error.authorize.title">
 
@@ -28,9 +30,27 @@
     <%-- <p>You do not have permission to perform the action you just attempted.</p> --%>
     <p><fmt:message key="jsp.error.authorize.text1"/></p>
 
+<%
+    // Is anyone logged in?
+    EPerson user = (EPerson) request.getAttribute("dspace.current.user");
+
+    if (user == null) {
+        /* nobody logged + authorization error => system decided based
+         * on implicit authorization (in PU case IPAutentocation) alone
+         */
+%>
+    <p>
+    If you have an account you should login and attempt your action again.
+    </p>
+<%
+    } else {
+%>
     <%-- <p>If you think you should have authorization, please feel free to
     contact the DSpace administrators:</p> --%>
     <p><fmt:message key="jsp.error.authorize.text2"/></p>
+<%
+    }
+%>
 
     <dspace:include page="/components/contact-info.jsp" />
 
@@ -38,5 +58,5 @@
         <%-- <a href="<%= request.getContextPath() %>/">Go to the DSpace home page</a> --%>
         <a href="<%= request.getContextPath() %>/"><fmt:message key="jsp.general.gohome"/></a>
     </p>
-	
+
 </dspace:layout>

--- a/dspace/config/modules/authentication.cfg
+++ b/dspace/config/modules/authentication.cfg
@@ -34,5 +34,26 @@
 #         org.dspace.authenticate.ShibAuthentication, \
 #         org.dspace.authenticate.PasswordAuthentication
 
+#---------------------------------------------------------------#
+# if using implicit authentication in some/all resource policies  
+# AND 
+# if you want to prevent DSPACE to explicitly prompt for credentials 
+# where authorization fails on content, that is community. collection, 
+# item pages and bisttreams 
+# THEN 
+# model your settings after the following:
+# 
+#plugin.sequence.org.dspace.authenticate.AuthenticationMethod = \
+#         org.dspace.authenticate.IPAuthentication, \
+#         org.dspace.authenticate.PasswordAuthentication
+#auto.explicit = false
+#---------------------------------------------------------------#
+
+#---------------------------------------------------------------#
+# default authorization settings 
+#---------------------------------------------------------------#
 plugin.sequence.org.dspace.authenticate.AuthenticationMethod = \
-        org.dspace.authenticate.PasswordAuthentication
+         org.dspace.authenticate.PasswordAuthentication
+
+auto.explicit = true    # this is the default 
+


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-1951

This feature is intended for the following use case 

A repository is configured with implicit and explicit authentication mechanisms. 
Some content is accessible to all, some is restricted to certain IP lists. 
User accounts are given to administrators only, who submit/edit items/metadata ... 
Document viewing in the repository is either restricted to IP address lists or open to the world. 

So lets assume authentication setup as follows: 

--- config/modules/authentication.cfg 
plugin.sequence.org.dspace.authenticate.AuthenticationMethod = \ 
         org.dspace.authenticate.IPAuthentication, \ 
         org.dspace.authenticate.PasswordAuthentication 

Let us assume that JaneJohn tries to access an item/bistream with READ restricted to a set of IP addresses, eg UniversityCampusIPs. 

If JaneJohn is a random site visitor coming from an IP address not in the access list, she should not be prompted to log in; she should simply be told : 'you can't do that' aka 403 

If JaneJohn issues her GET from an IP in the allowed list she should be presented with the relevant content. 

If JaneJohn happens to be at home and has an admin account, she might be a little puzzled why the system now decides not to show her what she is asking for. But she can always login and assuming her account is setup to view the said content, she can still get to it after logging in via /mydspace 

If JaneJohn wants to do admin work she should still be prompted to login if she has not yet done so. 
