### PR TITLE
Support Metadata On All DSpaceObjects

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemupdate/DeleteMetadataAction.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemupdate/DeleteMetadataAction.java
@@ -38,7 +38,7 @@ public class DeleteMetadataAction extends UpdateMetadataAction {
 		for (String f : targetFields)
 		{
 			DtoMetadata dummy = DtoMetadata.create(f, Item.ANY, "");
-			DCValue[] ardcv = item.getMetadata(f);
+			DCValue[] ardcv = item.getMetadataByMetadataString(f);
 
 			ItemUpdate.pr("Metadata to be deleted: ");
 			for (DCValue dcv : ardcv)

--- a/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemMetadataStrategy.java
+++ b/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemMetadataStrategy.java
@@ -35,14 +35,14 @@ public class RequestItemMetadataStrategy extends RequestItemSubmitterStrategy {
 			throws SQLException {
 		if (emailMetadata != null)
 		{
-			DCValue[] vals = item.getMetadata(emailMetadata);
+			DCValue[] vals = item.getMetadataByMetadataString(emailMetadata);
 			if (vals.length > 0)
 			{
 				String email = vals[0].value;
 				String fullname = null;
 				if (fullNameMatadata != null)
 				{
-					DCValue[] nameVals = item.getMetadata(fullNameMatadata); 
+					DCValue[] nameVals = item.getMetadataByMetadataString(fullNameMatadata);
 					if (nameVals.length > 0)
 					{
 						fullname = nameVals[0].value;

--- a/dspace-api/src/main/java/org/dspace/app/sherpa/submit/MetadataAuthorityISSNExtractor.java
+++ b/dspace-api/src/main/java/org/dspace/app/sherpa/submit/MetadataAuthorityISSNExtractor.java
@@ -29,7 +29,7 @@ public class MetadataAuthorityISSNExtractor implements ISSNItemExtractor
         List<String> values = new ArrayList<String>();
         for (String metadata : metadataList)
         {
-            DCValue[] dcvalues = item.getMetadata(metadata);
+            DCValue[] dcvalues = item.getMetadataByMetadataString(metadata);
             for (DCValue dcvalue : dcvalues)
             {
                 values.add(dcvalue.authority);

--- a/dspace-api/src/main/java/org/dspace/app/sherpa/submit/MetadataValueISSNExtractor.java
+++ b/dspace-api/src/main/java/org/dspace/app/sherpa/submit/MetadataValueISSNExtractor.java
@@ -29,7 +29,7 @@ public class MetadataValueISSNExtractor implements ISSNItemExtractor
         List<String> values = new ArrayList<String>();
         for (String metadata : metadataList)
         {
-            DCValue[] dcvalues = item.getMetadata(metadata);
+            DCValue[] dcvalues = item.getMetadataByMetadataString(metadata);
             for (DCValue dcvalue : dcvalues)
             {
                 values.add(dcvalue.value);

--- a/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
@@ -265,7 +265,7 @@ public class SyndicationFeed
                         df = df.replaceAll("\\(date\\)", "");
                     }
              
-                    DCValue dcv[] = item.getMetadata(df);
+                    DCValue dcv[] = item.getMetadataByMetadataString(df);
                     if (dcv.length > 0)
                     {
                         String fieldLabel = labels.get(MSG_METADATA + df);
@@ -298,7 +298,7 @@ public class SyndicationFeed
                 }
 
                 // This gets the authors into an ATOM feed
-                DCValue authors[] = item.getMetadata(authorField);
+                DCValue authors[] = item.getMetadataByMetadataString(authorField);
                 if (authors.length > 0)
                 {
                     List<SyndPerson> creators = new ArrayList<SyndPerson>();
@@ -318,7 +318,7 @@ public class SyndicationFeed
                     DCModule dc = new DCModuleImpl();
                     if (dcCreatorField != null)
                     {
-                        DCValue dcAuthors[] = item.getMetadata(dcCreatorField);
+                        DCValue dcAuthors[] = item.getMetadataByMetadataString(dcCreatorField);
                         if (dcAuthors.length > 0)
                         {
                             List<String> creators = new ArrayList<String>();
@@ -331,7 +331,7 @@ public class SyndicationFeed
                     }
                     if (dcDateField != null && !hasDate)
                     {
-                        DCValue v[] = item.getMetadata(dcDateField);
+                        DCValue v[] = item.getMetadataByMetadataString(dcDateField);
                         if (v.length > 0)
                         {
                             dc.setDate((new DCDate(v[0].value)).toDate());
@@ -339,7 +339,7 @@ public class SyndicationFeed
                     }
                     if (dcDescriptionField != null)
                     {
-                        DCValue v[] = item.getMetadata(dcDescriptionField);
+                        DCValue v[] = item.getMetadataByMetadataString(dcDescriptionField);
                         if (v.length > 0)
                         {
                             StringBuffer descs = new StringBuffer();
@@ -381,7 +381,7 @@ public class SyndicationFeed
                         }
                         //Also try to add an external value from dc.identifier.other
                         // We are assuming that if this is set, then it is a media file
-                        DCValue[] externalMedia = item.getMetadata(externalSourceField);
+                        DCValue[] externalMedia = item.getMetadataByMetadataString(externalSourceField);
                         if(externalMedia.length > 0)
                         {
                             for(int i = 0; i< externalMedia.length; i++)
@@ -567,7 +567,7 @@ public class SyndicationFeed
     // spoonful of syntactic sugar when we only need first value
     private String getOneDC(Item item, String field)
     {
-        DCValue dcv[] = item.getMetadata(field);
+        DCValue dcv[] = item.getMetadataByMetadataString(field);
         return (dcv.length > 0) ? dcv[0].value : null;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/authenticate/PasswordAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/PasswordAuthentication.java
@@ -128,7 +128,7 @@ public class PasswordAuthentication
 		// ensures they are password users
 		try
 		{
-			if (!context.getCurrentUser().getMetadata("password").equals(""))
+			if (context.getCurrentUser().getPasswordHash() != null && !context.getCurrentUser().getPasswordHash().toString().equals(""))
 			{
 				String groupName = ConfigurationManager.getProperty("authentication-password", "login.specialgroup");
 				if ((groupName != null) && (!groupName.trim().equals("")))

--- a/dspace-api/src/main/java/org/dspace/browse/BrowseItemDAOOracle.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseItemDAOOracle.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.browse;
 
+import org.dspace.core.Constants;
 import org.dspace.storage.rdbms.TableRowIterator;
 import org.dspace.storage.rdbms.DatabaseManager;
 import org.dspace.storage.rdbms.TableRow;
@@ -26,31 +27,34 @@ public class BrowseItemDAOOracle implements BrowseItemDAO
     /** query to get the text value of a metadata element only (qualifier is NULL) */
     private String getByMetadataElement = "SELECT authority, confidence, text_value,text_lang,element,qualifier FROM metadatavalue, metadatafieldregistry, metadataschemaregistry " +
 
-                                    "WHERE metadatavalue.item_id = ? " +
+                                    "WHERE metadatavalue.resource_id = ? " +
                                     " AND metadatavalue.metadata_field_id = metadatafieldregistry.metadata_field_id " +
                                     " AND metadatafieldregistry.element = ? " +
                                     " AND metadatafieldregistry.qualifier IS NULL " +
                                     " AND metadatafieldregistry.metadata_schema_id=metadataschemaregistry.metadata_schema_id " +
                                     " AND metadataschemaregistry.short_id = ? " +
+                                    " AND metadatavalue.resource_type_id = ? " +
                                     " ORDER BY metadatavalue.metadata_field_id, metadatavalue.place";
 
     /** query to get the text value of a metadata element and qualifier */
     private String getByMetadata = "SELECT authority, confidence, text_value,text_lang,element,qualifier FROM metadatavalue, metadatafieldregistry, metadataschemaregistry " +
-                                    "WHERE metadatavalue.item_id = ? " +
+                                    "WHERE metadatavalue.resource_id = ? " +
                                     " AND metadatavalue.metadata_field_id = metadatafieldregistry.metadata_field_id " +
                                     " AND metadatafieldregistry.element = ? " +
                                     " AND metadatafieldregistry.qualifier = ? " +
                                     " AND metadatafieldregistry.metadata_schema_id=metadataschemaregistry.metadata_schema_id " +
                                     " AND metadataschemaregistry.short_id = ? " +
+                                    " AND metadatavalue.resource_type_id = ? " +
                                     " ORDER BY metadatavalue.metadata_field_id, metadatavalue.place";
 
     /** query to get the text value of a metadata element with the wildcard qualifier (*) */
     private String getByMetadataAnyQualifier = "SELECT authority, confidence, text_value,text_lang,element,qualifier FROM metadatavalue, metadatafieldregistry, metadataschemaregistry " +
-                                    "WHERE metadatavalue.item_id = ? " +
+                                    "WHERE metadatavalue.resource_id = ? " +
                                     " AND metadatavalue.metadata_field_id = metadatafieldregistry.metadata_field_id " +
                                     " AND metadatafieldregistry.element = ? " +
                                     " AND metadatafieldregistry.metadata_schema_id=metadataschemaregistry.metadata_schema_id " +
                                     " AND metadataschemaregistry.short_id = ? " +
+                                    " AND metadatavalue.resource_type_id = ? " +
                                     " ORDER BY metadatavalue.metadata_field_id, metadatavalue.place";
 
     /** DSpace context */
@@ -101,17 +105,17 @@ public class BrowseItemDAOOracle implements BrowseItemDAO
         {
             if (qualifier == null)
             {
-                Object[] params = { Integer.valueOf(itemId), element, schema };
+                Object[] params = { Integer.valueOf(itemId), element, schema, Constants.ITEM };
                 tri = DatabaseManager.query(context, getByMetadataElement, params);
             }
             else if (Item.ANY.equals(qualifier))
             {
-                Object[] params = { Integer.valueOf(itemId), element, schema };
+                Object[] params = { Integer.valueOf(itemId), element, schema, Constants.ITEM };
                 tri = DatabaseManager.query(context, getByMetadataAnyQualifier, params);
             }
             else
             {
-                Object[] params = { Integer.valueOf(itemId), element, qualifier, schema };
+                Object[] params = { Integer.valueOf(itemId), element, qualifier, schema, Constants.ITEM };
                 tri = DatabaseManager.query(context, getByMetadata, params);
             }
 

--- a/dspace-api/src/main/java/org/dspace/browse/BrowseItemDAOPostgres.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseItemDAOPostgres.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.browse;
 
+import org.dspace.core.Constants;
 import org.dspace.storage.rdbms.TableRowIterator;
 import org.dspace.storage.rdbms.DatabaseManager;
 import org.dspace.storage.rdbms.TableRow;
@@ -25,31 +26,34 @@ public class BrowseItemDAOPostgres implements BrowseItemDAO
 
     /** query to get the text value of a metadata element only (qualifier is NULL) */
     private String getByMetadataElement = "SELECT authority, confidence, text_value,text_lang,element,qualifier FROM metadatavalue, metadatafieldregistry, metadataschemaregistry " +
-                                    "WHERE metadatavalue.item_id = ? " +
+                                    "WHERE metadatavalue.resource_id = ? " +
                                     " AND metadatavalue.metadata_field_id = metadatafieldregistry.metadata_field_id " +
                                     " AND metadatafieldregistry.element = ? " +
                                     " AND metadatafieldregistry.qualifier IS NULL " +
                                     " AND metadatafieldregistry.metadata_schema_id=metadataschemaregistry.metadata_schema_id " +
                                     " AND metadataschemaregistry.short_id = ? " +
+                                    " AND metadatavalue.resource_type_id = ? " +
                                     " ORDER BY metadatavalue.metadata_field_id, metadatavalue.place";
 
     /** query to get the text value of a metadata element and qualifier */
     private String getByMetadata = "SELECT authority, confidence, text_value,text_lang,element,qualifier FROM metadatavalue, metadatafieldregistry, metadataschemaregistry " +
-                                    "WHERE metadatavalue.item_id = ? " +
+                                    "WHERE metadatavalue.resource_id = ? " +
                                     " AND metadatavalue.metadata_field_id = metadatafieldregistry.metadata_field_id " +
                                     " AND metadatafieldregistry.element = ? " +
                                     " AND metadatafieldregistry.qualifier = ? " +
                                     " AND metadatafieldregistry.metadata_schema_id=metadataschemaregistry.metadata_schema_id " +
                                     " AND metadataschemaregistry.short_id = ? " +
+                                    " AND metadatavalue.resource_type_id = ? " +
                                     " ORDER BY metadatavalue.metadata_field_id, metadatavalue.place";
 
     /** query to get the text value of a metadata element with the wildcard qualifier (*) */
     private String getByMetadataAnyQualifier = "SELECT authority, confidence, text_value,text_lang,element,qualifier FROM metadatavalue, metadatafieldregistry, metadataschemaregistry " +
-                                    "WHERE metadatavalue.item_id = ? " +
+                                    "WHERE metadatavalue.resource_id = ? " +
                                     " AND metadatavalue.metadata_field_id = metadatafieldregistry.metadata_field_id " +
                                     " AND metadatafieldregistry.element = ? " +
                                     " AND metadatafieldregistry.metadata_schema_id=metadataschemaregistry.metadata_schema_id " +
                                     " AND metadataschemaregistry.short_id = ? " +
+                                    " AND metadatavalue.resource_type_id = ? " +
                                     " ORDER BY metadatavalue.metadata_field_id, metadatavalue.place";
 
     /** DSpace context */
@@ -101,16 +105,16 @@ public class BrowseItemDAOPostgres implements BrowseItemDAO
             if (qualifier == null)
             {
                 Object[] params = { Integer.valueOf(itemId), element, schema };
-                tri = DatabaseManager.query(context, getByMetadataElement, params);
+                tri = DatabaseManager.query(context, getByMetadataElement, params, Constants.ITEM);
             }
             else if (Item.ANY.equals(qualifier))
             {
                 Object[] params = { Integer.valueOf(itemId), element, schema };
-                tri = DatabaseManager.query(context, getByMetadataAnyQualifier, params);
+                tri = DatabaseManager.query(context, getByMetadataAnyQualifier, params, Constants.ITEM);
             }
             else
             {
-                Object[] params = { Integer.valueOf(itemId), element, qualifier, schema };
+                Object[] params = { Integer.valueOf(itemId), element, qualifier, schema, Constants.ITEM };
                 tri = DatabaseManager.query(context, getByMetadata, params);
             }
 

--- a/dspace-api/src/main/java/org/dspace/browse/SolrBrowseCreateDAO.java
+++ b/dspace-api/src/main/java/org/dspace/browse/SolrBrowseCreateDAO.java
@@ -330,7 +330,7 @@ public class SolrBrowseCreateDAO implements BrowseCreateDAO,
         {
             for (SortOption so : SortOption.getSortOptions())
             {
-                DCValue[] dcvalue = item.getMetadata(so.getMetadata());
+                DCValue[] dcvalue = item.getMetadataByMetadataString(so.getMetadata());
                 if (dcvalue != null && dcvalue.length > 0)
                 {
                     String nValue = OrderFormat

--- a/dspace-api/src/main/java/org/dspace/content/Bitstream.java
+++ b/dspace-api/src/main/java/org/dspace/content/Bitstream.java
@@ -41,8 +41,6 @@ public class Bitstream extends DSpaceObject
     /** log4j logger */
     private static Logger log = Logger.getLogger(Bitstream.class);
 
-    /** Our context */
-    private Context bContext;
 
     /** The row in the table representing this bitstream */
     private TableRow bRow;
@@ -52,9 +50,6 @@ public class Bitstream extends DSpaceObject
 
     /** Flag set when data is modified, for events */
     private boolean modified;
-
-    /** Flag set when metadata is modified, for events */
-    private boolean modifiedMetadata;
 
     /**
      * Private constructor for creating a Bitstream object based on the contents
@@ -68,7 +63,7 @@ public class Bitstream extends DSpaceObject
      */
     Bitstream(Context context, TableRow row) throws SQLException
     {
-        bContext = context;
+        super(context);
         bRow = row;
 
         // Get the bitstream format
@@ -91,7 +86,6 @@ public class Bitstream extends DSpaceObject
         context.cache(this, row.getIntColumn("bitstream_id"));
 
         modified = false;
-        modifiedMetadata = false;
         clearDetails();
     }
 
@@ -298,9 +292,8 @@ public class Bitstream extends DSpaceObject
      * 
      * @return the name of the bitstream
      */
-    public String getName()
-    {
-        return bRow.getStringColumn("name");
+    public String getName(){
+        return getMetadataFirstValue(MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
     }
 
     /**
@@ -309,11 +302,8 @@ public class Bitstream extends DSpaceObject
      * @param n
      *            the new name of the bitstream
      */
-    public void setName(String n)
-    {
-        bRow.setColumn("name", n);
-        modifiedMetadata = true;
-        addDetails("Name");
+    public void setName(String n) {
+        setMetadataSingleValue(MetadataSchema.DC_SCHEMA, "title", null, null, n);
     }
 
     /**
@@ -325,7 +315,7 @@ public class Bitstream extends DSpaceObject
      */
     public String getSource()
     {
-        return bRow.getStringColumn("source");
+        return getMetadataFirstValue(MetadataSchema.DC_SCHEMA, "source", null, Item.ANY);
     }
 
     /**
@@ -334,11 +324,8 @@ public class Bitstream extends DSpaceObject
      * @param n
      *            the new source of the bitstream
      */
-    public void setSource(String n)
-    {
-        bRow.setColumn("source", n);
-        modifiedMetadata = true;
-        addDetails("Source");
+    public void setSource(String n) {
+        setMetadataSingleValue(MetadataSchema.DC_SCHEMA, "source", null, null, n);
     }
 
     /**
@@ -349,7 +336,7 @@ public class Bitstream extends DSpaceObject
      */
     public String getDescription()
     {
-        return bRow.getStringColumn("description");
+        return getMetadataFirstValue(MetadataSchema.DC_SCHEMA, "description", null, Item.ANY);
     }
 
     /**
@@ -358,11 +345,8 @@ public class Bitstream extends DSpaceObject
      * @param n
      *            the new description of the bitstream
      */
-    public void setDescription(String n)
-    {
-        bRow.setColumn("description", n);
-        modifiedMetadata = true;
-        addDetails("Description");
+    public void setDescription(String n) {
+        setMetadataSingleValue(MetadataSchema.DC_SCHEMA, "description", null, null, n);
     }
 
     /**
@@ -403,14 +387,9 @@ public class Bitstream extends DSpaceObject
      *            the user's description of the format
      * @throws SQLException
      */
-    public void setUserFormatDescription(String desc) throws SQLException
-    {
-        // FIXME: Would be better if this didn't throw an SQLException,
-        // but we need to find the unknown format!
+    public void setUserFormatDescription(String desc) throws SQLException {
         setFormat(null);
-        bRow.setColumn("user_format_description", desc);
-        modifiedMetadata = true;
-        addDetails("UserFormatDescription");
+        setMetadataSingleValue(MetadataSchema.DC_SCHEMA, "format", null, null, desc);
     }
 
     /**
@@ -421,7 +400,7 @@ public class Bitstream extends DSpaceObject
      */
     public String getUserFormatDescription()
     {
-        return bRow.getStringColumn("user_format_description");
+        return getMetadataFirstValue(MetadataSchema.DC_SCHEMA, "format", null, Item.ANY);
     }
 
     /**
@@ -435,7 +414,7 @@ public class Bitstream extends DSpaceObject
         if (bitstreamFormat.getShortDescription().equals("Unknown"))
         {
             // Get user description if there is one
-            String desc = bRow.getStringColumn("user_format_description");
+            String desc = getUserFormatDescription();
 
             if (desc == null)
             {
@@ -476,7 +455,7 @@ public class Bitstream extends DSpaceObject
         if (f == null)
         {
             // Use "Unknown" format
-            bitstreamFormat = BitstreamFormat.findUnknown(bContext);
+            bitstreamFormat = BitstreamFormat.findUnknown(ourContext);
         }
         else
         {
@@ -484,7 +463,7 @@ public class Bitstream extends DSpaceObject
         }
 
         // Remove user type description
-        bRow.setColumnNull("user_format_description");
+        clearMetadata(MetadataSchema.DC_SCHEMA,"format",null, Item.ANY);
 
         // Update the ID in the table row
         bRow.setColumn("bitstream_format_id", bitstreamFormat.getID());
@@ -501,27 +480,24 @@ public class Bitstream extends DSpaceObject
     public void update() throws SQLException, AuthorizeException
     {
         // Check authorisation
-        AuthorizeManager.authorizeAction(bContext, this, Constants.WRITE);
+        AuthorizeManager.authorizeAction(ourContext, this, Constants.WRITE);
 
-        log.info(LogManager.getHeader(bContext, "update_bitstream",
+        log.info(LogManager.getHeader(ourContext, "update_bitstream",
                 "bitstream_id=" + getID()));
+
+        DatabaseManager.update(ourContext, bRow);
 
         if (modified)
         {
-            bContext.addEvent(new Event(Event.MODIFY, Constants.BITSTREAM, 
-                    getID(), null, getIdentifiers(bContext)));
+            ourContext.addEvent(new Event(Event.MODIFY, Constants.BITSTREAM, getID(), null, getIdentifiers(ourContext)));
             modified = false;
         }
         if (modifiedMetadata)
         {
-            bContext.addEvent(new Event(Event.MODIFY_METADATA, 
-                    Constants.BITSTREAM, getID(), getDetails(),
-                    getIdentifiers(bContext)));
-            modifiedMetadata = false;
+            updateMetadata();
             clearDetails();
         }
 
-        DatabaseManager.update(bContext, bRow);
     }
 
     /**
@@ -535,28 +511,30 @@ public class Bitstream extends DSpaceObject
 
         // changed to a check on remove
         // Check authorisation
-        //AuthorizeManager.authorizeAction(bContext, this, Constants.DELETE);
-        log.info(LogManager.getHeader(bContext, "delete_bitstream",
+        //AuthorizeManager.authorizeAction(ourContext, this, Constants.DELETE);
+        log.info(LogManager.getHeader(ourContext, "delete_bitstream",
                 "bitstream_id=" + getID()));
 
-        bContext.addEvent(new Event(Event.DELETE, Constants.BITSTREAM, getID(), 
-                String.valueOf(getSequenceID()), getIdentifiers(bContext)));
+        ourContext.addEvent(new Event(Event.DELETE, Constants.BITSTREAM, getID(),
+                String.valueOf(getSequenceID()), getIdentifiers(ourContext)));
 
         // Remove from cache
-        bContext.removeCached(this, getID());
+        ourContext.removeCached(this, getID());
 
         // Remove policies
-        AuthorizeManager.removeAllPolicies(bContext, this);
+        AuthorizeManager.removeAllPolicies(ourContext, this);
 
         // Remove references to primary bitstreams in bundle
         String query = "update bundle set primary_bitstream_id = ";
         query += (oracle ? "''" : "Null") + " where primary_bitstream_id = ? ";
-        DatabaseManager.updateQuery(bContext,
+        DatabaseManager.updateQuery(ourContext,
                 query, bRow.getIntColumn("bitstream_id"));
 
         // Remove bitstream itself
-        BitstreamStorageManager.delete(bContext, bRow
+        BitstreamStorageManager.delete(ourContext, bRow
                 .getIntColumn("bitstream_id"));
+
+        removeMetadataFromDatabase();
     }
 
     /**
@@ -568,7 +546,7 @@ public class Bitstream extends DSpaceObject
     boolean isDeleted() throws SQLException
     {
         String query = "select count(*) as mycount from Bitstream where deleted = '1' and bitstream_id = ? ";
-        TableRowIterator tri = DatabaseManager.query(bContext, query, bRow.getIntColumn("bitstream_id"));
+        TableRowIterator tri = DatabaseManager.query(ourContext, query, bRow.getIntColumn("bitstream_id"));
         long count = 0;
 
         try
@@ -600,9 +578,9 @@ public class Bitstream extends DSpaceObject
             AuthorizeException
     {
         // Maybe should return AuthorizeException??
-        AuthorizeManager.authorizeAction(bContext, this, Constants.READ);
+        AuthorizeManager.authorizeAction(ourContext, this, Constants.READ);
 
-        return BitstreamStorageManager.retrieve(bContext, bRow
+        return BitstreamStorageManager.retrieve(ourContext, bRow
                 .getIntColumn("bitstream_id"));
     }
 
@@ -615,11 +593,11 @@ public class Bitstream extends DSpaceObject
     public Bundle[] getBundles() throws SQLException
     {
         // Get the bundle table rows
-        TableRowIterator tri = DatabaseManager.queryTable(bContext, "bundle",
-                "SELECT bundle.* FROM bundle, bundle2bitstream WHERE " + 
-                "bundle.bundle_id=bundle2bitstream.bundle_id AND " +
-                "bundle2bitstream.bitstream_id= ? ",
-                 bRow.getIntColumn("bitstream_id"));
+        TableRowIterator tri = DatabaseManager.queryTable(ourContext, "bundle",
+                "SELECT bundle.* FROM bundle, bundle2bitstream WHERE " +
+                        "bundle.bundle_id=bundle2bitstream.bundle_id AND " +
+                        "bundle2bitstream.bitstream_id= ? ",
+                bRow.getIntColumn("bitstream_id"));
 
         // Build a list of Bundle objects
         List<Bundle> bundles = new ArrayList<Bundle>();
@@ -630,7 +608,7 @@ public class Bitstream extends DSpaceObject
                 TableRow r = tri.next();
 
                 // First check the cache
-                Bundle fromCache = (Bundle) bContext.fromCache(Bundle.class, r
+                Bundle fromCache = (Bundle) ourContext.fromCache(Bundle.class, r
                         .getIntColumn("bundle_id"));
 
                 if (fromCache != null)
@@ -639,7 +617,7 @@ public class Bitstream extends DSpaceObject
                 }
                 else
                 {
-                    bundles.add(new Bundle(bContext, r));
+                    bundles.add(new Bundle(ourContext, r));
                 }
             }
         }
@@ -716,23 +694,23 @@ public class Bitstream extends DSpaceObject
         else
         {
             // is the bitstream a logo for a community or a collection?
-            TableRow qResult = DatabaseManager.querySingle(bContext,
+            TableRow qResult = DatabaseManager.querySingle(ourContext,
                        "SELECT collection_id FROM collection " +
                        "WHERE logo_bitstream_id = ?",getID());
             if (qResult != null) 
             {
-                return Collection.find(bContext,qResult.getIntColumn("collection_id"));
+                return Collection.find(ourContext,qResult.getIntColumn("collection_id"));
             }
             else
             {   
                 // is the bitstream related to a community?
-                qResult = DatabaseManager.querySingle(bContext,
+                qResult = DatabaseManager.querySingle(ourContext,
                         "SELECT community_id FROM community " +
                         "WHERE logo_bitstream_id = ?",getID());
     
                 if (qResult != null)
                 {
-                    return Community.find(bContext,qResult.getIntColumn("community_id"));
+                    return Community.find(ourContext,qResult.getIntColumn("community_id"));
                 }
                 else
                 {
@@ -746,7 +724,6 @@ public class Bitstream extends DSpaceObject
     public void updateLastModified()
     {
         //Also fire a modified event since the bitstream HAS been modified
-        bContext.addEvent(new Event(Event.MODIFY, Constants.BITSTREAM, getID(), 
-                null, getIdentifiers(bContext)));
+        ourContext.addEvent(new Event(Event.MODIFY, Constants.BITSTREAM, getID(), null, getIdentifiers(ourContext)));
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/Community.java
+++ b/dspace-api/src/main/java/org/dspace/content/Community.java
@@ -16,10 +16,7 @@ import org.dspace.authorize.AuthorizeManager;
 import org.dspace.authorize.ResourcePolicy;
 import org.dspace.browse.ItemCountException;
 import org.dspace.browse.ItemCounter;
-import org.dspace.core.Constants;
-import org.dspace.core.Context;
-import org.dspace.core.I18nUtil;
-import org.dspace.core.LogManager;
+import org.dspace.core.*;
 import org.dspace.eperson.Group;
 import org.dspace.event.Event;
 import org.dspace.handle.HandleManager;
@@ -30,9 +27,7 @@ import org.dspace.storage.rdbms.TableRowIterator;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.MissingResourceException;
+import java.util.*;
 
 /**
  * Class representing a community
@@ -49,9 +44,6 @@ public class Community extends DSpaceObject
     /** log4j category */
     private static Logger log = Logger.getLogger(Community.class);
 
-    /** Our context */
-    private Context ourContext;
-
     /** The table row corresponding to this item */
     private TableRow communityRow;
 
@@ -63,9 +55,6 @@ public class Community extends DSpaceObject
 
     /** Flag set when data is modified, for events */
     private boolean modified;
-
-    /** Flag set when metadata is modified, for events */
-    private boolean modifiedMetadata;
 
     /** The default group of administrators */
     private Group admins;
@@ -86,7 +75,7 @@ public class Community extends DSpaceObject
      */
     Community(Context context, TableRow row) throws SQLException
     {
-        ourContext = context;
+        super(context);
         communityRow = row;
 
         // Get the logo bitstream
@@ -107,7 +96,6 @@ public class Community extends DSpaceObject
         context.cache(this, row.getIntColumn("community_id"));
 
         modified = false;
-        modifiedMetadata = false;
 
         admins = groupFromColumn("admin");
 
@@ -261,8 +249,25 @@ public class Community extends DSpaceObject
      */
     public static Community[] findAll(Context context) throws SQLException
     {
-        TableRowIterator tri = DatabaseManager.queryTable(context, "community",
-                "SELECT * FROM community ORDER BY name");
+        TableRowIterator tri = null;
+        try {
+            String query = "SELECT c.* FROM community c " +
+                    "LEFT JOIN metadatavalue m on (m.resource_id = c.community_id and m.resource_type_id = ? and m.metadata_field_id = ?) ";
+            if(DatabaseManager.isOracle()){
+                query += " ORDER BY cast(m.text_value as varchar2(128))";
+            }else{
+                query += " ORDER BY m.text_value";
+            }
+
+            tri = DatabaseManager.query(context,
+                    query,
+                    Constants.COMMUNITY,
+                    MetadataField.findByElement(context, MetadataSchema.find(context, MetadataSchema.DC_SCHEMA).getSchemaID(), "title", null).getFieldID()
+            );
+        } catch (SQLException e) {
+            log.error("Find all Communities - ",e);
+            throw e;
+        }
 
         List<Community> communities = new ArrayList<Community>();
 
@@ -314,10 +319,25 @@ public class Community extends DSpaceObject
     public static Community[] findAllTop(Context context) throws SQLException
     {
         // get all communities that are not children
-        TableRowIterator tri = DatabaseManager.queryTable(context, "community",
-                "SELECT * FROM community WHERE NOT community_id IN "
-                        + "(SELECT child_comm_id FROM community2community) "
-                        + "ORDER BY name");
+        TableRowIterator tri = null;
+        try {
+            String query = "SELECT c.* FROM community c  "
+                    + "LEFT JOIN metadatavalue m on (m.resource_id = c.community_id and m.resource_type_id = ? and m.metadata_field_id = ?) "
+                    + "WHERE NOT c.community_id IN (SELECT child_comm_id FROM community2community) ";
+            if(DatabaseManager.isOracle()){
+                query += " ORDER BY cast(m.text_value as varchar2(128))";
+            }else{
+                query += " ORDER BY m.text_value";
+            }
+            tri = DatabaseManager.query(context,
+                    query,
+                    Constants.COMMUNITY,
+                    MetadataField.findByElement(context, MetadataSchema.find(context, MetadataSchema.DC_SCHEMA).getSchemaID(), "title", null).getFieldID()
+            );
+        } catch (SQLException e) {
+            log.error("Find all Top Communities - ",e);
+            throw e;
+        }
 
         List<Community> topCommunities = new ArrayList<Community>();
 
@@ -393,10 +413,12 @@ public class Community extends DSpaceObject
      * @exception IllegalArgumentException
      *                if the requested metadata field doesn't exist
      */
+    @Deprecated
     public String getMetadata(String field)
     {
-    	String metadata = communityRow.getStringColumn(field);
-    	return (metadata == null) ? "" : metadata;
+        String[] MDValue = getMDValueByLegacyField(field);
+        String value = getMetadataFirstValue(MDValue[0], MDValue[1], MDValue[2], Item.ANY);
+        return value == null ? "" : value;
     }
 
     /**
@@ -411,9 +433,9 @@ public class Community extends DSpaceObject
      *                if the requested metadata field doesn't exist
      * @exception MissingResourceException
      */
-    public void setMetadata(String field, String value)throws MissingResourceException
-    {
-        if ((field.trim()).equals("name") 
+    @Deprecated
+    public void setMetadata(String field, String value) throws MissingResourceException {
+        if ((field.trim()).equals("name")
                 && (value == null || value.trim().equals("")))
         {
             try
@@ -425,28 +447,31 @@ public class Community extends DSpaceObject
                 value = "Untitled";
             }
         }
-        
-        /* 
-         * Set metadata field to null if null 
+
+        String[] MDValue = getMDValueByLegacyField(field);
+
+        /*
+         * Set metadata field to null if null
          * and trim strings to eliminate excess
          * whitespace.
          */
         if(value == null)
         {
-            communityRow.setColumnNull(field);
+            clearMetadata(MDValue[0], MDValue[1], MDValue[2], Item.ANY);
+            modifiedMetadata = true;
         }
         else
         {
-            communityRow.setColumn(field, value.trim());
+            setMetadataSingleValue(MDValue[0], MDValue[1], MDValue[2], null, value);
         }
-        
-        modifiedMetadata = true;
+
         addDetails(field);
     }
 
     public String getName()
     {
-        return getMetadata("name");
+        String value = getMetadataFirstValue(MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
+        return value == null ? "" : value;
     }
 
     /**
@@ -536,10 +561,7 @@ public class Community extends DSpaceObject
         }
         if (modifiedMetadata)
         {
-            ourContext.addEvent(new Event(Event.MODIFY_METADATA, 
-                    Constants.COMMUNITY, getID(), getDetails(), 
-                    getIdentifiers(ourContext)));
-            modifiedMetadata = false;
+            updateMetadata();
             clearDetails();
         }
     }
@@ -629,12 +651,27 @@ public class Community extends DSpaceObject
         List<Collection> collections = new ArrayList<Collection>();
 
         // Get the table rows
-        TableRowIterator tri = DatabaseManager.queryTable(
-        	ourContext,"collection",
-            "SELECT collection.* FROM collection, community2collection WHERE " +
-            "community2collection.collection_id=collection.collection_id " +
-            "AND community2collection.community_id= ? ORDER BY collection.name",
-            getID());
+        TableRowIterator tri = null;
+        try {
+            String query = "SELECT c.* FROM community2collection c2c, collection c "
+                    + "LEFT JOIN metadatavalue m on (m.resource_id = c.collection_id and m.resource_type_id = ? and m.metadata_field_id = ?) "
+                    + "WHERE c2c.collection_id=c.collection_id AND c2c.community_id=? ";
+            if(DatabaseManager.isOracle()){
+                query += " ORDER BY cast(m.text_value as varchar2(128))";
+            }else{
+                query += " ORDER BY m.text_value";
+            }
+            tri = DatabaseManager.query(
+                    ourContext,
+                    query,
+                    Constants.COLLECTION,
+                    MetadataField.findByElement(ourContext, MetadataSchema.find(ourContext, MetadataSchema.DC_SCHEMA).getSchemaID(), "title", null).getFieldID(),
+                    getID()
+            );
+        } catch (SQLException e) {
+            log.error("Find all Collections for this community - ",e);
+            throw e;
+        }
 
         // Make Collection objects
         try
@@ -685,13 +722,30 @@ public class Community extends DSpaceObject
         List<Community> subcommunities = new ArrayList<Community>();
 
         // Get the table rows
-        TableRowIterator tri = DatabaseManager.queryTable(
-                ourContext,"community",
-                "SELECT community.* FROM community, community2community WHERE " +
-                "community2community.child_comm_id=community.community_id " + 
-                "AND community2community.parent_comm_id= ? ORDER BY community.name",
-                getID());
-        
+        TableRowIterator tri = null;
+        try {
+            String query = "SELECT c.* FROM community2community c2c, community c " +
+                    "LEFT JOIN metadatavalue m on (m.resource_id = c.community_id and m.resource_type_id = ? and m.metadata_field_id = ?) " +
+                    "WHERE c2c.child_comm_id=c.community_id " +
+                    "AND c2c.parent_comm_id= ? ";
+            if(DatabaseManager.isOracle()){
+                query += " ORDER BY cast(m.text_value as varchar2(128))";
+            }else{
+                query += " ORDER BY m.text_value";
+            }
+
+            tri = DatabaseManager.query(
+                    ourContext,
+                    query,
+                    Constants.COMMUNITY,
+                    MetadataField.findByElement(ourContext, MetadataSchema.find(ourContext, MetadataSchema.DC_SCHEMA).getSchemaID(), "title", null).getFieldID(),
+                    getID()
+            );
+        } catch (SQLException e) {
+            log.error("Find all Sub Communities - ",e);
+            throw e;
+        }
+
 
         // Make Community objects
         try
@@ -1204,6 +1258,9 @@ public class Community extends DSpaceObject
 
         // Remove all associated authorization policies
         AuthorizeManager.removeAllPolicies(ourContext, this);
+
+        // Delete the Dublin Core
+        removeMetadataFromDatabase();
 
         // get rid of the content count cache if it exists
         try

--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
@@ -8,13 +8,24 @@
 package org.dspace.content;
 
 import java.sql.SQLException;
+import java.util.*;
 import org.apache.log4j.Logger;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.authority.ChoiceAuthorityManager;
+import org.dspace.content.authority.Choices;
+import org.dspace.content.authority.MetadataAuthorityManager;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
+import org.dspace.core.LogManager;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
+import org.dspace.event.Event;
+import org.dspace.storage.rdbms.DatabaseManager;
+import org.dspace.storage.rdbms.TableRow;
+import org.dspace.storage.rdbms.TableRowIterator;
 import org.dspace.handle.HandleManager;
 import org.dspace.identifier.IdentifierService;
 import org.dspace.utils.DSpace;
@@ -24,13 +35,248 @@ import org.dspace.utils.DSpace;
  */
 public abstract class DSpaceObject
 {
+    /** Our context */
+    protected Context ourContext;
+
+    /** log4j category */
     private static final Logger log = Logger.getLogger(DSpaceObject.class);
-    
+
+    /**
+     * True if anything else was changed since last update()
+     * (to drive event mechanism)
+     */
+    protected boolean modifiedMetadata;
+
+
     // accumulate information to add to "detail" element of content Event,
     // e.g. to document metadata fields touched, etc.
     private StringBuffer eventDetails = null;
     
     private String[] identifiers = null;
+
+    /** The Dublin Core metadata - inner class for lazy loading */
+    protected MetadataCache metadataCache = new MetadataCache();
+
+
+    /**
+     * Construct a DSpaceOBject with the given table row
+     *
+     * @throws SQLException
+     */
+    protected DSpaceObject()
+    {
+        modifiedMetadata = false;
+    }
+
+    protected DSpaceObject(Context context)
+    {
+        ourContext = context;
+        modifiedMetadata = false;
+    }
+
+
+    public void updateMetadata() throws SQLException, AuthorizeException {
+        // Map counting number of values for each element/qualifier.
+        // Keys are Strings: "element" or "element.qualifier"
+        // Values are Integers indicating number of values written for a
+        // element/qualifier
+        Map<String,Integer> elementCount = new HashMap<String,Integer>();
+
+        modifiedMetadata = false;
+
+        // Arrays to store the working information required
+        int[]     placeNum = new int[getMetadata().size()];
+        boolean[] storedDC = new boolean[getMetadata().size()];
+        MetadataField[] dcFields = new MetadataField[getMetadata().size()];
+
+        // Work out the place numbers for the in memory DC
+        for (int dcIdx = 0; dcIdx < getMetadata().size(); dcIdx++)
+        {
+            DCValue dcv = getMetadata().get(dcIdx);
+
+            // Work out the place number for ordering
+            int current = 0;
+
+            // Key into map is "element" or "element.qualifier"
+            String key = dcv.element + ((dcv.qualifier == null) ? "" : ("." + dcv.qualifier));
+
+            Integer currentInteger = elementCount.get(key);
+            if (currentInteger != null)
+            {
+                current = currentInteger.intValue();
+            }
+
+            current++;
+            elementCount.put(key, Integer.valueOf(current));
+
+            // Store the calculated place number, reset the stored flag, and cache the metadatafield
+            placeNum[dcIdx] = current;
+            storedDC[dcIdx] = false;
+            dcFields[dcIdx] = getMetadataField(dcv);
+            if (dcFields[dcIdx] == null)
+            {
+                // Bad DC field, log and throw exception
+                log.warn(LogManager
+                        .getHeader(ourContext, "bad_dc",
+                                "Bad DC field. schema=" + dcv.schema
+                                        + ", element: \""
+                                        + ((dcv.element == null) ? "null"
+                                        : dcv.element)
+                                        + "\" qualifier: \""
+                                        + ((dcv.qualifier == null) ? "null"
+                                        : dcv.qualifier)
+                                        + "\" value: \""
+                                        + ((dcv.value == null) ? "null"
+                                        : dcv.value) + "\""
+                        ));
+
+                throw new SQLException("bad_dublin_core "
+                        + "schema="+dcv.schema+", "
+                        + dcv.element
+                        + " " + dcv.qualifier);
+            }
+        }
+
+        // Now the precalculations are done, iterate through the existing metadata
+        // looking for matches
+        TableRowIterator tri = retrieveMetadata();
+        if (tri != null)
+        {
+            try
+            {
+                while (tri.hasNext())
+                {
+                    TableRow tr = tri.next();
+                    // Assume that we will remove this row, unless we get a match
+                    boolean removeRow = true;
+
+                    // Go through the in-memory metadata, unless we've already decided to keep this row
+                    for (int dcIdx = 0; dcIdx < getMetadata().size() && removeRow; dcIdx++)
+                    {
+                        // Only process if this metadata has not already been matched to something in the DB
+                        if (!storedDC[dcIdx])
+                        {
+                            boolean matched = true;
+                            DCValue dcv   = getMetadata().get(dcIdx);
+
+                            // Check the metadata field is the same
+                            if (matched && dcFields[dcIdx].getFieldID() != tr.getIntColumn("metadata_field_id"))
+                            {
+                                matched = false;
+                            }
+
+                            // Check the place is the same
+                            if (matched && placeNum[dcIdx] != tr.getIntColumn("place"))
+                            {
+                                matched = false;
+                            }
+
+                            // Check the text is the same
+                            if (matched)
+                            {
+                                String text = tr.getStringColumn("text_value");
+                                if (dcv.value == null && text == null)
+                                {
+                                    matched = true;
+                                }
+                                else if (dcv.value != null && dcv.value.equals(text))
+                                {
+                                    matched = true;
+                                }
+                                else
+                                {
+                                    matched = false;
+                                }
+                            }
+
+                            // Check the language is the same
+                            if (matched)
+                            {
+                                String lang = tr.getStringColumn("text_lang");
+                                if (dcv.language == null && lang == null)
+                                {
+                                    matched = true;
+                                }
+                                else if (dcv.language != null && dcv.language.equals(lang))
+                                {
+                                    matched = true;
+                                }
+                                else
+                                {
+                                    matched = false;
+                                }
+                            }
+
+                            // check that authority and confidence match
+                            if (matched)
+                            {
+                                String auth = tr.getStringColumn("authority");
+                                int conf = tr.getIntColumn("confidence");
+                                if (!((dcv.authority == null && auth == null) ||
+                                        (dcv.authority != null && auth != null && dcv.authority.equals(auth))
+                                                && dcv.confidence == conf))
+                                {
+                                    matched = false;
+                                }
+                            }
+
+                            // If the db record is identical to the in memory values
+                            if (matched)
+                            {
+                                // Flag that the metadata is already in the DB
+                                storedDC[dcIdx] = true;
+
+                                // Flag that we are not going to remove the row
+                                removeRow = false;
+                            }
+                        }
+                    }
+
+                    // If after processing all the metadata values, we didn't find a match
+                    // delete this row from the DB
+                    if (removeRow)
+                    {
+                        DatabaseManager.delete(ourContext, tr);
+                        modifiedMetadata = true;
+                    }
+                }
+            }
+            finally
+            {
+                tri.close();
+            }
+
+
+        }
+
+        // Add missing in-memory DC
+        for (int dcIdx = 0; dcIdx < getMetadata().size(); dcIdx++)
+        {
+            // Only write values that are not already in the db
+            if (!storedDC[dcIdx])
+            {
+                DCValue dcv = getMetadata().get(dcIdx);
+
+                // Write DCValue
+                MetadataValue metadata = new MetadataValue();
+                metadata.setResourceId(getID());
+                metadata.setResourceTypeId(getType());
+                metadata.setFieldId(dcFields[dcIdx].getFieldID());
+                metadata.setValue(dcv.value);
+                metadata.setLanguage(dcv.language);
+                metadata.setPlace(placeNum[dcIdx]);
+                metadata.setAuthority(dcv.authority);
+                metadata.setConfidence(dcv.confidence);
+                metadata.create(ourContext);
+                modifiedMetadata = true;
+            }
+        }
+
+        if(modifiedMetadata) {
+            ourContext.addEvent(new Event(Event.MODIFY_METADATA, getType(), getID(), getDetails(), getIdentifiers(ourContext)));
+            modifiedMetadata = false;
+        }
+    }
 
     /**
      * Reset the cache of event details.
@@ -242,4 +488,836 @@ public abstract class DSpaceObject
     public abstract void update() throws SQLException, AuthorizeException;
 
     public abstract void updateLastModified();
+
+    private TableRowIterator retrieveMetadata() throws SQLException
+    {
+        return DatabaseManager.queryTable(ourContext, "MetadataValue",
+                "SELECT * FROM MetadataValue WHERE resource_id= ? and resource_type_id = ? ORDER BY metadata_field_id, place",
+                getID(),
+                getType());
+    }
+
+    /**
+     * Get Dublin Core metadata for the DSpace Object.
+     * Passing in a <code>null</code> value for <code>qualifier</code>
+     * or <code>lang</code> only matches Dublin Core fields where that
+     * qualifier or languages is actually <code>null</code>.
+     * Passing in <code>DSpaceObject.ANY</code>
+     * retrieves all metadata fields with any value for the qualifier or
+     * language, including <code>null</code>
+     * <P>
+     * Examples:
+     * <P>
+     * Return values of the unqualified "title" field, in any language.
+     * Qualified title fields (e.g. "title.uniform") are NOT returned:
+     * <P>
+     * <code>dspaceobject.getDC( "title", null, DSpaceObject.ANY );</code>
+     * <P>
+     * Return all US English values of the "title" element, with any qualifier
+     * (including unqualified):
+     * <P>
+     * <code>dspaceobject.getDC( "title", DSpaceObject.ANY, "en_US" );</code>
+     * <P>
+     * The ordering of values of a particular element/qualifier/language
+     * combination is significant. When retrieving with wildcards, values of a
+     * particular element/qualifier/language combinations will be adjacent, but
+     * the overall ordering of the combinations is indeterminate.
+     *
+     * @param element
+     *            the Dublin Core element. <code>DSpaceObject.ANY</code> matches any
+     *            element. <code>null</code> doesn't really make sense as all
+     *            DC must have an element.
+     * @param qualifier
+     *            the qualifier. <code>null</code> means unqualified, and
+     *            <code>DSpaceObject.ANY</code> means any qualifier (including
+     *            unqualified.)
+     * @param lang
+     *            the ISO639 language code, optionally followed by an underscore
+     *            and the ISO3166 country code. <code>null</code> means only
+     *            values with no language are returned, and
+     *            <code>DSpaceObject.ANY</code> means values with any country code or
+     *            no country code are returned.
+     * @return Dublin Core fields that match the parameters
+     */
+    @Deprecated
+    public DCValue[] getDC(String element, String qualifier, String lang)
+    {
+        return getMetadata(MetadataSchema.DC_SCHEMA, element, qualifier, lang);
+    }
+
+    /**
+     * Get metadata for the DSpace Object in a chosen schema.
+     * See <code>MetadataSchema</code> for more information about schemas.
+     * Passing in a <code>null</code> value for <code>qualifier</code>
+     * or <code>lang</code> only matches metadata fields where that
+     * qualifier or languages is actually <code>null</code>.
+     * Passing in <code>DSpaceObject.ANY</code>
+     * retrieves all metadata fields with any value for the qualifier or
+     * language, including <code>null</code>
+     * <P>
+     * Examples:
+     * <P>
+     * Return values of the unqualified "title" field, in any language.
+     * Qualified title fields (e.g. "title.uniform") are NOT returned:
+     * <P>
+     * <code>dspaceobject.getMetadataByMetadataString("dc", "title", null, DSpaceObject.ANY );</code>
+     * <P>
+     * Return all US English values of the "title" element, with any qualifier
+     * (including unqualified):
+     * <P>
+     * <code>dspaceobject.getMetadataByMetadataString("dc, "title", DSpaceObject.ANY, "en_US" );</code>
+     * <P>
+     * The ordering of values of a particular element/qualifier/language
+     * combination is significant. When retrieving with wildcards, values of a
+     * particular element/qualifier/language combinations will be adjacent, but
+     * the overall ordering of the combinations is indeterminate.
+     *
+     * @param schema
+     *            the schema for the metadata field. <em>Must</em> match
+     *            the <code>name</code> of an existing metadata schema.
+     * @param element
+     *            the element name. <code>DSpaceObject.ANY</code> matches any
+     *            element. <code>null</code> doesn't really make sense as all
+     *            metadata must have an element.
+     * @param qualifier
+     *            the qualifier. <code>null</code> means unqualified, and
+     *            <code>DSpaceObject.ANY</code> means any qualifier (including
+     *            unqualified.)
+     * @param lang
+     *            the ISO639 language code, optionally followed by an underscore
+     *            and the ISO3166 country code. <code>null</code> means only
+     *            values with no language are returned, and
+     *            <code>DSpaceObject.ANY</code> means values with any country code or
+     *            no country code are returned.
+     * @return metadata fields that match the parameters
+     */
+    public DCValue[] getMetadata(String schema, String element, String qualifier,
+                                 String lang)
+    {
+        // Build up list of matching values
+        List<DCValue> values = new ArrayList<DCValue>();
+        for (DCValue dcv : getMetadata())
+        {
+            if (match(schema, element, qualifier, lang, dcv))
+            {
+                // We will return a copy of the object in case it is altered
+                DCValue copy = new DCValue();
+                copy.element = dcv.element;
+                copy.qualifier = dcv.qualifier;
+                copy.value = dcv.value;
+                copy.language = dcv.language;
+                copy.schema = dcv.schema;
+                copy.authority = dcv.authority;
+                copy.confidence = dcv.confidence;
+                values.add(copy);
+            }
+        }
+
+        // Create an array of matching values
+        DCValue[] valueArray = new DCValue[values.size()];
+        valueArray = (DCValue[]) values.toArray(valueArray);
+
+        return valueArray;
+    }
+
+    /**
+     * Retrieve metadata field values from a given metadata string
+     * of the form <schema prefix>.<element>[.<qualifier>|.*]
+     *
+     * @param mdString
+     *            The metadata string of the form
+     *            <schema prefix>.<element>[.<qualifier>|.*]
+     */
+    public DCValue[] getMetadataByMetadataString(String mdString)
+    {
+        StringTokenizer dcf = new StringTokenizer(mdString, ".");
+
+        String[] tokens = { "", "", "" };
+        int i = 0;
+        while(dcf.hasMoreTokens())
+        {
+            tokens[i] = dcf.nextToken().trim();
+            i++;
+        }
+        String schema = tokens[0];
+        String element = tokens[1];
+        String qualifier = tokens[2];
+
+        DCValue[] values;
+        if ("*".equals(qualifier))
+        {
+            values = getMetadata(schema, element, Item.ANY, Item.ANY);
+        }
+        else if ("".equals(qualifier))
+        {
+            values = getMetadata(schema, element, null, Item.ANY);
+        }
+        else
+        {
+            values = getMetadata(schema, element, qualifier, Item.ANY);
+        }
+
+        return values;
+    }
+
+    /**
+     * Retrieve first metadata field value
+     */
+    protected String getMetadataFirstValue(String schema, String element, String qualifier, String language){
+        DCValue[] dcvalues = getMetadata(schema, element, qualifier, Item.ANY);
+        if(dcvalues.length>0){
+            return dcvalues[0].value;
+        }
+        return null;
+    }
+
+    /**
+     * Set first metadata field value
+     */
+    protected void setMetadataSingleValue(String schema, String element, String qualifier, String language, String value) {
+        if(value != null)
+        {
+            clearMetadata(schema, element, qualifier, language);
+            addMetadata(schema, element, qualifier, language, value);
+            modifiedMetadata = true;
+        }
+    }
+
+    protected List<DCValue> getMetadata()
+    {
+        try
+        {
+            return metadataCache.get(ourContext, getID(), getType(), log);
+        }
+        catch (SQLException e)
+        {
+            log.error("Loading item - cannot load metadata");
+        }
+
+        return new ArrayList<DCValue>();
+    }
+
+    /**
+     * Get the value of a metadata field
+     *
+     * @param value
+     *            the name of the metadata field to get
+     *
+     * @return the value of the metadata field (or null if the column is an SQL NULL)
+     *
+     * @exception IllegalArgumentException
+     *                if the requested metadata field doesn't exist
+     */
+    public String getMetadata(String value){
+        DCValue[] dcvalues = getMetadataByMetadataString(value);
+
+        if(dcvalues.length>0) {
+            return dcvalues[0].toString();
+        }
+        return null;
+    }
+
+    /**
+     * Add Dublin Core metadata fields. These are appended to existing values.
+     * Use <code>clearDC</code> to remove values. The ordering of values
+     * passed in is maintained.
+     *
+     * @param element
+     *            the Dublin Core element
+     * @param qualifier
+     *            the Dublin Core qualifier, or <code>null</code> for
+     *            unqualified
+     * @param lang
+     *            the ISO639 language code, optionally followed by an underscore
+     *            and the ISO3166 country code. <code>null</code> means the
+     *            value has no language (for example, a date).
+     * @param values
+     *            the values to add.
+     */
+    @Deprecated
+    public void addDC(String element, String qualifier, String lang,
+                      String[] values)
+    {
+        addMetadata(MetadataSchema.DC_SCHEMA, element, qualifier, lang, values);
+    }
+
+    /**
+     * Add a single Dublin Core metadata field. This is appended to existing
+     * values. Use <code>clearDC</code> to remove values.
+     *
+     * @param element
+     *            the Dublin Core element
+     * @param qualifier
+     *            the Dublin Core qualifier, or <code>null</code> for
+     *            unqualified
+     * @param lang
+     *            the ISO639 language code, optionally followed by an underscore
+     *            and the ISO3166 country code. <code>null</code> means the
+     *            value has no language (for example, a date).
+     * @param value
+     *            the value to add.
+     */
+    @Deprecated
+    public void addDC(String element, String qualifier, String lang,
+                      String value)
+    {
+        addMetadata(MetadataSchema.DC_SCHEMA, element, qualifier, lang, value);
+    }
+
+    /**
+     * Add metadata fields. These are appended to existing values.
+     * Use <code>clearDC</code> to remove values. The ordering of values
+     * passed in is maintained.
+     * <p>
+     * If metadata authority control is available, try to get authority
+     * values.  The authority confidence depends on whether authority is
+     * <em>required</em> or not.
+     * @param schema
+     *            the schema for the metadata field. <em>Must</em> match
+     *            the <code>name</code> of an existing metadata schema.
+     * @param element
+     *            the metadata element name
+     * @param qualifier
+     *            the metadata qualifier name, or <code>null</code> for
+     *            unqualified
+     * @param lang
+     *            the ISO639 language code, optionally followed by an underscore
+     *            and the ISO3166 country code. <code>null</code> means the
+     *            value has no language (for example, a date).
+     * @param values
+     *            the values to add.
+     */
+    public void addMetadata(String schema, String element, String qualifier, String lang,
+                            String[] values)
+    {
+        MetadataAuthorityManager mam = MetadataAuthorityManager.getManager();
+        String fieldKey = MetadataAuthorityManager.makeFieldKey(schema, element, qualifier);
+        if (mam.isAuthorityControlled(fieldKey))
+        {
+            String authorities[] = new String[values.length];
+            int confidences[] = new int[values.length];
+            for (int i = 0; i < values.length; ++i)
+            {
+                getAuthoritiesAndConfidences(fieldKey, values, authorities, confidences, i);
+            }
+            addMetadata(schema, element, qualifier, lang, values, authorities, confidences);
+        }
+        else
+        {
+            addMetadata(schema, element, qualifier, lang, values, null, null);
+        }
+    }
+
+    protected void getAuthoritiesAndConfidences(String fieldKey, String[] values, String[] authorities, int[] confidences, int i) {
+        Choices c = ChoiceAuthorityManager.getManager().getBestMatch(fieldKey, values[i], -1, null);
+        authorities[i] = c.values.length > 0 ? c.values[0].authority : null;
+        confidences[i] = c.confidence;
+    }
+
+    /**
+     * Add metadata fields. These are appended to existing values.
+     * Use <code>clearDC</code> to remove values. The ordering of values
+     * passed in is maintained.
+     * @param schema
+     *            the schema for the metadata field. <em>Must</em> match
+     *            the <code>name</code> of an existing metadata schema.
+     * @param element
+     *            the metadata element name
+     * @param qualifier
+     *            the metadata qualifier name, or <code>null</code> for
+     *            unqualified
+     * @param lang
+     *            the ISO639 language code, optionally followed by an underscore
+     *            and the ISO3166 country code. <code>null</code> means the
+     *            value has no language (for example, a date).
+     * @param values
+     *            the values to add.
+     * @param authorities
+     *            the external authority key for this value (or null)
+     * @param confidences
+     *            the authority confidence (default 0)
+     */
+    public void addMetadata(String schema, String element, String qualifier, String lang,
+                            String[] values, String authorities[], int confidences[])
+    {
+        List<DCValue> dublinCore = getMetadata();
+        MetadataAuthorityManager mam = MetadataAuthorityManager.getManager();
+        boolean authorityControlled = mam.isAuthorityControlled(schema, element, qualifier);
+        boolean authorityRequired = mam.isAuthorityRequired(schema, element, qualifier);
+        String fieldName = schema+"."+element+((qualifier==null)? "": "."+qualifier);
+
+        // We will not verify that they are valid entries in the registry
+        // until update() is called.
+        for (int i = 0; i < values.length; i++)
+        {
+            DCValue dcv = new DCValue();
+            dcv.schema = schema;
+            dcv.element = element;
+            dcv.qualifier = qualifier;
+            dcv.language = (lang == null ? null : lang.trim());
+
+            // Logic to set Authority and Confidence:
+            //  - normalize an empty string for authority to NULL.
+            //  - if authority key is present, use given confidence or NOVALUE if not given
+            //  - otherwise, preserve confidence if meaningful value was given since it may document a failed authority lookup
+            //  - CF_UNSET signifies no authority nor meaningful confidence.
+            //  - it's possible to have empty authority & CF_ACCEPTED if e.g. user deletes authority key
+            if (authorityControlled)
+            {
+                if (authorities != null && authorities[i] != null && authorities[i].length() > 0)
+                {
+                    dcv.authority = authorities[i];
+                    dcv.confidence = confidences == null ? Choices.CF_NOVALUE : confidences[i];
+                }
+                else
+                {
+                    dcv.authority = null;
+                    dcv.confidence = confidences == null ? Choices.CF_UNSET : confidences[i];
+                }
+                // authority sanity check: if authority is required, was it supplied?
+                // XXX FIXME? can't throw a "real" exception here without changing all the callers to expect it, so use a runtime exception
+                if (authorityRequired && (dcv.authority == null || dcv.authority.length() == 0))
+                {
+                    throw new IllegalArgumentException("The metadata field \"" + fieldName + "\" requires an authority key but none was provided. Vaue=\"" + dcv.value + "\"");
+                }
+            }
+            if (values[i] != null)
+            {
+                // remove control unicode char
+                String temp = values[i].trim();
+                char[] dcvalue = temp.toCharArray();
+                for (int charPos = 0; charPos < dcvalue.length; charPos++)
+                {
+                    if (Character.isISOControl(dcvalue[charPos]) &&
+                            !String.valueOf(dcvalue[charPos]).equals("\u0009") &&
+                            !String.valueOf(dcvalue[charPos]).equals("\n") &&
+                            !String.valueOf(dcvalue[charPos]).equals("\r"))
+                    {
+                        dcvalue[charPos] = ' ';
+                    }
+                }
+                dcv.value = String.valueOf(dcvalue);
+            }
+            else
+            {
+                dcv.value = null;
+            }
+            dublinCore.add(dcv);
+            addDetails(fieldName);
+        }
+
+        if (values.length > 0)
+        {
+            modifiedMetadata = true;
+        }
+    }
+
+    /**
+     * Add a single metadata field. This is appended to existing
+     * values. Use <code>clearDC</code> to remove values.
+     *
+     * @param schema
+     *            the schema for the metadata field. <em>Must</em> match
+     *            the <code>name</code> of an existing metadata schema.
+     * @param element
+     *            the metadata element name
+     * @param qualifier
+     *            the metadata qualifier, or <code>null</code> for
+     *            unqualified
+     * @param lang
+     *            the ISO639 language code, optionally followed by an underscore
+     *            and the ISO3166 country code. <code>null</code> means the
+     *            value has no language (for example, a date).
+     * @param value
+     *            the value to add.
+     */
+    public void addMetadata(String schema, String element, String qualifier,
+                            String lang, String value)
+    {
+        String[] valArray = new String[1];
+        valArray[0] = value;
+
+        addMetadata(schema, element, qualifier, lang, valArray);
+    }
+
+    /**
+     * Add a single metadata field. This is appended to existing
+     * values. Use <code>clearDC</code> to remove values.
+     *
+     * @param schema
+     *            the schema for the metadata field. <em>Must</em> match
+     *            the <code>name</code> of an existing metadata schema.
+     * @param element
+     *            the metadata element name
+     * @param qualifier
+     *            the metadata qualifier, or <code>null</code> for
+     *            unqualified
+     * @param lang
+     *            the ISO639 language code, optionally followed by an underscore
+     *            and the ISO3166 country code. <code>null</code> means the
+     *            value has no language (for example, a date).
+     * @param value
+     *            the value to add.
+     * @param authority
+     *            the external authority key for this value (or null)
+     * @param confidence
+     *            the authority confidence (default 0)
+     */
+    public void addMetadata(String schema, String element, String qualifier,
+                            String lang, String value, String authority, int confidence)
+    {
+        String[] valArray = new String[1];
+        String[] authArray = new String[1];
+        int[] confArray = new int[1];
+        valArray[0] = value;
+        authArray[0] = authority;
+        confArray[0] = confidence;
+
+        addMetadata(schema, element, qualifier, lang, valArray, authArray, confArray);
+    }
+
+    /**
+     * Clear Dublin Core metadata values. As with <code>getDC</code> above,
+     * passing in <code>null</code> only matches fields where the qualifier or
+     * language is actually <code>null</code>.<code>Item.ANY</code> will
+     * match any element, qualifier or language, including <code>null</code>.
+     * Thus, <code>idspaceobject.clearDC(DSpaceObject.ANY, DSpaceObject.ANY, DSpaceObject.ANY)</code> will
+     * remove all Dublin Core metadata associated with an DSpaceObject.
+     *
+     * @param element
+     *            the Dublin Core element to remove, or <code>Item.ANY</code>
+     * @param qualifier
+     *            the qualifier. <code>null</code> means unqualified, and
+     *            <code>Item.ANY</code> means any qualifier (including
+     *            unqualified.)
+     * @param lang
+     *            the ISO639 language code, optionally followed by an underscore
+     *            and the ISO3166 country code. <code>null</code> means only
+     *            values with no language are removed, and <code>Item.ANY</code>
+     *            means values with any country code or no country code are
+     *            removed.
+     */
+    @Deprecated
+    public void clearDC(String element, String qualifier, String lang)
+    {
+        clearMetadata(MetadataSchema.DC_SCHEMA, element, qualifier, lang);
+    }
+
+    /**
+     * Clear metadata values. As with <code>getDC</code> above,
+     * passing in <code>null</code> only matches fields where the qualifier or
+     * language is actually <code>null</code>.<code>Item.ANY</code> will
+     * match any element, qualifier or language, including <code>null</code>.
+     * Thus, <code>dspaceobject.clearDC(Item.ANY, Item.ANY, Item.ANY)</code> will
+     * remove all Dublin Core metadata associated with an DSpaceObject.
+     *
+     * @param schema
+     *            the schema for the metadata field. <em>Must</em> match
+     *            the <code>name</code> of an existing metadata schema.
+     * @param element
+     *            the Dublin Core element to remove, or <code>Item.ANY</code>
+     * @param qualifier
+     *            the qualifier. <code>null</code> means unqualified, and
+     *            <code>Item.ANY</code> means any qualifier (including
+     *            unqualified.)
+     * @param lang
+     *            the ISO639 language code, optionally followed by an underscore
+     *            and the ISO3166 country code. <code>null</code> means only
+     *            values with no language are removed, and <code>Item.ANY</code>
+     *            means values with any country code or no country code are
+     *            removed.
+     */
+    public void clearMetadata(String schema, String element, String qualifier,
+                              String lang)
+    {
+        // We will build a list of values NOT matching the values to clear
+        List<DCValue> values = new ArrayList<DCValue>();
+        for (DCValue dcv : getMetadata())
+        {
+            if (!match(schema, element, qualifier, lang, dcv))
+            {
+                values.add(dcv);
+            }
+        }
+
+        // Now swap the old list of values for the new, unremoved values
+        setMetadata(values);
+        modifiedMetadata = true;
+    }
+
+    /**
+     * Utility method for pattern-matching metadata elements.  This
+     * method will return <code>true</code> if the given schema,
+     * element, qualifier and language match the schema, element,
+     * qualifier and language of the <code>DCValue</code> object passed
+     * in.  Any or all of the element, qualifier and language passed
+     * in can be the <code>Item.ANY</code> wildcard.
+     *
+     * @param schema
+     *            the schema for the metadata field. <em>Must</em> match
+     *            the <code>name</code> of an existing metadata schema.
+     * @param element
+     *            the element to match, or <code>Item.ANY</code>
+     * @param qualifier
+     *            the qualifier to match, or <code>Item.ANY</code>
+     * @param language
+     *            the language to match, or <code>Item.ANY</code>
+     * @param dcv
+     *            the Dublin Core value
+     * @return <code>true</code> if there is a match
+     */
+    private boolean match(String schema, String element, String qualifier,
+                          String language, DCValue dcv)
+    {
+        // We will attempt to disprove a match - if we can't we have a match
+        if (!element.equals(Item.ANY) && !element.equals(dcv.element))
+        {
+            // Elements do not match, no wildcard
+            return false;
+        }
+
+        if (qualifier == null)
+        {
+            // Value must be unqualified
+            if (dcv.qualifier != null)
+            {
+                // Value is qualified, so no match
+                return false;
+            }
+        }
+        else if (!qualifier.equals(Item.ANY))
+        {
+            // Not a wildcard, so qualifier must match exactly
+            if (!qualifier.equals(dcv.qualifier))
+            {
+                return false;
+            }
+        }
+
+        if (language == null)
+        {
+            // Value must be null language to match
+            if (dcv.language != null)
+            {
+                // Value is qualified, so no match
+                return false;
+            }
+        }
+        else if (!language.equals(Item.ANY))
+        {
+            // Not a wildcard, so language must match exactly
+            if (!language.equals(dcv.language))
+            {
+                return false;
+            }
+        }
+
+        if (!schema.equals(Item.ANY))
+        {
+            if (dcv.schema != null && !dcv.schema.equals(schema))
+            {
+                // The namespace doesn't match
+                return false;
+            }
+        }
+
+        // If we get this far, we have a match
+        return true;
+    }
+
+    protected transient MetadataField[] allMetadataFields = null;
+    protected MetadataField getMetadataField(DCValue dcv) throws SQLException, AuthorizeException
+    {
+        if (allMetadataFields == null)
+        {
+            allMetadataFields = MetadataField.findAll(ourContext);
+        }
+
+        if (allMetadataFields != null)
+        {
+            int schemaID = getMetadataSchemaID(dcv);
+            for (MetadataField field : allMetadataFields)
+            {
+                if (field.getSchemaID() == schemaID &&
+                        StringUtils.equals(field.getElement(), dcv.element) &&
+                        StringUtils.equals(field.getQualifier(), dcv.qualifier))
+                {
+                    return field;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private int getMetadataSchemaID(DCValue dcv) throws SQLException
+    {
+        int schemaID;
+        MetadataSchema schema = MetadataSchema.find(ourContext,dcv.schema);
+        if (schema == null)
+        {
+            schemaID = MetadataSchema.DC_SCHEMA_ID;
+        }
+        else
+        {
+            schemaID = schema.getSchemaID();
+        }
+        return schemaID;
+    }
+
+    /**
+     * Utility method to remove all descriptive metadata associated with the DSpaceObject from
+     * the database (regardless of in-memory version)
+     *
+     * @throws SQLException
+     */
+    protected void removeMetadataFromDatabase() throws SQLException
+    {
+        DatabaseManager.updateQuery(ourContext,
+                "DELETE FROM MetadataValue WHERE resource_id= ? and resource_type_id=?",
+                getID(),
+                getType());
+    }
+
+    private void setMetadata(List<DCValue> metadata)
+    {
+        metadataCache.set(metadata);
+        modifiedMetadata = true;
+    }
+
+    class MetadataCache
+    {
+        List<DCValue> metadata = null;
+
+        List<DCValue> get(Context c, int resourceId, int resourceTypeId, Logger log) throws SQLException
+        {
+            if (metadata == null)
+            {
+                metadata = new ArrayList<DCValue>();
+
+                // Get Dublin Core metadata
+                TableRowIterator tri = retrieveMetadata(resourceId, resourceTypeId);
+
+                if (tri != null)
+                {
+                    try
+                    {
+                        while (tri.hasNext())
+                        {
+                            TableRow resultRow = tri.next();
+
+                            // Get the associated metadata field and schema information
+                            int fieldID = resultRow.getIntColumn("metadata_field_id");
+                            MetadataField field = MetadataField.find(c, fieldID);
+
+                            if (field == null)
+                            {
+                                log.error("Loading item - cannot find metadata field " + fieldID);
+                            }
+                            else
+                            {
+                                MetadataSchema schema = MetadataSchema.find(c, field.getSchemaID());
+                                if (schema == null)
+                                {
+                                    log.error("Loading item - cannot find metadata schema " + field.getSchemaID() + ", field " + fieldID);
+                                }
+                                else
+                                {
+                                    // Make a DCValue object
+                                    DCValue dcv = new DCValue();
+                                    dcv.element = field.getElement();
+                                    dcv.qualifier = field.getQualifier();
+                                    dcv.value = resultRow.getStringColumn("text_value");
+                                    dcv.language = resultRow.getStringColumn("text_lang");
+                                    //dcv.namespace = schema.getNamespace();
+                                    dcv.schema = schema.getName();
+                                    dcv.authority = resultRow.getStringColumn("authority");
+                                    dcv.confidence = resultRow.getIntColumn("confidence");
+
+                                    // Add it to the list
+                                    metadata.add(dcv);
+                                }
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        // close the TableRowIterator to free up resources
+                        if (tri != null)
+                        {
+                            tri.close();
+                        }
+                    }
+                }
+            }
+
+            return metadata;
+        }
+
+        void set(List<DCValue> m)
+        {
+            metadata = m;
+        }
+
+        TableRowIterator retrieveMetadata(int resourceId, int resourceTypeId) throws SQLException
+        {
+            return DatabaseManager.queryTable(ourContext, "MetadataValue",
+                    "SELECT * FROM MetadataValue WHERE resource_id= ? and resource_type_id = ? ORDER BY metadata_field_id, place",
+                    resourceId,
+                    resourceTypeId);
+        }
+    }
+
+    protected String[] getMDValueByField(String field){
+        StringTokenizer dcf = new StringTokenizer(field, ".");
+
+        String[] tokens = { "", "", "" };
+        int i = 0;
+        while(dcf.hasMoreTokens()){
+            tokens[i] = dcf.nextToken().trim();
+            i++;
+        }
+
+        if(i!=0){
+            return tokens;
+        }else{
+            return getMDValueByLegacyField(field);
+        }
+    }
+
+    protected String[] getMDValueByLegacyField(String field){
+        switch (field) {
+            case "introductory_text":
+                return new String[]{MetadataSchema.DC_SCHEMA, "description", null};
+            case "short_description":
+                return new String[]{MetadataSchema.DC_SCHEMA, "description", "abstract"};
+            case "side_bar_text":
+                return new String[]{MetadataSchema.DC_SCHEMA, "description", "tableofcontents"};
+            case "copyright_text":
+                return new String[]{MetadataSchema.DC_SCHEMA, "rights", null};
+            case "name":
+                return new String[]{MetadataSchema.DC_SCHEMA, "title", null};
+            case "provenance_description":
+                return new String[]{MetadataSchema.DC_SCHEMA,"provenance", null};
+            case "license":
+                return new String[]{MetadataSchema.DC_SCHEMA, "rights", "license"};
+            case "user_format_description":
+                return new String[]{MetadataSchema.DC_SCHEMA,"format",null};
+            case "source":
+                return new String[]{MetadataSchema.DC_SCHEMA,"source",null};
+            case "firstname":
+                return new String[]{"eperson","firstname",null};
+            case "lastname":
+                return new String[]{"eperson","lastname",null};
+            case "phone":
+                return new String[]{"eperson","phone",null};
+            case "netid":
+                return new String[]{"eperson","netid",null};
+            case "language":
+                return new String[]{"eperson","language",null};
+            default:
+                return new String[]{null, null, null};
+        }
+    }
+    
 }

--- a/dspace-api/src/main/java/org/dspace/content/Item.java
+++ b/dspace-api/src/main/java/org/dspace/content/Item.java
@@ -14,12 +14,8 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.StringTokenizer;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.dspace.app.util.AuthorizeUtil;
 import org.dspace.authorize.AuthorizeConfiguration;
@@ -33,7 +29,6 @@ import org.dspace.core.Context;
 import org.dspace.core.LogManager;
 import org.dspace.content.authority.Choices;
 import org.dspace.content.authority.ChoiceAuthorityManager;
-import org.dspace.content.authority.MetadataAuthorityManager;
 import org.dspace.event.Event;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
@@ -70,9 +65,6 @@ public class Item extends DSpaceObject
     /** log4j category */
     private static final Logger log = Logger.getLogger(Item.class);
 
-    /** Our context */
-    private Context ourContext;
-
     /** The table row corresponding to this item */
     private TableRow itemRow;
 
@@ -82,17 +74,9 @@ public class Item extends DSpaceObject
     /** The bundles in this item - kept in sync with DB */
     private List<Bundle> bundles;
 
-    /** The Dublin Core metadata - inner class for lazy loading */
-    MetadataCache dublinCore = new MetadataCache();
 
     /** Handle, if any */
     private String handle;
-
-    /**
-     * True if the Dublin Core has changed since reading from the DB or the last
-     * update()
-     */
-    private boolean dublinCoreChanged;
 
     /**
      * True if anything else was changed since last update()
@@ -111,9 +95,8 @@ public class Item extends DSpaceObject
      */
     Item(Context context, TableRow row) throws SQLException
     {
-        ourContext = context;
+        super(context);
         itemRow = row;
-        dublinCoreChanged = false;
         modified = false;
         clearDetails();
 
@@ -124,12 +107,6 @@ public class Item extends DSpaceObject
         context.cache(this, row.getIntColumn("item_id"));
     }
 
-    private TableRowIterator retrieveMetadata() throws SQLException
-    {
-        return DatabaseManager.queryTable(ourContext, "MetadataValue",
-                "SELECT * FROM MetadataValue WHERE item_id= ? ORDER BY metadata_field_id, place",
-                itemRow.getIntColumn("item_id"));
-    }
 
     /**
      * Get an item from the database. The item, its Dublin Core metadata, and
@@ -423,573 +400,6 @@ public class Item extends DSpaceObject
     private int getOwningCollectionID()
     {
         return itemRow.getIntColumn("owning_collection");
-    }
-
-    /**
-     * Get Dublin Core metadata for the item.
-     * Passing in a <code>null</code> value for <code>qualifier</code>
-     * or <code>lang</code> only matches Dublin Core fields where that
-     * qualifier or languages is actually <code>null</code>.
-     * Passing in <code>Item.ANY</code>
-     * retrieves all metadata fields with any value for the qualifier or
-     * language, including <code>null</code>
-     * <P>
-     * Examples:
-     * <P>
-     * Return values of the unqualified "title" field, in any language.
-     * Qualified title fields (e.g. "title.uniform") are NOT returned:
-     * <P>
-     * <code>item.getDC( "title", null, Item.ANY );</code>
-     * <P>
-     * Return all US English values of the "title" element, with any qualifier
-     * (including unqualified):
-     * <P>
-     * <code>item.getDC( "title", Item.ANY, "en_US" );</code>
-     * <P>
-     * The ordering of values of a particular element/qualifier/language
-     * combination is significant. When retrieving with wildcards, values of a
-     * particular element/qualifier/language combinations will be adjacent, but
-     * the overall ordering of the combinations is indeterminate.
-     *
-     * @param element
-     *            the Dublin Core element. <code>Item.ANY</code> matches any
-     *            element. <code>null</code> doesn't really make sense as all
-     *            DC must have an element.
-     * @param qualifier
-     *            the qualifier. <code>null</code> means unqualified, and
-     *            <code>Item.ANY</code> means any qualifier (including
-     *            unqualified.)
-     * @param lang
-     *            the ISO639 language code, optionally followed by an underscore
-     *            and the ISO3166 country code. <code>null</code> means only
-     *            values with no language are returned, and
-     *            <code>Item.ANY</code> means values with any country code or
-     *            no country code are returned.
-     * @return Dublin Core fields that match the parameters
-     */
-    @Deprecated
-    public DCValue[] getDC(String element, String qualifier, String lang)
-    {
-        return getMetadata(MetadataSchema.DC_SCHEMA, element, qualifier, lang);
-    }
-
-    /**
-     * Get metadata for the item in a chosen schema.
-     * See <code>MetadataSchema</code> for more information about schemas.
-     * Passing in a <code>null</code> value for <code>qualifier</code>
-     * or <code>lang</code> only matches metadata fields where that
-     * qualifier or languages is actually <code>null</code>.
-     * Passing in <code>Item.ANY</code>
-     * retrieves all metadata fields with any value for the qualifier or
-     * language, including <code>null</code>
-     * <P>
-     * Examples:
-     * <P>
-     * Return values of the unqualified "title" field, in any language.
-     * Qualified title fields (e.g. "title.uniform") are NOT returned:
-     * <P>
-     * <code>item.getMetadata("dc", "title", null, Item.ANY );</code>
-     * <P>
-     * Return all US English values of the "title" element, with any qualifier
-     * (including unqualified):
-     * <P>
-     * <code>item.getMetadata("dc, "title", Item.ANY, "en_US" );</code>
-     * <P>
-     * The ordering of values of a particular element/qualifier/language
-     * combination is significant. When retrieving with wildcards, values of a
-     * particular element/qualifier/language combinations will be adjacent, but
-     * the overall ordering of the combinations is indeterminate.
-     *
-     * @param schema
-     *            the schema for the metadata field. <em>Must</em> match
-     *            the <code>name</code> of an existing metadata schema.
-     * @param element
-     *            the element name. <code>Item.ANY</code> matches any
-     *            element. <code>null</code> doesn't really make sense as all
-     *            metadata must have an element.
-     * @param qualifier
-     *            the qualifier. <code>null</code> means unqualified, and
-     *            <code>Item.ANY</code> means any qualifier (including
-     *            unqualified.)
-     * @param lang
-     *            the ISO639 language code, optionally followed by an underscore
-     *            and the ISO3166 country code. <code>null</code> means only
-     *            values with no language are returned, and
-     *            <code>Item.ANY</code> means values with any country code or
-     *            no country code are returned.
-     * @return metadata fields that match the parameters
-     */
-    public DCValue[] getMetadata(String schema, String element, String qualifier,
-            String lang)
-    {
-        // Build up list of matching values
-        List<DCValue> values = new ArrayList<DCValue>();
-        for (DCValue dcv : getMetadata())
-        {
-            if (match(schema, element, qualifier, lang, dcv))
-            {
-                // We will return a copy of the object in case it is altered
-                DCValue copy = new DCValue();
-                copy.element = dcv.element;
-                copy.qualifier = dcv.qualifier;
-                copy.value = dcv.value;
-                copy.language = dcv.language;
-                copy.schema = dcv.schema;
-                copy.authority = dcv.authority;
-                copy.confidence = dcv.confidence;
-                values.add(copy);
-            }
-        }
-
-        // Create an array of matching values
-        DCValue[] valueArray = new DCValue[values.size()];
-        valueArray = (DCValue[]) values.toArray(valueArray);
-
-        return valueArray;
-    }
-    
-    /**
-     * Retrieve metadata field values from a given metadata string
-     * of the form <schema prefix>.<element>[.<qualifier>|.*]
-     *
-     * @param mdString
-     *            The metadata string of the form
-     *            <schema prefix>.<element>[.<qualifier>|.*]
-     */
-    public DCValue[] getMetadata(String mdString)
-    {
-        StringTokenizer dcf = new StringTokenizer(mdString, ".");
-        
-        String[] tokens = { "", "", "" };
-        int i = 0;
-        while(dcf.hasMoreTokens())
-        {
-            tokens[i] = dcf.nextToken().trim();
-            i++;
-        }
-        String schema = tokens[0];
-        String element = tokens[1];
-        String qualifier = tokens[2];
-        
-        DCValue[] values;
-        if ("*".equals(qualifier))
-        {
-            values = getMetadata(schema, element, Item.ANY, Item.ANY);
-        }
-        else if ("".equals(qualifier))
-        {
-            values = getMetadata(schema, element, null, Item.ANY);
-        }
-        else
-        {
-            values = getMetadata(schema, element, qualifier, Item.ANY);
-        }
-        
-        return values;
-    }
-
-    /**
-     * Add Dublin Core metadata fields. These are appended to existing values.
-     * Use <code>clearDC</code> to remove values. The ordering of values
-     * passed in is maintained.
-     *
-     * @param element
-     *            the Dublin Core element
-     * @param qualifier
-     *            the Dublin Core qualifier, or <code>null</code> for
-     *            unqualified
-     * @param lang
-     *            the ISO639 language code, optionally followed by an underscore
-     *            and the ISO3166 country code. <code>null</code> means the
-     *            value has no language (for example, a date).
-     * @param values
-     *            the values to add.
-     */
-    @Deprecated
-    public void addDC(String element, String qualifier, String lang,
-            String[] values)
-    {
-        addMetadata(MetadataSchema.DC_SCHEMA, element, qualifier, lang, values);
-    }
-
-    /**
-     * Add a single Dublin Core metadata field. This is appended to existing
-     * values. Use <code>clearDC</code> to remove values.
-     *
-     * @param element
-     *            the Dublin Core element
-     * @param qualifier
-     *            the Dublin Core qualifier, or <code>null</code> for
-     *            unqualified
-     * @param lang
-     *            the ISO639 language code, optionally followed by an underscore
-     *            and the ISO3166 country code. <code>null</code> means the
-     *            value has no language (for example, a date).
-     * @param value
-     *            the value to add.
-     */
-    @Deprecated
-    public void addDC(String element, String qualifier, String lang,
-            String value)
-    {
-        addMetadata(MetadataSchema.DC_SCHEMA, element, qualifier, lang, value);
-    }
-    
-    /**
-     * Add metadata fields. These are appended to existing values.
-     * Use <code>clearDC</code> to remove values. The ordering of values
-     * passed in is maintained.
-     * <p>
-     * If metadata authority control is available, try to get authority
-     * values.  The authority confidence depends on whether authority is
-     * <em>required</em> or not.
-     * @param schema
-     *            the schema for the metadata field. <em>Must</em> match
-     *            the <code>name</code> of an existing metadata schema.
-     * @param element
-     *            the metadata element name
-     * @param qualifier
-     *            the metadata qualifier name, or <code>null</code> for
-     *            unqualified
-     * @param lang
-     *            the ISO639 language code, optionally followed by an underscore
-     *            and the ISO3166 country code. <code>null</code> means the
-     *            value has no language (for example, a date).
-     * @param values
-     *            the values to add.
-     */
-    public void addMetadata(String schema, String element, String qualifier, String lang,
-            String[] values)
-    {
-        MetadataAuthorityManager mam = MetadataAuthorityManager.getManager();
-        String fieldKey = MetadataAuthorityManager.makeFieldKey(schema, element, qualifier);
-        if (mam.isAuthorityControlled(fieldKey))
-        {
-            String authorities[] = new String[values.length];
-            int confidences[] = new int[values.length];
-            for (int i = 0; i < values.length; ++i)
-            {
-                Choices c = ChoiceAuthorityManager.getManager().getBestMatch(fieldKey, values[i], getOwningCollectionID(), null);
-                authorities[i] = c.values.length > 0 ? c.values[0].authority : null;
-                confidences[i] = c.confidence;
-            }
-            addMetadata(schema, element, qualifier, lang, values, authorities, confidences);
-        }
-        else
-        {
-            addMetadata(schema, element, qualifier, lang, values, null, null);
-        }
-    }
-
-    /**
-     * Add metadata fields. These are appended to existing values.
-     * Use <code>clearDC</code> to remove values. The ordering of values
-     * passed in is maintained.
-     * @param schema
-     *            the schema for the metadata field. <em>Must</em> match
-     *            the <code>name</code> of an existing metadata schema.
-     * @param element
-     *            the metadata element name
-     * @param qualifier
-     *            the metadata qualifier name, or <code>null</code> for
-     *            unqualified
-     * @param lang
-     *            the ISO639 language code, optionally followed by an underscore
-     *            and the ISO3166 country code. <code>null</code> means the
-     *            value has no language (for example, a date).
-     * @param values
-     *            the values to add.
-     * @param authorities
-     *            the external authority key for this value (or null)
-     * @param confidences
-     *            the authority confidence (default 0)
-     */
-    public void addMetadata(String schema, String element, String qualifier, String lang,
-            String[] values, String authorities[], int confidences[])
-    {
-        List<DCValue> dublinCore = getMetadata();
-        MetadataAuthorityManager mam = MetadataAuthorityManager.getManager();        
-        boolean authorityControlled = mam.isAuthorityControlled(schema, element, qualifier);
-        boolean authorityRequired = mam.isAuthorityRequired(schema, element, qualifier);
-        String fieldName = schema+"."+element+((qualifier==null)? "": "."+qualifier);
-
-        // We will not verify that they are valid entries in the registry
-        // until update() is called.
-        for (int i = 0; i < values.length; i++)
-        {
-            DCValue dcv = new DCValue();
-            dcv.schema = schema;
-            dcv.element = element;
-            dcv.qualifier = qualifier;
-            dcv.language = (lang == null ? null : lang.trim());
-
-            // Logic to set Authority and Confidence:
-            //  - normalize an empty string for authority to NULL.
-            //  - if authority key is present, use given confidence or NOVALUE if not given
-            //  - otherwise, preserve confidence if meaningful value was given since it may document a failed authority lookup
-            //  - CF_UNSET signifies no authority nor meaningful confidence.
-            //  - it's possible to have empty authority & CF_ACCEPTED if e.g. user deletes authority key
-            if (authorityControlled)
-            {
-                if (authorities != null && authorities[i] != null && authorities[i].length() > 0)
-                {
-                    dcv.authority = authorities[i];
-                    dcv.confidence = confidences == null ? Choices.CF_NOVALUE : confidences[i];
-                }
-                else
-                {
-                    dcv.authority = null;
-                    dcv.confidence = confidences == null ? Choices.CF_UNSET : confidences[i];
-                }
-                // authority sanity check: if authority is required, was it supplied?
-                // XXX FIXME? can't throw a "real" exception here without changing all the callers to expect it, so use a runtime exception
-                if (authorityRequired && (dcv.authority == null || dcv.authority.length() == 0))
-                {
-                    throw new IllegalArgumentException("The metadata field \"" + fieldName + "\" requires an authority key but none was provided. Vaue=\"" + dcv.value + "\"");
-                }
-            }
-            if (values[i] != null)
-            {
-                // remove control unicode char
-                String temp = values[i].trim();
-                char[] dcvalue = temp.toCharArray();
-                for (int charPos = 0; charPos < dcvalue.length; charPos++)
-                {
-                    if (Character.isISOControl(dcvalue[charPos]) &&
-                        !String.valueOf(dcvalue[charPos]).equals("\u0009") &&
-                        !String.valueOf(dcvalue[charPos]).equals("\n") &&
-                        !String.valueOf(dcvalue[charPos]).equals("\r"))
-                    {
-                        dcvalue[charPos] = ' ';
-                    }
-                }
-                dcv.value = String.valueOf(dcvalue);
-            }
-            else
-            {
-                dcv.value = null;
-            }
-            dublinCore.add(dcv);
-            addDetails(fieldName);
-        }
-
-        if (values.length > 0)
-        {
-            dublinCoreChanged = true;
-        }
-    }
-
-    /**
-     * Add a single metadata field. This is appended to existing
-     * values. Use <code>clearDC</code> to remove values.
-     *
-     * @param schema
-     *            the schema for the metadata field. <em>Must</em> match
-     *            the <code>name</code> of an existing metadata schema.
-     * @param element
-     *            the metadata element name
-     * @param qualifier
-     *            the metadata qualifier, or <code>null</code> for
-     *            unqualified
-     * @param lang
-     *            the ISO639 language code, optionally followed by an underscore
-     *            and the ISO3166 country code. <code>null</code> means the
-     *            value has no language (for example, a date).
-     * @param value
-     *            the value to add.
-     */
-    public void addMetadata(String schema, String element, String qualifier,
-            String lang, String value)
-    {
-        String[] valArray = new String[1];
-        valArray[0] = value;
-
-        addMetadata(schema, element, qualifier, lang, valArray);
-    }
-
-    /**
-     * Add a single metadata field. This is appended to existing
-     * values. Use <code>clearDC</code> to remove values.
-     *
-     * @param schema
-     *            the schema for the metadata field. <em>Must</em> match
-     *            the <code>name</code> of an existing metadata schema.
-     * @param element
-     *            the metadata element name
-     * @param qualifier
-     *            the metadata qualifier, or <code>null</code> for
-     *            unqualified
-     * @param lang
-     *            the ISO639 language code, optionally followed by an underscore
-     *            and the ISO3166 country code. <code>null</code> means the
-     *            value has no language (for example, a date).
-     * @param value
-     *            the value to add.
-     * @param authority
-     *            the external authority key for this value (or null)
-     * @param confidence
-     *            the authority confidence (default 0)
-     */
-    public void addMetadata(String schema, String element, String qualifier,
-            String lang, String value, String authority, int confidence)
-    {
-        String[] valArray = new String[1];
-        String[] authArray = new String[1];
-        int[] confArray = new int[1];
-        valArray[0] = value;
-        authArray[0] = authority;
-        confArray[0] = confidence;
-
-        addMetadata(schema, element, qualifier, lang, valArray, authArray, confArray);
-    }
-
-    /**
-     * Clear Dublin Core metadata values. As with <code>getDC</code> above,
-     * passing in <code>null</code> only matches fields where the qualifier or
-     * language is actually <code>null</code>.<code>Item.ANY</code> will
-     * match any element, qualifier or language, including <code>null</code>.
-     * Thus, <code>item.clearDC(Item.ANY, Item.ANY, Item.ANY)</code> will
-     * remove all Dublin Core metadata associated with an item.
-     *
-     * @param element
-     *            the Dublin Core element to remove, or <code>Item.ANY</code>
-     * @param qualifier
-     *            the qualifier. <code>null</code> means unqualified, and
-     *            <code>Item.ANY</code> means any qualifier (including
-     *            unqualified.)
-     * @param lang
-     *            the ISO639 language code, optionally followed by an underscore
-     *            and the ISO3166 country code. <code>null</code> means only
-     *            values with no language are removed, and <code>Item.ANY</code>
-     *            means values with any country code or no country code are
-     *            removed.
-     */
-    @Deprecated
-    public void clearDC(String element, String qualifier, String lang)
-    {
-        clearMetadata(MetadataSchema.DC_SCHEMA, element, qualifier, lang);
-    }
-
-    /**
-     * Clear metadata values. As with <code>getDC</code> above,
-     * passing in <code>null</code> only matches fields where the qualifier or
-     * language is actually <code>null</code>.<code>Item.ANY</code> will
-     * match any element, qualifier or language, including <code>null</code>.
-     * Thus, <code>item.clearDC(Item.ANY, Item.ANY, Item.ANY)</code> will
-     * remove all Dublin Core metadata associated with an item.
-     *
-     * @param schema
-     *            the schema for the metadata field. <em>Must</em> match
-     *            the <code>name</code> of an existing metadata schema.
-     * @param element
-     *            the Dublin Core element to remove, or <code>Item.ANY</code>
-     * @param qualifier
-     *            the qualifier. <code>null</code> means unqualified, and
-     *            <code>Item.ANY</code> means any qualifier (including
-     *            unqualified.)
-     * @param lang
-     *            the ISO639 language code, optionally followed by an underscore
-     *            and the ISO3166 country code. <code>null</code> means only
-     *            values with no language are removed, and <code>Item.ANY</code>
-     *            means values with any country code or no country code are
-     *            removed.
-     */
-    public void clearMetadata(String schema, String element, String qualifier,
-            String lang)
-    {
-        // We will build a list of values NOT matching the values to clear
-        List<DCValue> values = new ArrayList<DCValue>();
-        for (DCValue dcv : getMetadata())
-        {
-            if (!match(schema, element, qualifier, lang, dcv))
-            {
-                values.add(dcv);
-            }
-        }
-
-        // Now swap the old list of values for the new, unremoved values
-        setMetadata(values);
-        dublinCoreChanged = true;
-    }
-
-    /**
-     * Utility method for pattern-matching metadata elements.  This
-     * method will return <code>true</code> if the given schema,
-     * element, qualifier and language match the schema, element,
-     * qualifier and language of the <code>DCValue</code> object passed
-     * in.  Any or all of the element, qualifier and language passed
-     * in can be the <code>Item.ANY</code> wildcard.
-     *
-     * @param schema
-     *            the schema for the metadata field. <em>Must</em> match
-     *            the <code>name</code> of an existing metadata schema.
-     * @param element
-     *            the element to match, or <code>Item.ANY</code>
-     * @param qualifier
-     *            the qualifier to match, or <code>Item.ANY</code>
-     * @param language
-     *            the language to match, or <code>Item.ANY</code>
-     * @param dcv
-     *            the Dublin Core value
-     * @return <code>true</code> if there is a match
-     */
-    private boolean match(String schema, String element, String qualifier,
-            String language, DCValue dcv)
-    {
-        // We will attempt to disprove a match - if we can't we have a match
-        if (!element.equals(Item.ANY) && !element.equals(dcv.element))
-        {
-            // Elements do not match, no wildcard
-            return false;
-        }
-
-        if (qualifier == null)
-        {
-            // Value must be unqualified
-            if (dcv.qualifier != null)
-            {
-                // Value is qualified, so no match
-                return false;
-            }
-        }
-        else if (!qualifier.equals(Item.ANY))
-        {
-            // Not a wildcard, so qualifier must match exactly
-            if (!qualifier.equals(dcv.qualifier))
-            {
-                return false;
-            }
-        }
-
-        if (language == null)
-        {
-            // Value must be null language to match
-            if (dcv.language != null)
-            {
-                // Value is qualified, so no match
-                return false;
-            }
-        }
-        else if (!language.equals(Item.ANY))
-        {
-            // Not a wildcard, so language must match exactly
-            if (!language.equals(dcv.language))
-            {
-                return false;
-            }
-        }
-
-        if (!schema.equals(Item.ANY))
-        {
-            if (dcv.schema != null && !dcv.schema.equals(schema))
-            {
-                // The namespace doesn't match
-                return false;
-            }
-        }
-
-        // If we get this far, we have a match
-        return true;
     }
 
     /**
@@ -1585,205 +995,7 @@ public class Item extends DSpaceObject
             }
         }
 
-        // Map counting number of values for each element/qualifier.
-        // Keys are Strings: "element" or "element.qualifier"
-        // Values are Integers indicating number of values written for a
-        // element/qualifier
-        Map<String,Integer> elementCount = new HashMap<String,Integer>();
-
-        // Redo Dublin Core if it's changed
-        if (dublinCoreChanged)
-        {
-            dublinCoreChanged = false;
-
-            // Arrays to store the working information required
-            int[]     placeNum = new int[getMetadata().size()];
-            boolean[] storedDC = new boolean[getMetadata().size()];
-            MetadataField[] dcFields = new MetadataField[getMetadata().size()];
-
-            // Work out the place numbers for the in memory DC
-            for (int dcIdx = 0; dcIdx < getMetadata().size(); dcIdx++)
-            {
-                DCValue dcv = getMetadata().get(dcIdx);
-
-                // Work out the place number for ordering
-                int current = 0;
-
-                // Key into map is "element" or "element.qualifier"
-                String key = dcv.element + ((dcv.qualifier == null) ? "" : ("." + dcv.qualifier));
-
-                Integer currentInteger = elementCount.get(key);
-                if (currentInteger != null)
-                {
-                    current = currentInteger.intValue();
-                }
-
-                current++;
-                elementCount.put(key, Integer.valueOf(current));
-
-                // Store the calculated place number, reset the stored flag, and cache the metadatafield
-                placeNum[dcIdx] = current;
-                storedDC[dcIdx] = false;
-                dcFields[dcIdx] = getMetadataField(dcv);
-                if (dcFields[dcIdx] == null)
-                {
-                    // Bad DC field, log and throw exception
-                    log.warn(LogManager
-                            .getHeader(ourContext, "bad_dc",
-                                    "Bad DC field. schema="+dcv.schema
-                                            + ", element: \""
-                                            + ((dcv.element == null) ? "null"
-                                                    : dcv.element)
-                                            + "\" qualifier: \""
-                                            + ((dcv.qualifier == null) ? "null"
-                                                    : dcv.qualifier)
-                                            + "\" value: \""
-                                            + ((dcv.value == null) ? "null"
-                                                    : dcv.value) + "\""));
-
-                    throw new SQLException("bad_dublin_core "
-                            + "schema="+dcv.schema+", "
-                            + dcv.element
-                            + " " + dcv.qualifier);
-                }
-            }
-
-            // Now the precalculations are done, iterate through the existing metadata
-            // looking for matches
-            TableRowIterator tri = retrieveMetadata();
-            if (tri != null)
-            {
-                try
-                {
-                    while (tri.hasNext())
-                    {
-                        TableRow tr = tri.next();
-                        // Assume that we will remove this row, unless we get a match
-                        boolean removeRow = true;
-
-                        // Go through the in-memory metadata, unless we've already decided to keep this row
-                        for (int dcIdx = 0; dcIdx < getMetadata().size() && removeRow; dcIdx++)
-                        {
-                            // Only process if this metadata has not already been matched to something in the DB
-                            if (!storedDC[dcIdx])
-                            {
-                                boolean matched = true;
-                                DCValue dcv   = getMetadata().get(dcIdx);
-
-                                // Check the metadata field is the same
-                                if (matched && dcFields[dcIdx].getFieldID() != tr.getIntColumn("metadata_field_id"))
-                                {
-                                    matched = false;
-                                }
-
-                                // Check the place is the same
-                                if (matched && placeNum[dcIdx] != tr.getIntColumn("place"))
-                                {
-                                    matched = false;
-                                }
-
-                                // Check the text is the same
-                                if (matched)
-                                {
-                                    String text = tr.getStringColumn("text_value");
-                                    if (dcv.value == null && text == null)
-                                    {
-                                        matched = true;
-                                    }
-                                    else if (dcv.value != null && dcv.value.equals(text))
-                                    {
-                                        matched = true;
-                                    }
-                                    else
-                                    {
-                                        matched = false;
-                                    }
-                                }
-
-                                // Check the language is the same
-                                if (matched)
-                                {
-                                    String lang = tr.getStringColumn("text_lang");
-                                    if (dcv.language == null && lang == null)
-                                    {
-                                        matched = true;
-                                    }
-                                    else if (dcv.language != null && dcv.language.equals(lang))
-                                    {
-                                        matched = true;
-                                    }
-                                    else
-                                    {
-                                        matched = false;
-                                    }
-                                }
-
-                                // check that authority and confidence match
-                                if (matched)
-                                {
-                                    String auth = tr.getStringColumn("authority");
-                                    int conf = tr.getIntColumn("confidence");
-                                    if (!((dcv.authority == null && auth == null) ||
-                                      (dcv.authority != null && auth != null && dcv.authority.equals(auth))
-                                     && dcv.confidence == conf))
-                                    {
-                                        matched = false;
-                                    }
-                                }
-
-                                // If the db record is identical to the in memory values
-                                if (matched)
-                                {
-                                    // Flag that the metadata is already in the DB
-                                    storedDC[dcIdx] = true;
-
-                                    // Flag that we are not going to remove the row
-                                    removeRow = false;
-                                }
-                            }
-                        }
-
-                        // If after processing all the metadata values, we didn't find a match
-                        // delete this row from the DB
-                        if (removeRow)
-                        {
-                            DatabaseManager.delete(ourContext, tr);
-                            dublinCoreChanged = true;
-                            modified = true;
-                        }
-                    }
-                }
-                finally
-                {
-                    tri.close();
-                }
-            }
-
-            // Add missing in-memory DC
-            for (int dcIdx = 0; dcIdx < getMetadata().size(); dcIdx++)
-            {
-                // Only write values that are not already in the db
-                if (!storedDC[dcIdx])
-                {
-                    DCValue dcv = getMetadata().get(dcIdx);
-
-                    // Write DCValue
-                    MetadataValue metadata = new MetadataValue();
-                    metadata.setItemId(getID());
-                    metadata.setFieldId(dcFields[dcIdx].getFieldID());
-                    metadata.setValue(dcv.value);
-                    metadata.setLanguage(dcv.language);
-                    metadata.setPlace(placeNum[dcIdx]);
-                    metadata.setAuthority(dcv.authority);
-                    metadata.setConfidence(dcv.confidence);
-                    metadata.create(ourContext);
-                    dublinCoreChanged = true;
-                    modified = true;
-                }
-            }
-        }
-
-        if (dublinCoreChanged || modified)
+        if (modifiedMetadata || modified)
         {
             // Set the last modified date
             itemRow.setColumn("last_modified", new Date());
@@ -1807,12 +1019,9 @@ public class Item extends DSpaceObject
 
             DatabaseManager.update(ourContext, itemRow);
 
-            if (dublinCoreChanged)
-            {
-                ourContext.addEvent(new Event(Event.MODIFY_METADATA, Constants.ITEM, getID(), 
-                        getDetails(), getIdentifiers(ourContext)));
+            if (modifiedMetadata) {
+                updateMetadata();
                 clearDetails();
-                dublinCoreChanged = false;
             }
 
             ourContext.addEvent(new Event(Event.MODIFY, Constants.ITEM, getID(), 
@@ -1821,45 +1030,6 @@ public class Item extends DSpaceObject
         }
     }
 
-    private transient MetadataField[] allMetadataFields = null;
-    private MetadataField getMetadataField(DCValue dcv) throws SQLException, AuthorizeException
-    {
-        if (allMetadataFields == null)
-        {
-            allMetadataFields = MetadataField.findAll(ourContext);
-        }
-
-        if (allMetadataFields != null)
-        {
-            int schemaID = getMetadataSchemaID(dcv);
-            for (MetadataField field : allMetadataFields)
-            {
-                if (field.getSchemaID() == schemaID &&
-                        StringUtils.equals(field.getElement(), dcv.element) &&
-                        StringUtils.equals(field.getQualifier(), dcv.qualifier))
-                {
-                    return field;
-                }
-            }
-        }
-
-        return null;
-    }
-
-    private int getMetadataSchemaID(DCValue dcv) throws SQLException
-    {
-        int schemaID;
-        MetadataSchema schema = MetadataSchema.find(ourContext,dcv.schema);
-        if (schema == null)
-        {
-            schemaID = MetadataSchema.DC_SCHEMA_ID;
-        }
-        else
-        {
-            schemaID = schema.getSchemaID();
-        }
-        return schemaID;
-    }
 
     /**
      * Withdraw the item from the archive. It is kept in place, and the content
@@ -1918,6 +1088,7 @@ public class Item extends DSpaceObject
         log.info(LogManager.getHeader(ourContext, "withdraw_item", "user="
                 + e.getEmail() + ",item_id=" + getID()));
     }
+
 
     /**
      * Reinstate a withdrawn item
@@ -2167,19 +1338,6 @@ public class Item extends DSpaceObject
 
         // not the owner
         return false;
-    }
-
-    /**
-     * Utility method to remove all descriptive metadata associated with the item from
-     * the database (regardless of in-memory version)
-     *
-     * @throws SQLException
-     */
-    private void removeMetadataFromDatabase() throws SQLException
-    {
-        DatabaseManager.updateQuery(ourContext,
-                "DELETE FROM MetadataValue WHERE item_id= ? ",
-                getID());
     }
 
     /**
@@ -2529,10 +1687,9 @@ public class Item extends DSpaceObject
     
     public String getName()
     {
-        DCValue t[] = getMetadata("dc", "title", null, Item.ANY);
-        return (t.length >= 1) ? t[0].value : null;
+        return getMetadataFirstValue(MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
     }
-        
+
     /**
      * Returns an iterator of Items possessing the passed metadata field, or only
      * those matching the passed value, if value is not Item.ANY
@@ -2563,16 +1720,16 @@ public class Item extends DSpaceObject
         }
         
         String query = "SELECT item.* FROM metadatavalue,item WHERE item.in_archive='1' "+
-                       "AND item.item_id = metadatavalue.item_id AND metadata_field_id = ?";
+                       "AND item.item_id = metadatavalue.resource_id AND metadata_field_id = ? AND resource_type_id = ?";
         TableRowIterator rows = null;
         if (Item.ANY.equals(value))
         {
-                rows = DatabaseManager.queryTable(context, "item", query, mdf.getFieldID());
+                rows = DatabaseManager.queryTable(context, "item", query, mdf.getFieldID(), Constants.ITEM);
         }
         else
         {
                 query += " AND metadatavalue.text_value = ?";
-                rows = DatabaseManager.queryTable(context, "item", query, mdf.getFieldID(), value);
+                rows = DatabaseManager.queryTable(context, "item", query, mdf.getFieldID(),  Constants.ITEM, value);
         }
         return new ItemIterator(context, rows);
      }
@@ -2741,116 +1898,15 @@ public class Item extends DSpaceObject
 
         TableRowIterator rows = DatabaseManager.queryTable(context, "item",
             "SELECT item.* FROM metadatavalue,item WHERE item.in_archive='1' "+
-            "AND item.item_id = metadatavalue.item_id AND metadata_field_id = ? AND authority = ?",
-            mdf.getFieldID(), value);
+            "AND item.item_id = metadatavalue.resource_id AND metadata_field_id = ? AND authority = ? AND resource_type_id = ?",
+            mdf.getFieldID(), value, Constants.ITEM);
         return new ItemIterator(context, rows);
     }
 
-
-    private List<DCValue> getMetadata()
-    {
-        try
-        {
-            return dublinCore.get(ourContext, getID(), log);
-        }
-        catch (SQLException e)
-        {
-            log.error("Loading item - cannot load metadata");
-        }
-
-        return new ArrayList<DCValue>();
-    }
-
-    private void setMetadata(List<DCValue> metadata)
-    {
-        dublinCore.set(metadata);
-        dublinCoreChanged = true;
-    }
-
-    class MetadataCache
-    {
-        List<DCValue> metadata = null;
-
-        List<DCValue> get(Context c, int itemId, Logger log) throws SQLException
-        {
-            if (metadata == null)
-            {
-                metadata = new ArrayList<DCValue>();
-
-                // Get Dublin Core metadata
-                TableRowIterator tri = retrieveMetadata(itemId);
-
-                if (tri != null)
-                {
-                    try
-                    {
-                        while (tri.hasNext())
-                        {
-                            TableRow resultRow = tri.next();
-
-                            // Get the associated metadata field and schema information
-                            int fieldID = resultRow.getIntColumn("metadata_field_id");
-                            MetadataField field = MetadataField.find(c, fieldID);
-
-                            if (field == null)
-                            {
-                                log.error("Loading item - cannot find metadata field " + fieldID);
-                            }
-                            else
-                            {
-                                MetadataSchema schema = MetadataSchema.find(c, field.getSchemaID());
-                                if (schema == null)
-                                {
-                                    log.error("Loading item - cannot find metadata schema " + field.getSchemaID() + ", field " + fieldID);
-                                }
-                                else
-                                {
-                                    // Make a DCValue object
-                                    DCValue dcv = new DCValue();
-                                    dcv.element = field.getElement();
-                                    dcv.qualifier = field.getQualifier();
-                                    dcv.value = resultRow.getStringColumn("text_value");
-                                    dcv.language = resultRow.getStringColumn("text_lang");
-                                    //dcv.namespace = schema.getNamespace();
-                                    dcv.schema = schema.getName();
-                                    dcv.authority = resultRow.getStringColumn("authority");
-                                    dcv.confidence = resultRow.getIntColumn("confidence");
-
-                                    // Add it to the list
-                                    metadata.add(dcv);
-                                }
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        // close the TableRowIterator to free up resources
-                        if (tri != null)
-                        {
-                            tri.close();
-                        }
-                    }
-                }
-            }
-
-            return metadata;
-        }
-
-        void set(List<DCValue> m)
-        {
-            metadata = m;
-        }
-
-        TableRowIterator retrieveMetadata(int itemId) throws SQLException
-        {
-            if (itemId > 0)
-            {
-                return DatabaseManager.queryTable(ourContext, "MetadataValue",
-                        "SELECT * FROM MetadataValue WHERE item_id= ? ORDER BY metadata_field_id, place",
-                        itemId);
-            }
-
-            return null;
-        }
+    @Override
+    protected void getAuthoritiesAndConfidences(String fieldKey, String[] values, String[] authorities, int[] confidences, int i) {
+        Choices c = ChoiceAuthorityManager.getManager().getBestMatch(fieldKey, values[i], getOwningCollectionID(), null);
+        authorities[i] = c.values.length > 0 ? c.values[0].authority : null;
+        confidences[i] = c.confidence;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/MetadataValue.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataValue.java
@@ -38,8 +38,11 @@ public class MetadataValue
     /** The primary key for the metadata value */
     private int valueId = 0;
 
-    /** The reference to the DSpace item */
-    private int itemId;
+    /** The reference to the DSpace resource */
+    private int resourceId;
+
+    /** The reference to the DSpace resource type*/
+    private int resourceTypeId;
 
     /** The value of the field */
     public String value;
@@ -73,7 +76,8 @@ public class MetadataValue
         {
             fieldId = row.getIntColumn("metadata_field_id");
             valueId = row.getIntColumn("metadata_value_id");
-            itemId = row.getIntColumn("item_id");
+            resourceId = row.getIntColumn("resource_id");
+            resourceTypeId = row.getIntColumn("resource_type_id");
             value = row.getStringColumn("text_value");
             language = row.getStringColumn("text_lang");
             place = row.getIntColumn("place");
@@ -121,23 +125,39 @@ public class MetadataValue
     }
 
     /**
-     * Get the item ID.
+     * Get the resource type ID.
      *
-     * @return item ID
+     * @return resource type ID
      */
-    public int getItemId()
-    {
-        return itemId;
+    public int getResourceTypeId() {
+        return resourceTypeId;
     }
 
     /**
-     * Set the item ID.
+     * Set the resource type ID.
      *
-     * @param itemId new item ID
+     * @param resourceTypeId new resource type ID
      */
-    public void setItemId(int itemId)
-    {
-        this.itemId = itemId;
+    public void setResourceTypeId(int resourceTypeId) {
+        this.resourceTypeId = resourceTypeId;
+    }
+
+    /**
+     * Get the resource id
+     *
+     * @return resource ID
+     */
+    public int getResourceId() {
+        return resourceId;
+    }
+
+    /**
+     * Set the resource type ID.
+     *
+     * @param resourceId new resource ID
+     */
+    public void setResourceId(int resourceId) {
+        this.resourceId = resourceId;
     }
 
     /**
@@ -262,7 +282,8 @@ public class MetadataValue
     {
         // Create a table row and update it with the values
         row = DatabaseManager.row("MetadataValue");
-        row.setColumn("item_id", itemId);
+        row.setColumn("resource_id", resourceId);
+        row.setColumn("resource_type_id", resourceTypeId);
         row.setColumn("metadata_field_id", fieldId);
         row.setColumn("text_value", value);
         row.setColumn("text_lang", language);
@@ -372,7 +393,8 @@ public class MetadataValue
      */
     public void update(Context context) throws SQLException, AuthorizeException
     {
-        row.setColumn("item_id", itemId);
+        row.setColumn("resource_id", resourceId);
+        row.setColumn("resource_type_id", resourceTypeId);
         row.setColumn("metadata_field_id", fieldId);
         row.setColumn("text_value", value);
         row.setColumn("text_lang", language);
@@ -429,7 +451,11 @@ public class MetadataValue
         {
             return false;
         }
-        if (this.itemId != other.itemId)
+        if (this.resourceId != other.resourceId)
+        {
+            return false;
+        }
+        if (this.resourceTypeId != other.resourceTypeId)
         {
             return false;
         }
@@ -442,7 +468,8 @@ public class MetadataValue
         int hash = 7;
         hash = 47 * hash + this.fieldId;
         hash = 47 * hash + this.valueId;
-        hash = 47 * hash + this.itemId;
+        hash = 47 * hash + this.resourceId;
+        hash = 47 * hash + this.resourceTypeId;
         return hash;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/SupervisedItem.java
+++ b/dspace-api/src/main/java/org/dspace/content/SupervisedItem.java
@@ -105,8 +105,7 @@ public class SupervisedItem extends WorkspaceItem
                        "WHERE epersongroup2workspaceitem.workspace_item_id" +
                        " = ? " +
                        " AND epersongroup2workspaceitem.eperson_group_id =" +
-                       " epersongroup.eperson_group_id " +
-                       "ORDER BY epersongroup.name";
+                       " epersongroup.eperson_group_id ";
         
         TableRowIterator tri = DatabaseManager.queryTable(c,"epersongroup",query, wi);
 
@@ -151,8 +150,7 @@ public class SupervisedItem extends WorkspaceItem
                        "WHERE epersongroup2workspaceitem.workspace_item_id" +
                        " = ? " + 
                        " AND epersongroup2workspaceitem.eperson_group_id =" +
-                       " epersongroup.eperson_group_id " +
-                       "ORDER BY epersongroup.name";
+                       " epersongroup.eperson_group_id ";
         
         TableRowIterator tri = DatabaseManager.queryTable(ourContext,
                                     "epersongroup",

--- a/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
@@ -53,7 +53,7 @@ public class ItemService
     }
 
     public static String getFirstMetadataValue(Item item, String metadataKey) {
-        DCValue[] dcValue = item.getMetadata(metadataKey);
+        DCValue[] dcValue = item.getMetadataByMetadataString(metadataKey);
         if(dcValue.length > 0) {
             return dcValue[0].value;
         } else {

--- a/dspace-api/src/main/java/org/dspace/ctask/general/AbstractTranslator.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/AbstractTranslator.java
@@ -89,7 +89,7 @@ public abstract class AbstractTranslator extends AbstractCurationTask
             String handle = item.getHandle();
             log.debug("Translating metadata for " + handle);
 
-            DCValue[] authLangs = item.getMetadata(authLangField);
+            DCValue[] authLangs = item.getMetadataByMetadataString(authLangField);
             if(authLangs.length > 0)
             {
                 /* Assume the first... multiple

--- a/dspace-api/src/main/java/org/dspace/ctask/general/MetadataWebService.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/MetadataWebService.java
@@ -236,7 +236,7 @@ public class MetadataWebService extends AbstractCurationTask implements Namespac
             }
             resultSb.append(itemId);
             // Only proceed if item has a value for service template parameter
-            DCValue[] dcVals = item.getMetadata(lookupField);
+            DCValue[] dcVals = item.getMetadataByMetadataString(lookupField);
             if (dcVals.length > 0 && dcVals[0].value.length() > 0) {
             	String value = transform(dcVals[0].value, lookupTransform);
             	status = callService(value, item, resultSb);

--- a/dspace-api/src/main/java/org/dspace/ctask/general/RequiredMetadata.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/RequiredMetadata.java
@@ -81,7 +81,7 @@ public class RequiredMetadata extends AbstractCurationTask
                 sb.append("Item: ").append(handle);
                 for (String req : getReqList(item.getOwningCollection().getHandle()))
                 {
-                    DCValue[] vals = item.getMetadata(req);
+                    DCValue[] vals = item.getMetadataByMetadataString(req);
                     if (vals.length == 0)
                     {
                         sb.append(" missing required field: ").append(req);

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -1320,7 +1320,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
         try {
 
-            DCValue[] values = item.getMetadata("dc.relation.ispartof");
+            DCValue[] values = item.getMetadataByMetadataString("dc.relation.ispartof");
 
             if(values != null && values.length > 0 && values[0] != null && values[0].value != null)
             {

--- a/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
@@ -24,7 +24,7 @@ import org.apache.commons.codec.DecoderException;
 import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.AuthorizeManager;
-import org.dspace.content.DSpaceObject;
+import org.dspace.content.*;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
@@ -61,17 +61,11 @@ public class EPerson extends DSpaceObject
     /** log4j logger */
     private static final Logger log = Logger.getLogger(EPerson.class);
 
-    /** Our context */
-    private final Context myContext;
-
     /** The row in the table representing this eperson */
     private final TableRow myRow;
 
     /** Flag set when data is modified, for events */
     private boolean modified;
-
-    /** Flag set when metadata is modified, for events */
-    private boolean modifiedMetadata;
 
     /**
      * Construct an EPerson
@@ -81,15 +75,13 @@ public class EPerson extends DSpaceObject
      * @param row
      *            the corresponding row in the table
      */
-    EPerson(Context context, TableRow row)
-    {
-        myContext = context;
+    EPerson(Context context, TableRow row) throws SQLException {
+        super(context);
         myRow = row;
 
         // Cache ourselves
         context.cache(this, row.getIntColumn("eperson_id"));
         modified = false;
-        modifiedMetadata = false;
         clearDetails();
     }
 
@@ -290,8 +282,17 @@ public class EPerson extends DSpaceObject
 	{
 		String params = "%"+query.toLowerCase()+"%";
         StringBuffer queryBuf = new StringBuffer();
-        queryBuf.append("SELECT * FROM eperson WHERE eperson_id = ? OR ");
-        queryBuf.append("LOWER(firstname) LIKE LOWER(?) OR LOWER(lastname) LIKE LOWER(?) OR LOWER(email) LIKE LOWER(?) ORDER BY lastname, firstname ASC ");
+        queryBuf.append("select e.* from eperson e " +
+                " LEFT JOIN metadatavalue fn on (resource_id=e.eperson_id AND fn.resource_type_id=? and fn.metadata_field_id=?) " +
+                " LEFT JOIN metadatavalue ln on (ln.resource_id=e.eperson_id AND ln.resource_type_id=? and ln.metadata_field_id=?) " +
+                " WHERE e.eperson_id = ? OR " +
+                "LOWER(fn.text_value) LIKE LOWER(?) OR LOWER(ln.text_value) LIKE LOWER(?) OR LOWER(email) LIKE LOWER(?) ORDER BY  ");
+
+        if(DatabaseManager.isOracle()) {
+            queryBuf.append(" dbms_lob.substr(ln.text_value), dbms_lob.substr(fn.text_value) ASC");
+        }else{
+            queryBuf.append(" ln.text_value, fn.text_value ASC");
+        }
 
         // Add offset and limit restrictions - Oracle requires special code
         if (DatabaseManager.isOracle())
@@ -341,23 +342,28 @@ public class EPerson extends DSpaceObject
 		try {
 			int_param = Integer.valueOf(query);
 		}
+
 		catch (NumberFormatException e) {
 			int_param = Integer.valueOf(-1);
 		}
 
+
+        Integer f = MetadataField.findByElement(context, MetadataSchema.find(context, "eperson").getSchemaID(), "firstname", null).getFieldID();
+        Integer l = MetadataField.findByElement(context, MetadataSchema.find(context, "eperson").getSchemaID(), "lastname", null).getFieldID();
+
         // Create the parameter array, including limit and offset if part of the query
-        Object[] paramArr = new Object[] {int_param,params,params,params};
+        Object[] paramArr = new Object[] {Constants.EPERSON,f, Constants.EPERSON,l, int_param,params,params,params};
         if (limit > 0 && offset > 0)
         {
-            paramArr = new Object[]{int_param, params, params, params, limit, offset};
+            paramArr = new Object[]{Constants.EPERSON,f, Constants.EPERSON,l, int_param,params,params,params, limit, offset};
         }
         else if (limit > 0)
         {
-            paramArr = new Object[]{int_param, params, params, params, limit};
+            paramArr = new Object[]{Constants.EPERSON,f, Constants.EPERSON,l, int_param,params,params,params, limit};
         }
         else if (offset > 0)
         {
-            paramArr = new Object[]{int_param, params, params, params, offset};
+            paramArr = new Object[]{Constants.EPERSON,f, Constants.EPERSON,l, int_param,params,params,params, offset};
         }
 
         // Get all the epeople that match the query
@@ -422,12 +428,29 @@ public class EPerson extends DSpaceObject
 		catch (NumberFormatException e) {
 			int_param = Integer.valueOf(-1);
 		}
-		
+
 		// Get all the epeople that match the query
 		TableRow row = DatabaseManager.querySingle(context,
-		        "SELECT count(*) as epcount FROM eperson WHERE eperson_id = ? OR " +
-		        "LOWER(firstname) LIKE LOWER(?) OR LOWER(lastname) LIKE LOWER(?) OR LOWER(email) LIKE LOWER(?)",
-		        new Object[] {int_param,dbquery,dbquery,dbquery});
+		        "SELECT count(*) as epcount FROM eperson " +
+                "WHERE eperson_id = ? OR " +
+		        "LOWER((select text_value from metadatavalue where resource_id=? and resource_type_id=? and metadata_field_id=?)) LIKE LOWER(?) " +
+                "OR LOWER((select text_value from metadatavalue where resource_id=? and resource_type_id=? and metadata_field_id=?)) LIKE LOWER(?) " +
+                "OR LOWER(eperson.email) LIKE LOWER(?)",
+		        new Object[] {
+                        int_param,
+
+                        int_param,
+                        Constants.EPERSON,
+                        MetadataField.findByElement(context, MetadataSchema.find(context, "eperson").getSchemaID(), "firstname", null).getFieldID(),
+                        dbquery,
+
+                        int_param,
+                        Constants.EPERSON,
+                        MetadataField.findByElement(context, MetadataSchema.find(context, "eperson").getSchemaID(), "lastname", null).getFieldID(),
+                        dbquery,
+
+                        dbquery
+                });
 				
 		// use getIntColumn for Oracle count data
         if (DatabaseManager.isOracle())
@@ -458,33 +481,47 @@ public class EPerson extends DSpaceObject
     public static EPerson[] findAll(Context context, int sortField)
             throws SQLException
     {
-        String s;
+        String s, t = "", theQuery = "";
 
         switch (sortField)
         {
         case ID:
-            s = "eperson_id";
+            s = "e.eperson_id";
             break;
 
         case EMAIL:
-            s = "email";
+            s = "e.email";
             break;
 
         case LANGUAGE:
-            s = "language";
+            s = "m_text_value";
+            t = "language";
             break;
         case NETID:
-            s = "netid";
+            s = "m_text_value";
+            t = "netid";
             break;
 
         default:
-            s = "lastname";
+            s = "m_text_value";
+            t = "lastname";
         }
 
-        // NOTE: The use of 's' in the order by clause can not cause an SQL 
+        // NOTE: The use of 's' in the order by clause can not cause an SQL
         // injection because the string is derived from constant values above.
-        TableRowIterator rows = DatabaseManager.query(context, 
-                "SELECT * FROM eperson ORDER BY "+s);
+        TableRowIterator rows = DatabaseManager.query(context, "SELECT * FROM eperson e ORDER BY ?",s);
+        if(t!="") {
+            rows = DatabaseManager.query(context,
+                    "SELECT * FROM eperson e " +
+                            "LEFT JOIN metadatavalue m on (m.resource_id = e.eperson_id and m.resource_type_id = ? and m.metadata_field_id = ?) " +
+                            "ORDER BY ?",
+                    Constants.EPERSON,
+                    MetadataField.findByElement(context, MetadataSchema.find(context, "eperson").getSchemaID(), t, null).getFieldID(),
+                    s
+            );
+        }
+
+
 
         try
         {
@@ -559,7 +596,7 @@ public class EPerson extends DSpaceObject
             EPersonDeletionException
     {
         // authorized?
-        if (!AuthorizeManager.isAdmin(myContext))
+        if (!AuthorizeManager.isAdmin(ourContext))
         {
             throw new AuthorizeException(
                     "You must be an admin to delete an EPerson");
@@ -576,29 +613,31 @@ public class EPerson extends DSpaceObject
             throw new EPersonDeletionException(constraintList);
         }
 
-        myContext.addEvent(new Event(Event.DELETE, Constants.EPERSON, getID(), 
-                getEmail(), getIdentifiers(myContext)));
+        // Delete the Dublin Core
+        removeMetadataFromDatabase();
+
+        ourContext.addEvent(new Event(Event.DELETE, Constants.EPERSON, getID(), getEmail(), getIdentifiers(ourContext)));
 
         // Remove from cache
-        myContext.removeCached(this, getID());
+        ourContext.removeCached(this, getID());
 
         // XXX FIXME: This sidesteps the object model code so it won't
         // generate  REMOVE events on the affected Groups.
 
         // Remove any group memberships first
-        DatabaseManager.updateQuery(myContext,
+        DatabaseManager.updateQuery(ourContext,
                 "DELETE FROM EPersonGroup2EPerson WHERE eperson_id= ? ",
                 getID());
 
         // Remove any subscriptions
-        DatabaseManager.updateQuery(myContext,
+        DatabaseManager.updateQuery(ourContext,
                 "DELETE FROM subscription WHERE eperson_id= ? ",
                 getID());
 
         // Remove ourself
-        DatabaseManager.delete(myContext, myRow);
+        DatabaseManager.delete(ourContext, myRow);
 
-        log.info(LogManager.getHeader(myContext, "delete_eperson",
+        log.info(LogManager.getHeader(ourContext, "delete_eperson",
                 "eperson_id=" + getID()));
     }
 
@@ -619,7 +658,7 @@ public class EPerson extends DSpaceObject
      */
      public String getLanguage()
      {
-         return myRow.getStringColumn("language");
+         return getMetadataFirstValue("eperson", "language", null, Item.ANY);
      }
      
      /**
@@ -630,9 +669,8 @@ public class EPerson extends DSpaceObject
      * @param language
      *            language code
      */
-     public void setLanguage(String language)
-     {
-         myRow.setColumn("language", language);
+     public void setLanguage(String language) {
+         setMetadataSingleValue("eperson", "language", null, null, language);
      }
   
 
@@ -681,7 +719,7 @@ public class EPerson extends DSpaceObject
      */
     public String getNetid()
     {
-        return myRow.getStringColumn("netid");
+        return getMetadataFirstValue("eperson", "netid", null, Item.ANY);
     }
 
     /**
@@ -690,9 +728,8 @@ public class EPerson extends DSpaceObject
      * @param s
      *            the new netid
      */
-    public void setNetid(String s)
-    {
-        myRow.setColumn("netid", s);
+    public void setNetid(String s) {
+        setMetadataSingleValue("eperson", "netid", null, null, s);
         modified = true;
     }
 
@@ -704,8 +741,8 @@ public class EPerson extends DSpaceObject
      */
     public String getFullName()
     {
-        String f = myRow.getStringColumn("firstname");
-        String l = myRow.getStringColumn("lastname");
+        String f = getFirstName();
+        String l= getLastName();
 
         if ((l == null) && (f == null))
         {
@@ -728,7 +765,7 @@ public class EPerson extends DSpaceObject
      */
     public String getFirstName()
     {
-        return myRow.getStringColumn("firstname");
+        return getMetadataFirstValue("eperson", "firstname", null, Item.ANY);
     }
 
     /**
@@ -737,9 +774,8 @@ public class EPerson extends DSpaceObject
      * @param firstname
      *            the person's first name
      */
-    public void setFirstName(String firstname)
-    {
-        myRow.setColumn("firstname", firstname);
+    public void setFirstName(String firstname) {
+        setMetadataSingleValue("eperson", "firstname", null, null, firstname);
         modified = true;
     }
 
@@ -750,7 +786,7 @@ public class EPerson extends DSpaceObject
      */
     public String getLastName()
     {
-        return myRow.getStringColumn("lastname");
+        return getMetadataFirstValue("eperson", "lastname", null, Item.ANY);
     }
 
     /**
@@ -759,9 +795,8 @@ public class EPerson extends DSpaceObject
      * @param lastname
      *            the person's last name
      */
-    public void setLastName(String lastname)
-    {
-        myRow.setColumn("lastname", lastname);
+    public void setLastName(String lastname) {
+        setMetadataSingleValue("eperson", "lastname", null, null, lastname);
         modified = true;
     }
 
@@ -833,18 +868,20 @@ public class EPerson extends DSpaceObject
 
     /**
      * Get the value of a metadata field
-     * 
+     *
      * @param field
      *            the name of the metadata field to get
-     * 
+     *
      * @return the value of the metadata field (or null if the column is an SQL NULL)
-     * 
+     *
      * @exception IllegalArgumentException
      *                if the requested metadata field doesn't exist
      */
+    @Deprecated
     public String getMetadata(String field)
     {
-        return myRow.getStringColumn(field);
+        String[] MDValue = getMDValueByLegacyField(field);
+        return getMetadataFirstValue(MDValue[0], MDValue[1], MDValue[2], Item.ANY);
     }
 
     /**
@@ -858,11 +895,11 @@ public class EPerson extends DSpaceObject
      * @exception IllegalArgumentException
      *                if the requested metadata field doesn't exist
      */
+    @Deprecated
     public void setMetadata(String field, String value)
     {
-        myRow.setColumn(field, value);
-        modifiedMetadata = true;
-        addDetails(field);
+        String[] MDValue = getMDValueByLegacyField(field);
+        setMetadataSingleValue(MDValue[0], MDValue[1], MDValue[2], null, value);
     }
 
     /**
@@ -951,14 +988,14 @@ public class EPerson extends DSpaceObject
             log.info("Upgrading password hash for EPerson " + getID());
             setPassword(attempt);
             try {
-                myContext.turnOffAuthorisationSystem();
+                ourContext.turnOffAuthorisationSystem();
                 update();
             } catch (SQLException ex) {
                 log.error("Could not update password hash", ex);
             } catch (AuthorizeException ex) {
                 log.error("Could not update password hash", ex);
             } finally {
-                myContext.restoreAuthSystemState();
+                ourContext.restoreAuthSystemState();
             }
         }
 
@@ -992,29 +1029,27 @@ public class EPerson extends DSpaceObject
     {
         // Check authorisation - if you're not the eperson
         // see if the authorization system says you can
-        if (!myContext.ignoreAuthorization()
-                && ((myContext.getCurrentUser() == null) || (getID() != myContext
+        if (!ourContext.ignoreAuthorization()
+                && ((ourContext.getCurrentUser() == null) || (getID() != ourContext
                         .getCurrentUser().getID())))
         {
-            AuthorizeManager.authorizeAction(myContext, this, Constants.WRITE);
+            AuthorizeManager.authorizeAction(ourContext, this, Constants.WRITE);
         }
 
-        DatabaseManager.update(myContext, myRow);
+        DatabaseManager.update(ourContext, myRow);
 
-        log.info(LogManager.getHeader(myContext, "update_eperson",
+        log.info(LogManager.getHeader(ourContext, "update_eperson",
                 "eperson_id=" + getID()));
 
         if (modified)
         {
-            myContext.addEvent(new Event(Event.MODIFY, Constants.EPERSON, 
-                    getID(), null, getIdentifiers(myContext)));
+            ourContext.addEvent(new Event(Event.MODIFY, Constants.EPERSON,
+                    getID(), null, getIdentifiers(ourContext)));
             modified = false;
         }
         if (modifiedMetadata)
         {
-            myContext.addEvent(new Event(Event.MODIFY_METADATA, Constants.EPERSON, 
-                    getID(), getDetails(), getIdentifiers(myContext)));
-            modifiedMetadata = false;
+            updateMetadata();
             clearDetails();
         }
     }
@@ -1042,7 +1077,7 @@ public class EPerson extends DSpaceObject
         List<String> tableList = new ArrayList<String>();
 
         // check for eperson in item table
-        TableRowIterator tri = DatabaseManager.query(myContext, 
+        TableRowIterator tri = DatabaseManager.query(ourContext,
                 "SELECT * from item where submitter_id= ? ",
                 getID());
 
@@ -1076,7 +1111,7 @@ public class EPerson extends DSpaceObject
     private void getXMLWorkflowConstraints(List<String> tableList) throws SQLException {
          TableRowIterator tri;
         // check for eperson in claimtask table
-        tri = DatabaseManager.queryTable(myContext, "cwf_claimtask",
+        tri = DatabaseManager.queryTable(ourContext, "cwf_claimtask",
                 "SELECT * from cwf_claimtask where owner_id= ? ",
                 getID());
 
@@ -1097,7 +1132,7 @@ public class EPerson extends DSpaceObject
         }
 
         // check for eperson in pooltask table
-        tri = DatabaseManager.queryTable(myContext, "cwf_pooltask",
+        tri = DatabaseManager.queryTable(ourContext, "cwf_pooltask",
                 "SELECT * from cwf_pooltask where eperson_id= ? ",
                 getID());
 
@@ -1118,7 +1153,7 @@ public class EPerson extends DSpaceObject
         }
 
         // check for eperson in workflowitemrole table
-        tri = DatabaseManager.queryTable(myContext, "cwf_workflowitemrole",
+        tri = DatabaseManager.queryTable(ourContext, "cwf_workflowitemrole",
                 "SELECT * from cwf_workflowitemrole where eperson_id= ? ",
                 getID());
 
@@ -1143,7 +1178,7 @@ public class EPerson extends DSpaceObject
     private void getOriginalWorkflowConstraints(List<String> tableList) throws SQLException {
         TableRowIterator tri;
         // check for eperson in workflowitem table
-        tri = DatabaseManager.query(myContext, 
+        tri = DatabaseManager.query(ourContext,
                 "SELECT * from workflowitem where owner= ? ",
                 getID());
 
@@ -1164,7 +1199,7 @@ public class EPerson extends DSpaceObject
         }
 
         // check for eperson in tasklistitem table
-        tri = DatabaseManager.query(myContext, 
+        tri = DatabaseManager.query(ourContext,
                 "SELECT * from tasklistitem where eperson_id= ? ",
                 getID());
 
@@ -1223,8 +1258,7 @@ public class EPerson extends DSpaceObject
      * Tool for manipulating user accounts.
      */
     public static void main(String argv[])
-            throws ParseException, SQLException
-    {
+            throws ParseException, SQLException, AuthorizeException {
         final OptionGroup VERBS = new OptionGroup();
         VERBS.addOption(VERB_ADD);
         VERBS.addOption(VERB_DELETE);
@@ -1284,8 +1318,7 @@ public class EPerson extends DSpaceObject
     }
 
     /** Command to create an EPerson. */
-    private static int cmdAdd(Context context, String[] argv)
-    {
+    private static int cmdAdd(Context context, String[] argv) throws AuthorizeException {
         Options options = new Options();
 
         options.addOption(VERB_ADD);
@@ -1455,8 +1488,7 @@ public class EPerson extends DSpaceObject
     }
 
     /** Command to modify an EPerson. */
-    private static int cmdModify(Context context, String[] argv)
-    {
+    private static int cmdModify(Context context, String[] argv) throws AuthorizeException {
         Options options = new Options();
 
         options.addOption(VERB_MODIFY);

--- a/dspace-api/src/main/java/org/dspace/eperson/Group.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/Group.java
@@ -20,9 +20,7 @@ import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeConfiguration;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.AuthorizeManager;
-import org.dspace.content.Collection;
-import org.dspace.content.Community;
-import org.dspace.content.DSpaceObject;
+import org.dspace.content.*;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
@@ -54,9 +52,6 @@ public class Group extends DSpaceObject
     /** ID of Administrator Group */
     public static final int ADMIN_ID = 1;
 
-    /** Our context */
-    private final Context myContext;
-
     /** The row in the table representing this object */
     private final TableRow myRow;
 
@@ -73,8 +68,6 @@ public class Group extends DSpaceObject
     /** is this just a stub, or is all data loaded? */
     private boolean isDataLoaded = false;
 
-    /** Flag set when metadata is modified, for events */
-    private boolean modifiedMetadata;
 
     /**
      * Construct a Group from a given context and tablerow
@@ -84,13 +77,12 @@ public class Group extends DSpaceObject
      */
     Group(Context context, TableRow row) throws SQLException
     {
-        myContext = context;
+        super(context);
         myRow = row;
 
         // Cache ourselves
         context.cache(this, row.getIntColumn("eperson_group_id"));
 
-        modifiedMetadata = false;
         clearDetails();
     }
 
@@ -110,7 +102,7 @@ public class Group extends DSpaceObject
             try
             {
                 // get epeople objects
-                TableRowIterator tri = DatabaseManager.queryTable(myContext,"eperson",
+                TableRowIterator tri = DatabaseManager.queryTable(ourContext,"eperson",
                                 "SELECT eperson.* FROM eperson, epersongroup2eperson WHERE " +
                                 "epersongroup2eperson.eperson_id=eperson.eperson_id AND " +
                                 "epersongroup2eperson.eperson_group_id= ?",
@@ -123,7 +115,7 @@ public class Group extends DSpaceObject
                         TableRow r = (TableRow) tri.next();
 
                         // First check the cache
-                        EPerson fromCache = (EPerson) myContext.fromCache(
+                        EPerson fromCache = (EPerson) ourContext.fromCache(
                                 EPerson.class, r.getIntColumn("eperson_id"));
 
                         if (fromCache != null)
@@ -132,7 +124,7 @@ public class Group extends DSpaceObject
                         }
                         else
                         {
-                            epeople.add(new EPerson(myContext, r));
+                            epeople.add(new EPerson(ourContext, r));
                         }
                     }
                 }
@@ -146,7 +138,7 @@ public class Group extends DSpaceObject
                 }
 
                 // now get Group objects
-                tri = DatabaseManager.queryTable(myContext,"epersongroup",
+                tri = DatabaseManager.queryTable(ourContext,"epersongroup",
                                 "SELECT epersongroup.* FROM epersongroup, group2group WHERE " +
                                 "group2group.child_id=epersongroup.eperson_group_id AND "+
                                 "group2group.parent_id= ? ",
@@ -159,7 +151,7 @@ public class Group extends DSpaceObject
                         TableRow r = (TableRow) tri.next();
 
                         // First check the cache
-                        Group fromCache = (Group) myContext.fromCache(Group.class,
+                        Group fromCache = (Group) ourContext.fromCache(Group.class,
                                 r.getIntColumn("eperson_group_id"));
 
                         if (fromCache != null)
@@ -168,7 +160,7 @@ public class Group extends DSpaceObject
                         }
                         else
                         {
-                            groups.add(new Group(myContext, r));
+                            groups.add(new Group(ourContext, r));
                         }
                     }
                 }
@@ -237,7 +229,7 @@ public class Group extends DSpaceObject
      */
     public String getName()
     {
-        return myRow.getStringColumn("name");
+        return getMetadataFirstValue(MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
     }
 
     /**
@@ -246,11 +238,8 @@ public class Group extends DSpaceObject
      * @param name
      *            new group name
      */
-    public void setName(String name)
-    {
-        myRow.setColumn("name", name);
-        modifiedMetadata = true;
-        addDetails("name");
+    public void setName(String name) {
+        setMetadataSingleValue(MetadataSchema.DC_SCHEMA, "title", null, null, name);
     }
 
     /**
@@ -271,9 +260,7 @@ public class Group extends DSpaceObject
         epeople.add(e);
         epeopleChanged = true;
 
-        myContext.addEvent(new Event(Event.ADD, Constants.GROUP, getID(), 
-                Constants.EPERSON, e.getID(), e.getEmail(), 
-                getIdentifiers(myContext)));
+        ourContext.addEvent(new Event(Event.ADD, Constants.GROUP, getID(), Constants.EPERSON, e.getID(), e.getEmail(), getIdentifiers(ourContext)));
     }
 
     /**
@@ -295,9 +282,7 @@ public class Group extends DSpaceObject
         groups.add(g);
         groupsChanged = true;
 
-        myContext.addEvent(new Event(Event.ADD, Constants.GROUP, getID(), 
-                Constants.GROUP, g.getID(), g.getName(), 
-                getIdentifiers(myContext)));
+        ourContext.addEvent(new Event(Event.ADD, Constants.GROUP, getID(), Constants.GROUP, g.getID(), g.getName(), getIdentifiers(ourContext)));
     }
 
     /**
@@ -313,9 +298,7 @@ public class Group extends DSpaceObject
         if (epeople.remove(e))
         {
             epeopleChanged = true;
-            myContext.addEvent(new Event(Event.REMOVE, Constants.GROUP, getID(), 
-                    Constants.EPERSON, e.getID(), e.getEmail(), 
-                    getIdentifiers(myContext)));
+            ourContext.addEvent(new Event(Event.REMOVE, Constants.GROUP, getID(), Constants.EPERSON, e.getID(), e.getEmail(), getIdentifiers(ourContext)));
         }
     }
 
@@ -331,9 +314,7 @@ public class Group extends DSpaceObject
         if (groups.remove(g))
         {
             groupsChanged = true;
-            myContext.addEvent(new Event(Event.REMOVE, Constants.GROUP, getID(), 
-                    Constants.GROUP, g.getID(), g.getName(),
-                    getIdentifiers(myContext)));
+            ourContext.addEvent(new Event(Event.REMOVE, Constants.GROUP, getID(), Constants.GROUP, g.getID(), g.getName(), getIdentifiers(ourContext)));
         }
     }
 
@@ -717,8 +698,20 @@ public class Group extends DSpaceObject
     public static Group findByName(Context context, String name)
             throws SQLException
     {
-        TableRow row = DatabaseManager.findByUnique(context, "epersongroup",
-                "name", name);
+        String query = "select * from epersongroup e " +
+                "LEFT JOIN metadatavalue m on (m.resource_id = e.eperson_group_id and m.resource_type_id = ? and m.metadata_field_id = ?) " +
+                "where ";
+        if(DatabaseManager.isOracle()) {
+            query += " dbms_lob.substr(m.text_value) = ?";
+        }else{
+            query += " m.text_value = ?";
+
+        }
+        TableRow row = DatabaseManager.querySingle(context, query,
+                Constants.GROUP,
+                MetadataField.findByElement(context, MetadataSchema.find(context, MetadataSchema.DC_SCHEMA).getSchemaID(), "title", null).getFieldID(),
+                name
+        );
 
         if (row == null)
         {
@@ -759,24 +752,31 @@ public class Group extends DSpaceObject
         switch (sortField)
         {
         case ID:
-            s = "eperson_group_id";
+            s = "e.eperson_group_id";
 
             break;
 
         case NAME:
-            s = "name";
+            s = "m_text_value";
 
             break;
 
         default:
-            s = "name";
+            s = "m_text_value";
         }
 
         // NOTE: The use of 's' in the order by clause can not cause an SQL 
         // injection because the string is derived from constant values above.
-        TableRowIterator rows = DatabaseManager.queryTable(
-        		context, "epersongroup",
-                "SELECT * FROM epersongroup ORDER BY "+s);
+        TableRowIterator rows = DatabaseManager.query(
+                context,
+                "select e.* from epersongroup e " +
+                        "LEFT JOIN metadatavalue m on (m.resource_id = e.eperson_group_id and m.resource_type_id = ? and m.metadata_field_id = ?) " +
+                        "order by ?",
+                Constants.GROUP,
+                MetadataField.findByElement(context, MetadataSchema.find(context, MetadataSchema.DC_SCHEMA).getSchemaID(), "title", null).getFieldID(),
+                s
+        );
+
 
         try
         {
@@ -849,8 +849,17 @@ public class Group extends DSpaceObject
 	{
 		String params = "%"+query.toLowerCase()+"%";
         StringBuffer queryBuf = new StringBuffer();
-		queryBuf.append("SELECT * FROM epersongroup WHERE LOWER(name) LIKE LOWER(?) OR eperson_group_id = ? ORDER BY name ASC ");
-		
+		queryBuf.append("SELECT * FROM epersongroup " +
+                "LEFT JOIN metadatavalue m on (m.resource_id = epersongroup.eperson_group_id and m.resource_type_id = ? and m.metadata_field_id = ?) " +
+                "WHERE LOWER(m.text_value) LIKE LOWER(?) OR eperson_group_id = ? ");
+
+        if(DatabaseManager.isOracle()){
+            queryBuf.append(" ORDER BY cast(m.text_value as varchar2(128))");
+        }else{
+            queryBuf.append(" ORDER BY m.text_value");
+        }
+        queryBuf.append(" ASC");
+
         // Add offset and limit restrictions - Oracle requires special code
         if (DatabaseManager.isOracle())
         {
@@ -904,18 +913,21 @@ public class Group extends DSpaceObject
 		}
 
         // Create the parameter array, including limit and offset if part of the query
-        Object[] paramArr = new Object[]{params, int_param};
+
+        int metadataFieldId = MetadataField.findByElement(context, MetadataSchema.find(context, MetadataSchema.DC_SCHEMA).getSchemaID(), "title", null).getFieldID();
+
+        Object[] paramArr = new Object[]{Constants.GROUP, metadataFieldId, params, int_param};
         if (limit > 0 && offset > 0)
         {
-            paramArr = new Object[]{params, int_param, limit, offset};
+            paramArr = new Object[]{Constants.GROUP, metadataFieldId,params, int_param, limit, offset};
         }
         else if (limit > 0)
         {
-            paramArr = new Object[]{params, int_param, limit};
+            paramArr = new Object[]{Constants.GROUP, metadataFieldId,params, int_param, limit};
         }
         else if (offset > 0)
         {
-            paramArr = new Object[]{params, int_param, offset};
+            paramArr = new Object[]{Constants.GROUP, metadataFieldId,params, int_param, offset};
         }
 
         TableRowIterator rows =
@@ -969,7 +981,9 @@ public class Group extends DSpaceObject
     	throws SQLException
 	{
 		String params = "%"+query.toLowerCase()+"%";
-		String dbquery = "SELECT count(*) as gcount FROM epersongroup WHERE LOWER(name) LIKE LOWER(?) OR eperson_group_id = ? ";
+		String dbquery = "SELECT count(*) as gcount FROM epersongroup " +
+                "LEFT JOIN metadatavalue m on (m.resource_id = epersongroup.eperson_group_id and m.resource_type_id = ? and m.metadata_field_id = ?) " +
+                "WHERE LOWER(m.text_value) LIKE LOWER(?) OR eperson_group_id = ? ";
 		
 		// When checking against the eperson-id, make sure the query can be made into a number
 		Integer int_param;
@@ -981,7 +995,16 @@ public class Group extends DSpaceObject
 		}
 		
 		// Get all the epeople that match the query
-		TableRow row = DatabaseManager.querySingle(context, dbquery, new Object[] {params, int_param});
+		TableRow row = DatabaseManager.querySingle(
+                context,
+                dbquery,
+                new Object[] {
+                        Constants.GROUP,
+                        MetadataField.findByElement(context, MetadataSchema.find(context, MetadataSchema.DC_SCHEMA).getSchemaID(), "title", null).getFieldID(),
+                        params,
+                        int_param
+                }
+        );
 		
 		// use getIntColumn for Oracle count data
 		Long count;
@@ -1006,40 +1029,43 @@ public class Group extends DSpaceObject
     {
         // FIXME: authorizations
 
-        myContext.addEvent(new Event(Event.DELETE, Constants.GROUP, getID(), 
-                getName(), getIdentifiers(myContext)));
+        ourContext.addEvent(new Event(Event.DELETE, Constants.GROUP, getID(), getName(), getIdentifiers(ourContext)));
 
         // Remove from cache
-        myContext.removeCached(this, getID());
+        ourContext.removeCached(this, getID());
 
         // Remove any ResourcePolicies that reference this group
-        AuthorizeManager.removeGroupPolicies(myContext, getID());
+        AuthorizeManager.removeGroupPolicies(ourContext, getID());
 
         // Remove any group memberships first
-        DatabaseManager.updateQuery(myContext,
+        DatabaseManager.updateQuery(ourContext,
                 "DELETE FROM EPersonGroup2EPerson WHERE eperson_group_id= ? ",
                 getID());
 
         // remove any group2groupcache entries
-        DatabaseManager.updateQuery(myContext,
+        DatabaseManager.updateQuery(ourContext,
                 "DELETE FROM group2groupcache WHERE parent_id= ? OR child_id= ? ",
                 getID(),getID());
 
         // Now remove any group2group assignments
-        DatabaseManager.updateQuery(myContext,
+        DatabaseManager.updateQuery(ourContext,
                 "DELETE FROM group2group WHERE parent_id= ? OR child_id= ? ",
                 getID(),getID());
+
+        // Delete the Dublin Core
+        removeMetadataFromDatabase();
 
         // don't forget the new table
         deleteEpersonGroup2WorkspaceItem();
 
         // Remove ourself
-        DatabaseManager.delete(myContext, myRow);
+        DatabaseManager.delete(ourContext, myRow);
 
         epeople.clear();
 
-        log.info(LogManager.getHeader(myContext, "delete_group", "group_id="
+        log.info(LogManager.getHeader(ourContext, "delete_group", "group_id="
                 + getID()));
+
     }
 
     /**
@@ -1047,7 +1073,7 @@ public class Group extends DSpaceObject
      */
     private void deleteEpersonGroup2WorkspaceItem() throws SQLException
     {
-        DatabaseManager.updateQuery(myContext,
+        DatabaseManager.updateQuery(ourContext,
                 "DELETE FROM EPersonGroup2WorkspaceItem WHERE eperson_group_id= ? ",
                 getID());
     }
@@ -1111,13 +1137,11 @@ public class Group extends DSpaceObject
     public void update() throws SQLException, AuthorizeException
     {
         // FIXME: Check authorisation
-        DatabaseManager.update(myContext, myRow);
+        DatabaseManager.update(ourContext, myRow);
 
         if (modifiedMetadata)
         {
-            myContext.addEvent(new Event(Event.MODIFY_METADATA, Constants.GROUP, 
-                    getID(), getDetails(), getIdentifiers(myContext)));
-            modifiedMetadata = false;
+            updateMetadata();
             clearDetails();
         }
 
@@ -1125,7 +1149,7 @@ public class Group extends DSpaceObject
         if (epeopleChanged)
         {
             // Remove any existing mappings
-            DatabaseManager.updateQuery(myContext,
+            DatabaseManager.updateQuery(ourContext,
                     "delete from epersongroup2eperson where eperson_group_id= ? ",
                     getID());
 
@@ -1139,7 +1163,7 @@ public class Group extends DSpaceObject
                 TableRow mappingRow = DatabaseManager.row("epersongroup2eperson");
                 mappingRow.setColumn("eperson_id", e.getID());
                 mappingRow.setColumn("eperson_group_id", getID());
-                DatabaseManager.insert(myContext, mappingRow);
+                DatabaseManager.insert(ourContext, mappingRow);
             }
 
             epeopleChanged = false;
@@ -1149,7 +1173,7 @@ public class Group extends DSpaceObject
         if (groupsChanged)
         {
             // Remove any existing mappings
-            DatabaseManager.updateQuery(myContext,
+            DatabaseManager.updateQuery(ourContext,
                     "delete from group2group where parent_id= ? ",
                     getID());
 
@@ -1163,7 +1187,7 @@ public class Group extends DSpaceObject
                 TableRow mappingRow = DatabaseManager.row("group2group");
                 mappingRow.setColumn("parent_id", getID());
                 mappingRow.setColumn("child_id", g.getID());
-                DatabaseManager.insert(myContext, mappingRow);
+                DatabaseManager.insert(ourContext, mappingRow);
             }
 
             // groups changed, now change group cache
@@ -1172,7 +1196,7 @@ public class Group extends DSpaceObject
             groupsChanged = false;
         }
 
-        log.info(LogManager.getHeader(myContext, "update_group", "group_id="
+        log.info(LogManager.getHeader(ourContext, "update_group", "group_id="
                 + getID()));
     }
 
@@ -1233,7 +1257,7 @@ public class Group extends DSpaceObject
     private void rethinkGroupCache() throws SQLException
     {
         // read in the group2group table
-        TableRowIterator tri = DatabaseManager.queryTable(myContext, "group2group",
+        TableRowIterator tri = DatabaseManager.queryTable(ourContext, "group2group",
                 "SELECT * FROM group2group");
 
         Map<Integer,Set<Integer>> parents = new HashMap<Integer,Set<Integer>>();
@@ -1286,7 +1310,7 @@ public class Group extends DSpaceObject
         }
 
         // empty out group2groupcache table
-        DatabaseManager.updateQuery(myContext,
+        DatabaseManager.updateQuery(ourContext,
                 "DELETE FROM group2groupcache WHERE id >= 0");
 
         // write out new one
@@ -1301,7 +1325,7 @@ public class Group extends DSpaceObject
                 row.setColumn("parent_id", parentID);
                 row.setColumn("child_id", child);
 
-                DatabaseManager.insert(myContext, row);
+                DatabaseManager.insert(ourContext, row);
             }
         }
     }
@@ -1365,7 +1389,7 @@ public class Group extends DSpaceObject
             // is this a collection related group?
             TableRow qResult = DatabaseManager
                     .querySingle(
-                            myContext,
+                            ourContext,
                             "SELECT collection_id, workflow_step_1, workflow_step_2, " +
                             " workflow_step_3, submitter, admin FROM collection "
                                     + " WHERE workflow_step_1 = ? OR "
@@ -1375,7 +1399,7 @@ public class Group extends DSpaceObject
                             getID(), getID(), getID(), getID(), getID());
             if (qResult != null)
             {
-                Collection collection = Collection.find(myContext, qResult
+                Collection collection = Collection.find(ourContext, qResult
                         .getIntColumn("collection_id"));
                 
                 if ((qResult.getIntColumn("workflow_step_1") == getID() ||
@@ -1418,13 +1442,13 @@ public class Group extends DSpaceObject
             // to manage it?
             else if (AuthorizeConfiguration.canCommunityAdminManageAdminGroup())
             {
-                qResult = DatabaseManager.querySingle(myContext,
+                qResult = DatabaseManager.querySingle(ourContext,
                         "SELECT community_id FROM community "
                                 + "WHERE admin = ?", getID());
 
                 if (qResult != null)
                 {
-                    Community community = Community.find(myContext, qResult
+                    Community community = Community.find(ourContext, qResult
                             .getIntColumn("community_id"));
                     return community;
                 }
@@ -1437,5 +1461,38 @@ public class Group extends DSpaceObject
     public void updateLastModified()
     {
 
+    }
+
+    /**
+     * Main script used to set the group names for anonymous group & admin group, only to be called once on DSpace fresh_install
+     * @param args not used
+     * @throws SQLException database exception
+     * @throws AuthorizeException should not occur since we disable authentication for this method.
+     */
+    public static void main(String[] args) throws SQLException, AuthorizeException {
+        Context context = new Context();
+        context.turnOffAuthorisationSystem();
+
+        initDefaultGroupNames(context);
+
+        //Clear the events to avoid the consumers which aren't needed at this time
+        context.getEvents().clear();
+        context.complete();
+    }
+
+    /**
+     * Initializes the group names for anymous & administrator
+     * @param context the dspace context
+     * @throws SQLException database exception
+     * @throws AuthorizeException
+     */
+    public static void initDefaultGroupNames(Context context) throws SQLException, AuthorizeException {
+        Group anonymousGroup = Group.find(context, 0);
+        anonymousGroup.setName("Anonymous");
+        anonymousGroup.update();
+
+        Group adminGroup = Group.find(context, 1);
+        adminGroup.setName("Administrator");
+        adminGroup.update();
     }
 }

--- a/dspace-api/src/main/java/org/dspace/identifier/EZIDIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/EZIDIdentifierProvider.java
@@ -629,7 +629,7 @@ public class EZIDIdentifierProvider
 
         for (Entry<String, String> datum : crosswalk.entrySet())
         {
-            DCValue[] values = item.getMetadata(datum.getValue());
+            DCValue[] values = item.getMetadataByMetadataString(datum.getValue());
             if (null != values)
             {
                 for (DCValue value : values)

--- a/dspace-api/src/main/java/org/dspace/submit/lookup/DSpaceWorkspaceItemOutputGenerator.java
+++ b/dspace-api/src/main/java/org/dspace/submit/lookup/DSpaceWorkspaceItemOutputGenerator.java
@@ -171,7 +171,7 @@ public class DSpaceWorkspaceItemOutputGenerator implements OutputGenerator
             {
                 continue;
             }
-            if (item.getMetadata(metadata).length == 0
+            if (item.getMetadataByMetadataString(metadata).length == 0
                     || addedMetadata.contains(metadata))
             {
                 addedMetadata.add(metadata);

--- a/dspace-api/src/main/java/org/dspace/submit/step/DescribeStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/DescribeStep.java
@@ -145,9 +145,9 @@ public class DescribeStep extends AbstractProcessingStep
 
         // Fetch the document type (dc.type)
         String documentType = "";
-        if( (item.getMetadata("dc.type") != null) && (item.getMetadata("dc.type").length >0) )
+        if( (item.getMetadataByMetadataString("dc.type") != null) && (item.getMetadataByMetadataString("dc.type").length >0) )
         {
-            documentType = item.getMetadata("dc.type")[0].value;
+            documentType = item.getMetadataByMetadataString("dc.type")[0].value;
         }
         
         // Step 1:

--- a/dspace-api/src/test/java/org/dspace/AbstractUnitTest.java
+++ b/dspace-api/src/test/java/org/dspace/AbstractUnitTest.java
@@ -36,6 +36,7 @@ import org.dspace.core.I18nUtil;
 import org.dspace.discovery.IndexingService;
 import org.dspace.discovery.MockIndexEventConsumer;
 import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
 import org.dspace.servicemanager.DSpaceKernelImpl;
 import org.dspace.servicemanager.DSpaceKernelInit;
 import org.dspace.storage.rdbms.DatabaseManager;
@@ -148,6 +149,8 @@ public class AbstractUnitTest
 
                 RegistryLoader.loadBitstreamFormats(ctx, base + "bitstream-formats.xml");
                 MetadataImporter.loadRegistry(base + "dublin-core-types.xml", true);
+                MetadataImporter.loadRegistry(base + "eperson-types.xml", true);
+                MetadataImporter.loadRegistry(base + "bitstream-formats.xml", true);
                 MetadataImporter.loadRegistry(base + "sword-metadata.xml", true);
                 ctx.commit();
 
@@ -173,6 +176,7 @@ public class AbstractUnitTest
                 dspace = null;
                 indexer = null;
             }
+            Group.initDefaultGroupNames(ctx);
             ctx.restoreAuthSystemState();
             if(ctx.isValid())
             {

--- a/dspace-api/src/test/java/org/dspace/content/CollectionTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/CollectionTest.java
@@ -222,9 +222,7 @@ public class CollectionTest extends AbstractDSpaceObjectTest
         assertThat("testGetMetadata 0",c.getMetadata("name"), equalTo(""));
         assertThat("testGetMetadata 1",c.getMetadata("short_description"), equalTo(""));
         assertThat("testGetMetadata 2",c.getMetadata("introductory_text"), equalTo(""));
-        assertThat("testGetMetadata 3",c.getMetadata("logo_bitstream_id"), equalTo(""));
         assertThat("testGetMetadata 4",c.getMetadata("copyright_text"), equalTo(""));
-        assertThat("testGetMetadata 5",c.getMetadata("template_item_id"), equalTo(""));
         assertThat("testGetMetadata 6",c.getMetadata("provenance_description"), equalTo(""));
         assertThat("testGetMetadata 7",c.getMetadata("side_bar_text"), equalTo(""));
         assertThat("testGetMetadata 8",c.getMetadata("license"), equalTo(""));
@@ -234,12 +232,10 @@ public class CollectionTest extends AbstractDSpaceObjectTest
      * Test of setMetadata method, of class Collection.
      */
     @Test
-    public void testSetMetadata()
-    {
+    public void testSetMetadata() throws SQLException {
         String name = "name";
         String sdesc = "short description";
         String itext = "introductory text";
-        String logo = "1";
         String copy = "copyright declaration";
         String sidebar = "side bar text";
         String tempItem = "3";
@@ -249,20 +245,16 @@ public class CollectionTest extends AbstractDSpaceObjectTest
         c.setMetadata("name", name);
         c.setMetadata("short_description", sdesc);
         c.setMetadata("introductory_text", itext);
-        c.setMetadata("logo_bitstream_id", logo);
         c.setMetadata("copyright_text", copy);
         c.setMetadata("side_bar_text", sidebar);
-        c.setMetadata("template_item_id", tempItem);
         c.setMetadata("provenance_description", provDesc);
         c.setMetadata("license", license);
 
         assertThat("testSetMetadata 0",c.getMetadata("name"), equalTo(name));
         assertThat("testSetMetadata 1",c.getMetadata("short_description"), equalTo(sdesc));
         assertThat("testSetMetadata 2",c.getMetadata("introductory_text"), equalTo(itext));
-        assertThat("testSetMetadata 3",c.getMetadata("logo_bitstream_id"), equalTo(logo));
         assertThat("testSetMetadata 4",c.getMetadata("copyright_text"), equalTo(copy));
         assertThat("testSetMetadata 5",c.getMetadata("side_bar_text"), equalTo(sidebar));
-        assertThat("testGetMetadata 6",c.getMetadata("template_item_id"), equalTo(tempItem));
         assertThat("testGetMetadata 7",c.getMetadata("provenance_description"), equalTo(provDesc));
         assertThat("testGetMetadata 8",c.getMetadata("license"), equalTo(license));
     }
@@ -689,8 +681,7 @@ public class CollectionTest extends AbstractDSpaceObjectTest
      * Test of setLicense method, of class Collection.
      */
     @Test
-    public void testSetLicense()
-    {
+    public void testSetLicense() throws SQLException {
         String license = "license for test";
         c.setLicense(license);
         assertThat("testSetLicense 0", c.getLicense(), notNullValue());

--- a/dspace-api/src/test/java/org/dspace/content/CommunityTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/CommunityTest.java
@@ -334,7 +334,6 @@ public class CommunityTest extends AbstractDSpaceObjectTest
         assertThat("testGetMetadata 0",c.getMetadata("name"), equalTo(""));
         assertThat("testGetMetadata 1",c.getMetadata("short_description"), equalTo(""));
         assertThat("testGetMetadata 2",c.getMetadata("introductory_text"), equalTo(""));
-        assertThat("testGetMetadata 3",c.getMetadata("logo_bitstream_id"), equalTo(""));
         assertThat("testGetMetadata 4",c.getMetadata("copyright_text"), equalTo(""));
         assertThat("testGetMetadata 5",c.getMetadata("side_bar_text"), equalTo(""));
     }
@@ -348,21 +347,18 @@ public class CommunityTest extends AbstractDSpaceObjectTest
         String name = "name";
         String sdesc = "short description";
         String itext = "introductory text";
-        String logo = "1";
         String copy = "copyright declaration";
         String sidebar = "side bar text";
 
         c.setMetadata("name", name);
         c.setMetadata("short_description", sdesc);
         c.setMetadata("introductory_text", itext);
-        c.setMetadata("logo_bitstream_id", logo);
         c.setMetadata("copyright_text", copy);
         c.setMetadata("side_bar_text", sidebar);
 
         assertThat("testSetMetadata 0",c.getMetadata("name"), equalTo(name));
         assertThat("testSetMetadata 1",c.getMetadata("short_description"), equalTo(sdesc));
         assertThat("testSetMetadata 2",c.getMetadata("introductory_text"), equalTo(itext));
-        assertThat("testSetMetadata 3",c.getMetadata("logo_bitstream_id"), equalTo(logo));
         assertThat("testSetMetadata 4",c.getMetadata("copyright_text"), equalTo(copy));
         assertThat("testSetMetadata 5",c.getMetadata("side_bar_text"), equalTo(sidebar));
     }

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -9,7 +9,6 @@ package org.dspace.content;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.sql.SQLException;
 
@@ -294,23 +293,23 @@ public class ItemTest  extends AbstractDSpaceObjectTest
     }
 
     /**
-     * Test of getMetadata method, of class Item.
+     * Test of getMetadataByMetadataString method, of class Item.
      */
     @Test
     public void testGetMetadata_String()
     {
         String mdString = "dc.contributor.author";
-        DCValue[] dc = it.getMetadata(mdString);
+        DCValue[] dc = it.getMetadataByMetadataString(mdString);
         assertThat("testGetMetadata_String 0",dc,notNullValue());
         assertTrue("testGetMetadata_String 1",dc.length == 0);
 
         mdString = "dc.contributor.*";
-        dc = it.getMetadata(mdString);
+        dc = it.getMetadataByMetadataString(mdString);
         assertThat("testGetMetadata_String 2",dc,notNullValue());
         assertTrue("testGetMetadata_String 3",dc.length == 0);
 
         mdString = "dc.contributor";
-        dc = it.getMetadata(mdString);
+        dc = it.getMetadataByMetadataString(mdString);
         assertThat("testGetMetadata_String 4",dc,notNullValue());
         assertTrue("testGetMetadata_String 5",dc.length == 0);
     }

--- a/dspace-api/src/test/java/org/dspace/content/MetadataFieldTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/MetadataFieldTest.java
@@ -65,11 +65,6 @@ public class MetadataFieldTest extends AbstractUnitTest
                     MetadataSchema.DC_SCHEMA_ID, element, qualifier);
             this.mf.setScopeNote(scopeNote);
         }
-        catch (AuthorizeException ex)
-        {
-            log.error("Authorize Error in init", ex);
-            fail("Authorize Error in init: " + ex.getMessage());
-        }
         catch (SQLException ex)
         {
             log.error("SQL Error in init", ex);

--- a/dspace-api/src/test/java/org/dspace/content/MetadataIntegrationTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/MetadataIntegrationTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import org.apache.log4j.Logger;
 import org.dspace.AbstractIntegrationTest;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.core.Constants;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -84,12 +85,14 @@ public class MetadataIntegrationTest  extends AbstractIntegrationTest
         field2.create(context);
 
         MetadataValue value1 = new MetadataValue(field1);
-        value1.setItemId(it.getID());
+        value1.setResourceId(it.getID());
+        value1.setResourceTypeId(Constants.ITEM);
         value1.setValue("value1");
         value1.create(context);
 
         MetadataValue value2 = new MetadataValue(field2);
-        value2.setItemId(it.getID());
+        value2.setResourceId(it.getID());
+        value2.setResourceTypeId(Constants.ITEM);
         value2.setValue("value2");
         value2.create(context);
         

--- a/dspace-api/src/test/java/org/dspace/content/MetadataValueTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/MetadataValueTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import org.dspace.AbstractUnitTest;
 import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.core.Constants;
 import org.junit.*;
 import static org.junit.Assert.* ;
 import static org.hamcrest.CoreMatchers.*;
@@ -66,7 +67,8 @@ public class MetadataValueTest extends AbstractUnitTest
             this.mf = MetadataField.findByElement(context,
                     MetadataSchema.DC_SCHEMA_ID, element, qualifier);
             this.mv = new MetadataValue(mf);
-            this.mv.setItemId(Item.create(context).getID());
+            this.mv.setResourceId(Item.create(context).getID());
+            this.mv.setResourceTypeId(Constants.ITEM);
             context.commit();
             context.restoreAuthSystemState();
         }
@@ -127,7 +129,7 @@ public class MetadataValueTest extends AbstractUnitTest
     @Test
     public void testGetItemId() 
     {
-        assertTrue("testGetItemId 0", mv.getItemId() >= 0);
+        assertTrue("testGetItemId 0", mv.getResourceId() >= 0);
     }
 
     /**
@@ -137,8 +139,9 @@ public class MetadataValueTest extends AbstractUnitTest
     public void testSetItemId()
     {
         int itemId = 55;
-        mv.setItemId(itemId);
-        assertThat("testSetItemId 0", mv.getItemId(), equalTo(itemId));
+        mv.setResourceId(itemId);
+        mv.setResourceTypeId(Constants.ITEM);
+        assertThat("testSetItemId 0", mv.getResourceId(), equalTo(itemId));
     }
 
     /**

--- a/dspace-api/src/test/resources/database_schema.sql
+++ b/dspace-api/src/test/resources/database_schema.sql
@@ -152,13 +152,9 @@ CREATE TABLE Bitstream
 (
    bitstream_id            INTEGER PRIMARY KEY,
    bitstream_format_id     INTEGER REFERENCES BitstreamFormatRegistry(bitstream_format_id),
-   name                    VARCHAR(256),
    size_bytes              BIGINT,
    checksum                VARCHAR(64),
    checksum_algorithm      VARCHAR(32),
-   description             TEXT,
-   user_format_description TEXT,
-   source                  VARCHAR(256),
    internal_id             VARCHAR(256),
    deleted                 BOOL,
    store_number            INTEGER,
@@ -175,16 +171,11 @@ CREATE TABLE EPerson
   eperson_id          INTEGER PRIMARY KEY,
   email               VARCHAR(64),
   password            VARCHAR(64),
-  firstname           VARCHAR(64),
-  lastname            VARCHAR(64),
   can_log_in          BOOL,
   require_certificate BOOL,
   self_registered     BOOL,
   last_active         TIMESTAMP,
-  sub_frequency       INTEGER,
-  phone               VARCHAR(32),
-  netid               VARCHAR(64),
-  language            VARCHAR(64)
+  sub_frequency       INTEGER
 );
 
 -- index by email
@@ -198,8 +189,7 @@ CREATE INDEX eperson_netid_idx ON EPerson(netid);
 -------------------------------------------------------
 CREATE TABLE EPersonGroup
 (
-  eperson_group_id INTEGER PRIMARY KEY,
-  name             VARCHAR(256)
+  eperson_group_id INTEGER PRIMARY KEY
 );
 
 ------------------------------------------------------
@@ -256,7 +246,6 @@ CREATE INDEX item_submitter_fk_idx ON Item(submitter_id);
 CREATE TABLE Bundle
 (
   bundle_id          INTEGER PRIMARY KEY,
-  name               VARCHAR(16),  
   primary_bitstream_id  INTEGER REFERENCES Bitstream(bitstream_id)
 );
 
@@ -315,7 +304,8 @@ CREATE TABLE MetadataFieldRegistry
 CREATE TABLE MetadataValue
 (
   metadata_value_id  INTEGER PRIMARY KEY,
-  item_id            INTEGER REFERENCES Item(item_id),
+  resource_id        INTEGER NOT NULL,
+  resource_type_id   INTEGER NOT NULL,
   metadata_field_id  INTEGER REFERENCES MetadataFieldRegistry(metadata_field_id),
   text_value         TEXT,
   text_lang          VARCHAR(24),
@@ -325,19 +315,17 @@ CREATE TABLE MetadataValue
 );
 
 -- Create a dcvalue view for backwards compatibilty
-CREATE VIEW dcvalue AS 
-  SELECT MetadataValue.metadata_value_id AS "dc_value_id", MetadataValue.item_id,
+CREATE VIEW dcvalue AS
+  SELECT MetadataValue.metadata_value_id AS "dc_value_id", MetadataValue.resource_id,
     MetadataValue.metadata_field_id AS "dc_type_id", MetadataValue.text_value,
     MetadataValue.text_lang, MetadataValue.place
   FROM MetadataValue, MetadataFieldRegistry
   WHERE MetadataValue.metadata_field_id = MetadataFieldRegistry.metadata_field_id
-  AND MetadataFieldRegistry.metadata_schema_id = 1;
+  AND MetadataFieldRegistry.metadata_schema_id = 1 AND MetadataValue.resource_type_id = 2;
 
 -- An index for item_id - almost all access is based on
 -- instantiating the item object, which grabs all values
 -- related to that item
-CREATE INDEX metadatavalue_item_idx ON MetadataValue(item_id);
-CREATE INDEX metadatavalue_item_idx2 ON MetadataValue(item_id,metadata_field_id);
 CREATE INDEX metadatavalue_field_fk_idx ON MetadataValue(metadata_field_id);
 CREATE INDEX metadatafield_schema_idx ON MetadataFieldRegistry(metadata_schema_id);
   
@@ -347,12 +335,7 @@ CREATE INDEX metadatafield_schema_idx ON MetadataFieldRegistry(metadata_schema_i
 CREATE TABLE Community
 (
   community_id      INTEGER PRIMARY KEY,
-  name              VARCHAR(128),
-  short_description VARCHAR(512),
-  introductory_text TEXT,
   logo_bitstream_id INTEGER REFERENCES Bitstream(bitstream_id),
-  copyright_text    TEXT,
-  side_bar_text     TEXT,
   admin             INTEGER REFERENCES EPersonGroup( eperson_group_id )
 );
 
@@ -365,15 +348,8 @@ CREATE INDEX community_admin_fk_idx ON Community(admin);
 CREATE TABLE Collection
 (
   collection_id     INTEGER PRIMARY KEY,
-  name              VARCHAR(128),
-  short_description VARCHAR(512),
-  introductory_text TEXT,
   logo_bitstream_id INTEGER REFERENCES Bitstream(bitstream_id),
   template_item_id  INTEGER REFERENCES Item(item_id),
-  provenance_description  TEXT,
-  license           TEXT,
-  copyright_text    TEXT,
-  side_bar_text     TEXT,
   workflow_step_1   INTEGER REFERENCES EPersonGroup( eperson_group_id ),
   workflow_step_2   INTEGER REFERENCES EPersonGroup( eperson_group_id ),
   workflow_step_3   INTEGER REFERENCES EPersonGroup( eperson_group_id ),
@@ -632,8 +608,8 @@ CREATE TABLE community_item_count (
 --  and administrators
 -------------------------------------------------------
 -- We don't use getnextid() for 'anonymous' since the sequences start at '1'
-INSERT INTO epersongroup VALUES(0, 'Anonymous');
-INSERT INTO epersongroup VALUES(NEXTVAL('epersongroup_seq'), 'Administrator');
+INSERT INTO epersongroup VALUES(0);
+INSERT INTO epersongroup VALUES(NEXTVAL('epersongroup_seq'));
 
 
 -------------------------------------------------------

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/BrowseListTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/BrowseListTag.java
@@ -624,12 +624,7 @@ public class BrowseListTag extends TagSupport
         catch (IOException ie)
         {
             throw new JspException(ie);
-        }
-        catch (SQLException e)
-        {
-        	throw new JspException(e);
-        }
-        catch (BrowseException e)
+        } catch (BrowseException e)
         {
         	throw new JspException(e);
         }

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/util/MetadataStyleSelection.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/util/MetadataStyleSelection.java
@@ -34,7 +34,7 @@ public class MetadataStyleSelection extends AKeyBasedStyleSelection
     public String getStyleForItem(Item item) throws SQLException
     {
         String metadata = ConfigurationManager.getProperty("webui.itemdisplay.metadata-style");
-        DCValue[] value = item.getMetadata(metadata);
+        DCValue[] value = item.getMetadataByMetadataString(metadata);
         String styleName = "default";
         if (value.length > 0)
         {

--- a/dspace-jspui/src/main/webapp/dspace-admin/curate-item.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/curate-item.jsp
@@ -40,7 +40,7 @@
     String title = "Unknown Item";
     if (item != null)
     {
-        DCValue[] dcvs = item.getMetadata("dc.title");
+        DCValue[] dcvs = item.getMetadataByMetadataString("dc.title");
         if (dcvs != null && dcvs.length > 0)
         {
             title = dcvs[0].value;

--- a/dspace-jspui/src/main/webapp/submit/edit-metadata.jsp
+++ b/dspace-jspui/src/main/webapp/submit/edit-metadata.jsp
@@ -1188,9 +1188,9 @@
 
     // Fetch the document type (dc.type)
     String documentType = "";
-    if( (item.getMetadata("dc.type") != null) && (item.getMetadata("dc.type").length >0) )
+    if( (item.getMetadataByMetadataString("dc.type") != null) && (item.getMetadataByMetadataString("dc.type").length >0) )
     {
-        documentType = item.getMetadata("dc.type")[0].value;
+        documentType = item.getMetadataByMetadataString("dc.type")[0].value;
     }
 %>
 

--- a/dspace-jspui/src/main/webapp/tools/curate-item.jsp
+++ b/dspace-jspui/src/main/webapp/tools/curate-item.jsp
@@ -40,7 +40,7 @@
     String title = "Unknown Item";
     if (item != null)
     {
-        DCValue[] dcvs = item.getMetadata("dc.title");
+        DCValue[] dcvs = item.getMetadataByMetadataString("dc.title");
         if (dcvs != null && dcvs.length > 0)
         {
             title = dcvs[0].value;

--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceAtLeastOneMetadataFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceAtLeastOneMetadataFilter.java
@@ -18,6 +18,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.solr.client.solrj.util.ClientUtils;
+import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.xoai.data.DSpaceItem;
 import org.dspace.xoai.exceptions.InvalidMetadataFieldException;
@@ -154,7 +155,7 @@ public class DSpaceAtLeastOneMetadataFilter extends DSpaceFilter {
         for (String v : values)
             this.buildWhere(v, parts, params);
         if (parts.size() > 0) {
-            String query = "EXISTS (SELECT tmp.* FROM metadatavalue tmp WHERE tmp.item_id=i.item_id AND tmp.metadata_field_id=?"
+            String query = "EXISTS (SELECT tmp.* FROM metadatavalue tmp WHERE tmp.resource_id=i.item_id AND tmp.resource_type_id=" + Constants.ITEM+ " AND tmp.metadata_field_id=?"
                     + " AND ("
                     + StringUtils.join(parts.iterator(), " OR ")
                     + "))";

--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceMetadataExistsFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceMetadataExistsFilter.java
@@ -12,6 +12,7 @@ import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.ParameterValue;
 import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.SimpleType;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
+import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.xoai.data.DSpaceItem;
 import org.dspace.xoai.exceptions.InvalidMetadataFieldException;
@@ -72,7 +73,7 @@ public class DSpaceMetadataExistsFilter extends DSpaceFilter {
             List<Object> args = new ArrayList<Object>(fields.size());
             where.append("(");
             for (int i = 0; i < fields.size(); i++) {
-                where.append("EXISTS (SELECT tmp.* FROM metadatavalue tmp WHERE tmp.item_id=i.item_id AND tmp.metadata_field_id=?)");
+                where.append("EXISTS (SELECT tmp.* FROM metadatavalue tmp WHERE tmp.resource_id=i.item_id AND tmp.resource_type_id=" + Constants.ITEM+ " AND tmp.metadata_field_id=?)");
                 args.add(fieldResolver.getFieldID(context, fields.get(i)));
 
                 if (i < fields.size() - 1)

--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceSetSpecFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceSetSpecFilter.java
@@ -50,7 +50,7 @@ public class DSpaceSetSpecFilter extends DSpaceFilter
             {
                 DSpaceObject dso = handleResolver.resolve(setSpec.replace("col_", ""));
                 return new DatabaseFilterResult(
-                        "EXISTS (SELECT tmp.* FROM collection2item tmp WHERE tmp.item_id=i.item_id AND collection_id = ?)",
+                        "EXISTS (SELECT tmp.* FROM collection2item tmp WHERE tmp.resource_id=i.item_id AND collection_id = ?)",
                         dso.getID());
             }
             catch (Exception ex)
@@ -66,7 +66,7 @@ public class DSpaceSetSpecFilter extends DSpaceFilter
                 List<Integer> list = collectionsService.getAllSubCollections(dso.getID());
                 String subCollections = StringUtils.join(list.iterator(), ",");
                 return new DatabaseFilterResult(
-                        "EXISTS (SELECT tmp.* FROM collection2item tmp WHERE tmp.item_id=i.item_id AND collection_id IN ("
+                        "EXISTS (SELECT tmp.* FROM collection2item tmp WHERE tmp.resource_id=i.item_id AND collection_id IN ("
                                 + subCollections + "))");
             }
             catch (Exception e)

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/services/impl/database/DSpaceDatabaseQueryResolverTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/services/impl/database/DSpaceDatabaseQueryResolverTest.java
@@ -17,6 +17,7 @@ import com.lyncode.xoai.dataprovider.filter.conditions.CustomCondition;
 import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.ParameterList;
 import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.ParameterMap;
 import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.StringValue;
+import org.dspace.core.Constants;
 import org.dspace.xoai.filter.DSpaceMetadataExistsFilter;
 import org.dspace.xoai.filter.DSpaceSetSpecFilter;
 import org.dspace.xoai.filter.DateFromFilter;
@@ -116,7 +117,7 @@ public class DSpaceDatabaseQueryResolverTest extends AbstractQueryResolverTest {
 
         DatabaseQuery result = underTest.buildQuery(scopedFilters, START, LENGTH);
 
-        assertThat(result.getQuery(), is("SELECT i.* FROM item i  WHERE i.in_archive=true AND ((EXISTS (SELECT tmp.* FROM metadatavalue tmp WHERE tmp.item_id=i.item_id AND tmp.metadata_field_id=?))) ORDER BY i.item_id OFFSET ? LIMIT ?"));
+        assertThat(result.getQuery(), is("SELECT i.* FROM item i  WHERE i.in_archive=true AND ((EXISTS (SELECT tmp.* FROM metadatavalue tmp WHERE tmp.resource_id=i.item_id AND tmp.resource_type_id=" + Constants.ITEM + " AND tmp.metadata_field_id=?))) ORDER BY i.item_id OFFSET ? LIMIT ?"));
         assertThat(((Integer) result.getParameters().get(0)), is(1));
         assertThat((Integer) result.getParameters().get(1), is(START));
         assertThat((Integer) result.getParameters().get(2), is(LENGTH));
@@ -140,7 +141,7 @@ public class DSpaceDatabaseQueryResolverTest extends AbstractQueryResolverTest {
 
         DatabaseQuery result = underTest.buildQuery(scopedFilters, START, LENGTH);
 
-        assertThat(result.getQuery(), is("SELECT i.* FROM item i  WHERE i.in_archive=true AND ((EXISTS (SELECT tmp.* FROM metadatavalue tmp WHERE tmp.item_id=i.item_id AND tmp.metadata_field_id=?) OR EXISTS (SELECT tmp.* FROM metadatavalue tmp WHERE tmp.item_id=i.item_id AND tmp.metadata_field_id=?))) ORDER BY i.item_id OFFSET ? LIMIT ?"));
+        assertThat(result.getQuery(), is("SELECT i.* FROM item i  WHERE i.in_archive=true AND ((EXISTS (SELECT tmp.* FROM metadatavalue tmp WHERE tmp.resource_id=i.item_id AND tmp.resource_type_id=" + Constants.ITEM + " AND tmp.metadata_field_id=?) OR EXISTS (SELECT tmp.* FROM metadatavalue tmp WHERE tmp.resource_id=i.item_id AND tmp.resource_type_id=" + Constants.ITEM + " AND tmp.metadata_field_id=?))) ORDER BY i.item_id OFFSET ? LIMIT ?"));
         assertThat(((Integer) result.getParameters().get(0)), is(1));
         assertThat(((Integer) result.getParameters().get(1)), is(2));
         assertThat((Integer) result.getParameters().get(2), is(START));

--- a/dspace-sword/src/main/java/org/dspace/sword/ItemCollectionGenerator.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/ItemCollectionGenerator.java
@@ -54,7 +54,7 @@ public class ItemCollectionGenerator extends ATOMCollectionGenerator
 
 		// the item title is the sword collection title, or "untitled" otherwise
 		String title = "Untitled";
-		DCValue[] dcv = item.getMetadata("dc.title");
+		DCValue[] dcv = item.getMetadataByMetadataString("dc.title");
 		if (dcv.length > 0)
 		{
 			title = dcv[0].value;
@@ -67,7 +67,7 @@ public class ItemCollectionGenerator extends ATOMCollectionGenerator
 
 		// abstract is the short description of the item, if it exists
 		String dcAbstract = "";
-		DCValue[] dcva = item.getMetadata("dc.description.abstract");
+		DCValue[] dcva = item.getMetadataByMetadataString("dc.description.abstract");
 		if (dcva.length > 0)
 		{
 			dcAbstract = dcva[0].value;

--- a/dspace-sword/src/main/java/org/dspace/sword/ItemEntryGenerator.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/ItemEntryGenerator.java
@@ -47,7 +47,7 @@ public class ItemEntryGenerator extends DSpaceATOMEntry
 	 */
 	protected void addCategories()
 	{
-		DCValue[] dcv = item.getMetadata("dc.subject.*");
+		DCValue[] dcv = item.getMetadataByMetadataString("dc.subject.*");
 		if (dcv != null)
 		{
 			for (int i = 0; i < dcv.length; i++)
@@ -233,7 +233,7 @@ public class ItemEntryGenerator extends DSpaceATOMEntry
 	 */
 	protected void addPublishDate()
 	{
-		DCValue[] dcv = item.getMetadata("dc.date.issued");
+		DCValue[] dcv = item.getMetadataByMetadataString("dc.date.issued");
 		if (dcv != null && dcv.length == 1)
         {
             entry.setPublished(dcv[0].value);
@@ -298,7 +298,7 @@ public class ItemEntryGenerator extends DSpaceATOMEntry
 	 */
 	protected void addSummary()
 	{
-		DCValue[] dcv = item.getMetadata("dc.description.abstract");
+		DCValue[] dcv = item.getMetadataByMetadataString("dc.description.abstract");
 		if (dcv != null)
 		{
 			for (int i = 0; i < dcv.length; i++)
@@ -317,7 +317,7 @@ public class ItemEntryGenerator extends DSpaceATOMEntry
 	 */
 	protected void addTitle()
 	{
-		DCValue[] dcv = item.getMetadata("dc.title");
+		DCValue[] dcv = item.getMetadataByMetadataString("dc.title");
 		if (dcv != null)
 		{
 			for (int i = 0; i < dcv.length; i++)
@@ -337,7 +337,7 @@ public class ItemEntryGenerator extends DSpaceATOMEntry
 	protected void addLastUpdatedDate()
 	{
 		String config = ConfigurationManager.getProperty("sword-server", "updated.field");
-		DCValue[] dcv = item.getMetadata(config);
+		DCValue[] dcv = item.getMetadataByMetadataString(config);
 		if (dcv != null && dcv.length == 1)
         {
             DCDate dcd = new DCDate(dcv[0].value);

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/AtomStatementDisseminator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/AtomStatementDisseminator.java
@@ -43,7 +43,7 @@ public class AtomStatementDisseminator extends GenericStatementDisseminator impl
 			return null;
 		}
 
-		DCValue[] dcvs = item.getMetadata(field);
+		DCValue[] dcvs = item.getMetadataByMetadataString(field);
 		if (dcvs == null || dcvs.length == 0)
 		{
 			return null;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/CollectionListManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/CollectionListManagerDSpace.java
@@ -180,7 +180,7 @@ public class CollectionListManagerDSpace extends DSpaceSwordAPI implements Colle
 			return null;
 		}
 
-		DCValue[] dcvs = item.getMetadata(field);
+		DCValue[] dcvs = item.getMetadataByMetadataString(field);
 		if (dcvs == null)
 		{
 			return null;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/ReceiptGenerator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/ReceiptGenerator.java
@@ -222,7 +222,7 @@ public class ReceiptGenerator
 	 */
 	protected void addCategories(DepositResult result, DepositReceipt receipt)
 	{
-		DCValue[] dcv = result.getItem().getMetadata("dc.subject.*");
+		DCValue[] dcv = result.getItem().getMetadataByMetadataString("dc.subject.*");
 		if (dcv != null)
 		{
 			for (int i = 0; i < dcv.length; i++)
@@ -234,7 +234,7 @@ public class ReceiptGenerator
 
 	protected void addCategories(Item item, DepositReceipt receipt)
 	{
-		DCValue[] dcv = item.getMetadata("dc.subject.*");
+		DCValue[] dcv = item.getMetadataByMetadataString("dc.subject.*");
 		if (dcv != null)
 		{
 			for (int i = 0; i < dcv.length; i++)
@@ -250,7 +250,7 @@ public class ReceiptGenerator
 	 */
 	protected void addPublishDate(DepositResult result, DepositReceipt receipt)
 	{
-		DCValue[] dcv = result.getItem().getMetadata("dc.date.issued");
+		DCValue[] dcv = result.getItem().getMetadataByMetadataString("dc.date.issued");
 		if (dcv != null && dcv.length == 1)
         {
             try
@@ -269,7 +269,7 @@ public class ReceiptGenerator
 
 	protected void addPublishDate(Item item, DepositReceipt receipt)
 	{
-		DCValue[] dcv = item.getMetadata("dc.date.issued");
+		DCValue[] dcv = item.getMetadataByMetadataString("dc.date.issued");
 		if (dcv != null && dcv.length == 1)
         {
             try
@@ -293,7 +293,7 @@ public class ReceiptGenerator
 	protected void addLastUpdatedDate(DepositResult result, DepositReceipt receipt)
 	{
 		String config = ConfigurationManager.getProperty("swordv2-server", "updated.field");
-		DCValue[] dcv = result.getItem().getMetadata(config);
+		DCValue[] dcv = result.getItem().getMetadataByMetadataString(config);
 		if (dcv != null && dcv.length == 1)
         {
             try
@@ -313,7 +313,7 @@ public class ReceiptGenerator
 	protected void addLastUpdatedDate(Item item, DepositReceipt receipt)
 	{
 		String config = ConfigurationManager.getProperty("swordv2-server", "updated.field");
-		DCValue[] dcv = item.getMetadata(config);
+		DCValue[] dcv = item.getMetadataByMetadataString(config);
 		if (dcv != null && dcv.length == 1)
         {
             try

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/statisticsElasticSearch/CSVOutputter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/statisticsElasticSearch/CSVOutputter.java
@@ -26,7 +26,6 @@ import org.dspace.content.DCValue;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
-import org.dspace.storage.rdbms.TableRow;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 
@@ -189,9 +188,9 @@ public class CSVOutputter extends AbstractReader implements Recyclable
                 entryValues[2] = bitstream.getBundles()[0].getName();
                 entryValues[3] = item.getName();
                 entryValues[4] = "http://hdl.handle.net/" + item.getHandle();
-                entryValues[5] = wrapInDelimitedString(item.getMetadata("dc.creator"));
-                entryValues[6] = wrapInDelimitedString(item.getMetadata("dc.publisher"));
-                entryValues[7] = wrapInDelimitedString(item.getMetadata("dc.date.issued"));
+                entryValues[5] = wrapInDelimitedString(item.getMetadataByMetadataString("dc.creator"));
+                entryValues[6] = wrapInDelimitedString(item.getMetadataByMetadataString("dc.publisher"));
+                entryValues[7] = wrapInDelimitedString(item.getMetadataByMetadataString("dc.date.issued"));
                 entryValues[8] = facetEntry.getCount() + "";
                 writer.writeNext(entryValues);
             } else {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/statisticsElasticSearch/ElasticSearchStatsViewer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/statisticsElasticSearch/ElasticSearchStatsViewer.java
@@ -409,7 +409,7 @@ public class ElasticSearchStatsViewer extends AbstractDSpaceTransformer {
     }
     
     private String getFirstMetadataValue(Item item, String metadataKey) {
-        DCValue[] dcValue = item.getMetadata(metadataKey);
+        DCValue[] dcValue = item.getMetadataByMetadataString(metadataKey);
         if(dcValue.length > 0) {
             return dcValue[0].value;
         } else {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/DescribeStep.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/DescribeStep.java
@@ -181,9 +181,9 @@ public class DescribeStep extends AbstractSubmissionStep
 
                 // Fetch the document type (dc.type)
                 String documentType = "";
-                if( (item.getMetadata("dc.type") != null) && (item.getMetadata("dc.type").length >0) )
+                if( (item.getMetadataByMetadataString("dc.type") != null) && (item.getMetadataByMetadataString("dc.type").length >0) )
                 {
-                    documentType = item.getMetadata("dc.type")[0].value;
+                    documentType = item.getMetadataByMetadataString("dc.type")[0].value;
                 }
                 
                 // Iterate over all inputs and add it to the form.

--- a/dspace-xmlui/src/main/java/org/dspace/springmvc/BibTexView.java
+++ b/dspace-xmlui/src/main/java/org/dspace/springmvc/BibTexView.java
@@ -25,8 +25,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * @author Fabio Bolognesi (fabio at atmire dot com)
@@ -133,7 +131,7 @@ public class BibTexView implements View {
 
     private String getMetadataValue(Item item, String metadatafield)
     {
-        for (DCValue value : item.getMetadata(metadatafield))
+        for (DCValue value : item.getMetadataByMetadataString(metadatafield))
         {
             return value.value;
         }
@@ -145,16 +143,16 @@ public class BibTexView implements View {
     {
         ArrayList<String> authors = new ArrayList<String>();
 
-        authors.addAll(getAuthors(aItem.getMetadata("dc.contributor.author")));
-        authors.addAll(getAuthors(aItem.getMetadata("dc.creator")));
-        authors.addAll(getAuthors(aItem.getMetadata("dc.contributor")));
+        authors.addAll(getAuthors(aItem.getMetadataByMetadataString("dc.contributor.author")));
+        authors.addAll(getAuthors(aItem.getMetadataByMetadataString("dc.creator")));
+        authors.addAll(getAuthors(aItem.getMetadataByMetadataString("dc.contributor")));
 
         return authors.toArray(new String[authors.size()]);
     }
 
     private String getYear(Item aItem)
     {
-        for (DCValue date : aItem.getMetadata("dc.date.issued"))
+        for (DCValue date : aItem.getMetadataByMetadataString("dc.date.issued"))
         {
             return date.value.substring(0, 4);
         }

--- a/dspace-xmlui/src/main/java/org/dspace/springmvc/RisView.java
+++ b/dspace-xmlui/src/main/java/org/dspace/springmvc/RisView.java
@@ -13,8 +13,6 @@ import org.dspace.content.DCValue;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
-import org.dspace.identifier.IdentifierService;
-import org.dspace.utils.DSpace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.View;
@@ -28,8 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * @author Fabio Bolognesi (fabio at atmire dot com)
@@ -159,9 +155,9 @@ public class RisView implements View {
     {
         ArrayList<String> authors = new ArrayList<String>();
 
-        authors.addAll(getAuthors(aItem.getMetadata("dc.contributor.author")));
-        authors.addAll(getAuthors(aItem.getMetadata("dc.creator")));
-        authors.addAll(getAuthors(aItem.getMetadata("dc.contributor")));
+        authors.addAll(getAuthors(aItem.getMetadataByMetadataString("dc.contributor.author")));
+        authors.addAll(getAuthors(aItem.getMetadataByMetadataString("dc.creator")));
+        authors.addAll(getAuthors(aItem.getMetadataByMetadataString("dc.contributor")));
 
         return authors.toArray(new String[authors.size()]);
     }
@@ -170,7 +166,7 @@ public class RisView implements View {
     {
         ArrayList<String> keywordList = new ArrayList<String>();
 
-        for (DCValue keyword : aItem.getMetadata("dc.subject"))
+        for (DCValue keyword : aItem.getMetadataByMetadataString("dc.subject"))
         {
             if (keyword.value.length() < 255)
             {
@@ -178,7 +174,7 @@ public class RisView implements View {
             }
         }
 
-        for (DCValue keyword : aItem.getMetadata("dwc.ScientificName"))
+        for (DCValue keyword : aItem.getMetadataByMetadataString("dwc.ScientificName"))
         {
             if (keyword.value.length() < 255)
             {
@@ -193,7 +189,7 @@ public class RisView implements View {
     {
         StringTokenizer tokenizer;
 
-        for (DCValue date : item.getMetadata("dc.date.issued"))
+        for (DCValue date : item.getMetadataByMetadataString("dc.date.issued"))
         {
             tokenizer = new StringTokenizer(date.value, "-/ T");
             String[] dateParts = new String[tokenizer.countTokens()];
@@ -211,7 +207,7 @@ public class RisView implements View {
 
     private String getMetadataValue(Item item, String metadatafield)
     {
-        for (DCValue value : item.getMetadata(metadatafield))
+        for (DCValue value : item.getMetadataByMetadataString(metadatafield))
         {
             return value.value;
         }

--- a/dspace/config/registries/dublin-core-types.xml
+++ b/dspace/config/registries/dublin-core-types.xml
@@ -584,4 +584,18 @@
     <scope_note>Nature or genre of content.</scope_note>
   </dc-type>
 
+
+    <dc-type>
+        <schema>dc</schema>
+        <element>provenance</element>
+        <!-- unqualified -->
+        <scope_note></scope_note>
+    </dc-type>
+
+    <dc-type>
+        <schema>dc</schema>
+        <element>rights</element>
+        <qualifier>license</qualifier>
+        <scope_note></scope_note>
+    </dc-type>
 </dspace-dc-types>

--- a/dspace/config/registries/eperson-types.xml
+++ b/dspace/config/registries/eperson-types.xml
@@ -1,0 +1,47 @@
+<dspace-dc-types>
+
+    <dspace-header>
+        <title>DSpace EPerson</title>
+        <contributor.author>Kevin Van de Velde</contributor.author>
+        <contributor.author>Bert Vanderhallen</contributor.author>
+        <contributor.author>Ben Bosman</contributor.author>
+        <contributor.author>Mark Diggory</contributor.author>
+    </dspace-header>
+
+    <dc-schema>
+        <name>eperson</name>
+        <namespace>http://dspace.org/eperson</namespace>
+    </dc-schema>
+
+
+    <dc-type>
+        <schema>eperson</schema>
+        <element>firstname</element>
+        <scope_note>Metadata field used for the first name</scope_note>
+    </dc-type>
+
+    <dc-type>
+        <schema>eperson</schema>
+        <element>lastname</element>
+        <scope_note>Metadata field used for the last name</scope_note>
+    </dc-type>
+
+    <dc-type>
+        <schema>eperson</schema>
+        <element>phone</element>
+        <scope_note>Metadata field used for the phone number</scope_note>
+    </dc-type>
+
+    <dc-type>
+        <schema>eperson</schema>
+        <element>netid</element>
+        <scope_note>Metadata field used for the net id</scope_note>
+    </dc-type>
+
+    <dc-type>
+        <schema>eperson</schema>
+        <element>language</element>
+        <scope_note>Metadata field used for the language</scope_note>
+    </dc-type>
+
+</dspace-dc-types>

--- a/dspace/etc/oracle/database_schema_4-5.sql
+++ b/dspace/etc/oracle/database_schema_4-5.sql
@@ -12,3 +12,349 @@
 ------------------------------------------------------
 ALTER TABLE requestitem ADD request_message VARCHAR2(2000);
 
+
+DECLARE
+statement VARCHAR2(2000);
+constr_name VARCHAR2(300);
+BEGIN
+  SELECT CONSTRAINT_NAME INTO constr_name
+   FROM USER_CONS_COLUMNS
+   WHERE table_name  = 'METADATAVALUE' AND COLUMN_NAME='ITEM_ID';
+   statement := 'ALTER TABLE METADATAVALUE DROP CONSTRAINT '|| constr_name;
+   EXECUTE IMMEDIATE(statement);
+END;
+/
+
+alter table metadatavalue rename column item_id to resource_id;
+
+alter table metadatavalue MODIFY(resource_id not null);
+alter table metadatavalue add resource_type_id integer;
+UPDATE metadatavalue SET resource_type_id = 2;
+alter table metadatavalue MODIFY(resource_type_id not null);
+
+
+
+-- ---------
+-- community
+-- ---------
+
+INSERT INTO metadatavalue (metadata_value_id, resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+metadatavalue_seq.nextval as metadata_value_id,
+community_id AS resource_id,
+4 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'description' and qualifier is null) AS metadata_field_id,
+introductory_text AS text_value,
+null AS text_lang,
+0 AS place
+FROM community where not introductory_text is null;
+
+INSERT INTO metadatavalue (metadata_value_id, resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+metadatavalue_seq.nextval as metadata_value_id,
+community_id AS resource_id,
+4 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'description' and qualifier = 'abstract') AS metadata_field_id,
+short_description AS text_value,
+null AS text_lang,
+0 AS place
+FROM community where not short_description is null;
+
+INSERT INTO metadatavalue (metadata_value_id, resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+metadatavalue_seq.nextval as metadata_value_id,
+community_id AS resource_id,
+4 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'description' and qualifier = 'tableofcontents') AS metadata_field_id,
+side_bar_text AS text_value,
+null AS text_lang,
+0 AS place
+FROM community where not side_bar_text is null;
+
+INSERT INTO metadatavalue (metadata_value_id, resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+metadatavalue_seq.nextval as metadata_value_id,
+community_id AS resource_id,
+4 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'rights' and qualifier is null) AS metadata_field_id,
+copyright_text AS text_value,
+null AS text_lang,
+0 AS place
+FROM community where not copyright_text is null;
+
+INSERT INTO metadatavalue (metadata_value_id, resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+metadatavalue_seq.nextval as metadata_value_id,
+community_id AS resource_id,
+4 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'title' and qualifier is null) AS metadata_field_id,
+name AS text_value,
+null AS text_lang,
+0 AS place
+FROM community where not name is null;
+
+alter table community drop (introductory_text, short_description, side_bar_text, copyright_text, name);
+
+
+-- ----------
+-- collection
+-- ----------
+
+
+
+INSERT INTO metadatavalue (metadata_value_id, resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+metadatavalue_seq.nextval as metadata_value_id,
+collection_id AS resource_id,
+3 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'description' and qualifier is null) AS metadata_field_id,
+introductory_text AS text_value,
+null AS text_lang,
+0 AS place
+FROM collection where not introductory_text is null;
+
+INSERT INTO metadatavalue (metadata_value_id, resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+metadatavalue_seq.nextval as metadata_value_id,
+collection_id AS resource_id,
+3 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'description' and qualifier = 'abstract') AS metadata_field_id,
+short_description AS text_value,
+null AS text_lang,
+0 AS place
+FROM collection where not short_description is null;
+
+INSERT INTO metadatavalue (metadata_value_id, resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+metadatavalue_seq.nextval as metadata_value_id,
+collection_id AS resource_id,
+3 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'description' and qualifier = 'tableofcontents') AS metadata_field_id,
+side_bar_text AS text_value,
+null AS text_lang,
+0 AS place
+FROM collection where not side_bar_text is null;
+
+INSERT INTO metadatavalue (metadata_value_id, resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+metadatavalue_seq.nextval as metadata_value_id,
+collection_id AS resource_id,
+3 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'rights' and qualifier is null) AS metadata_field_id,
+copyright_text AS text_value,
+null AS text_lang,
+0 AS place
+FROM collection where not copyright_text is null;
+
+INSERT INTO metadatavalue (metadata_value_id, resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+metadatavalue_seq.nextval as metadata_value_id,
+collection_id AS resource_id,
+3 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'title' and qualifier is null) AS metadata_field_id,
+name AS text_value,
+null AS text_lang,
+0 AS place
+FROM collection where not name is null;
+
+INSERT INTO metadatavalue (metadata_value_id, resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+metadatavalue_seq.nextval as metadata_value_id,
+collection_id AS resource_id,
+3 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'provenance' and qualifier is null) AS metadata_field_id,
+provenance_description AS text_value,
+null AS text_lang,
+0 AS place
+FROM collection where not provenance_description is null;
+
+INSERT INTO metadatavalue (metadata_value_id, resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+metadatavalue_seq.nextval as metadata_value_id,
+collection_id AS resource_id,
+3 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'rights' and qualifier = 'license') AS metadata_field_id,
+license AS text_value,
+null AS text_lang,
+0 AS place
+FROM collection where not license is null;
+
+alter table collection drop (introductory_text, short_description, copyright_text, side_bar_text, name, license, provenance_description);
+
+
+-- ---------
+-- bundle
+-- ---------
+
+INSERT INTO metadatavalue (metadata_value_id, resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+metadatavalue_seq.nextval as metadata_value_id,
+bundle_id AS resource_id,
+1 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'title' and qualifier is null) AS metadata_field_id,
+name AS text_value,
+null AS text_lang,
+0 AS place
+FROM bundle where not name is null;
+
+alter table bundle drop column name;
+
+
+
+-- ---------
+-- bitstream
+-- ---------
+
+
+INSERT INTO metadatavalue (metadata_value_id, resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+metadatavalue_seq.nextval as metadata_value_id,
+bitstream_id AS resource_id,
+0 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'title' and qualifier is null) AS metadata_field_id,
+name AS text_value,
+null AS text_lang,
+0 AS place
+FROM bitstream where not name is null;
+
+INSERT INTO metadatavalue (metadata_value_id, resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+metadatavalue_seq.nextval as metadata_value_id,
+bitstream_id AS resource_id,
+0 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'description' and qualifier is null) AS metadata_field_id,
+description AS text_value,
+null AS text_lang,
+0 AS place
+FROM bitstream where not description is null;
+
+INSERT INTO metadatavalue (metadata_value_id, resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+metadatavalue_seq.nextval as metadata_value_id,
+bitstream_id AS resource_id,
+0 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'format' and qualifier is null) AS metadata_field_id,
+user_format_description AS text_value,
+null AS text_lang,
+0 AS place
+FROM bitstream where not user_format_description is null;
+
+INSERT INTO metadatavalue (metadata_value_id, resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+metadatavalue_seq.nextval as metadata_value_id,
+bitstream_id AS resource_id,
+0 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'source' and qualifier is null) AS metadata_field_id,
+source AS text_value,
+null AS text_lang,
+0 AS place
+FROM bitstream where not source is null;
+
+alter table bitstream drop (name, description, user_format_description, source);
+
+
+-- ---------
+-- epersongroup
+-- ---------
+
+INSERT INTO metadatavalue (metadata_value_id, resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+metadatavalue_seq.nextval as metadata_value_id,
+eperson_group_id AS resource_id,
+6 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'title' and qualifier is null) AS metadata_field_id,
+name AS text_value,
+null AS text_lang,
+0 AS place
+FROM epersongroup where not name is null;
+
+alter table epersongroup drop column name;
+
+
+
+-- ---------
+-- eperson
+-- ---------
+
+
+
+INSERT INTO metadatavalue (metadata_value_id, resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+metadatavalue_seq.nextval as metadata_value_id,
+eperson_id AS resource_id,
+7 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='eperson') and element = 'email' and qualifier is null) AS metadata_field_id,
+email AS text_value,
+null AS text_lang,
+0 AS place
+FROM eperson where not email is null;
+
+INSERT INTO metadatavalue (metadata_value_id, resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+metadatavalue_seq.nextval as metadata_value_id,
+eperson_id AS resource_id,
+7 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='eperson') and element = 'firstname' and qualifier is null) AS metadata_field_id,
+firstname AS text_value,
+null AS text_lang,
+0 AS place
+FROM eperson where not firstname is null;
+
+INSERT INTO metadatavalue (metadata_value_id, resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+metadatavalue_seq.nextval as metadata_value_id,
+eperson_id AS resource_id,
+7 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='eperson') and element = 'lastname' and qualifier is null) AS metadata_field_id,
+lastname AS text_value,
+null AS text_lang,
+0 AS place
+FROM eperson where not lastname is null;
+
+INSERT INTO metadatavalue (metadata_value_id, resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+metadatavalue_seq.nextval as metadata_value_id,
+eperson_id AS resource_id,
+7 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='eperson') and element = 'phone' and qualifier is null) AS metadata_field_id,
+phone AS text_value,
+null AS text_lang,
+0 AS place
+FROM eperson where not phone is null;
+
+
+INSERT INTO metadatavalue (metadata_value_id, resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+metadatavalue_seq.nextval as metadata_value_id,
+eperson_id AS resource_id,
+7 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='eperson') and element = 'netid' and qualifier is null) AS metadata_field_id,
+netid AS text_value,
+null AS text_lang,
+0 AS place
+FROM eperson where not netid is null;
+
+
+INSERT INTO metadatavalue (metadata_value_id, resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+metadatavalue_seq.nextval as metadata_value_id,
+eperson_id AS resource_id,
+7 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='eperson') and element = 'language' and qualifier is null) AS metadata_field_id,
+language AS text_value,
+null AS text_lang,
+0 AS place
+FROM eperson where not language is null;
+
+
+alter table eperson  drop (firstname, lastname, phone, netid, language);
+
+drop view dcvalue;
+
+CREATE VIEW dcvalue AS
+  SELECT MetadataValue.metadata_value_id AS "dc_value_id", MetadataValue.resource_id,
+    MetadataValue.metadata_field_id AS "dc_type_id", MetadataValue.text_value,
+    MetadataValue.text_lang, MetadataValue.place
+  FROM MetadataValue, MetadataFieldRegistry
+  WHERE MetadataValue.metadata_field_id = MetadataFieldRegistry.metadata_field_id
+  AND MetadataFieldRegistry.metadata_schema_id = 1 AND MetadataValue.resource_type_id = 2;

--- a/dspace/etc/postgres/database_schema_4_5.sql
+++ b/dspace/etc/postgres/database_schema_4_5.sql
@@ -14,4 +14,317 @@ BEGIN;
 ALTER TABLE requestitem ADD request_message TEXT;
 
 
+alter table metadatavalue rename item_id to resource_id;
+alter table metadatavalue alter column resource_id set not null;
+alter table metadatavalue add column resource_type_id integer;
+UPDATE metadatavalue SET resource_type_id = 2;
+alter table metadatavalue alter column resource_type_id set not null;
+alter table metadatavalue drop constraint metadatavalue_item_id_fkey;
+
+
+-- ---------
+-- community
+-- ---------
+
+INSERT INTO metadatavalue (resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+community_id AS resource_id,
+4 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'description' and qualifier is null) AS metadata_field_id,
+introductory_text AS text_value,
+null AS text_lang,
+0 AS place
+FROM community where not introductory_text is null;
+
+INSERT INTO metadatavalue (resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+community_id AS resource_id,
+4 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'description' and qualifier = 'abstract') AS metadata_field_id,
+short_description AS text_value,
+null AS text_lang,
+0 AS place
+FROM community where not short_description is null;
+
+INSERT INTO metadatavalue (resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+community_id AS resource_id,
+4 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'description' and qualifier = 'tableofcontents') AS metadata_field_id,
+side_bar_text AS text_value,
+null AS text_lang,
+0 AS place
+FROM community where not side_bar_text is null;
+
+INSERT INTO metadatavalue (resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+community_id AS resource_id,
+4 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'rights' and qualifier is null) AS metadata_field_id,
+copyright_text AS text_value,
+null AS text_lang,
+0 AS place
+FROM community where not copyright_text is null;
+
+INSERT INTO metadatavalue (resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+community_id AS resource_id,
+4 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'title' and qualifier is null) AS metadata_field_id,
+name AS text_value,
+null AS text_lang,
+0 AS place
+FROM community where not name is null;
+
+alter table community drop column introductory_text, drop column short_description, drop column side_bar_text, drop column copyright_text, drop column name;
+
+
+-- ----------
+-- collection
+-- ----------
+
+
+
+INSERT INTO metadatavalue (resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+collection_id AS resource_id,
+3 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'description' and qualifier is null) AS metadata_field_id,
+introductory_text AS text_value,
+null AS text_lang,
+0 AS place
+FROM collection where not introductory_text is null;
+
+INSERT INTO metadatavalue (resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+collection_id AS resource_id,
+3 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'description' and qualifier = 'abstract') AS metadata_field_id,
+short_description AS text_value,
+null AS text_lang,
+0 AS place
+FROM collection where not short_description is null;
+
+INSERT INTO metadatavalue (resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+collection_id AS resource_id,
+3 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'description' and qualifier = 'tableofcontents') AS metadata_field_id,
+side_bar_text AS text_value,
+null AS text_lang,
+0 AS place
+FROM collection where not side_bar_text is null;
+
+INSERT INTO metadatavalue (resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+collection_id AS resource_id,
+3 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'rights' and qualifier is null) AS metadata_field_id,
+copyright_text AS text_value,
+null AS text_lang,
+0 AS place
+FROM collection where not copyright_text is null;
+
+INSERT INTO metadatavalue (resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+collection_id AS resource_id,
+3 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'title' and qualifier is null) AS metadata_field_id,
+name AS text_value,
+null AS text_lang,
+0 AS place
+FROM collection where not name is null;
+
+INSERT INTO metadatavalue (resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+collection_id AS resource_id,
+3 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'provenance' and qualifier is null) AS metadata_field_id,
+provenance_description AS text_value,
+null AS text_lang,
+0 AS place
+FROM collection where not provenance_description is null;
+
+INSERT INTO metadatavalue (resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+collection_id AS resource_id,
+3 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'rights' and qualifier = 'license') AS metadata_field_id,
+license AS text_value,
+null AS text_lang,
+0 AS place
+FROM collection where not license is null;
+
+alter table collection drop column introductory_text, drop column short_description, drop column copyright_text, drop column side_bar_text, drop column name, drop column license, drop column provenance_description;
+
+
+-- ---------
+-- bundle
+-- ---------
+
+INSERT INTO metadatavalue (resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+bundle_id AS resource_id,
+1 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'title' and qualifier is null) AS metadata_field_id,
+name AS text_value,
+null AS text_lang,
+0 AS place
+FROM bundle where not name is null;
+
+alter table bundle drop column name;
+
+
+
+-- ---------
+-- bitstream
+-- ---------
+
+
+INSERT INTO metadatavalue (resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+bitstream_id AS resource_id,
+0 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'title' and qualifier is null) AS metadata_field_id,
+name AS text_value,
+null AS text_lang,
+0 AS place
+FROM bitstream where not name is null;
+
+INSERT INTO metadatavalue (resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+bitstream_id AS resource_id,
+0 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'description' and qualifier is null) AS metadata_field_id,
+description AS text_value,
+null AS text_lang,
+0 AS place
+FROM bitstream where not description is null;
+
+INSERT INTO metadatavalue (resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+bitstream_id AS resource_id,
+0 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'format' and qualifier is null) AS metadata_field_id,
+user_format_description AS text_value,
+null AS text_lang,
+0 AS place
+FROM bitstream where not user_format_description is null;
+
+INSERT INTO metadatavalue (resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+bitstream_id AS resource_id,
+0 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'source' and qualifier is null) AS metadata_field_id,
+source AS text_value,
+null AS text_lang,
+0 AS place
+FROM bitstream where not source is null;
+
+alter table bitstream drop column name, drop column description, drop column user_format_description, drop column source;
+
+
+-- ---------
+-- epersongroup
+-- ---------
+
+INSERT INTO metadatavalue (resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+eperson_group_id AS resource_id,
+6 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='dc') and element = 'title' and qualifier is null) AS metadata_field_id,
+name AS text_value,
+null AS text_lang,
+0 AS place
+FROM epersongroup where not name is null;
+
+alter table epersongroup drop column name;
+
+
+
+-- ---------
+-- eperson
+-- ---------
+
+
+
+INSERT INTO metadatavalue (resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+eperson_id AS resource_id,
+7 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='eperson') and element = 'email' and qualifier is null) AS metadata_field_id,
+email AS text_value,
+null AS text_lang,
+0 AS place
+FROM eperson where not email is null;
+
+INSERT INTO metadatavalue (resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+eperson_id AS resource_id,
+7 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='eperson') and element = 'firstname' and qualifier is null) AS metadata_field_id,
+firstname AS text_value,
+null AS text_lang,
+0 AS place
+FROM eperson where not firstname is null;
+
+INSERT INTO metadatavalue (resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+eperson_id AS resource_id,
+7 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='eperson') and element = 'lastname' and qualifier is null) AS metadata_field_id,
+lastname AS text_value,
+null AS text_lang,
+0 AS place
+FROM eperson where not lastname is null;
+
+INSERT INTO metadatavalue (resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+eperson_id AS resource_id,
+7 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='eperson') and element = 'phone' and qualifier is null) AS metadata_field_id,
+phone AS text_value,
+null AS text_lang,
+0 AS place
+FROM eperson where not phone is null;
+
+
+INSERT INTO metadatavalue (resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+eperson_id AS resource_id,
+7 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='eperson') and element = 'netid' and qualifier is null) AS metadata_field_id,
+netid AS text_value,
+null AS text_lang,
+0 AS place
+FROM eperson where not netid is null;
+
+
+INSERT INTO metadatavalue (resource_id, resource_type_id, metadata_field_id, text_value, text_lang, place)
+SELECT
+eperson_id AS resource_id,
+7 AS resource_type_id,
+(select metadata_field_id from metadatafieldregistry where metadata_schema_id=(select metadata_schema_id from metadataschemaregistry where short_id='eperson') and element = 'language' and qualifier is null) AS metadata_field_id,
+language AS text_value,
+null AS text_lang,
+0 AS place
+FROM eperson where not language is null;
+
+
+alter table eperson  drop column firstname, drop column lastname, drop column phone, drop column netid, drop column language;
+
+-- ---------
+-- dcvalue view
+-- ---------
+
+drop view dcvalue;
+
+CREATE VIEW dcvalue AS
+  SELECT MetadataValue.metadata_value_id AS "dc_value_id", MetadataValue.resource_id,
+    MetadataValue.metadata_field_id AS "dc_type_id", MetadataValue.text_value,
+    MetadataValue.text_lang, MetadataValue.place
+  FROM MetadataValue, MetadataFieldRegistry
+  WHERE MetadataValue.metadata_field_id = MetadataFieldRegistry.metadata_field_id
+  AND MetadataFieldRegistry.metadata_schema_id = 1 AND MetadataValue.resource_type_id = 2;
+
 COMMIT;

--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -185,7 +185,7 @@ Common usage:
     <!-- Update an installation (except database)                      -->
     <!-- ============================================================= -->
 
-    <target name="update" depends="update_configs,update_code,update_webapps" description="Update installed code and web applications (without clobbering data/config)">
+    <target name="update" depends="update_configs,update_code,update_webapps,update_registries" description="Update installed code and web applications (without clobbering data/config)">
     </target>
 
     <!-- ============================================================= -->
@@ -879,6 +879,14 @@ Common usage:
             <arg line="-f '${dspace.dir}/config/registries/dcterms-types.xml'" />
         </java>
 
+        <!-- Import the new EPerson schema -->
+        <java classname="org.dspace.administer.MetadataImporter" classpathref="class.path" fork="yes" failonerror="yes">
+            <sysproperty key="log4j.configuration" value="file:config/log4j-console.properties" />
+            <sysproperty key="dspace.log.init.disable" value="true" />
+            <sysproperty key="dspace.configuration" value="${config}" />
+            <arg line="-f '${dspace.dir}/config/registries/eperson-types.xml'" />
+        </java>
+
         <!-- FIXME: this should be more modular -->
         <!-- import the SWORD required metadata -->
         <java classname="org.dspace.administer.MetadataImporter" classpathref="class.path" fork="yes" failonerror="yes">
@@ -890,6 +898,52 @@ Common usage:
 
     </target>
 
+
+    <!-- ============================================================= -->
+    <!-- Update contents of the registries -->
+    <!-- ============================================================= -->
+
+    <target name="update_registries" description="Update the metadata registries">
+        <java classname="org.dspace.administer.MetadataImporter" classpathref="class.path" fork="yes" failonerror="yes">
+            <sysproperty key="log4j.configuration" value="file:config/log4j-console.properties" />
+            <sysproperty key="dspace.log.init.disable" value="true" />
+            <sysproperty key="dspace.configuration" value="${config}" />
+            <arg line="-f '${dspace.dir}/config/registries/dublin-core-types.xml'" />
+            <arg line="-u"/>
+        </java>
+
+        <java classname="org.dspace.administer.MetadataImporter" classpathref="class.path" fork="yes" failonerror="yes">
+            <sysproperty key="log4j.configuration" value="file:config/log4j-console.properties" />
+            <sysproperty key="dspace.log.init.disable" value="true" />
+            <sysproperty key="dspace.configuration" value="${config}" />
+            <arg line="-f '${dspace.dir}/config/registries/dcterms-types.xml'" />
+            <arg line="-u"/>
+        </java>
+
+        <java classname="org.dspace.administer.MetadataImporter" classpathref="class.path" fork="yes" failonerror="yes">
+            <sysproperty key="log4j.configuration" value="file:config/log4j-console.properties" />
+            <sysproperty key="dspace.log.init.disable" value="true" />
+            <sysproperty key="dspace.configuration" value="${config}" />
+            <arg line="-f '${dspace.dir}/config/registries/eperson-types.xml'" />
+            <arg line="-u"/>
+        </java>
+
+        <java classname="org.dspace.administer.MetadataImporter" classpathref="class.path" fork="yes" failonerror="yes">
+            <sysproperty key="log4j.configuration" value="file:config/log4j-console.properties" />
+            <sysproperty key="dspace.log.init.disable" value="true" />
+            <sysproperty key="dspace.configuration" value="${config}" />
+            <arg line="-f '${dspace.dir}/config/registries/sword-metadata.xml'" />
+            <arg line="-u"/>
+        </java>
+
+        <java classname="org.dspace.administer.MetadataImporter" classpathref="class.path" fork="yes" failonerror="yes">
+            <sysproperty key="log4j.configuration" value="file:config/log4j-console.properties" />
+            <sysproperty key="dspace.log.init.disable" value="true" />
+            <sysproperty key="dspace.configuration" value="${config}" />
+            <arg line="-f '${dspace.dir}/config/registries/workflow-types.xml'" />
+            <arg line="-u"/>
+        </java>
+    </target>
 
     <!-- ============================================================= -->
     <!-- Install fresh code but do not touch the database              -->
@@ -957,6 +1011,14 @@ Common usage:
         <antcall target="copy_webapps" />
 
     	<antcall target="init_geolite" />
+
+        <!--Set the group names for admin & anonymous-->
+        <java classname="org.dspace.app.launcher.ScriptLauncher" classpathref="class.path" fork="yes" failonerror="yes">
+            <sysproperty key="log4j.configuration" value="file:config/log4j-console.properties" />
+            <sysproperty key="dspace.log.init.disable" value="true" />
+            <sysproperty key="dspace.configuration" value="${config}" />
+            <arg line="dsrun org.dspace.eperson.Group"/>
+        </java>
 
         <java classname="org.dspace.browse.IndexBrowse" classpathref="class.path" fork="yes" failonerror="yes">
             <sysproperty key="log4j.configuration" value="file:config/log4j-console.properties" />


### PR DESCRIPTION
Jira: https://jira.duraspace.org/browse/DS-1582

This pull request adds metadata to all DSpace Objects. The metadata is stored in the already existing metadatavalue table.

Community/Collection/Bundle/Bitstream "metadata" columns have been moved from their database tables to the metadata registry. For example the "name" of these objects has been moved to a dc.title metadata field.

The EPerson class has received a separate "schema" in order to support the eperson metadata, this schema will be created on ant fresh_install/update.
