### PR TITLE
DS-1990: Events should contain all identifiers, not only handles.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/Bitstream.java
+++ b/dspace-api/src/main/java/org/dspace/content/Bitstream.java
@@ -212,7 +212,7 @@ public class Bitstream extends DSpaceObject
         bitstream.setFormat(null);
 
         context.addEvent(new Event(Event.CREATE, Constants.BITSTREAM, 
-                bitstreamID, null, bitstream.lookupIdentifiers(context)));
+                bitstreamID, null, bitstream.getIdentifiers(context)));
 
         return bitstream;
     }
@@ -248,7 +248,7 @@ public class Bitstream extends DSpaceObject
         bitstream.setFormat(null);
 
         context.addEvent(new Event(Event.CREATE, Constants.BITSTREAM, 
-                bitstreamID, "REGISTER", bitstream.lookupIdentifiers(context)));
+                bitstreamID, "REGISTER", bitstream.getIdentifiers(context)));
 
         return bitstream;
     }
@@ -509,14 +509,14 @@ public class Bitstream extends DSpaceObject
         if (modified)
         {
             bContext.addEvent(new Event(Event.MODIFY, Constants.BITSTREAM, 
-                    getID(), null, lookupIdentifiers(bContext)));
+                    getID(), null, getIdentifiers(bContext)));
             modified = false;
         }
         if (modifiedMetadata)
         {
             bContext.addEvent(new Event(Event.MODIFY_METADATA, 
                     Constants.BITSTREAM, getID(), getDetails(),
-                    lookupIdentifiers(bContext)));
+                    getIdentifiers(bContext)));
             modifiedMetadata = false;
             clearDetails();
         }
@@ -544,7 +544,7 @@ public class Bitstream extends DSpaceObject
                 "bitstream_id=" + getID()));
 
         bContext.addEvent(new Event(Event.DELETE, Constants.BITSTREAM, getID(), 
-                String.valueOf(getSequenceID()), lookupIdentifiers(bContext)));
+                String.valueOf(getSequenceID()), getIdentifiers(bContext)));
 
         // Remove from cache
         bContext.removeCached(this, getID());
@@ -751,6 +751,6 @@ public class Bitstream extends DSpaceObject
     {
         //Also fire a modified event since the bitstream HAS been modified
         bContext.addEvent(new Event(Event.MODIFY, Constants.BITSTREAM, getID(), 
-                null, lookupIdentifiers(bContext)));
+                null, getIdentifiers(bContext)));
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/Bitstream.java
+++ b/dspace-api/src/main/java/org/dspace/content/Bitstream.java
@@ -211,7 +211,8 @@ public class Bitstream extends DSpaceObject
         Bitstream bitstream = find(context, bitstreamID);
         bitstream.setFormat(null);
 
-        context.addEvent(new Event(Event.CREATE, Constants.BITSTREAM, bitstreamID, null));
+        context.addEvent(new Event(Event.CREATE, Constants.BITSTREAM, 
+                bitstreamID, null, bitstream.lookupIdentifiers(context)));
 
         return bitstream;
     }
@@ -246,7 +247,8 @@ public class Bitstream extends DSpaceObject
         Bitstream bitstream = find(context, bitstreamID);
         bitstream.setFormat(null);
 
-        context.addEvent(new Event(Event.CREATE, Constants.BITSTREAM, bitstreamID, "REGISTER"));
+        context.addEvent(new Event(Event.CREATE, Constants.BITSTREAM, 
+                bitstreamID, "REGISTER", bitstream.lookupIdentifiers(context)));
 
         return bitstream;
     }
@@ -506,12 +508,15 @@ public class Bitstream extends DSpaceObject
 
         if (modified)
         {
-            bContext.addEvent(new Event(Event.MODIFY, Constants.BITSTREAM, getID(), null));
+            bContext.addEvent(new Event(Event.MODIFY, Constants.BITSTREAM, 
+                    getID(), null, lookupIdentifiers(bContext)));
             modified = false;
         }
         if (modifiedMetadata)
         {
-            bContext.addEvent(new Event(Event.MODIFY_METADATA, Constants.BITSTREAM, getID(), getDetails()));
+            bContext.addEvent(new Event(Event.MODIFY_METADATA, 
+                    Constants.BITSTREAM, getID(), getDetails(),
+                    lookupIdentifiers(bContext)));
             modifiedMetadata = false;
             clearDetails();
         }
@@ -538,7 +543,8 @@ public class Bitstream extends DSpaceObject
         log.info(LogManager.getHeader(bContext, "delete_bitstream",
                 "bitstream_id=" + getID()));
 
-        bContext.addEvent(new Event(Event.DELETE, Constants.BITSTREAM, getID(), String.valueOf(getSequenceID())));
+        bContext.addEvent(new Event(Event.DELETE, Constants.BITSTREAM, getID(), 
+                String.valueOf(getSequenceID()), lookupIdentifiers(bContext)));
 
         // Remove from cache
         bContext.removeCached(this, getID());
@@ -744,6 +750,7 @@ public class Bitstream extends DSpaceObject
     public void updateLastModified()
     {
         //Also fire a modified event since the bitstream HAS been modified
-        bContext.addEvent(new Event(Event.MODIFY, Constants.BITSTREAM, getID(), null));
+        bContext.addEvent(new Event(Event.MODIFY, Constants.BITSTREAM, getID(), 
+                null, lookupIdentifiers(bContext)));
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/Bundle.java
+++ b/dspace-api/src/main/java/org/dspace/content/Bundle.java
@@ -201,6 +201,9 @@ public class Bundle extends DSpaceObject
         log.info(LogManager.getHeader(context, "create_bundle", "bundle_id="
                 + row.getIntColumn("bundle_id")));
 
+        // if we ever use the identifier service for bundles, we should
+        // create the bundle before we create the Event and should add all 
+        // identifiers to it.
         context.addEvent(new Event(Event.CREATE, Constants.BUNDLE, row.getIntColumn("bundle_id"), null));
 
         return new Bundle(context, row);
@@ -443,7 +446,9 @@ public class Bundle extends DSpaceObject
         // Add the bitstream object
         bitstreams.add(b);
 
-        ourContext.addEvent(new Event(Event.ADD, Constants.BUNDLE, getID(), Constants.BITSTREAM, b.getID(), String.valueOf(b.getSequenceID())));
+        ourContext.addEvent(new Event(Event.ADD, Constants.BUNDLE, getID(), 
+                Constants.BITSTREAM, b.getID(), String.valueOf(b.getSequenceID()),
+                lookupIdentifiers(ourContext)));
 
         // copy authorization policies from bundle to bitstream
         // FIXME: multiple inclusion is affected by this...
@@ -546,7 +551,9 @@ public class Bundle extends DSpaceObject
             }
         }
 
-        ourContext.addEvent(new Event(Event.REMOVE, Constants.BUNDLE, getID(), Constants.BITSTREAM, b.getID(), String.valueOf(b.getSequenceID())));
+        ourContext.addEvent(new Event(Event.REMOVE, Constants.BUNDLE, getID(), 
+                Constants.BITSTREAM, b.getID(), String.valueOf(b.getSequenceID()),
+                lookupIdentifiers(ourContext)));
 
         //Ensure that the last modified from the item is triggered !
         Item owningItem = (Item) getParentObject();
