### PR TITLE
More Travis CI build fixes related to DS-2133

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: java
 
 env: 
-  # Give Maven 2GB of memory to work with
-  - MAVEN_OPTS=-Xmx2048M
+  # Give Maven 1GB of memory to work with
+  - MAVEN_OPTS=-Xmx1024M
 
 # Install prerequisites for building Mirage2 more rapidly
 before_install:
@@ -23,16 +23,23 @@ before_install:
   - gem install compass
   - compass version
 
-# Run a quick version of "mvn install" to download module dependencies
-# Skip building the "dspace" assembly module, as we'll do that below
-install: "mvn install -P !dspace"
+# Skip install stage, as we'll do it below
+install: "echo 'Skipping install stage, dependencies will be downloaded during build and test stages.'"
 
-# Build and test 
-#  travis_retry => Retry build/test up to 3 times
-#  license:check => Validate all source code license headers
-#  -Dmaven.test.skip=false => Enable DSpace Unit Tests
-#  -Dmirage2.on=true => Build Mirage2
-#  -Dmirage2.deps.included=false => Don't include Mirage2 build dependencies (We installed them in before_install)
-#  -B => Maven batch/non-interactive mode (recommended for CI)
-#  -V => Display Maven version info before build
-script: "travis_retry mvn clean package license:check -Dmaven.test.skip=false -Dmirage2.on=true -Dmirage2.deps.included=false -B -V"
+# Two stage Build and Test
+# 1. Install & Unit Test APIs
+# 2. Assemble DSpace
+script:
+  # 1. [Install & Unit Test] Check source code licenses and run source code Unit Tests
+  #    (This explicitly skips building the 'dspace' assembly module, since we only want to do that ONCE.)
+  #        license:check => Validate all source code license headers
+  #        -Dmaven.test.skip=false => Enable DSpace Unit Tests
+  #        -P !dspace => SKIP full DSpace assembly (will do below)
+  #        -B => Maven batch/non-interactive mode (recommended for CI)
+  #        -V => Display Maven version info before build
+  - "mvn install license:check -Dmaven.test.skip=false -P !dspace -B -V"
+  # 2. [Assemble DSpace] Ensure full assembly process works (from [src]/dspace/), including Mirage 2
+  #        travis_retry => RETRY this step up to 3 times. TravisCI is randomly KILLING the packaging of 'dspace-installer' (possible memory issue?)
+  #        -Dmirage2.on=true => Build Mirage2
+  #        -Dmirage2.deps.included=false => Don't include Mirage2 build dependencies (We installed them in before_install)
+  - "cd dspace && travis_retry mvn package -Dmirage2.on=true -Dmirage2.deps.included=false -B -V"

--- a/dspace/pom.xml
+++ b/dspace/pom.xml
@@ -29,32 +29,6 @@
             <!-- Filter using the properties file defined by dspace-parent POM -->
             <filter>${filters.file}</filter>
         </filters>
-    
-        <plugins>
-            <!--  Default project assembly. Calls 'assembly.xml', which
-                  generates the DSpace build directory. -->
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <configuration>
-                    <!-- Don't "attach" the assembly results to this project. As
-                         this assembly builds a directory, setting this to "true"
-                         (default value) will just result in a WARNING message.-->
-                    <attach>false</attach>
-                    <finalName>${project.artifactId}</finalName>
-                    <descriptors>
-                        <descriptor>src/main/assembly/assembly.xml</descriptor>
-                    </descriptors>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
     </build>
 
     <profiles>
@@ -63,15 +37,53 @@
         <profile>
             <id>default</id>
             <activation>
-
                 <file><exists>modules/pom.xml</exists></file>
             </activation>
-            <!--
-                Builds Overlay Modules for DSpace
-            -->
+            <!-- Build all Overlay submodules -->
             <modules>
                 <module>modules</module>
             </modules>
+        </profile>
+
+        <!--
+            DSpace Assembly profile. By default this is enabled.
+            This profile actually assembles the 'dspace-installer'
+            from the resulting JARs/WARs of all submodules.
+            See 'assembly.xml' for more info.
+            This profile can only be deactivated by passing '-P!assembly'.
+        -->
+        <profile>
+            <id>assembly</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                   <!-- Assemble 'target/dspace-installer' using 'assembly.xml' -->
+                   <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <inherited>false</inherited>
+                        <configuration>
+                            <!-- Don't "attach" the assembly results to this project. As
+                                 this assembly builds a directory, setting this to "true"
+                                (default value) will just result in a WARNING message.-->
+                            <attach>false</attach>
+                            <finalName>${project.artifactId}</finalName>
+                            <descriptors>
+                                <descriptor>src/main/assembly/assembly.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
 
 

