### PR TITLE
DS-2135 changed the import url for bootstrap in _main.scss

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/styles/bootstrap_color_scheme/_main.scss
+++ b/dspace-xmlui-mirage2/src/main/webapp/styles/bootstrap_color_scheme/_main.scss
@@ -9,7 +9,7 @@
 @function twbs-font-path($font-name) {
     @return "../vendor/bootstrap-sass-official/assets/fonts/" + $font-name
 }
-@import "../vendor/bootstrap-sass-official/assets/stylesheets/bootstrap/bootstrap";
+@import "../vendor/bootstrap-sass-official/assets/stylesheets/bootstrap";
 @import "shared/dspace-bootstrap-tweaks";
 @import "../vendor/jquery-ui/themes/base/jquery-ui.css";
 @import "style";

--- a/dspace-xmlui-mirage2/src/main/webapp/styles/classic_mirage_color_scheme/_main.scss
+++ b/dspace-xmlui-mirage2/src/main/webapp/styles/classic_mirage_color_scheme/_main.scss
@@ -13,7 +13,7 @@
 @function twbs-font-path($font-name) {
     @return "../vendor/bootstrap-sass-official/assets/fonts/" + $font-name
 }
-@import "../vendor/bootstrap-sass-official/assets/stylesheets/bootstrap/bootstrap";
+@import "../vendor/bootstrap-sass-official/assets/stylesheets/bootstrap";
 
 @import "classic_mirage_color_scheme/dspace_variables";
 


### PR DESCRIPTION
bootstrap changed the path of the _bootstrap.scss file in version 3.2

issue: https://jira.duraspace.org/browse/DS-2135
