### PR TITLE
DS-1955 Lengthened embargo reason field (rpdescription) in resourcepolicy

### DIFF
--- a/dspace/etc/postgres/database_schema_4_5.sql
+++ b/dspace/etc/postgres/database_schema_4_5.sql
@@ -13,5 +13,11 @@ BEGIN;
 ------------------------------------------------------
 ALTER TABLE requestitem ADD request_message TEXT;
 
+------------------------------------------------------
+-- DS-1955 resize rpdescription for embargo reason
+------------------------------------------------------
+ALTER TABLE resourcepolicy ALTER COLUMN rpdescription TYPE TEXT;
+
+
 
 COMMIT;


### PR DESCRIPTION
...mmodate longer reasons and stopuncaught exceptions caused by reasons of more than 100 characters. Changes made in database_schema_4_5.sql. To completely solve the problem a similar change would need to be made to the oracle schema.
