### PR TITLE
More memory fixes for Travis CI, related to DS-2133

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: java
 
 env: 
-  # Give Maven 2GB of memory to work with
-  - MAVEN_OPTS=-Xmx2048M
+  # Give Maven 1GB of memory to work with
+  - MAVEN_OPTS="-Xms256m -Xmx1024m -XX:MaxPermSize=128m"
 
 # Install prerequisites for building Mirage2 more rapidly
 before_install:
@@ -31,8 +31,9 @@ install: "mvn install -P !dspace"
 #  travis_retry => Retry build/test up to 3 times
 #  license:check => Validate all source code license headers
 #  -Dmaven.test.skip=false => Enable DSpace Unit Tests
+#  -Dsurefire.argLine => Ensure Unit Tests get same MAVEN_OPTS settings
 #  -Dmirage2.on=true => Build Mirage2
 #  -Dmirage2.deps.included=false => Don't include Mirage2 build dependencies (We installed them in before_install)
 #  -B => Maven batch/non-interactive mode (recommended for CI)
 #  -V => Display Maven version info before build
-script: "travis_retry mvn clean package license:check -Dmaven.test.skip=false -Dmirage2.on=true -Dmirage2.deps.included=false -B -V"
+script: 'travis_retry mvn clean package license:check -Dmaven.test.skip=false -Dsurefire.argLine="$MAVEN_OPTS" -Dmirage2.on=true -Dmirage2.deps.included=false -B -V'

--- a/dspace-api/src/test/java/org/dspace/AbstractUnitTest.java
+++ b/dspace-api/src/test/java/org/dspace/AbstractUnitTest.java
@@ -168,6 +168,10 @@ public class AbstractUnitTest
                 IndexingService indexer = dspace.getServiceManager().getServiceByName(IndexingService.class.getName(),IndexingService.class);
                 indexer.createIndex(ctx);
                 ctx.commit();
+                
+                // Nullify resources, so Junit will clean them up
+                dspace = null;
+                indexer = null;
             }
             ctx.restoreAuthSystemState();
             if(ctx.isValid())
@@ -365,6 +369,11 @@ public class AbstractUnitTest
         //we clear the properties
         testProps.clear();
         testProps = null;
+        
+        //Also clear out the kernel & nullify (so JUnit will clean it up)
+        if (kernelImpl!=null)
+            kernelImpl.destroy();
+        kernelImpl = null;
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/DSpaceCSVTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/DSpaceCSVTest.java
@@ -56,6 +56,7 @@ public class DSpaceCSVTest extends AbstractUnitTest
             }
             out.flush();
             out.close();
+            out = null;
 
             // Test the CSV parsing was OK
             DSpaceCSV dcsv = new DSpaceCSV(new File(filename), context);
@@ -69,6 +70,7 @@ public class DSpaceCSVTest extends AbstractUnitTest
             value.add("Abstract with\ntwo\nnew lines");    
             assertThat("testDSpaceCSV New lines", line.valueToCSV(value),
                                                   equalTo("\"Abstract with\ntwo\nnew lines\""));
+            line = null;
 
             // Test the CSV parsing with a bad heading element value
             csv[0] = "id,collection,\"dc.title[en]\",dc.contributor.foobar[en-US],dc.description.abstract";
@@ -82,6 +84,7 @@ public class DSpaceCSVTest extends AbstractUnitTest
             }
             out.flush();
             out.close();
+            out = null;
 
             // Test the CSV parsing was OK
             try
@@ -111,6 +114,7 @@ public class DSpaceCSVTest extends AbstractUnitTest
             }
             out.flush();
             out.close();
+            out = null;
 
             // Test the CSV parsing was OK
             try
@@ -128,6 +132,11 @@ public class DSpaceCSVTest extends AbstractUnitTest
             // Delete the test file
             File toDelete = new File(filename);
             toDelete.delete();