@@ -606,12 +613,14 @@ public class Bundle extends DSpaceObject
 
         if (modified)
         {
-            ourContext.addEvent(new Event(Event.MODIFY, Constants.BUNDLE, getID(), null));
+            ourContext.addEvent(new Event(Event.MODIFY, Constants.BUNDLE, getID(),
+                    null, lookupIdentifiers(ourContext)));
             modified = false;
         }
         if (modifiedMetadata)
         {
-            ourContext.addEvent(new Event(Event.MODIFY_METADATA, Constants.BUNDLE, getID(), null));
+            ourContext.addEvent(new Event(Event.MODIFY_METADATA, Constants.BUNDLE,
+                    getID(), null, lookupIdentifiers(ourContext)));
             modifiedMetadata = false;
         }
 
@@ -628,7 +637,8 @@ public class Bundle extends DSpaceObject
         log.info(LogManager.getHeader(ourContext, "delete_bundle", "bundle_id="
                 + getID()));
 
-        ourContext.addEvent(new Event(Event.DELETE, Constants.BUNDLE, getID(), getName()));
+        ourContext.addEvent(new Event(Event.DELETE, Constants.BUNDLE, getID(), 
+                getName(), lookupIdentifiers(ourContext)));
 
         // Remove from cache
         ourContext.removeCached(this, getID());

--- a/dspace-api/src/main/java/org/dspace/content/Bundle.java
+++ b/dspace-api/src/main/java/org/dspace/content/Bundle.java
@@ -448,7 +448,7 @@ public class Bundle extends DSpaceObject
 
         ourContext.addEvent(new Event(Event.ADD, Constants.BUNDLE, getID(), 
                 Constants.BITSTREAM, b.getID(), String.valueOf(b.getSequenceID()),
-                lookupIdentifiers(ourContext)));
+                getIdentifiers(ourContext)));
 
         // copy authorization policies from bundle to bitstream
         // FIXME: multiple inclusion is affected by this...
@@ -553,7 +553,7 @@ public class Bundle extends DSpaceObject
 
         ourContext.addEvent(new Event(Event.REMOVE, Constants.BUNDLE, getID(), 
                 Constants.BITSTREAM, b.getID(), String.valueOf(b.getSequenceID()),
-                lookupIdentifiers(ourContext)));
+                getIdentifiers(ourContext)));
 
         //Ensure that the last modified from the item is triggered !
         Item owningItem = (Item) getParentObject();
@@ -614,13 +614,13 @@ public class Bundle extends DSpaceObject
         if (modified)
         {
             ourContext.addEvent(new Event(Event.MODIFY, Constants.BUNDLE, getID(),
-                    null, lookupIdentifiers(ourContext)));
+                    null, getIdentifiers(ourContext)));
             modified = false;
         }
         if (modifiedMetadata)
         {
             ourContext.addEvent(new Event(Event.MODIFY_METADATA, Constants.BUNDLE,
-                    getID(), null, lookupIdentifiers(ourContext)));
+                    getID(), null, getIdentifiers(ourContext)));
             modifiedMetadata = false;
         }
 
@@ -638,7 +638,7 @@ public class Bundle extends DSpaceObject
                 + getID()));
 
         ourContext.addEvent(new Event(Event.DELETE, Constants.BUNDLE, getID(), 
-                getName(), lookupIdentifiers(ourContext)));
+                getName(), getIdentifiers(ourContext)));
 
         // Remove from cache
         ourContext.removeCached(this, getID());

--- a/dspace-api/src/main/java/org/dspace/content/Collection.java
+++ b/dspace-api/src/main/java/org/dspace/content/Collection.java
@@ -279,7 +279,8 @@ public class Collection extends DSpaceObject
         myPolicy.setGroup(anonymousGroup);
         myPolicy.update();
 
-        context.addEvent(new Event(Event.CREATE, Constants.COLLECTION, c.getID(), c.handle));
+        context.addEvent(new Event(Event.CREATE, Constants.COLLECTION, 
+                c.getID(), c.handle, c.lookupIdentifiers(context)));
 
         log.info(LogManager.getHeader(context, "create_collection",
                 "collection_id=" + row.getIntColumn("collection_id"))
@@ -969,7 +970,8 @@ public class Collection extends DSpaceObject
             template = null;
         }
 
