### PR TITLE
DS-2103: Reordering/Reorganizing of Administrative menu

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/Navigation.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/Navigation.java
@@ -70,6 +70,7 @@ public class Navigation extends AbstractDSpaceTransformer implements CacheablePr
     private static final Message T_administrative_registries 		= message("xmlui.administrative.Navigation.administrative_registries");
     private static final Message T_administrative_metadata 			= message("xmlui.administrative.Navigation.administrative_metadata");
     private static final Message T_administrative_format 			= message("xmlui.administrative.Navigation.administrative_format");
+    private static final Message T_administrative_content           = message("xmlui.administrative.Navigation.administrative_content");
     private static final Message T_administrative_items 			= message("xmlui.administrative.Navigation.administrative_items");
     private static final Message T_administrative_withdrawn  		= message("xmlui.administrative.Navigation.administrative_withdrawn");
     private static final Message T_administrative_private  		= message("xmlui.administrative.Navigation.administrative_private");
@@ -277,26 +278,33 @@ public class Navigation extends AbstractDSpaceTransformer implements CacheablePr
         // System Administrator options!
         if (isSystemAdmin)
         {
-	        admin.setHead(T_administrative_head);
-	                
-	        List epeople = admin.addList("epeople");
-	        List registries = admin.addList("registries");
-	        
-	        epeople.setHead(T_administrative_access_control);	        
-	        epeople.addItemXref(contextPath+"/admin/epeople", T_administrative_people);	        
-	        epeople.addItemXref(contextPath+"/admin/groups", T_administrative_groups);	        
-	        epeople.addItemXref(contextPath+"/admin/authorize", T_administrative_authorizations);	        
-	        
-	        registries.setHead(T_administrative_registries);	        
-	        registries.addItemXref(contextPath+"/admin/metadata-registry",T_administrative_metadata);	        
-	        registries.addItemXref(contextPath+"/admin/format-registry",T_administrative_format);	        
-	        
-	        admin.addItemXref(contextPath+"/admin/item", T_administrative_items);
-            admin.addItemXref(contextPath+"/admin/withdrawn", T_administrative_withdrawn);
-            admin.addItemXref(contextPath+"/admin/private", T_administrative_private);
-	        admin.addItemXref(contextPath+"/admin/panel", T_administrative_control_panel);
+            admin.setHead(T_administrative_head);
+
+            // Control panel
+            admin.addItemXref(contextPath+"/admin/panel", T_administrative_control_panel);
+
+            // Access Controls
+            List epeople = admin.addList("epeople");
+            epeople.setHead(T_administrative_access_control);
+            epeople.addItemXref(contextPath+"/admin/epeople", T_administrative_people);
+            epeople.addItemXref(contextPath+"/admin/groups", T_administrative_groups);
+            epeople.addItemXref(contextPath+"/admin/authorize", T_administrative_authorizations);
+
+            // Content Admin
+            List content = admin.addList("content");
+            content.setHead(T_administrative_content);
+            content.addItemXref(contextPath+"/admin/item", T_administrative_items);
+            content.addItemXref(contextPath+"/admin/withdrawn", T_administrative_withdrawn);
+            content.addItemXref(contextPath+"/admin/private", T_administrative_private);
+            content.addItemXref(contextPath+ "/admin/metadataimport", T_administrative_import_metadata);
+
+            // Registries
+            List registries = admin.addList("registries");
+            registries.setHead(T_administrative_registries);
+            registries.addItemXref(contextPath+"/admin/metadata-registry",T_administrative_metadata);
+            registries.addItemXref(contextPath+"/admin/format-registry",T_administrative_format);
+
             admin.addItemXref(contextPath+"/statistics", T_statistics);
-            admin.addItemXref(contextPath+ "/admin/metadataimport", T_administrative_import_metadata);
             admin.addItemXref(contextPath+ "/admin/curate", T_administrative_curation);
         }
     }

--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -1014,13 +1014,14 @@
 	<message key="xmlui.administrative.Navigation.administrative_registries">Registries</message>
 	<message key="xmlui.administrative.Navigation.administrative_metadata">Metadata</message>
 	<message key="xmlui.administrative.Navigation.administrative_format">Format</message>
+    <message key="xmlui.administrative.Navigation.administrative_content">Content Administration</message>
 	<message key="xmlui.administrative.Navigation.administrative_items">Items</message>
     <message key="xmlui.administrative.Navigation.administrative_withdrawn">Withdrawn Items</message>
     <message key="xmlui.administrative.Navigation.administrative_private">Private Items</message>
     <message key="xmlui.administrative.Navigation.administrative_control_panel">Control Panel</message>
-    <message key="xmlui.administrative.Navigation.statistics">Statistics</message>
-        <message key="xmlui.administrative.Navigation.administrative_import_metadata">Import Metadata</message>
-        <message key="xmlui.administrative.Navigation.administrative_curation">Curation Tasks</message>
+    <message key="xmlui.administrative.Navigation.statistics">Administrative Statistics</message>
+    <message key="xmlui.administrative.Navigation.administrative_import_metadata">Import Metadata</message>
+    <message key="xmlui.administrative.Navigation.administrative_curation">Curation Tasks</message>
 
     <!-- my account items -->
 	<message key="xmlui.administrative.Navigation.account_export">My Exports</message>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2103

This PR reorders the Administrative menu in the XMLUI to this ordering:

ADMINISTRATIVE MENU
- Control Panel
- Access Control
  - People
  - Groups
  - Authorizations
- Content Administration (new grouping)
  - Items
  - Withdrawn Items
  - Private Items
  - Import Metadata
- Registries
  - Metadata
  - Format
- Administrative Statistics (renaming of "Statistics")
- Curation Tasks