--- a/dspace/src/main/assembly/assembly.xml
+++ b/dspace/src/main/assembly/assembly.xml
@@ -90,8 +90,8 @@
    </files>
 
    <!--
-   Still allow anyone to put a JAR dependency into
-   [src]/dspace/pom.xml and have it go into 'lib' directory
+   Copy ALL JAR dependencies specified in [src]/dspace/pom.xml
+   into the DSpace 'lib' directory.
    -->
    <dependencySets>
       <dependencySet>
@@ -102,42 +102,42 @@
       </dependencySet>
    </dependencySets>
 
-
    <moduleSets>
       <!--
-      Take all jar modules in [src]/dspace/modules/ dir
-      and add them into 'lib' directory
+      Take all JAR modules (and their dependencies) under
+      [src]/dspace/modules/ dir and add them into 'lib' directory
       -->
       <moduleSet>
          <includes>
-            <include>*:jar:*</include>
+            <include>org.dspace.modules:*:jar:*</include>
          </includes>
          <binaries>
             <includeDependencies>true</includeDependencies>
             <outputDirectory>lib</outputDirectory>
             <unpack>false</unpack>
+            <!-- Include any dependency JARs as well -->
             <dependencySets>
                <dependencySet>
                   <includes>
                      <include>*:jar:*</include>
                   </includes>
-                  <outputDirectory>lib</outputDirectory>
                </dependencySet>
             </dependencySets>
          </binaries>
       </moduleSet>
 
       <!--
-      Take all war modules (in [src]/dspace/modules/) and explode them into
+      Take all WAR modules (in [src]/dspace/modules/) and unpack them into
       'webapps' directory
       -->
       <moduleSet>
          <includes>
             <include>org.dspace.modules:*:war:*</include>
          </includes>
-          <excludes>
-              <exclude>org.dspace.modules:xmlui-mirage2:war:*</exclude>
-          </excludes>
+         <!-- Exclude Mirage2, as it is copied into the XMLUI WAR when enabled -->
+         <excludes>
+            <exclude>org.dspace.modules:xmlui-mirage2:war:*</exclude>
+         </excludes>
          <binaries>
             <includeDependencies>false</includeDependencies>
             <outputDirectory>webapps/${module.artifactId}</outputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -83,8 +83,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>
-                <!-- tests whose name starts by Abstract will be ignored -->
                 <configuration>
+                    <!-- Allow for the ability to pass JVM memory flags for Unit Tests. Since
+                         maven-surefire-plugin forks a new JVM, it ignores MAVEN_OPTS.-->
+                    <argLine>${surefire.argLine}</argLine>
+                    <!-- tests whose name starts by Abstract will be ignored -->
                     <excludes>
                         <exclude>**/Abstract*</exclude>
                     </excludes>
@@ -275,6 +278,22 @@
                <maven.test.skip>true</maven.test.skip>
            </properties>
        </profile>
+
+        <!-- Allow for passing extra memory to Unit tests (via maven-surefire-plugin).
+             By default this gives unit tests 512MB of memory (when tests are enabled), 
+             unless tweaked on commandline (e.g. "-Dsurefire.argLine=-Xmx512m"). Since 
+             m-surefire-p forks a new JVM for testing, it ignores MAVEN_OPTS. -->
+        <profile>
+            <id>surefire-argLine</id>
+            <activation>
+                <property>
+                    <name>!surefire.argLine</name>
+                </property>
+            </activation>
+            <properties>
+                <surefire.argLine>-Xmx512m</surefire.argLine>
+            </properties>
+        </profile>
 
         <!-- This profile ensures that we ONLY generate the Unit Test Environment,
              if the testEnvironment.xml file is found AND we are not skipping Unit 

--- a/src/main/assembly/testEnvironment.xml
+++ b/src/main/assembly/testEnvironment.xml
@@ -24,42 +24,37 @@
     </formats>
     <includeBaseDirectory>false</includeBaseDirectory>
 
-    <moduleSets>
-        <!-- First, copy the following from our 'dspace' assembly project into
-             a "dspace" subdirectory in the final ZIP file. -->
-        <moduleSet>
+    <!-- First, copy the following from our 'dspace' subfolder assembly project into the
+         same subdirectory in the final ZIP file. NOTE: We do this in a <fileSet> INSTEAD
+         of a <moduleSet> so that we don't have to first build the "dspace" module. -->
+    <fileSets>
+        <fileSet>
+            <!-- Copy necessary DSpace subdirectories into Test environment -->
             <includes>
