### PR TITLE
DS-2066 : Maven plugin updates and general POM cleanup

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -73,7 +73,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.3</version>
+                <version>2.8</version>
                 <executions>
                     <execution>
                         <id>setupTestEnvironment</id>
@@ -97,8 +97,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.mycila.maven-license-plugin</groupId>
-                <artifactId>maven-license-plugin</artifactId>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
                 <configuration>
                     <excludes>
                         <exclude>**/src/test/resources/**</exclude>
@@ -120,8 +120,8 @@
             -->
             <plugin>
                 <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>gmaven-plugin</artifactId>
-                <version>1.4</version>
+                <artifactId>groovy-maven-plugin</artifactId>
+                <version>2.0</version>
                 <executions>
                     <execution>
                         <id>setproperty</id>
@@ -131,7 +131,7 @@
                         </goals>
                         <configuration>
                             <source>
-                            pom.properties['agnostic.build.dir']=project.build.directory.replace('\\','/');
+                            project.properties['agnostic.build.dir']=project.build.directory.replace(File.separator,'/');
                             println("Initializing Maven property 'agnostic.build.dir' to: " + project.properties['agnostic.build.dir']);
                             </source>
                         </configuration>
@@ -211,7 +211,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.7</version>
+                <version>1.9</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>
@@ -225,7 +225,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>buildnumber-maven-plugin</artifactId>
-                <version>1.2</version>
+                <version>1.3</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>
@@ -527,11 +527,11 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
 		
-		<dependency>
-	    	<groupId>backport-util-concurrent</groupId>
-	    	<artifactId>backport-util-concurrent</artifactId>
-	    	<version>3.1</version>
-		</dependency>
+        <dependency>
+            <groupId>backport-util-concurrent</groupId>
+            <artifactId>backport-util-concurrent</artifactId>
+            <version>3.1</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -107,7 +107,9 @@ public class ItemTest  extends AbstractDSpaceObjectTest
     @Test
     public void testItemFind() throws Exception
     {
-        int id = 1;
+        // Get ID of item created in init()
+        int id = this.it.getID();
+        // Make sure we can find it via its ID
         Item found =  Item.find(context, id);
         assertThat("testItemFind 0", found, notNullValue());
         assertThat("testItemFind 1", found.getID(), equalTo(id));

--- a/dspace-jspui/pom.xml
+++ b/dspace-jspui/pom.xml
@@ -53,8 +53,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.mycila.maven-license-plugin</groupId>
-                <artifactId>maven-license-plugin</artifactId>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
                 <configuration>
                     <!--Exclude license check for JSPUI files which don't need it-->
                     <excludes>
@@ -65,6 +65,7 @@
                         <exclude>**/scriptaculous/**</exclude>
                         <exclude>**/jquery*</exclude>
                         <exclude>**/bootstrap/**</exclude>
+                        <exclude>**/fonts/**</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -3,8 +3,8 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>dspace-oai</artifactId>
     <packaging>war</packaging>
-    <name>DSpace OAI 2.0</name>
-    <description>Parent project for the OAI API and Webapp</description>
+    <name>DSpace OAI-PMH</name>
+    <description>DSpace OAI-PMH Web Application and API</description>
 
     <parent>
         <artifactId>dspace-parent</artifactId>
@@ -52,8 +52,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.mycila.maven-license-plugin</groupId>
-                <artifactId>maven-license-plugin</artifactId>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
                 <configuration>
                     <excludes>
                         <exclude>src/main/webapp/**</exclude>

--- a/dspace-rest/pom.xml
+++ b/dspace-rest/pom.xml
@@ -4,7 +4,8 @@
     <artifactId>dspace-rest</artifactId>
     <packaging>war</packaging>
     <version>5.0-SNAPSHOT</version>
-    <name>DSpace RESTful web services API</name>
+    <name>DSpace REST :: API and Implementation</name>
+    <description>DSpace RESTful Web Services API</description>
     <url>http://demo.dspace.org</url>
 
     <parent>
@@ -37,59 +38,55 @@
             <artifactId>jersey-json</artifactId>
             <version>1.17.1</version>
         </dependency>
-        
-        
-        
-		<!-- Spring 3 dependencies -->
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-core</artifactId>
-		</dependency>
+                
+        <!-- Spring 3 dependencies -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+        </dependency>
  
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-context</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
  
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-web</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+        </dependency>
 		
- 
-		<!-- Jersey + Spring -->
-		<dependency>
-			<groupId>com.sun.jersey.contribs</groupId>
-			<artifactId>jersey-spring</artifactId>
-			<version>1.8</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.springframework</groupId>
-					<artifactId>spring</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.springframework</groupId>
-					<artifactId>spring-core</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.springframework</groupId>
-					<artifactId>spring-web</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.springframework</groupId>
-					<artifactId>spring-beans</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.springframework</groupId>
-					<artifactId>spring-context</artifactId>
-				</exclusion>
-				<exclusion>
-        			<groupId>org.springframework</groupId>
-        			<artifactId>spring-aop</artifactId>
-      			</exclusion>
-			</exclusions>
-		</dependency>
- 
+        <!-- Jersey + Spring -->
+        <dependency>
+            <groupId>com.sun.jersey.contribs</groupId>
+            <artifactId>jersey-spring</artifactId>
+            <version>1.8</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-web</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-beans</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-context</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-aop</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
         <!-- Use DSpace, for now, an older version to minimize spring generated dependency on Discovery -->
         <dependency>
@@ -122,8 +119,8 @@
             <artifactId>log4j</artifactId>
         </dependency>
         <dependency>
-        	<groupId>org.dspace</groupId>
-        	<artifactId>dspace-services</artifactId>
+            <groupId>org.dspace</groupId>
+            <artifactId>dspace-services</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/dspace-services/src/test/java/org/dspace/services/caching/CachingServiceTest.java
+++ b/dspace-services/src/test/java/org/dspace/services/caching/CachingServiceTest.java
@@ -156,9 +156,11 @@ public class CachingServiceTest extends DSpaceAbstractKernelTest {
         assertNotNull(memCache);
         assertTrue(caches.contains(memCache));
 
-        Cache c1 = cachingService.getCache("org.dspace.aztest.new", null);
+        // This should create a new cache (as cache name is unique)
+        Cache c1 = cachingService.getCache("org.dspace.timtest.newcache", null);
         assertNotNull(c1);
 
+        // Test that new cache was created and total caches increases by one 
         caches = cachingService.getCaches();
         assertNotNull(caches);
         assertEquals(curSize+1, caches.size());

--- a/dspace-solr/pom.xml
+++ b/dspace-solr/pom.xml
@@ -31,8 +31,8 @@
     <packaging>war</packaging>
 
     <properties>
-		<lucene.version>4.4.0</lucene.version>
-		<solr.version>4.4.0</solr.version>
+        <lucene.version>4.4.0</lucene.version>
+        <solr.version>4.4.0</solr.version>
         <!-- 'root.basedir' is the path to the root [dspace-src] dir. It must be redefined by each child POM,
              as it is used to reference the LICENSE_HEADER and *.properties file(s) in that directory. -->
         <root.basedir>${basedir}/..</root.basedir>
@@ -47,7 +47,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.4</version>
                 <configuration>
                     <!-- This 'dspace-solr' WAR overlays the Apache Solr Web Application
                          available in Maven Central -->
@@ -120,19 +119,19 @@
             <groupId>org.apache.solr</groupId>
             <artifactId>solr</artifactId>
             <version>${solr.version}</version>
-		    <type>war</type>
+            <type>war</type>
         </dependency>
         <dependency>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-core</artifactId>
             <version>${solr.version}</version>            
             <type>jar</type>
-			<exclusions>
-				<exclusion>
-					<groupId>jdk.tools</groupId>
-					<artifactId>jdk.tools</artifactId>
-				</exclusion>
-			</exclusions>              
+            <exclusions>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
+            </exclusions>              
         </dependency>
         <dependency>
             <groupId>org.apache.solr</groupId>

--- a/dspace-xmlui/pom.xml
+++ b/dspace-xmlui/pom.xml
@@ -51,8 +51,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.mycila.maven-license-plugin</groupId>
-                <artifactId>maven-license-plugin</artifactId>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
                 <configuration>
                     <!--Exclude license check for XMLUI files which don't need it-->
                     <excludes>

--- a/dspace/modules/oai/pom.xml
+++ b/dspace/modules/oai/pom.xml
@@ -3,10 +3,10 @@
     <groupId>org.dspace.modules</groupId>
     <artifactId>oai</artifactId>
     <packaging>war</packaging>
-    <name>DSpace OAI 2.0 :: Local Customizations</name>
+    <name>DSpace OAI-PMH :: Local Customizations</name>
     <description>
         This project allows you to overlay your own local OAI customizations
-        on top of the default OAI 2.0 web application provided with DSpace.
+        on top of the default OAI-PMH web application provided with DSpace.
     </description>
 
     <parent>
@@ -99,11 +99,11 @@
             <artifactId>solr-core</artifactId>
             <version>${solr.version}</version>
             <exclusions>
-				<exclusion>
-					<groupId>jdk.tools</groupId>
-					<artifactId>jdk.tools</artifactId>
-				</exclusion>
-			</exclusions> 
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
+            </exclusions> 
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/dspace/modules/pom.xml
+++ b/dspace/modules/pom.xml
@@ -1,17 +1,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.dspace</groupId>
-	<artifactId>modules</artifactId>
-	<packaging>pom</packaging>
-	<name>DSpace Addon Modules</name>
-	<description>DSpace Addon Modules</description>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.dspace</groupId>
+    <artifactId>modules</artifactId>
+    <packaging>pom</packaging>
+    <name>DSpace Addon Modules</name>
+    <description>DSpace Addon Modules</description>
 
-	<parent>
-		<groupId>org.dspace</groupId>
-		<artifactId>dspace-parent</artifactId>
-		<version>5.0-SNAPSHOT</version>
-		<relativePath>../../pom.xml</relativePath>
-	</parent>
+    <parent>
+        <groupId>org.dspace</groupId>
+        <artifactId>dspace-parent</artifactId>
+        <version>5.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
 
     <properties>
         <!-- This is the path to the root [dspace-src] directory. -->

--- a/dspace/modules/rest/pom.xml
+++ b/dspace/modules/rest/pom.xml
@@ -3,9 +3,10 @@
     <groupId>org.dspace.modules</groupId>
     <artifactId>rest</artifactId>
     <packaging>war</packaging>
-    <name>DSpace REST (JAX RS 1 - Jersey) :: Local Customizations</name>
+    <name>DSpace REST :: Local Customizations</name>
     <description>
-        Overlay REST customizations
+        This project allows you to overlay your own local REST customizations
+        on top of the default REST API provided with DSpace.
     </description>
 
     <parent>

--- a/dspace/pom.xml
+++ b/dspace/pom.xml
@@ -40,7 +40,7 @@
                          this assembly builds a directory, setting this to "true"
                          (default value) will just result in a WARNING message.-->
                     <attach>false</attach>
-                    <finalName>${artifactId}</finalName>
+                    <finalName>${project.artifactId}</finalName>
                     <descriptors>
                         <descriptor>src/main/assembly/assembly.xml</descriptor>
                     </descriptors>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
-        <version>7</version>
+        <version>9</version>
         <relativePath />
     </parent>
 
@@ -46,7 +46,7 @@
           <plugins>
               <plugin>
                   <artifactId>maven-compiler-plugin</artifactId>
-                  <version>2.3.2</version>
+                  <version>3.1</version>
                   <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -55,7 +55,7 @@
               <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>2.5</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -68,11 +68,7 @@
               <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <!-- We'd rather this be an open-ended range of versions.
-                     But, because of a Maven bug, we must force a specific version:
-                     http://jira.codehaus.org/browse/MNG-2742
-                     Once the bug is fixed, we should put open-ended range in dspace-pom -->
-                <version>2.1.1</version>
+                <version>2.4</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                     <archive>
@@ -86,7 +82,7 @@
              <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.6</version>
+                <version>2.17</version>
                 <!-- tests whose name starts by Abstract will be ignored -->
                 <configuration>
                     <excludes>
@@ -100,12 +96,12 @@
              </plugin>
              <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>2.4</version>
              </plugin>
              <plugin>
-                <groupId>com.mycila.maven-license-plugin</groupId>
-                <artifactId>maven-license-plugin</artifactId>
-                <version>1.9.0</version>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>2.6</version>
              </plugin>
           </plugins>
       </pluginManagement>
@@ -147,7 +143,7 @@
 
          <plugin>
             <artifactId>maven-release-plugin</artifactId>
-            <version>2.3.2</version>
+            <version>2.5</version>
             <configuration>
                 <!-- During release:perform, enable the "release" profile (see below) -->
                 <releaseProfiles>release</releaseProfiles>
@@ -159,8 +155,8 @@
             </configuration>
          </plugin>
          <plugin>
-                <groupId>com.mycila.maven-license-plugin</groupId>
-                <artifactId>maven-license-plugin</artifactId>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
                 <configuration>
                     <!-- License header file (can be a URL, but that's less stable if external site is down on occasion) -->
                     <header>${root.basedir}/LICENSE_HEADER</header>
@@ -1075,10 +1071,10 @@
       <mailingList>
          <name>DSpace Technical Users List</name>
          <subscribe>
-            http://lists.sourceforge.net/mailman/listinfo/dspace-tech
+            http://lists.sourceforge.net/lists/listinfo/dspace-tech
          </subscribe>
          <unsubscribe>
-            http://lists.sourceforge.net/mailman/listinfo/dspace-tech
+            http://lists.sourceforge.net/lists/listinfo/dspace-tech
          </unsubscribe>
          <post>dspace-tech AT lists.sourceforge.net</post>
          <archive>
@@ -1088,10 +1084,10 @@
       <mailingList>
          <name>DSpace Developers List</name>
          <subscribe>
-            http://lists.sourceforge.net/mailman/listinfo/dspace-devel
+            http://lists.sourceforge.net/lists/listinfo/dspace-devel
          </subscribe>
          <unsubscribe>
-            http://lists.sourceforge.net/mailman/listinfo/dspace-devel
+            http://lists.sourceforge.net/lists/listinfo/dspace-devel
          </unsubscribe>
          <post>dspace-devel AT lists.sourceforge.net</post>
          <archive>
@@ -1101,10 +1097,10 @@
       <mailingList>
          <name>DSpace General Issues List</name>
          <subscribe>
-            http://lists.sourceforge.net/mailman/listinfo/dspace-general
+            http://lists.sourceforge.net/lists/listinfo/dspace-general
          </subscribe>
          <unsubscribe>
-            http://lists.sourceforge.net/mailman/listinfo/dspace-general
+            http://lists.sourceforge.net/lists/listinfo/dspace-general
          </unsubscribe>
          <post>dspace-general AT lists.sourceforge.net</post>
          <archive>
@@ -1114,10 +1110,10 @@
       <mailingList>
          <name>DSpace SCM Commit Change-Log</name>
          <subscribe>
-            http://lists.sourceforge.net/mailman/listinfo/dspace-changelog
+            http://lists.sourceforge.net/lists/listinfo/dspace-changelog
          </subscribe>
          <unsubscribe>
-            http://lists.sourceforge.net/mailman/listinfo/dspace-changelog
+            http://lists.sourceforge.net/lists/listinfo/dspace-changelog
          </unsubscribe>
          <post>noreply AT lists.sourceforge.net</post>
          <archive>
@@ -1328,7 +1324,7 @@
    </contributors>
 
    <!--
-      The Subversion repository location is used by Continuum to update against
+      The SCM repository location is used by Continuum to update against
       when changes have occurred.  This spawns a new build cycle and releases
       snapshots into the snapshot repository below.
    -->
@@ -1336,8 +1332,8 @@
       <connection>scm:git:git@github.com:DSpace/DSpace.git</connection>
       <developerConnection>scm:git:git@github.com:DSpace/DSpace.git</developerConnection>
       <url>git@github.com:DSpace/DSpace.git</url>
-     <tag>HEAD</tag>
-  </scm>
+      <tag>HEAD</tag>
+   </scm>
 
     <!--
         Distribution Management is currently used by the Continuum


### PR DESCRIPTION
This updates all Maven plugin versions (to latest versions I could find on Maven Central) in all of our POM files. In most cases, this is just a simple version change...but a few plugins have been renamed or work slightly differently, including:
- maven-license-plugin is now called "license-maven-plugin"
- gmaven-plugin is now called "groovy-maven-plugin", and its config requires some minor changes

I've also performed some general POM cleanup, including:
- Improving readability / alignment (by replacing tabs with spaces and similar)
- Changed 'name' tag in a few POMs (OAI, REST) whose names were slightly non-standard (based how others are named)

UPDATE: Also fixes two broken unit tests (https://github.com/tdonohue/DSpace/commit/ab14cabea5cb46ccba37c678bb2fbdb1349d8d76 and https://github.com/tdonohue/DSpace/commit/6512718272a854ca9cdd42aadcdbd7e43db6a9a3) , which have been slyly hiding, but now made themselves known after upgrading maven-surefire-plugin.
Finally, I've updated our Sonatype 'oss-parent' to version 9 (we were on version 7).

I've tested all these changes using both the default build command:

```
    mvn clean package
```

and the build command to check license headers & perform all unit tests:

```
    mvn clean package license:check -Dmaven.test.skip=false
```

and a "dry run" of a release:

```
     mvn release:prepare -DdryRun=true
```

Everything builds/tests successfully on Linux.

This does need a quick sanity review by others, and perhaps some quick build tests on both Windows and Mac OSX, just to ensure there's no OS-specific build issues encountered by all these plugin updates.

If possible, I'm hoping we can get this merged sooner rather than later, since it touches a large number of POMs, and is therefore likely to encounter conflicts as we get closer to the 5.0 release deadlines, etc.
