### PR TITLE
DS-740 Public derivative thumbnails of restricted original bitstreams

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -454,6 +454,11 @@ filter.org.dspace.app.mediafilter.PowerPointFilter.inputFormats = Microsoft Powe
 filter.org.dspace.app.mediafilter.JPEGFilter.inputFormats = BMP, GIF, JPEG, image/png
 filter.org.dspace.app.mediafilter.BrandedPreviewJPEGFilter.inputFormats = BMP, GIF, JPEG, image/png
 
+#Publicly accessible thumbnails of restricted content.
+#List the MediaFilter name's that would get publicly accessible permissions
+#Any media filters not listed will instead inherit the permissions of the parent bitstream
+filter.org.dspace.app.mediafilter.publicPermission = JPEGFilter, XPDF2Thumbnail
+
 #Custom settings for PDFFilter
 # If true, all PDF extractions are written to temp files as they are indexed...this
 # is slower, but helps ensure that PDFBox software DSpace uses doesn't eat up

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -457,7 +457,7 @@ filter.org.dspace.app.mediafilter.BrandedPreviewJPEGFilter.inputFormats = BMP, G
 #Publicly accessible thumbnails of restricted content.
 #List the MediaFilter name's that would get publicly accessible permissions
 #Any media filters not listed will instead inherit the permissions of the parent bitstream
-filter.org.dspace.app.mediafilter.publicPermission = JPEGFilter, XPDF2Thumbnail
+#filter.org.dspace.app.mediafilter.publicPermission = JPEGFilter, XPDF2Thumbnail
 
 #Custom settings for PDFFilter
 # If true, all PDF extractions are written to temp files as they are indexed...this


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-740

Adding a config where you specify which MediaFilters to be white-listed to generate publicly accessible derivatives, i.e. thumbnails. In case the original parent bitstream is restricted. Otherwise a visitor might get a broken image thumbnail since its restricted.

```
#Publicly accessible thumbnails of restricted content.
#List the MediaFilter name's that would get publicly accessible permissions
#Any media filters not listed will instead inherit the permissions of the parent bitstream
filter.org.dspace.app.mediafilter.publicPermission = JPEGFilter, XPDF2Thumbnail
```

![image](https://cloud.githubusercontent.com/assets/58014/3109756/366267fa-e69d-11e3-9727-32a7d6367603.png)

By default, this will not be enabled, to preserve existing behavior. But many people that I have talked to were open to having publicly accessible thumbnails of restricted content, nobodies use case is to store Top Secret documents in DSpace, yet.
