### PR TITLE
DS-2071 Fix DSpace Import to accept zip, adding subfolder to sourceDir

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -515,6 +515,7 @@ public class ItemImport
                 // If this is a zip archive, unzip it first
                 if (zip)
                 {
+                    String sourceDirForZip = sourcedir;
                     ZipFile zf = new ZipFile(zipfilename);
                     ZipEntry entry;
                     Enumeration<? extends ZipEntry> entries = zf.entries();
@@ -544,6 +545,17 @@ public class ItemImport
                                 {
                                     log.error("Unable to create directory");
                                 }
+
+                                //Entries could have too many directories, and we need to adjust the sourcedir
+                                //regex supports either windows or *nix file paths
+                                String[] entryChunks = entry.getName().split("/|\\\\");
+                                if(entryChunks.length > 1) {
+                                    if(sourceDirForZip == sourcedir) {
+                                        sourceDirForZip += "/" + entryChunks[0];
+                                    }
+                                }
+
+
                             }
                             byte[] buffer = new byte[1024];
                             int len;
@@ -557,6 +569,11 @@ public class ItemImport
                             in.close();
                             out.close();
                         }
+                    }
+
+                    if(sourceDirForZip != sourcedir) {
+                        sourcedir = sourceDirForZip;
+                        System.out.println("Set sourceDir using path inside of Zip: " + sourcedir);
                     }
                 }
 


### PR DESCRIPTION
Addresses an issue with Item Import, using Zip content.
https://jira.duraspace.org/browse/DS-2071

The JIRA Ticket DS-2071 explains the issue, where the subdirectory that the zipped content was being extracted to, wasn't being specified as the sourceDir, thus, when it became time for the importer to pull in the extracted content of the ZIP, it had the parent of the sourceDir, which wasn't a valid SimpleArchiveFormat. This detects when the entries of the zip are in the sub-subdirectories, and sets that common subdirectory as the sourceDir for the zip importer to pass along to the regular DSpace Item Importer.