-        ourContext.addEvent(new Event(Event.MODIFY, Constants.COLLECTION, getID(), "remove_template_item"));
+        ourContext.addEvent(new Event(Event.MODIFY, Constants.COLLECTION, 
+                getID(), "remove_template_item", lookupIdentifiers(ourContext)));
     }
 
     /**
@@ -999,7 +1001,9 @@ public class Collection extends DSpaceObject
 
         DatabaseManager.insert(ourContext, row);
 
-        ourContext.addEvent(new Event(Event.ADD, Constants.COLLECTION, getID(), Constants.ITEM, item.getID(), item.getHandle()));
+        ourContext.addEvent(new Event(Event.ADD, Constants.COLLECTION, getID(), 
+                Constants.ITEM, item.getID(), item.getHandle(), 
+                lookupIdentifiers(ourContext)));
     }
 
     /**
@@ -1037,7 +1041,9 @@ public class Collection extends DSpaceObject
                 getID(), item.getID());
         DatabaseManager.setConstraintImmediate(ourContext, "coll2item_item_fk");
 
-        ourContext.addEvent(new Event(Event.REMOVE, Constants.COLLECTION, getID(), Constants.ITEM, item.getID(), item.getHandle()));
+        ourContext.addEvent(new Event(Event.REMOVE, Constants.COLLECTION, 
+                getID(), Constants.ITEM, item.getID(), item.getHandle(),
+                lookupIdentifiers(ourContext)));
     }
 
     /**
@@ -1060,12 +1066,15 @@ public class Collection extends DSpaceObject
 
         if (modified)
         {
-            ourContext.addEvent(new Event(Event.MODIFY, Constants.COLLECTION, getID(), null));
+            ourContext.addEvent(new Event(Event.MODIFY, Constants.COLLECTION, 
+                    getID(), null, lookupIdentifiers(ourContext)));
             modified = false;
         }
         if (modifiedMetadata)
         {
-            ourContext.addEvent(new Event(Event.MODIFY_METADATA, Constants.COLLECTION, getID(), getDetails()));
+            ourContext.addEvent(new Event(Event.MODIFY_METADATA, 
+                    Constants.COLLECTION, getID(), getDetails(), 
+                    lookupIdentifiers(ourContext)));
             modifiedMetadata = false;
             clearDetails();
         }
@@ -1131,7 +1140,8 @@ public class Collection extends DSpaceObject
         log.info(LogManager.getHeader(ourContext, "delete_collection",
                 "collection_id=" + getID()));
 
-        ourContext.addEvent(new Event(Event.DELETE, Constants.COLLECTION, getID(), getHandle()));
+        ourContext.addEvent(new Event(Event.DELETE, Constants.COLLECTION, 
+                getID(), getHandle(), lookupIdentifiers(ourContext)));
 
         // Remove from cache
         ourContext.removeCached(this, getID());
@@ -1566,6 +1576,7 @@ public class Collection extends DSpaceObject
     public void updateLastModified()
     {
         //Also fire a modified event since the collection HAS been modified
-        ourContext.addEvent(new Event(Event.MODIFY, Constants.COLLECTION, getID(), null));
+        ourContext.addEvent(new Event(Event.MODIFY, Constants.COLLECTION, 
+                getID(), null, lookupIdentifiers(ourContext)));
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/Collection.java
+++ b/dspace-api/src/main/java/org/dspace/content/Collection.java
@@ -280,7 +280,7 @@ public class Collection extends DSpaceObject
         myPolicy.update();
 
         context.addEvent(new Event(Event.CREATE, Constants.COLLECTION, 
-                c.getID(), c.handle, c.lookupIdentifiers(context)));
+                c.getID(), c.handle, c.getIdentifiers(context)));
 
         log.info(LogManager.getHeader(context, "create_collection",
                 "collection_id=" + row.getIntColumn("collection_id"))
@@ -971,7 +971,7 @@ public class Collection extends DSpaceObject
         }
 
         ourContext.addEvent(new Event(Event.MODIFY, Constants.COLLECTION, 
-                getID(), "remove_template_item", lookupIdentifiers(ourContext)));
+                getID(), "remove_template_item", getIdentifiers(ourContext)));
     }
 
     /**
@@ -1003,7 +1003,7 @@ public class Collection extends DSpaceObject
 
         ourContext.addEvent(new Event(Event.ADD, Constants.COLLECTION, getID(), 
                 Constants.ITEM, item.getID(), item.getHandle(), 
-                lookupIdentifiers(ourContext)));
+                getIdentifiers(ourContext)));
     }
 
     /**
@@ -1043,7 +1043,7 @@ public class Collection extends DSpaceObject
 
         ourContext.addEvent(new Event(Event.REMOVE, Constants.COLLECTION, 
                 getID(), Constants.ITEM, item.getID(), item.getHandle(),
-                lookupIdentifiers(ourContext)));
+                getIdentifiers(ourContext)));
     }
 
     /**
@@ -1067,14 +1067,14 @@ public class Collection extends DSpaceObject
         if (modified)
         {
             ourContext.addEvent(new Event(Event.MODIFY, Constants.COLLECTION, 
-                    getID(), null, lookupIdentifiers(ourContext)));
+                    getID(), null, getIdentifiers(ourContext)));
             modified = false;
         }
         if (modifiedMetadata)
         {
             ourContext.addEvent(new Event(Event.MODIFY_METADATA, 
                     Constants.COLLECTION, getID(), getDetails(), 
-                    lookupIdentifiers(ourContext)));
+                    getIdentifiers(ourContext)));
             modifiedMetadata = false;
             clearDetails();
         }
@@ -1141,7 +1141,7 @@ public class Collection extends DSpaceObject
                 "collection_id=" + getID()));
 
         ourContext.addEvent(new Event(Event.DELETE, Constants.COLLECTION, 
-                getID(), getHandle(), lookupIdentifiers(ourContext)));
+                getID(), getHandle(), getIdentifiers(ourContext)));
 
         // Remove from cache
         ourContext.removeCached(this, getID());
@@ -1577,6 +1577,6 @@ public class Collection extends DSpaceObject
     {
         //Also fire a modified event since the collection HAS been modified
         ourContext.addEvent(new Event(Event.MODIFY, Constants.COLLECTION, 
-                getID(), null, lookupIdentifiers(ourContext)));
+                getID(), null, getIdentifiers(ourContext)));
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/Community.java
+++ b/dspace-api/src/main/java/org/dspace/content/Community.java
@@ -233,14 +233,14 @@ public class Community extends DSpaceObject
         myPolicy.update();
 
         context.addEvent(new Event(Event.CREATE, Constants.COMMUNITY, c.getID(), 
-                c.handle, c.lookupIdentifiers(context)));
+                c.handle, c.getIdentifiers(context)));
 
         // if creating a top-level Community, simulate an ADD event at the Site.
         if (parent == null)
         {
             context.addEvent(new Event(Event.ADD, Constants.SITE, Site.SITE_ID, 
                     Constants.COMMUNITY, c.getID(), c.handle, 
-                    c.lookupIdentifiers(context)));
+                    c.getIdentifiers(context)));
         }
 
         log.info(LogManager.getHeader(context, "create_community",
@@ -531,14 +531,14 @@ public class Community extends DSpaceObject
         if (modified)
         {
             ourContext.addEvent(new Event(Event.MODIFY, Constants.COMMUNITY, 
-                    getID(), null, lookupIdentifiers(ourContext)));
+                    getID(), null, getIdentifiers(ourContext)));
             modified = false;
         }
         if (modifiedMetadata)
         {
             ourContext.addEvent(new Event(Event.MODIFY_METADATA, 
                     Constants.COMMUNITY, getID(), getDetails(), 
-                    lookupIdentifiers(ourContext)));
+                    getIdentifiers(ourContext)));
             modifiedMetadata = false;
             clearDetails();
         }
@@ -911,7 +911,7 @@ public class Community extends DSpaceObject
 
                 ourContext.addEvent(new Event(Event.ADD, Constants.COMMUNITY, 
                         getID(), Constants.COLLECTION, c.getID(), c.getHandle(),
-                        lookupIdentifiers(ourContext)));
+                        getIdentifiers(ourContext)));
 
                 DatabaseManager.insert(ourContext, mappingRow);
             }
@@ -988,7 +988,7 @@ public class Community extends DSpaceObject
 
                 ourContext.addEvent(new Event(Event.ADD, Constants.COMMUNITY, 
                         getID(), Constants.COMMUNITY, c.getID(), c.getHandle(),
-                        lookupIdentifiers(ourContext)));
+                        getIdentifiers(ourContext)));
 
                 DatabaseManager.insert(ourContext, mappingRow);
             }
@@ -1026,7 +1026,7 @@ public class Community extends DSpaceObject
             // Capture ID & Handle of Collection we are removing, so we can trigger events later
             int removedId = c.getID();
             String removedHandle = c.getHandle();
-            String[] removedIdentifiers = c.lookupIdentifiers(ourContext);
+            String[] removedIdentifiers = c.getIdentifiers(ourContext);
 
             // How many parent(s) does this collection have?
             TableRow trow = DatabaseManager.querySingle(ourContext,
@@ -1087,7 +1087,7 @@ public class Community extends DSpaceObject
             // Capture ID & Handle of Community we are removing, so we can trigger events later
             int removedId = c.getID();
             String removedHandle = c.getHandle();
-            String[] removedIdentifiers = c.lookupIdentifiers(ourContext);
+            String[] removedIdentifiers = c.getIdentifiers(ourContext);
         
             // How many parent(s) does this subcommunity have?
             TableRow trow = DatabaseManager.querySingle(ourContext,
@@ -1158,7 +1158,7 @@ public class Community extends DSpaceObject
 
             // Since this is a top level Community, simulate a REMOVE event at the Site.
             ourContext.addEvent(new Event(Event.REMOVE, Constants.SITE, Site.SITE_ID,
-                    Constants.COMMUNITY, getID(), getHandle(), lookupIdentifiers(ourContext)));
+                    Constants.COMMUNITY, getID(), getHandle(), getIdentifiers(ourContext)));
         } else {
             // This is a subcommunity, so let the parent remove it
             // NOTE: this essentially just logs event and calls "rawDelete()"
@@ -1182,7 +1182,7 @@ public class Community extends DSpaceObject
         // Capture ID & Handle of object we are removing, so we can trigger events later
         int deletedId = getID();
         String deletedHandle = getHandle();
-        String[] deletedIdentifiers = lookupIdentifiers(ourContext);
+        String[] deletedIdentifiers = getIdentifiers(ourContext);
 
         // Remove Community object from cache
         ourContext.removeCached(this, getID());
@@ -1401,6 +1401,6 @@ public class Community extends DSpaceObject
     {
         //Also fire a modified event since the community HAS been modified
         ourContext.addEvent(new Event(Event.MODIFY, Constants.COMMUNITY, 
-                getID(), null, lookupIdentifiers(ourContext)));
+                getID(), null, getIdentifiers(ourContext)));
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
@@ -134,6 +134,13 @@ public abstract class DSpaceObject
             }
         }
 
+        // it the DSO has no identifiers at all including handle, we should return an empty array.
+        // G.e. items during submission (workspace items) have no handle and no other identifier.
+        if (identifiers == null)
+        {
+            identifiers = new String[] {};
+        }
+
         if (log.isDebugEnabled())
         {
             StringBuilder dbgMsg = new StringBuilder();

--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
@@ -8,18 +8,24 @@
 package org.dspace.content;
 
 import java.sql.SQLException;
+import org.apache.log4j.Logger;
 
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
+import org.dspace.handle.HandleManager;
+import org.dspace.identifier.IdentifierService;
+import org.dspace.utils.DSpace;
 
 /**
  * Abstract base class for DSpace objects
  */
 public abstract class DSpaceObject
 {
+    private static final Logger log = Logger.getLogger(DSpaceObject.class);
+    
     // accumulate information to add to "detail" element of content Event,
     // e.g. to document metadata fields touched, etc.
     private StringBuffer eventDetails = null;
@@ -98,6 +104,32 @@ public abstract class DSpaceObject
      *         one
      */
     public abstract String getName();
+    
+    /**
+     * Tries to lookup all Identifiers of this DSpaceObject.
+     * @return An array containing all found identifiers or an array with a length of 0.
+     */
+    public String[] lookupIdentifiers(Context context)
+    {
+        String[] identifiers = new String[0];
+        IdentifierService identifierService = 
+                new DSpace().getSingletonService(IdentifierService.class);
+        
+        if (identifierService != null)
+        {
+            return identifierService.lookup(context, this);
+        }
+        
+        log.warn("No IdentifierService found, will return an array containing "
+                + "the Handle only.");
+        
+        if (getHandle() != null)
+        {
+            return new String[] { HandleManager.getCanonicalForm(getHandle()) };
+        }
+
+        return new String[0];
+    }
 
     /**
      * Generic find for when the precise type of a DSO is not known, just the

--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
@@ -29,6 +29,8 @@ public abstract class DSpaceObject
     // accumulate information to add to "detail" element of content Event,
     // e.g. to document metadata fields touched, etc.
     private StringBuffer eventDetails = null;
+    
+    private String[] identifiers = null;
 
     /**
      * Reset the cache of event details.
@@ -109,26 +111,52 @@ public abstract class DSpaceObject
      * Tries to lookup all Identifiers of this DSpaceObject.
      * @return An array containing all found identifiers or an array with a length of 0.
      */
-    public String[] lookupIdentifiers(Context context)
+    public String[] getIdentifiers(Context context)
     {
-        String[] identifiers = new String[0];
-        IdentifierService identifierService = 
-                new DSpace().getSingletonService(IdentifierService.class);
-        
-        if (identifierService != null)
+        if (identifiers == null)
         {
-            return identifierService.lookup(context, this);
-        }
-        
-        log.warn("No IdentifierService found, will return an array containing "
-                + "the Handle only.");
-        
-        if (getHandle() != null)
-        {
-            return new String[] { HandleManager.getCanonicalForm(getHandle()) };
+            log.debug("This DSO's identifiers cache is empty, looking for identifiers...");
+            identifiers = new String[0];
+
+            IdentifierService identifierService = 
+                    new DSpace().getSingletonService(IdentifierService.class);
+
+            if (identifierService != null)
+            {
+                identifiers = identifierService.lookup(context, this);
+            } else {
+                log.warn("No IdentifierService found, will return an array containing "
+                        + "the Handle only.");
+                if (getHandle() != null)
+                {
+                    identifiers = new String[] { HandleManager.getCanonicalForm(getHandle()) };
+                }
+            }
         }
 
-        return new String[0];
+        if (log.isDebugEnabled())
+        {
+            StringBuilder dbgMsg = new StringBuilder();
+            for (String id : identifiers)
+            {
+                if (dbgMsg.capacity() == 0)
+                {
+                    dbgMsg.append("This DSO's Identifiers are: ");
+                } else {
+                    dbgMsg.append(", ");
+                }
+                dbgMsg.append(id);
+            }
+            dbgMsg.append(".");
+            log.debug(dbgMsg.toString());
+        }
+
+        return identifiers;
+    }
+    
+    public void resetIdentifiersCache()
+    {
+        identifiers = null;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/InstallItem.java
+++ b/dspace-api/src/main/java/org/dspace/content/InstallItem.java
@@ -224,7 +224,7 @@ public class InstallItem
 
         // Notify interested parties of newly archived Item
         c.addEvent(new Event(Event.INSTALL, Constants.ITEM, item.getID(),
-                item.getHandle()));
+                item.getHandle(), item.lookupIdentifiers(c)));
 
         // remove in-progress submission
         is.deleteWrapper();

