### PR TITLE
DS-1933 Enhancement for cli batch import regarding collections

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -469,12 +469,12 @@
         <dependency>
             <groupId>gr.ekt.bte</groupId>
             <artifactId>bte-core</artifactId>
-            <version>0.9.2.4</version>
+            <version>0.9.2.5</version>
         </dependency>
         <dependency>
             <groupId>gr.ekt.bte</groupId>
             <artifactId>bte-io</artifactId>
-            <version>0.9.2.4</version>
+            <version>0.9.2.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -344,10 +344,8 @@ public class ItemImport
 
                 if (collections == null)
                 {
-                    System.out
-                            .println("Error - at least one destination collection must be specified");
-                    System.out.println(" (run with -h flag for details)");
-                    System.exit(1);
+                    System.out.println("No collections given. Assuming 'collections' file inside item directory");
+                    commandLineCollections = false;
                 }
 
                 if (bteInputType == null)

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -208,12 +208,12 @@ public class ItemImport
             {
                 command = "delete";
             }
-            
+
             if (line.hasOption('b'))
             {
                 command = "add-bte";
             }
-            
+
             if (line.hasOption('i'))
             {
                 bteInputType = line.getOptionValue('i');
@@ -280,6 +280,8 @@ public class ItemImport
                 zipfilename = sourcedir + System.getProperty("file.separator") + line.getOptionValue('z');
             }
 
+            //By default assume collections will be given on the command line
+            boolean commandLineCollections = true;
             // now validate
             // must have a command set
             if (command == null)
