### PR TITLE
DS-2138 Discovery should get user's special groups (i.e. IPAuth)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceResourceRestrictionPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceResourceRestrictionPlugin.java
@@ -67,12 +67,14 @@ public class SolrServiceResourceRestrictionPlugin implements SolrServiceIndexPlu
                 EPerson currentUser = context.getCurrentUser();
                 if(currentUser != null){
                     resourceQuery.append(" OR e").append(currentUser.getID());
-                    //Retrieve all the groups the current user is a member of !
-                    Set<Integer> groupIds = Group.allMemberGroupIDs(context, currentUser);
-                    for (Integer groupId : groupIds) {
-                        resourceQuery.append(" OR g").append(groupId);
-                    }
                 }
+
+                //Retrieve all the groups the current user is a member of !
+                Set<Integer> groupIds = Group.allMemberGroupIDs(context, currentUser);
+                for (Integer groupId : groupIds) {
+                    resourceQuery.append(" OR g").append(groupId);
+                }
+
                 resourceQuery.append(")");
                 
                 solrQuery.addFilterQuery(resourceQuery.toString());


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2138

Discovery would calculate the objects that are accessible to the current user, by looking up the current user's epersonID, and group's their a member of. The Discovery index has already cached the objects readable per epersonID / groupID. The issue however, is that Discovery failed to account for specialGroups that a user could be a member of, such as AuthenticationManager / IPAuthentication, where an un-authenticated user could be an implicit member of a group, since their IP address is in a certain range (i.e. on-campus-users = 192.168.*)

Context mostly had this information, we just needed to pull the special groups, and not stop if the user wasn't "logged in" as a specific eperson.
