### PR TITLE
DS-1986 REST to use new context for each request

### DIFF
--- a/dspace-rest/src/main/java/org/dspace/rest/CollectionsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/CollectionsResource.java
@@ -49,36 +49,6 @@ public class CollectionsResource {
 		writeStatistics=ConfigurationManager.getBooleanProperty("rest","stats",false);
 	}
 
-    /*
-    The "GET" annotation indicates this method will respond to HTTP Get requests.
-    The "Produces" annotation indicates the MIME response the method will return.
-     */
-    @GET
-    @Path("/")
-    @Produces(MediaType.TEXT_HTML)
-    public String listHTML() {
-        StringBuilder everything = new StringBuilder();
-        try {
-            if(context == null || !context.isValid() ) {
-                context = new org.dspace.core.Context();
-                //Failed SQL is ignored as a failed SQL statement, prevent: current transaction is aborted, commands ignored until end of transaction block
-                context.getDBConnection().setAutoCommit(true);
-            }
-
-            org.dspace.content.Collection[] collections = org.dspace.content.Collection.findAll(context);
-            for(org.dspace.content.Collection collection : collections) {
-                //TODO check auth...
-                everything.append("<li><a href='" + servletContext.getContextPath() + "/collections/" + collection.getID() + "'>" + collection.getID() + " - " + collection.getName() + "</a></li>\n");
-            }
-
-            return "<html><title>Hello!</title><body>Collections<br/><ul>" + everything.toString() + "</ul>.</body></html> ";
-
-        } catch (SQLException e) {
-            log.error(e.getMessage());
-            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
-        }
-    }
-
     @GET
     @Path("/")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})

--- a/dspace-rest/src/main/java/org/dspace/rest/CommunitiesResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/CommunitiesResource.java
@@ -36,8 +36,6 @@ http://localhost:8080/<webapp>/communities
 public class CommunitiesResource {
     private static Logger log = Logger.getLogger(CommunitiesResource.class);
 
-    private static org.dspace.core.Context context;
-
     private static final boolean writeStatistics;
 	
 	static{
@@ -48,12 +46,9 @@ public class CommunitiesResource {
     @Path("/")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     public org.dspace.rest.common.Community[] list(@QueryParam("expand") String expand) {
+        org.dspace.core.Context context = null;
         try {
-            if(context == null || !context.isValid() ) {
-                context = new org.dspace.core.Context();
-                //Failed SQL is ignored as a failed SQL statement, prevent: current transaction is aborted, commands ignored until end of transaction block
-                context.getDBConnection().setAutoCommit(true);
-            }
+            context = new org.dspace.core.Context();
 
             org.dspace.content.Community[] topCommunities = org.dspace.content.Community.findAllTop(context);
             ArrayList<org.dspace.rest.common.Community> communityArrayList = new ArrayList<org.dspace.rest.common.Community>();
@@ -70,7 +65,15 @@ public class CommunitiesResource {
         } catch (SQLException e) {
             log.error(e.getMessage());
             throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
-        } //finally?
+        } finally {
+            if(context != null) {
+                try {
+                    context.complete();
+                } catch (SQLException e) {
+                    log.error(e.getMessage() + " occurred while trying to close");
+                }
+            }
+        }
     }
 
     @GET
@@ -79,17 +82,14 @@ public class CommunitiesResource {
     public org.dspace.rest.common.Community getCommunity(@PathParam("community_id") Integer community_id, @QueryParam("expand") String expand,
     		@QueryParam("userIP") String user_ip, @QueryParam("userAgent") String user_agent, @QueryParam("xforwarderfor") String xforwarderfor,
     		@Context HttpHeaders headers, @Context HttpServletRequest request) {
+        org.dspace.core.Context context = null;
         try {
-            if(context == null || !context.isValid() ) {
-                context = new org.dspace.core.Context();
-                //Failed SQL is ignored as a failed SQL statement, prevent: current transaction is aborted, commands ignored until end of transaction block
-                context.getDBConnection().setAutoCommit(true);
-            }
+            context = new org.dspace.core.Context();
 
             org.dspace.content.Community community = org.dspace.content.Community.find(context, community_id);
             if(AuthorizeManager.authorizeActionBoolean(context, community, org.dspace.core.Constants.READ)) {
             	if(writeStatistics){
-    				writeStats(community_id, user_ip, user_agent, xforwarderfor, headers, request);
+    				writeStats(context, community_id, user_ip, user_agent, xforwarderfor, headers, request);
     			}
                 return new org.dspace.rest.common.Community(community, expand, context);
             } else {
@@ -98,10 +98,18 @@ public class CommunitiesResource {
         } catch (SQLException e) {
             log.error(e.getMessage());
             throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
-        } //finally?
+        } finally {
+            if(context != null) {
+                try {
+                    context.complete();
+                } catch (SQLException e) {
+                    log.error(e.getMessage() + " occurred while trying to close");
+                }
+            }
+        }
     }
     
-    private void writeStats(Integer community_id, String user_ip, String user_agent,
+    private void writeStats(org.dspace.core.Context context, Integer community_id, String user_ip, String user_agent,
  			String xforwarderfor, HttpHeaders headers,
  			HttpServletRequest request) {
  		

--- a/dspace-rest/src/main/java/org/dspace/rest/CommunitiesResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/CommunitiesResource.java
@@ -43,34 +43,6 @@ public class CommunitiesResource {
 	static{
 		writeStatistics=ConfigurationManager.getBooleanProperty("rest","stats",false);
 	}
-    
-    /*
-    The "GET" annotation indicates this method will respond to HTTP Get requests.
-    The "Produces" annotation indicates the MIME response the method will return.
-     */
-    @GET
-    @Produces(MediaType.TEXT_HTML)
-    public String list() {
-        StringBuilder everything = new StringBuilder();
-        try {
-            if(context == null || !context.isValid() ) {
-                context = new org.dspace.core.Context();
-                //Failed SQL is ignored as a failed SQL statement, prevent: current transaction is aborted, commands ignored until end of transaction block
-                context.getDBConnection().setAutoCommit(true);
-            }
-            org.dspace.content.Community[] communities = org.dspace.content.Community.findAllTop(context);
-            for(org.dspace.content.Community community : communities) {
-                everything.append(community.getName() + "<br/>\n");
-            }
-            return "<html><title>Hello!</title><body>Communities:<br/>" + everything.toString() + ".</body></html> ";
-
-        } catch (SQLException e) {
-            log.error(e.getMessage());
-            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
-        }
-    }
-
-    //TODO Respond to html for communities/:id
 
     @GET
     @Path("/")


### PR DESCRIPTION
This fixes: https://jira.duraspace.org/browse/DS-1986

Where previously REST had to cache org.dspace.core.Context, and hold it forever. Caching the context is bad, it causes stale data. Fixing this was easy, thanks for @RichardRodgers advice at OR2014, i.e. close the context in the finally.

I've JMETER tested all the rest methods after this change, and the performance is fine. I don't notice any issue with not caching the context, and the error rate is 0 as before.

This fix should apply to DSpace 4.2, and to DSpace 5.x
