### PR TITLE
DS-2069 Edit item via swordv2 using its handle

### DIFF
--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordUrlManager.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordUrlManager.java
@@ -131,20 +131,29 @@ public class SwordUrlManager
 				throw new SwordError(DSpaceUriRegistry.BAD_URL, "The item URL is invalid");
 			}
 
-            String iid = location.substring(cBaseUrl.length());
-            if (iid.endsWith(".atom"))
+            String identifier = location.substring(cBaseUrl.length());
+            if (identifier.endsWith(".atom"))
             {
                 // this is the atom url, so we need to strip that to ge tthe item id
-                iid = iid.substring(0, iid.length() - ".atom".length());
+                identifier = identifier.substring(0, identifier.length() - ".atom".length());
             }
-			else if (iid.endsWith(".rdf"))
+			else if (identifier.endsWith(".rdf"))
 			{
 				// this is the rdf url so we need to strip that to get the item id
-				iid = iid.substring(0, iid.length() - ".rdf".length());
+				identifier = identifier.substring(0, identifier.length() - ".rdf".length());
 			}
 			
-            int itemId = Integer.parseInt(iid);
-            Item item = Item.find(context, itemId);
+			int itemId;
+            
+			try {
+				itemId = Integer.parseInt(identifier);
+			} catch (NumberFormatException e) {
+				DSpaceObject dso = HandleManager.resolveToObject(context, identifier);  
+				itemId = dso.getID();
+			}
+            
+			Item item = Item.find(context, itemId);
+			
 			return item;
 		}
 		catch (SQLException e)


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2069
###### Issue description

Currently, to update a DSpace item using Swordv2, one needs to know the item's internal ID. 

Example of replace: PUT /swordv2/edit-media/INTERNAL-ID 

But it would be of extreme importance if one could use the handle as well to do the update. Something like: 

PUT /swordv2/edit-media/ITEM-HANDLE 

Which would be similar to Swordv1 deposit: 

POST /sword/deposit/COLLECTION-HANDLE 

This need popped out because I needed to sync (add and update if it was previously added) a system with DSpace using Swordv2 and only knowing the item's handle. That's way I think this is an interesting/valuable feature to be added to DSpace. 
