### PR TITLE
[DS-2060] Extended SOLR commit duration due to SpellCheckComponent ("Did you mean")

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
@@ -66,6 +66,10 @@ public class IndexClient {
                 "(re)build index, wiping out current one if it exists").create(
                 "b"));
 
+        options.addOption(OptionBuilder.isRequired(false).withDescription(
+                "Rebuild the spellchecker, can be combined with -b and -f.").create(
+                "s"));
+
         options
                 .addOption(OptionBuilder
                         .isRequired(false)
@@ -111,15 +115,32 @@ public class IndexClient {
         } else if (line.hasOption("b")) {
             log.info("(Re)building index from scratch.");
             indexer.createIndex(context);
+            checkRebuildSpellCheck(line, indexer);
         } else if (line.hasOption("o")) {
             log.info("Optimizing search core.");
             indexer.optimize();
+        } else if(line.hasOption('s')) {
+            checkRebuildSpellCheck(line, indexer);
         } else {
             log.info("Updating and Cleaning Index");
             indexer.cleanIndex(line.hasOption("f"));
             indexer.updateIndex(context, line.hasOption("f"));
+            checkRebuildSpellCheck(line, indexer);
         }
 
         log.info("Done with indexing");
 	}
+
+    /**
+     * Check the command line options and rebuild the spell check if active.
+     * @param line the command line options
+     * @param indexer the solr indexer
+     * @throws SearchServiceException in case of a solr exception
+     */
+    protected static void checkRebuildSpellCheck(CommandLine line, IndexingService indexer) throws SearchServiceException {
+        if (line.hasOption("s")) {
+            log.info("Rebuilding spell checker.");
+            indexer.buildSpellCheck();
+        }
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexingService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexingService.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.discovery;
 
+import org.apache.solr.client.solrj.SolrServerException;
 import org.dspace.content.DSpaceObject;
 import org.dspace.core.Context;
 
@@ -58,4 +59,6 @@ public interface IndexingService {
     void commit() throws SearchServiceException;
 
     void optimize() throws SearchServiceException;
+
+    void buildSpellCheck() throws SearchServiceException;
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -519,6 +519,23 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         }
     }
 
+    public void buildSpellCheck() throws SearchServiceException {
+        try {
+            if (getSolr() == null) {
+                return;
+            }
+            SolrQuery solrQuery = new SolrQuery();
+            solrQuery.set("spellcheck", true);
+            solrQuery.set(SpellingParams.SPELLCHECK_BUILD, true);
+            getSolr().query(solrQuery);
+        }catch (SolrServerException e)
+        {
+            //Make sure to also log the exception since this command is usually run from a crontab.
+            log.error(e, e);
+            throw new SearchServiceException(e);
+        }
+    }
+
     // //////////////////////////////////
     // Private
     // //////////////////////////////////

--- a/dspace/solr/search/conf/solrconfig.xml
+++ b/dspace/solr/search/conf/solrconfig.xml
@@ -1244,7 +1244,7 @@
       <str name="name">default</str>
       <str name="field">a_spell</str>
       <str name="spellcheckIndexDir">./spellchecker</str>
-      <str name="buildOnCommit">true</str>
+      <str name="buildOnOptimize">true</str>
       <str name="spellcheck.onlyMorePopular">false</str>
     </lst>
 


### PR DESCRIPTION
This pull request will ensure that the spellChecker index isn't rebuilt from scratch every time a commit event occurs. When a document is modified only that document will be updated in the spell check index.

I also added an extra option to the command line tool from discovery to reindex the spell check index from scratch (should it ever be needed).