--- a/dspace-api/src/main/java/org/dspace/content/InstallItem.java
+++ b/dspace-api/src/main/java/org/dspace/content/InstallItem.java
@@ -224,7 +224,7 @@ public class InstallItem
 
         // Notify interested parties of newly archived Item
         c.addEvent(new Event(Event.INSTALL, Constants.ITEM, item.getID(),
-                item.getHandle(), item.lookupIdentifiers(c)));
+                item.getHandle(), item.getIdentifiers(c)));
 
         // remove in-progress submission
         is.deleteWrapper();

--- a/dspace-api/src/main/java/org/dspace/content/Item.java
+++ b/dspace-api/src/main/java/org/dspace/content/Item.java
@@ -201,7 +201,7 @@ public class Item extends DSpaceObject
         context.restoreAuthSystemState();
 
         context.addEvent(new Event(Event.CREATE, Constants.ITEM, i.getID(), 
-                null, i.lookupIdentifiers(context)));
+                null, i.getIdentifiers(context)));
 
         log.info(LogManager.getHeader(context, "create_item", "item_id="
                 + row.getIntColumn("item_id")));
@@ -358,7 +358,7 @@ public class Item extends DSpaceObject
             itemRow.setColumn("last_modified", lastModified);
             DatabaseManager.updateQuery(ourContext, "UPDATE item SET last_modified = ? WHERE item_id= ? ", lastModified, getID());
             //Also fire a modified event since the item HAS been modified
-            ourContext.addEvent(new Event(Event.MODIFY, Constants.ITEM, getID(), null, lookupIdentifiers(ourContext)));
+            ourContext.addEvent(new Event(Event.MODIFY, Constants.ITEM, getID(), null, getIdentifiers(ourContext)));
         } catch (SQLException e) {
             log.error(LogManager.getHeader(ourContext, "Error while updating last modified timestamp", "Item: " + getID()));
         }
