### PR TITLE
DS-2133 : Update Travis to install Mirage2 prerequisites and build Mirage2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,9 @@ before_install:
   - gem install compass
   - compass version
 
-# Skip 'mvn install', not really needed for our tests
-install: "echo 'Skipping install, dependencies will be downloaded during build and test.'"
+# Run a quick version of "mvn install" to download module dependencies
+# Skip building the "dspace" assembly module, as we'll do that below
+install: "mvn install -P !dspace"
 
 # Build and test 
 #  travis_retry => Retry build/test up to 3 times

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,37 @@
 language: java
 
+env: 
+  # Give Maven 2GB of memory to work with
+  - MAVEN_OPTS=-Xmx2048M
+
+# Install prerequisites for building Mirage2 more rapidly
+before_install:
+  # Install latest Node.js 0.10.x & print version info
+  - nvm install 0.10
+  - node --version
+  # Install Bower
+  - npm install -g bower
+  # Install Grunt & print version info
+  - npm install -g grunt && npm install -g grunt-cli
+  - grunt --version
+  # Print ruby version info (should be installed)
+  - ruby -v
+  # Install Sass & print version info
+  - gem install sass
+  - sass -v
+  # Install Compass & print version info
+  - gem install compass
+  - compass version
+
 # Skip 'mvn install', not really needed for our tests
 install: "echo 'Skipping install, dependencies will be downloaded during build and test.'"
 
 # Build and test 
-#  travis_retry = retry build/test up to 3 times
-#  -B = batch/non-interactive mode (recommended for CI)
-#  -V = display version info before build
-script: "travis_retry mvn clean package license:check -Dmaven.test.skip=false -B -V"
-
-# Give Maven 2GB of memory to work with
-env: MAVEN_OPTS=-Xmx2048M
+#  travis_retry => Retry build/test up to 3 times
+#  license:check => Validate all source code license headers
+#  -Dmaven.test.skip=false => Enable DSpace Unit Tests
+#  -Dmirage2.on=true => Build Mirage2
+#  -Dmirage2.deps.included=false => Don't include Mirage2 build dependencies (We installed them in before_install)
+#  -B => Maven batch/non-interactive mode (recommended for CI)
+#  -V => Display Maven version info before build
+script: "travis_retry mvn clean package license:check -Dmaven.test.skip=false -Dmirage2.on=true -Dmirage2.deps.included=false -B -V"

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -84,141 +84,6 @@
                     </excludes>
                 </configuration>
             </plugin>
