### PR TITLE
DS-1781 : Ensure LDAP "email_field" is not ignored entirely

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
@@ -250,17 +250,24 @@ public class LDAPAuthentication
                 log.info(LogManager.getHeader(context,
                                 "autoregister", "netid=" + netid));
 
-                // If there is no email and the email domain is set, add it to the netid
                 String email = ldap.ldapEmail;
 
-                if ((StringUtils.isEmpty(email)) &&
-                        (StringUtils.isNotEmpty(ConfigurationManager.getProperty("authentication-ldap", "netid_email_domain"))))
+                // Check if we were able to determine an email address from LDAP
+                if (StringUtils.isEmpty(email))
                 {
-                    email = netid + ConfigurationManager.getProperty("authentication-ldap", "netid_email_domain");
-                }
-                else
-                {
-                    email = netid;
+                    // If no email, check if we have a "netid_email_domain". If so, append it to the netid to create email
+                    if (StringUtils.isNotEmpty(ConfigurationManager.getProperty("authentication-ldap", "netid_email_domain")))
+                    {
+                        email = netid + ConfigurationManager.getProperty("authentication-ldap", "netid_email_domain");
+                    }
+                    else
+                    {
+                        // We don't have a valid email address. We'll default it to 'netid' but log a warning
+                        log.warn(LogManager.getHeader(context, "autoregister",
+                                "Unable to locate email address for account '" + netid + "', so it has been set to '" + netid + "'. " +
+                                "Please check the LDAP 'email_field' OR consider configuring 'netid_email_domain'."));
+                        email = netid;
+                    }
                 }
 
                 if (StringUtils.isNotEmpty(email))


### PR DESCRIPTION
Simple PR to ensure the LDAP "email_field" setting is no longer entirely ignored. Previously, the "if" logic in the code was incorrect (as described in DS-1781)

https://jira.duraspace.org/browse/DS-1781

This also logs a warning if during auto-registration the email cannot be determined (as LDAPAuthentication plugin sets email = netid in this scenario). In many use cases, if the "email" cannot be determined, it is likely a misconfiguration of the LDAP plugin (hence the warning).
