### PR TITLE
[DS-1958] Discovery OutOfMemoryError when indexing Large Bitstreams

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -464,6 +464,21 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.apache.solr</groupId>
+            <artifactId>solr-cell</artifactId>
+            <version>${solr.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jcl-over-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>commons-configuration</groupId>
             <artifactId>commons-configuration</artifactId>
             <version>1.8</version>

--- a/dspace-api/src/main/java/org/dspace/discovery/BitstreamContentStream.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/BitstreamContentStream.java
@@ -1,0 +1,73 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.discovery;
+
+import org.apache.log4j.Logger;
+import org.apache.solr.common.util.ContentStreamBase;
+import org.dspace.content.Bitstream;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Construct a <code>ContentStream</code> from a <code>File</code>
+ */
+public class BitstreamContentStream extends ContentStreamBase
+{
+    private static final Logger log = Logger.getLogger(BitstreamContentStream.class);
+    private final Bitstream file;
+
+    public BitstreamContentStream( Bitstream f ) {
+        file = f;
+
+        contentType = f.getFormat().getMIMEType();
+        name = file.getName();
+        size = file.getSize();
+        sourceInfo = file.getName();
+    }
+
+    @Override
+    public String getContentType() {
+        if(contentType==null) {
+            InputStream stream = null;
+            try {
+                stream = file.retrieve();
+                char first = (char)stream.read();
+                if(first == '<') {
+                    return "application/xml";
+                }
+                if(first == '{') {
+                    return "application/json";
+                }
+            } catch(Exception ex) {
+                log.error("Error determining content type for bitstream:" + file.getID(), ex);
+            } finally {
+                if (stream != null) try {
+                    stream.close();
+                } catch (IOException ioe) {
+                    log.error("Error closing stream:" + file.getID(), ioe);
+
+                }
+            }
+        }
+        return contentType;
+    }
+
+    @Override
+    public InputStream getStream() throws IOException {
+        try {
+            return file.retrieve();
+        } catch (Exception e) {
+            log.error(e.getMessage(),e);
+            return new ByteArrayInputStream(e.getMessage().getBytes(StandardCharsets.UTF_8));
+        }
+    }
+}
+

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -7,12 +7,7 @@
  */
 package org.dspace.discovery;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.net.MalformedURLException;
+import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.sql.SQLException;
@@ -31,7 +26,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
-import java.util.TreeMap;
 import java.util.Vector;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -39,8 +33,6 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.commons.collections.Transformer;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.methods.GetMethod;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.input.AutoCloseInputStream;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.time.DateFormatUtils;
@@ -54,6 +46,8 @@ import org.apache.log4j.Logger;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpSolrServer;
+import org.apache.solr.client.solrj.request.AbstractUpdateRequest;
+import org.apache.solr.client.solrj.request.ContentStreamUpdateRequest;
 import org.apache.solr.client.solrj.response.FacetField;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.client.solrj.util.ClientUtils;
@@ -62,6 +56,7 @@ import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.params.*;
 import org.apache.solr.common.util.NamedList;
+import org.apache.solr.handler.extraction.ExtractingParams;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
@@ -149,7 +144,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                     solr = new HttpSolrServer(solrService);
 
                     solr.setBaseURL(solrService);
-
+                    solr.setUseMultiPartPost(true);
                     SolrQuery solrQuery = new SolrQuery()
                             .setQuery("search.resourcetype:2 AND search.resourceid:1");
 
@@ -505,11 +500,11 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                 return;
             }
             long start = System.currentTimeMillis();
-            System.out.println("SOLR Search Optimize -- Process Started:"+start);
+            System.out.println("SOLR Search Optimize -- Process Started:" + start);
             getSolr().optimize();
             long finish = System.currentTimeMillis();
