### PR TITLE
Fixes DS-2113: JSPUI HTML5 upload should store Bitstreams...

### DIFF
--- a/dspace-api/src/main/java/org/dspace/submit/step/UploadStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/UploadStep.java
@@ -435,7 +435,7 @@ public class UploadStep extends AbstractProcessingStep
      *         UI-related code! (if STATUS_COMPLETE or 0 is returned,
      *         no errors occurred!)
      */
-    protected int processUploadFile(Context context, HttpServletRequest request,
+    public int processUploadFile(Context context, HttpServletRequest request,
             HttpServletResponse response, SubmissionInfo subInfo)
             throws ServletException, IOException, SQLException,
             AuthorizeException

--- a/dspace-api/src/main/java/org/dspace/submit/step/UploadWithEmbargoStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/UploadWithEmbargoStep.java
@@ -315,7 +315,7 @@ public class UploadWithEmbargoStep extends UploadStep
      *         UI-related code! (if STATUS_COMPLETE or 0 is returned,
      *         no errors occurred!)
      */
-    protected int processUploadFile(Context context, HttpServletRequest request,
+    public int processUploadFile(Context context, HttpServletRequest request,
                                     HttpServletResponse response, SubmissionInfo subInfo)
             throws ServletException, IOException, SQLException,
             AuthorizeException

--- a/dspace-jspui/src/main/webapp/submit/choose-file.jsp
+++ b/dspace-jspui/src/main/webapp/submit/choose-file.jsp
@@ -41,6 +41,7 @@
 
 	//get submission information object
     SubmissionInfo subInfo = SubmissionController.getSubmissionInfo(context, request);
+    request.setAttribute("submission.info", subInfo);
 
     boolean withEmbargo = ((Boolean)request.getAttribute("with_embargo")).booleanValue();
 
@@ -419,7 +420,8 @@
             simultaneousUploads:1,
             testChunks: true,
             throttleProgressCallbacks:1,
-            method: "multipart"
+            method: "multipart",
+            query:{workspace_item_id:'<%= subInfo.getSubmissionItem().getID()%>'}
           });
         // Resumable.js isn't supported, fall back on a different method
 


### PR DESCRIPTION
JIRA: https://jira.duraspace.org/browse/DS-2113
Currently the HTML5 upload in JSPUI submission stores uploaded files in the session and creates the necessary Bitstreams not until the user clicks the next button. So there is a time where the UI alredy shows a green check mark but the file is not stored safely in the repository (after upload, before the next button is clicked). A PR to change this is in preparation.
- [x] JSPUI person to test/verify
