### PR TITLE
[DS-1992] License checker should not run in dspace/modules/*

### DIFF
--- a/dspace/modules/pom.xml
+++ b/dspace/modules/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <!-- This is the path to the root [dspace-src] directory. -->
         <root.basedir>${basedir}/../..</root.basedir>
+        <license.skip>true</license.skip>
     </properties>
 
     <!-- The 'additions' module must *always* be built, as it is included


### PR DESCRIPTION
Turned off with a property, because I couldn't get plugin configuration to work in 1.9.0.
