### PR TITLE
[DS-2116] Mirage 2 build fails without including maven clean target

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/Gruntfile.js
+++ b/dspace-xmlui-mirage2/src/main/webapp/Gruntfile.js
@@ -31,6 +31,14 @@ module.exports = function (grunt) {
                         dest: 'styles/main.scss'
                     }
                 ]
+            },
+            scriptsxml: {
+                files: [
+                    {
+                        src: ['scripts.xml'],
+                        dest: 'scripts-dist.xml'
+                    }
+                ]
             }
         },
         compass: {
@@ -71,25 +79,16 @@ module.exports = function (grunt) {
             }
         },
         useminPrepare:{
-            prod: {
-                src: ['scripts.xml'],
-                options: {
-                    // fool usemin in to putting theme.js straight into the scripts
-                    // folder, and not in a separate dist folder. And no, you can't
-                    // just use an empty string, I tried ;)
-                    dest: 'dist/../'
-                }
-            },
-            dev: {
-                src: ['scripts.xml'],
-                options: {
-                    // same deal
-                    dest: 'dist/../'
-                }
+            src: ['scripts-dist.xml'],
+            options: {
+                // fool usemin in to putting theme.js straight into the scripts
+                // folder, and not in a separate dist folder. And no, you can't
+                // just use an empty string, I tried ;)
+                dest: 'dist/../'
             }
         } ,
         usemin: {
-            html:'scripts.xml'
+            html:'scripts-dist.xml'
         }
     });
 
@@ -100,11 +99,14 @@ module.exports = function (grunt) {
     grunt.registerTask('bootstrap_color_scheme', [
         'copy:bootstrap_color_scheme'
     ]);
+    grunt.registerTask('shared-steps', [
+        'copy:scriptsxml', 'coffee', 'handlebars', 'useminPrepare','concat'
+    ]);
     grunt.registerTask('no-compass-prod', [
-        'coffee', 'handlebars', 'useminPrepare:prod','concat','uglify','usemin'
+        'shared-steps','uglify','usemin'
     ]);
     grunt.registerTask('no-compass-dev', [
-        'coffee', 'handlebars', 'useminPrepare:dev','concat','uglify:generated'
+        'shared-steps','uglify:generated'
     ]);
     grunt.registerTask('prod', [
         'compass:prod', 'no-compass-prod'

--- a/dspace-xmlui-mirage2/src/main/webapp/scripts.xml
+++ b/dspace-xmlui-mirage2/src/main/webapp/scripts.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The contents of this file are subject to the license and copyright
@@ -38,7 +39,8 @@
     <script src="scripts/vendor-extensions.js">&#160;</script>
     <script src="scripts/templates.js">&#160;</script>
     <!-- endbuild -->
-    <!-- build:remove -->
-    <script src="scripts/set-devmode.js">&#160;</script>
-    <!-- endbuild -->
+
+    <!--the build comments below need to be inline to fix the 'undefined'
+    issue mentioned at https://github.com/yeoman/grunt-usemin/issues/128 -->
+    <!-- build:remove --><script src="scripts/set-devmode.js">&#160;</script><!-- endbuild -->
 </scripts>

--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/core/page-structure.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/core/page-structure.xsl
@@ -744,7 +744,7 @@
             <!--we can't use $theme-path, because that contains the context path,
             and cocoon:// urls don't need the context path-->
             <xsl:value-of select="$pagemeta/dri:metadata[@element='theme'][@qualifier='path']"/>
-            <xsl:text>scripts.xml</xsl:text>
+            <xsl:text>scripts-dist.xml</xsl:text>
         </xsl:variable>
         <xsl:for-each select="document($scriptURL)/scripts/script">
             <script src="{$theme-path}{@src}">&#160;</script>


### PR DESCRIPTION
This PR fixes an issue where running mvn package without clean would break the usemin step of the grunt build.
