### PR TITLE
cleanup for DS-1998: removed unused option (classpath) in launcher.xml

### DIFF
--- a/dspace/config/launcher.xml
+++ b/dspace/config/launcher.xml
@@ -18,12 +18,6 @@
     </command>
 
     <command>
-        <name>classpath</name>
-        <description>Calculate and display the DSpace classpath</description>
-        <step></step>
-    </command>
-
-    <command>
         <name>cleanup</name>
         <description>Remove deleted bitstreams from the assetstore</description>
         <step>


### PR DESCRIPTION
this one is no longer used by ScriptLauncher.java
