### PR TITLE
DS-682 Optimize Select Collection Performance

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/OptimizeSelectCollection.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/OptimizeSelectCollection.java
@@ -1,0 +1,101 @@
+package org.dspace.app.util;
+
+import org.apache.log4j.Logger;
+import org.dspace.content.Collection;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
+import org.springframework.util.StopWatch;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: peterdietz
+ * Date: 3/25/13
+ * Time: 2:57 PM
+ * To change this template use File | Settings | File Templates.
+ */
+public class OptimizeSelectCollection {
+    private static final Logger log = Logger.getLogger(OptimizeSelectCollection.class);
+    private static Context context;
+
+    private static ArrayList<EPerson> brokenPeople;
+
+    public static void main(String[] argv) throws Exception
+    {
+        System.out.println("OptimizeSelectCollection tool.");
+        System.out.println("We want to verify that the optimized version of select collection logic produces the same " +
+                "values as the legacy select-collection logic.");
+
+        context = new Context();
+        brokenPeople = new ArrayList<EPerson>();
+
+        if(argv != null && argv.length > 0) {
+            for(String email : argv) {
+                EPerson person = EPerson.findByEmail(context, email);
+                checkSelectCollectionForUser(person);
+            }
+        } else {
+            //default case, run as specific user, or run all...
+            EPerson[] people = EPerson.findAll(context, EPerson.EMAIL);
+            for(EPerson person : people) {
+                checkSelectCollectionForUser(person);
+            }
+        }
+
+        if(brokenPeople.size() > 0) {
+            System.out.println("NOT DONE YET!!! Some people don't have all their collections.");
+            for(EPerson person : brokenPeople) {
+                System.out.println("-- " + person.getEmail());
+            }
+        }
+
+    }
+
+    private static void checkSelectCollectionForUser(EPerson person) throws SQLException {
+        context.setCurrentUser(person);
+
+        StopWatch stopWatch = new StopWatch("SelectCollectionStep Optimization (" + person.getEmail() + ")");
+        System.out.println("User: " + person.getEmail());
+
+        stopWatch.start("findAuthorized");
+        Collection[] collections = Collection.findAuthorized(context, null, Constants.ADD);
+        stopWatch.stop();
+
+
+        stopWatch.start("ListingCollections");
+        System.out.println("Legacy Find Authorized");
+        reportCollections(collections);
+        stopWatch.stop();
+
+        stopWatch.start("findAuthorizedOptimized");
+        Collection[] collectionsOptimized = Collection.findAuthorizedOptimized(context, Constants.ADD);
+        stopWatch.stop();
+
+        stopWatch.start("ListingCollectionsWithOptimizedCollections");
+        System.out.println("Find Authorized Optimized");
+        reportCollections(collectionsOptimized);
+        stopWatch.stop();
+
+        if (collections.length == collectionsOptimized.length) {
+            System.out.println("Number of collections matches - Good");
+        } else {
+            System.out.println("Number of collections doesn't match -- Bad");
+            brokenPeople.add(person);
+        }
+
+        System.out.println(stopWatch.prettyPrint());
+    }
+
+    private static void reportCollections(Collection[] collections) {
+        System.out.println("====================================");
+        System.out.println("This user is permitted to submit to the following collections.");
+
+        for(Collection collection : collections) {
+            System.out.println(" - " + collection.getHandle() + " -- " + collection.getName());
+        }
+        System.out.println("Total: " + collections.length);
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/app/util/OptimizeSelectCollection.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/OptimizeSelectCollection.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.app.util;
 
 import org.apache.log4j.Logger;
@@ -11,11 +18,9 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 
 /**
- * Created with IntelliJ IDEA.
- * User: peterdietz
- * Date: 3/25/13
- * Time: 2:57 PM
- * To change this template use File | Settings | File Templates.
+ * @author peterdietz
+ * A command line tool to verify/test the accuracy and speed gains of Collection.findAuthorizedOptimized()
+ * Invocation: dsrun org.dspace.app.util.OptimizeSelectCollection
  */
 public class OptimizeSelectCollection {
     private static final Logger log = Logger.getLogger(OptimizeSelectCollection.class);

--- a/dspace-api/src/main/java/org/dspace/app/util/OptimizeSelectCollection.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/OptimizeSelectCollection.java
@@ -22,6 +22,7 @@ public class OptimizeSelectCollection {
     private static Context context;
 
     private static ArrayList<EPerson> brokenPeople;
+    private static Long timeSavedMS = 0L;
 
     public static void main(String[] argv) throws Exception
     {
@@ -31,17 +32,21 @@ public class OptimizeSelectCollection {
 
         context = new Context();
         brokenPeople = new ArrayList<EPerson>();
+        int peopleChecked = 0;
+        timeSavedMS = 0L;
 
         if(argv != null && argv.length > 0) {
             for(String email : argv) {
                 EPerson person = EPerson.findByEmail(context, email);
                 checkSelectCollectionForUser(person);
+                peopleChecked++;
             }
         } else {
             //default case, run as specific user, or run all...
             EPerson[] people = EPerson.findAll(context, EPerson.EMAIL);
             for(EPerson person : people) {
                 checkSelectCollectionForUser(person);
+                peopleChecked++;
             }
         }
 
@@ -50,6 +55,8 @@ public class OptimizeSelectCollection {
             for(EPerson person : brokenPeople) {
                 System.out.println("-- " + person.getEmail());
             }
+        } else {
+            System.out.println("All Good: " + peopleChecked + " people have been checked, with same submission powers. TimeSaved(ms): " + timeSavedMS);
         }
 
     }
@@ -63,7 +70,7 @@ public class OptimizeSelectCollection {
         stopWatch.start("findAuthorized");
         Collection[] collections = Collection.findAuthorized(context, null, Constants.ADD);
         stopWatch.stop();
-
+        Long defaultMS = stopWatch.getLastTaskTimeMillis();
 
         stopWatch.start("ListingCollections");
         System.out.println("Legacy Find Authorized");
@@ -73,6 +80,9 @@ public class OptimizeSelectCollection {
         stopWatch.start("findAuthorizedOptimized");
         Collection[] collectionsOptimized = Collection.findAuthorizedOptimized(context, Constants.ADD);
         stopWatch.stop();
+        Long optimizedMS = stopWatch.getLastTaskTimeMillis();
+        timeSavedMS += defaultMS - optimizedMS;
+
 
         stopWatch.start("ListingCollectionsWithOptimizedCollections");
         System.out.println("Find Authorized Optimized");

--- a/dspace-api/src/main/java/org/dspace/content/Collection.java
+++ b/dspace-api/src/main/java/org/dspace/content/Collection.java
@@ -1506,6 +1506,11 @@ public class Collection extends DSpaceObject
 
     public static Collection[] findAuthorizedOptimized(Context context, int actionID) throws java.sql.SQLException
     {
+        if(! ConfigurationManager.getBooleanProperty("org.dspace.content.Collection.findAuthorizedPerformanceOptimize", true)) {
+            // Fallback to legacy query if config says so. The rationale could be that a site found a bug.
+            return findAuthorized(context, null, actionID);
+        }
+
         List<Collection> myResults = new ArrayList<Collection>();
 
         if(AuthorizeManager.isAdmin(context))

--- a/dspace-api/src/main/java/org/dspace/content/Collection.java
+++ b/dspace-api/src/main/java/org/dspace/content/Collection.java
@@ -1554,6 +1554,14 @@ public class Collection extends DSpaceObject
         // i.e. Typical Community Admin -- name.# > COMMUNITY_10_ADMIN > Ohio State University Press
 
         //Check eperson->comm-admin
+        Collection[] group2commCollections = findGroup2CommunityMapped(context);
+        for (int i = 0; i< group2commCollections.length; i++)
+        {
+            if(!myResults.contains(group2commCollections[i]))
+            {
+                myResults.add(group2commCollections[i]);
+            }
+        }
 
 
         // Return the collections, sorted alphabetically

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/submit/step/JSPSelectCollectionStep.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/submit/step/JSPSelectCollectionStep.java
@@ -136,7 +136,7 @@ public class JSPSelectCollectionStep extends JSPStep
             else
             {
                 // Show all collections
-                collections = Collection.findAuthorized(context, null,
+                collections = Collection.findAuthorizedOptimized(context,
                         Constants.ADD);
             }
 

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/submit/step/JSPStartSubmissionLookupStep.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/submit/step/JSPStartSubmissionLookupStep.java
@@ -153,7 +153,7 @@ public class JSPStartSubmissionLookupStep extends JSPStep
             else
             {
                 // Show all collections
-                collections = Collection.findAuthorized(context, null,
+                collections = Collection.findAuthorizedOptimized(context,
                         Constants.ADD);
             }
 

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/MoveItemForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/MoveItemForm.java
@@ -67,7 +67,7 @@ public class MoveItemForm extends AbstractDSpaceTransformer {
         Division main = body.addInteractiveDivision("move-item", contextPath+"/admin/item", Division.METHOD_POST, "primary administrative item");
         main.setHead(T_head1.parameterize(item.getHandle()));
 
-        Collection[] collections = Collection.findAuthorized(context, null, Constants.ADD);
+        Collection[] collections = Collection.findAuthorizedOptimized(context, Constants.ADD);
 
         List list = main.addList("select-collection", List.TYPE_FORM);
         Select select = list.addItem().addSelect("collectionID");

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/Submissions.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/Submissions.java
@@ -172,7 +172,7 @@ public class Submissions extends AbstractDSpaceTransformer
 
     	if (unfinishedItems.length <= 0 && supervisedItems.length <= 0)
     	{
-            Collection[] collections = Collection.findAuthorized(context, null, Constants.ADD);
+            Collection[] collections = Collection.findAuthorizedOptimized(context, Constants.ADD);
 
             if (collections.length > 0)
             {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/SelectCollectionStep.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/SelectCollectionStep.java
@@ -82,7 +82,7 @@ public class SelectCollectionStep extends AbstractSubmissionStep
         } 
         else
         {
-            collections = Collection.findAuthorized(context, null, Constants.ADD);
+            collections = Collection.findAuthorizedOptimized(context, Constants.ADD);
         }
         
         // Basic form with a drop down list of all the collections

--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -709,7 +709,7 @@
 	<message key="xmlui.Submission.submit.ResumeStep.submit_resume">Resume</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.SelectCollection -->
-	<message key="batch">Select a collection</message>
+	<message key="xmlui.Submission.submit.SelectCollection.head">Select a collection</message>
 	<message key="xmlui.Submission.submit.SelectCollection.collection">Collection</message>
 	<message key="xmlui.Submission.submit.SelectCollection.collection_help">Select the collection you wish to submit an item to.</message>
 	<message key="xmlui.Submission.submit.SelectCollection.collection_default">Select a collection...</message>

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -814,6 +814,11 @@ org.dspace.app.itemexport.max.size = 200
 # The directory where the results of imports will be placed (mapfile, upload file)
 org.dspace.app.batchitemimport.work.dir = ${dspace.dir}/imports
 
+# Enable performance optimization for select-collection-step collection query
+# The only reason you might opt-out is in case the optimized algorithm missed a policy
+# default = true, (enabled)
+#org.dspace.content.Collection.findAuthorizedPerformanceOptimize = false
+
 # For backwards compatibility, the subscription emails by default include any modified items
 # uncomment the following entry for only new items to be emailed
 # eperson.subscription.onlynew = true


### PR DESCRIPTION
If you have a site with greater than say 50 collections, there becomes a noticeable lag when waiting for the Select a Collection dropdown to load. We're talking like 10, 20, 30 seconds on large sites.

https://jira.duraspace.org/browse/DS-682
This would be an example slow page: http://localhost:8080/xmlui/submit

This work was sponsored by [The Ohio State University Libraries](http://library.osu.edu/)
![osu-universitylibraries](https://cloud.githubusercontent.com/assets/58014/4421119/ca6f5c9a-4580-11e4-92b9-88c48fe0550e.png)

The huge performance delay is due to Collection.findAuthorized() iterating through Collection.findAll(), and then using AuthorizationManager to ask if the current user has permission to view that Collection. So, the performance of this dropdown is O(n), where n is the number of collections. Also, it's making a SQL call per authorization lookup, so 1000 collections = 1000 queries. So, instead of refactoring the DSpace datamodel to use a graph database, we've come up with an approach of that queries for collections the user is authorized to ADD (submit) to from the opposite direction. 
Slow: All collections, iterate each to find out which the user is authorized. O(n)
Optimized: One user, find their direct policy enabled collection, find their groups with policy, find group2group policies, find communities with policy and get child collections. About 5 queries. So: O(1)

Developers: If your laptop has an SSD, you might not realize accurate results, because your DB is so fast, if your production DB has slower IO you'll see much more significant gains.

I have two types of tests for this feature, one is the integration test, which I have about 5 scenarios that I'm checking, it passes. Feel free to suggest additional tests. I also have a standalone class that you call through dsrun (not a real test), but it checks all users in your DB, and compares the results of Collection.findAuthorized() with Collection.findAuthorizedOptimized to check that the new version has all the same collections, and gives you a caliper time benchmark that lets you know how much faster the optimized version is.

```
/dspace/bin/dspace dsrun org.dspace.app.util.OptimizeSelectCollection
OptimizeSelectCollection tool.
We want to verify that the optimized version of select collection logic produces the same values as the legacy select-collection logic.
User: personA@example.edu
...
...
...
User: personZ@example.edu
Legacy Find Authorized
====================================
This user is permitted to submit to the following collections.
 - 123456789/35 -- SigPort Demonstration Collection
Total: 1
Find Authorized Optimized
====================================
This user is permitted to submit to the following collections.
 - 123456789/35 -- SigPort Demonstration Collection
Total: 1
Number of collections matches - Good
StopWatch 'SelectCollectionStep Optimization (personZ@example.edu)': running time (millis) = 8569
-----------------------------------------
ms     %     Task name
-----------------------------------------
08242  096%  findAuthorized
00000  000%  ListingCollections
00327  004%  findAuthorizedOptimized
00000  000%  ListingCollectionsWithOptimizedCollections

All Good: 26 people have been checked, with same submission powers. TimeSaved(ms): 187027
```

So, if you check this on a clone of your production data, let me know that all corner cases have been covered. I've checked this against a number of instances already.

Full Test:
    /dspace/bin/dspace dsrun org.dspace.app.util.OptimizeSelectCollection

Single User Test:
    /dspace/bin/dspace dsrun org.dspace.app.util.OptimizeSelectCollection user@example.edu
- [ ] Make config to disable to the optimzation, in case someone didn't want to use it
