### PR TITLE
DS-1989 - ant fails on prepare_configs

### DIFF
--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -353,7 +353,10 @@ Common usage:
         Prepare properly filtered files
         -->
         <copy todir="config-temp" preservelastmodified="true" overwrite="true" failonerror="false">
-            <fileset dir="config" excludes="dspace.cfg" />
+            <fileset dir="config"> 
+                <exclude name="dspace.cfg" />
+                <exclude name="GeoLiteCity.dat" />
+            </fileset> 
             <filterchain>
                 <expandproperties />
             </filterchain>


### PR DESCRIPTION
see    https://jira.duraspace.org/browse/DS-1989

I fixed the immediate issue by explicitly excluding GeoLiteCity.dat from ant's  expandproperties filter 

it is probably a better idea to change such that the filter applies to a restricted subset of all config files only, eg all *.properties, *.xml, ...      I would have put that in place, but am not sure which files should be on the change list 
