### PR TITLE
Mirage2 POM cleanup/refactoring, related to DS-2052

### DIFF
--- a/dspace-xmlui-mirage2/pom.xml
+++ b/dspace-xmlui-mirage2/pom.xml
@@ -1,12 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-   <modelVersion>4.0.0</modelVersion>
-   <groupId>org.dspace</groupId>
-   <artifactId>dspace-xmlui-mirage2</artifactId>
-   <packaging>war</packaging>
-   <name>DSpace Mirage2 - src</name>
-   <description>
-      This project generates an overlay war for inclusion in XMLUI using the overlay mechanism.
-   </description>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.dspace</groupId>
+    <artifactId>dspace-xmlui-mirage2</artifactId>
+    <packaging>war</packaging>
+    <name>DSpace XML-UI Mirage2 Theme</name>
+    <description>
+      DSpace Mirage2 Theme for the XMLUI (Cocoon based interface).
+    </description>
 
     <parent>
         <groupId>org.dspace</groupId>
@@ -15,74 +15,56 @@
         <relativePath>..</relativePath>
     </parent>
 
-   <properties>
-       <!-- This is the path to the root [dspace-src] directory. -->
-       <root.basedir>${basedir}/..</root.basedir>
+    <properties>
+        <!-- This is the path to the root [dspace-src] directory. -->
+        <root.basedir>${basedir}/..</root.basedir>
+    </properties>
 
-   </properties>
-
-   <build>
-       <filters>
-           <!-- Filter using the properties file defined by dspace-parent POM -->
-           <filter>${filters.file}</filter>
-       </filters>
-      <plugins>
-
-
+    <build>
+        <filters>
+            <!-- Filter using the properties file defined by dspace-parent POM -->
+            <filter>${filters.file}</filter>
+        </filters>
+        <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-war-plugin</artifactId>
-            <configuration>
-               <archiveClasses>false</archiveClasses>
+                <artifactId>maven-war-plugin</artifactId>
+                <configuration>
+                    <archiveClasses>false</archiveClasses>
                     <warSourceExcludes>themes/**</warSourceExcludes>
-               <webResources>
-                  <resource>
-                     <filtering>false</filtering>
-                     <directory>${basedir}/src/main/webapp</directory>
-
-                  </resource>
-
-               </webResources>
-               <overlays>
-                  <!--  
-                     the priority of overlays is determined here
-                     1.) default: anything in the current project has highest
-                     2.) anything defined here has precedence in the order defined
-                     3.) any war found transitively in the dependencies will be applied
-                     next. the order is unpredictable.
-                  -->
-
-               </overlays>
-            </configuration>
-            <executions>
-               <execution>
-                  <phase>prepare-package</phase>
-               </execution>
-            </executions>
-         </plugin>
-          <plugin>
-              <groupId>com.mycila</groupId>
-              <artifactId>license-maven-plugin</artifactId>
-              <configuration>
-                  <!-- Exclude license check for essential config files, these files cannot have a license comment or Mirage 2 will not compile -->
-                  <excludes>
-                      <exclude>**/*.json</exclude>
-                      <exclude>**/*.LICENSE</exclude>
-                      <exclude>**/readme.txt</exclude>
-                      <exclude>**/.bowerrc</exclude>
-                  </excludes>
-              </configuration>
-          </plugin>
-
-      </plugins>
-   </build>
-
-
-
-
-   <dependencies>
-
-
-   </dependencies>
-
+                    <webResources>
+                        <resource>
+                            <filtering>false</filtering>
+                            <directory>${basedir}/src/main/webapp</directory>
+                        </resource>
+                    </webResources>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>prepare-package</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <!-- Exclude license check for essential config files, these files cannot have a license comment or Mirage 2 will not compile -->
+                    <excludes>
+                        <exclude>**/*.json</exclude>
+                        <exclude>**/*.LICENSE</exclude>
+                        <exclude>**/*.svg</exclude>
+                        <exclude>**/readme.txt</exclude>
+                        <exclude>**/.bowerrc</exclude>
+                    </excludes>
+                    <mapping>
+                        <!-- File extensions which are not recognized by license-maven-plugin:
+                             *.hbs, *.scss -->
+                        <hbs>XML_STYLE</hbs>
+                        <scss>JAVADOC_STYLE</scss>
+                    </mapping>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/dspace/modules/xmlui-mirage2/pom.xml
+++ b/dspace/modules/xmlui-mirage2/pom.xml
@@ -4,9 +4,10 @@
     <groupId>org.dspace.modules</groupId>
     <artifactId>xmlui-mirage2</artifactId>
     <packaging>war</packaging>
