### PR TITLE
[DS-1750] Git clone is becoming slow

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,3 @@
-Installation instructions are included in this release package under
-
- - dspace/docs/DSpace-Manual.pdf
-
 DSpace version information can be viewed online at
  - https://wiki.duraspace.org/display/DSDOC/
 
@@ -9,6 +5,10 @@ Documentation for the most recent stable release(s) may be downloaded
 or viewed online at
  - http://www.dspace.org/latest-release/
  - https://wiki.duraspace.org/display/DSDOC/
+ - http://sourceforge.net/projects/dspace/files/DSpace%20Stable/
+     (select a version and read DSpace-Manual.pdf)
+
+Installation instructions are to be found in that documentation.
 
 In addition, a listing of all known contributors to DSpace software can be
 found online at:
@@ -16,7 +16,7 @@ https://wiki.duraspace.org/display/DSPACE/DSpaceContributors
 
 Installation instructions for other versions may be different, so you
 are encouraged to obtain the appropriate version of the Documentation
-(from the links above or from the source repository).
+from the links above.
 
 To obtain files from the repository and build, please see:
 
@@ -51,4 +51,4 @@ places to seek help, news articles and lists of other users, please see:
 DSpace source code licensing information available online at:
  - http://www.dspace.org/license/
 
-Copyright (c) 2002-2013, DuraSpace.  All rights reserved.
+Copyright (c) 2002-2014, DuraSpace.  All rights reserved.


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-1750

Delete DSpace-Manual.pdf from the source kit.  This should stop some ongoing binary bloat.  Users are now directed to the wiki or SourceForge for documentation.