+            toDelete = null;
+            
+            // Nullify resources so JUnit will clean them up
+            dcsv = null;
+            lines = null;
         }
         catch (Exception ex) {
             log.error("IO Error while creating test CSV file", ex);

--- a/dspace-api/src/test/java/org/dspace/statistics/util/SpiderDetectorTest.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/util/SpiderDetectorTest.java
@@ -77,6 +77,8 @@ public class SpiderDetectorTest
         candidate = "wiki.dspace.org";
         req.setRemoteHost(candidate);
         assertFalse(candidate + " matched DNS patterns", SpiderDetector.isSpider(req));
+        
+        req = null;
     }
 
     /**

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/integration/xoai/AbstractDSpaceTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/integration/xoai/AbstractDSpaceTest.java
@@ -20,6 +20,7 @@ import org.dspace.xoai.services.api.database.EarliestDateResolver;
 import org.dspace.xoai.services.api.database.FieldResolver;
 import org.dspace.xoai.tests.DSpaceTestConfiguration;
 import org.dspace.xoai.tests.helpers.stubs.*;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -67,6 +68,19 @@ public abstract class AbstractDSpaceTest {
 //        solrServer = this.wac.getBean(SolrServer.class);
         resourceResolver = (StubbedResourceResolver) this.wac.getBean(ResourceResolver.class);
         xoaiManagerResolver.configuration();
+    }
+    
+    @After
+    public void teardown() {
+        // Nullify all resources so that JUnit will clean them up
+        xoaiManagerResolver = null;
+        configurationService = null;
+        databaseService = null;
+        earliestDateResolver = null;
+        setRepository = null;
+        resourceResolver = null;
+        mockMvc = null;
+        solrServer = null;
     }
 
     protected MockMvc againstTheDataProvider() {

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/integration/xoai/PipelineTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/integration/xoai/PipelineTest.java
@@ -32,5 +32,11 @@ public class PipelineTest {
                 .getTransformed());
 
         assertThat(output, xPath("/oai_dc:dc/dc:title", equalTo("Teste")));
+        
+        input.close();
+        input = null;
+        xslt.close();
+        xslt = null;
+        output = null;
     }
 }

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/services/impl/AbstractQueryResolverTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/services/impl/AbstractQueryResolverTest.java
@@ -16,6 +16,7 @@ import org.dspace.xoai.services.api.database.HandleResolver;
 import org.dspace.xoai.services.api.xoai.DSpaceFilterResolver;
 import org.dspace.xoai.tests.DSpaceBasicTestConfiguration;
 import org.dspace.xoai.tests.helpers.stubs.StubbedFieldResolver;
+import org.junit.After;
 import org.junit.Before;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -33,6 +34,14 @@ public abstract class AbstractQueryResolverTest {
     @Before
     public void setUp () {
         applicationContext = new AnnotationConfigApplicationContext(DSpaceBasicTestConfiguration.class);
+    }
+    
+    @After
+    public void tearDown() {
+        //Nullify all resoruces so that JUnit cleans them up
+        applicationContext = null;
+        handleResolver = null;
+        collectionsService = null;
     }
 
 

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/services/impl/database/DSpaceDatabaseQueryResolverTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/services/impl/database/DSpaceDatabaseQueryResolverTest.java
@@ -24,6 +24,7 @@ import org.dspace.xoai.filter.DateUntilFilter;
 import org.dspace.xoai.services.api.database.DatabaseQuery;
 import org.dspace.xoai.services.impl.database.DSpaceDatabaseQueryResolver;
 import org.dspace.xoai.tests.unit.services.impl.AbstractQueryResolverTest;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -48,6 +49,11 @@ public class DSpaceDatabaseQueryResolverTest extends AbstractQueryResolverTest {
     @Before
     public void autowire () {
         autowire(underTest);
+    }
+    
+    @After
+    public void cleanup() {
+        underTest = null;
     }
 
     @Test

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/services/impl/solr/DSpaceSolrQueryResolverTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/services/impl/solr/DSpaceSolrQueryResolverTest.java
@@ -22,6 +22,7 @@ import org.dspace.xoai.filter.DateFromFilter;
 import org.dspace.xoai.filter.DateUntilFilter;
 import org.dspace.xoai.services.impl.solr.DSpaceSolrQueryResolver;
 import org.dspace.xoai.tests.unit.services.impl.AbstractQueryResolverTest;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -45,6 +46,11 @@ public class DSpaceSolrQueryResolverTest extends AbstractQueryResolverTest {
         autowire(underTest);
     }
 
+    @After
+    public void cleanup() {
+        underTest = null;
+    }
+    
     @Test
     public void fromFilterQuery() throws Exception {
         List<ScopedFilter> scopedFilters = new ArrayList<ScopedFilter>();

--- a/dspace-services/src/test/java/org/dspace/servicemanager/DSpaceKernelImplTest.java
+++ b/dspace-services/src/test/java/org/dspace/servicemanager/DSpaceKernelImplTest.java
@@ -56,6 +56,8 @@ public class DSpaceKernelImplTest {
         assertEquals(kernel.getConfigurationService(), kernelImpl.getConfigurationService());
         assertEquals(kernel.getServiceManager(), kernelImpl.getServiceManager());
         kernelImpl.stop();
+        
+        kernel = null;
     }
 
     @Test
@@ -87,6 +89,10 @@ public class DSpaceKernelImplTest {
         assertNotSame(kernel.getServiceManager(), kernel2.getServiceManager());
 
         kernelImpl2.stop();
+        kernelImpl2.destroy();
+        kernelImpl2 = null;
+        kernel = kernel2 = null;
+        
         kernelImpl.stop();
     }
 
@@ -96,6 +102,9 @@ public class DSpaceKernelImplTest {
         ClassLoader cl1 = new URLClassLoader(new URL[0], current);
         cl1.getParent();
         // TODO
+        
+        cl1 = null;
+        current = null;
     }
 
 }

--- a/dspace-services/src/test/java/org/dspace/servicemanager/DSpaceKernelManagerTest.java
+++ b/dspace-services/src/test/java/org/dspace/servicemanager/DSpaceKernelManagerTest.java
@@ -41,6 +41,7 @@ public class DSpaceKernelManagerTest {
             kernelImpl.destroy();
         }
         kernelImpl = null;
+        kernelManager = null;
     }
 
     /**
@@ -53,6 +54,8 @@ public class DSpaceKernelManagerTest {
         DSpaceKernel k2 = kernelManager.getKernel();
         assertNotNull(k2);
         assertEquals(kernel, k2);
+        
+        kernel = k2 = null;
     }
 
 }

--- a/dspace-services/src/test/java/org/dspace/servicemanager/DSpaceServiceManagerTest.java
+++ b/dspace-services/src/test/java/org/dspace/servicemanager/DSpaceServiceManagerTest.java
@@ -19,10 +19,8 @@ import org.dspace.kernel.mixins.ShutdownService;
 import org.dspace.servicemanager.config.DSpaceConfigurationService;
 import org.dspace.servicemanager.example.ConcreteExample;
 import org.dspace.servicemanager.fakeservices.FakeService1;
-import org.dspace.servicemanager.fakeservices.FakeService2;
 import org.dspace.servicemanager.spring.SpringAnnotationBean;
 import org.dspace.servicemanager.spring.TestSpringServiceManager;
-import org.dspace.services.ConfigurationService;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -112,10 +110,12 @@ public class DSpaceServiceManagerTest {
 
         SampleAnnotationBean sab = dsm.registerServiceClass("newAnnote", SampleAnnotationBean.class);
         assertNotNull(sab);
+        sab = null;
 
         List<SampleAnnotationBean> l = dsm.getServicesByType(SampleAnnotationBean.class);
         assertNotNull(l);
         assertEquals(currentSize+1, l.size());
+        l = null;
 
         try {
             dsm.registerService("fakey", (Class<?>)null);
@@ -152,10 +152,12 @@ public class DSpaceServiceManagerTest {
         ConcreteExample concrete = dsm.getServiceByName(ConcreteExample.class.getName(), ConcreteExample.class);
         assertNotNull(concrete);
         assertEquals("azeckoski", concrete.getName());
+        concrete = null;
 
         SampleAnnotationBean sab = dsm.getServiceByName(SampleAnnotationBean.class.getName(), SampleAnnotationBean.class);
         assertNotNull(sab);
         assertEquals(null, sab.getSampleValue());
+        sab = null;
     }
 
     @Test
@@ -165,10 +167,12 @@ public class DSpaceServiceManagerTest {
         ConcreteExample concrete = dsm.getServiceByName(ConcreteExample.class.getName(), ConcreteExample.class);
         assertNotNull(concrete);
         assertEquals("azeckoski", concrete.getName());
+        concrete = null;
 
         SampleAnnotationBean sab = dsm.getServiceByName(SampleAnnotationBean.class.getName(), SampleAnnotationBean.class);
         assertNotNull(sab);
         assertEquals("beckyz", sab.getSampleValue());
+        sab = null;
     }
 
     /**
@@ -184,14 +188,17 @@ public class DSpaceServiceManagerTest {
         List<ConcreteExample> l = dsm.getServicesByType(ConcreteExample.class);
         assertNotNull(l);
         assertEquals("azeckoski", l.get(0).getName());
+        l = null;
 
         List<SampleAnnotationBean> l2 = dsm.getServicesByType(SampleAnnotationBean.class);
         assertNotNull(l2);
         assertTrue(l2.size() >= 1);
+        l2 = null;
 
         List<ServiceConfig> l3 = dsm.getServicesByType(ServiceConfig.class);
         assertNotNull(l3);
         assertEquals(0, l3.size());
+        l3 = null;
     }
 
     /**
@@ -256,13 +263,15 @@ public class DSpaceServiceManagerTest {
         SampleAnnotationBean sab = dsm.getServiceByName(SampleAnnotationBean.class.getName(), SampleAnnotationBean.class);
         assertNotNull(sab);
         assertEquals(1, sab.initCounter);
-
+        sab = null;
+        
         TestService ts = new TestService();
         assertEquals(0, ts.value);
         dsm.registerService(TestService.class.getName(), ts);
         assertEquals(1, ts.value);
         dsm.unregisterService(TestService.class.getName());
         assertEquals(2, ts.value);
+        ts = null;
     }
 
     @Test
@@ -291,6 +300,9 @@ public class DSpaceServiceManagerTest {
         dsm.unregisterService(serviceName);
         assertEquals("shutdown", service.getSomething());
         assertEquals(3, service.getTriggers());
+        
+        service = null;
+        properties = null;
     }
 
     public static class TestService implements InitializedService, ShutdownService {

--- a/dspace-services/src/test/java/org/dspace/servicemanager/DSpaceTest.java
+++ b/dspace-services/src/test/java/org/dspace/servicemanager/DSpaceTest.java
@@ -71,7 +71,13 @@ public class DSpaceTest {
         assertNotNull(o);
         assertEquals(o, kernel.getServiceManager());
 
-        kernelImpl.destroy(); // cleanup the kernel
+        //trash the references
+        kernelImpl.destroy();
+        kernelImpl = null;
+        kernel = null;
+        dspace = null;
+        dspace2 = null;
+        o = null;
     }
     
 /*********

--- a/dspace-services/src/test/java/org/dspace/servicemanager/config/DSpaceConfigurationServiceTest.java
+++ b/dspace-services/src/test/java/org/dspace/servicemanager/config/DSpaceConfigurationServiceTest.java
@@ -44,6 +44,7 @@ public class DSpaceConfigurationServiceTest {
         l.add( new DSpaceConfig("test.key2", "This is key1=${test.key1}") );
 
         configurationService.loadConfiguration(l, true);
+        l = null;
     }
 
     @After
@@ -87,6 +88,10 @@ public class DSpaceConfigurationServiceTest {
                 configMap.get("circular").getValue(), l.get(dirIdx).getValue());
         assertEquals("Indirect circular reference should not be replaced",
                 configMap.get("indirect.circular").getValue(), l.get(indirIdx).getValue());
+        
+        //trash the references
+        l = null;
+        configMap = null;
     }
 
     /**
@@ -99,6 +104,9 @@ public class DSpaceConfigurationServiceTest {
         assertEquals(8, props.size());
         assertNotNull(props.get("service.name"));
         assertEquals("DSpace", props.get("service.name"));
+        
+        //trash the references
+        props = null;
     }
 
     /**
@@ -111,6 +119,9 @@ public class DSpaceConfigurationServiceTest {
         assertEquals(8, props.size());
         assertNotNull(props.get("service.name"));
         assertEquals("DSpace", props.get("service.name"));
+        
+        //trash the references
+        props = null;
     }
 
     /**
@@ -124,6 +135,7 @@ public class DSpaceConfigurationServiceTest {
  
         prop = configurationService.getProperty("XXXXX");
         assertNull(prop);
+        prop = null;
     }
 
     /**
@@ -151,6 +163,7 @@ public class DSpaceConfigurationServiceTest {
 
         prop = configurationService.getPropertyAsType("XXXXX", String.class);
         assertNull(prop);
+        prop = null;
     }
 
     /**
@@ -181,6 +194,7 @@ public class DSpaceConfigurationServiceTest {
 
         prop = configurationService.getPropertyAsType("XXXXX", "XXX");
         assertEquals("XXX", prop);
+        prop = null;
     }
 
     @Test
@@ -202,6 +216,7 @@ public class DSpaceConfigurationServiceTest {
         prop = configurationService.getProperty("service.fake.thing");
         assertNotNull(prop);
         assertEquals("Fakey", prop);
+        prop = null;
     }
 
     @Test
@@ -234,6 +249,7 @@ public class DSpaceConfigurationServiceTest {
 
         prop = configurationService.getProperty("newBool");
         assertNull(prop);
+        prop = null;
     }
 
     /**
@@ -287,6 +303,9 @@ public class DSpaceConfigurationServiceTest {
         dscs = new DSpaceConfigurationService();
         assertEquals(size + 1, dscs.getConfiguration().size());
         assertEquals("Hello", dscs.getProperty("az.system.config"));
+        
+        dscs.clear();
+        dscs = null;
     }
 
 }

--- a/dspace-services/src/test/java/org/dspace/servicemanager/servlet/DSpaceKernelServletContextListenerTest.java
+++ b/dspace-services/src/test/java/org/dspace/servicemanager/servlet/DSpaceKernelServletContextListenerTest.java
@@ -110,6 +110,10 @@ public class DSpaceKernelServletContextListenerTest {
         } catch (IllegalStateException e) {
             assertNotNull(e.getMessage());
         }
+        
+        tester = null;
+        request = null;
+        response = null;
     }
 
     @Test

--- a/dspace-services/src/test/java/org/dspace/servicemanager/spring/TestSpringServiceManager.java
+++ b/dspace-services/src/test/java/org/dspace/servicemanager/spring/TestSpringServiceManager.java
@@ -53,6 +53,7 @@ public class TestSpringServiceManager {
             ssm.shutdown();
         }
         ssm = null;
+        configurationService = null;
     }
 
     /**
@@ -91,10 +92,12 @@ public class TestSpringServiceManager {
         ConcreteExample concrete = ssm.getServiceByName(ConcreteExample.class.getName(), ConcreteExample.class);
         assertNotNull(concrete);
         assertEquals("azeckoski", concrete.getName());
+        concrete = null;
 
         SampleAnnotationBean sab = ssm.getServiceByName(SampleAnnotationBean.class.getName(), SampleAnnotationBean.class);
         assertNotNull(sab);
         assertEquals(null, sab.getSampleValue());
+        sab = null;
     }
 
     @Test
@@ -104,16 +107,19 @@ public class TestSpringServiceManager {
         ConcreteExample concrete = ssm.getServiceByName(ConcreteExample.class.getName(), ConcreteExample.class);
         assertNotNull(concrete);
         assertEquals("azeckoski", concrete.getName());
+        concrete = null;
 
         SampleAnnotationBean sab = ssm.getServiceByName(SampleAnnotationBean.class.getName(), SampleAnnotationBean.class);
         assertNotNull(sab);
         assertEquals("beckyz", sab.getSampleValue());
+        sab = null;
 
         SpringAnnotationBean spr = ssm.getServiceByName(SpringAnnotationBean.class.getName(), SpringAnnotationBean.class);
         assertNotNull(spr);
         assertEquals("azeckoski", spr.getConcreteName());
         assertEquals("aaronz", spr.getExampleName());
         assertEquals(null, spr.getSampleValue());
+        spr = null;
     }
 
     /**
@@ -127,14 +133,17 @@ public class TestSpringServiceManager {
         assertNotNull(l);
         assertEquals(1, l.size());
         assertEquals("azeckoski", l.get(0).getName());
+        l = null;
 
         List<SampleAnnotationBean> l2 = ssm.getServicesByType(SampleAnnotationBean.class);
         assertNotNull(l2);
         assertEquals(1, l2.size());
+        l2 = null;
 
         List<ServiceConfig> l3 = ssm.getServicesByType(ServiceConfig.class);
         assertNotNull(l3);
         assertEquals(0, l3.size());
+        l3 = null;
     }
 
     /**
@@ -146,10 +155,12 @@ public class TestSpringServiceManager {
 
         SampleAnnotationBean sab = ssm.registerServiceClass("newAnnote", SampleAnnotationBean.class);
         assertNotNull(sab);
+        sab = null;
 
         List<SampleAnnotationBean> l = ssm.getServicesByType(SampleAnnotationBean.class);
         assertNotNull(l);
         assertEquals(2, l.size());
+        l = null;
 
         try {
             ssm.registerService("fakey", (Class<?>)null);
@@ -172,8 +183,6 @@ public class TestSpringServiceManager {
         assertNotNull(service);
         assertEquals("AZ", service);
 
-        List<String> names = ssm.getServicesNames();
-        
         try {
             ssm.registerService("fakey", (Object)null);
             fail("should have thrown exception");
@@ -202,6 +211,7 @@ public class TestSpringServiceManager {
         List<String> names = ssm.getServicesNames();
         assertNotNull(names);
         assertTrue(names.size() >= 3);
+        names = null;
     }
 
     @Test

--- a/dspace-services/src/test/java/org/dspace/services/caching/CachingServiceTest.java
+++ b/dspace-services/src/test/java/org/dspace/services/caching/CachingServiceTest.java
@@ -44,6 +44,7 @@ public class CachingServiceTest extends DSpaceAbstractKernelTest {
     @After
     public void tearDown() {
         cachingService = null;
+        requestService = null;
     }
 
     /**
@@ -79,6 +80,9 @@ public class CachingServiceTest extends DSpaceAbstractKernelTest {
         EhcacheCache cache2 = cachingService.instantiateEhCache("aaronz-eh", null);
         assertNotNull(cache2);
         assertEquals(cache2, cache);
+        
+        //trash the references
+        cache = cache2 = null;
     }
 
     /**
@@ -101,6 +105,9 @@ public class CachingServiceTest extends DSpaceAbstractKernelTest {
         assertEquals(cache2, cache);
 
         requestService.endRequest(null);
+        
+        //trash the references
+        cache = cache2 = null;
     }
 
     /**
@@ -139,6 +146,9 @@ public class CachingServiceTest extends DSpaceAbstractKernelTest {
         Cache c2 = cachingService.getCache("org.dspace.aztest", null);
         assertNotNull(c2);
         assertEquals(c1, c2);
+        
+        //trash the references
+        cache = sampleCache = c1 = rc1 = c2 = null;
 
     }
 
@@ -165,6 +175,9 @@ public class CachingServiceTest extends DSpaceAbstractKernelTest {
         assertNotNull(caches);
         assertEquals(curSize+1, caches.size());
         assertTrue(caches.contains(c1));
+        
+        //trash the references
+        memCache = c1 = null;
     }
 
     /**
@@ -200,6 +213,8 @@ public class CachingServiceTest extends DSpaceAbstractKernelTest {
 
         assertEquals(null, c1.get("AZ"));
         assertEquals(0, c1.size());
+        
+        c1 = null;
     }
 
     /**
@@ -229,6 +244,9 @@ public class CachingServiceTest extends DSpaceAbstractKernelTest {
         Cache cb = cachingService.getCache("org.dspace.aztest", null);
         assertNotNull(cb);
         assertNotSame(ca, cb);
+        
+        //trash the references
+        cache = c2 = ca = cb = null;
     }
 
 }

--- a/dspace-services/src/test/java/org/dspace/services/caching/EhcacheCacheTest.java
+++ b/dspace-services/src/test/java/org/dspace/services/caching/EhcacheCacheTest.java
@@ -17,6 +17,7 @@ import org.dspace.services.model.Cache;
 import org.dspace.services.model.CacheConfig;
 import org.dspace.services.model.CacheConfig.CacheScope;
 import org.dspace.test.DSpaceAbstractKernelTest;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -40,6 +41,14 @@ public class EhcacheCacheTest extends DSpaceAbstractKernelTest {
         cache = cachingService.getCache(cacheName, new CacheConfig(CacheScope.INSTANCE));
     }
 
+    @AfterClass
+    public static void tearDownClass() {
+        if(cacheManager!=null)
+            cacheManager.shutdown();
+        cacheManager = null;
+        cache = null;
+    }
+    
     @Before
     public void init() {
         cache.clear();
@@ -65,6 +74,10 @@ public class EhcacheCacheTest extends DSpaceAbstractKernelTest {
 
         EhcacheCache cache = new EhcacheCache(ehcache, new CacheConfig(CacheScope.INSTANCE));
         assertEquals("org.dspace.ehcache", cache.getName());
+        
+        //trash the references
+        ehcache = null;
+        cache = null;
     }
 
     /**
@@ -74,6 +87,8 @@ public class EhcacheCacheTest extends DSpaceAbstractKernelTest {
     public void testGetConfig() {
         CacheConfig cacheConfig = cache.getConfig();
         assertNotNull(cacheConfig);
+        
+        cacheConfig = null;
     }
 
     /**

--- a/dspace-services/src/test/java/org/dspace/utils/servicemanager/ProviderHolderTest.java
+++ b/dspace-services/src/test/java/org/dspace/utils/servicemanager/ProviderHolderTest.java
@@ -9,8 +9,6 @@ package org.dspace.utils.servicemanager;
 
 import static org.junit.Assert.*;
 
-import org.dspace.utils.servicemanager.ProviderHolder;
-import org.dspace.utils.servicemanager.ProviderNotFoundException;
 import org.junit.Test;
 
 /**
@@ -35,6 +33,9 @@ public class ProviderHolderTest {
         Thing t2 = holder.getProvider();
         assertNotNull(t2);
         assertEquals(t, t2);
+        
+        //trash the references
+        t = t2 = null;
     }
 
     @Test
@@ -55,6 +56,8 @@ public class ProviderHolderTest {
 
         Thing t3 = holder.getProvider();
         assertNull(t3);
+        
+        t3 = null;
     }
 
     @Test
@@ -73,6 +76,9 @@ public class ProviderHolderTest {
         Thing t2 = holder.getProviderOrFail();
         assertNotNull(t2);
         assertEquals(t, t2);
+        
+        //trash the references
+        t = t2 = null;
     }
 
     @Test
@@ -86,6 +92,8 @@ public class ProviderHolderTest {
         assertNotNull( holder.hashCode() );
         assertFalse( holder.equals(null) );
         assertNotNull( holder.toString() );
+        
+        holder = null;
     }
     
 }

--- a/dspace-services/src/test/java/org/dspace/utils/servicemanager/ProviderStackTest.java
+++ b/dspace-services/src/test/java/org/dspace/utils/servicemanager/ProviderStackTest.java
@@ -86,6 +86,7 @@ public class ProviderStackTest {
         assertTrue(providers.getProviders().size() == 0);
 
         providers.clear();
+        providers = null;
     }
 
     /**
@@ -111,6 +112,7 @@ public class ProviderStackTest {
 
         l = null;
         providers.clear();
+        providers = null;
     }
 
     /**
@@ -173,7 +175,9 @@ public class ProviderStackTest {
         assertEquals("eee", l.get(6).getPrefix());
 
         l = null;
+        p5 = p6 = p7 = null;
         providers.clear();
+        providers = null;
     }
 
     /**
@@ -204,6 +208,7 @@ public class ProviderStackTest {
 
         l = null;
         providers.clear();
+        providers = null;
     }
 
     /**
@@ -234,6 +239,7 @@ public class ProviderStackTest {
 
         l = null;
         providers.clear();
+        providers = null;
     }
 
     /**
@@ -271,6 +277,7 @@ public class ProviderStackTest {
 
         it = null;
         providers.clear();
+        providers = null;
     }
 
     /**
@@ -299,6 +306,7 @@ public class ProviderStackTest {
         assertEquals(null, providers.getProvider(-1));
 
         providers.clear();
+        providers = null;
     }
 
     /**
@@ -318,6 +326,7 @@ public class ProviderStackTest {
         assertEquals(4, providers.size());
 
         providers.clear();
+        providers = null;
     }
 
     /**
@@ -342,6 +351,7 @@ public class ProviderStackTest {
         assertEquals(0, providers.size());
 
         providers.clear();
+        providers = null;
     }
 
     /**
@@ -377,7 +387,9 @@ public class ProviderStackTest {
         assertEquals(1, providers.size());
         assertEquals(p2, providers.getProvider(0));
 
+        p2 = null;
         providers.clear();
+        providers = null;
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
              </plugin>
              <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
+                <version>2.4.1</version>
              </plugin>
              <plugin>
                 <groupId>com.mycila</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -83,8 +83,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>
-                <!-- tests whose name starts by Abstract will be ignored -->
                 <configuration>
+                    <!-- Allow for the ability to pass JVM memory flags for Unit Tests. Since
+                         surefire-plugin forks a new JVM, it won't use MAVEN_OPTS or JAVA_OPTS.-->
+                    <argLine>${surefire.argLine}</argLine>
+                    <!-- tests whose name starts by Abstract will be ignored -->
                     <excludes>
                         <exclude>**/Abstract*</exclude>
                     </excludes>
