### PR TITLE
[DS-2191] Fixed bug where + wouldn't expand or collapse the hidden <div> for Mirage2 Community List

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/preprocess/communitylist.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/preprocess/communitylist.xsl
@@ -146,7 +146,7 @@
             </xsl:call-template>
         </xsl:variable>
 
-        <xsl:variable name="handle">
+        <xsl:variable name="handle_pre1">
             <xsl:call-template name="string-replace-all">
                 <xsl:with-param name="text" select="$handle_pre"/>
                 <xsl:with-param name="replace" select="'/mets.xml'"/>
@@ -154,9 +154,17 @@
             </xsl:call-template>
         </xsl:variable>
 
+        <xsl:variable name="handle">
+            <xsl:call-template name="string-replace-all">
+                <xsl:with-param name="text" select="$handle_pre1"/>
+                <xsl:with-param name="replace" select="'/'"/>
+                <xsl:with-param name="by" select="'_'"/>
+            </xsl:call-template>
+        </xsl:variable>
+
         <xsl:call-template name="string-replace-all">
             <xsl:with-param name="text" select="$handle"/>
-            <xsl:with-param name="replace" select="'/'"/>
+            <xsl:with-param name="replace" select="'.'"/>
             <xsl:with-param name="by" select="'_'"/>
         </xsl:call-template>
     </xsl:template>


### PR DESCRIPTION
In community-list when a DSpace has a handle prefix configured with a '.' in it (example handle prefix: 2346.1) the data-target value in the <a> tag for the + sign would not match the id in the <div>

Fixed it by replacing instances of '.' in a handle prefix with '_' to sanitize the handle being used in the <div> and <a> tags in community-list
