### PR TITLE
Backporting fix for DS-1928 in PR#493 to DSpace 4.x

### DIFF
--- a/dspace-oai/src/main/webapp/static/style.xsl
+++ b/dspace-oai/src/main/webapp/static/style.xsl
@@ -728,14 +728,20 @@
 									</td>
 									<td class="clear"></td>
 								</tr>
-								<tr class="info">
-									<td class="name">Description</td>
-									<td class="value">
-										<xsl:value-of
-											select="oai:OAI-PMH/oai:Identify/oai:description/node()/text()" />
-									</td>
-									<td class="clear"></td>
-								</tr>
+                                                                <tr class="info">
+                                                                        <td class="name">Repository identifier</td>
+                                                                        <td class="value">
+                                                                                <xsl:value-of select="oai:OAI-PMH/oai:Identify/oai:description//*[local-name() = 'repositoryIdentifier']/text()" />
+                                                                        </td>
+                                                                        <td class="clear"></td>
+                                                                </tr>
+                                                                <tr class="info">
+                                                                        <td class="name">Sample identifier</td>
+                                                                        <td class="value">
+                                                                                <xsl:value-of select="oai:OAI-PMH/oai:Identify/oai:description//*[local-name() = 'sampleIdentifier']/text()" />
+                                                                        </td>
+                                                                        <td class="clear"></td>
+                                                                </tr>
 								<tr>
 									<td class="separator"></td>
 								</tr>

--- a/dspace/config/crosswalks/oai/description.xml
+++ b/dspace/config/crosswalks/oai/description.xml
@@ -1,1 +1,6 @@
-<XOAIDescription xmlns="http://www.lyncode.com/XOAIConfiguration">XOAI: OAI-PMH Java Toolkit</XOAIDescription>
+<oai-identifier xmlns="http://www.openarchives.org/OAI/2.0/oai-identifier" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai-identifier http://www.openarchives.org/OAI/2.0/oai-identifier.xsd">
+<scheme>oai</scheme>
+<repositoryIdentifier>${dspace.hostname}</repositoryIdentifier>
+<delimiter>:</delimiter>
+<sampleIdentifier>oai:${dspace.hostname}:${handle.prefix}/1234</sampleIdentifier>
+</oai-identifier>

--- a/dspace/src/main/assembly/assembly.xml
+++ b/dspace/src/main/assembly/assembly.xml
@@ -81,6 +81,11 @@
          <outputDirectory>config</outputDirectory>
          <filtered>true</filtered>
       </file>
+      <file>
+         <source>config/crosswalks/oai/description.xml</source>
+         <outputDirectory>config</outputDirectory>
+         <filtered>true</filtered>
+      </file>
    </files>
 
    <!--


### PR DESCRIPTION
See PR #493 and https://jira.duraspace.org/browse/DS-1928

Because the style/theme (style.xsl) for OAI-PMH changed significantly between DSpace 4 and 5, the fix in PR #493 had to be backported to 'dspace-4_x' instead of being cherry-picked.

I've tested this backport. Seems to work fine, and it's really only the style.xsl which requires different changes.