-    <name>DSpace Mirage2 :: local customisations</name>
+    <name>DSpace XML-UI Mirage2 Theme :: Local Customisations</name>
     <description>
-        This project generates an overlay war for inclusion in XMLUI using the overlay mechanism.
+        This project allows you to overlay your own local Mirage2 Theme customizations
+        on top of the default Mirage2 Theme provided with DSpace.
     </description>
 
     <parent>
@@ -22,6 +23,11 @@
         <grunt.environment>prod</grunt.environment>
         <grunt.color.scheme>classic_mirage_color_scheme</grunt.color.scheme>
         <mirage2.deps.included>true</mirage2.deps.included>
+        <!-- Versions of build dependencies to be auto-installed when "mirage2.deps.included=true" -->
+        <sass.version>3.4.3</sass.version>
+        <compass.version>1.0.1</compass.version>
+        <node.version>0.10.31</node.version>
+        <npm.version>1.4.23</npm.version>
     </properties>
 
     <build>
@@ -29,11 +35,21 @@
             <!-- Filter using the properties file defined by dspace-parent POM -->
             <filter>${filters.file}</filter>
         </filters>
+        <!-- Centrally manage the versions of all plugins used below -->
+        <pluginManagement>
+            <plugins>
+                <!-- This iterator plugin is used by all build <profiles> below -->
+                <plugin>
+                    <groupId>com.soebes.maven.plugins</groupId>
+                    <artifactId>iterator-maven-plugin</artifactId>
+                    <version>0.3</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.8</version>
                 <executions>
                     <execution>
                         <id>unpack-dependencies</id>
@@ -56,7 +72,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>2.6</version>
                 <executions>
                     <execution>
                         <goals>
@@ -106,7 +121,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.1</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>
@@ -115,29 +129,18 @@
                         </goals>
                         <configuration>
                             <tasks>
-                                <echoproperties>
-                                </echoproperties>
-                                <echo>${env.PATH}</echo>
-                                <echo>${env.GEM_PATH}</echo>
-                                <echo>${env.GEM_HOME}</echo>
-                                <echo>${mirage2.deps.included}</echo>
-                                <echo>${grunt.color.scheme}</echo>
-                                <echo>${grunt.environment}</echo>
-                                <echo>${basedir}/src/main/webapp/themes/</echo>
+                                <echo>PATH=${env.PATH}</echo>
+                                <echo>GEM_PATH=${env.GEM_PATH}</echo>
+                                <echo>GEM_HOME=${env.GEM_HOME}</echo>
+                                <echo>mirage2.deps.included=${mirage2.deps.included}</echo>
+                                <echo>grunt.color.scheme=${grunt.color.scheme}</echo>
+                                <echo>grunt.environment=${grunt.environment}</echo>
+                                <echo>source=${basedir}/src/main/webapp/themes/</echo>
                             </tasks>
                         </configuration>
                     </execution>
                 </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.ant</groupId>
-                        <artifactId>ant</artifactId>
-                        <version>1.9.2</version>
-                    </dependency>
-                </dependencies>
             </plugin>
-
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
@@ -186,10 +189,11 @@
                     </execution>
                 </executions>
             </plugin>