@@ -1307,7 +1307,7 @@ public class Item extends DSpaceObject
 
         ourContext.addEvent(new Event(Event.ADD, Constants.ITEM, getID(), 
                 Constants.BUNDLE, b.getID(), b.getName(), 
-                lookupIdentifiers(ourContext)));
+                getIdentifiers(ourContext)));
     }
 
     /**
@@ -1349,7 +1349,7 @@ public class Item extends DSpaceObject
                 getID(), b.getID());
 
         ourContext.addEvent(new Event(Event.REMOVE, Constants.ITEM, getID(), 
-                Constants.BUNDLE, b.getID(), b.getName(), lookupIdentifiers(ourContext)));
+                Constants.BUNDLE, b.getID(), b.getName(), getIdentifiers(ourContext)));
 
         // If the bundle is orphaned, it's removed
         TableRowIterator tri = DatabaseManager.query(ourContext,
@@ -1810,13 +1810,13 @@ public class Item extends DSpaceObject
             if (dublinCoreChanged)
             {
                 ourContext.addEvent(new Event(Event.MODIFY_METADATA, Constants.ITEM, getID(), 
-                        getDetails(), lookupIdentifiers(ourContext)));
+                        getDetails(), getIdentifiers(ourContext)));
                 clearDetails();
                 dublinCoreChanged = false;
             }
 
             ourContext.addEvent(new Event(Event.MODIFY, Constants.ITEM, getID(), 
-                    null, lookupIdentifiers(ourContext)));
+                    null, getIdentifiers(ourContext)));
             modified = false;
         }
     }
@@ -1909,7 +1909,7 @@ public class Item extends DSpaceObject
         update();
 
         ourContext.addEvent(new Event(Event.MODIFY, Constants.ITEM, getID(), 
-                "WITHDRAW", lookupIdentifiers(ourContext)));
+                "WITHDRAW", getIdentifiers(ourContext)));
 
         // remove all authorization policies, saving the custom ones
         AuthorizeManager.removeAllPoliciesByDSOAndTypeNotEqualsTo(ourContext, this, ResourcePolicy.TYPE_CUSTOM);
@@ -1967,7 +1967,7 @@ public class Item extends DSpaceObject
         update();
 
         ourContext.addEvent(new Event(Event.MODIFY, Constants.ITEM, getID(), 
-                "REINSTATE", lookupIdentifiers(ourContext)));
+                "REINSTATE", getIdentifiers(ourContext)));
 
         // authorization policies
         if (colls.length > 0)
@@ -2001,7 +2001,7 @@ public class Item extends DSpaceObject
         AuthorizeManager.authorizeAction(ourContext, this, Constants.REMOVE);
 
         ourContext.addEvent(new Event(Event.DELETE, Constants.ITEM, getID(), 
-                getHandle(), lookupIdentifiers(ourContext)));
+                getHandle(), getIdentifiers(ourContext)));
 
         log.info(LogManager.getHeader(ourContext, "delete_item", "item_id="
                 + getID()));
@@ -2424,7 +2424,7 @@ public class Item extends DSpaceObject
             // so we only do this here if the owning collection hasn't changed.
             
             ourContext.addEvent(new Event(Event.MODIFY, Constants.ITEM, getID(), 
-                    null, lookupIdentifiers(ourContext)));
+                    null, getIdentifiers(ourContext)));
         }
     }
     

--- a/dspace-api/src/main/java/org/dspace/content/Item.java
+++ b/dspace-api/src/main/java/org/dspace/content/Item.java
@@ -200,7 +200,8 @@ public class Item extends DSpaceObject
         i.update();
         context.restoreAuthSystemState();
 
-        context.addEvent(new Event(Event.CREATE, Constants.ITEM, i.getID(), null));
+        context.addEvent(new Event(Event.CREATE, Constants.ITEM, i.getID(), 
+                null, i.lookupIdentifiers(context)));
 
         log.info(LogManager.getHeader(context, "create_item", "item_id="
                 + row.getIntColumn("item_id")));
@@ -357,7 +358,7 @@ public class Item extends DSpaceObject
             itemRow.setColumn("last_modified", lastModified);
             DatabaseManager.updateQuery(ourContext, "UPDATE item SET last_modified = ? WHERE item_id= ? ", lastModified, getID());
             //Also fire a modified event since the item HAS been modified
-            ourContext.addEvent(new Event(Event.MODIFY, Constants.ITEM, getID(), null));
+            ourContext.addEvent(new Event(Event.MODIFY, Constants.ITEM, getID(), null, lookupIdentifiers(ourContext)));
         } catch (SQLException e) {
             log.error(LogManager.getHeader(ourContext, "Error while updating last modified timestamp", "Item: " + getID()));
         }
@@ -1304,7 +1305,9 @@ public class Item extends DSpaceObject
         mappingRow.setColumn("bundle_id", b.getID());
         DatabaseManager.insert(ourContext, mappingRow);
 
-        ourContext.addEvent(new Event(Event.ADD, Constants.ITEM, getID(), Constants.BUNDLE, b.getID(), b.getName()));
+        ourContext.addEvent(new Event(Event.ADD, Constants.ITEM, getID(), 
+                Constants.BUNDLE, b.getID(), b.getName(), 
+                lookupIdentifiers(ourContext)));
     }
 
     /**
@@ -1345,7 +1348,8 @@ public class Item extends DSpaceObject
                 "AND bundle_id= ? ",
                 getID(), b.getID());
 
-        ourContext.addEvent(new Event(Event.REMOVE, Constants.ITEM, getID(), Constants.BUNDLE, b.getID(), b.getName()));
+        ourContext.addEvent(new Event(Event.REMOVE, Constants.ITEM, getID(), 
+                Constants.BUNDLE, b.getID(), b.getName(), lookupIdentifiers(ourContext)));
 
         // If the bundle is orphaned, it's removed
         TableRowIterator tri = DatabaseManager.query(ourContext,
@@ -1805,12 +1809,14 @@ public class Item extends DSpaceObject
 
             if (dublinCoreChanged)
             {
-                ourContext.addEvent(new Event(Event.MODIFY_METADATA, Constants.ITEM, getID(), getDetails()));
+                ourContext.addEvent(new Event(Event.MODIFY_METADATA, Constants.ITEM, getID(), 
+                        getDetails(), lookupIdentifiers(ourContext)));
                 clearDetails();
                 dublinCoreChanged = false;
             }
 
-            ourContext.addEvent(new Event(Event.MODIFY, Constants.ITEM, getID(), null));
+            ourContext.addEvent(new Event(Event.MODIFY, Constants.ITEM, getID(), 
+                    null, lookupIdentifiers(ourContext)));
             modified = false;
         }
     }
@@ -1902,7 +1908,8 @@ public class Item extends DSpaceObject
         // Update item in DB
         update();
 
-        ourContext.addEvent(new Event(Event.MODIFY, Constants.ITEM, getID(), "WITHDRAW"));
+        ourContext.addEvent(new Event(Event.MODIFY, Constants.ITEM, getID(), 
+                "WITHDRAW", lookupIdentifiers(ourContext)));
 
         // remove all authorization policies, saving the custom ones
         AuthorizeManager.removeAllPoliciesByDSOAndTypeNotEqualsTo(ourContext, this, ResourcePolicy.TYPE_CUSTOM);
@@ -1959,7 +1966,8 @@ public class Item extends DSpaceObject
         // Update item in DB
         update();
 
-        ourContext.addEvent(new Event(Event.MODIFY, Constants.ITEM, getID(), "REINSTATE"));
+        ourContext.addEvent(new Event(Event.MODIFY, Constants.ITEM, getID(), 
+                "REINSTATE", lookupIdentifiers(ourContext)));
 
         // authorization policies
         if (colls.length > 0)
@@ -1992,7 +2000,8 @@ public class Item extends DSpaceObject
         // leaving the database in an inconsistent state
         AuthorizeManager.authorizeAction(ourContext, this, Constants.REMOVE);
 
-        ourContext.addEvent(new Event(Event.DELETE, Constants.ITEM, getID(), getHandle()));
+        ourContext.addEvent(new Event(Event.DELETE, Constants.ITEM, getID(), 
+                getHandle(), lookupIdentifiers(ourContext)));
 
         log.info(LogManager.getHeader(ourContext, "delete_item", "item_id="
                 + getID()));
@@ -2414,7 +2423,8 @@ public class Item extends DSpaceObject
             // Note that updating the owning collection above will have the same effect,
             // so we only do this here if the owning collection hasn't changed.
             
-            ourContext.addEvent(new Event(Event.MODIFY, Constants.ITEM, getID(), null));
+            ourContext.addEvent(new Event(Event.MODIFY, Constants.ITEM, getID(), 
+                    null, lookupIdentifiers(ourContext)));
         }
     }
     

--- a/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
@@ -546,7 +546,8 @@ public class EPerson extends DSpaceObject
         log.info(LogManager.getHeader(context, "create_eperson", "eperson_id="
                 + e.getID()));
 
-        context.addEvent(new Event(Event.CREATE, Constants.EPERSON, e.getID(), null));
+        context.addEvent(new Event(Event.CREATE, Constants.EPERSON, e.getID(), 
+                null, e.lookupIdentifiers(context)));
 
         return e;
     }
@@ -576,7 +577,8 @@ public class EPerson extends DSpaceObject
             throw new EPersonDeletionException(constraintList);
         }
 
-        myContext.addEvent(new Event(Event.DELETE, Constants.EPERSON, getID(), getEmail()));
+        myContext.addEvent(new Event(Event.DELETE, Constants.EPERSON, getID(), 
+                getEmail(), lookupIdentifiers(myContext)));
 
         // Remove from cache
         myContext.removeCached(this, getID());
@@ -1005,12 +1007,14 @@ public class EPerson extends DSpaceObject
 
         if (modified)
         {
-            myContext.addEvent(new Event(Event.MODIFY, Constants.EPERSON, getID(), null));
+            myContext.addEvent(new Event(Event.MODIFY, Constants.EPERSON, 
+                    getID(), null, lookupIdentifiers(myContext)));
             modified = false;
         }
         if (modifiedMetadata)
         {
-            myContext.addEvent(new Event(Event.MODIFY_METADATA, Constants.EPERSON, getID(), getDetails()));
+            myContext.addEvent(new Event(Event.MODIFY_METADATA, Constants.EPERSON, 
+                    getID(), getDetails(), lookupIdentifiers(myContext)));
             modifiedMetadata = false;
             clearDetails();
         }

--- a/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
@@ -547,7 +547,7 @@ public class EPerson extends DSpaceObject
                 + e.getID()));
 
         context.addEvent(new Event(Event.CREATE, Constants.EPERSON, e.getID(), 
-                null, e.lookupIdentifiers(context)));
+                null, e.getIdentifiers(context)));
 
         return e;
     }
@@ -578,7 +578,7 @@ public class EPerson extends DSpaceObject
         }
 
         myContext.addEvent(new Event(Event.DELETE, Constants.EPERSON, getID(), 
-                getEmail(), lookupIdentifiers(myContext)));
+                getEmail(), getIdentifiers(myContext)));
 
         // Remove from cache
         myContext.removeCached(this, getID());
@@ -1008,13 +1008,13 @@ public class EPerson extends DSpaceObject
         if (modified)
         {
             myContext.addEvent(new Event(Event.MODIFY, Constants.EPERSON, 
-                    getID(), null, lookupIdentifiers(myContext)));
+                    getID(), null, getIdentifiers(myContext)));
             modified = false;
         }
         if (modifiedMetadata)
         {
             myContext.addEvent(new Event(Event.MODIFY_METADATA, Constants.EPERSON, 
-                    getID(), getDetails(), lookupIdentifiers(myContext)));
+                    getID(), getDetails(), getIdentifiers(myContext)));
             modifiedMetadata = false;
             clearDetails();
         }

--- a/dspace-api/src/main/java/org/dspace/eperson/Group.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/Group.java
@@ -214,7 +214,8 @@ public class Group extends DSpaceObject
         log.info(LogManager.getHeader(context, "create_group", "group_id="
                 + g.getID()));
 
-        context.addEvent(new Event(Event.CREATE, Constants.GROUP, g.getID(), null));
+        context.addEvent(new Event(Event.CREATE, Constants.GROUP, g.getID(),
+                null, g.lookupIdentifiers(context)));
 
         return g;
     }
@@ -270,7 +271,9 @@ public class Group extends DSpaceObject
         epeople.add(e);
         epeopleChanged = true;
 
-        myContext.addEvent(new Event(Event.ADD, Constants.GROUP, getID(), Constants.EPERSON, e.getID(), e.getEmail()));
+        myContext.addEvent(new Event(Event.ADD, Constants.GROUP, getID(), 
+                Constants.EPERSON, e.getID(), e.getEmail(), 
+                lookupIdentifiers(myContext)));
     }
 
     /**
@@ -292,7 +295,9 @@ public class Group extends DSpaceObject
         groups.add(g);
         groupsChanged = true;
 
-        myContext.addEvent(new Event(Event.ADD, Constants.GROUP, getID(), Constants.GROUP, g.getID(), g.getName()));
+        myContext.addEvent(new Event(Event.ADD, Constants.GROUP, getID(), 
+                Constants.GROUP, g.getID(), g.getName(), 
+                lookupIdentifiers(myContext)));
     }
 
     /**
@@ -308,7 +313,9 @@ public class Group extends DSpaceObject
         if (epeople.remove(e))
         {
             epeopleChanged = true;
-            myContext.addEvent(new Event(Event.REMOVE, Constants.GROUP, getID(), Constants.EPERSON, e.getID(), e.getEmail()));
+            myContext.addEvent(new Event(Event.REMOVE, Constants.GROUP, getID(), 
+                    Constants.EPERSON, e.getID(), e.getEmail(), 
+                    lookupIdentifiers(myContext)));
         }
     }
 
@@ -324,7 +331,9 @@ public class Group extends DSpaceObject
         if (groups.remove(g))
         {
             groupsChanged = true;
-            myContext.addEvent(new Event(Event.REMOVE, Constants.GROUP, getID(), Constants.GROUP, g.getID(), g.getName()));
+            myContext.addEvent(new Event(Event.REMOVE, Constants.GROUP, getID(), 
+                    Constants.GROUP, g.getID(), g.getName(),
+                    lookupIdentifiers(myContext)));
         }
     }
 
@@ -997,7 +1006,8 @@ public class Group extends DSpaceObject
     {
         // FIXME: authorizations
 
-        myContext.addEvent(new Event(Event.DELETE, Constants.GROUP, getID(), getName()));
+        myContext.addEvent(new Event(Event.DELETE, Constants.GROUP, getID(), 
+                getName(), lookupIdentifiers(myContext)));
 
         // Remove from cache
         myContext.removeCached(this, getID());
@@ -1105,7 +1115,8 @@ public class Group extends DSpaceObject
 
         if (modifiedMetadata)
         {
-            myContext.addEvent(new Event(Event.MODIFY_METADATA, Constants.GROUP, getID(), getDetails()));
+            myContext.addEvent(new Event(Event.MODIFY_METADATA, Constants.GROUP, 
+                    getID(), getDetails(), lookupIdentifiers(myContext)));
             modifiedMetadata = false;
             clearDetails();
         }

--- a/dspace-api/src/main/java/org/dspace/eperson/Group.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/Group.java
@@ -215,7 +215,7 @@ public class Group extends DSpaceObject
                 + g.getID()));
 
         context.addEvent(new Event(Event.CREATE, Constants.GROUP, g.getID(),
-                null, g.lookupIdentifiers(context)));
+                null, g.getIdentifiers(context)));
 
         return g;
     }
@@ -273,7 +273,7 @@ public class Group extends DSpaceObject
 
         myContext.addEvent(new Event(Event.ADD, Constants.GROUP, getID(), 
                 Constants.EPERSON, e.getID(), e.getEmail(), 
-                lookupIdentifiers(myContext)));
+                getIdentifiers(myContext)));
     }
 
     /**
@@ -297,7 +297,7 @@ public class Group extends DSpaceObject
 
         myContext.addEvent(new Event(Event.ADD, Constants.GROUP, getID(), 
                 Constants.GROUP, g.getID(), g.getName(), 
-                lookupIdentifiers(myContext)));
+                getIdentifiers(myContext)));
     }
 
     /**
@@ -315,7 +315,7 @@ public class Group extends DSpaceObject
             epeopleChanged = true;
             myContext.addEvent(new Event(Event.REMOVE, Constants.GROUP, getID(), 
                     Constants.EPERSON, e.getID(), e.getEmail(), 
-                    lookupIdentifiers(myContext)));
+                    getIdentifiers(myContext)));
         }
     }
 
@@ -333,7 +333,7 @@ public class Group extends DSpaceObject
             groupsChanged = true;
             myContext.addEvent(new Event(Event.REMOVE, Constants.GROUP, getID(), 
                     Constants.GROUP, g.getID(), g.getName(),
-                    lookupIdentifiers(myContext)));
+                    getIdentifiers(myContext)));
         }
     }
 
@@ -1007,7 +1007,7 @@ public class Group extends DSpaceObject
         // FIXME: authorizations
 
         myContext.addEvent(new Event(Event.DELETE, Constants.GROUP, getID(), 
-                getName(), lookupIdentifiers(myContext)));
+                getName(), getIdentifiers(myContext)));
 
         // Remove from cache
         myContext.removeCached(this, getID());
@@ -1116,7 +1116,7 @@ public class Group extends DSpaceObject
         if (modifiedMetadata)
         {
             myContext.addEvent(new Event(Event.MODIFY_METADATA, Constants.GROUP, 
-                    getID(), getDetails(), lookupIdentifiers(myContext)));
+                    getID(), getDetails(), getIdentifiers(myContext)));
             modifiedMetadata = false;
             clearDetails();
         }

--- a/dspace-api/src/main/java/org/dspace/event/Event.java
+++ b/dspace-api/src/main/java/org/dspace/event/Event.java
@@ -576,7 +576,7 @@ public class Event implements Serializable
     }
     
     /**
-     * @return value of detail element of the event.
+     * @return array of identifiers of this event's subject.
      */
     public String[] getIdentifiers()
     {

--- a/dspace-api/src/main/java/org/dspace/event/Event.java
+++ b/dspace-api/src/main/java/org/dspace/event/Event.java
@@ -162,6 +162,22 @@ public class Event implements Serializable
      * for more complex consumer abilities that are beyond our purview.
      */
     private String detail;
+    
+    /**
+     * Contains all identifiers of the DSpaceObject that was changed (added, 
+     * modified, deleted, ...).
+     * 
+     * All events gets fired when a context that contains events gets commited.
+     * When the delete event is fired, a deleted DSpaceObject is already gone.
+     * This array contains all identifiers of the object, not only the handle
+     * as the detail field does. The field may be an empty array if no
+     * identifiers could be found.
+     * 
+     * FIXME: As the detail field describes it would be even better if all
+     * metadata would be available to a consumer, but the identifiers are the
+     * most important once.
+     */
+    private String[] identifiers;
 
     /** unique key to bind together events from one context's transaction */
     private String transactionID;
@@ -182,6 +198,9 @@ public class Event implements Serializable
     /**
      * Constructor.
      * 
+     * You should consider to use 
+     * {@link Event#Event(int, int, int, java.lang.String, java.lang.String[])}.
+     * 
      * @param eventType
      *            action type, e.g. Event.ADD.
      * @param subjectType
@@ -193,15 +212,38 @@ public class Event implements Serializable
      */
     public Event(int eventType, int subjectType, int subjectID, String detail)
     {
+        this(eventType, subjectType, subjectID, detail, new String[0]);
+    }
+    
+    /**
+     * Constructor.
+     * 
+     * @param eventType
+     *            action type, e.g. Event.ADD.
+     * @param subjectType
+     *            DSpace Object Type of subject e.g. Constants.ITEM.
+     * @param subjectID
+     *            database ID of subject instance.
+     * @param detail
+     *            detail information that depends on context.
+     * @param identifiers
+     *            array containing all identifiers of the dso or an empty array
+     */
+    public Event(int eventType, int subjectType, int subjectID, String detail, String[] identifiers)
+    {
         this.eventType = eventType;
         this.subjectType = coreTypeToMask(subjectType);
         this.subjectID = subjectID;
         timeStamp = System.currentTimeMillis();
         this.detail = detail;
+        this.identifiers = identifiers.clone();
     }
-
+    
     /**
      * Constructor.
+     * 
+     * You should consider to use 
+     * {@link Event#Event(int, int, int, int, int, java.lang.String)} instead.
      * 
      * @param eventType
      *            action type, e.g. Event.ADD.
@@ -219,6 +261,31 @@ public class Event implements Serializable
     public Event(int eventType, int subjectType, int subjectID, int objectType,
             int objectID, String detail)
     {
+        this(eventType, subjectType, subjectID, objectType, objectID, detail, 
+                new String[0]);
+    }
+
+    /**
+     * Constructor.
+     * 
+     * @param eventType
+     *            action type, e.g. Event.ADD.
+     * @param subjectType
+     *            DSpace Object Type of subject e.g. Constants.ITEM.
+     * @param subjectID
+     *            database ID of subject instance.
+     * @param objectType
+     *            DSpace Object Type of object e.g. Constants.BUNDLE.
+     * @param objectID
+     *            database ID of object instance.
+     * @param detail
+     *            detail information that depends on context.
+     * @param identifiers
+     *            array containing all identifiers of the dso or an empty array
+     */
+    public Event(int eventType, int subjectType, int subjectID, int objectType,
+            int objectID, String detail, String[] identifiers)
+    {
         this.eventType = eventType;
         this.subjectType = coreTypeToMask(subjectType);
         this.subjectID = subjectID;
@@ -226,6 +293,7 @@ public class Event implements Serializable
         this.objectID = objectID;
         timeStamp = System.currentTimeMillis();
         this.detail = detail;
+        this.identifiers = identifiers.clone();
     }
 
     /**
@@ -505,6 +573,15 @@ public class Event implements Serializable
     public String getDetail()
     {
         return detail;
+    }
+    
+    /**
+     * @return value of detail element of the event.
+     */
+    public String[] getIdentifiers()
+    {
+        // don't return a reference to our private array, clone it.
+        return identifiers.clone();
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/event/TestConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/event/TestConsumer.java
@@ -10,6 +10,7 @@ package org.dspace.event;
 import java.io.PrintStream;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import org.apache.commons.lang3.ArrayUtils;
 
 import org.apache.log4j.Logger;
 import org.dspace.core.ConfigurationManager;
@@ -66,6 +67,8 @@ public class TestConsumer implements Consumer
                 + event.getObjectTypeAsString()
                 + ", ObjectID="
                 + String.valueOf(event.getObjectID())
+                + ", Identifiers="
+                + ArrayUtils.toString(event.getIdentifiers())
                 + ", TimeStamp="
                 + applyDateFormat(new Date(event.getTimeStamp()))
                 + ", user=\""

--- a/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
@@ -328,7 +328,8 @@ public class DOIIdentifierProvider
         }
         
         doiRow.setColumn("status", IS_REGISTERED);
-        DatabaseManager.update(context, doiRow);        
+        DatabaseManager.update(context, doiRow);
+        dso.resetIdentifiersCache();
     }
     
     public void updateMetadata(Context context, DSpaceObject dso, String identifier)