-            System.out.println("SOLR Search Optimize -- Process Finished:"+finish);
-            System.out.println("SOLR Search Optimize -- Total time taken:"+(finish-start) + " (ms).");
+            System.out.println("SOLR Search Optimize -- Process Finished:" + finish);
+            System.out.println("SOLR Search Optimize -- Total time taken:" + (finish - start) + " (ms).");
         } catch (SolrServerException sse)
         {
             System.err.println(sse.getMessage());
@@ -667,15 +662,47 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
     /**
      * Write the document to the index under the appropriate handle.
+     *
      * @param doc the solr document to be written to the server
+     * @param streams
      * @throws IOException IO exception
      */
-    protected void writeDocument(SolrInputDocument doc) throws IOException {
+    protected void writeDocument(SolrInputDocument doc, List<BitstreamContentStream> streams) throws IOException {
 
         try {
             if(getSolr() != null)
             {
-                getSolr().add(doc);
+                if(CollectionUtils.isNotEmpty(streams))
+                {
+                    ContentStreamUpdateRequest req = new ContentStreamUpdateRequest("/update/extract");
+
+                    for(BitstreamContentStream bce : streams)
+                    {
+                        req.addContentStream(bce);
+                    }
+
+                    ModifiableSolrParams params = new ModifiableSolrParams();
+
+                    //req.setParam(ExtractingParams.EXTRACT_ONLY, "true");
+                    for(String name : doc.getFieldNames())
+                    {
+                        for(Object val : doc.getFieldValues(name))
+                        {
+                             params.add(ExtractingParams.LITERALS_PREFIX + name,val.toString());
+                        }
+                    }
+
+                    req.setParams(params);
+                    req.setParam(ExtractingParams.UNKNOWN_FIELD_PREFIX, "attr_");
+                    req.setParam(ExtractingParams.MAP_PREFIX + "content", "fulltext");
+                    req.setParam(ExtractingParams.EXTRACT_FORMAT, "text");
+                    req.setAction(AbstractUpdateRequest.ACTION.COMMIT, true, true);
+                    req.process(getSolr());
+                }
+                else
+                {
+                    getSolr().add(doc);
+                }
             }
         } catch (SolrServerException e)
         {
@@ -728,7 +755,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
             solrServiceIndexPlugin.additionalIndex(context, community, doc);
         }
 
-        writeDocument(doc);
+        writeDocument(doc, null);
     }
 
     /**
@@ -784,7 +811,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
             solrServiceIndexPlugin.additionalIndex(context, collection, doc);
         }
 
-        writeDocument(doc);
+        writeDocument(doc, null);
     }
 
     /**
@@ -1302,6 +1329,8 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
 
 
+        List<BitstreamContentStream> streams = new ArrayList<BitstreamContentStream>();
+
         try {
             // now get full text of any bitstreams in the TEXT bundle
             // trundle through the bundles
@@ -1319,12 +1348,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                     {
                         try {
 
-                            doc.addField("fulltext", new AutoCloseInputStream(myBitstream.retrieve()));
-
-                            if(hitHighlightingFields.contains("*") || hitHighlightingFields.contains("fulltext"))
-                            {
-                                doc.addField("fulltext_hl", new AutoCloseInputStream(myBitstream.retrieve()));
-                            }
+                            streams.add(new BitstreamContentStream(myBitstream));
 
                             log.debug("  Added BitStream: "
                                     + myBitstream.getStoreNumber() + "	"
@@ -1354,15 +1378,13 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
         // write the index and close the inputstreamreaders
         try {
-            writeDocument(doc);
+            writeDocument(doc, streams);
             log.info("Wrote Item: " + handle + " to Index");
         } catch (RuntimeException e)
         {
             log.error("Error while writing item to discovery index: " + handle + " message:"+ e.getMessage(), e);
         }
     }
-
-
 
     /**
      * Create Lucene document with all the shared fields initialized.

--- a/dspace-solr/pom.xml
+++ b/dspace-solr/pom.xml
@@ -127,6 +127,11 @@
             <version>${solr.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.solr</groupId>
+            <artifactId>solr-cell</artifactId>
+            <version>${solr.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
         </dependency>

--- a/dspace/solr/search/conf/schema.xml
+++ b/dspace/solr/search/conf/schema.xml
@@ -544,6 +544,7 @@
 
     <field name="a_spell" type="textSpell" />
     <copyField source="fulltext" dest="a_spell" />
+    <copyField source="fulltext" dest="fulltext_hl" />
 
     <!-- used by the DSpace Discovery Solr Indexer to track the last time a document was indexed -->
    <field name="SolrIndexer.lastIndexed" type="date" indexed="true" stored="true" default="NOW" multiValued="false" omitNorms="true" />

--- a/dspace/solr/search/conf/solrconfig.xml
+++ b/dspace/solr/search/conf/solrconfig.xml
@@ -1042,13 +1042,13 @@
                   startup="lazy"
                   class="solr.extraction.ExtractingRequestHandler" >
     <lst name="defaults">
-      <str name="lowernames">true</str>
+      <!--<str name="lowernames">true</str>-->
       <str name="uprefix">ignored_</str>
 
       <!-- capture link hrefs but ignore div attributes -->
-      <str name="captureAttr">true</str>
-      <str name="fmap.a">links</str>
-      <str name="fmap.div">ignored_</str>
+      <str name="captureAttr">false</str>
+      <!--<str name="fmap.a">links</str>-->
+      <!--<str name="fmap.div">ignored_</str>-->
     </lst>
   </requestHandler>
 


### PR DESCRIPTION
In newer versions of Solr, passing InputStreams as values has stopped working. This has caused inconsistent full text indexing in some newer DSpace instances.
Together with Mark Diggory I created a new pull request that will fix the issue for DSpace 4.2 & 5.0 (since these use solr 4).
