### PR TITLE
DS-1408 : Increase database lock timeout to avoid lock errors

### DIFF
--- a/src/main/filters/testEnvironment.properties
+++ b/src/main/filters/testEnvironment.properties
@@ -32,7 +32,8 @@ default.language = en_US
 # Database name ("oracle", or "postgres")
 
 db.name = oracle
-db.url = jdbc:h2:mem:test;MODE=Oracle
+# Use a 10 second database lock timeout to avoid occasional JDBC lock timeout errors
+db.url = jdbc:h2:mem:test;MODE=Oracle;LOCK_TIMEOUT=10000
 db.driver = org.h2.Driver
 db.username = sa
 db.password = sa


### PR DESCRIPTION
It seems that PR #582 may have caused DS-1408 to re-emerge:

https://jira.duraspace.org/browse/DS-1408

This PR is an attempt to instead resolve JDBC lock timeout errors by simply increasing the default timeout from 1 sec to 10 seconds.
