### PR TITLE
[DS-2005] Discovery hit highlighting issue with abstracts/fulltext

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/AbstractSearch.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/AbstractSearch.java
@@ -616,8 +616,8 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
                         }
                         break;
                     default:
-                        //Partial match allowed, only render the highlighted part
-                        if(value.contains(highlight.replaceAll("</?em>", "")))
+                        //Partial match allowed, only render the highlighted part (will also remove \r since this char is not indexed in solr & will cause issues
+                        if(value.replace("\r", "").contains(highlight.replaceAll("</?em>", "")))
                         {
                             value = highlight;
                         }


### PR DESCRIPTION
When the metadata contains the \r character and the metadata field set to hit highlighting uses the maxSize property the highlighting will not work.

The fix I created is the same as on line 613, this appears to have been forgotten when the maxSize attribute is used.
