### PR TITLE
DS-2098 Allow EPerson with ADMIN permission to move items

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/Collection.java
+++ b/dspace-api/src/main/java/org/dspace/content/Collection.java
@@ -1015,7 +1015,7 @@ public class Collection extends DSpaceObject
             IOException
     {
         // Check authorisation
-        AuthorizeManager.authorizeAction(ourContext, this, Constants.REMOVE);
+        AuthorizeManager.authorizeAction(ourContext, this, Constants.ADMIN);
 
         // will the item be an orphan?
         TableRow row = DatabaseManager.querySingle(ourContext,
@@ -1026,6 +1026,7 @@ public class Collection extends DSpaceObject
         if (row.getLongColumn("num") == 1)
         {
             // Orphan; delete it
+            AuthorizeManager.authorizeAction(ourContext, this, Constants.REMOVE);
             item.delete();
         }
         log.info(LogManager.getHeader(ourContext, "remove_item",


### PR DESCRIPTION
Changed collection.java to allow moving an item when eperson has admin privileges even if that eperson is not authorized for REMOVE

https://jira.duraspace.org/browse/DS-2098
