### PR TITLE
DS-2027 Update bitstream-ordering.js

### DIFF
--- a/dspace-xmlui/src/main/webapp/static/js/bitstream-ordering.js
+++ b/dspace-xmlui/src/main/webapp/static/js/bitstream-ordering.js
@@ -65,8 +65,8 @@
         }
         orderElement.val(newOrder);
 
-        var upArrow = row.find('input[name$^="submit_order_"][name$="_up"]');
-        var downArrow = row.find('input[name$^="submit_order_"][name$="_down"]');
+        var upArrow = row.find('input[name^="submit_order_"][name$="_up"]');
+        var downArrow = row.find('input[name^="submit_order_"][name$="_down"]');
 
         //Check if we are the first row, if so hide the up arrow
         if(isBundleRow(row.prev())){

--- a/dspace-xmlui/src/main/webapp/static/js/bitstream-ordering.js
+++ b/dspace-xmlui/src/main/webapp/static/js/bitstream-ordering.js
@@ -93,7 +93,11 @@
      */
     function isBundleRow(row){
         // Checks if the identifier starts with the bundle head identifier
-        return row.attr("id").indexOf("aspect_administrative_item_EditItemBitstreamsForm_row_bundle_head_") == 0;
+
+        //DS-2027, found error condition in which attribute is not set when reordering original bitstreams
+    	var id = row.attr("id");
+    	if (id === undefined) return false;
+        return id.indexOf("aspect_administrative_item_EditItemBitstreamsForm_row_bundle_head_") == 0;
     }
 
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2027

There is a bad JQuery selector in the following code. This causes a submit to take place each time an up or down arrow is clicked. It is difficult to see the error in the javascript console because the submit takes place immediately. 

Due to the page refresh delay, this is confusing to users when a large number of bitstreams are present. 

Note that "$^=" is not a valid selector. 

http://api.jquery.com/category/selectors/