@@ -262,6 +265,23 @@
                <maven.test.skip>true</maven.test.skip>
            </properties>
        </profile>
+
+       <!-- Allow for passing extra memory to Unit tests (via maven-surefire-plugin).
+            By default this just gives tests 512MB of memory, unless specified on commandline
+            via "-Dsurefire.argLine=-Xmx512m" or similar. Since surefire-plugin forks a new
+            JVM for testing, this is the only way to set memory for Unit Tests. -->
+       <profile>
+           <id>surefire-argLine</id>
+           <activation>
+               <property>
+                   <name>!surefire.argLine</name>
+               </property>
+           </activation>
+           <properties>
+               <surefire.argLine>-Xmx512m</surefire.argLine>
+           </properties>
+       </profile>
+
 
         <!-- This profile ensures that we ONLY generate the Unit Test Environment,
              if the testEnvironment.xml file is found AND we are not skipping Unit 


### PR DESCRIPTION
Since merging #637 (for https://jira.duraspace.org/browse/DS-2133), we still seem to be having some Travis CI issues.

Recent PRs seem to still be having some random "Killed" errors from Travis CI, seemingly related to memory issues (or at least that's what is claimed in the Travis docs here: http://docs.travis-ci.com/user/common-build-problems/#My-build-script-is-killed-without-any-error ) 

This PR seeks to solve that (and after 5 tests with my own Travis it _seems_ to work).
- Adds a new "surefire.argLine" Maven option (to our main POM), which lets you specific JVM options to our Unit Tests (i.e. maven-surefire-plugin). By default 'maven-surefire-plugin' forks off a new JVM to run tests, so it ignores any settings in MAVEN_OPTS or JAVA_OPTS
- Tweaks the `.travis.yml` file to use this new `-Dsurefire.argLine` setting, in order to ensure our Unit Tests are getting enough memory on Travis servers.

We'll see what Travis thinks of this PR. As mentioned, it's working for me on my own Travis repo (tdonohue/DSpace), so hopefully it'll work just as well in DSpace/DSpace.