@@ -316,16 +318,14 @@ public class ItemImport
 
                 if (collections == null)
                 {
-                    System.out
-                            .println("Error - at least one destination collection must be specified");
-                    System.out.println(" (run with -h flag for details)");
-                    System.exit(1);
+                    System.out.println("No collections given. Assuming 'collections' file inside item directory");
+                    commandLineCollections = false;
                 }
             }
             else if ("add-bte".equals(command))
             {
             	//Source dir can be null, the user can specify the parameters for his loader in the Spring XML configuration file
-            	
+
                 if (mapfile == null)
                 {
                     System.out
@@ -349,7 +349,7 @@ public class ItemImport
                     System.out.println(" (run with -h flag for details)");
                     System.exit(1);
                 }
-                
+
                 if (bteInputType == null)
                 {
                     System.out
@@ -458,7 +458,8 @@ public class ItemImport
             Collection[] mycollections = null;
 
             // don't need to validate collections set if command is "delete"
-            if (!"delete".equals(command))
+            // also if no collections are given in the command line
+            if (!"delete".equals(command) && commandLineCollections)
             {
                 System.out.println("Destination collections:");
 
@@ -667,12 +668,12 @@ public class ItemImport
     	else { //This indicates a UI import, working dir is preconfigured
     		outputFolder = workingDir + File.separator + ".bte_output_dspace";
     	}
-    	
+
         BTEBatchImportService dls  = new DSpace().getSingletonService(BTEBatchImportService.class);
         DataLoader dataLoader = dls.getDataLoaders().get(inputType);
         Map<String, String> outputMap = dls.getOutputMap();
         TransformationEngine te = dls.getTransformationEngine();
-        
+
         if (dataLoader==null){
             System.out.println("ERROR: The key used in -i parameter must match a valid DataLoader in the BTE Spring XML configuration file!");
             return;
@@ -702,10 +703,10 @@ public class ItemImport
             System.out.println("INFO: Dataloader " + dataLoader.toString()+" will be used for the import!");
 
         	te.setDataLoader(dataLoader);
-        	
+
         	DSpaceOutputGenerator outputGenerator = new DSpaceOutputGenerator(outputMap);
         	outputGenerator.setOutputDirectory(outputFolder);
-        	
+
         	te.setOutputGenerator(outputGenerator);
 
         	try {
@@ -766,7 +767,7 @@ public class ItemImport
         }
 
         String[] dircontents = d.list(directoryFilter);
-        
+
         Arrays.sort(dircontents);
 
         for (int i = 0; i < dircontents.length; i++)
@@ -777,6 +778,17 @@ public class ItemImport
             }
             else
             {
+                if (mycollections == null) {
+                    String path = sourceDir + File.separatorChar + dircontents[i];
+                    Collection [] cols = processCollectionFile(c, path, "collections");
+                    if (cols == null) {
+                        System.out.println("No collections specified for item " + dircontents[i] + ". Skipping.");
+                        continue;
+                    }
+
+                    mycollections = cols;
+                }
+
                 addItem(c, mycollections, sourceDir, dircontents[i], mapOut, template);
                 System.out.println(i + " " + dircontents[i]);
                 c.clearCache();
@@ -883,7 +895,7 @@ public class ItemImport
      * item? try and add it to the archive.
      * @param mycollections - add item to these Collections.
      * @param path - directory containing the item directories.
-     * @param itemname handle - non-null means we have a pre-defined handle already 
+     * @param itemname handle - non-null means we have a pre-defined handle already
      * @param mapOut - mapfile we're writing
      */
     private Item addItem(Context c, Collection[] mycollections, String path,
@@ -1113,7 +1125,7 @@ public class ItemImport
         {
             schema = schemaAttr.getNodeValue();
         }
-         
+
         // Get the nodes corresponding to formats
         NodeList dcNodes = XPathAPI.selectNodeList(document,
                 "/dublin_core/dcvalue");
@@ -1181,22 +1193,93 @@ public class ItemImport
         {
             // If we're just test the import, let's check that the actual metadata field exists.
         	MetadataSchema foundSchema = MetadataSchema.find(c,schema);
-        	
+
         	if (foundSchema == null)
         	{
         		System.out.println("ERROR: schema '"+schema+"' was not found in the registry.");
         		return;
         	}
-        	
+
         	int schemaID = foundSchema.getSchemaID();
         	MetadataField foundField = MetadataField.findByElement(c, schemaID, element, qualifier);
-        	
+
         	if (foundField == null)
         	{
         		System.out.println("ERROR: Metadata field: '"+schema+"."+element+"."+qualifier+"' was not found in the registry.");
         		return;
-            }		
+            }
         }
+    }
+
+    /**
+     * Read the collections file inside the item directory. If there is one and it is not empty return a list of
+     * collections in which the item should be inserted. If it does not exist or it is empty return null.
+     *
+     * @param c
+     * @param path
+     * @param filename
+     * @return
+     */
+
+    private Collection[] processCollectionFile(Context c, String path, String filename) throws IOException, SQLException {
+        File file = new File(path + File.separatorChar + filename);
+        ArrayList<Collection> collections = new ArrayList<Collection>();
+        Collection[] result = null;
+        System.out.println("Processing collections file: " + filename);
+
+        if(file.exists())
+        {
+            BufferedReader br = null;
+            try
+            {
+                br = new BufferedReader(new FileReader(file));
+                String line = null;
+                while ((line = br.readLine()) != null)
+                {
+                    DSpaceObject obj = null;
+                    if (line.indexOf('/') != -1)
+                    {
+                        obj = HandleManager.resolveToObject(c, line);
+                        if (obj == null || obj.getType() != Constants.COLLECTION)
+                        {
+                            obj = null;
+                        }
+                    }
+                    else
+                    {
+                        obj = Collection.find(c, Integer.parseInt(line));
+                    }
+
+                    if (obj == null) {
+                        throw new IllegalArgumentException("Cannot resolve " + line + " to a collection");
+                    }
+                    collections.add((Collection)obj);
+
+                }
+
+                result = new Collection[collections.size()];
+                for (int i = 0; i < result.length; i++) {
+                    result[i] = collections.get(i);
+                }
+            }
+            catch (FileNotFoundException e)
+            {
+                System.out.println("No collections file found.");
+            }
+            finally
+            {
+                if (br != null)
+                {
+                    try {
+                        br.close();
+                    } catch (IOException e) {
+                        System.out.println("Non-critical problem releasing resources.");
+                    }
+                }
+            }
+        }
+
+        return result;
     }
 
     /**
@@ -1339,7 +1422,7 @@ public class ItemImport
                                     + sRegistrationLine);
                             continue;
                         }
-                        
+
                         // look for descriptions
                         boolean descriptionExists = false;
                         String descriptionMarker = "\tdescription:";
@@ -1496,7 +1579,7 @@ public class ItemImport
 
             System.out.println("No contents file found - but only metadata files found. Assuming metadata only.");
         }
-        
+
         return options;
     }
 
@@ -1537,7 +1620,7 @@ public class ItemImport
                 newBundleName = "ORIGINAL";
             }
         }
-        
+
         if (!isTest)
         {
             // find the bundle
@@ -1581,7 +1664,7 @@ public class ItemImport
 
     /**
      * Register the bitstream file into DSpace
-     * 
+     *
      * @param c
      * @param i
      * @param assetstore
@@ -1591,7 +1674,7 @@ public class ItemImport
      * @throws IOException
      * @throws AuthorizeException
      */
-    private void registerBitstream(Context c, Item i, int assetstore, 
+    private void registerBitstream(Context c, Item i, int assetstore,
             String bitstreamPath, String bundleName, String description )
         	throws SQLException, IOException, AuthorizeException
     {
@@ -1600,7 +1683,7 @@ public class ItemImport
 
         Bitstream bs = null;
         String newBundleName = bundleName;
-        
+
         if (bundleName == null)
         {
             // is it license.txt?
@@ -1650,18 +1733,18 @@ public class ItemImport
     }
 
     /**
-     * 
+     *
      * Process the Options to apply to the Item. The options are tab delimited
-     * 
+     *
      * Options:
      *      48217870-MIT.pdf        permissions: -r 'MIT Users'     description: Full printable version (MIT only)
      *      permissions:[r|w]-['group name']
      *      description: 'the description of the file'
-     *      
+     *
      *      where:
      *          [r|w] (meaning: read|write)
      *          ['MIT Users'] (the group name)
-     *          
+     *
      * @param c
      * @param myItem
      * @param options
@@ -1819,7 +1902,7 @@ public class ItemImport
 
     /**
      * Set the Permission on a Bitstream.
-     * 
+     *
      * @param c
      * @param g
      * @param actionID
@@ -1882,7 +1965,7 @@ public class ItemImport
         return "";
     }
 
-    
+
     /**
      * Return the String value of a Node.
      * @param node
@@ -1907,10 +1990,10 @@ public class ItemImport
 
     /**
      * Load in the XML from file.
-     * 
+     *
      * @param filename
      *            the filename to load from
-     * 
+     *
      * @return the DOM representation of the XML file
      */
     private static Document loadXML(String filename) throws IOException,
@@ -1951,7 +2034,7 @@ public class ItemImport
         boolean pathDeleted = path.delete();
         return (pathDeleted);
     }
-    
+
     /**
      * Generate a random filename based on current time
      * @param hidden: add . as a prefix to make the file hidden
@@ -1959,16 +2042,16 @@ public class ItemImport
      */
     private static String generateRandomFilename(boolean hidden)
     {
-    	String filename = String.format("%s", RandomStringUtils.randomAlphanumeric(8));                        
+    	String filename = String.format("%s", RandomStringUtils.randomAlphanumeric(8));
         SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmm");
         String datePart = sdf.format(new Date());
         filename = datePart+"_"+filename;
-        
+
         return filename;
     }
-    
+
     /**
-     * Given an uploaded file, this method calls the method to instantiate a BTE instance to 
+     * Given an uploaded file, this method calls the method to instantiate a BTE instance to
      * transform the input data and batch import them to DSpace
      * @param file The input file to read data from
      * @param collections The collections the created items will be inserted to
@@ -1976,14 +2059,14 @@ public class ItemImport
      * @param context The context
      * @throws Exception
      */
-    public static void processUploadableImport(File file, Collection[] collections, 
+    public static void processUploadableImport(File file, Collection[] collections,
     		String bteInputType, Context context) throws Exception
     {
         final EPerson eperson = context.getCurrentUser();
         final File myFile = file;
         final Collection[] mycollections = collections;
         final String myBteInputType = bteInputType;
-        
+
         // if the file exists
         if (file.exists())
         {
@@ -1999,7 +2082,7 @@ public class ItemImport
                         context = new Context();
                         context.setCurrentUser(eperson);
                         context.setIgnoreAuthorization(true);
-                        
+
                         File importDir = new File(ConfigurationManager.getProperty("org.dspace.app.batchitemimport.work.dir"));
                         if (!importDir.exists()){
                         	boolean success = importDir.mkdir();
@@ -2012,24 +2095,24 @@ public class ItemImport
                         //more that one batch imports take place at the same time
                         String subDirName = generateRandomFilename(false);
                         String workingDir = importDir.getAbsolutePath() + File.separator + subDirName;
-                        
+
                         //Create the import working directory
                         boolean success = (new File(workingDir)).mkdir();
                     	if (!success) {
                     		log.info("Cannot create batch import working directory!");
                     		throw new Exception();
                     	}
-                    	
+
                         //Create random mapfile;
                         String mapfile = workingDir + File.separator+ "mapfile";
-                        
+
                         ItemImport myloader = new ItemImport();
                         myloader.addBTEItems(context, mycollections, myFile.getAbsolutePath(), mapfile, template, myBteInputType, workingDir);
-                        
+
                         // email message letting user know the file is ready for
                         // download
                         emailSuccessMessage(context, eperson, mapfile);
-                        
+
                         // return to enforcing auths
                         context.setIgnoreAuthorization(false);
                     }
@@ -2051,7 +2134,7 @@ public class ItemImport
                         {
                             iitems.close();
                         }
-                        
+
                         // close the mapfile writer
                         if (mapOut != null)
                         {
@@ -2076,7 +2159,7 @@ public class ItemImport
         	log.error("Unable to find the uploadable file");
         }
     }
-    
+
     /**
      * Since the BTE batch import is done in a new thread we are unable to communicate
      * with calling method about success or failure. We accomplish this
@@ -2100,7 +2183,7 @@ public class ItemImport
             Email email = Email.getEmail(I18nUtil.getEmailFilename(supportedLocale, "bte_batch_import_success"));
             email.addRecipient(eperson.getEmail());
             email.addArgument(fileName);
-           
+
             email.send();
         }
         catch (Exception e)

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -1226,13 +1226,15 @@ public class ItemImport
     }
 
     /**
-     * Read the collections file inside the item directory. If there is one and it is not empty return a list of
-     * collections in which the item should be inserted. If it does not exist or it is empty return null.
+     * Read the collections file inside the item directory. If there
+     * is one and it is not empty return a list of collections in
+     * which the item should be inserted. If it does not exist or it
+     * is empty return null.
      *
-     * @param c
-     * @param path
-     * @param filename
-     * @return
+     * @param c The context
+     * @param path The path to the data directory for this item
+     * @param filename The collections file filename. Should be "collections"
+     * @return A list of collections in which to insert the item or null
      */
 
     private Collection[] processCollectionFile(Context c, String path, String filename) throws IOException, SQLException

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -738,6 +738,11 @@ public class ItemImport
 
         // create the mapfile
         File outFile = null;
+        boolean directoryFileCollections = false;
+        if (mycollections == null)
+        {
+            directoryFileCollections = true;
+        }
 
         if (!isTest)
         {
@@ -778,7 +783,8 @@ public class ItemImport
             }
             else
             {
-                if (mycollections == null) {
+                Collection [] clist;
+                if (directoryFileCollections) {
                     String path = sourceDir + File.separatorChar + dircontents[i];
                     try {
                         Collection[] cols = processCollectionFile(c, path, "collections");
@@ -786,7 +792,7 @@ public class ItemImport
                             System.out.println("No collections specified for item " + dircontents[i] + ". Skipping.");
                             continue;
                         }
-                        mycollections = cols;
+                        clist = cols;
                     }
                     catch (IllegalArgumentException e)
                     {
@@ -794,8 +800,12 @@ public class ItemImport
                         continue;
                     }
                 }
+                else
+                {
+                    clist = mycollections;
+                }
 
-                addItem(c, mycollections, sourceDir, dircontents[i], mapOut, template);
+                addItem(c, clist, sourceDir, dircontents[i], mapOut, template);
                 System.out.println(i + " " + dircontents[i]);
                 c.clearCache();
             }

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -373,10 +373,10 @@ public class ItemImport
             }
 
             // can only resume for adds
-            if (isResume && !"add".equals(command))
+            if (isResume && !"add".equals(command) && !"add-bte".equals(command))
             {
                 System.out
-                        .println("Error - resume option only works with --add command");
+                        .println("Error - resume option only works with the --add or the --add-bte commands");
                 System.exit(1);
             }
 

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -780,13 +780,19 @@ public class ItemImport
             {
                 if (mycollections == null) {
                     String path = sourceDir + File.separatorChar + dircontents[i];
-                    Collection [] cols = processCollectionFile(c, path, "collections");
-                    if (cols == null) {
-                        System.out.println("No collections specified for item " + dircontents[i] + ". Skipping.");
+                    try {
+                        Collection[] cols = processCollectionFile(c, path, "collections");
+                        if (cols == null) {
+                            System.out.println("No collections specified for item " + dircontents[i] + ". Skipping.");
+                            continue;
+                        }
+                        mycollections = cols;
+                    }
+                    catch (IllegalArgumentException e)
+                    {
+                        System.out.println(e.getMessage() + " Skipping." );
                         continue;
                     }
-
-                    mycollections = cols;
                 }
 
                 addItem(c, mycollections, sourceDir, dircontents[i], mapOut, template);
@@ -1221,7 +1227,8 @@ public class ItemImport
      * @return
      */
 
-    private Collection[] processCollectionFile(Context c, String path, String filename) throws IOException, SQLException {
+    private Collection[] processCollectionFile(Context c, String path, String filename) throws IOException, SQLException
+    {
         File file = new File(path + File.separatorChar + filename);
         ArrayList<Collection> collections = new ArrayList<Collection>();
         Collection[] result = null;
@@ -1251,7 +1258,7 @@ public class ItemImport
                     }
 
                     if (obj == null) {
-                        throw new IllegalArgumentException("Cannot resolve " + line + " to a collection");
+                        throw new IllegalArgumentException("Cannot resolve " + line + " to a collection.");
                     }
                     collections.add((Collection)obj);
 


### PR DESCRIPTION
Jira Issue: https://jira.duraspace.org/browse/DS-1933

Documentation (to be included in https://wiki.duraspace.org/display/DSDOC5x/Importing+and+Exporting+Items+via+Simple+Archive+Format)
- Importing (per item) into multiple collections from the command line administration tool
  
  If you omit the -c flag, which normally is mandatory, the
  ItemImporter searches for a file named <collections> in each item
  directory. This file should contain a list of collections, one per
  line, specified either by their handle, or by their internal db
  id. The ItemImporter then will put the item in each of the specified
  collections. The owning collection is the collection specified in
  the first line of the collections file.
  
  If both the -c flag is specified and the collections file exists in
  the item directory, the ItemImporter will ignore the collections
  file and will put the item in the collection specified on the
  command line.
  
  Since the collections file can differ between item directories, you
  have more fine grained control of the process of batch adding items
  to collections.
- Importing with BTE 
  
  The DSpaceOutputGenerator, that writes the metadata in DSpace
  Simple Archive Format, has been updated to produce the collections
  file, if a metadata field named collections (reserved word) exists
  in the original metadata. This is mainly applicable to the CSV
  input format which is more flexible, but could also be
  implemented with a Modifier that adds the collections field to
  each Record in the BTE pipeline.
  
  Important note: an entry with key "collections" should be in the
  output map that is used by the DSpaceOutputGenerator.