-            <!-- Unit/Integration Testing setup: This plugin unzips the
-                 'testEnvironment.zip' file (created by dspace-parent POM), into
-                 the 'target/testing/' folder, to essentially create a test
-                 install of DSpace, against which Tests can be run. -->
-            <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.8</version>
-                <executions>
-                    <execution>
-                        <id>setupTestEnvironment</id>
-                        <phase>generate-test-resources</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/testing</outputDirectory>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.dspace</groupId>
-                                    <artifactId>dspace-parent</artifactId>
-                                    <version>${project.version}</version>
-                                    <type>zip</type>
-                                    <classifier>testEnvironment</classifier>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <!-- This plugin allows us to run a Groovy script in our Maven POM
-                 (see: http://gmaven.codehaus.org/Executing+Groovy+Code )
-                 We are generating a OS-agnostic version (agnostic.build.dir) of
-                 the ${project.build.directory} property (full path of target dir).
-                 This is needed by the FileWeaver & Surefire plugins (see below)
-                 to initialize the Unit Test environment's dspace.cfg file.
-                 Otherwise, the Unit Test Framework will not work on Windows OS.
-                 This Groovy code was mostly borrowed from:
-                 http://stackoverflow.com/questions/3872355/how-to-convert-file-separator-in-maven
-            -->
-            <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>groovy-maven-plugin</artifactId>
-                <version>2.0</version>
-                <executions>
-                    <execution>
-                        <id>setproperty</id>
-                        <phase>generate-test-resources</phase>
-                        <goals>
-                            <goal>execute</goal>
-                        </goals>
-                        <configuration>
-                            <source>
-                            project.properties['agnostic.build.dir']=project.build.directory.replace(File.separator,'/');
-                            println("Initializing Maven property 'agnostic.build.dir' to: " + project.properties['agnostic.build.dir']);
-                            </source>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <!-- FileWeaver plugin is in charge of initializing & "weaving" together
-                 the dspace.cfg file to be used by the Unit Testing environment.
-                 It weaves two files, the default 'dspace.cfg' and 'dspace.cfg.more',
-                 both of which are included in the testEnvironment.zip. -->
-            <plugin>
-                <groupId>edu.iu.ul.maven.plugins</groupId>
-                <artifactId>fileweaver</artifactId>
-                <version>1.0</version>
-                <configuration>
-                    <outputs>
-                        <output>
-                            <outputPath>${agnostic.build.dir}/testing</outputPath>
-                            <name>dspace.cfg.woven</name>
-                            <parts>
-                                <part>
-                                    <path>${agnostic.build.dir}/testing/dspace/config/dspace.cfg</path>
-                                </part>
-                                <part>
-                                    <path>${agnostic.build.dir}/testing/dspace.cfg.more</path>
-                                </part>
-                            </parts>
-                            <properties>
-                                <dspace.install.dir>${agnostic.build.dir}/testing/dspace</dspace.install.dir>
-                            </properties>
-                        </output>
-                    </outputs>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>edit-dspace-cfg</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>weave</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <!--
-                The ant plugin below ensures that the final "woven" dspace.cfg
-                ends up in the /target/testing/dspace/ directory. This becomes
-                our final dspace.cfg for the Unit Testing environment. The dspace
-                service manager needs this "woven" configuration file when it starts.
-            -->
-            <plugin>
-              <artifactId>maven-antrun-plugin</artifactId>
-              <executions>
-                <execution>
-                  <phase>process-test-resources</phase>
-                  <configuration>
-                    <target>
-                        <copy file="${agnostic.build.dir}/testing/dspace.cfg.woven" tofile="${agnostic.build.dir}/testing/dspace/config/dspace.cfg" />
-                    </target>
-                  </configuration>
-                  <goals>
-                    <goal>run</goal>
-                  </goals>
-                </execution>
-              </executions>
-            </plugin>
-
-            <!-- Run Unit/Integration Testing! This plugin just kicks off the tests (when enabled). -->
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <!-- Specify the dspace.cfg file to use for test environment -->
-                        <dspace.configuration>${agnostic.build.dir}/testing/dspace/config/dspace.cfg</dspace.configuration>
-                        <!-- This config tells AbstractUnitTest which database schema to load. We use H2 database,
-                             running in Oracle Mode, for Unit Tests. So, we'll load the Oracle schema. -->
-                        <db.schema.path>${agnostic.build.dir}/testing/dspace/etc/oracle/database_schema.sql</db.schema.path>
-                        <!-- Turn off any DSpace logging -->
-                        <dspace.log.init.disable>true</dspace.log.init.disable>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
 
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -249,6 +114,162 @@
             </plugin>
         </plugins>
     </build>
+
+
+    <profiles>
+        <!-- If Unit Testing is enabled, then setup the Unit Test Environment.
+             See also the 'skiptests' profile in Parent POM. -->
+        <profile>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>maven.test.skip</name>
+                    <value>false</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- Unit/Integration Testing setup: This plugin unzips the
+                         'testEnvironment.zip' file (created by dspace-parent POM), into
+                         the 'target/testing/' folder, to essentially create a test
+                         install of DSpace, against which Tests can be run. -->
+                    <plugin>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <version>2.8</version>
+                        <executions>
+                            <execution>
+                                <id>setupTestEnvironment</id>
+                                <phase>generate-test-resources</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}/testing</outputDirectory>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.dspace</groupId>
+                                            <artifactId>dspace-parent</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>zip</type>
+                                            <classifier>testEnvironment</classifier>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- This plugin allows us to run a Groovy script in our Maven POM
+                         (see: http://gmaven.codehaus.org/Executing+Groovy+Code )
+                         We are generating a OS-agnostic version (agnostic.build.dir) of
+                         the ${project.build.directory} property (full path of target dir).
+                         This is needed by the FileWeaver & Surefire plugins (see below)
+                         to initialize the Unit Test environment's dspace.cfg file.
+                         Otherwise, the Unit Test Framework will not work on Windows OS.
+                         This Groovy code was mostly borrowed from:
+                         http://stackoverflow.com/questions/3872355/how-to-convert-file-separator-in-maven
+                    -->
+                    <plugin>
+                        <groupId>org.codehaus.gmaven</groupId>
+                        <artifactId>groovy-maven-plugin</artifactId>
+                        <version>2.0</version>
+                        <executions>
+                            <execution>
+                                <id>setproperty</id>
+                                <phase>generate-test-resources</phase>
+                                <goals>
+                                    <goal>execute</goal>
+                                </goals>
+                                <configuration>
+                                    <source>
+                                    project.properties['agnostic.build.dir']=project.build.directory.replace(File.separator,'/');
+                                    println("Initializing Maven property 'agnostic.build.dir' to: " + project.properties['agnostic.build.dir']);
+                                    </source>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    
+                    <!-- FileWeaver plugin is in charge of initializing & "weaving" together
+                         the dspace.cfg file to be used by the Unit Testing environment.
+                         It weaves two files, the default 'dspace.cfg' and 'dspace.cfg.more',
+                         both of which are included in the testEnvironment.zip. -->
+                    <plugin>
+                        <groupId>edu.iu.ul.maven.plugins</groupId>
+                        <artifactId>fileweaver</artifactId>
+                        <version>1.0</version>
+                        <configuration>
+                            <outputs>
+                                <output>
+                                    <outputPath>${agnostic.build.dir}/testing</outputPath>
+                                    <name>dspace.cfg.woven</name>
+                                    <parts>
+                                        <part>
+                                            <path>${agnostic.build.dir}/testing/dspace/config/dspace.cfg</path>
+                                        </part>
+                                        <part>
+                                            <path>${agnostic.build.dir}/testing/dspace.cfg.more</path>
+                                        </part>
+                                    </parts>
+                                    <properties>
+                                        <dspace.install.dir>${agnostic.build.dir}/testing/dspace</dspace.install.dir>
+                                    </properties>
+                                </output>
+                            </outputs>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>edit-dspace-cfg</id>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>weave</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- The ant plugin below ensures that the final "woven" dspace.cfg
+                         ends up in the /target/testing/dspace/ directory. This becomes
+                         our final dspace.cfg for the Unit Testing environment. The dspace
+                         service manager needs this "woven" configuration file when it starts.-->
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>process-test-resources</phase>
+                                <configuration>
+                                    <target>
+                                        <copy file="${agnostic.build.dir}/testing/dspace.cfg.woven" tofile="${agnostic.build.dir}/testing/dspace/config/dspace.cfg" />
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Run Unit/Integration Testing! This plugin just kicks off the tests (when enabled). -->
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <!-- Specify the dspace.cfg file to use for test environment -->
+                                <dspace.configuration>${agnostic.build.dir}/testing/dspace/config/dspace.cfg</dspace.configuration>
+                                <!-- This config tells AbstractUnitTest which database schema to load. We use H2 database,
+                                     running in Oracle Mode, for Unit Tests. So, we'll load the Oracle schema. -->
+                                <db.schema.path>${agnostic.build.dir}/testing/dspace/etc/oracle/database_schema.sql</db.schema.path>
+                                <!-- Turn off any DSpace logging -->
+                                <dspace.log.init.disable>true</dspace.log.init.disable>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+
+        </profile>
+    </profiles>
+
 
     <dependencies>
         <dependency>

--- a/dspace-api/src/test/java/org/dspace/AbstractUnitTest.java
+++ b/dspace-api/src/test/java/org/dspace/AbstractUnitTest.java
@@ -349,12 +349,9 @@ public class AbstractUnitTest
      */
     @After
     public void destroy()
-    {        
-        if(context != null && context.isValid())
-        {
-            context.abort();
-            context = null;
-        }
+    {
+        // Cleanup our global context object
+        cleanupContext(context);
     }
 
     /**
@@ -382,8 +379,6 @@ public class AbstractUnitTest
         assertTrue(5 != 0.67) ;
     }
     */
-     
-    
 
     /**
      * This method expects and exception to be thrown. It also has a time
@@ -396,7 +391,22 @@ public class AbstractUnitTest
         throw new Exception("Fail!");
     }
     */
-    
+
+    /**
+     *  Utility method to cleanup a created Context object (to save memory).
+     *  This can also be used by individual tests to cleanup context objects they create.
+     */
+    protected void cleanupContext(Context c)
+    {
+        // If context still valid, abort it
+        if(c!=null && c.isValid())
+           c.abort();
+
+        // Cleanup Context object by setting it to null
+        if(c!=null)
+           c = null;
+    }
+
     /**
       * Create the database tables by running the schema SQL specified
       * in the 'db.schema.path' system property

--- a/dspace-api/src/test/java/org/dspace/core/ContextTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/ContextTest.java
@@ -198,7 +198,9 @@ public class ContextTest extends AbstractUnitTest
         instance.complete();
         assertThat("testComplete 3", instance.getDBConnection(), nullValue());
         assertThat("testComplete 4", instance.isValid(), equalTo(false));
-        
+
+        // Cleanup our new context
+        cleanupContext(instance);
         // TODO: May also want to test that complete() is calling commit()?
     }
     
@@ -215,6 +217,9 @@ public class ContextTest extends AbstractUnitTest
         // and effectively does nothing
         instance.complete();
         instance.complete();
+
+        // Cleanup our new context
+        cleanupContext(instance);
     }
 
     /**
@@ -245,9 +250,9 @@ public class ContextTest extends AbstractUnitTest
         Context newInstance = new Context();
         EPerson found = EPerson.findByEmail(newInstance, createdEmail);
         assertThat("testCommit 0", found, notNullValue());
-        
-        // Close our new context
-        newInstance.abort();
+
+        // Cleanup our new context
+        cleanupContext(newInstance);
     }
     
     /**
@@ -266,10 +271,9 @@ public class ContextTest extends AbstractUnitTest
         }
         finally
         {
-            // Close our context
-            instance.abort();
+            // Cleanup our context
+            cleanupContext(instance);
         }
-        
     }
     
     /**
@@ -283,9 +287,17 @@ public class ContextTest extends AbstractUnitTest
 
         // Close context (invalidating it)
         instance.abort();
-        
-        // Attempt to commit to it - should throw an exception
-        instance.commit();
+
+        try
+        {
+            // Attempt to commit to it - should throw an exception
+            instance.commit();
+        }
+        finally
+        {
+            // Cleanup our context
+            cleanupContext(instance);
+        }
     }
 
     /**
@@ -321,9 +333,10 @@ public class ContextTest extends AbstractUnitTest
         Context newInstance = new Context();
         EPerson found = EPerson.findByEmail(newInstance, createdEmail);
         assertThat("testAbort 1", found, nullValue());
-        
-        // close our new context
-        newInstance.abort();
+
+        // Cleanup our contexts
+        cleanupContext(instance);
+        cleanupContext(newInstance);
     }
     
     /**
@@ -339,6 +352,9 @@ public class ContextTest extends AbstractUnitTest
         // and effectively does nothing
         instance.abort();
         instance.abort();
+
+        // Cleanup our context
+        cleanupContext(instance);
     }
 
     /**
@@ -361,9 +377,9 @@ public class ContextTest extends AbstractUnitTest
         // Create a new read-only context
         Context instance = new Context(Context.READ_ONLY);
         assertThat("testIsReadOnly 1", instance.isReadOnly(), equalTo(true));
-        
-        // Close our new context
-        instance.abort();
+
+        // Cleanup our context
+        cleanupContext(instance);
     }
 
     /**
@@ -396,9 +412,9 @@ public class ContextTest extends AbstractUnitTest
         EPerson fromCache = (EPerson) instance.fromCache(EPerson.class, newEperson.getID());
         assertThat("testFromCache 0", fromCache, notNullValue());
         assertThat("testFromCache 1", fromCache, equalTo(newEperson));
-        
-        // Close our context
-        instance.abort();
+
+        // Cleanup our context
+        cleanupContext(instance);
     }
 
     /**
@@ -421,9 +437,9 @@ public class ContextTest extends AbstractUnitTest
         String fromCache = (String) instance.fromCache(String.class, cacheMeID);
         assertThat("testCache 0", fromCache, notNullValue());
         assertThat("testCache 1", fromCache, equalTo(cacheMe));
-        
-        // Close our context
-        instance.abort();
+
+        // Cleanup our context
+        cleanupContext(instance);
     }
 
     /**
@@ -450,9 +466,9 @@ public class ContextTest extends AbstractUnitTest
         // Now, can we remove it?
         instance.removeCached(cacheMe, cacheMeID);
         assertThat("testRemoveCache 3", instance.fromCache(String.class, cacheMeID), nullValue());
-       
-        // Close our context
-        instance.abort();
+
+        // Cleanup our context
+        cleanupContext(instance);
     }
 
     /**
@@ -479,9 +495,9 @@ public class ContextTest extends AbstractUnitTest
         
         // Ensure cache is empty
         assertThat("testClearCache 1", instance.getCacheSize(), equalTo(0));
-        
-        // Close our context
-        instance.abort();      
+
+        // Cleanup our context
+        cleanupContext(instance);
     }
 
     /**
@@ -508,9 +524,9 @@ public class ContextTest extends AbstractUnitTest
         assertThat("testSetSpecialGroup 0", instance.inSpecialGroup(10000), equalTo(true));
         assertThat("testSetSpecialGroup 1", instance.inSpecialGroup(10001), equalTo(true));
         assertThat("testSetSpecialGroup 2", instance.inSpecialGroup(20000), equalTo(false));
-        
-        // Close our context
-        instance.abort();
+
+        // Cleanup our context
+        cleanupContext(instance);
     }
 
     /**
@@ -551,9 +567,9 @@ public class ContextTest extends AbstractUnitTest
         assertThat("testGetSpecialGroup 0", specialGroups.length, equalTo(2));
         assertThat("testGetSpecialGroup 1", specialGroups[0], equalTo(group));
         assertThat("testGetSpecialGroup 1", specialGroups[1], equalTo(adminGroup));
-        
-        // Close our context
-        instance.abort();
+
+        // Cleanup our context
+        cleanupContext(instance);
     }
 
     /**
@@ -568,7 +584,8 @@ public class ContextTest extends AbstractUnitTest
         
         // Finalize is like abort()...should invalidate our context
         assertThat("testSetSpecialGroup 0", instance.isValid(), equalTo(false));
+
+        // Cleanup our context
+        cleanupContext(instance);
     }
-    
-    
 }

--- a/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
@@ -705,7 +705,7 @@ public class EPersonTest extends AbstractUnitTest
             throws SQLException
     {
         System.out.println("getType");
-        EPerson instance = new EPerson(new Context(), row1);
+        EPerson instance = new EPerson(context, row1);
         int expResult = Constants.EPERSON;
         int result = instance.getType();
         assertEquals("Should return Constants.EPERSON", expResult, result);

--- a/pom.xml
+++ b/pom.xml
@@ -247,13 +247,34 @@
            </properties>
        </profile>
 
+       <!-- Skip Unit Tests by default, but allow override on command line
+           by setting property "-Dmaven.test.skip=false" -->
+       <profile>
+           <id>skiptests</id>
+           <activation>
+               <!-- This profile should be active at all times, unless the user
+                    specifies a different value for "maven.test.skip" -->
+               <property>
+                   <name>!maven.test.skip</name>
+               </property>
+           </activation>
+           <properties>
+               <maven.test.skip>true</maven.test.skip>
+           </properties>
+       </profile>
 
-        <!-- This profile ensures that we ONLY generate the Unit Test Environment
-             if the testEnvironment.xml file is found. That way the Test Environment
-             is NOT built when running a 'mvn package' on a "binary" release. -->
+        <!-- This profile ensures that we ONLY generate the Unit Test Environment,
+             if the testEnvironment.xml file is found AND we are not skipping Unit 
+             Tests (see also skiptests profile). That way the Test Environment is 
+             also NOT built when running a 'mvn package' on a "binary" release. -->
         <profile>
             <id>generate-test-env</id>
             <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>maven.test.skip</name>
+                    <value>false</value>
+                </property>
                 <file>
                     <exists>src/main/assembly/testEnvironment.xml</exists>
                 </file>
@@ -458,10 +479,11 @@
                 <module>dspace-swordv2</module>
             </modules>
         </profile>
-       <!--
-      Builds MIRAGE2 WAR for DSpace
-   -->
-       <profile>
+
+        <!--
+           Builds MIRAGE2 WAR for DSpace
+        -->
+        <profile>
            <id>dspace-xmlui-mirage2</id>
            <activation>
                <file>
@@ -471,7 +493,8 @@
            <modules>
                <module>dspace-xmlui-mirage2</module>
            </modules>
-       </profile>
+        </profile>
+        
         <!--
            Builds XMLUI WAR for DSpace
         -->
@@ -486,8 +509,6 @@
                 <module>dspace-xmlui</module>
             </modules>
         </profile>
-
-
 
         <!--
            Builds LNI WAR & Client for DSpace
@@ -530,24 +551,6 @@
          </modules>
       </profile>
 
-      <!-- Skip Unit Tests by default, but allow override on command line
-           by setting property "-Dmaven.test.skip=false" -->
-      <profile>
-        <id>skiptests</id>
-        <activation>
-            <!-- This profile should be active at all times, unless the user
-                 specifies a different value for "maven.test.skip" -->
-            <property>
-                <name>!maven.test.skip</name>
-            </property>
-        </activation>
-        <properties>
-            <maven.test.skip>true</maven.test.skip>
-        </properties>
-      </profile>
-
-
-    
    </profiles>
 
    <!--


### PR DESCRIPTION
Updated PR (to replace PR #636). This one provides a couple of extra fixes around Unit Testing which seemingly help avoid Travis CI "killed" messages. These fixes include:
- First, just enabling Mirage2 build process for Travis CI. I chose to preinstall Mirage2 prerequisites via our .travis.yml (in the `before_install` settings) to speed up the Mirage 2 build. See https://github.com/tdonohue/DSpace/commit/a0f44f618244964df5caf7402452fd0511d153da
- Improve the memory management of Unit Tests. Namely, ensure any Context objects are fully closed and set to null, to try to decrease memory usage of individual Unit Tests. See https://github.com/tdonohue/DSpace/commit/d4d63083bbca66dcf506ff5dc437f109680ab013
- Minor POM reorganization which _disables_ all Unit Testing related Maven Plugins by default (i.e. they are only enabled when unit testing is being performed). This is needed to enable the next Travis CI tweak.. See https://github.com/tdonohue/DSpace/commit/bd98997dd69996139a051e5d0fcc045ff07af12a
- Change Travis CI settings to run `mvn install -P !dspace` PRIOR to the actual build & test. The idea is to split up the downloading of dependencies from the build & test, to hopefully help keep our memory usage lower. Therefore, this setting ensures most DSpace Maven dependencies are downloaded, but it _skips_ building the 'dspace' module (so DSpace isn't actually packaged up), which speeds up this initial build. The "-P !dspace" setting required the POM reorg mentioned above. See https://github.com/tdonohue/DSpace/commit/8b53258b5ee8ba7ddf76e505f5b65aa6b6dfa57f

This all seems to be working much better on my own Travis CI builds. Let's see what Travis says about this new PR though.