-                <include>org.dspace:dspace</include>
+                <include>dspace/bin/**</include>
+                <include>dspace/config/**</include>
+                <include>dspace/etc/**</include>
+                <include>dspace/solr/**</include>
             </includes>
-            <sources>
-                <outputDirectoryMapping>dspace</outputDirectoryMapping>
-                <fileSets>
-                    <fileSet>
-                        <!-- Copy necessary DSpace subdirectories into Test environment -->
-                        <includes>
-                            <include>bin/**</include>
-                            <include>config/**</include>
-                            <include>etc/**</include>
-                            <include>solr/**</include>
-                        </includes>
-                        <!-- Exclude specific configs (which require filtering) -->
-                        <excludes>
-                            <exclude>config/dspace.cfg</exclude>
-                            <exclude>config/log4j.properties</exclude>
-                            <exclude>config/modules/**</exclude>
-                        </excludes> 
-                    </fileSet>
-                    <fileSet> <!-- Copy specific configs (filtering their content) also into Test environment -->
-                        <includes>
-                            <include>config/modules/**</include>
-                            <include>config/dspace.cfg</include>
-                            <include>config/log4j.properties</include>
-                        </includes>
-                        <filtered>true</filtered>
-                    </fileSet>
-                </fileSets>
-            </sources>
-        </moduleSet>
+            <!-- But, exclude specific configs (which require filtering) -->
+            <excludes>
+                <exclude>dspace/config/dspace.cfg</exclude>
+                <exclude>dspace/config/log4j.properties</exclude>
+                <exclude>dspace/config/modules/**</exclude>
+            </excludes>
+        </fileSet>
+        <fileSet> 
+            <!-- Copy specific configs (filtering their content) also into Test environment -->
+            <includes>
+                <include>dspace/config/modules/**</include>
+                <include>dspace/config/dspace.cfg</include>
+                <include>dspace/config/log4j.properties</include>
+            </includes>
+            <filtered>true</filtered>
+        </fileSet>        
+    </fileSets>
+
+    <moduleSets>
         <!-- Next, search for a 'src/test/data/dspaceFolder' data directory in
              ANY of our modules. If found, copy its contents into the same "dspace"
              subdirectory in the final ZIP file, as this is data to be used in testing.


### PR DESCRIPTION
Travis CI continues to randomly "kill" some of our builds (ever since merging #637). However, from my tests, disabling the Mirage2 build also doesn't fully work either (see #646) -- we still get "Killed" messages at times. According to Travis CI, this is probably a Memory-related issue:

http://docs.travis-ci.com/user/common-build-problems/#My-build-script-is-killed-without-any-error

After some testing, I've seemingly narrowed it down to the DSpace assembly process (specifically when we build the "dspace-installer" folder itself). Sometimes Travis will perform this step fine, and other times it will return a "Killed" message. My guess is the more modules we have, the more processing/memory that assembly takes.

This PR reworks our Travis tests slightly to try and decrease the frequency of these "Killed" messages (I'm still not certain that they will disappear entirely though).

Essentially, this PR does the following:
1. Decreases the MAVEN_OPTS memory setting to just 1GB. It doesn't seem to really need more than that, and I don't want Java reserving too much of the total of 3GB that Travis allows us.
2. Reworks the Travis build & test into two separate steps (see https://github.com/tdonohue/DSpace/commit/217aea08c3da5b61ffeb456f1bde84591a2de9ca)
   1. First, run all Unit Tests for all source code modules (via a `mvn install`), but SKIP building the "dspace" assembly module
   2. Second, run a `mvn package` from the `[src]/dspace/` folder to actually assemble DSpace. Retry this step if it fails the first time (as this is the step that occasionally throws the "Killed" messages).
3. Adds the ability to _disable_ just the assembly of the `target/dspace-installer` (by passing `-P !assembly`) should we ever need to use it. (Currently I'm NOT using it for Travis, but it may be necessary to enable if we cannot get a stable Travis build). See https://github.com/tdonohue/DSpace/commit/98acddd6c260fcdfdc51f2df29d68405d3b5251d
4. Specifically gives Unit Tests 512MB of memory by default (which seems to be more than enough). This setting is also configurable via commandline via `-Dsurefire.argLine=-Xmx512M` or similar. The maven-surefire-plugin always forks a new JVM to run Unit Tests, so it ignores MAVEN_OPTS settings (which is why this new flag is necessary). See https://github.com/tdonohue/DSpace/commit/599931f520797383d5f5f936f6a79f8cd5bb77c1

In order to achieve all this, I had to also make some minor modifications to POMs, the `assembly.xml` (mostly I tried to clean it up, and ensure it wasn't matching _too many_ modules, which could cause memory issues), and the `testEnvironment.xml` (to ensure that we could SKIP building "dspace" while also running our Unit Tests).
