### PR TITLE
DS-2075 Put detailed test logs in *-output.txt files instead of stdout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,8 @@
                     <excludes>
                         <exclude>**/Abstract*</exclude>
                     </excludes>
+                    <!-- Detailed logs in reportsDirectory/testName-output.txt instead of stdout -->
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <!--
                     Enable to debug Maven Surefire tests in remote proces
                     <debugForkedProcess>true</debugForkedProcess>


### PR DESCRIPTION
Related to https://jira.duraspace.org/browse/DS-2075

This tiny POM tweak tells maven-surefire-plugin to no longer dump all the unit testing logs onto stdout, instead they are written to the appropriate `target/surefire-reports/*-output.txt` file.  This keeps the Unit testing details on STDOUT much more at a summary level, so you'll still see messages like this when running Maven:

```
    Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 20.866 sec - in org.dspace.authenticate.IPMatcherTest
```

But, all the extra INFO messages, etc are sent into a log file under `target/surefire-reports/`

This also should help fix some current issues where Travis CI is killing our builds because our log files grow above 4MB in size (mostly because of these detailed unit test logs being sent to STDOUT).
