### PR TITLE
DS-2133 : Update Travis to install Mirage2 prerequisites and build Mirage2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,37 @@
 language: java
 
+env: 
+  # Give Maven 2GB of memory to work with
+  - MAVEN_OPTS=-Xmx2048M
+
+# Install prerequisites for building Mirage2 more rapidly
+before_install:
+  # Install latest Node.js 0.10.x & print version info
+  - nvm install 0.10
+  - node --version
+  # Install Bower
+  - npm install -g bower
+  # Install Grunt & print version info
+  - npm install -g grunt && npm install -g grunt-cli
+  - grunt --version
+  # Print ruby version info (should be installed)
+  - ruby -v
+  # Install Sass & print version info
+  - gem install sass
+  - sass -v
+  # Install Compass & print version info
+  - gem install compass
+  - compass version
+
 # Skip 'mvn install', not really needed for our tests
 install: "echo 'Skipping install, dependencies will be downloaded during build and test.'"
 
 # Build and test 
-#  travis_retry = retry build/test up to 3 times
-#  -B = batch/non-interactive mode (recommended for CI)
-#  -V = display version info before build
-script: "travis_retry mvn clean package license:check -Dmaven.test.skip=false -B -V"
-
-# Give Maven 2GB of memory to work with
-env: MAVEN_OPTS=-Xmx2048M
+#  travis_retry => Retry build/test up to 3 times
+#  license:check => Validate all source code license headers
+#  -Dmaven.test.skip=false => Enable DSpace Unit Tests
+#  -Dmirage2.on=true => Build Mirage2
+#  -Dmirage2.deps.included=false => Don't include Mirage2 build dependencies (We installed them in before_install)
+#  -B => Maven batch/non-interactive mode (recommended for CI)
+#  -V => Display Maven version info before build
+script: "travis_retry mvn clean package license:check -Dmaven.test.skip=false -Dmirage2.on=true -Dmirage2.deps.included=false -B -V"


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2133

This change should be pretty self-explanatory. This PR just updates our `.travis.yml` to first install all the Mirage2 prerequisites (based on https://github.com/DSpace/DSpace/tree/master/dspace-xmlui-mirage2) and then ensure Mirage2 is built in our Travis CI test build.

I'll make sure Travis CI is OK with these changes before merging.
