### PR TITLE
DS-2125 Fix possible NPEs in Context object commit/complete/abort

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -311,6 +311,9 @@ public class Context
      * Close the context object after all of the operations performed in the
      * context have completed successfully. Any transaction with the database is
      * committed.
+     * <p>
+     * Calling complete() on a Context which is no longer valid (isValid()==false),
+     * is a no-op.
      * 
      * @exception SQLException
      *                if there was an error completing the database transaction
@@ -322,15 +325,17 @@ public class Context
         // been written using this connection
         try
         {
-            // Commit any changes made as part of the transaction
-            if (! isReadOnly())
+            // As long as we have a valid, writeable database connection,
+            // commit any changes made as part of the transaction
+            if (isValid() && !isReadOnly())
             {
                 commit();
             }
         }
         finally
         {
-            // Free the connection
+            // Free the DB connection
+            // If connection is closed or null, this is a no-op
             DatabaseManager.freeConnection(connection);
             connection = null;
             clearCache();
@@ -344,17 +349,25 @@ public class Context
      * @exception SQLException
      *                if there was an error completing the database transaction
      *                or closing the connection
+     * @exception IllegalStateException
+     *                if the Context is read-only or is no longer valid
      */
     public void commit() throws SQLException
     {
-        /* 
-         * invalid condition if in read-only mode: no valid
-         * transactions can be committed: no recourse but to bail
-         */
+        // Invalid Condition. The Context is Read-Only, and transactions cannot
+        // be committed.
         if (isReadOnly())
         {
             throw new IllegalStateException("Attempt to commit transaction in read-only context");
         }
+
+        // Invalid Condition. The Context has been either completed or aborted
+        // and is no longer valid
+        if (!isValid())
+        {
+            throw new IllegalStateException("Attempt to commit transaction to a completed or aborted context");
+        }
+
         // Commit any changes made as part of the transaction
         Dispatcher dispatcher = null;
 
@@ -462,17 +475,18 @@ public class Context
      * there is an error freeing the database connection, since this method may
      * be called as part of an error-handling routine where an SQLException has
      * already been thrown.
+     * <p>
+     * Calling abort() on a Context which is no longer valid (isValid()==false),
+     * is a no-op.
      */
     public void abort()
     {
         try
         {
-            if (!connection.isClosed())
+            // Rollback if we have a database connection, and it is NOT Read Only
+            if (isValid() && !connection.isClosed() && !isReadOnly())
             {
-                if (! isReadOnly())
-                {
-                    connection.rollback();
-                }
+                connection.rollback();
             }
         }
         catch (SQLException se)
@@ -483,10 +497,9 @@ public class Context
         {
             try
             {
-                if (!connection.isClosed())
-                {
-                    DatabaseManager.freeConnection(connection);
-                }
+                // Free the DB connection
+                // If connection is closed or null, this is a no-op
+                DatabaseManager.freeConnection(connection);
             }
             catch (Exception ex)
             {

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -321,6 +321,10 @@ public class Context
      */
     public void complete() throws SQLException
     {
+        // If Context is no longer open/valid, just note that it has already been closed
+        if(!isValid())
+            log.info("complete() was called on a closed Context object. No changes to commit.");
+
         // FIXME: Might be good not to do a commit() if nothing has actually
         // been written using this connection
         try
@@ -481,6 +485,10 @@ public class Context
      */
     public void abort()
     {
+        // If Context is no longer open/valid, just note that it has already been closed
+        if(!isValid())
+            log.info("abort() was called on a closed Context object. No changes to abort.");
+
         try
         {
             // Rollback if we have a database connection, and it is NOT Read Only

--- a/dspace-api/src/test/java/org/dspace/core/ContextTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/ContextTest.java
@@ -1,0 +1,574 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.core;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Locale;
+import mockit.NonStrictExpectations;
+import org.dspace.AbstractUnitTest;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.AuthorizeManager;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
+import org.junit.*;
+import static org.junit.Assert.* ;
+import static org.hamcrest.CoreMatchers.*;
+
+/**
+ * Perform some basic unit tests for Context Class
+ * @author tdonohue
+ */
+public class ContextTest extends AbstractUnitTest
+{
+    /**
+     * Test of getDBConnection method, of class Context.
+     */
+    @Test
+    public void testGetDBConnection() throws SQLException
+    {
+        Connection connection = context.getDBConnection();
+        
+        assertThat("testGetDBConnection 0", connection, notNullValue());
+        assertThat("testGetDBConnection 1", connection.isClosed(), equalTo(false));
+    }
+
+    /**
+     * Test of setCurrentUser method, of class Context.
+     */
+    @Test
+    public void testSetCurrentUser() throws SQLException, AuthorizeException
+    {
+        new NonStrictExpectations(AuthorizeManager.class)
+        {{
+            // Allow Admin permissions - needed to create a new EPerson
+            AuthorizeManager.isAdmin((Context) any); result = true;
+        }};
+        
+        EPerson oldUser = context.getCurrentUser();
+        
+        // Create a dummy EPerson to set as current user
+        EPerson newUser = EPerson.create(context);
+        newUser.setFirstName("Jane");
+        newUser.setLastName("Doe");
+        newUser.setEmail("jane@email.com");
+        newUser.setCanLogIn(true);
+        newUser.setLanguage(I18nUtil.getDefaultLocale().getLanguage());
+        
+        context.setCurrentUser(newUser);
+        
+        assertThat("testSetCurrentUser 0", context.getCurrentUser(), notNullValue());
+        assertThat("testSetCurrentUser 1", context.getCurrentUser(), equalTo(newUser));
+        
+        // Restore the previous current user
+        context.setCurrentUser(oldUser);
+    }
+
+    /**
+     * Test of getCurrentUser method, of class Context.
+     */
+    @Test
+    public void testGetCurrentUser() 
+    {
+        //NOTE: 'eperson' is initialized by AbstractUnitTest & set as the "currentUser" there
+        assertThat("testGetCurrentUser 0", context.getCurrentUser(), notNullValue());
+        assertThat("testGetCurrentUser 1", context.getCurrentUser(), equalTo(eperson));
+    }
+
+    /**
+     * Test of getCurrentLocale method, of class Context.
+     */
+    @Test
+    public void testGetCurrentLocale() 
+    {
+        //NOTE: CurrentLocale is not initialized in AbstractUnitTest. So it should be DEFAULTLOCALE
+        assertThat("testGetCurrentLocale 0", context.getCurrentLocale(), notNullValue());
+        assertThat("testGetCurrentLocale 1", context.getCurrentLocale(), equalTo(I18nUtil.DEFAULTLOCALE));
+    }
+
+    /**
+     * Test of setCurrentLocale method, of class Context.
+     */
+    @Test
+    public void testSetCurrentLocale() {
+        
+        //Get previous value
+        Locale oldLocale = context.getCurrentLocale();
+        
+        //Set a new, non-English value
+        Locale newLocale = Locale.FRENCH;
+        context.setCurrentLocale(newLocale);
+        
+        assertThat("testSetCurrentLocale 0", context.getCurrentLocale(), notNullValue());
+        assertThat("testSetCurrentLocale 1", context.getCurrentLocale(), equalTo(newLocale));
+        
+        // Restore previous value
+        context.setCurrentLocale(oldLocale);
+    }
+
+    /**
+     * Test of ignoreAuthorization method, of class Context.
+     */
+    @Test
+    public void testIgnoreAuthorization() 
+    {
+        // Turn off authorization
+        context.turnOffAuthorisationSystem();
+        assertThat("testIgnoreAuthorization 0", context.ignoreAuthorization(), equalTo(true));
+        
+        // Turn it back on
+        context.restoreAuthSystemState();
+        assertThat("testIgnoreAuthorization 1", context.ignoreAuthorization(), equalTo(false));
+    }
+
+    /**
+     * Test of turnOffAuthorisationSystem method, of class Context.
+     */
+    /*@Test
+    public void testTurnOffAuthorisationSystem() {
+        // Already tested in testIgnoreAuthorization() 
+    }*/
+
+    /**
+     * Test of restoreAuthSystemState method, of class Context.
+     */
+    /*@Test
+    public void testRestoreAuthSystemState() {
+        // Already tested in testIgnoreAuthorization()
+    }*/
+
+    /**
+     * Test of setIgnoreAuthorization method, of class Context.
+     */
+    /*@Test
+    public void testSetIgnoreAuthorization() {
+        // Deprecated method
+    }*/
+
+    /**
+     * Test of setExtraLogInfo method, of class Context.
+     */
+    @Test
+    public void testSetExtraLogInfo() 
+    {
+        // Get the previous value
+        String oldValue = context.getExtraLogInfo();
+       
+        // Set a new value
+        String newValue = "This is some extra log info";
+        context.setExtraLogInfo(newValue);
+        
+        assertThat("testSetExtraLogInfo 0", context.getExtraLogInfo(), notNullValue());
+        assertThat("testSetExtraLogInfo 1", context.getExtraLogInfo(), equalTo(newValue));
+    }
+
+    /**
+     * Test of getExtraLogInfo method, of class Context.
+     */
+    @Test
+    public void testGetExtraLogInfo() 
+    {
+        // Extra log info has a default value of "", and AbstractUnitTest doesn't change it
+        String defaultValue = "";
+        
+        assertThat("testGetExtraLogInfo 0", context.getExtraLogInfo(), notNullValue());
+        assertThat("testGetExtraLogInfo 1", context.getExtraLogInfo(), equalTo(defaultValue));
+    }
+
+    /**
+     * Test of complete method, of class Context.
+     */
+    @Test
+    public void testComplete() throws SQLException 
+    {
+        // To test complete() we need a new Context object
+        Context instance = new Context();
+        
+        // By default, we should have a new DB connection, so let's make sure it is there
+        assertThat("testComplete 0", instance.getDBConnection(), notNullValue());
+        assertThat("testComplete 1", instance.getDBConnection().isClosed(), equalTo(false));
+        assertThat("testComplete 2", instance.isValid(), equalTo(true));
+        
+        // Now, call complete(). This should set DB connection to null & invalidate context
+        instance.complete();
+        assertThat("testComplete 3", instance.getDBConnection(), nullValue());
+        assertThat("testComplete 4", instance.isValid(), equalTo(false));
+        
+        // TODO: May also want to test that complete() is calling commit()?
+    }
+    
+    /**
+     * Test of complete method, of class Context.
+     */
+    @Test
+    public void testComplete2() throws SQLException 
+    {
+        // To test complete() we need a new Context object
+        Context instance = new Context();
+        
+        // Call complete twice. The second call should NOT throw an error 
+        // and effectively does nothing
+        instance.complete();
+        instance.complete();
+    }
+
+    /**
+     * Test of commit method, of class Context.
+     */
+    @Test
+    public void testCommit() throws Exception 
+    {
+        new NonStrictExpectations(AuthorizeManager.class)
+        {{
+            // Allow Admin permissions - needed to create a new EPerson
+            AuthorizeManager.isAdmin((Context) any); result = true;
+        }};
+        
+        // Create a new EPerson & commit it
+        String createdEmail = "jimmy@email.com";
+        EPerson newUser = EPerson.create(context);
+        newUser.setFirstName("Jimmy");
+        newUser.setLastName("Doe");
+        newUser.setEmail(createdEmail);
+        newUser.setCanLogIn(true);
+        newUser.setLanguage(I18nUtil.getDefaultLocale().getLanguage());
+        // Ensure EPerson is committed
+        newUser.update();
+        context.commit();
+        
+        //Now, open a new context, and see if this eperson can be found!
+        Context newInstance = new Context();
+        EPerson found = EPerson.findByEmail(newInstance, createdEmail);
+        assertThat("testCommit 0", found, notNullValue());
+        
+        // Close our new context
+        newInstance.abort();
+    }
+    
+    /**
+     * Test of commit method, of class Context.
+     */
+    @Test(expected=IllegalStateException.class)
+    public void testCommitReadOnlyContext() throws Exception
+    {
+        // Create a read-only Context
+        Context instance = new Context(Context.READ_ONLY);
+
+        try
+        {
+            // Attempt to commit to it - should throw an exception
+            instance.commit();
+        }
+        finally
+        {
+            // Close our context
+            instance.abort();
+        }
+        
+    }
+    
+    /**
+     * Test of commit method, of class Context.
+     */
+    @Test(expected=IllegalStateException.class)
+    public void testCommitInvalidContext() throws Exception
+    {
+        // Create a new Context
+        Context instance = new Context();
+
+        // Close context (invalidating it)
+        instance.abort();
+        
+        // Attempt to commit to it - should throw an exception
+        instance.commit();
+    }
+
+    /**
+     * Test of abort method, of class Context.
+     */
+    @Test
+    public void testAbort() throws SQLException, AuthorizeException
+    {
+        new NonStrictExpectations(AuthorizeManager.class)
+        {{
+            // Allow Admin permissions - needed to create a new EPerson
+            AuthorizeManager.isAdmin((Context) any); result = true;
+        }};
+        
+        // To test abort() we need a new Context object
+        Context instance = new Context();
+        
+        // Create a new EPerson (DO NOT COMMIT IT)
+        String createdEmail = "susie@email.com";
+        EPerson newUser = EPerson.create(instance);
+        newUser.setFirstName("Susan");
+        newUser.setLastName("Doe");
+        newUser.setEmail(createdEmail);
+        newUser.setCanLogIn(true);
+        newUser.setLanguage(I18nUtil.getDefaultLocale().getLanguage());
+        
+        // Abort our context
+        instance.abort();
+        // Ensure the context is no longer valid
+        assertThat("testAbort 0", instance.isValid(), equalTo(false));
+        
+        // Open a new context, let's make sure that EPerson isn't there
+        Context newInstance = new Context();
+        EPerson found = EPerson.findByEmail(newInstance, createdEmail);
+        assertThat("testAbort 1", found, nullValue());
+        
+        // close our new context
+        newInstance.abort();
+    }
+    
+    /**
+     * Test of abort method, of class Context.
+     */
+    @Test
+    public void testAbort2() throws SQLException 
+    {
+        // To test abort() we need a new Context object
+        Context instance = new Context();
+        
+        // Call abort twice. The second call should NOT throw an error 
+        // and effectively does nothing
+        instance.abort();
+        instance.abort();
+    }
+
+    /**
+     * Test of isValid method, of class Context.
+     */
+    /*@Test
+    public void testIsValid() {
+        // This is already tested by testComplete() and testAbort()
+    }*/
+
+    /**
+     * Test of isReadOnly method, of class Context.
+     */
+    @Test
+    public void testIsReadOnly() throws SQLException
+    {
+        // Our default context should NOT be read only
+        assertThat("testIsReadOnly 0", context.isReadOnly(), equalTo(false));
+        
+        // Create a new read-only context
+        Context instance = new Context(Context.READ_ONLY);
+        assertThat("testIsReadOnly 1", instance.isReadOnly(), equalTo(true));
+        
+        // Close our new context
+        instance.abort();
+    }
+
+    /**
+     * Test of fromCache method, of class Context.
+     */
+    @Test
+    public void testFromCache() throws SQLException, AuthorizeException
+    {
+        new NonStrictExpectations(AuthorizeManager.class)
+        {{
+            // Allow Admin permissions - needed to create a new EPerson
+            AuthorizeManager.isAdmin((Context) any); result = true;
+        }};
+        
+        // To test caching we need a new Context object
+        Context instance = new Context();
+        
+        // Create a new Eperson object
+        EPerson newEperson = EPerson.create(instance);
+        newEperson.setFirstName("Sam");
+        newEperson.setLastName("Smith");
+        newEperson.setEmail("sammy@smith.com");
+        newEperson.setCanLogIn(true);
+        newEperson.setLanguage(I18nUtil.getDefaultLocale().getLanguage());
+        
+        // Cache the object
+        instance.cache(newEperson, newEperson.getID());
+        
+        // Now, pull the object out of the cache
+        EPerson fromCache = (EPerson) instance.fromCache(EPerson.class, newEperson.getID());
+        assertThat("testFromCache 0", fromCache, notNullValue());
+        assertThat("testFromCache 1", fromCache, equalTo(newEperson));
+        
+        // Close our context
+        instance.abort();
+    }
+
+    /**
+     * Test of cache method, of class Context.
+     */
+    @Test
+    public void testCache() throws SQLException
+    {
+        // To test caching we need a new Context object
+        Context instance = new Context();
+        
+        // Create a simple object to cache
+        String cacheMe = "Look for me in your local cache!";
+        int cacheMeID = 9999999;
+        
+        // Cache the object
+        instance.cache(cacheMe, cacheMeID);
+        
+        // Now, can we get it back?
+        String fromCache = (String) instance.fromCache(String.class, cacheMeID);
+        assertThat("testCache 0", fromCache, notNullValue());
+        assertThat("testCache 1", fromCache, equalTo(cacheMe));
+        
+        // Close our context
+        instance.abort();
+    }
+
+    /**
+     * Test of removeCached method, of class Context.
+     */
+    @Test
+    public void testRemoveCached() throws SQLException
+    {
+        // To test caching we need a new Context object
+        Context instance = new Context();
+        
+        // Create a simple object to cache
+        String cacheMe = "Look for me in your local cache!";
+        int cacheMeID = 9999999;
+        
+        // Cache the object
+        instance.cache(cacheMe, cacheMeID);
+        
+        // Can we get it back?
+        String fromCache = (String) instance.fromCache(String.class, cacheMeID);
+        assertThat("testRemoveCache 0", fromCache, notNullValue());
+        assertThat("testRemoveCache 1", fromCache, equalTo(cacheMe));
+        
+        // Now, can we remove it?
+        instance.removeCached(cacheMe, cacheMeID);
+        assertThat("testRemoveCache 3", instance.fromCache(String.class, cacheMeID), nullValue());
+       
+        // Close our context
+        instance.abort();
+    }
+
+    /**
+     * Test of clearCache method, of class Context.
+     */
+    @Test
+    public void testClearCache() throws SQLException
+    {
+        // To test caching we need a new Context object
+        Context instance = new Context();
+        
+        // Create a simple object to cache
+        String cacheMe = "Look for me in your local cache!";
+        int cacheMeID = 9999999;
+        
+        // Cache the object
+        instance.cache(cacheMe, cacheMeID);
+        
+         // Ensure cache is non-empty
+        assertThat("testClearCache 0", instance.getCacheSize(), equalTo(1));
+        
+        // Clear our cache
+        instance.clearCache();
+        
+        // Ensure cache is empty
+        assertThat("testClearCache 1", instance.getCacheSize(), equalTo(0));
+        
+        // Close our context
+        instance.abort();      
+    }
+
+    /**
+     * Test of getCacheSize method, of class Context.
+     */
+    /*@Test
+    public void testGetCacheSize() {
+        // Tested in testClearCache()
+    }*/
+
+    /**
+     * Test of setSpecialGroup method, of class Context.
+     */
+    @Test
+    public void testSetSpecialGroup() throws SQLException
+    {
+        // To test special groups we need a new Context object
+        Context instance = new Context();
+        
+        // Pass in random integers (need not be valid group IDs)
+        instance.setSpecialGroup(10000);
+        instance.setSpecialGroup(10001);
+        
+        assertThat("testSetSpecialGroup 0", instance.inSpecialGroup(10000), equalTo(true));
+        assertThat("testSetSpecialGroup 1", instance.inSpecialGroup(10001), equalTo(true));
+        assertThat("testSetSpecialGroup 2", instance.inSpecialGroup(20000), equalTo(false));
+        
+        // Close our context
+        instance.abort();
+    }
+
+    /**
+     * Test of inSpecialGroup method, of class Context.
+     */
+    /*@Test
+    public void testInSpecialGroup() {
+        // tested in testSetSpecialGroup
+    }*/
+
+    /**
+     * Test of getSpecialGroups method, of class Context.
+     */
+    @Test
+    public void testGetSpecialGroups() throws SQLException, AuthorizeException
+    {
+        new NonStrictExpectations(AuthorizeManager.class)
+        {{
+            // Allow Admin permissions - needed to create a new Group
+            AuthorizeManager.isAdmin((Context) any); result = true;
+        }};
+        
+        // To test special groups we need a new Context object
+        Context instance = new Context();
+        
+        // Create a new group & add it as a special group
+        Group group = Group.create(instance);
+        int groupID = group.getID();
+        instance.setSpecialGroup(groupID);
+        
+        // Also add Administrator group as a special group
+        Group adminGroup = Group.find(instance, Group.ADMIN_ID);
+        int adminGroupID = adminGroup.getID();
+        instance.setSpecialGroup(adminGroupID);
+        
+        // Now get our special groups
+        Group[] specialGroups = instance.getSpecialGroups();
+        assertThat("testGetSpecialGroup 0", specialGroups.length, equalTo(2));
+        assertThat("testGetSpecialGroup 1", specialGroups[0], equalTo(group));
+        assertThat("testGetSpecialGroup 1", specialGroups[1], equalTo(adminGroup));
+        
+        // Close our context
+        instance.abort();
+    }
+
+    /**
+     * Test of finalize method, of class Context.
+     */
+    @Test
+    public void testFinalize() throws Throwable {
+        // We need a new Context object
+        Context instance = new Context();
+        
+        instance.finalize();
+        
+        // Finalize is like abort()...should invalidate our context
+        assertThat("testSetSpecialGroup 0", instance.isValid(), equalTo(false));
+    }
+    
+    
+}


### PR DESCRIPTION
This PR fixes DS-2125 and also adds Unit Tests for the Context Object
https://jira.duraspace.org/browse/DS-2125

While most of the new Unit Tests succeeded by default, the following three tests failed initially but have been fixed by minor modifications to the Context object's commit()/complete()/abort() methods:
- `testAbort2()` - Tests calling abort() twice
- `testComplete2()` - Tests calling complete() twice
- `testCommitInvalidContext()` - Tests calling commit() on a Context which was previously aborted or completed.

The above three tests now succeed and the changes to the Context object resolve DS-2125.

UPDATE: To clarify a possible point of confusion based on comments below. With this PR, here's how calling commit()/complete()/abort() on a closed/invalid (read-only or write) Context react:
- Calling `commit()` on a closed/invalid Context results in an `IllegalStateException` (previously it threw a NPE). See the `testCommitInvalidContext()` unit test which tests for this scenario. I chose to make this throw an `IllegalStateException` as that is how calling `commit()` on a read-only Context also reacts.
- Calling `complete()` on a closed/invalid Context results in a no-op (previously it threw a NPE). See `testComplete2()` unit test which tests for this scenario.  I chose to make this a no-op as that seemed to be the goal of how the code previously worked, except it failed to check for a possible `null` database connection.
- Calling `abort()` on a closed/invalid Context results in a no-op (previously it threw a NPE). See `testAbort2()` unit test which tests for this scenario.  I chose to make this a no-op as that seemed to be the goal of how the code previously worked, except it failed to check for a possible `null` database connection.
