### PR TITLE
[DS-2003] WorkflowManager.notifyOfArchive() discards reason for email failure

### DIFF
--- a/dspace-api/src/main/java/org/dspace/workflow/WorkflowManager.java
+++ b/dspace-api/src/main/java/org/dspace/workflow/WorkflowManager.java
@@ -113,7 +113,7 @@ public class WorkflowManager
     private static Map<Integer, Boolean> noEMail = new HashMap<Integer, Boolean>();
 
     /** log4j logger */
-    private static Logger log = Logger.getLogger(WorkflowManager.class);
+    private static final Logger log = Logger.getLogger(WorkflowManager.class);
 
     /**
      * Translate symbolic name of workflow state into number.
@@ -773,7 +773,8 @@ public class WorkflowManager
         catch (MessagingException e)
         {
             log.warn(LogManager.getHeader(c, "notifyOfArchive",
-                    "cannot email user" + " item_id=" + i.getID()));
+                    "cannot email user; item_id=" + i.getID()
+                    + ":  " + e.getMessage()));
         }
     }
 
@@ -935,8 +936,9 @@ public class WorkflowManager
         }
         catch (MessagingException e)
         {
-            log.warn(LogManager.getHeader(c, "notifyOfCuration", "cannot email users" +
-                                          " of workflow_item_id" + wi.getID()));
+            log.warn(LogManager.getHeader(c, "notifyOfCuration",
+                    "cannot email users of workflow_item_id " + wi.getID()
+                            + ":  " + e.getMessage()));
         }
     }
 
@@ -1005,8 +1007,9 @@ public class WorkflowManager
                 String gid = (mygroup != null) ?
                              String.valueOf(mygroup.getID()) : "none";
                 log.warn(LogManager.getHeader(c, "notifyGroupofTask",
-                        "cannot email user" + " group_id" + gid
-                                + " workflow_item_id" + wi.getID()));
+                        "cannot email user group_id=" + gid
+                                + " workflow_item_id=" + wi.getID()
+                                + ":  " + e.getMessage()));
             }
         }
     }
@@ -1045,9 +1048,10 @@ public class WorkflowManager
         {
             // log this email error
             log.warn(LogManager.getHeader(c, "notify_of_reject",
-                    "cannot email user" + " eperson_id" + e.getID()
-                            + " eperson_email" + e.getEmail()
-                            + " workflow_item_id" + wi.getID()));
+                    "cannot email user eperson_id=" + e.getID()
+                            + " eperson_email=" + e.getEmail()
+                            + " workflow_item_id=" + wi.getID()
+                            + ":  " + re.getMessage()));
 
             throw re;
         }
@@ -1055,9 +1059,10 @@ public class WorkflowManager
         {
             // log this email error
             log.warn(LogManager.getHeader(c, "notify_of_reject",
-                    "cannot email user" + " eperson_id" + e.getID()
-                            + " eperson_email" + e.getEmail()
-                            + " workflow_item_id" + wi.getID()));
+                    "cannot email user eperson_id=" + e.getID()
+                            + " eperson_email=" + e.getEmail()
+                            + " workflow_item_id=" + wi.getID()
+                            + ":  " + ex.getMessage()));
         }
     }
 


### PR DESCRIPTION
It turned out that several notify\* methods had similar issues.

Also clean up message formatting.