-
         </plugins>
     </build>
 
+    <!-- Faster build profile (enable with -Dmirage2.deps.included=true).
+         However you must manually install dependencies on your machine for this to work. -->
     <profiles>
         <profile>
             <id>mirage2-deps-preinstalled-fast</id>
@@ -200,11 +204,20 @@
                 </property>
             </activation>
             <build>
+                <!-- Centrally manage the versions of all plugins used by this profile -->
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>exec-maven-plugin</artifactId>
+                            <version>1.3.1</version>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
                 <plugins>
                     <plugin>
                         <groupId>com.soebes.maven.plugins</groupId>
                         <artifactId>iterator-maven-plugin</artifactId>
-                        <version>0.3</version>
                         <executions>
                             <execution>
                                 <phase>prepare-package</phase>
@@ -218,7 +231,6 @@
                                             <plugin>
                                                 <groupId>org.apache.maven.plugins</groupId>
                                                 <artifactId>maven-resources-plugin</artifactId>
-                                                <version>2.6</version>
                                             </plugin>
                                             <goal>copy-resources</goal>
                                             <configuration>
@@ -239,7 +251,6 @@
                                             <plugin>
                                                 <groupId>org.apache.maven.plugins</groupId>
                                                 <artifactId>maven-resources-plugin</artifactId>
-                                                <version>2.6</version>
                                             </plugin>
                                             <goal>copy-resources</goal>
                                             <configuration>
@@ -260,7 +271,6 @@
                                             <plugin>
                                                 <groupId>org.codehaus.mojo</groupId>
                                                 <artifactId>exec-maven-plugin</artifactId>
-                                                <version>1.3.1</version>
                                             </plugin>
                                             <goal>exec</goal>
                                             <configuration>
@@ -279,7 +289,6 @@
                                             <plugin>
                                                 <groupId>org.codehaus.mojo</groupId>
                                                 <artifactId>exec-maven-plugin</artifactId>
-                                                <version>1.3.1</version>
                                             </plugin>
                                             <goal>exec</goal>
                                             <configuration>
@@ -306,6 +315,10 @@
                 </plugins>
             </build>
         </profile>
+
+        <!-- DEFAULT profile. Automatically installs all necessary dependencies (Node.js, etc.)
+             to a temp location EVERY time project is built. This results in a slower build, but
+             it doesn't require that you install these dependencies yourself. -->
         <profile>
             <id>mirage2-deps-included-slow</id>
             <activation>
@@ -325,22 +338,36 @@
                 <dependency>
                     <groupId>rubygems</groupId>
                     <artifactId>sass</artifactId>
-                    <version>3.2.6</version>
+                    <version>${sass.version}</version>
                     <type>gem</type>
                 </dependency>
                 <dependency>
                     <groupId>rubygems</groupId>
                     <artifactId>compass</artifactId>
-                    <version>0.12.2</version>
+                    <version>${compass.version}</version>
                     <type>gem</type>
                 </dependency>
             </dependencies>
             <build>
+                <!-- Centrally manage the versions of all plugins used by this profile -->
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>de.saumya.mojo</groupId>
+                            <artifactId>gem-maven-plugin</artifactId>
+                            <version>1.0.6</version>
+                        </plugin>
+                        <plugin>
+                            <groupId>com.github.eirslett</groupId>
+                            <artifactId>frontend-maven-plugin</artifactId>
+                            <version>0.0.16</version>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
                 <plugins>
                     <plugin>
                         <groupId>de.saumya.mojo</groupId>
                         <artifactId>gem-maven-plugin</artifactId>
-                        <version>1.0.0-rc</version>
                         <executions>
                             <execution>
                                 <goals>
@@ -352,7 +379,6 @@
                     <plugin>
                         <groupId>com.soebes.maven.plugins</groupId>
                         <artifactId>iterator-maven-plugin</artifactId>
-                        <version>0.3</version>
                         <executions>
                             <execution>
                                 <phase>prepare-package</phase>
