### PR TITLE
DS-2064 METS ingester doesn't check if the files in the zip exist.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSIngester.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSIngester.java
@@ -1487,7 +1487,13 @@ public abstract class AbstractMETSIngester extends AbstractPackageIngester
             ZipEntry manifestEntry = zipPackage.getEntry(path);
 
             // Get inputStream associated with this file
-            return zipPackage.getInputStream(manifestEntry);
+            if (manifestEntry != null)
+                return zipPackage.getInputStream(manifestEntry);
+            else
+            {
+                throw new MetadataValidationException("Manifest file references file '"
+                                        + path + "' not included in the zip.");
+            }
         }
     }
 


### PR DESCRIPTION
Fixes https://jira.duraspace.org/browse/DS-2064
