### PR TITLE
Fix build issues on 'master' from DS-2133 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,9 @@ script:
   #        -P !dspace => SKIP full DSpace assembly (will do below)
   #        -B => Maven batch/non-interactive mode (recommended for CI)
   #        -V => Display Maven version info before build
-  - "mvn install license:check -Dmaven.test.skip=false -P !dspace -B -V"
-  # 2. [Assemble DSpace] Ensure full assembly process works (from [src]/dspace/), including Mirage 2
-  #        travis_retry => RETRY this step up to 3 times. TravisCI is randomly KILLING the packaging of 'dspace-installer' (possible memory issue?)
+  - "mvn clean install license:check -Dmaven.test.skip=false -P !dspace -B -V"
+  # 2. [Assemble DSpace] Ensure assembly process works (from [src]/dspace/), including Mirage 2
   #        -Dmirage2.on=true => Build Mirage2
   #        -Dmirage2.deps.included=false => Don't include Mirage2 build dependencies (We installed them in before_install)
-  - "cd dspace && travis_retry mvn package -Dmirage2.on=true -Dmirage2.deps.included=false -B -V"
+  #        -P !assembly => SKIP the actual building of [src]/dspace/dspace-installer (as it can be memory intensive)
+  - "cd dspace && mvn package -Dmirage2.on=true -Dmirage2.deps.included=false -P !assembly -B -V"

--- a/dspace/pom.xml
+++ b/dspace/pom.xml
@@ -33,29 +33,35 @@
 
     <profiles>
 
-        <!-- Default Profile. This builds all Overlay modules for DSpace -->
+        <!-- Build Profile. This builds all Overlay modules for DSpace -->   
         <profile>
-            <id>default</id>
+            <id>build</id>
             <activation>
-                <file><exists>modules/pom.xml</exists></file>
+                <!-- Enabled as long as we are NOT creating a zip/tarball distribution -->
+                <property>
+                    <name>!distributions</name>
+                </property>
             </activation>
             <!-- Build all Overlay submodules -->
             <modules>
                 <module>modules</module>
-            </modules>
+            </modules> 
         </profile>
 
         <!--
             DSpace Assembly profile. By default this is enabled.
-            This profile actually assembles the 'dspace-installer'
-            from the resulting JARs/WARs of all submodules.
+            This profile actually builds all submodules and then assembles
+            the 'dspace-installer' from the resulting JARs/WARs.
             See 'assembly.xml' for more info.
-            This profile can only be deactivated by passing '-P!assembly'.
+            This profile can be optionally deactivated by passing '-P!assembly'.
         -->
         <profile>
             <id>assembly</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <!-- Enabled as long as we are NOT creating a zip/tarball distribution -->
+                <property>
+                    <name>!distributions</name>
+                </property>
             </activation>
             <build>
                 <plugins>
@@ -86,9 +92,28 @@
             </build>
         </profile>
 
+        <!-- This profile simply determines whether we are creating 
+             zip / tarball distributions to upload to SourceFore or similar. 
+             By running "mvn package -Ddistributions=true" you'll
+             SKIP normal build & assembly (see above profiles) and
+             INSTEAD just run the "distributions" profile below. -->
+        <profile>
+            <id>build-and-assembly</id>
+            <activation>
+                <!-- This profile should be active at all times, unless the user
+                     specifies a different value for "distributions" -->
+                <property>
+                    <name>!distributions</name>
+                </property>
+            </activation>
+            <properties>
+                <distributions>false</distributions>
+            </properties>
+        </profile> 
+
 
         <!--
-            Run this profile (e.g. 'mvn package -Pdistributions') to create
+            Run this profile (e.g. 'mvn package -Ddistributions=true') to create
             zip / tarball distributions to upload to SourceForge or similar.
             When this profile is run, DSpace is NOT compiled as normal.
             Instead, a zip/tarball is generated from the parent [dspace-src] directory.
@@ -96,7 +121,11 @@
         <profile>
            <id>distributions</id>
            <activation>
-              <activeByDefault>false</activeByDefault>
+              <!-- Only enabled if "distributions=true" was passed on commandline -->
+              <property>
+                  <name>distributions</name>
+                  <value>true</value>
+              </property>
            </activation>
            <build>
               <plugins>


### PR DESCRIPTION
This fixes current build issues on "master" branch, which I accidentally caused by #648 

Does two things:
- Fixes the new profiles added to `[src]/dspace/pom.xml`. Previously, the assembly step was accidentally disabled by default. Now, it is enabled by default, but can be easily disabled by using `-P !assembly`
- Update Travis CI settings to specify `-P !assembly`, which therefore skips building of 'dspace-installer'. Travis will still run all our Unit Tests and build all modules (including those under `[src]/dspace/modules`). It just skips the final creation of the 'dspace-installer' directory.
