### PR TITLE
DS-2073 - Fix "covarage" typo in XSL transforms (OAI-PMH Crosswalks)

### DIFF
--- a/dspace/config/crosswalks/oai/metadataFormats/didl.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/didl.xsl
@@ -86,11 +86,11 @@
 							<xsl:for-each select="doc:metadata/doc:element[@name='bitstreams']/doc:element[@name='bitstream']/doc:field[@name='format']">
 								<dc:format><xsl:value-of select="." /></dc:format>
 							</xsl:for-each>
-							<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='covarage']/doc:element/doc:field[@name='value']">
-								<dc:covarage><xsl:value-of select="." /></dc:covarage>
+							<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='coverage']/doc:element/doc:field[@name='value']">
+								<dc:coverage><xsl:value-of select="." /></dc:coverage>
 							</xsl:for-each>
-							<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='covarage']/doc:element/doc:element/doc:field[@name='value']">
-								<dc:covarage><xsl:value-of select="." /></dc:covarage>
+							<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='coverage']/doc:element/doc:element/doc:field[@name='value']">
+								<dc:coverage><xsl:value-of select="." /></dc:coverage>
 							</xsl:for-each>
 							<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='publisher']/doc:element/doc:field[@name='value']">
 								<dc:publisher><xsl:value-of select="." /></dc:publisher>

--- a/dspace/config/crosswalks/oai/metadataFormats/etdms.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/etdms.xsl
@@ -65,11 +65,11 @@
 			<xsl:for-each select="doc:metadata/doc:element[@name='bitstreams']/doc:element[@name='bitstream']/doc:field[@name='format']">
 				<format><xsl:value-of select="." /></format>
 			</xsl:for-each>
-			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='covarage']/doc:element/doc:field[@name='value']">
-				<covarage><xsl:value-of select="." /></covarage>
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='coverage']/doc:element/doc:field[@name='value']">
+				<coverage><xsl:value-of select="." /></coverage>
 			</xsl:for-each>
-			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='covarage']/doc:element/doc:element/doc:field[@name='value']">
-				<covarage><xsl:value-of select="." /></covarage>
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='coverage']/doc:element/doc:element/doc:field[@name='value']">
+				<coverage><xsl:value-of select="." /></coverage>
 			</xsl:for-each>
 			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='publisher']/doc:element/doc:field[@name='value']">
 				<publisher><xsl:value-of select="." /></publisher>

--- a/dspace/config/crosswalks/oai/metadataFormats/qdc.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/qdc.xsl
@@ -104,15 +104,15 @@
 				<xsl:value-of select="." />
 			</dc:format>
 		</xsl:for-each>
-		<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='covarage']/doc:element/doc:field[@name='value']">
-			<dc:covarage xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://purl.org/dc/terms/ http://dublincore.org/schemas/xmls/qdc/2006/01/06/dcterms.xsd http://purl.org/dc/elements/1.1/ http://dublincore.org/schemas/xmls/qdc/2006/01/06/dc.xsd">
+		<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='coverage']/doc:element/doc:field[@name='value']">
+			<dc:coverage xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://purl.org/dc/terms/ http://dublincore.org/schemas/xmls/qdc/2006/01/06/dcterms.xsd http://purl.org/dc/elements/1.1/ http://dublincore.org/schemas/xmls/qdc/2006/01/06/dc.xsd">
 				<xsl:value-of select="." />
-			</dc:covarage>
+			</dc:coverage>
 		</xsl:for-each>
-		<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='covarage']/doc:element/doc:element/doc:field[@name='value']">
-			<dc:covarage xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://purl.org/dc/terms/ http://dublincore.org/schemas/xmls/qdc/2006/01/06/dcterms.xsd http://purl.org/dc/elements/1.1/ http://dublincore.org/schemas/xmls/qdc/2006/01/06/dc.xsd">
+		<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='coverage']/doc:element/doc:element/doc:field[@name='value']">
+			<dc:coverage xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://purl.org/dc/terms/ http://dublincore.org/schemas/xmls/qdc/2006/01/06/dcterms.xsd http://purl.org/dc/elements/1.1/ http://dublincore.org/schemas/xmls/qdc/2006/01/06/dc.xsd">
 				<xsl:value-of select="." />
-			</dc:covarage>
+			</dc:coverage>
 		</xsl:for-each>
 		<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='publisher']/doc:element/doc:field[@name='value']">
 			<dc:publisher xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://purl.org/dc/terms/ http://dublincore.org/schemas/xmls/qdc/2006/01/06/dcterms.xsd http://purl.org/dc/elements/1.1/ http://dublincore.org/schemas/xmls/qdc/2006/01/06/dc.xsd">

--- a/dspace/config/crosswalks/oai/metadataFormats/rdf.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/rdf.xsl
@@ -73,11 +73,11 @@
 				<xsl:for-each select="doc:metadata/doc:element[@name='bitstreams']/doc:element[@name='bitstream']/doc:field[@name='format']">
 					<dc:format><xsl:value-of select="." /></dc:format>
 				</xsl:for-each>
-				<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='covarage']/doc:element/doc:field[@name='value']">
-					<dc:covarage><xsl:value-of select="." /></dc:covarage>
+				<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='coverage']/doc:element/doc:field[@name='value']">
+					<dc:coverage><xsl:value-of select="." /></dc:coverage>
 				</xsl:for-each>
-				<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='covarage']/doc:element/doc:element/doc:field[@name='value']">
-					<dc:covarage><xsl:value-of select="." /></dc:covarage>
+				<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='coverage']/doc:element/doc:element/doc:field[@name='value']">
+					<dc:coverage><xsl:value-of select="." /></dc:coverage>
 				</xsl:for-each>
 				<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='publisher']/doc:element/doc:field[@name='value']">
 					<dc:publisher><xsl:value-of select="." /></dc:publisher>


### PR DESCRIPTION
To the best of my knowledge, no actual XML format requires the
"covarage" typo as an element or attribute, and no site should be
entering a "covarage" metadata field.

Signed-off-by: Dan Scott dan@coffeecode.net
