### PR TITLE
DS-1408 - revert unnecessary  MVCC setting for H2 database

### DIFF
--- a/src/main/filters/testEnvironment.properties
+++ b/src/main/filters/testEnvironment.properties
@@ -32,8 +32,7 @@ default.language = en_US
 # Database name ("oracle", or "postgres")
 
 db.name = oracle
-# MVCC=true tells H2 to use multi-version concurrency to avoid "timeout trying to lock" errors (http://www.h2database.com/html/advanced.html#mvcc)
-db.url = jdbc:h2:mem:test;MODE=Oracle;MVCC=true
+db.url = jdbc:h2:mem:test;MODE=Oracle
 db.driver = org.h2.Driver
 db.username = sa
 db.password = sa


### PR DESCRIPTION
This reverts commit 4f808e72367e821557ba18a3e086b04b3c504db2 related to DS-1408:

https://jira.duraspace.org/browse/DS-1408

As noted by @mwoodiupui in PR #351 , this particular commit may accidentally "mask" problems in our unit tests.  As DS-1408 no longer seems to occur, I tried reverting this old change...and unit testing still succeeds after reverting.

More on MVCC setting, which has several warnings attached (including one saying "The MVCC feature is not fully tested yet"): http://www.h2database.com/html/advanced.html#mvcc

Therefore, assuming Travis CI doesn't complain about this PR, I'd like to revert this setting as it no longer seems to be necessary.