--- a/dspace-api/src/main/java/org/dspace/identifier/IdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/IdentifierProvider.java
@@ -54,6 +54,9 @@ public abstract class IdentifierProvider {
 
     /**
      * Create and apply an identifier to a DSpaceObject.
+     * If you just mark an identifier for an asynchronous registration, please call
+     * {@link org.dspace.content.DSpaceObject#resetIdentifiersCache()} after its registration. If you register
+     * identifiers directly in this method the IdentifierService will call this method for you.
      * 
      * @param context
      * @param item object to be named.

--- a/dspace-api/src/main/java/org/dspace/identifier/IdentifierService.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/IdentifierService.java
@@ -33,6 +33,17 @@ public interface IdentifierService {
      *  is a Site, or null if no matching identifier is found.
      */
     String lookup(Context context, DSpaceObject dso, Class<? extends Identifier> identifier);
+    
+    /**
+     * Gets the identifiers all registered IdentifierProvider returns if asked 
+     * to lookup the provided DSpaceObject.
+     *
+     * @param context
+     * @param dso the object to be identified.
+     * @return the matching identifiers, or the site identifier if the object
+     *  is a Site, or an empty array if no matching identifier is found.
+     */
+    String[] lookup(Context contex, DSpaceObject dso);
 
     /**
      *

--- a/dspace-api/src/main/java/org/dspace/identifier/IdentifierServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/IdentifierServiceImpl.java
@@ -82,6 +82,7 @@ public class IdentifierServiceImpl implements IdentifierService {
         {
             service.register(context, dso);
         }
+        dso.resetIdentifiersCache();
         //Update our item
         dso.update();
     }
@@ -105,6 +106,7 @@ public class IdentifierServiceImpl implements IdentifierService {
             throw new IdentifierException("Cannot register identifier: Didn't "
                 + "find a provider that supports this identifier.");
         }
+        object.resetIdentifiersCache();
         //Update our item
         object.update();
     }
@@ -159,6 +161,13 @@ public class IdentifierServiceImpl implements IdentifierService {
                     
                     identifiers.add(result);
                 }
+            }
+            catch (IdentifierNotFoundException ex)
+            {
+                log.info(service.getClass().getName() + " doesn't find an "
+                        + "Identifier for " + dso.getTypeText() + ", " 
+                        + Integer.toString(dso.getID()) + ".");
+                log.debug(ex.getMessage(), ex);
             }
             catch (IdentifierException ex)
             {
@@ -227,6 +236,7 @@ public class IdentifierServiceImpl implements IdentifierService {
                 log.error(e.getMessage(),e);
             }
         }
+       dso.resetIdentifiersCache();
     }
 
     @Override
@@ -243,5 +253,6 @@ public class IdentifierServiceImpl implements IdentifierService {
                 log.error(e.getMessage(),e);
             }
         }
+        dso.resetIdentifiersCache();
     }
 }

--- a/dspace-api/src/main/java/org/dspace/identifier/IdentifierServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/IdentifierServiceImpl.java
@@ -15,7 +15,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Required;
 
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.lang.StringUtils;
+import org.dspace.handle.HandleManager;
 
 /**
  * The main service class used to reserve, register and resolve identifiers
@@ -132,6 +135,66 @@ public class IdentifierServiceImpl implements IdentifierService {
             }
         }
         return null;
+    }
+    
+    @Override
+    public String[] lookup(Context context, DSpaceObject dso)
+    {
+        List<String> identifiers = new ArrayList<>();
+        for (IdentifierProvider service : providers)
+        {
+            try {
+                String result = service.lookup(context, dso);
+                if (!StringUtils.isEmpty(result))
+                {
+                    if (log.isDebugEnabled())
+                    {
+                        try {
+                            log.debug("Got an identifier from " 
+                                    + service.getClass().getCanonicalName() + ".");
+                        } catch (NullPointerException ex) {
+                            log.debug(ex.getMessage(), ex);
+                        }
+                    }
+                    
+                    identifiers.add(result);
+                }
+            }
+            catch (IdentifierException ex)
+            {
+                log.error(ex.getMessage(), ex);
+            }
+        }
+        
+        try {
+            String handle = dso.getHandle();
+            if (!StringUtils.isEmpty(handle))
+            {
+                if (!identifiers.contains(handle)
+                        && !identifiers.contains("hdl:" + handle)
+                        && !identifiers.contains(HandleManager.getCanonicalForm(handle)))
+                {
+                    // The VerionedHandleIdentifierProvider gets loaded by default
+                    // it returns handles without any scheme (neither hdl: nor http:).
+                    // If the VersionedHandleIdentifierProvider is not loaded,
+                    // we adds the handle in way it would.
+                    // Generally it would be better if identifiers would be added
+                    // here in a way they could be recognized.
+                    log.info("Adding handle '" + handle + "' to the "
+                            + "array of looked up identifiers.");
+                    identifiers.add(handle);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // nothing is expected here, but if an exception is thrown it
+            // should not stop everything running.
+            log.error(ex.getMessage(), ex);
+        }
+        
+        log.debug("Found identifiers: " + identifiers.toString());
+        return identifiers.toArray(new String[0]);
     }
 
     public DSpaceObject resolve(Context context, String identifier) throws IdentifierNotFoundException, IdentifierNotResolvableException{

--- a/dspace-api/src/main/java/org/dspace/versioning/VersioningConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/VersioningConsumer.java
@@ -57,7 +57,7 @@ public class VersioningConsumer implements Consumer {
                             //and browse index we need to fire a new event
                             ctx.addEvent(new Event(Event.MODIFY, 
                                     previousItem.getType(), previousItem.getID(),
-                                    null, previousItem.lookupIdentifiers(ctx)));
+                                    null, previousItem.getIdentifiers(ctx)));
                         }
                     }
                 }

--- a/dspace-api/src/main/java/org/dspace/versioning/VersioningConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/VersioningConsumer.java
@@ -53,8 +53,11 @@ public class VersioningConsumer implements Consumer {
                             previousItem.setArchived(false);
                             itemsToProcess.add(previousItem);
                             //Fire a new modify event for our previous item
-                            //Due to the need to reindex the item in the search & browse index we need to fire a new event
-                            ctx.addEvent(new Event(Event.MODIFY, previousItem.getType(), previousItem.getID(), null));
+                            //Due to the need to reindex the item in the search 
+                            //and browse index we need to fire a new event
+                            ctx.addEvent(new Event(Event.MODIFY, 
+                                    previousItem.getType(), previousItem.getID(),
+                                    null, previousItem.lookupIdentifiers(ctx)));
                         }
                     }
                 }


### PR DESCRIPTION
This adds a field identifiers to the event class that contains all identifiers of an DSpaceObject.

Currently the IdentifierService is called to create identifiers only when an Item is submitted. Nevertheless this PR uses the identifier field for every DSpaceObject as the IdentifierService supports to register identifiers for every DSpaceObject.

To achieve this this PR extends the IdentifierService, the DSpaceObject class and the initialization of Events.
