### PR TITLE
[DS-2128] Fix 'ant fresh_install' breakage

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DataSourceInit.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DataSourceInit.java
@@ -92,8 +92,6 @@ public class DataSourceInit {
             // the "real" Connections created by the ConnectionFactory with
             // the classes that implement the pooling functionality.
             //
-            String validationQuery = "SELECT 1";
-
             GenericKeyedObjectPoolFactory statementFactory = null;
             if (useStatementPool)
             {
@@ -118,7 +116,7 @@ public class DataSourceInit {
 
             PoolableConnectionFactory poolableConnectionFactory = new PoolableConnectionFactory(
                     connectionFactory, connectionPool, statementFactory,
-                    validationQuery, // validation query
+                    null, // validation query (none until we know DBMS brand)
                     false, // read only is not default for now
                     false); // Autocommit defaults to none
 
@@ -136,9 +134,15 @@ public class DataSourceInit {
 
             // Set the proper validation query by DBMS brand.
             Connection connection = dataSource.getConnection();
-            if ("oracle".equals(connection.getMetaData().getDatabaseProductName().toLowerCase()))
+            String productNameLC = connection.getMetaData().getDatabaseProductName()
+                    .toLowerCase();
+            if (productNameLC.contains("oracle"))
             {
                 poolableConnectionFactory.setValidationQuery("SELECT 1 FROM DUAL");
+            }
+            else
+            {
+                poolableConnectionFactory.setValidationQuery("SELECT 1");
             }
             connection.close();
 

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseManager.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseManager.java
@@ -64,6 +64,9 @@ public class DatabaseManager
     /** Name of the DBMS, as returned by its driver. */
     private static String dbms;
 
+    /** Name of the DBMS, as used in DSpace:  "postgres", "oracle", or "h2". */
+    private static String dbms_keyword;
+
     /** Name to use for the pool */
     private static String poolName = "dspacepool";
 
@@ -1484,16 +1487,19 @@ public class DatabaseManager
             if (dbms_lc.contains("postgresql"))
             {
                 isPostgres = true;
+                dbms_keyword = "postgres";
                 log.info("DBMS is PostgreSQL");
             }
             else if (dbms_lc.contains("oracle"))
             {
                 isOracle = true;
+                dbms_keyword = "oracle";
                 log.info("DBMS is Oracle Database");
             }
             else if (dbms_lc.contains("h2")) // Used in testing
             {
                 isOracle = true;
+                dbms_keyword = "h2";
                 log.info("DBMS is H2");
             }
             else
@@ -1534,6 +1540,20 @@ public class DatabaseManager
         return dbms;
     }
 
+    /**
+     * What is the string that we use to name the DBMS brand?
+     *
+     * @return a normalized "keyword" for the DBMS brand:  postgres, oracle, h2.
+     */
+    public static String getDbKeyword()
+    {
+        try {
+            initialize();
+        } catch (SQLException ex) {
+            log.error("Failed to initialize the database:  ", ex);
+        }
+        return dbms_keyword;
+    }
     /**
 	 * Iterate over the given parameters and add them to the given prepared statement.
 	 * Only a select number of datatypes are supported by the JDBC driver.

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/InitializeDatabase.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/InitializeDatabase.java
@@ -67,7 +67,7 @@ public class InitializeDatabase
      */
     private static FileReader getScript(String name) throws FileNotFoundException, IOException
     {
-        String dbName = DatabaseManager.getDbName().toLowerCase(Locale.ROOT);
+        String dbName = DatabaseManager.getDbKeyword();
 
         File myFile = null;
         

--- a/dspace-api/src/test/java/org/dspace/storage/rdbms/DatabaseManagerTest.java
+++ b/dspace-api/src/test/java/org/dspace/storage/rdbms/DatabaseManagerTest.java
@@ -56,7 +56,7 @@ public class DatabaseManagerTest
         System.out.println("isOracle");
         boolean expResult = true;
         boolean result = DatabaseManager.isOracle();
-        assertEquals(expResult, result);
+        assertEquals("isOracle is true for Oracle-like DBMSs", expResult, result);
     }
 
     /**
@@ -630,7 +630,20 @@ public class DatabaseManagerTest
         System.out.println("getDbName");
         String expResult = "H2";
         String result = DatabaseManager.getDbName();
-        assertEquals(expResult, result);
+        assertEquals("Database name names the configured database driver",
+                expResult, result);
+    }
+
+    /**
+     * Test of getDbKeyword method, of class DatabaseManager.
+     */
+    @Test
+    public void testGetDbKeyword()
+    {
+        System.out.println("getDbKeyword");
+        String expResult = "h2";
+        String result = DatabaseManager.getDbKeyword();
+        assertEquals("Database 'keyword' names the configured DBMS", expResult, result);
     }
 
     /**


### PR DESCRIPTION
1)  PostgreSQL driver returns "postgresql" rather than "postgres", which breaks path construction when initializing the database.  Invent a "DSpace DBMS keyword" which will have a value that we control, and use it here.

2)  Validation query was set before knowing whether it should be Oracle-style or nearly-everything-else-style.  Set no validation until we know which DBMS is in use.
