### PR TITLE
DS-2120: IdentifierServiceImpl should log less aggressive

### DIFF
--- a/dspace-api/src/main/java/org/dspace/identifier/IdentifierServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/IdentifierServiceImpl.java
@@ -117,7 +117,16 @@ public class IdentifierServiceImpl implements IdentifierService {
                    if (result != null){
                        return result;
                    }
-               } catch (IdentifierException e) {
+               }
+               catch (IdentifierNotFoundException ex)
+               {
+                   log.info(service.getClass().getName() + " doesn't find an "
+                           + "Identifier for " + dso.getTypeText() + ", " 
+                           + Integer.toString(dso.getID()) + ".");
+                   log.debug(ex.getMessage(), ex);
+               }
+               catch (IdentifierException e)
+               {
                    log.error(e.getMessage(),e);
                }
             }


### PR DESCRIPTION
The IdentifierProvider API uses exceptions to state that an Identifier
for a specific DSO cannot be found. These exceptions shouldn't get
logged as error.
