### PR TITLE
Travis CI tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,13 @@
 language: java
-script: "travis_retry mvn clean package license:check -Dmaven.test.skip=false"
-cache:
-  directories:
-  - $HOME/.m2
+
+# Skip 'mvn install', not really needed for our tests
+install: "echo 'Skipping install, dependencies will be downloaded during build and test.'"
+
+# Build and test 
+#  travis_retry = retry build/test up to 3 times
+#  -B = batch/non-interactive mode (recommended for CI)
+#  -V = display version info before build
+script: "travis_retry mvn clean package license:check -Dmaven.test.skip=false -B -V"
+
+# Give Maven 2GB of memory to work with
+env: MAVEN_OPTS=-Xmx2048M


### PR DESCRIPTION
Some minor Travis CI tweaks to improve performance/speed of tests.  We seem to still be having some randomly "Killed" builds in Travis CI, which I suspect may be memory related.

The following minor tweaks to `.travis.yml` are included in this PR:
- Speed tweak: Skip the 'mvn install' process, which Travis uses to download all Maven dependencies. It's really not needed. We can just let Travis download these during the build/test.
- Performance tweak: Set MAVEN_OPTS to give Maven 2GB of memory to work with. By default, on Travis CI, this seems to be set to 800MB in JAVA_OPTS by default (or at least that's what Travis is telling me when I tell it to run 'echo $JAVA_OPTS' as part of the build)
- Finally, I removed the `cache` settings. On further review, they are only offered for private repos in the paid (travis-ci.com) plans. See http://docs.travis-ci.com/user/caching/

Assuming Travis CI doesn't complain about this PR, I'm going to merge this immediately. I don't think any of this is controversial, and I'm hoping the tweak to MAVEN_OPTS will help avoid some of the "Killed" builds.
