### PR TITLE
[DS-2052] Mirage 2 separate webapp fix

### DIFF
--- a/dspace/src/main/assembly/assembly.xml
+++ b/dspace/src/main/assembly/assembly.xml
@@ -135,6 +135,9 @@
          <includes>
             <include>org.dspace.modules:*:war:*</include>
          </includes>
+          <excludes>
+              <exclude>org.dspace.modules:xmlui-mirage2:war:*</exclude>
+          </excludes>
          <binaries>
             <includeDependencies>false</includeDependencies>
             <outputDirectory>webapps/${module.artifactId}</outputDirectory>


### PR DESCRIPTION
This pull request fixes an issue where a separate webapp would be created in the dspace install folder.
