### PR TITLE
DS-2104 Only clear metadata for qualifiers actually present

### DIFF
--- a/dspace-api/src/main/java/org/dspace/submit/step/DescribeStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/DescribeStep.java
@@ -163,14 +163,21 @@ public class DescribeStep extends AbstractProcessingStep
             {
                 continue;
             }
-            String qualifier = inputs[i].getQualifier();
-            if (qualifier == null
-                    && inputs[i].getInputType().equals("qualdrop_value"))
-            {
-                qualifier = Item.ANY;
-            }
-            item.clearMetadata(inputs[i].getSchema(), inputs[i].getElement(),
-                    qualifier, Item.ANY);
+	        if (inputs[i].getInputType().equals("qualdrop_value"))
+	        {
+		        @SuppressWarnings("unchecked") // This cast is correct
+		        List<String> pairs = inputs[i].getPairs();
+		        for (int j = 0; j < pairs.size(); j += 2)
+		        {
+			        String qualifier = pairs.get(j+1);
+			        item.clearMetadata(inputs[i].getSchema(), inputs[i].getElement(), qualifier, Item.ANY);
+		        }
+	        }
+	        else
+	        {
+		        String qualifier = inputs[i].getQualifier();
+		        item.clearMetadata(inputs[i].getSchema(), inputs[i].getElement(), qualifier, Item.ANY);
+	        }
         }
 
         // Clear required-field errors first since missing authority


### PR DESCRIPTION
This is a bug fix for an issue where metadata values could disappear during
submission or in the workflow when a qualdrop input item is placed on a
different page from another input item for the same schema+element. The
previous version of this code processed a page by removing all metadata values
from the item for fields listed on that page. For qualdrop inputs, metadata
values for all qualifiers (including no qualifier) were removed rather than
just those qualifiers actually listed in the qualdrop. This bugfix changes the
code to use the qualifiers from the value pairs of the qualdrop.