@@ -367,7 +393,6 @@
                                             <plugin>
                                                 <groupId>org.apache.maven.plugins</groupId>
                                                 <artifactId>maven-resources-plugin</artifactId>
-                                                <version>2.6</version>
                                             </plugin>
                                             <goal>copy-resources</goal>
                                             <configuration>
@@ -388,7 +413,6 @@
                                             <plugin>
                                                 <groupId>org.apache.maven.plugins</groupId>
                                                 <artifactId>maven-resources-plugin</artifactId>
-                                                <version>2.6</version>
                                             </plugin>
                                             <goal>copy-resources</goal>
                                             <configuration>
@@ -410,14 +434,13 @@
                                             <plugin>
                                                 <groupId>com.github.eirslett</groupId>
                                                 <artifactId>frontend-maven-plugin</artifactId>
-                                                <version>0.0.14</version>
                                             </plugin>
                                             <goal>install-node-and-npm</goal>
                                             <!--<phase>process-resources</phase>-->
                                             <configuration>
                                                 <workingDirectory>${project.build.directory}/themes/@item@</workingDirectory>
-                                                <nodeVersion>v0.10.18</nodeVersion>
-                                                <npmVersion>1.3.8</npmVersion>
+                                                <nodeVersion>v${node.version}</nodeVersion>
+                                                <npmVersion>${npm.version}</npmVersion>
                                             </configuration>
                                         </pluginExecutor>
                                         <pluginExecutor>
@@ -425,7 +448,6 @@
                                             <plugin>
                                                 <groupId>com.github.eirslett</groupId>
                                                 <artifactId>frontend-maven-plugin</artifactId>
-                                                <version>0.0.14</version>
                                             </plugin>
                                             <goal>npm</goal>
                                             <!--<phase>prepare-package</phase>-->
@@ -439,7 +461,6 @@
                                             <plugin>
                                                 <groupId>com.github.eirslett</groupId>
                                                 <artifactId>frontend-maven-plugin</artifactId>
-                                                <version>0.0.14</version>
                                             </plugin>
                                             <goal>grunt</goal>
                                             <!--<phase>prepare-package</phase>-->
@@ -453,7 +474,6 @@
                                             <plugin>
                                                 <groupId>de.saumya.mojo</groupId>
                                                 <artifactId>gem-maven-plugin</artifactId>
-                                                <version>1.0.0-rc</version>
                                             </plugin>
                                             <goal>exec</goal>
                                             <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -97,9 +97,23 @@
                 </configuration>
              </plugin>
              <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.7</version>
              </plugin>
+             <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.4.1</version>
+             </plugin>
+             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.8</version>
+             </plugin>
+             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>2.6</version>
+              </plugin>
              <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
@@ -114,7 +128,6 @@
          <!-- Ensure that any *.properties files have UTF-8 chars encoded (e.g. "\u00e9") *before* using them to filter dspace.cfg and other configs -->
          <plugin>
            <artifactId>maven-antrun-plugin</artifactId>
-           <version>1.7</version>
            <executions>
              <execution>
                <id>native2ascii-utf8</id>


### PR DESCRIPTION
This PR simply cleans up the new Mirage2 POMs (added in DS-2052) to make them more in line with our other POMs. Namely it:
- Avoids duplication of plugin versions in several POMs (moving some versions to our Parent POM). Also updated those versions to the latest available (which all seem to work fine).
- Changes build dependency version numbers (for Node.js, etc) into POM properties, to make them easier to find and tweak. Also updated some of those versions to the latest available (which all seem to work fine).
- Removes / cleans up some bad spacing/tabbing, and also cleans up some empty POM tags which were not doing anything.

Essentially, this PR is just a refactoring of the POMs...it doesn't change what they do, just streamlines it.

Assuming Travis doesn't complain, I'll get this merged soon. It's just cleanup which is necessary but not controversial.
