### PR TITLE
fixes DS-2118, adds assetstore.dir to the testing dspace.cfg.more 

### DIFF
--- a/dspace-api/src/test/data/dspace.cfg.more
+++ b/dspace-api/src/test/data/dspace.cfg.more
@@ -8,3 +8,6 @@ plugin.selfnamed.org.dspace.content.authority.ChoiceAuthority = \
 choices.plugin.dc.language.iso = common_iso_languages
 choices.presentation.dc.language.iso = select
 authority.controlled.dc.language.iso = true
+
+# use the testing assetstore.dir
+assetstore.dir = ${dspace.dir}/assetstore


### PR DESCRIPTION
The file dspace.cfg.more is used by the Fileweaver plugin, to overlay dspace.cfg with settings more appropriate for testing purposes. Using the correct assetstore is a good idea for testing purposes.
