### PR TITLE
[DS-1883] Rehabilitate DCValue

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/BulkEditChange.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/BulkEditChange.java
@@ -8,7 +8,7 @@
 package org.dspace.app.bulkedit;
 
 import org.dspace.content.Item;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Collection;
 
 import java.util.ArrayList;
@@ -25,16 +25,16 @@ public class BulkEditChange
     private Item item;
 
     /** The List of hashtables with the new elements */
-    private List<DCValue> adds;
+    private List<Metadatum> adds;
 
     /** The List of hashtables with the removed elements */
-    private List<DCValue> removes;
+    private List<Metadatum> removes;
 
     /** The List of hashtables with the unchanged elements */
-    private List<DCValue> constant;
+    private List<Metadatum> constant;
 
     /** The List of the complete set of new values (constant + adds) */
-    private List<DCValue> complete;
+    private List<Metadatum> complete;
 
     /** The list of old collections the item used to be mapped to */
     private List<Collection> oldMappedCollections;
@@ -77,10 +77,10 @@ public class BulkEditChange
         newOwningCollection = null;
 
         // Initialise the arrays
-        adds = new ArrayList<DCValue>();
-        removes = new ArrayList<DCValue>();
-        constant = new ArrayList<DCValue>();
-        complete = new ArrayList<DCValue>();
+        adds = new ArrayList<Metadatum>();
+        removes = new ArrayList<Metadatum>();
+        constant = new ArrayList<Metadatum>();
+        complete = new ArrayList<Metadatum>();
         oldMappedCollections = new ArrayList<Collection>();
         newMappedCollections = new ArrayList<Collection>();
     }
@@ -98,10 +98,10 @@ public class BulkEditChange
         empty = true;
 
         // Initialise the arrays
-        adds = new ArrayList<DCValue>();
-        removes = new ArrayList<DCValue>();
-        constant = new ArrayList<DCValue>();
-        complete = new ArrayList<DCValue>();
+        adds = new ArrayList<Metadatum>();
+        removes = new ArrayList<Metadatum>();
+        constant = new ArrayList<Metadatum>();
+        complete = new ArrayList<Metadatum>();
         oldMappedCollections = new ArrayList<Collection>();
         newMappedCollections = new ArrayList<Collection>();
     }
@@ -122,7 +122,7 @@ public class BulkEditChange
      *
      * @param dcv The value to add
      */
-    public void registerAdd(DCValue dcv)
+    public void registerAdd(Metadatum dcv)
     {
         // Add the added value
         adds.add(dcv);
@@ -135,7 +135,7 @@ public class BulkEditChange
      *
      * @param dcv The value to remove
      */
-    public void registerRemove(DCValue dcv)
+    public void registerRemove(Metadatum dcv)
     {
         // Add the removed value
         removes.add(dcv);
@@ -147,7 +147,7 @@ public class BulkEditChange
      *
      * @param dcv The value to keep unchanged
      */
-    public void registerConstant(DCValue dcv)
+    public void registerConstant(Metadatum dcv)
     {
         // Add the removed value
         constant.add(dcv);
@@ -241,7 +241,7 @@ public class BulkEditChange
      *
      * @return the list of elements and their values that have been added.
      */
-    public List<DCValue> getAdds()
+    public List<Metadatum> getAdds()
     {
         // Return the array
         return adds;
@@ -252,7 +252,7 @@ public class BulkEditChange
      *
      * @return the list of elements and their values that have been removed.
      */
-    public List<DCValue> getRemoves()
+    public List<Metadatum> getRemoves()
     {
         // Return the array
         return removes;
@@ -263,7 +263,7 @@ public class BulkEditChange
      *
      * @return the list of unchanged values
      */
-    public List<DCValue> getConstant()
+    public List<Metadatum> getConstant()
     {
         // Return the array
         return constant;
@@ -274,7 +274,7 @@ public class BulkEditChange
      *
      * @return the list of all values
      */
-    public List<DCValue> getComplete()
+    public List<Metadatum> getComplete()
     {
         // Return the array
         return complete;

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSV.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSV.java
@@ -423,8 +423,8 @@ public class DSpaceCSV implements Serializable
         }
 
         // Populate it
-        DCValue md[] = i.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
-        for (DCValue value : md)
+        Metadatum md[] = i.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+        for (Metadatum value : md)
         {
             // Get the key (schema.element)
             String key = value.schema + "." + value.element;
@@ -652,10 +652,10 @@ public class DSpaceCSV implements Serializable
      *
      * The list can be configured via the key ignore-on-export in bulkedit.cfg
      *
-     * @param md The DCValue to examine
+     * @param md The Metadatum to examine
      * @return Whether or not it is OK to export this element
      */
-    private final boolean okToExport(DCValue md)
+    private final boolean okToExport(Metadatum md)
     {
         // Now compare with the list to ignore
         String key = md.schema + "." + md.element;

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -336,7 +336,7 @@ public class MetadataImport
                         Item item = wsItem.getItem();
 
                         // Add the metadata to the item
-                        for (DCValue dcv : whatHasChanged.getAdds())
+                        for (Metadatum dcv : whatHasChanged.getAdds())
                         {
                             item.addMetadata(dcv.schema,
                                              dcv.element,
@@ -473,11 +473,11 @@ public class MetadataImport
                                        ",looking_for_element=" + element +
                                        ",looking_for_qualifier=" + qualifier +
                                        ",looking_for_language=" + language));
-        DCValue[] current = item.getMetadata(schema, element, qualifier, language);
+        Metadatum[] current = item.getMetadata(schema, element, qualifier, language);
         
         String[] dcvalues = new String[current.length];
         int i = 0;
-        for (DCValue dcv : current)
+        for (Metadatum dcv : current)
         {
             if (dcv.authority == null || !isAuthorityControlledField(md))
             {
@@ -497,7 +497,7 @@ public class MetadataImport
         // Compare from current->csv
         for (int v = 0; v < fromCSV.length; v++) {
             String value = fromCSV[v];
-            DCValue dcv = getDcValueFromCSV(language, schema, element, qualifier, value, fromAuthority);
+            Metadatum dcv = getDcValueFromCSV(language, schema, element, qualifier, value, fromAuthority);
             if (fromAuthority!=null) {
                 value = dcv.value + DSpaceCSV.authoritySeparator + dcv.authority + DSpaceCSV.authoritySeparator + dcv.confidence;
                 fromCSV[v] = value;
@@ -515,7 +515,7 @@ public class MetadataImport
         for (String value : dcvalues)
         {
             // Look to see if it should be removed
-            DCValue dcv = new DCValue();
+            Metadatum dcv = new Metadatum();
             dcv.schema = schema;
             dcv.element = element;
             dcv.qualifier = qualifier;
@@ -548,11 +548,11 @@ public class MetadataImport
             ((changes.getAdds().size() > 0) || (changes.getRemoves().size() > 0)))
         {
             // Get the complete list of what values should now be in that element
-            List<DCValue> list = changes.getComplete();
+            List<Metadatum> list = changes.getComplete();
             List<String> values = new ArrayList<String>();
             List<String> authorities = new ArrayList<String>();
             List<Integer> confidences = new ArrayList<Integer>();
-            for (DCValue value : list)
+            for (Metadatum value : list)
             {
                 if ((qualifier == null) && (language == null))
                 {
@@ -825,7 +825,7 @@ public class MetadataImport
         // Add all the values
         for (String value : fromCSV)
         {
-            DCValue dcv = getDcValueFromCSV(language, schema, element, qualifier, value, fromAuthority);
+            Metadatum dcv = getDcValueFromCSV(language, schema, element, qualifier, value, fromAuthority);
             if(fromAuthority!=null){
                 value = dcv.value + DSpaceCSV.authoritySeparator + dcv.authority + DSpaceCSV.authoritySeparator + dcv.confidence;
             }
@@ -849,9 +849,9 @@ public class MetadataImport
         return fromAuthority;
     }
 
-    private DCValue getDcValueFromCSV(String language, String schema, String element, String qualifier, String value, AuthorityValue fromAuthority) {
+    private Metadatum getDcValueFromCSV(String language, String schema, String element, String qualifier, String value, AuthorityValue fromAuthority) {
         // Look to see if it should be removed
-        DCValue dcv = new DCValue();
+        Metadatum dcv = new Metadatum();
         dcv.schema = schema;
         dcv.element = element;
         dcv.qualifier = qualifier;
@@ -887,7 +887,7 @@ public class MetadataImport
         return dcv;
     }
 
-    private void simplyCopyValue(String value, DCValue dcv) {
+    private void simplyCopyValue(String value, Metadatum dcv) {
         dcv.value = value;
         dcv.authority = null;
         dcv.confidence = Choices.CF_UNSET;
@@ -960,8 +960,8 @@ public class MetadataImport
         for (BulkEditChange change : changes)
         {
             // Get the changes
-            List<DCValue> adds = change.getAdds();
-            List<DCValue> removes = change.getRemoves();
+            List<Metadatum> adds = change.getAdds();
+            List<Metadatum> removes = change.getRemoves();
             List<Collection> newCollections = change.getNewMappedCollections();
             List<Collection> oldCollections = change.getOldMappedCollections();
             if ((adds.size() > 0) || (removes.size() > 0) ||
@@ -1099,7 +1099,7 @@ public class MetadataImport
             }
 
             // Show additions
-            for (DCValue dcv : adds)
+            for (Metadatum dcv : adds)
             {
                 String md = dcv.schema + "." + dcv.element;
                 if (dcv.qualifier != null)
@@ -1128,7 +1128,7 @@ public class MetadataImport
             }
 
             // Show removals
-            for (DCValue dcv : removes)
+            for (Metadatum dcv : removes)
             {
                 String md = dcv.schema + "." + dcv.element;
                 if (dcv.qualifier != null)

--- a/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExport.java
@@ -45,7 +45,7 @@ import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.ItemIterator;
@@ -403,8 +403,8 @@ public class ItemExport
             throws Exception
     {
         Set<String> schemas = new HashSet<String>();
-        DCValue[] dcValues = i.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
-        for (DCValue dcValue : dcValues)
+        Metadatum[] dcValues = i.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+        for (Metadatum dcValue : dcValues)
         {
             schemas.add(dcValue.schema);
         }
@@ -439,7 +439,7 @@ public class ItemExport
             BufferedOutputStream out = new BufferedOutputStream(
                     new FileOutputStream(outFile));
 
-            DCValue[] dcorevalues = i.getMetadata(schema, Item.ANY, Item.ANY,
+            Metadatum[] dcorevalues = i.getMetadata(schema, Item.ANY, Item.ANY,
                     Item.ANY);
 
             // XML preamble
@@ -454,7 +454,7 @@ public class ItemExport
             String dateIssued = null;
             String dateAccessioned = null;
 
-            for (DCValue dcv : dcorevalues)
+            for (Metadatum dcv : dcorevalues)
             {
                 String qualifier = dcv.qualifier;
 

--- a/dspace-api/src/main/java/org/dspace/app/itemmarking/ItemMarkingMetadataStrategy.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemmarking/ItemMarkingMetadataStrategy.java
@@ -11,8 +11,8 @@ import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.dspace.content.DCValue;
 import org.dspace.content.Item;
+import org.dspace.content.Metadatum;
 import org.dspace.core.Context;
 
 /**
@@ -37,10 +37,10 @@ public class ItemMarkingMetadataStrategy implements ItemMarkingExtractor {
 		
 		if (metadataField != null && mapping!=null)
 		{
-			DCValue[] vals = item.getMetadataByMetadataString(metadataField);
+			Metadatum[] vals = item.getMetadataByMetadataString(metadataField);
 			if (vals.length > 0)
 			{
-				for (DCValue value : vals){
+				for (Metadatum value : vals){
 					String type = value.value;
 					if (mapping.containsKey(type)){
 						return mapping.get(type);

--- a/dspace-api/src/main/java/org/dspace/app/itemupdate/AddMetadataAction.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemupdate/AddMetadataAction.java
@@ -10,7 +10,7 @@ package org.dspace.app.itemupdate;
 import java.sql.SQLException;
 
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataField;
 import org.dspace.content.MetadataSchema;
@@ -47,11 +47,11 @@ public class AddMetadataAction extends UpdateMetadataAction {
 				{
 					// match against metadata for this field/value in repository
 					// qualifier must be strictly matched, possibly null					
-					DCValue[] ardcv = null;
+					Metadatum[] ardcv = null;
 					ardcv = item.getMetadata(dtom.schema, dtom.element, dtom.qualifier, Item.ANY);
 					
 					boolean found = false;
-					for (DCValue dcv : ardcv)
+					for (Metadatum dcv : ardcv)
 					{
 						if (dcv.value.equals(dtom.value))
 						{
@@ -102,7 +102,7 @@ public class AddMetadataAction extends UpdateMetadataAction {
 								//ItemUpdate.pr("Undo metadata: " + dtom);
 								
 								// add all as a replace record to be preceded by delete
-								for (DCValue dcval : ardcv)
+								for (Metadatum dcval : ardcv)
 								{							
 									itarch.addUndoMetadataField(DtoMetadata.create(dcval.schema, dcval.element, 
 											dcval.qualifier, dcval.language, dcval.value));

--- a/dspace-api/src/main/java/org/dspace/app/itemupdate/DeleteMetadataAction.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemupdate/DeleteMetadataAction.java
@@ -10,7 +10,7 @@ package org.dspace.app.itemupdate;
 import java.text.ParseException;
 
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 
@@ -38,10 +38,10 @@ public class DeleteMetadataAction extends UpdateMetadataAction {
 		for (String f : targetFields)
 		{
 			DtoMetadata dummy = DtoMetadata.create(f, Item.ANY, "");
-			DCValue[] ardcv = item.getMetadataByMetadataString(f);
+			Metadatum[] ardcv = item.getMetadataByMetadataString(f);
 
 			ItemUpdate.pr("Metadata to be deleted: ");
-			for (DCValue dcv : ardcv)
+			for (Metadatum dcv : ardcv)
 			{
 				ItemUpdate.pr("  " + MetadataUtilities.getDCValueString(dcv));
 			}
@@ -50,7 +50,7 @@ public class DeleteMetadataAction extends UpdateMetadataAction {
 			{
 				if (!suppressUndo)
 				{
-					for (DCValue dcv : ardcv)
+					for (Metadatum dcv : ardcv)
 					{
 						itarch.addUndoMetadataField(DtoMetadata.create(dcv.schema, dcv.element, 
 								dcv.qualifier, dcv.language, dcv.value));					

--- a/dspace-api/src/main/java/org/dspace/app/itemupdate/MetadataUtilities.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemupdate/MetadataUtilities.java
@@ -40,7 +40,7 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataSchema;
 import org.dspace.core.ConfigurationManager;
@@ -59,10 +59,10 @@ public class MetadataUtilities {
 	
     /**      
      * 
-     *  Working around Item API to delete a value-specific DCValue
-     *  For a given element/qualifier/lang:
-     *      get all DCValues
-     *      clear (i.e. delete) all of these DCValues
+     *  Working around Item API to delete a value-specific Metadatum
+  For a given element/qualifier/lang:
+      get all DCValues
+      clear (i.e. delete) all of these DCValues
      *      add them back, minus the one to actually delete
      *  
      * 
@@ -74,7 +74,7 @@ public class MetadataUtilities {
      */
     public static boolean deleteMetadataByValue(Item item, DtoMetadata dtom, boolean isLanguageStrict)
     {   	
-    	DCValue[] ar = null;
+    	Metadatum[] ar = null;
     	
     	if (isLanguageStrict)
     	{   // get all for given type
@@ -89,7 +89,7 @@ public class MetadataUtilities {
     	
     	//build new set minus the one to delete
     	List<String> vals = new ArrayList<String>();
-    	for (DCValue dcv : ar)
+    	for (Metadatum dcv : ar)
     	{
     		if (dcv.value.equals(dtom.value))
     		{
@@ -130,7 +130,7 @@ public class MetadataUtilities {
     		String textToAppend)
     throws IllegalArgumentException
     {   	
-    	DCValue[] ar = null;
+    	Metadatum[] ar = null;
     	
     	// get all values for given element/qualifier
     	if (isLanguageStrict)  // get all for given element/qualifier
@@ -472,12 +472,12 @@ public class MetadataUtilities {
     }
 
     /**
-     *    Get display of DCValue    
+     *    Get display of Metadatum    
 	 *
      * @param dcv
-     * @return string displaying elements of the DCValue
+     * @return string displaying elements of the Metadatum
      */
-    public static String getDCValueString(DCValue dcv)
+    public static String getDCValueString(Metadatum dcv)
     {
     	return "schema: " + dcv.schema + "; element: " + dcv.element + "; qualifier: " + dcv.qualifier +
     	       "; language: " + dcv.language + "; value: " + dcv.value;

--- a/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemMetadataStrategy.java
+++ b/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemMetadataStrategy.java
@@ -10,7 +10,7 @@ package org.dspace.app.requestitem;
 import java.sql.SQLException;
 
 import org.apache.commons.lang.StringUtils;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 import org.dspace.core.I18nUtil;
@@ -35,14 +35,14 @@ public class RequestItemMetadataStrategy extends RequestItemSubmitterStrategy {
 			throws SQLException {
 		if (emailMetadata != null)
 		{
-			DCValue[] vals = item.getMetadataByMetadataString(emailMetadata);
+			Metadatum[] vals = item.getMetadataByMetadataString(emailMetadata);
 			if (vals.length > 0)
 			{
 				String email = vals[0].value;
 				String fullname = null;
 				if (fullNameMatadata != null)
 				{
-					DCValue[] nameVals = item.getMetadataByMetadataString(fullNameMatadata);
+					Metadatum[] nameVals = item.getMetadataByMetadataString(fullNameMatadata);
 					if (nameVals.length > 0)
 					{
 						fullname = nameVals[0].value;

--- a/dspace-api/src/main/java/org/dspace/app/sfx/SFXFileReader.java
+++ b/dspace-api/src/main/java/org/dspace/app/sfx/SFXFileReader.java
@@ -16,7 +16,7 @@ import org.apache.log4j.Logger;
 import org.w3c.dom.Document;
 
 import org.dspace.content.DCPersonName;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.core.Constants;
 
@@ -207,7 +207,7 @@ public class SFXFileReader {
                         }
                         if (finish == 4)
                         {
-                        DCValue[] dcvalue = item.getMetadata(schema, element, qualifier, Item.ANY);
+                        Metadatum[] dcvalue = item.getMetadata(schema, element, qualifier, Item.ANY);
                         if (dcvalue.length > 0)
                             {
                             // Issued Date

--- a/dspace-api/src/main/java/org/dspace/app/sherpa/submit/MetadataAuthorityISSNExtractor.java
+++ b/dspace-api/src/main/java/org/dspace/app/sherpa/submit/MetadataAuthorityISSNExtractor.java
@@ -10,7 +10,7 @@ package org.dspace.app.sherpa.submit;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 
@@ -29,8 +29,8 @@ public class MetadataAuthorityISSNExtractor implements ISSNItemExtractor
         List<String> values = new ArrayList<String>();
         for (String metadata : metadataList)
         {
-            DCValue[] dcvalues = item.getMetadataByMetadataString(metadata);
-            for (DCValue dcvalue : dcvalues)
+            Metadatum[] dcvalues = item.getMetadataByMetadataString(metadata);
+            for (Metadatum dcvalue : dcvalues)
             {
                 values.add(dcvalue.authority);
             }

--- a/dspace-api/src/main/java/org/dspace/app/sherpa/submit/MetadataValueISSNExtractor.java
+++ b/dspace-api/src/main/java/org/dspace/app/sherpa/submit/MetadataValueISSNExtractor.java
@@ -10,7 +10,7 @@ package org.dspace.app.sherpa.submit;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 
@@ -29,8 +29,8 @@ public class MetadataValueISSNExtractor implements ISSNItemExtractor
         List<String> values = new ArrayList<String>();
         for (String metadata : metadataList)
         {
-            DCValue[] dcvalues = item.getMetadataByMetadataString(metadata);
-            for (DCValue dcvalue : dcvalues)
+            Metadatum[] dcvalues = item.getMetadataByMetadataString(metadata);
+            for (Metadatum dcvalue : dcvalues)
             {
                 values.add(dcvalue.value);
             }

--- a/dspace-api/src/main/java/org/dspace/app/statistics/ReportGenerator.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/ReportGenerator.java
@@ -27,7 +27,7 @@ import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
@@ -801,8 +801,8 @@ public class ReportGenerator
         // build the referece
         // FIXME: here we have blurred the line between content and presentation
         // and it should probably be un-blurred
-        DCValue[] title = item.getDC("title", null, Item.ANY);
-        DCValue[] author = item.getDC("contributor", "author", Item.ANY);
+        Metadatum[] title = item.getDC("title", null, Item.ANY);
+        Metadatum[] author = item.getDC("contributor", "author", Item.ANY);
         
         StringBuffer authors = new StringBuffer();
         if (author.length > 0)

--- a/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
@@ -268,7 +268,7 @@ public class GoogleMetadata
             }
         }
 
-        DCValue v = resolveMetadataField(config);
+        Metadatum v = resolveMetadataField(config);
 
         if (null != v && (null != v.value) && !v.value.trim().equals(""))
         {
@@ -289,10 +289,10 @@ public class GoogleMetadata
      * @param configFilter
      * @return The first configured match of metadata field for the item.
      */
-    private DCValue resolveMetadataField(String configFilter)
+    private Metadatum resolveMetadataField(String configFilter)
     {
 
-        ArrayList<DCValue> fields = resolveMetadata(configFilter, SINGLE);
+        ArrayList<Metadatum> fields = resolveMetadata(configFilter, SINGLE);
         if (null != fields && fields.size() > 0)
         {
             return fields.get(0);
@@ -308,10 +308,10 @@ public class GoogleMetadata
      * @return Aggregate of all matching metadata fields configured in the first
      *         option field-set to return any number of filter matches.
      */
-    private ArrayList<DCValue> resolveMetadataFields(String configFilter)
+    private ArrayList<Metadatum> resolveMetadataFields(String configFilter)
     {
 
-        ArrayList<DCValue> fields = resolveMetadata(configFilter, MULTI);
+        ArrayList<Metadatum> fields = resolveMetadata(configFilter, MULTI);
         if (null != fields && fields.size() > 0)
         {
             return fields;
@@ -326,7 +326,7 @@ public class GoogleMetadata
      * @param configValue
      * @return Array of configuration -> item-field matches
      */
-    private ArrayList<DCValue> resolveMetadata(String configFilter,
+    private ArrayList<Metadatum> resolveMetadata(String configFilter,
             int returnType)
     {
 
@@ -367,8 +367,8 @@ public class GoogleMetadata
 
             int optionMatches = 0;
             String[] components;
-            DCValue[] values;
-            ArrayList<DCValue> resolvedFields = new ArrayList<DCValue>();
+            Metadatum[] values;
+            ArrayList<Metadatum> resolvedFields = new ArrayList<Metadatum>();
 
             for (String field : optionFields)
             {
@@ -379,7 +379,7 @@ public class GoogleMetadata
 
                 if (values.length > 0)
                 {
-                    for (DCValue v : values)
+                    for (Metadatum v : values)
                     {
 
                         resolvedFields.add(v);
@@ -392,7 +392,7 @@ public class GoogleMetadata
                                 {
                                     log
                                             .debug("Resolved Field Value For This Item:");
-                                    for (DCValue r : resolvedFields)
+                                    for (Metadatum r : resolvedFields)
                                     {
                                         log.debug("{" + r.value + "}");
                                     }
@@ -411,7 +411,7 @@ public class GoogleMetadata
                 if (log.isDebugEnabled())
                 {
                     log.debug("Resolved Field Values For This Item:");
-                    for (DCValue v : resolvedFields)
+                    for (Metadatum v : resolvedFields)
                     {
                         log.debug("{" + v.value + "}");
                     }
@@ -599,11 +599,11 @@ public class GoogleMetadata
                 }
             }
 
-            DCValue[] allMD = item.getMetadata(components[0], components[1],
+            Metadatum[] allMD = item.getMetadata(components[0], components[1],
                     components[2], Item.ANY);
 
             ArrayList<String> expandedDC = new ArrayList<String>();
-            for (DCValue v : allMD)
+            for (Metadatum v : allMD)
             {
 
                 // De-dup multiple occurrences of field names in item
@@ -628,13 +628,13 @@ public class GoogleMetadata
     }
 
     /**
-     * Construct metadata field name out of DCValue components
+     * Construct metadata field name out of Metadatum components
      * 
      * @param v
-     *            The DCValue to construct a name for.
+     *            The Metadatum to construct a name for.
      * @return The complete metadata field name.
      */
-    private String buildFieldName(DCValue v)
+    private String buildFieldName(Metadatum v)
     {
 
         StringBuilder name = new StringBuilder();
@@ -1098,7 +1098,7 @@ public class GoogleMetadata
     {
 
         String authorConfig = configuredFields.get(FIELD);
-        ArrayList<DCValue> fields = resolveMetadataFields(authorConfig);
+        ArrayList<Metadatum> fields = resolveMetadataFields(authorConfig);
 
         if (null != fields && !fields.isEmpty())
         {
@@ -1106,7 +1106,7 @@ public class GoogleMetadata
             StringBuilder fieldMetadata = new StringBuilder();
             int count = 0;
 
-            for (DCValue field : fields)
+            for (Metadatum field : fields)
             {
                 fieldMetadata.append(field.value);
                 if (count < fields.size() - 1)
@@ -1234,10 +1234,10 @@ public class GoogleMetadata
         }
 
         // Check resolved/present metadata fields against configured values
-        ArrayList<DCValue> presentMD = resolveMetadataFields(sb.toString());
+        ArrayList<Metadatum> presentMD = resolveMetadataFields(sb.toString());
         if (null != presentMD && presentMD.size() != 0)
         {
-            for (DCValue v : presentMD)
+            for (Metadatum v : presentMD)
             {
                 String fieldName = buildFieldName(v);
                 if (mdPairs.containsKey(fieldName))

--- a/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
@@ -23,7 +23,7 @@ import org.dspace.content.Bitstream;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.DCDate;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.ConfigurationManager;
@@ -265,7 +265,7 @@ public class SyndicationFeed
                         df = df.replaceAll("\\(date\\)", "");
                     }
              
-                    DCValue dcv[] = item.getMetadataByMetadataString(df);
+                    Metadatum dcv[] = item.getMetadataByMetadataString(df);
                     if (dcv.length > 0)
                     {
                         String fieldLabel = labels.get(MSG_METADATA + df);
@@ -274,7 +274,7 @@ public class SyndicationFeed
                             db.append(fieldLabel).append(": ");
                         }
                         boolean first = true;
-                        for (DCValue v : dcv)
+                        for (Metadatum v : dcv)
                         {
                             if (first)
                             {
@@ -298,11 +298,11 @@ public class SyndicationFeed
                 }
 
                 // This gets the authors into an ATOM feed
-                DCValue authors[] = item.getMetadataByMetadataString(authorField);
+                Metadatum authors[] = item.getMetadataByMetadataString(authorField);
                 if (authors.length > 0)
                 {
                     List<SyndPerson> creators = new ArrayList<SyndPerson>();
-                    for (DCValue author : authors)
+                    for (Metadatum author : authors)
                     {
                         SyndPerson sp = new SyndPersonImpl();
                         sp.setName(author.value);
@@ -318,11 +318,11 @@ public class SyndicationFeed
                     DCModule dc = new DCModuleImpl();
                     if (dcCreatorField != null)
                     {
-                        DCValue dcAuthors[] = item.getMetadataByMetadataString(dcCreatorField);
+                        Metadatum dcAuthors[] = item.getMetadataByMetadataString(dcCreatorField);
                         if (dcAuthors.length > 0)
                         {
                             List<String> creators = new ArrayList<String>();
-                            for (DCValue author : dcAuthors)
+                            for (Metadatum author : dcAuthors)
                             {
                                 creators.add(author.value);
                             }
@@ -331,7 +331,7 @@ public class SyndicationFeed
                     }
                     if (dcDateField != null && !hasDate)
                     {
-                        DCValue v[] = item.getMetadataByMetadataString(dcDateField);
+                        Metadatum v[] = item.getMetadataByMetadataString(dcDateField);
                         if (v.length > 0)
                         {
                             dc.setDate((new DCDate(v[0].value)).toDate());
@@ -339,11 +339,11 @@ public class SyndicationFeed
                     }
                     if (dcDescriptionField != null)
                     {
-                        DCValue v[] = item.getMetadataByMetadataString(dcDescriptionField);
+                        Metadatum v[] = item.getMetadataByMetadataString(dcDescriptionField);
                         if (v.length > 0)
                         {
                             StringBuffer descs = new StringBuffer();
-                            for (DCValue d : v)
+                            for (Metadatum d : v)
                             {
                                 if (descs.length() > 0)
                                 {
@@ -381,7 +381,7 @@ public class SyndicationFeed
                         }
                         //Also try to add an external value from dc.identifier.other
                         // We are assuming that if this is set, then it is a media file
-                        DCValue[] externalMedia = item.getMetadataByMetadataString(externalSourceField);
+                        Metadatum[] externalMedia = item.getMetadataByMetadataString(externalSourceField);
                         if(externalMedia.length > 0)
                         {
                             for(int i = 0; i< externalMedia.length; i++)
@@ -567,7 +567,7 @@ public class SyndicationFeed
     // spoonful of syntactic sugar when we only need first value
     private String getOneDC(Item item, String field)
     {
-        DCValue dcv[] = item.getMetadataByMetadataString(field);
+        Metadatum dcv[] = item.getMetadataByMetadataString(field);
         return (dcv.length > 0) ? dcv[0].value : null;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/app/util/Util.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/Util.java
@@ -22,7 +22,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.apache.log4j.Logger;
 import org.dspace.content.Collection;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.core.Constants;
 import org.dspace.core.I18nUtil;
@@ -366,7 +366,7 @@ public class Util {
      * @param item
      *            The Dspace Item
      * @param values
-     *            A DCValue[] array of the specific "stored-value(s)"
+     *            A Metadatum[] array of the specific "stored-value(s)"
      * @param schema
      *            A String with the schema name of the metadata field
      * @param element
@@ -377,7 +377,7 @@ public class Util {
      */
 
     public static List<String> getControlledVocabulariesDisplayValueLocalized(
-            Item item, DCValue[] values, String schema, String element,
+            Item item, Metadatum[] values, String schema, String element,
             String qualifier, Locale locale) throws SQLException,
             DCInputsReaderException
     {
@@ -404,7 +404,7 @@ public class Util {
 
         DCInputSet inputSet = inputsReader.getInputs(col_handle);
 
-        // Replace the values of DCValue[] with the correct ones in case of
+        // Replace the values of Metadatum[] with the correct ones in case of
         // controlled vocabularies
         String currentField = schema + "." + element
                 + (qualifier == null ? "" : "." + qualifier);

--- a/dspace-api/src/main/java/org/dspace/authority/AuthorityValue.java
+++ b/dspace-api/src/main/java/org/dspace/authority/AuthorityValue.java
@@ -11,7 +11,6 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrInputDocument;
-import org.dspace.content.DCValue;
 import org.dspace.content.Item;
 import org.dspace.utils.DSpace;
 import org.joda.time.DateTime;
@@ -19,6 +18,7 @@ import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 
 import java.util.*;
+import org.dspace.content.Metadatum;
 
 /**
  *
@@ -167,8 +167,8 @@ public class AuthorityValue {
     /**
      * Replace an item's DCValue with this authority
      */
-    public void updateItem(Item currentItem, DCValue value) {
-        DCValue newValue = value.copy();
+    public void updateItem(Item currentItem, Metadatum value) {
+        Metadatum newValue = value.copy();
         newValue.value = getValue();
         newValue.authority = getId();
         currentItem.replaceMetadataValue(value,newValue);

--- a/dspace-api/src/main/java/org/dspace/authority/UpdateAuthorities.java
+++ b/dspace-api/src/main/java/org/dspace/authority/UpdateAuthorities.java
@@ -9,7 +9,6 @@ package org.dspace.authority;
 
 import org.apache.commons.cli.*;
 import org.apache.log4j.Logger;
-import org.dspace.content.DCValue;
 import org.dspace.content.Item;
 import org.dspace.content.ItemIterator;
 import org.dspace.core.ConfigurationManager;
@@ -20,6 +19,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.dspace.content.Metadatum;
 
 /**
  *
@@ -150,9 +150,9 @@ public class UpdateAuthorities {
             ItemIterator itemIterator = Item.findByMetadataFieldAuthority(context, authority.getField(), authority.getId());
             while (itemIterator.hasNext()) {
                 Item next = itemIterator.next();
-                List<DCValue> metadata = next.getMetadata(authority.getField(), authority.getId());
+                List<Metadatum> metadata = next.getMetadata(authority.getField(), authority.getId());
                 authority.updateItem(next, metadata.get(0)); //should be only one
-                List<DCValue> metadataAfter = next.getMetadata(authority.getField(), authority.getId());
+                List<Metadatum> metadataAfter = next.getMetadata(authority.getField(), authority.getId());
                 if (!metadata.get(0).value.equals(metadataAfter.get(0).value)) {
                     print.println("Updated item with handle " + next.getHandle());
                 }

--- a/dspace-api/src/main/java/org/dspace/authority/indexer/DSpaceAuthorityIndexer.java
+++ b/dspace-api/src/main/java/org/dspace/authority/indexer/DSpaceAuthorityIndexer.java
@@ -12,7 +12,7 @@ import org.dspace.authority.AuthorityValueFinder;
 import org.dspace.authority.AuthorityValueGenerator;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.content.ItemIterator;
 import org.dspace.core.ConfigurationManager;
@@ -107,7 +107,7 @@ public class DSpaceAuthorityIndexer implements AuthorityIndexerInterface {
         // 1. iterate over the metadata values
 
         String metadataField = metadataFields.get(currentFieldIndex);
-        DCValue[] values = currentItem.getMetadataByMetadataString(metadataField);
+        Metadatum[] values = currentItem.getMetadataByMetadataString(metadataField);
         if (currentMetadataIndex < values.length) {
             prepareNextValue(metadataField, values[currentMetadataIndex]);
 
@@ -156,7 +156,7 @@ public class DSpaceAuthorityIndexer implements AuthorityIndexerInterface {
      * @param metadataField Is one of the fields defined in dspace.cfg to be indexed.
      * @param value         Is one of the values of the given metadataField in one of the items being indexed.
      */
-    private void prepareNextValue(String metadataField, DCValue value) {
+    private void prepareNextValue(String metadataField, Metadatum value) {
 
         nextValue = null;
 

--- a/dspace-api/src/main/java/org/dspace/browse/BrowseInfo.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseInfo.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
@@ -888,7 +888,7 @@ public class BrowseInfo
     				sb.append("{{ NULL METADATA }}");
     				break;
     			}
-				DCValue[] values = bi.getMetadata(md[0], md[1], md[2], Item.ANY);
+				Metadatum[] values = bi.getMetadata(md[0], md[1], md[2], Item.ANY);
 				StringBuffer value = new StringBuffer();
 				if (values != null)
 				{

--- a/dspace-api/src/main/java/org/dspace/browse/BrowseItem.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseItem.java
@@ -41,7 +41,7 @@ public class BrowseItem extends DSpaceObject
     private static Logger log = Logger.getLogger(BrowseItem.class);
     
 	/** a List of all the metadata */
-	private List<DCValue> metadata = new ArrayList<DCValue>();
+	private List<Metadatum> metadata = new ArrayList<Metadatum>();
 	
 	/** database id of the item */
 	private int id = -1;
@@ -84,7 +84,7 @@ public class BrowseItem extends DSpaceObject
 	 * @return			array of matching values
 	 * @throws SQLException
 	 */
-	public DCValue[] getMetadata(String schema, String element, String qualifier, String lang) {
+	public Metadatum[] getMetadata(String schema, String element, String qualifier, String lang) {
         try
         {
             BrowseItemDAO dao = BrowseDAOFactory.getItemInstance(ourContext);
@@ -102,12 +102,12 @@ public class BrowseItem extends DSpaceObject
 
             if (!metadata.isEmpty())
             {
-                List<DCValue> values = new ArrayList<DCValue>();
-                Iterator<DCValue> i = metadata.iterator();
+                List<Metadatum> values = new ArrayList<Metadatum>();
+                Iterator<Metadatum> i = metadata.iterator();
 
                 while (i.hasNext())
                 {
-                    DCValue dcv = i.next();
+                    Metadatum dcv = i.next();
 
                     if (match(schema, element, qualifier, lang, dcv))
                     {
@@ -117,7 +117,7 @@ public class BrowseItem extends DSpaceObject
 
                 if (values.isEmpty())
                 {
-                    DCValue[] dcvs = new DCValue[0];
+                    Metadatum[] dcvs = new Metadatum[0];
                     try {
                         dcvs = dao.queryMetadata(id, schema, element, qualifier, lang);
                     } catch (SQLException e) {
@@ -131,14 +131,14 @@ public class BrowseItem extends DSpaceObject
                 }
 
                 // else, Create an array of matching values
-                DCValue[] valueArray = new DCValue[values.size()];
-                valueArray = (DCValue[]) values.toArray(valueArray);
+                Metadatum[] valueArray = new Metadatum[values.size()];
+                valueArray = (Metadatum[]) values.toArray(valueArray);
 
                 return valueArray;
             }
             else
             {
-                DCValue[] dcvs = new DCValue[0];
+                Metadatum[] dcvs = new Metadatum[0];
                 try {
                     dcvs = dao.queryMetadata(id, schema, element, qualifier, lang);
                 } catch (SQLException e) {
@@ -209,7 +209,7 @@ public class BrowseItem extends DSpaceObject
      * Utility method for pattern-matching metadata elements.  This
      * method will return <code>true</code> if the given schema,
      * element, qualifier and language match the schema, element,
-     * qualifier and language of the <code>DCValue</code> object passed
+     * qualifier and language of the <code>Metadatum</code> object passed
      * in.  Any or all of the element, qualifier and language passed
      * in can be the <code>Item.ANY</code> wildcard.
      *
@@ -227,7 +227,7 @@ public class BrowseItem extends DSpaceObject
      * @return <code>true</code> if there is a match
      */
     private boolean match(String schema, String element, String qualifier,
-            String language, DCValue dcv)
+            String language, Metadatum dcv)
     {
         // We will attempt to disprove a match - if we can't we have a match
         if (!element.equals(Item.ANY) && !element.equals(dcv.element))

--- a/dspace-api/src/main/java/org/dspace/browse/BrowseItemDAO.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseItemDAO.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.browse;
 
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 
 import java.sql.SQLException;
 
@@ -40,6 +40,6 @@ public interface BrowseItemDAO
      * @return matching metadata values.
      * @throws SQLException
      */
-    public DCValue[] queryMetadata(int itemId, String schema, String element, String qualifier, String lang)
+    public Metadatum[] queryMetadata(int itemId, String schema, String element, String qualifier, String lang)
     	throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/browse/BrowseItemDAOOracle.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseItemDAOOracle.java
@@ -12,7 +12,7 @@ import org.dspace.storage.rdbms.TableRowIterator;
 import org.dspace.storage.rdbms.DatabaseManager;
 import org.dspace.storage.rdbms.TableRow;
 import org.dspace.core.Context;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 
 import java.sql.SQLException;
@@ -95,10 +95,10 @@ public class BrowseItemDAOOracle implements BrowseItemDAO
         return items.toArray(bis);
     }
 
-    public DCValue[] queryMetadata(int itemId, String schema, String element, String qualifier, String lang)
+    public Metadatum[] queryMetadata(int itemId, String schema, String element, String qualifier, String lang)
     	throws SQLException
     {
-        List<DCValue> values = new ArrayList<DCValue>();
+        List<Metadatum> values = new ArrayList<Metadatum>();
         TableRowIterator tri = null;
 
         try
@@ -121,13 +121,13 @@ public class BrowseItemDAOOracle implements BrowseItemDAO
 
             if (!tri.hasNext())
             {
-                return new DCValue[0];
+                return new Metadatum[0];
             }
 
             while (tri.hasNext())
             {
                 TableRow tr = tri.next();
-                DCValue dcv = new DCValue();
+                Metadatum dcv = new Metadatum();
                 dcv.schema = schema;
                 dcv.element = tr.getStringColumn("element");
                 dcv.qualifier = tr.getStringColumn("qualifier");
@@ -146,7 +146,7 @@ public class BrowseItemDAOOracle implements BrowseItemDAO
             }
         }
 
-        DCValue[] dcvs = new DCValue[values.size()];
+        Metadatum[] dcvs = new Metadatum[values.size()];
         return values.toArray(dcvs);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/browse/BrowseItemDAOPostgres.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseItemDAOPostgres.java
@@ -12,7 +12,7 @@ import org.dspace.storage.rdbms.TableRowIterator;
 import org.dspace.storage.rdbms.DatabaseManager;
 import org.dspace.storage.rdbms.TableRow;
 import org.dspace.core.Context;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 
 import java.sql.SQLException;
@@ -94,10 +94,10 @@ public class BrowseItemDAOPostgres implements BrowseItemDAO
         return items.toArray(bis);
     }
 
-    public DCValue[] queryMetadata(int itemId, String schema, String element, String qualifier, String lang)
+    public Metadatum[] queryMetadata(int itemId, String schema, String element, String qualifier, String lang)
     	throws SQLException
     {
-    	List<DCValue> values = new ArrayList<DCValue>();
+    	List<Metadatum> values = new ArrayList<Metadatum>();
     	TableRowIterator tri = null;
 
         try
@@ -120,13 +120,13 @@ public class BrowseItemDAOPostgres implements BrowseItemDAO
 
             if (!tri.hasNext())
             {
-                return new DCValue[0];
+                return new Metadatum[0];
             }
 
             while (tri.hasNext())
             {
                 TableRow tr = tri.next();
-                DCValue dcv = new DCValue();
+                Metadatum dcv = new Metadatum();
                 dcv.schema = schema;
                 dcv.element = tr.getStringColumn("element");
                 dcv.qualifier = tr.getStringColumn("qualifier");
@@ -145,7 +145,7 @@ public class BrowseItemDAOPostgres implements BrowseItemDAO
             }
         }
         
-        DCValue[] dcvs = new DCValue[values.size()];
+        Metadatum[] dcvs = new Metadatum[values.size()];
         return values.toArray(dcvs);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/browse/IndexBrowse.java
+++ b/dspace-api/src/main/java/org/dspace/browse/IndexBrowse.java
@@ -26,7 +26,7 @@ import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PosixParser;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.content.authority.ChoiceAuthorityManager;
 import org.dspace.content.authority.MetadataAuthorityManager;
@@ -409,7 +409,7 @@ public class IndexBrowse
                         for (int mdIdx = 0; mdIdx < bis[i].getMetadataCount(); mdIdx++)
                         {
                             String[] md = bis[i].getMdBits(mdIdx);
-                            DCValue[] values = item.getMetadata(md[0], md[1], md[2], Item.ANY);
+                            Metadatum[] values = item.getMetadata(md[0], md[1], md[2], Item.ANY);
 
                             // if we have values to index on, then do so
                             if (values != null && values.length > 0)
@@ -417,7 +417,7 @@ public class IndexBrowse
                                 int minConfidence = MetadataAuthorityManager.getManager()
                                         .getMinConfidence(values[0].schema, values[0].element, values[0].qualifier);
 
-                                for (DCValue value : values)
+                                for (Metadatum value : values)
                                 {
                                     // Ensure that there is a value to index before inserting it
                                     if (StringUtils.isEmpty(value.value))
@@ -537,18 +537,18 @@ public class IndexBrowse
 
                 // If we've already used the metadata for this Item
                 // it will be cached in the map
-                DCValue value = null;
+                Metadatum value = null;
 
                 if (itemMDMap != null)
                 {
-                    value = (DCValue) itemMDMap.get(metadata);
+                    value = (Metadatum) itemMDMap.get(metadata);
                 }
 
                 // We haven't used this metadata before, so grab it from the item
                 if (value == null)
                 {
                     String[] somd = so.getMdBits();
-                    DCValue[] dcv = item.getMetadata(somd[0], somd[1], somd[2], Item.ANY);
+                    Metadatum[] dcv = item.getMetadata(somd[0], somd[1], somd[2], Item.ANY);
 
                     if (dcv == null)
                     {
@@ -1218,7 +1218,7 @@ public class IndexBrowse
 	        this.id         = id;
 	    }
 
-	    public DCValue[] getMetadata(String schema, String element, String qualifier, String lang)
+	    public Metadatum[] getMetadata(String schema, String element, String qualifier, String lang)
 	        throws SQLException
 	    {
 	        if (item != null)

--- a/dspace-api/src/main/java/org/dspace/browse/SolrBrowseCreateDAO.java
+++ b/dspace-api/src/main/java/org/dspace/browse/SolrBrowseCreateDAO.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.apache.solr.common.SolrInputDocument;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.authority.ChoiceAuthorityManager;
@@ -128,7 +128,7 @@ public class SolrBrowseCreateDAO implements BrowseCreateDAO,
                     for (int mdIdx = 0; mdIdx < bi.getMetadataCount(); mdIdx++)
                     {
                         String[] md = bi.getMdBits(mdIdx);
-                        DCValue[] values = item.getMetadata(md[0], md[1],
+                        Metadatum[] values = item.getMetadata(md[0], md[1],
                                 md[2], Item.ANY);
 
                         // if we have values to index on, then do so
@@ -330,7 +330,7 @@ public class SolrBrowseCreateDAO implements BrowseCreateDAO,
         {
             for (SortOption so : SortOption.getSortOptions())
             {
-                DCValue[] dcvalue = item.getMetadataByMetadataString(so.getMetadata());
+                Metadatum[] dcvalue = item.getMetadataByMetadataString(so.getMetadata());
                 if (dcvalue != null && dcvalue.length > 0)
                 {
                     String nValue = OrderFormat

--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
@@ -94,7 +94,7 @@ public abstract class DSpaceObject
         // Work out the place numbers for the in memory DC
         for (int dcIdx = 0; dcIdx < getMetadata().size(); dcIdx++)
         {
-            DCValue dcv = getMetadata().get(dcIdx);
+            Metadatum dcv = getMetadata().get(dcIdx);
 
             // Work out the place number for ordering
             int current = 0;
@@ -143,7 +143,7 @@ public abstract class DSpaceObject
                         if (!storedDC[dcIdx])
                         {
                             boolean matched = true;
-                            DCValue dcv   = getMetadata().get(dcIdx);
+                            Metadatum dcv   = getMetadata().get(dcIdx);
 
                             // Check the metadata field is the same
                             if (matched && dcFields[dcIdx].getFieldID() != tr.getIntColumn("metadata_field_id"))
@@ -241,9 +241,9 @@ public abstract class DSpaceObject
             // Only write values that are not already in the db
             if (!storedDC[dcIdx])
             {
-                DCValue dcv = getMetadata().get(dcIdx);
+                Metadatum dcv = getMetadata().get(dcIdx);
 
-                // Write DCValue
+                // Write Metadatum
                 MetadataValue metadata = new MetadataValue();
                 metadata.setResourceId(getID());
                 metadata.setResourceTypeId(getType());
@@ -526,7 +526,7 @@ public abstract class DSpaceObject
      * @return Dublin Core fields that match the parameters
      */
     @Deprecated
-    public DCValue[] getDC(String element, String qualifier, String lang)
+    public Metadatum[] getDC(String element, String qualifier, String lang)
     {
         return getMetadata(MetadataSchema.DC_SCHEMA, element, qualifier, lang);
     }
@@ -577,17 +577,17 @@ public abstract class DSpaceObject
      *            no country code are returned.
      * @return metadata fields that match the parameters
      */
-    public DCValue[] getMetadata(String schema, String element, String qualifier,
+    public Metadatum[] getMetadata(String schema, String element, String qualifier,
                                  String lang)
     {
         // Build up list of matching values
-        List<DCValue> values = new ArrayList<DCValue>();
-        for (DCValue dcv : getMetadata())
+        List<Metadatum> values = new ArrayList<Metadatum>();
+        for (Metadatum dcv : getMetadata())
         {
             if (match(schema, element, qualifier, lang, dcv))
             {
                 // We will return a copy of the object in case it is altered
-                DCValue copy = new DCValue();
+                Metadatum copy = new Metadatum();
                 copy.element = dcv.element;
                 copy.qualifier = dcv.qualifier;
                 copy.value = dcv.value;
@@ -600,8 +600,8 @@ public abstract class DSpaceObject
         }
 
         // Create an array of matching values
-        DCValue[] valueArray = new DCValue[values.size()];
-        valueArray = (DCValue[]) values.toArray(valueArray);
+        Metadatum[] valueArray = new Metadatum[values.size()];
+        valueArray = (Metadatum[]) values.toArray(valueArray);
 
         return valueArray;
     }
@@ -614,7 +614,7 @@ public abstract class DSpaceObject
      *            The metadata string of the form
      *            <schema prefix>.<element>[.<qualifier>|.*]
      */
-    public DCValue[] getMetadataByMetadataString(String mdString)
+    public Metadatum[] getMetadataByMetadataString(String mdString)
     {
         StringTokenizer dcf = new StringTokenizer(mdString, ".");
 
@@ -629,7 +629,7 @@ public abstract class DSpaceObject
         String element = tokens[1];
         String qualifier = tokens[2];
 
-        DCValue[] values;
+        Metadatum[] values;
         if ("*".equals(qualifier))
         {
             values = getMetadata(schema, element, Item.ANY, Item.ANY);
@@ -650,7 +650,7 @@ public abstract class DSpaceObject
      * Retrieve first metadata field value
      */
     protected String getMetadataFirstValue(String schema, String element, String qualifier, String language){
-        DCValue[] dcvalues = getMetadata(schema, element, qualifier, Item.ANY);
+        Metadatum[] dcvalues = getMetadata(schema, element, qualifier, Item.ANY);
         if(dcvalues.length>0){
             return dcvalues[0].value;
         }
@@ -669,7 +669,7 @@ public abstract class DSpaceObject
         }
     }
 
-    protected List<DCValue> getMetadata()
+    protected List<Metadatum> getMetadata()
     {
         try
         {
@@ -680,7 +680,7 @@ public abstract class DSpaceObject
             log.error("Loading item - cannot load metadata");
         }
 
-        return new ArrayList<DCValue>();
+        return new ArrayList<Metadatum>();
     }
 
     /**
@@ -695,7 +695,7 @@ public abstract class DSpaceObject
      *                if the requested metadata field doesn't exist
      */
     public String getMetadata(String value){
-        DCValue[] dcvalues = getMetadataByMetadataString(value);
+        Metadatum[] dcvalues = getMetadataByMetadataString(value);
 
         if(dcvalues.length>0) {
             return dcvalues[0].value;
@@ -906,7 +906,7 @@ public abstract class DSpaceObject
     public void addMetadata(String schema, String element, String qualifier, String lang,
                             String[] values, String authorities[], int confidences[])
     {
-        List<DCValue> dublinCore = getMetadata();
+        List<Metadatum> dublinCore = getMetadata();
         MetadataAuthorityManager mam = MetadataAuthorityManager.getManager();
         boolean authorityControlled = mam.isAuthorityControlled(schema, element, qualifier);
         boolean authorityRequired = mam.isAuthorityRequired(schema, element, qualifier);
@@ -916,7 +916,7 @@ public abstract class DSpaceObject
         // until update() is called.
         for (int i = 0; i < values.length; i++)
         {
-            DCValue dcv = new DCValue();
+            Metadatum dcv = new Metadatum();
             dcv.schema = schema;
             dcv.element = element;
             dcv.qualifier = qualifier;
@@ -1097,8 +1097,8 @@ public abstract class DSpaceObject
                               String lang)
     {
         // We will build a list of values NOT matching the values to clear
-        List<DCValue> values = new ArrayList<DCValue>();
-        for (DCValue dcv : getMetadata())
+        List<Metadatum> values = new ArrayList<Metadatum>();
+        for (Metadatum dcv : getMetadata())
         {
             if (!match(schema, element, qualifier, lang, dcv))
             {
@@ -1115,7 +1115,7 @@ public abstract class DSpaceObject
      * Utility method for pattern-matching metadata elements.  This
      * method will return <code>true</code> if the given schema,
      * element, qualifier and language match the schema, element,
-     * qualifier and language of the <code>DCValue</code> object passed
+     * qualifier and language of the <code>Metadatum</code> object passed
      * in.  Any or all of the element, qualifier and language passed
      * in can be the <code>Item.ANY</code> wildcard.
      *
@@ -1133,7 +1133,7 @@ public abstract class DSpaceObject
      * @return <code>true</code> if there is a match
      */
     private boolean match(String schema, String element, String qualifier,
-                          String language, DCValue dcv)
+                          String language, Metadatum dcv)
     {
         // We will attempt to disprove a match - if we can't we have a match
         if (!element.equals(Item.ANY) && !element.equals(dcv.element))
@@ -1192,7 +1192,7 @@ public abstract class DSpaceObject
     }
 
     protected transient MetadataField[] allMetadataFields = null;
-    protected MetadataField getMetadataField(DCValue dcv) throws SQLException, AuthorizeException
+    protected MetadataField getMetadataField(Metadatum dcv) throws SQLException, AuthorizeException
     {
         if (allMetadataFields == null)
         {
@@ -1216,7 +1216,7 @@ public abstract class DSpaceObject
         return null;
     }
 
-    private int getMetadataSchemaID(DCValue dcv) throws SQLException
+    private int getMetadataSchemaID(Metadatum dcv) throws SQLException
     {
         int schemaID;
         MetadataSchema schema = MetadataSchema.find(ourContext,dcv.schema);
@@ -1245,7 +1245,7 @@ public abstract class DSpaceObject
                 getType());
     }
 
-    private void setMetadata(List<DCValue> metadata)
+    private void setMetadata(List<Metadatum> metadata)
     {
         metadataCache.set(metadata);
         modifiedMetadata = true;
@@ -1253,13 +1253,13 @@ public abstract class DSpaceObject
 
     class MetadataCache
     {
-        List<DCValue> metadata = null;
+        List<Metadatum> metadata = null;
 
-        List<DCValue> get(Context c, int resourceId, int resourceTypeId, Logger log) throws SQLException
+        List<Metadatum> get(Context c, int resourceId, int resourceTypeId, Logger log) throws SQLException
         {
             if (metadata == null)
             {
-                metadata = new ArrayList<DCValue>();
+                metadata = new ArrayList<Metadatum>();
 
                 // Get Dublin Core metadata
                 TableRowIterator tri = retrieveMetadata(resourceId, resourceTypeId);
@@ -1289,8 +1289,8 @@ public abstract class DSpaceObject
                                 }
                                 else
                                 {
-                                    // Make a DCValue object
-                                    DCValue dcv = new DCValue();
+                                    // Make a Metadatum object
+                                    Metadatum dcv = new Metadatum();
                                     dcv.element = field.getElement();
                                     dcv.qualifier = field.getQualifier();
                                     dcv.value = resultRow.getStringColumn("text_value");
@@ -1320,7 +1320,7 @@ public abstract class DSpaceObject
             return metadata;
         }
 
-        void set(List<DCValue> m)
+        void set(List<Metadatum> m)
         {
             metadata = m;
         }

--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
@@ -703,18 +703,18 @@ public abstract class DSpaceObject
         return null;
     }
 
-    public List<DCValue> getMetadata(String mdString, String authority) {
+    public List<Metadatum> getMetadata(String mdString, String authority) {
         String[] elements = getElements(mdString);
         return getMetadata(elements[0], elements[1], elements[2], elements[3], authority);
     }
 
-    public List<DCValue> getMetadata(String schema, String element, String qualifier, String lang, String authority) {
-        DCValue[] metadata = getMetadata(schema, element, qualifier, lang);
-        List<DCValue> dcValues = Arrays.asList(metadata);
+    public List<Metadatum> getMetadata(String schema, String element, String qualifier, String lang, String authority) {
+        Metadatum[] metadata = getMetadata(schema, element, qualifier, lang);
+        List<Metadatum> dcValues = Arrays.asList(metadata);
         if (!authority.equals(Item.ANY)) {
-            Iterator<DCValue> iterator = dcValues.iterator();
+            Iterator<Metadatum> iterator = dcValues.iterator();
             while (iterator.hasNext()) {
-                DCValue dcValue = iterator.next();
+                Metadatum dcValue = iterator.next();
                 if (!authority.equals(dcValue.authority)) {
                     iterator.remove();
                 }
@@ -759,7 +759,7 @@ public abstract class DSpaceObject
         return elements;
     }
 
-    public void replaceMetadataValue(DCValue oldValue, DCValue newValue)
+    public void replaceMetadataValue(Metadatum oldValue, Metadatum newValue)
     {
         // check both dcvalues are for the same field
         if (oldValue.hasSameFieldAs(newValue)) {
@@ -769,9 +769,9 @@ public abstract class DSpaceObject
             String qualifier = oldValue.qualifier;
 
             // Save all metadata for this field
-            DCValue[] dcvalues = getMetadata(schema, element, qualifier, Item.ANY);
+            Metadatum[] dcvalues = getMetadata(schema, element, qualifier, Item.ANY);
             clearMetadata(schema, element, qualifier, Item.ANY);
-            for (DCValue dcvalue : dcvalues) {
+            for (Metadatum dcvalue : dcvalues) {
                 if (dcvalue.equals(oldValue)) {
                     addMetadata(schema, element, qualifier, newValue.language, newValue.value, newValue.authority, newValue.confidence);
                 } else {

--- a/dspace-api/src/main/java/org/dspace/content/InstallItem.java
+++ b/dspace-api/src/main/java/org/dspace/content/InstallItem.java
@@ -117,7 +117,7 @@ public class InstallItem
         DCDate now = DCDate.getCurrent();
         
         // If the item doesn't have a date.accessioned, set it to today
-        DCValue[] dateAccessioned = item.getDC("date", "accessioned", Item.ANY);
+        Metadatum[] dateAccessioned = item.getDC("date", "accessioned", Item.ANY);
         if (dateAccessioned.length == 0)
         {
 	        item.addDC("date", "accessioned", null, now.toString());
@@ -127,9 +127,9 @@ public class InstallItem
         // In the below loop, we temporarily clear all issued dates and re-add, one-by-one,
         // replacing "today" with today's date.
         // NOTE: As of DSpace 4.0, DSpace no longer sets an issue date by default
-        DCValue[] currentDateIssued = item.getDC("date", "issued", Item.ANY);
+        Metadatum[] currentDateIssued = item.getDC("date", "issued", Item.ANY);
         item.clearDC("date", "issued", Item.ANY);
-        for (DCValue dcv : currentDateIssued)
+        for (Metadatum dcv : currentDateIssued)
         {
             if(dcv.value!=null && dcv.value.equalsIgnoreCase("today"))
             {
@@ -170,9 +170,9 @@ public class InstallItem
         // In the below loop, we temporarily clear all issued dates and re-add, one-by-one,
         // replacing "today" with today's date.
         // NOTE: As of DSpace 4.0, DSpace no longer sets an issue date by default
-        DCValue[] currentDateIssued = item.getDC("date", "issued", Item.ANY);
+        Metadatum[] currentDateIssued = item.getDC("date", "issued", Item.ANY);
         item.clearDC("date", "issued", Item.ANY);
-        for (DCValue dcv : currentDateIssued)
+        for (Metadatum dcv : currentDateIssued)
         {
             if(dcv.value!=null && dcv.value.equalsIgnoreCase("today"))
             {

--- a/dspace-api/src/main/java/org/dspace/content/ItemComparator.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemComparator.java
@@ -21,9 +21,9 @@ import org.dspace.sort.OrderFormat;
  * Compare two Items by their DCValues.
  * 
  * The DCValues to be compared are specified by the element, qualifier and
- * language parameters to the constructor. If the Item has more than one
- * matching DCValue, then the max parameter to the constructor specifies whether
- * the maximum or minimum lexicographic value will be used.
+ language parameters to the constructor. If the Item has more than one
+ matching Metadatum, then the max parameter to the constructor specifies whether
+ the maximum or minimum lexicographic value will be used.
  * 
  * @author Peter Breton
  * @version $Revision$
@@ -52,9 +52,9 @@ public class ItemComparator implements Comparator, Serializable
      * @param language
      *            The language for the DCValues
      * @param max
-     *            If true, and there is more than one DCValue for element,
-     *            qualifier and language, then use the maximum value
-     *            lexicographically; otherwise use the minimum value.
+     *            If true, and there is more than one Metadatum for element,
+            qualifier and language, then use the maximum value
+            lexicographically; otherwise use the minimum value.
      */
     public ItemComparator(String element, String qualifier, String language,
             boolean max)
@@ -176,7 +176,7 @@ public class ItemComparator implements Comparator, Serializable
     private String getValue(Item item)
     {
         // The overall array and each element are guaranteed non-null
-        DCValue[] dcvalues = item.getDC(element, qualifier, language);
+        Metadatum[] dcvalues = item.getDC(element, qualifier, language);
 
         if (dcvalues.length == 0)
         {
@@ -189,7 +189,7 @@ public class ItemComparator implements Comparator, Serializable
         }
 
         // We want to sort using Strings, but also keep track of
-        // which DCValue the value came from.
+        // which Metadatum the value came from.
         Map<String, Integer> values = new HashMap<String, Integer>();
 
         for (int i = 0; i < dcvalues.length; i++)
@@ -217,9 +217,9 @@ public class ItemComparator implements Comparator, Serializable
     }
 
     /**
-     * Normalize the title of a DCValue.
+     * Normalize the title of a Metadatum.
      */
-    private String normalizeTitle(DCValue value)
+    private String normalizeTitle(Metadatum value)
     {
         if (!"title".equals(element))
         {

--- a/dspace-api/src/main/java/org/dspace/content/Metadatum.java
+++ b/dspace-api/src/main/java/org/dspace/content/Metadatum.java
@@ -10,44 +10,45 @@ package org.dspace.content;
 import org.dspace.content.authority.Choices;
 
 /**
- * Simple data structure-like class representing a Dublin Core value. It has an
- * element, qualifier, value and language.
+ * Simple data structure-like class representing a flat metadata value. It has a
+ * schema, element, qualifier, value, language and authority.
  *
  * @author Robert Tansley
  * @author Martin Hald
  * @version $Revision$
  */
-@Deprecated
-public class DCValue
+public class Metadatum
 {
-    /** The DC element */
+    /** The element name. */
     public String element;
 
-    /** The DC qualifier, or <code>null</code> if unqualified */
+    /** The name's qualifier, or <code>null</code> if unqualified. */
     public String qualifier;
 
-    /** The value of the field */
+    /** The value of the field. */
     public String value;
 
-    /** The language of the field, may be <code>null</code> */
+    /** The language of the field, may be <code>null</code>. */
     public String language;
 
-    /** The schema name of the metadata element */
+    /** The schema name of the metadata element. */
     public String schema;
 
-    /** Authority control key */
+    /** Authority control key. */
     public String authority = null;
 
-    /** Authority control confidence  */
+    /** Authority control confidence. */
     public int confidence = Choices.CF_UNSET;
 
     /**
-     * Get the field in dot notation. i.e. schema.element.qualifier, as in dc.date.issued
-     * @return
+     * Get the name of the field in dot notation:  schema.element.qualifier,
+     * as in {@code dc.date.issued}.
+     *
+     * @return stringified name of this field.
      */
 
-    public DCValue copy() {
-        DCValue copy = new DCValue();
+    public Metadatum copy() {
+        Metadatum copy = new Metadatum();
         copy.value = this.value;
         copy.authority = this.authority;
         copy.confidence = this.confidence;
@@ -62,7 +63,7 @@ public class DCValue
         return schema + "." + element + (qualifier==null?"":("." + qualifier));
     }
 
-    public boolean hasSameFieldAs(DCValue dcValue) {
+    public boolean hasSameFieldAs(Metadatum dcValue) {
         if (dcValue == this) {
             return true;
         }
@@ -87,7 +88,7 @@ public class DCValue
             return false;
         }
 
-        DCValue dcValue = (DCValue) o;
+        Metadatum dcValue = (Metadatum) o;
 
         if (confidence != dcValue.confidence) {
             return false;

--- a/dspace-api/src/main/java/org/dspace/content/WorkspaceItem.java
+++ b/dspace-api/src/main/java/org/dspace/content/WorkspaceItem.java
@@ -240,7 +240,7 @@ public class WorkspaceItem implements InProgressSubmission
 
         if (template && (templateItem != null))
         {
-            DCValue[] md = templateItem.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+            Metadatum[] md = templateItem.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
 
             for (int n = 0; n < md.length; n++)
             {

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/AIPTechMDCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/AIPTechMDCrosswalk.java
@@ -16,7 +16,7 @@ import java.sql.SQLException;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.ConfigurationManager;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.content.Bitstream;
 import org.dspace.content.BitstreamFormat;
@@ -185,7 +185,7 @@ public class AIPTechMDCrosswalk
         throws CrosswalkException, IOException, SQLException,
                AuthorizeException
     {
-        List<DCValue> dc = new ArrayList<DCValue>();
+        List<Metadatum> dc = new ArrayList<Metadatum>();
         if (dso.getType() == Constants.ITEM)
         {
             Item item = (Item)dso;
@@ -295,13 +295,13 @@ public class AIPTechMDCrosswalk
             dc.add(makeDC("identifier", "uri", site.getURL()));
         }
 
-        DCValue result[] = (DCValue[])dc.toArray(new DCValue[dc.size()]);
+        Metadatum result[] = (Metadatum[])dc.toArray(new Metadatum[dc.size()]);
         return XSLTDisseminationCrosswalk.createDIM(dso, result);
     }
 
-    private static DCValue makeDC(String element, String qualifier, String value)
+    private static Metadatum makeDC(String element, String qualifier, String value)
     {
-        DCValue dcv = new DCValue();
+        Metadatum dcv = new Metadatum();
         dcv.schema = "dc";
         dcv.language = null;
         dcv.element = element;

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/DIMDisseminationCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/DIMDisseminationCrosswalk.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.Constants;
@@ -61,7 +61,7 @@ public class DIMDisseminationCrosswalk
         }
         Item item = (Item)dso;
         
-    	DCValue[] dc = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+    	Metadatum[] dc = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
         Element dim = new Element("dim", DIM_NS);
         for (int i = 0; i < dc.length; i++)
         {

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/MODSDisseminationCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/MODSDisseminationCrosswalk.java
@@ -23,7 +23,7 @@ import java.util.Properties;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
@@ -328,7 +328,7 @@ public class MODSDisseminationCrosswalk extends SelfNamedPlugin
     private List<Element> disseminateListInternal(DSpaceObject dso, boolean addSchema)
         throws CrosswalkException, IOException, SQLException, AuthorizeException
     {
-        DCValue[] dcvs = null;
+        Metadatum[] dcvs = null;
         if (dso.getType() == Constants.ITEM)
         {
             dcvs = item2Metadata((Item) dso);
@@ -446,9 +446,9 @@ public class MODSDisseminationCrosswalk extends SelfNamedPlugin
      * @param site
      *            The site to derive metadata from
      */
-    protected DCValue[] site2Metadata(Site site)
+    protected Metadatum[] site2Metadata(Site site)
     {
-        List<DCValue> metadata = new ArrayList<DCValue>();
+        List<Metadatum> metadata = new ArrayList<Metadatum>();
 
         String identifier_uri = "http://hdl.handle.net/"
                 + site.getHandle();
@@ -471,7 +471,7 @@ public class MODSDisseminationCrosswalk extends SelfNamedPlugin
             metadata.add(createDCValue("title", null, title));
         }
 
-        return (DCValue[]) metadata.toArray(new DCValue[metadata.size()]);
+        return (Metadatum[]) metadata.toArray(new Metadatum[metadata.size()]);
     }
     /**
      * Generate a list of metadata elements for the given DSpace
@@ -480,9 +480,9 @@ public class MODSDisseminationCrosswalk extends SelfNamedPlugin
      * @param community
      *            The community to derive metadata from
      */
-    protected DCValue[] community2Metadata(Community community)
+    protected Metadatum[] community2Metadata(Community community)
     {
-        List<DCValue> metadata = new ArrayList<DCValue>();
+        List<Metadatum> metadata = new ArrayList<Metadatum>();
 
         String description = community.getMetadata("introductory_text");
         String description_abstract = community
@@ -523,7 +523,7 @@ public class MODSDisseminationCrosswalk extends SelfNamedPlugin
             metadata.add(createDCValue("title", null, title));
         }
 
-        return (DCValue[]) metadata.toArray(new DCValue[metadata.size()]);
+        return (Metadatum[]) metadata.toArray(new Metadatum[metadata.size()]);
     }
 
     /**
@@ -533,9 +533,9 @@ public class MODSDisseminationCrosswalk extends SelfNamedPlugin
      * @param collection
      *            The collection to derive metadata from
      */
-    protected DCValue[] collection2Metadata(Collection collection)
+    protected Metadatum[] collection2Metadata(Collection collection)
     {
-        List<DCValue> metadata = new ArrayList<DCValue>();
+        List<Metadatum> metadata = new ArrayList<Metadatum>();
 
         String description = collection.getMetadata("introductory_text");
         String description_abstract = collection
@@ -588,7 +588,7 @@ public class MODSDisseminationCrosswalk extends SelfNamedPlugin
             metadata.add(createDCValue("title", null, title));
         }
 
-        return (DCValue[]) metadata.toArray(new DCValue[metadata.size()]);
+        return (Metadatum[]) metadata.toArray(new Metadatum[metadata.size()]);
     }
 
     /**
@@ -597,16 +597,16 @@ public class MODSDisseminationCrosswalk extends SelfNamedPlugin
      * @param item
      *            The item to derive metadata from
      */
-    protected DCValue[] item2Metadata(Item item)
+    protected Metadatum[] item2Metadata(Item item)
     {
-        DCValue[] dcvs = item.getMetadata(Item.ANY, Item.ANY, Item.ANY,
+        Metadatum[] dcvs = item.getMetadata(Item.ANY, Item.ANY, Item.ANY,
                 Item.ANY);
 
         return dcvs;
     }
 
-    private DCValue createDCValue(String element, String qualifier, String value) {
-        DCValue dcv = new DCValue();
+    private Metadatum createDCValue(String element, String qualifier, String value) {
+        Metadatum dcv = new Metadatum();
         dcv.schema = "dc";
         dcv.element = element;
         dcv.qualifier = qualifier;

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/OREDisseminationCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/OREDisseminationCrosswalk.java
@@ -20,7 +20,7 @@ import org.apache.commons.lang.ArrayUtils;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataSchema;
@@ -116,8 +116,8 @@ public class OREDisseminationCrosswalk
         aggregation.addContent(atomId);
         
         Element aggLink;
-        DCValue[] uris = item.getMetadata(MetadataSchema.DC_SCHEMA,"identifier","uri",Item.ANY);
-        for (DCValue uri : uris) {
+        Metadatum[] uris = item.getMetadata(MetadataSchema.DC_SCHEMA,"identifier","uri",Item.ANY);
+        for (Metadatum uri : uris) {
         	aggLink = new Element("link",ATOM_NS);
         	aggLink.setAttribute("rel", "alternate");
         	aggLink.setAttribute("href", uri.value);
@@ -153,7 +153,7 @@ public class OREDisseminationCrosswalk
         
         // Information about the aggregation (item) itself 
         Element aggTitle = new Element("title",ATOM_NS);
-        DCValue[] titles = item.getMetadata(MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
+        Metadatum[] titles = item.getMetadata(MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
         if (titles != null && titles.length>0)
         {
             aggTitle.addContent(titles[0].value);
@@ -166,8 +166,8 @@ public class OREDisseminationCrosswalk
         
         Element aggAuthor;
         Element aggAuthorName;
-        DCValue[] authors = item.getMetadata(MetadataSchema.DC_SCHEMA,"contributor","author",Item.ANY);
-        for (DCValue author : authors) {
+        Metadatum[] authors = item.getMetadata(MetadataSchema.DC_SCHEMA,"contributor","author",Item.ANY);
+        for (Metadatum author : authors) {
         	aggAuthor = new Element("author",ATOM_NS);
         	aggAuthorName = new Element("name",ATOM_NS);
         	aggAuthorName.addContent(author.value);

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/QDCCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/QDCCrosswalk.java
@@ -22,7 +22,7 @@ import java.util.Properties;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataSchema;
@@ -98,7 +98,7 @@ public class QDCCrosswalk extends SelfNamedPlugin
     // map of qdc to JDOM Element
     private Map<String, Element> qdc2element = new HashMap<String, Element>();
 
-    // map of JDOM Element to qdc DCValue
+    // map of JDOM Element to qdc Metadatum
     private Map<String, String> element2qdc = new HashMap<String, String>();
 
     // the XML namespaces from config file for this name.
@@ -352,7 +352,7 @@ public class QDCCrosswalk extends SelfNamedPlugin
         Item item = (Item)dso;
         init();
 
-        DCValue[] dc = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+        Metadatum[] dc = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
         List<Element> result = new ArrayList<Element>(dc.length);
         for (int i = 0; i < dc.length; i++)
         {

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/SimpleDCDisseminationCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/SimpleDCDisseminationCrosswalk.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.Constants;
@@ -91,7 +91,7 @@ public class SimpleDCDisseminationCrosswalk extends SelfNamedPlugin
         }
 
         Item item = (Item)dso;
-        DCValue[] allDC = item.getDC(Item.ANY, Item.ANY, Item.ANY);
+        Metadatum[] allDC = item.getDC(Item.ANY, Item.ANY, Item.ANY);
 
         List<Element> dcl = new ArrayList<Element>(allDC.length);
 

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/XHTMLHeadDisseminationCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/XHTMLHeadDisseminationCrosswalk.java
@@ -9,7 +9,7 @@ package org.dspace.content.crosswalk;
 
 import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.ConfigurationManager;
@@ -174,7 +174,7 @@ public class XHTMLHeadDisseminationCrosswalk extends SelfNamedPlugin implements
         Item item = (Item) dso;
         String handle = item.getHandle();
         List<Element> metas = new ArrayList<Element>();
-        DCValue[] values = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+        Metadatum[] values = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
 
         // Add in schema URLs e.g. <link rel="schema.DC" href="...." />
         Iterator<String> schemaIterator = schemaURLs.keySet().iterator();
@@ -190,7 +190,7 @@ public class XHTMLHeadDisseminationCrosswalk extends SelfNamedPlugin implements
 
         for (int i = 0; i < values.length; i++)
         {
-            DCValue v = values[i];
+            Metadatum v = values[i];
 
             // Work out the key for the Maps that will tell us which metadata
             // name + scheme to use

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/XSLTDisseminationCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/XSLTDisseminationCrosswalk.java
@@ -20,7 +20,7 @@ import java.util.List;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
@@ -296,7 +296,7 @@ public class XSLTDisseminationCrosswalk
      *
      * @param dso The dspace object to build a representation of.
      */
-    public static Element createDIM(DSpaceObject dso, DCValue[] dcvs)
+    public static Element createDIM(DSpaceObject dso, Metadatum[] dcvs)
     {
         Element dim = new Element("dim", DIM_NS);
         String type = Constants.typeText[dso.getType()];
@@ -304,7 +304,7 @@ public class XSLTDisseminationCrosswalk
 
         for (int i = 0; i < dcvs.length; i++)
         {
-            DCValue dcv = dcvs[i];
+            Metadatum dcv = dcvs[i];
             Element field =
             createField(dcv.schema, dcv.element, dcv.qualifier,
                         dcv.language, dcv.value, dcv.authority, dcv.confidence);

--- a/dspace-api/src/main/java/org/dspace/content/packager/DSpaceAIPIngester.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/DSpaceAIPIngester.java
@@ -16,7 +16,7 @@ import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Collection;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataField;
@@ -326,10 +326,10 @@ public class DSpaceAIPIngester
         throws PackageValidationException, AuthorizeException, IOException, SQLException
     {
         // Get all metadata fields/values currently added to this Item
-        DCValue allMD[] = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+        Metadatum allMD[] = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
 
         // For each field, we'll check if it exists. If not, we'll create it.
-        for(DCValue md : allMD)
+        for(Metadatum md : allMD)
         {
             MetadataSchema mdSchema = null;
             MetadataField mdField = null;

--- a/dspace-api/src/main/java/org/dspace/content/packager/PackageUtils.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/PackageUtils.java
@@ -26,7 +26,7 @@ import org.dspace.content.BitstreamFormat;
 import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.FormatIdentifier;
 import org.dspace.content.InstallItem;
@@ -129,7 +129,7 @@ public class PackageUtils
     public static void checkItemMetadata(Item item)
         throws PackageValidationException
     {
-        DCValue t[] = item.getDC( "title", null, Item.ANY);
+        Metadatum t[] = item.getDC( "title", null, Item.ANY);
         if (t == null || t.length == 0)
         {
             throw new PackageValidationException("Item cannot be created without the required \"title\" DC metadata.");

--- a/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.content.service;
 
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.content.dao.ItemDAO;
 import org.dspace.content.dao.ItemDAOFactory;
@@ -53,7 +53,7 @@ public class ItemService
     }
 
     public static String getFirstMetadataValue(Item item, String metadataKey) {
-        DCValue[] dcValue = item.getMetadataByMetadataString(metadataKey);
+        Metadatum[] dcValue = item.getMetadataByMetadataString(metadataKey);
         if(dcValue.length > 0) {
             return dcValue[0].value;
         } else {

--- a/dspace-api/src/main/java/org/dspace/ctask/general/AbstractTranslator.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/AbstractTranslator.java
@@ -8,7 +8,7 @@
 package org.dspace.ctask.general;
 
 import org.apache.log4j.Logger;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.ConfigurationManager;
@@ -89,7 +89,7 @@ public abstract class AbstractTranslator extends AbstractCurationTask
             String handle = item.getHandle();
             log.debug("Translating metadata for " + handle);
 
-            DCValue[] authLangs = item.getMetadataByMetadataString(authLangField);
+            Metadatum[] authLangs = item.getMetadataByMetadataString(authLangField);
             if(authLangs.length > 0)
             {
                 /* Assume the first... multiple
@@ -107,11 +107,11 @@ public abstract class AbstractTranslator extends AbstractCurationTask
                     boolean translated = false;
                     field = field.trim();
                     String[] fieldSegments = field.split("\\.");
-                    DCValue[] fieldMetadata = null;
+                    Metadatum[] fieldMetadata = null;
                     
                     if(fieldSegments.length > 2) {
                         // First, check to see if we've already got this in the target language
-                        DCValue[] checkMetadata = item.getMetadata(fieldSegments[0], fieldSegments[1], fieldSegments[2], lang);
+                        Metadatum[] checkMetadata = item.getMetadata(fieldSegments[0], fieldSegments[1], fieldSegments[2], lang);
                         if(checkMetadata.length > 0)
                         {
                             // We've already translated this, move along
@@ -126,7 +126,7 @@ public abstract class AbstractTranslator extends AbstractCurationTask
                     }
                     else {
                         // First, check to see if we've already got this in the target language
-                        DCValue[] checkMetadata = item.getMetadata(fieldSegments[0], fieldSegments[1], null, lang);
+                        Metadatum[] checkMetadata = item.getMetadata(fieldSegments[0], fieldSegments[1], null, lang);
                         if(checkMetadata.length > 0)
                         {
                             // We've already translated this, move along
@@ -143,7 +143,7 @@ public abstract class AbstractTranslator extends AbstractCurationTask
 
                     if(!translated && fieldMetadata.length > 0)
                     {
-                        for(DCValue metadataValue : fieldMetadata) {
+                        for(Metadatum metadataValue : fieldMetadata) {
                             String value = metadataValue.value;
                             String translatedText = translateText(authLang, lang, value);
                             if(translatedText != null && !"".equals(translatedText))

--- a/dspace-api/src/main/java/org/dspace/ctask/general/BasicLinkChecker.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/BasicLinkChecker.java
@@ -8,7 +8,7 @@
 package org.dspace.ctask.general;
 
 import org.apache.log4j.Logger;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.curate.AbstractCurationTask;
@@ -101,9 +101,9 @@ public class BasicLinkChecker extends AbstractCurationTask
     protected List<String> getURLs(Item item)
     {
         // Get URIs from anyschema.anyelement.uri.*
-        DCValue[] urls = item.getMetadata(Item.ANY, Item.ANY, "uri", Item.ANY);
+        Metadatum[] urls = item.getMetadata(Item.ANY, Item.ANY, "uri", Item.ANY);
         ArrayList<String> theURLs = new ArrayList<String>();
-        for (DCValue url : urls)
+        for (Metadatum url : urls)
         {
             theURLs.add(url.value);
         }

--- a/dspace-api/src/main/java/org/dspace/ctask/general/MetadataValueLinkChecker.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/MetadataValueLinkChecker.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.ctask.general;
 
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 
 import java.util.ArrayList;
@@ -26,9 +26,9 @@ public class MetadataValueLinkChecker extends BasicLinkChecker {
     protected List<String> getURLs(Item item)
     {
         // Get all metadata elements that start with http:// or https://
-        DCValue[] urls = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+        Metadatum[] urls = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
         ArrayList<String> theURLs = new ArrayList<String>();
-        for (DCValue url : urls)
+        for (Metadatum url : urls)
         {
             if ((url.value.startsWith("http://")) || (url.value.startsWith("https://")))
             {

--- a/dspace-api/src/main/java/org/dspace/ctask/general/MetadataWebService.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/MetadataWebService.java
@@ -45,7 +45,7 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.ConfigurationManager;
@@ -228,7 +228,7 @@ public class MetadataWebService extends AbstractCurationTask implements Namespac
             String itemId = item.getHandle();
             if (itemId == null) {
             	// we are still in workflow - no handle assigned - try title
-            	DCValue[] titleDc = item.getMetadata("dc", "title", null, Item.ANY);
+            	Metadatum[] titleDc = item.getMetadata("dc", "title", null, Item.ANY);
             	String title = (titleDc.length > 0) ? titleDc[0].value : "untitled - dbId: " + item.getID();
             	itemId = "Workflow item: " + title;
             } else {
@@ -236,7 +236,7 @@ public class MetadataWebService extends AbstractCurationTask implements Namespac
             }
             resultSb.append(itemId);
             // Only proceed if item has a value for service template parameter
-            DCValue[] dcVals = item.getMetadataByMetadataString(lookupField);
+            Metadatum[] dcVals = item.getMetadataByMetadataString(lookupField);
             if (dcVals.length > 0 && dcVals[0].value.length() > 0) {
             	String value = transform(dcVals[0].value, lookupTransform);
             	status = callService(value, item, resultSb);
@@ -319,7 +319,7 @@ public class MetadataWebService extends AbstractCurationTask implements Namespac
        						continue;
        					}
        				} else {
-       					for (DCValue dcVal : item.getMetadata(info.schema, info.element, info.qualifier, Item.ANY)) {
+       					for (Metadatum dcVal : item.getMetadata(info.schema, info.element, info.qualifier, Item.ANY)) {
        						values.add(dcVal.value);
        					}
        				}

--- a/dspace-api/src/main/java/org/dspace/ctask/general/RequiredMetadata.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/RequiredMetadata.java
@@ -18,7 +18,7 @@ import org.dspace.app.util.DCInput;
 import org.dspace.app.util.DCInputSet;
 import org.dspace.app.util.DCInputsReader;
 import org.dspace.app.util.DCInputsReaderException;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.Constants;
@@ -81,7 +81,7 @@ public class RequiredMetadata extends AbstractCurationTask
                 sb.append("Item: ").append(handle);
                 for (String req : getReqList(item.getOwningCollection().getHandle()))
                 {
-                    DCValue[] vals = item.getMetadataByMetadataString(req);
+                    Metadatum[] vals = item.getMetadataByMetadataString(req);
                     if (vals.length == 0)
                     {
                         sb.append(" missing required field: ").append(req);

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -65,7 +65,7 @@ import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.ItemIterator;
@@ -971,8 +971,8 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                 }
             }
 
-            DCValue[] mydc = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
-            for (DCValue meta : mydc)
+            Metadatum[] mydc = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+            for (Metadatum meta : mydc)
             {
                 String field = meta.schema + "." + meta.element;
                 String unqualifiedField = field;
@@ -1325,7 +1325,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
         try {
 
-            DCValue[] values = item.getMetadataByMetadataString("dc.relation.ispartof");
+            Metadatum[] values = item.getMetadataByMetadataString("dc.relation.ispartof");
 
             if(values != null && values.length > 0 && values[0] != null && values[0].value != null)
             {

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceSpellIndexingPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceSpellIndexingPlugin.java
@@ -8,7 +8,7 @@
 package org.dspace.discovery;
 
 import org.apache.solr.common.SolrInputDocument;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
@@ -25,8 +25,8 @@ public class SolrServiceSpellIndexingPlugin implements SolrServiceIndexPlugin {
     @Override
     public void additionalIndex(Context context, DSpaceObject dso, SolrInputDocument document) {
         if(dso instanceof Item){
-            DCValue[] dcValues = ((Item) dso).getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
-            for (DCValue dcValue : dcValues) {
+            Metadatum[] dcValues = ((Item) dso).getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+            for (Metadatum dcValue : dcValues) {
                 document.addField("a_spell", dcValue.value);
 
             }

--- a/dspace-api/src/main/java/org/dspace/disseminate/CitationDocument.java
+++ b/dspace-api/src/main/java/org/dspace/disseminate/CitationDocument.java
@@ -487,11 +487,11 @@ public class CitationDocument {
     }
 
     public String getAllMetadataSeparated(Item item, String metadataKey) {
-        DCValue[] dcValues = item.getMetadataByMetadataString(metadataKey);
+        Metadatum[] dcValues = item.getMetadataByMetadataString(metadataKey);
 
         ArrayList<String> valueArray = new ArrayList<String>();
 
-        for(DCValue dcValue : dcValues) {
+        for(Metadatum dcValue : dcValues) {
             if(StringUtils.isNotBlank(dcValue.value)) {
                 valueArray.add(dcValue.value);
             }

--- a/dspace-api/src/main/java/org/dspace/embargo/EmbargoManager.java
+++ b/dspace-api/src/main/java/org/dspace/embargo/EmbargoManager.java
@@ -128,7 +128,7 @@ public class EmbargoManager
         throws SQLException, AuthorizeException, IOException
     {
         init();
-        DCValue terms[] = item.getMetadata(terms_schema, terms_element,
+        Metadatum terms[] = item.getMetadata(terms_schema, terms_element,
                 terms_qualifier, Item.ANY);
 
         DCDate result = null;
@@ -338,7 +338,7 @@ public class EmbargoManager
         throws Exception
     {
         boolean status = false;
-        DCValue lift[] = item.getMetadata(lift_schema, lift_element, lift_qualifier, Item.ANY);
+        Metadatum lift[] = item.getMetadata(lift_schema, lift_element, lift_qualifier, Item.ANY);
 
         if (lift.length > 0)
         {
@@ -448,7 +448,7 @@ public class EmbargoManager
     // it was never under embargo, or the lift date has passed.
     private static DCDate recoverEmbargoDate(Item item) {
         DCDate liftDate = null;
-        DCValue lift[] = item.getMetadata(lift_schema, lift_element, lift_qualifier, Item.ANY);
+        Metadatum lift[] = item.getMetadata(lift_schema, lift_element, lift_qualifier, Item.ANY);
         if (lift.length > 0)
         {
             liftDate = new DCDate(lift[0].value);

--- a/dspace-api/src/main/java/org/dspace/eperson/Subscribe.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/Subscribe.java
@@ -32,7 +32,7 @@ import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.AuthorizeManager;
 import org.dspace.content.Collection;
 import org.dspace.content.DCDate;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.content.Site;
 import org.dspace.core.ConfigurationManager;
@@ -464,7 +464,7 @@ public class Subscribe
                         HarvestedItemInfo hii = (HarvestedItemInfo) itemInfos
                                 .get(j);
 
-                        DCValue[] titles = hii.item.getDC("title", null, Item.ANY);
+                        Metadatum[] titles = hii.item.getDC("title", null, Item.ANY);
                         emailText.append("      ").append(labels.getString("org.dspace.eperson.Subscribe.title")).append(" ");
 
                         if (titles.length > 0)
@@ -476,7 +476,7 @@ public class Subscribe
                             emailText.append(labels.getString("org.dspace.eperson.Subscribe.untitled"));
                         }
 
-                        DCValue[] authors = hii.item.getDC("contributor", Item.ANY,
+                        Metadatum[] authors = hii.item.getDC("contributor", Item.ANY,
                                 Item.ANY);
 
                         if (authors.length > 0)
@@ -621,12 +621,12 @@ public class Subscribe
             // has the item modified today?
             if (lastUpdateStr.equals(today))
             {
-                DCValue[] dateAccArr = infoObject.item.getMetadata("dc",
+                Metadatum[] dateAccArr = infoObject.item.getMetadata("dc",
                         "date", "accessioned", Item.ANY);
                 // we need only the item archived yesterday
                 if (dateAccArr != null && dateAccArr.length > 0)
                 {
-                    for (DCValue date : dateAccArr)
+                    for (Metadatum date : dateAccArr)
                     {
                         if (date != null && date.value != null)
                         {
@@ -678,11 +678,11 @@ public class Subscribe
 
         for (HarvestedItemInfo infoObject : completeList)
         {
-            DCValue[] dateAccArr = infoObject.item.getMetadata("dc", "date", "accessioned", Item.ANY);
+            Metadatum[] dateAccArr = infoObject.item.getMetadata("dc", "date", "accessioned", Item.ANY);
 
             if (dateAccArr != null && dateAccArr.length > 0)
             {
-                for(DCValue date : dateAccArr)
+                for(Metadatum date : dateAccArr)
                 {
                     if(date != null && date.value != null)
                     {

--- a/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
@@ -38,7 +38,7 @@ import org.dspace.content.BitstreamFormat;
 import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
 import org.dspace.content.DCDate;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.FormatIdentifier;
 import org.dspace.content.InstallItem;
@@ -615,14 +615,14 @@ public class OAIHarvester {
             rejectedHandlePrefixString = "123456789";
         }
 
-    	DCValue[] values = item.getMetadata("dc", "identifier", Item.ANY, Item.ANY);
+    	Metadatum[] values = item.getMetadata("dc", "identifier", Item.ANY, Item.ANY);
 
     	if (values.length > 0 && !acceptedHandleServersString.equals(""))
     	{
     		String[] acceptedHandleServers = acceptedHandleServersString.split(",");
     		String[] rejectedHandlePrefixes = rejectedHandlePrefixString.split(",");
 
-    		for (DCValue value : values)
+    		for (Metadatum value : values)
     		{
     			//     0   1       2         3   4
     			//   http://hdl.handle.net/1234/12
@@ -672,8 +672,8 @@ public class OAIHarvester {
 
     	List<String> clearList = new ArrayList<String>();
 
-    	DCValue[] values = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
-    	for (DCValue value : values)
+    	Metadatum[] values = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+    	for (Metadatum value : values)
     	{
     		// Verify that the schema exists
     		MetadataSchema mdSchema = MetadataSchema.find(ourContext, value.schema);

--- a/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.FormatIdentifier;
 import org.dspace.content.Item;
@@ -848,8 +848,8 @@ public class DOIIdentifierProvider
         }
         Item item = (Item)dso;
 
-        DCValue[] metadata = item.getMetadata(MD_SCHEMA, DOI_ELEMENT, DOI_QUALIFIER, null);
-        for (DCValue id : metadata)
+        Metadatum[] metadata = item.getMetadata(MD_SCHEMA, DOI_ELEMENT, DOI_QUALIFIER, null);
+        for (Metadatum id : metadata)
         {
             if (id.value.startsWith(DOI.RESOLVER + "/10."))
             {
@@ -911,10 +911,10 @@ public class DOIIdentifierProvider
         }
         Item item = (Item)dso;
 
-        DCValue[] metadata = item.getMetadata(MD_SCHEMA, DOI_ELEMENT, DOI_QUALIFIER, null);
+        Metadatum[] metadata = item.getMetadata(MD_SCHEMA, DOI_ELEMENT, DOI_QUALIFIER, null);
         List<String> remainder = new ArrayList<String>();
 
-        for (DCValue id : metadata)
+        for (Metadatum id : metadata)
         {
             if (!id.value.equals(DOI.DOIToExternalForm(doi)))
             {

--- a/dspace-api/src/main/java/org/dspace/identifier/EZIDIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/EZIDIdentifierProvider.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.ItemIterator;
@@ -130,8 +130,8 @@ public class EZIDIdentifierProvider
         }
 
         Item item = (Item)dso;
-        DCValue[] identifiers = item.getMetadata(MD_SCHEMA, DOI_ELEMENT, DOI_QUALIFIER, null);
-        for (DCValue identifier : identifiers)
+        Metadatum[] identifiers = item.getMetadata(MD_SCHEMA, DOI_ELEMENT, DOI_QUALIFIER, null);
+        for (Metadatum identifier : identifiers)
         {
             if ((null != identifier.value) && (identifier.value.startsWith(DOI_SCHEME)))
             {
@@ -367,8 +367,8 @@ public class EZIDIdentifierProvider
         }
 
         Item item = (Item)object;
-        DCValue found = null;
-        for (DCValue candidate : item.getMetadata(MD_SCHEMA, DOI_ELEMENT, DOI_QUALIFIER, null))
+        Metadatum found = null;
+        for (Metadatum candidate : item.getMetadata(MD_SCHEMA, DOI_ELEMENT, DOI_QUALIFIER, null))
         {
             if (candidate.value.startsWith(DOI_SCHEME))
             {
@@ -402,10 +402,10 @@ public class EZIDIdentifierProvider
         Item item = (Item)dso;
 
         // delete from EZID
-        DCValue[] metadata = item.getMetadata(MD_SCHEMA, DOI_ELEMENT, DOI_QUALIFIER, null);
+        Metadatum[] metadata = item.getMetadata(MD_SCHEMA, DOI_ELEMENT, DOI_QUALIFIER, null);
         List<String> remainder = new ArrayList<String>();
         int skipped = 0;
-        for (DCValue id : metadata)
+        for (Metadatum id : metadata)
         {
             if (!id.value.startsWith(DOI_SCHEME))
             {
@@ -472,10 +472,10 @@ public class EZIDIdentifierProvider
 
         Item item = (Item)dso;
 
-        DCValue[] metadata = item.getMetadata(MD_SCHEMA, DOI_ELEMENT, DOI_QUALIFIER, null);
+        Metadatum[] metadata = item.getMetadata(MD_SCHEMA, DOI_ELEMENT, DOI_QUALIFIER, null);
         List<String> remainder = new ArrayList<String>();
         int skipped = 0;
-        for (DCValue id : metadata)
+        for (Metadatum id : metadata)
         {
             if (!id.value.equals(idToDOI(identifier)))
             {
@@ -629,10 +629,10 @@ public class EZIDIdentifierProvider
 
         for (Entry<String, String> datum : crosswalk.entrySet())
         {
-            DCValue[] values = item.getMetadataByMetadataString(datum.getValue());
+            Metadatum[] values = item.getMetadataByMetadataString(datum.getValue());
             if (null != values)
             {
-                for (DCValue value : values)
+                for (Metadatum value : values)
                 {
                     String key = datum.getKey();
                     String mappedValue;

--- a/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
@@ -432,8 +432,8 @@ public class HandleIdentifierProvider extends IdentifierProvider {
         // Add handle as identifier.uri DC value.
         // First check that identifier doesn't already exist.
         boolean identifierExists = false;
-        DCValue[] identifiers = item.getDC("identifier", "uri", Item.ANY);
-        for (DCValue identifier : identifiers)
+        Metadatum[] identifiers = item.getDC("identifier", "uri", Item.ANY);
+        for (Metadatum identifier : identifiers)
         {
             if (handleref.equals(identifier.value))
             {

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
@@ -633,8 +633,8 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
         // Add handle as identifier.uri DC value.
         // First check that identifier doesn't already exist.
         boolean identifierExists = false;
-        DCValue[] identifiers = item.getDC("identifier", "uri", Item.ANY);
-        for (DCValue identifier : identifiers)
+        Metadatum[] identifiers = item.getDC("identifier", "uri", Item.ANY);
+        for (Metadatum identifier : identifiers)
         {
             if (handleref.equals(identifier.value))
             {

--- a/dspace-api/src/main/java/org/dspace/license/CreativeCommons.java
+++ b/dspace-api/src/main/java/org/dspace/license/CreativeCommons.java
@@ -26,7 +26,7 @@ import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bitstream;
 import org.dspace.content.BitstreamFormat;
 import org.dspace.content.Bundle;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
@@ -490,8 +490,8 @@ public class CreativeCommons
     	 */
     	public String ccItemValue(Item item)
     	{
-            DCValue[] dcvalues = item.getMetadata(params[0], params[1], params[2], params[3]);
-            for (DCValue dcvalue : dcvalues)
+            Metadatum[] dcvalues = item.getMetadata(params[0], params[1], params[2], params[3]);
+            for (Metadatum dcvalue : dcvalues)
             {
                 if ((dcvalue.value).indexOf(ccShib) != -1) 
                 {
@@ -516,8 +516,8 @@ public class CreativeCommons
     		 CCLookup ccLookup = new CCLookup();
              ccLookup.issue(key);
              String matchValue = ccLookup.getLicenseName();
-             DCValue[] dcvalues = item.getMetadata(params[0], params[1], params[2], params[3]);
-             for (DCValue dcvalue : dcvalues)
+             Metadatum[] dcvalues = item.getMetadata(params[0], params[1], params[2], params[3]);
+             for (Metadatum dcvalue : dcvalues)
              {
             	 if (dcvalue.value.equals(matchValue))
             	 {
@@ -538,9 +538,9 @@ public class CreativeCommons
     	{
     		if (value != null)
     		{
-    			 DCValue[] dcvalues  = item.getMetadata(params[0], params[1], params[2], params[3]);
+    			 Metadatum[] dcvalues  = item.getMetadata(params[0], params[1], params[2], params[3]);
                  ArrayList<String> arrayList = new ArrayList<String>();
-                 for (DCValue dcvalue : dcvalues)
+                 for (Metadatum dcvalue : dcvalues)
                  {
                      if (! dcvalue.value.equals(value))
                      {

--- a/dspace-api/src/main/java/org/dspace/rdf/conversion/MetadataConverterPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/rdf/conversion/MetadataConverterPlugin.java
@@ -28,9 +28,9 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.dspace.app.util.MetadataExposure;
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.content.DCValue;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
+import org.dspace.content.Metadatum;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.rdf.RDFUtil;
@@ -134,8 +134,8 @@ public class MetadataConverterPlugin implements ConverterPlugin
         }
         
         Item item = (Item) dso;
-        DCValue[] metadata_values = item.getDC(Item.ANY, Item.ANY, Item.ANY);
-        for (DCValue value : metadata_values)
+        Metadatum[] metadata_values = item.getDC(Item.ANY, Item.ANY, Item.ANY);
+        for (Metadatum value : metadata_values)
         {
             String fieldname = value.schema + "." + value.element;
             if (value.qualifier != null) 

--- a/dspace-api/src/main/java/org/dspace/search/DSIndexer.java
+++ b/dspace-api/src/main/java/org/dspace/search/DSIndexer.java
@@ -55,7 +55,7 @@ import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.ItemIterator;
@@ -1080,7 +1080,7 @@ public class DSIndexer
         int j;
         if (indexConfigArr.length > 0)
         {
-            DCValue[] mydc;
+            Metadatum[] mydc;
 
             for (int i = 0; i < indexConfigArr.length; i++)
             {
@@ -1246,7 +1246,7 @@ public class DSIndexer
             for (SortOption so : SortOption.getSortOptions())
             {
                 String[] somd = so.getMdBits();
-                DCValue[] dcv = item.getMetadata(somd[0], somd[1], somd[2], Item.ANY);
+                Metadatum[] dcv = item.getMetadata(somd[0], somd[1], somd[2], Item.ANY);
                 if (dcv.length > 0)
                 {
                     String value = OrderFormat.makeSortString(dcv[0].value, dcv[0].language, so.getType());

--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
@@ -493,7 +493,7 @@ public class StatisticsDataVisits extends StatisticsData
                         case Constants.ITEM:
                             Item item = (Item) dso;
                             String name = "untitled";
-                            DCValue[] vals = item.getMetadata("dc", "title", null, Item.ANY);
+                            Metadatum[] vals = item.getMetadata("dc", "title", null, Item.ANY);
                             if(vals != null && 0 < vals.length)
                             {
                                 name = vals[0].value;

--- a/dspace-api/src/main/java/org/dspace/submit/lookup/SubmissionLookupUtils.java
+++ b/dspace-api/src/main/java/org/dspace/submit/lookup/SubmissionLookupUtils.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import org.apache.log4j.Logger;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataSchema;
 import org.dspace.core.ConfigurationManager;
@@ -50,7 +50,7 @@ public class SubmissionLookupUtils
         {
             LookupProvidersCheck check = new LookupProvidersCheck();
             MetadataSchema[] schemas = MetadataSchema.findAll(context);
-            DCValue[] values = item.getMetadata(dcSchema, dcElement,
+            Metadatum[] values = item.getMetadata(dcSchema, dcElement,
                     dcQualifier, Item.ANY);
 
             for (MetadataSchema schema : schemas)
@@ -59,7 +59,7 @@ public class SubmissionLookupUtils
                 if (schema.getNamespace().startsWith(
                         SubmissionLookupService.SL_NAMESPACE_PREFIX))
                 {
-                    DCValue[] slCache = item.getMetadata(schema.getName(),
+                    Metadatum[] slCache = item.getMetadata(schema.getName(),
                             dcElement, dcQualifier, Item.ANY);
                     if (slCache.length == 0)
                         continue;
@@ -72,8 +72,8 @@ public class SubmissionLookupUtils
                     {
                         for (int idx = 0; idx < values.length; idx++)
                         {
-                            DCValue v = values[idx];
-                            DCValue sl = slCache[idx];
+                            Metadatum v = values[idx];
+                            Metadatum sl = slCache[idx];
                             // FIXME gestire authority e possibilita' multiple:
                             // match non sicuri, affiliation, etc.
                             if (!v.value.equals(sl.value))

--- a/dspace-api/src/main/java/org/dspace/submit/step/CCLicenseStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/CCLicenseStep.java
@@ -19,7 +19,7 @@ import org.apache.log4j.Logger;
 import org.dspace.app.util.SubmissionInfo;
 import org.dspace.app.util.Util;
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;

--- a/dspace-api/src/main/java/org/dspace/submit/step/DescribeStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/DescribeStep.java
@@ -29,7 +29,7 @@ import org.dspace.content.Collection;
 import org.dspace.content.DCDate;
 import org.dspace.content.DCPersonName;
 import org.dspace.content.DCSeriesNumber;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataField;
 import org.dspace.content.authority.MetadataAuthorityManager;
@@ -324,7 +324,7 @@ public class DescribeStep extends AbstractProcessingStep
                 {
                     qualifier = Item.ANY;
                 }
-                DCValue[] values = item.getMetadata(inputs[i].getSchema(),
+                Metadatum[] values = item.getMetadata(inputs[i].getSchema(),
                         inputs[i].getElement(), qualifier, Item.ANY);
 
                 if ((inputs[i].isRequired() && values.length == 0) &&

--- a/dspace-api/src/main/java/org/dspace/submit/step/InitialQuestionsStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/InitialQuestionsStep.java
@@ -19,7 +19,7 @@ import org.dspace.app.util.Util;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.core.ConfigurationManager;
@@ -155,7 +155,7 @@ public class InitialQuestionsStep extends AbstractProcessingStep
                 // shouldn't need to check if submission is null, but just in case!
                 if (!multipleTitles)
                 {
-                    DCValue[] altTitles = subInfo.getSubmissionItem().getItem()
+                    Metadatum[] altTitles = subInfo.getSubmissionItem().getItem()
                             .getDC("title", "alternative", Item.ANY);
 
                     willRemoveTitles = altTitles.length > 0;
@@ -163,11 +163,11 @@ public class InitialQuestionsStep extends AbstractProcessingStep
 
                 if (!publishedBefore)
                 {
-                    DCValue[] dateIssued = subInfo.getSubmissionItem().getItem()
+                    Metadatum[] dateIssued = subInfo.getSubmissionItem().getItem()
                             .getDC("date", "issued", Item.ANY);
-                    DCValue[] citation = subInfo.getSubmissionItem().getItem()
+                    Metadatum[] citation = subInfo.getSubmissionItem().getItem()
                             .getDC("identifier", "citation", Item.ANY);
-                    DCValue[] publisher = subInfo.getSubmissionItem().getItem()
+                    Metadatum[] publisher = subInfo.getSubmissionItem().getItem()
                             .getDC("publisher", null, Item.ANY);
 
                     willRemoveDate = (dateIssued.length > 0)
@@ -219,7 +219,7 @@ public class InitialQuestionsStep extends AbstractProcessingStep
         // (This logic is necessary since the date field is hidden on DescribeStep when publishedBefore==false)
         if(!publishedBefore)
         {
-            DCValue[] dateIssued = subInfo.getSubmissionItem().getItem()
+            Metadatum[] dateIssued = subInfo.getSubmissionItem().getItem()
                             .getDC("date", "issued", Item.ANY);
             if(dateIssued.length==0)
             {

--- a/dspace-api/src/main/java/org/dspace/testing/PubMedToImport.java
+++ b/dspace-api/src/main/java/org/dspace/testing/PubMedToImport.java
@@ -13,7 +13,7 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.PosixParser;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.jdom.Document;
 import org.jdom.Element;
 import org.jdom.output.Format;
@@ -90,7 +90,7 @@ public class PubMedToImport {
 
     private static class PubMedHandler extends DefaultHandler {
         private static int recordCount = 1;
-        private static List<DCValue> dcValues;
+        private static List<Metadatum> dcValues;
 
         private static StringBuilder value;
         private static StringBuilder lastName;
@@ -102,10 +102,10 @@ public class PubMedToImport {
 
         private static void addDCValue(String element, String qualifier, String value) {
             if (dcValues == null) {
-                dcValues = new ArrayList<DCValue>();
+                dcValues = new ArrayList<Metadatum>();
             }
 
-            DCValue thisValue = new DCValue();
+            Metadatum thisValue = new Metadatum();
             thisValue.schema = "dc";
             thisValue.element = element;
             thisValue.qualifier = qualifier;
@@ -203,7 +203,7 @@ public class PubMedToImport {
 
             doc.setRootElement(root);
 
-            for (DCValue dcValue : dcValues)
+            for (Metadatum dcValue : dcValues)
             {
                 Element dcNode = new Element("dcvalue");
 

--- a/dspace-api/src/main/java/org/dspace/versioning/AbstractVersionProvider.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/AbstractVersionProvider.java
@@ -27,8 +27,8 @@ public abstract class AbstractVersionProvider {
     private Set<String> ignoredMetadataFields;
 
     protected void copyMetadata(Item itemNew, Item nativeItem){
-        DCValue[] md = nativeItem.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
-        for (DCValue aMd : md) {
+        Metadatum[] md = nativeItem.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+        for (Metadatum aMd : md) {
             String unqualifiedMetadataField = aMd.schema + "." + aMd.element;
             String qualifiedMetadataField = unqualifiedMetadataField + (aMd.qualifier == null ? "" : "." + aMd.qualifier);
             if(getIgnoredMetadataFields().contains(qualifiedMetadataField) ||

--- a/dspace-api/src/main/java/org/dspace/versioning/VersioningServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/VersioningServiceImpl.java
@@ -9,7 +9,7 @@ package org.dspace.versioning;
 
 import org.dspace.content.Collection;
 import org.dspace.content.DCDate;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 import org.springframework.beans.factory.annotation.Required;
@@ -46,7 +46,7 @@ public class VersioningServiceImpl implements VersioningService{
                 vh=versionHistoryDAO.create(c);
 
                 // get dc:date.accessioned to be set as first version date...
-                DCValue[] values = item.getMetadata("dc", "date", "accessioned", Item.ANY);
+                Metadatum[] values = item.getMetadata("dc", "date", "accessioned", Item.ANY);
                 Date versionDate = new Date();
                 if(values!=null && values.length > 0){
                     String date = values[0].value;

--- a/dspace-api/src/main/java/org/dspace/workflow/WorkflowManager.java
+++ b/dspace-api/src/main/java/org/dspace/workflow/WorkflowManager.java
@@ -25,7 +25,7 @@ import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.AuthorizeManager;
 import org.dspace.content.Collection;
 import org.dspace.content.DCDate;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.InstallItem;
 import org.dspace.content.Item;
 import org.dspace.content.WorkspaceItem;
@@ -748,7 +748,7 @@ public class WorkflowManager
             String handle = HandleManager.findHandle(c, i);
 
             // Get title
-            DCValue[] titles = i.getDC("title", null, Item.ANY);
+            Metadatum[] titles = i.getDC("title", null, Item.ANY);
             String title = "";
             try
             {
@@ -1083,7 +1083,7 @@ public class WorkflowManager
     public static String getItemTitle(WorkflowItem wi) throws SQLException
     {
         Item myitem = wi.getItem();
-        DCValue[] titles = myitem.getDC("title", null, Item.ANY);
+        Metadatum[] titles = myitem.getDC("title", null, Item.ANY);
 
         // only return the first element, or "Untitled"
         if (titles.length > 0)

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowManager.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowManager.java
@@ -402,7 +402,7 @@ public class XmlWorkflowManager {
             String handle = HandleManager.findHandle(c, i);
 
             // Get title
-            DCValue[] titles = i.getMetadata(MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
+            Metadatum[] titles = i.getMetadata(MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
             String title = "";
             try {
                 title = I18nUtil.getMessage("org.dspace.workflow.WorkflowManager.untitled");

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/ScoreEvaluationAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/ScoreEvaluationAction.java
@@ -8,7 +8,7 @@
 package org.dspace.xmlworkflow.state.actions.processingaction;
 
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataSchema;
 import org.dspace.core.Context;
@@ -47,10 +47,10 @@ public class ScoreEvaluationAction extends ProcessingAction{
     public ActionResult execute(Context c, XmlWorkflowItem wfi, Step step, HttpServletRequest request) throws SQLException, AuthorizeException, IOException, WorkflowException {
         boolean hasPassed = false;
         //Retrieve all our scores from the metadata & add em up
-        DCValue[] scores = wfi.getItem().getMetadata(WorkflowRequirementsManager.WORKFLOW_SCHEMA, "score", null, Item.ANY);
+        Metadatum[] scores = wfi.getItem().getMetadata(WorkflowRequirementsManager.WORKFLOW_SCHEMA, "score", null, Item.ANY);
         if(0 < scores.length){
             int totalScoreCount = 0;
-            for (DCValue score : scores) {
+            for (Metadatum score : scores) {
                 totalScoreCount += Integer.parseInt(score.value);
             }
             int scoreMean = totalScoreCount / scores.length;

--- a/dspace-api/src/test/java/org/dspace/content/InstallItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/InstallItemTest.java
@@ -132,9 +132,9 @@ public class InstallItemTest extends AbstractUnitTest
         assertThat("testRestoreItem 0", result, equalTo(is.getItem()));
 
         //Make sure that restore did NOT insert a new provenance message with today's date
-        DCValue[] provMsgValues = result.getMetadata("dc", "description", "provenance", Item.ANY);
+        Metadatum[] provMsgValues = result.getMetadata("dc", "description", "provenance", Item.ANY);
         int i = 1;
-        for(DCValue val : provMsgValues)
+        for(Metadatum val : provMsgValues)
         {
             assertFalse("testRestoreItem " + i, val.value.startsWith(provDescriptionBegins));
             i++;
@@ -202,7 +202,7 @@ public class InstallItemTest extends AbstractUnitTest
         context.restoreAuthSystemState();
 
         //Make sure the string "today" was replaced with today's date
-        DCValue[] issuedDates = result.getMetadata("dc", "date", "issued", Item.ANY);
+        Metadatum[] issuedDates = result.getMetadata("dc", "date", "issued", Item.ANY);
 
         assertThat("testInstallItem_todayAsIssuedDate 0", issuedDates[0].value, equalTo(date));
         assertThat("testInstallItem_todayAsIssuedDate 1", issuedDates[1].value, equalTo("2011-01-01"));
@@ -224,7 +224,7 @@ public class InstallItemTest extends AbstractUnitTest
         context.restoreAuthSystemState();
 
         //Make sure dc.date.issued is NOT set
-        DCValue[] issuedDates = result.getMetadata("dc", "date", "issued", Item.ANY);
+        Metadatum[] issuedDates = result.getMetadata("dc", "date", "issued", Item.ANY);
         assertThat("testInstallItem_nullIssuedDate 0", issuedDates.length, equalTo(0));
     }
 
@@ -254,7 +254,7 @@ public class InstallItemTest extends AbstractUnitTest
         context.restoreAuthSystemState();
 
         //Make sure the string "today" was replaced with today's date
-        DCValue[] issuedDates = result.getMetadata("dc", "date", "issued", Item.ANY);
+        Metadatum[] issuedDates = result.getMetadata("dc", "date", "issued", Item.ANY);
 
         assertThat("testRestoreItem_todayAsIssuedDate 0", issuedDates[0].value, equalTo(date));
         assertThat("testRestoreItem_todayAsIssuedDate 1", issuedDates[1].value, equalTo("2011-01-01"));

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -272,7 +272,7 @@ public class ItemTest  extends AbstractDSpaceObjectTest
         String element = "contributor";
         String qualifier = "author";
         String lang = Item.ANY;
-        DCValue[] dc = it.getDC(element, qualifier, lang);
+        Metadatum[] dc = it.getDC(element, qualifier, lang);
         assertThat("testGetDC 0",dc,notNullValue());
         assertTrue("testGetDC 1",dc.length == 0);
     }
@@ -287,7 +287,7 @@ public class ItemTest  extends AbstractDSpaceObjectTest
         String element = "contributor";
         String qualifier = "author";
         String lang = Item.ANY;
-        DCValue[] dc = it.getMetadata(schema, element, qualifier, lang);
+        Metadatum[] dc = it.getMetadata(schema, element, qualifier, lang);
         assertThat("testGetMetadata_4args 0",dc,notNullValue());
         assertTrue("testGetMetadata_4args 1",dc.length == 0);
     }
@@ -299,7 +299,7 @@ public class ItemTest  extends AbstractDSpaceObjectTest
     public void testGetMetadata_String()
     {
         String mdString = "dc.contributor.author";
-        DCValue[] dc = it.getMetadataByMetadataString(mdString);
+        Metadatum[] dc = it.getMetadataByMetadataString(mdString);
         assertThat("testGetMetadata_String 0",dc,notNullValue());
         assertTrue("testGetMetadata_String 1",dc.length == 0);
 
@@ -327,7 +327,7 @@ public class ItemTest  extends AbstractDSpaceObjectTest
         it.addMetadata("test", "type", null, null, testType);
 
         // Check that only one is returned when we ask for all dc.type values
-        DCValue[] values = it.getMetadata("dc", "type", null, null);
+        Metadatum[] values = it.getMetadata("dc", "type", null, null);
         assertTrue("Return results", values.length == 1);
     }
 
@@ -343,7 +343,7 @@ public class ItemTest  extends AbstractDSpaceObjectTest
         String[] values = {"value0","value1"};
         it.addDC(element, qualifier, lang, values);
 
-        DCValue[] dc = it.getDC(element, qualifier, lang);
+        Metadatum[] dc = it.getDC(element, qualifier, lang);
         assertThat("testAddDC_4args_1 0",dc,notNullValue());
         assertTrue("testAddDC_4args_1 1",dc.length == 2);
         assertThat("testAddDC_4args_1 2",dc[0].element,equalTo(element));
@@ -368,7 +368,7 @@ public class ItemTest  extends AbstractDSpaceObjectTest
         String value = "value";
         it.addDC(element, qualifier, lang, value);
 
-        DCValue[] dc = it.getDC(element, qualifier, lang);
+        Metadatum[] dc = it.getDC(element, qualifier, lang);
         assertThat("testAddDC_4args_2 0",dc,notNullValue());
         assertTrue("testAddDC_4args_2 1",dc.length == 1);
         assertThat("testAddDC_4args_2 2",dc[0].element,equalTo(element));
@@ -390,7 +390,7 @@ public class ItemTest  extends AbstractDSpaceObjectTest
         String[] values = {"value0","value1"};
         it.addMetadata(schema, element, qualifier, lang, values);
 
-        DCValue[] dc = it.getMetadata(schema, element, qualifier, lang);
+        Metadatum[] dc = it.getMetadata(schema, element, qualifier, lang);
         assertThat("testAddMetadata_5args_1 0",dc,notNullValue());
         assertTrue("testAddMetadata_5args_1 1",dc.length == 2);
         assertThat("testAddMetadata_5args_1 2",dc[0].schema,equalTo(schema));
@@ -423,7 +423,7 @@ public class ItemTest  extends AbstractDSpaceObjectTest
         int[] confidences = {0,0};
         it.addMetadata(schema, element, qualifier, lang, values, authorities, confidences);
 
-        DCValue[] dc = it.getMetadata(schema, element, qualifier, lang);
+        Metadatum[] dc = it.getMetadata(schema, element, qualifier, lang);
         assertThat("testAddMetadata_7args_1 0",dc,notNullValue());
         assertTrue("testAddMetadata_7args_1 1",dc.length == 2);
         assertThat("testAddMetadata_7args_1 2",dc[0].schema,equalTo(schema));
@@ -459,7 +459,7 @@ public class ItemTest  extends AbstractDSpaceObjectTest
         int[] confidences = {0,0};
         it.addMetadata(schema, element, qualifier, lang, values, authorities, confidences);
 
-        DCValue[] dc = it.getMetadata(schema, element, qualifier, lang);
+        Metadatum[] dc = it.getMetadata(schema, element, qualifier, lang);
         assertThat("testAddMetadata_7args_1 0",dc,notNullValue());
         assertTrue("testAddMetadata_7args_1 1",dc.length == 2);
         assertThat("testAddMetadata_7args_1 2",dc[0].schema,equalTo(schema));
@@ -491,7 +491,7 @@ public class ItemTest  extends AbstractDSpaceObjectTest
         String[] values = {"value0","value1"};
         it.addMetadata(schema, element, qualifier, lang, values);
 
-        DCValue[] dc = it.getMetadata(schema, element, qualifier, lang);
+        Metadatum[] dc = it.getMetadata(schema, element, qualifier, lang);
         assertThat("testAddMetadata_5args_2 0",dc,notNullValue());
         assertTrue("testAddMetadata_5args_2 1",dc.length == 2);
         assertThat("testAddMetadata_5args_2 2",dc[0].schema,equalTo(schema));
@@ -524,7 +524,7 @@ public class ItemTest  extends AbstractDSpaceObjectTest
         int confidences = 0;
         it.addMetadata(schema, element, qualifier, lang, values, authorities, confidences);
 
-        DCValue[] dc = it.getMetadata(schema, element, qualifier, lang);
+        Metadatum[] dc = it.getMetadata(schema, element, qualifier, lang);
         assertThat("testAddMetadata_7args_2 0",dc,notNullValue());
         assertTrue("testAddMetadata_7args_2 1",dc.length == 1);
         assertThat("testAddMetadata_7args_2 2",dc[0].schema,equalTo(schema));
@@ -553,7 +553,7 @@ public class ItemTest  extends AbstractDSpaceObjectTest
         int confidences = 0;
         it.addMetadata(schema, element, qualifier, lang, values, authorities, confidences);
 
-        DCValue[] dc = it.getMetadata(schema, element, qualifier, lang);
+        Metadatum[] dc = it.getMetadata(schema, element, qualifier, lang);
         assertThat("testAddMetadata_7args_2 0",dc,notNullValue());
         assertTrue("testAddMetadata_7args_2 1",dc.length == 1);
         assertThat("testAddMetadata_7args_2 2",dc[0].schema,equalTo(schema));
@@ -579,7 +579,7 @@ public class ItemTest  extends AbstractDSpaceObjectTest
 
         it.clearDC(element, qualifier, lang);
 
-        DCValue[] dc = it.getDC(element, qualifier, lang);
+        Metadatum[] dc = it.getDC(element, qualifier, lang);
         assertThat("testClearDC 0",dc,notNullValue());
         assertTrue("testClearDC 1",dc.length == 0);
     }
@@ -599,7 +599,7 @@ public class ItemTest  extends AbstractDSpaceObjectTest
 
         it.clearMetadata(schema, element, qualifier, lang);
 
-        DCValue[] dc = it.getMetadata(schema, element, qualifier, lang);
+        Metadatum[] dc = it.getMetadata(schema, element, qualifier, lang);
         assertThat("testClearMetadata 0",dc,notNullValue());
         assertTrue("testClearMetadata 1",dc.length == 0);
     }

--- a/dspace-api/src/test/java/org/dspace/content/MetadatumTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/MetadatumTest.java
@@ -13,20 +13,20 @@ import static org.junit.Assert.*;
 import org.junit.*;
 
 /**
- * DCValue is a deprecated class with no methods (just a Data Object). This
+ * Metadatum is a deprecated class with no methods (just a Data Object). This
  * class does no real testing, is just here for the sake of coberture completeness
  * and in case the class is refactored and requires some extra testing.
  * @author pvillega
  */
-public class DCValueTest extends AbstractUnitTest
+public class MetadatumTest extends AbstractUnitTest
 {
     /** log4j category */
-    private final static Logger log = Logger.getLogger(DCValueTest.class);
+    private final static Logger log = Logger.getLogger(MetadatumTest.class);
 
     /**
      * Object to use in the tests
      */
-    private DCValue dcval;
+    private Metadatum dcval;
 
 
     /**
@@ -41,7 +41,7 @@ public class DCValueTest extends AbstractUnitTest
     public void init()
     {
         super.init();
-        dcval =  new DCValue();
+        dcval =  new Metadatum();
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/identifier/DOIIdentifierProviderTest.java
+++ b/dspace-api/src/test/java/org/dspace/identifier/DOIIdentifierProviderTest.java
@@ -125,8 +125,8 @@ public class DOIIdentifierProviderTest
 
     private static void dumpMetadata(Item eyetem)
     {
-        DCValue[] metadata = eyetem.getMetadata("dc", Item.ANY, Item.ANY, Item.ANY);
-        for (DCValue metadatum : metadata)
+        Metadatum[] metadata = eyetem.getMetadata("dc", Item.ANY, Item.ANY, Item.ANY);
+        for (Metadatum metadatum : metadata)
             System.out.printf("Metadata: %s.%s.%s(%s) = %s\n",
                     metadatum.schema,
                     metadatum.element,
@@ -161,14 +161,14 @@ public class DOIIdentifierProviderTest
         String sql = "DELETE FROM Doi WHERE resource_type_id = ? AND resource_id = ?";
         DatabaseManager.updateQuery(context, sql, item.getType(), item.getID());
         
-        DCValue[] metadata = item.getMetadata(
+        Metadatum[] metadata = item.getMetadata(
                 DOIIdentifierProvider.MD_SCHEMA, 
                 DOIIdentifierProvider.DOI_ELEMENT,
                 DOIIdentifierProvider.DOI_QUALIFIER,
                 null);
         List<String> remainder = new ArrayList<String>();
 
-        for (DCValue id : metadata)
+        for (Metadatum id : metadata)
         {
             if (!id.value.startsWith(DOI.RESOLVER))
             {
@@ -310,12 +310,12 @@ public class DOIIdentifierProviderTest
         provider.saveDOIToObject(context, item, doi);
         context.restoreAuthSystemState();
         
-        DCValue[] metadata = item.getMetadata(DOIIdentifierProvider.MD_SCHEMA, 
+        Metadatum[] metadata = item.getMetadata(DOIIdentifierProvider.MD_SCHEMA, 
                 DOIIdentifierProvider.DOI_ELEMENT,
                 DOIIdentifierProvider.DOI_QUALIFIER,
                 null);
         boolean result = false;
-        for (DCValue id : metadata)
+        for (Metadatum id : metadata)
         {
             if (id.value.equals(DOI.DOIToExternalForm(doi)))
             {
@@ -365,12 +365,12 @@ public class DOIIdentifierProviderTest
         provider.removeDOIFromObject(context, item, doi);
         context.restoreAuthSystemState();
         
-        DCValue[] metadata = item.getMetadata(DOIIdentifierProvider.MD_SCHEMA, 
+        Metadatum[] metadata = item.getMetadata(DOIIdentifierProvider.MD_SCHEMA, 
                 DOIIdentifierProvider.DOI_ELEMENT,
                 DOIIdentifierProvider.DOI_QUALIFIER,
                 null);
         boolean foundDOI = false;
-        for (DCValue id : metadata)
+        for (Metadatum id : metadata)
         {
             if (id.value.equals(DOI.DOIToExternalForm(doi)))
             {
@@ -461,13 +461,13 @@ public class DOIIdentifierProviderTest
         context.restoreAuthSystemState();
 
         // assure that the right one was removed
-        DCValue[] metadata = item.getMetadata(DOIIdentifierProvider.MD_SCHEMA, 
+        Metadatum[] metadata = item.getMetadata(DOIIdentifierProvider.MD_SCHEMA, 
                 DOIIdentifierProvider.DOI_ELEMENT,
                 DOIIdentifierProvider.DOI_QUALIFIER,
                 null);
         boolean foundDOI1 = false;
         boolean foundDOI2 = false;
-        for (DCValue id : metadata)
+        for (Metadatum id : metadata)
         {
             if (id.value.equals(DOI.DOIToExternalForm(doi1)))
             {
@@ -494,7 +494,7 @@ public class DOIIdentifierProviderTest
                 null);
         foundDOI1 = false;
         foundDOI2 = false;
-        for (DCValue id : metadata)
+        for (Metadatum id : metadata)
         {
             if (id.value.equals(DOI.DOIToExternalForm(doi1)))
             {
@@ -643,13 +643,13 @@ public class DOIIdentifierProviderTest
         context.restoreAuthSystemState();
 
         // assure that the right one was removed
-        DCValue[] metadata = item.getMetadata(DOIIdentifierProvider.MD_SCHEMA, 
+        Metadatum[] metadata = item.getMetadata(DOIIdentifierProvider.MD_SCHEMA, 
                 DOIIdentifierProvider.DOI_ELEMENT,
                 DOIIdentifierProvider.DOI_QUALIFIER,
                 null);
         boolean foundDOI1 = false;
         boolean foundDOI2 = false;
-        for (DCValue id : metadata)
+        for (Metadatum id : metadata)
         {
             if (id.value.equals(DOI.DOIToExternalForm(doi1)))
             {
@@ -690,13 +690,13 @@ public class DOIIdentifierProviderTest
         context.restoreAuthSystemState();
 
         // assure that the right one was removed
-        DCValue[] metadata = item.getMetadata(DOIIdentifierProvider.MD_SCHEMA, 
+        Metadatum[] metadata = item.getMetadata(DOIIdentifierProvider.MD_SCHEMA, 
                 DOIIdentifierProvider.DOI_ELEMENT,
                 DOIIdentifierProvider.DOI_QUALIFIER,
                 null);
         boolean foundDOI1 = false;
         boolean foundDOI2 = false;
-        for (DCValue id : metadata)
+        for (Metadatum id : metadata)
         {
             if (id.value.equals(DOI.DOIToExternalForm(doi1)))
             {

--- a/dspace-api/src/test/java/org/dspace/identifier/EZIDIdentifierProviderTest.java
+++ b/dspace-api/src/test/java/org/dspace/identifier/EZIDIdentifierProviderTest.java
@@ -49,8 +49,8 @@ public class EZIDIdentifierProviderTest
 
     private static void dumpMetadata(Item eyetem)
     {
-        DCValue[] metadata = eyetem.getMetadata("dc", Item.ANY, Item.ANY, Item.ANY);
-        for (DCValue metadatum : metadata)
+        Metadatum[] metadata = eyetem.getMetadata("dc", Item.ANY, Item.ANY, Item.ANY);
+        for (Metadatum metadatum : metadata)
             System.out.printf("Metadata:  %s.%s.%s(%s) = %s\n",
                     metadatum.schema,
                     metadatum.element,

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/BrowseListTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/BrowseListTag.java
@@ -16,7 +16,7 @@ import org.dspace.app.webui.util.UIUtil;
 import org.dspace.browse.*;
 import org.dspace.content.Bitstream;
 import org.dspace.content.DCDate;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.content.Thumbnail;
 import org.dspace.content.service.ItemService;
@@ -457,7 +457,7 @@ public class BrowseListTag extends TagSupport
                     String qualifier = tokens[2];
 
                     // first get hold of the relevant metadata for this column
-                    DCValue[] metadataArray;
+                    Metadatum[] metadataArray;
                     if (qualifier.equals("*"))
                     {
                         metadataArray = items[i].getMetadata(schema, element, Item.ANY, Item.ANY);
@@ -474,7 +474,7 @@ public class BrowseListTag extends TagSupport
                     // save on a null check which would make the code untidy
                     if (metadataArray == null)
                     {
-                    	metadataArray = new DCValue[0];
+                    	metadataArray = new Metadatum[0];
                     }
 
                     // now prepare the content of the table division

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemListTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemListTag.java
@@ -20,7 +20,7 @@ import org.dspace.browse.CrossLinks;
 
 import org.dspace.content.Bitstream;
 import org.dspace.content.DCDate;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.content.Thumbnail;
 import org.dspace.content.service.ItemService;
@@ -422,7 +422,7 @@ public class ItemListTag extends TagSupport
                     String qualifier = tokens[2];
 
                     // first get hold of the relevant metadata for this column
-                    DCValue[] metadataArray;
+                    Metadatum[] metadataArray;
                     if (qualifier.equals("*"))
                     {
                         metadataArray = items[i].getMetadata(schema, element, Item.ANY, Item.ANY);
@@ -439,7 +439,7 @@ public class ItemListTag extends TagSupport
                     // save on a null check which would make the code untidy
                     if (metadataArray == null)
                     {
-                        metadataArray = new DCValue[0];
+                        metadataArray = new Metadatum[0];
                     }
 
                     // now prepare the content of the table division

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemPreviewTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemPreviewTag.java
@@ -11,7 +11,7 @@ import org.dspace.app.webui.util.UIUtil;
 
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 
 import org.dspace.core.ConfigurationManager;
@@ -98,7 +98,7 @@ public class ItemPreviewTag extends TagSupport
             String s = ConfigurationManager.getProperty("webui.preview.dc");
             if (s != null)
             {
-            	DCValue[] dcValue;
+            	Metadatum[] dcValue;
             	
             	int i = s.indexOf('.');
             	

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemTag.java
@@ -40,7 +40,7 @@ import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
 import org.dspace.content.DCDate;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.content.authority.MetadataAuthorityManager;
 import org.dspace.core.ConfigurationManager;
@@ -463,7 +463,7 @@ public class ItemTag extends TagSupport
             }
 
             // FIXME: Still need to fix for metadata language?
-            DCValue[] values = item.getMetadata(schema, element, qualifier, Item.ANY);
+            Metadatum[] values = item.getMetadata(schema, element, qualifier, Item.ANY);
             
             if (values.length > 0)
             {
@@ -647,7 +647,7 @@ public class ItemTag extends TagSupport
         Context context = UIUtil.obtainContext(request);
 
         // Get all the metadata
-        DCValue[] values = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+        Metadatum[] values = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
 
         out.println("<div class=\"panel panel-info\"><div class=\"panel-heading\">"
                 + LocaleSupport.getLocalizedMessage(pageContext,

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/RequestItemServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/RequestItemServlet.java
@@ -17,7 +17,7 @@ import org.dspace.app.webui.util.UIUtil;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.core.*;
 import org.dspace.eperson.EPerson;
@@ -149,7 +149,7 @@ public class RequestItemServlet extends DSpaceServlet
         {   
         	JSPManager.showInvalidIDError(request, response, handle, -1);
         }
-        DCValue[] titleDC = item.getDC("title", null, Item.ANY);
+        Metadatum[] titleDC = item.getDC("title", null, Item.ANY);
         if (titleDC != null || titleDC.length > 0)
         {
             title = titleDC[0].value;
@@ -290,7 +290,7 @@ public class RequestItemServlet extends DSpaceServlet
             String title = "";
              if (item != null)
             {   
-                DCValue[] titleDC = item.getDC("title", null, Item.ANY);
+                Metadatum[] titleDC = item.getDC("title", null, Item.ANY);
                 if (titleDC != null || titleDC.length > 0) 
                     title = titleDC[0].value; 
             }
@@ -327,7 +327,7 @@ public class RequestItemServlet extends DSpaceServlet
 		if (requestItem != null && (yes || no)) {
 			Item item = Item.find(context, requestItem.getIntColumn("item_id"));
 
-			DCValue[] titleDC = item.getDC("title", null, Item.ANY);
+			Metadatum[] titleDC = item.getDC("title", null, Item.ANY);
 			String title = titleDC.length > 0 ? titleDC[0].value : I18nUtil
 					.getMessage("jsp.general.untitled", context);
 			

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SuggestServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SuggestServlet.java
@@ -31,7 +31,7 @@ import org.dspace.eperson.EPerson;
 import org.dspace.handle.HandleManager;
 import org.dspace.content.Item;
 import org.dspace.content.Collection;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 
 
 /**
@@ -86,7 +86,7 @@ public class SuggestServlet extends DSpaceServlet
             Item item = (Item) HandleManager.resolveToObject(context, handle);
             if (item != null)
             {
-                DCValue[] titleDC = item.getDC("title", null, Item.ANY);
+                Metadatum[] titleDC = item.getDC("title", null, Item.ANY);
                 if (titleDC != null && titleDC.length > 0)
                 {
                     title = titleDC[0].value;

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/util/MetadataStyleSelection.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/util/MetadataStyleSelection.java
@@ -10,7 +10,7 @@ package org.dspace.app.webui.util;
 import java.sql.SQLException;
 
 import org.apache.log4j.Logger;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.core.ConfigurationManager;
 
@@ -34,7 +34,7 @@ public class MetadataStyleSelection extends AKeyBasedStyleSelection
     public String getStyleForItem(Item item) throws SQLException
     {
         String metadata = ConfigurationManager.getProperty("webui.itemdisplay.metadata-style");
-        DCValue[] value = item.getMetadataByMetadataString(metadata);
+        Metadatum[] value = item.getMetadataByMetadataString(metadata);
         String styleName = "default";
         if (value.length > 0)
         {

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/util/VersionUtil.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/util/VersionUtil.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.AuthorizeManager;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.InProgressSubmission;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataSchema;
@@ -330,7 +330,7 @@ public class VersionUtil
         String[] result = null;
         String itemHandle = version.getItem().getHandle();
 
-        DCValue[] identifiers = version.getItem().getMetadata(
+        Metadatum[] identifiers = version.getItem().getMetadata(
                 MetadataSchema.DC_SCHEMA, "identifier", null, Item.ANY);
         String itemIdentifier = null;
         if (identifiers != null && identifiers.length > 0)

--- a/dspace-lni/src/main/java/org/dspace/app/dav/DAVItem.java
+++ b/dspace-lni/src/main/java/org/dspace/app/dav/DAVItem.java
@@ -25,7 +25,7 @@ import org.dspace.authorize.AuthorizeManager;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.content.crosswalk.CrosswalkException;
 import org.dspace.content.packager.PackageDisseminator;
@@ -303,7 +303,7 @@ class DAVItem extends DAVDSpaceObject
         else if (elementsEqualIsh(property, displaynameProperty))
         {
             // displayname - title or handle.
-            DCValue titleDc[] = this.item.getDC("title", Item.ANY, Item.ANY);
+            Metadatum titleDc[] = this.item.getDC("title", Item.ANY, Item.ANY);
             value = titleDc.length > 0 ? titleDc[0].value : this.item.getHandle();
         }
         else if (elementsEqualIsh(property, handleProperty))

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -253,9 +253,9 @@ public class XOAI {
             doc.addField("item.communities",
                     "com_" + com.getHandle().replace("/", "_"));
 
-        DCValue[] allData = item.getMetadata(Item.ANY, Item.ANY, Item.ANY,
+        Metadatum[] allData = item.getMetadata(Item.ANY, Item.ANY, Item.ANY,
                 Item.ANY);
-        for (DCValue dc : allData) {
+        for (Metadatum dc : allData) {
             String key = "metadata." + dc.schema + "." + dc.element;
             if (dc.qualifier != null) {
                 key += "." + dc.qualifier;

--- a/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
@@ -15,7 +15,7 @@ import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.content.authority.Choices;
 import org.dspace.core.ConfigurationManager;
@@ -69,8 +69,8 @@ public class ItemUtils
         
         // read all metadata into Metadata Object
         metadata = new Metadata();
-        DCValue[] vals = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
-        for (DCValue val : vals)
+        Metadatum[] vals = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+        for (Metadatum val : vals)
         {
             Element valueElem = null;
             Element schema = getElement(metadata.getElement(), val.schema);

--- a/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
@@ -37,8 +37,8 @@ import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.AuthorizeManager;
 import org.dspace.content.BitstreamFormat;
 import org.dspace.content.Bundle;
-import org.dspace.content.DCValue;
 import org.dspace.content.ItemIterator;
+import org.dspace.content.Metadatum;
 import org.dspace.eperson.Group;
 import org.dspace.rest.common.Bitstream;
 import org.dspace.rest.common.Item;
@@ -771,10 +771,10 @@ public class ItemsResource extends Resource
 
             log.trace("Deleting metadata.");
             // TODO Rewrite without deprecated object. Leave there only generated metadata.
-            DCValue[] value = dspaceItem.getMetadata("dc", "date", "accessioned", org.dspace.content.Item.ANY);
-            DCValue[] value2 = dspaceItem.getMetadata("dc", "date", "available", org.dspace.content.Item.ANY);
-            DCValue[] value3 = dspaceItem.getMetadata("dc", "identifier", "uri", org.dspace.content.Item.ANY);
-            DCValue[] value4 = dspaceItem.getMetadata("dc", "description", "provenance", org.dspace.content.Item.ANY);
+            Metadatum[] value = dspaceItem.getMetadata("dc", "date", "accessioned", org.dspace.content.Item.ANY);
+            Metadatum[] value2 = dspaceItem.getMetadata("dc", "date", "available", org.dspace.content.Item.ANY);
+            Metadatum[] value3 = dspaceItem.getMetadata("dc", "identifier", "uri", org.dspace.content.Item.ANY);
+            Metadatum[] value4 = dspaceItem.getMetadata("dc", "description", "provenance", org.dspace.content.Item.ANY);
 
             dspaceItem.clearMetadata(org.dspace.content.Item.ANY, org.dspace.content.Item.ANY, org.dspace.content.Item.ANY,
                     org.dspace.content.Item.ANY);

--- a/dspace-rest/src/main/java/org/dspace/rest/common/Item.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/common/Item.java
@@ -11,7 +11,7 @@ import org.apache.log4j.Logger;
 import org.dspace.app.util.MetadataExposure;
 import org.dspace.authorize.AuthorizeManager;
 import org.dspace.content.Bundle;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.core.Context;
 
 import javax.ws.rs.WebApplicationException;
@@ -60,10 +60,11 @@ public class Item extends DSpaceObject {
 
         if(expandFields.contains("metadata") || expandFields.contains("all")) {
             metadata = new ArrayList<MetadataEntry>();
-            DCValue[] dcvs = item.getMetadata(org.dspace.content.Item.ANY, org.dspace.content.Item.ANY, org.dspace.content.Item.ANY, org.dspace.content.Item.ANY);
-            for (DCValue dcv : dcvs) {
-                if (!MetadataExposure.isHidden(context, dcv.schema, dcv.element, dcv.qualifier))
+            Metadatum[] dcvs = item.getMetadata(org.dspace.content.Item.ANY, org.dspace.content.Item.ANY, org.dspace.content.Item.ANY, org.dspace.content.Item.ANY);
+            for (Metadatum dcv : dcvs) {
+                if (!MetadataExposure.isHidden(context, dcv.schema, dcv.element, dcv.qualifier)) {
                     metadata.add(new MetadataEntry(dcv.getField(), dcv.value, dcv.language));
+                }
             }
         } else {
             this.addExpand("metadata");

--- a/dspace-sword/src/main/java/org/dspace/sword/ItemCollectionGenerator.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/ItemCollectionGenerator.java
@@ -54,7 +54,7 @@ public class ItemCollectionGenerator extends ATOMCollectionGenerator
 
 		// the item title is the sword collection title, or "untitled" otherwise
 		String title = "Untitled";
-		DCValue[] dcv = item.getMetadataByMetadataString("dc.title");
+		Metadatum[] dcv = item.getMetadataByMetadataString("dc.title");
 		if (dcv.length > 0)
 		{
 			title = dcv[0].value;
@@ -67,7 +67,7 @@ public class ItemCollectionGenerator extends ATOMCollectionGenerator
 
 		// abstract is the short description of the item, if it exists
 		String dcAbstract = "";
-		DCValue[] dcva = item.getMetadataByMetadataString("dc.description.abstract");
+		Metadatum[] dcva = item.getMetadataByMetadataString("dc.description.abstract");
 		if (dcva.length > 0)
 		{
 			dcAbstract = dcva[0].value;

--- a/dspace-sword/src/main/java/org/dspace/sword/ItemEntryGenerator.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/ItemEntryGenerator.java
@@ -11,7 +11,7 @@ import org.dspace.content.Bitstream;
 import org.dspace.content.BitstreamFormat;
 import org.dspace.content.Bundle;
 import org.dspace.content.DCDate;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.handle.HandleManager;
 import org.purl.sword.atom.Content;
@@ -47,7 +47,7 @@ public class ItemEntryGenerator extends DSpaceATOMEntry
 	 */
 	protected void addCategories()
 	{
-		DCValue[] dcv = item.getMetadataByMetadataString("dc.subject.*");
+		Metadatum[] dcv = item.getMetadataByMetadataString("dc.subject.*");
 		if (dcv != null)
 		{
 			for (int i = 0; i < dcv.length; i++)
@@ -233,7 +233,7 @@ public class ItemEntryGenerator extends DSpaceATOMEntry
 	 */
 	protected void addPublishDate()
 	{
-		DCValue[] dcv = item.getMetadataByMetadataString("dc.date.issued");
+		Metadatum[] dcv = item.getMetadataByMetadataString("dc.date.issued");
 		if (dcv != null && dcv.length == 1)
         {
             entry.setPublished(dcv[0].value);
@@ -298,7 +298,7 @@ public class ItemEntryGenerator extends DSpaceATOMEntry
 	 */
 	protected void addSummary()
 	{
-		DCValue[] dcv = item.getMetadataByMetadataString("dc.description.abstract");
+		Metadatum[] dcv = item.getMetadataByMetadataString("dc.description.abstract");
 		if (dcv != null)
 		{
 			for (int i = 0; i < dcv.length; i++)
@@ -317,7 +317,7 @@ public class ItemEntryGenerator extends DSpaceATOMEntry
 	 */
 	protected void addTitle()
 	{
-		DCValue[] dcv = item.getMetadataByMetadataString("dc.title");
+		Metadatum[] dcv = item.getMetadataByMetadataString("dc.title");
 		if (dcv != null)
 		{
 			for (int i = 0; i < dcv.length; i++)
@@ -337,7 +337,7 @@ public class ItemEntryGenerator extends DSpaceATOMEntry
 	protected void addLastUpdatedDate()
 	{
 		String config = ConfigurationManager.getProperty("sword-server", "updated.field");
-		DCValue[] dcv = item.getMetadataByMetadataString(config);
+		Metadatum[] dcv = item.getMetadataByMetadataString(config);
 		if (dcv != null && dcv.length == 1)
         {
             DCDate dcd = new DCDate(dcv[0].value);

--- a/dspace-sword/src/main/java/org/dspace/sword/SWORDMETSIngester.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/SWORDMETSIngester.java
@@ -15,7 +15,7 @@ import org.apache.log4j.Logger;
 
 import org.dspace.content.Collection;
 import org.dspace.content.DCDate;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.packager.PackageIngester;
@@ -179,7 +179,7 @@ public class SWORDMETSIngester implements SWORDIngester
 			throw new DSpaceSWORDException("No configuration, or configuration is invalid for: sword.updated.field");
 		}
 		
-		DCValue dc = this.configToDC(field, null);
+		Metadatum dc = this.configToDC(field, null);
 		item.clearMetadata(dc.schema, dc.element, dc.qualifier, Item.ANY);
 		DCDate date = new DCDate(new Date());
 		item.addMetadata(dc.schema, dc.element, dc.qualifier, null, date.toString());
@@ -212,7 +212,7 @@ public class SWORDMETSIngester implements SWORDIngester
 			throw new DSpaceSWORDException("No configuration, or configuration is invalid for: sword.slug.field");
 		}
 		
-		DCValue dc = this.configToDC(field, null);
+		Metadatum dc = this.configToDC(field, null);
 		item.clearMetadata(dc.schema, dc.element, dc.qualifier, Item.ANY);
 		item.addMetadata(dc.schema, dc.element, dc.qualifier, null, slugVal);
 
@@ -221,19 +221,19 @@ public class SWORDMETSIngester implements SWORDIngester
 	
 	/**
 	 * utility method to turn given metadata fields of the form
-	 * schema.element.qualifier into DCValue objects which can be 
-	 * used to access metadata in items.
+ schema.element.qualifier into Metadatum objects which can be 
+ used to access metadata in items.
 	 * 
 	 * The def parameter should be null, * or "" depending on how
-	 * you intend to use the DCValue object
+ you intend to use the Metadatum object
 	 * 
 	 * @param config
 	 * @param def
 	 * @return
 	 */
-	private DCValue configToDC(String config, String def)
+	private Metadatum configToDC(String config, String def)
 	{
-		DCValue dcv = new DCValue();
+		Metadatum dcv = new Metadatum();
 		dcv.schema = def;
 		dcv.element= def;
 		dcv.qualifier = def;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/AbstractSimpleDC.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/AbstractSimpleDC.java
@@ -8,7 +8,7 @@
 
 package org.dspace.sword2;
 
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.core.ConfigurationManager;
 
@@ -61,9 +61,9 @@ public class AbstractSimpleDC
         this.loadMetadataMaps();
 
         SimpleDCMetadata md = new SimpleDCMetadata();
-        DCValue[] all = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+        Metadatum[] all = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
 
-        for (DCValue dcv : all)
+        for (Metadatum dcv : all)
         {
             String valueMatch = dcv.schema + "." + dcv.element;
             if (dcv.qualifier != null)

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/AbstractSwordContentIngester.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/AbstractSwordContentIngester.java
@@ -13,7 +13,7 @@ import org.dspace.content.BitstreamFormat;
 import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
 import org.dspace.content.DCDate;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.ConfigurationManager;
@@ -104,7 +104,7 @@ public abstract class AbstractSwordContentIngester implements SwordContentIngest
 			throw new DSpaceSwordException("No configuration, or configuration is invalid for: sword.updated.field");
 		}
 
-		DCValue dc = this.configToDC(field, null);
+		Metadatum dc = this.configToDC(field, null);
 		item.clearMetadata(dc.schema, dc.element, dc.qualifier, Item.ANY);
 		DCDate date = new DCDate(new Date());
 		item.addMetadata(dc.schema, dc.element, dc.qualifier, null, date.toString());
@@ -137,7 +137,7 @@ public abstract class AbstractSwordContentIngester implements SwordContentIngest
 			throw new DSpaceSwordException("No configuration, or configuration is invalid for: sword.slug.field");
 		}
 
-		DCValue dc = this.configToDC(field, null);
+		Metadatum dc = this.configToDC(field, null);
 		item.clearMetadata(dc.schema, dc.element, dc.qualifier, Item.ANY);
 		item.addMetadata(dc.schema, dc.element, dc.qualifier, null, slugVal);
 
@@ -146,18 +146,18 @@ public abstract class AbstractSwordContentIngester implements SwordContentIngest
 
 	/**
 	 * Utility method to turn given metadata fields of the form
-	 * schema.element.qualifier into DCValue objects which can be
-	 * used to access metadata in items.
+ schema.element.qualifier into Metadatum objects which can be
+ used to access metadata in items.
 	 *
 	 * The def parameter should be null, * or "" depending on how
-	 * you intend to use the DCValue object.
+ you intend to use the Metadatum object.
 	 *
 	 * @param config
 	 * @param def
 	 */
-	protected DCValue configToDC(String config, String def)
+	protected Metadatum configToDC(String config, String def)
 	{
-		DCValue dcv = new DCValue();
+		Metadatum dcv = new Metadatum();
 		dcv.schema = def;
 		dcv.element= def;
 		dcv.qualifier = def;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/AtomStatementDisseminator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/AtomStatementDisseminator.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.sword2;
 
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
@@ -43,14 +43,14 @@ public class AtomStatementDisseminator extends GenericStatementDisseminator impl
 			return null;
 		}
 
-		DCValue[] dcvs = item.getMetadataByMetadataString(field);
+		Metadatum[] dcvs = item.getMetadataByMetadataString(field);
 		if (dcvs == null || dcvs.length == 0)
 		{
 			return null;
 		}
 
 		StringBuilder md = new StringBuilder();
-		for (DCValue dcv : dcvs)
+		for (Metadatum dcv : dcvs)
 		{
 			if (md.length() > 0)
 			{

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/CollectionListManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/CollectionListManagerDSpace.java
@@ -13,7 +13,7 @@ import org.apache.abdera.i18n.iri.IRI;
 import org.apache.abdera.model.Entry;
 import org.apache.abdera.model.Feed;
 import org.dspace.content.Collection;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.content.ItemIterator;
 import org.dspace.content.WorkspaceItem;
@@ -180,14 +180,14 @@ public class CollectionListManagerDSpace extends DSpaceSwordAPI implements Colle
 			return null;
 		}
 
-		DCValue[] dcvs = item.getMetadataByMetadataString(field);
+		Metadatum[] dcvs = item.getMetadataByMetadataString(field);
 		if (dcvs == null)
 		{
 			return null;
 		}
 
 		StringBuilder md = new StringBuilder();
-		for (DCValue dcv : dcvs)
+		for (Metadatum dcv : dcvs)
 		{
 			if (md.length() > 0)
 			{

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/ReceiptGenerator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/ReceiptGenerator.java
@@ -10,7 +10,7 @@ package org.dspace.sword2;
 import org.apache.abdera.i18n.iri.IRI;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
@@ -222,7 +222,7 @@ public class ReceiptGenerator
 	 */
 	protected void addCategories(DepositResult result, DepositReceipt receipt)
 	{
-		DCValue[] dcv = result.getItem().getMetadataByMetadataString("dc.subject.*");
+		Metadatum[] dcv = result.getItem().getMetadataByMetadataString("dc.subject.*");
 		if (dcv != null)
 		{
 			for (int i = 0; i < dcv.length; i++)
@@ -234,7 +234,7 @@ public class ReceiptGenerator
 
 	protected void addCategories(Item item, DepositReceipt receipt)
 	{
-		DCValue[] dcv = item.getMetadataByMetadataString("dc.subject.*");
+		Metadatum[] dcv = item.getMetadataByMetadataString("dc.subject.*");
 		if (dcv != null)
 		{
 			for (int i = 0; i < dcv.length; i++)
@@ -250,7 +250,7 @@ public class ReceiptGenerator
 	 */
 	protected void addPublishDate(DepositResult result, DepositReceipt receipt)
 	{
-		DCValue[] dcv = result.getItem().getMetadataByMetadataString("dc.date.issued");
+		Metadatum[] dcv = result.getItem().getMetadataByMetadataString("dc.date.issued");
 		if (dcv != null && dcv.length == 1)
         {
             try
@@ -269,7 +269,7 @@ public class ReceiptGenerator
 
 	protected void addPublishDate(Item item, DepositReceipt receipt)
 	{
-		DCValue[] dcv = item.getMetadataByMetadataString("dc.date.issued");
+		Metadatum[] dcv = item.getMetadataByMetadataString("dc.date.issued");
 		if (dcv != null && dcv.length == 1)
         {
             try
@@ -293,7 +293,7 @@ public class ReceiptGenerator
 	protected void addLastUpdatedDate(DepositResult result, DepositReceipt receipt)
 	{
 		String config = ConfigurationManager.getProperty("swordv2-server", "updated.field");
-		DCValue[] dcv = result.getItem().getMetadataByMetadataString(config);
+		Metadatum[] dcv = result.getItem().getMetadataByMetadataString(config);
 		if (dcv != null && dcv.length == 1)
         {
             try
@@ -313,7 +313,7 @@ public class ReceiptGenerator
 	protected void addLastUpdatedDate(Item item, DepositReceipt receipt)
 	{
 		String config = ConfigurationManager.getProperty("swordv2-server", "updated.field");
-		DCValue[] dcv = item.getMetadataByMetadataString(config);
+		Metadatum[] dcv = item.getMetadataByMetadataString(config);
 		if (dcv != null && dcv.length == 1)
         {
             try

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleDCEntryIngester.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleDCEntryIngester.java
@@ -10,7 +10,7 @@ package org.dspace.sword2;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Collection;
 import org.dspace.content.DCDate;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.WorkspaceItem;
@@ -115,12 +115,12 @@ public class SimpleDCEntryIngester extends AbstractSimpleDC implements SwordEntr
         String[] parts = raw.split(",");
         for (String part : parts)
         {
-            DCValue dcv = this.makeDCValue(part.trim(), null);
+            Metadatum dcv = this.makeDCValue(part.trim(), null);
             item.clearMetadata(dcv.schema, dcv.element, dcv.qualifier, Item.ANY);
         }
     }
 
-    private void addUniqueMetadata(DCValue dcv, Item item)
+    private void addUniqueMetadata(Metadatum dcv, Item item)
     {
         String qual = dcv.qualifier;
         if (dcv.qualifier == null)
@@ -133,8 +133,8 @@ public class SimpleDCEntryIngester extends AbstractSimpleDC implements SwordEntr
         {
             lang = Item.ANY;
         }
-        DCValue[] existing = item.getMetadata(dcv.schema, dcv.element, qual, lang);
-        for (DCValue dcValue : existing)
+        Metadatum[] existing = item.getMetadata(dcv.schema, dcv.element, qual, lang);
+        for (Metadatum dcValue : existing)
         {
             // FIXME: probably we want to be slightly more careful about qualifiers and languages
             //
@@ -163,7 +163,7 @@ public class SimpleDCEntryIngester extends AbstractSimpleDC implements SwordEntr
 			String titleField = this.dcMap.get("title");
 			if (titleField != null)
 			{
-				DCValue dcv = this.makeDCValue(titleField, title);
+				Metadatum dcv = this.makeDCValue(titleField, title);
                 this.addUniqueMetadata(dcv, item);
 			}
 		}
@@ -172,7 +172,7 @@ public class SimpleDCEntryIngester extends AbstractSimpleDC implements SwordEntr
 			String abstractField = this.dcMap.get("abstract");
 			if (abstractField != null)
 			{
-				DCValue dcv = this.makeDCValue(abstractField, summary);
+				Metadatum dcv = this.makeDCValue(abstractField, summary);
                 this.addUniqueMetadata(dcv, item);
 			}
 		}
@@ -188,7 +188,7 @@ public class SimpleDCEntryIngester extends AbstractSimpleDC implements SwordEntr
 			}
 
 			// now add all the metadata terms
-            DCValue dcv = this.makeDCValue(dsTerm, null);
+            Metadatum dcv = this.makeDCValue(dsTerm, null);
 			for (String value : dc.get(term))
 			{
                 dcv.value = value;
@@ -262,10 +262,10 @@ public class SimpleDCEntryIngester extends AbstractSimpleDC implements SwordEntr
 		}
     }
 
-    public DCValue makeDCValue(String field, String value)
+    public Metadatum makeDCValue(String field, String value)
             throws DSpaceSwordException
     {
-        DCValue dcv = new DCValue();
+        Metadatum dcv = new Metadatum();
         String[] bits = field.split("\\.");
         if (bits.length < 2 || bits.length > 3)
         {
@@ -298,7 +298,7 @@ public class SimpleDCEntryIngester extends AbstractSimpleDC implements SwordEntr
 			throw new DSpaceSwordException("No configuration, or configuration is invalid for: sword.updated.field");
 		}
 
-		DCValue dc = this.makeDCValue(field, null);
+		Metadatum dc = this.makeDCValue(field, null);
 		item.clearMetadata(dc.schema, dc.element, dc.qualifier, Item.ANY);
 		DCDate date = new DCDate(new Date());
 		item.addMetadata(dc.schema, dc.element, dc.qualifier, null, date.toString());
@@ -331,7 +331,7 @@ public class SimpleDCEntryIngester extends AbstractSimpleDC implements SwordEntr
 			throw new DSpaceSwordException("No configuration, or configuration is invalid for: sword.slug.field");
 		}
 
-		DCValue dc = this.makeDCValue(field, null);
+		Metadatum dc = this.makeDCValue(field, null);
 		item.clearMetadata(dc.schema, dc.element, dc.qualifier, Item.ANY);
 		item.addMetadata(dc.schema, dc.element, dc.qualifier, null, slugVal);
 

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/batchimport/BatchImportConfirm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/batchimport/BatchImportConfirm.java
@@ -8,8 +8,6 @@
 package org.dspace.app.xmlui.aspect.administrative.batchimport;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.cocoon.environment.ObjectModelHelper;
 import org.apache.cocoon.environment.Request;
@@ -22,15 +20,8 @@ import org.dspace.app.xmlui.wing.element.Button;
 import org.dspace.app.xmlui.wing.element.Division;
 import org.dspace.app.xmlui.wing.element.PageMeta;
 import org.dspace.app.xmlui.wing.element.Para;
-import org.dspace.app.xmlui.wing.element.Table;
-import org.dspace.app.xmlui.wing.element.Row;
-import org.dspace.app.xmlui.wing.element.Cell;
-import org.dspace.content.Collection;
-import org.dspace.content.Item;
-import org.dspace.content.DCValue;
 import org.xml.sax.SAXException;
 
-import org.dspace.app.bulkedit.BulkEditChange;
 
 /**
  * Web interface to Batch Import app.
@@ -51,6 +42,7 @@ public class BatchImportConfirm extends AbstractDSpaceTransformer {
 
     private static final Message T_success = message("xmlui.administrative.metadataimport.MetadataImportConfirm.success");
 
+    @Override
     public void addPageMeta(PageMeta pageMeta) throws WingException
     {
         pageMeta.addMetadata("title").addContent(T_title);
@@ -60,6 +52,7 @@ public class BatchImportConfirm extends AbstractDSpaceTransformer {
     }
 
 
+    @Override
     public void addBody(Body body) throws SAXException, WingException, SQLException
     {
         // Get list of changes

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/batchimport/BatchImportUpload.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/batchimport/BatchImportUpload.java
@@ -8,8 +8,6 @@
 package org.dspace.app.xmlui.aspect.administrative.batchimport;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.cocoon.environment.ObjectModelHelper;
 import org.apache.cocoon.environment.Request;
@@ -18,19 +16,10 @@ import org.dspace.app.xmlui.cocoon.AbstractDSpaceTransformer;
 import org.dspace.app.xmlui.wing.Message;
 import org.dspace.app.xmlui.wing.WingException;
 import org.dspace.app.xmlui.wing.element.Body;
-import org.dspace.app.xmlui.wing.element.Button;
 import org.dspace.app.xmlui.wing.element.Division;
 import org.dspace.app.xmlui.wing.element.PageMeta;
-import org.dspace.app.xmlui.wing.element.Para;
-import org.dspace.app.xmlui.wing.element.Table;
-import org.dspace.app.xmlui.wing.element.Row;
-import org.dspace.app.xmlui.wing.element.Cell;
-import org.dspace.content.Collection;
-import org.dspace.content.Item;
-import org.dspace.content.DCValue;
 import org.xml.sax.SAXException;
 
-import org.dspace.app.bulkedit.BulkEditChange;
 
 /**
  * Web interface to Batch Import app.
@@ -48,6 +37,7 @@ public class BatchImportUpload extends AbstractDSpaceTransformer {
     private static final Message T_title = message("xmlui.administrative.batchimport.general.title");
     private static final Message T_head1 = message("xmlui.administrative.batchimport.general.head1");
 
+    @Override
     public void addPageMeta(PageMeta pageMeta) throws WingException
     {
         pageMeta.addMetadata("title").addContent(T_title);
@@ -57,6 +47,7 @@ public class BatchImportUpload extends AbstractDSpaceTransformer {
     }
 
 
+    @Override
     public void addBody(Body body) throws SAXException, WingException, SQLException
     {
         // Get list of changes

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/ConfirmItemForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/ConfirmItemForm.java
@@ -22,7 +22,7 @@ import org.dspace.app.xmlui.wing.element.List;
 import org.dspace.app.xmlui.wing.element.PageMeta;
 import org.dspace.app.xmlui.wing.element.Row;
 import org.dspace.app.xmlui.wing.element.Table;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 
 
@@ -78,7 +78,7 @@ public class ConfirmItemForm extends AbstractDSpaceTransformer {
 		// Get our parameters and state
 		int itemID = parameters.getParameterAsInteger("itemID",-1);
 		Item item = Item.find(context, itemID);
-		final DCValue[] values = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+		final Metadatum[] values = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
 		Arrays.sort(values, new DCValueComparator());
 
 		String confirm = parameters.getParameter("confirm",null);
@@ -109,7 +109,7 @@ public class ConfirmItemForm extends AbstractDSpaceTransformer {
 		header.addCell().addContent(T_column1);
 		header.addCell().addContent(T_column2);
 		header.addCell().addContent(T_column3);
-		for(final DCValue value:values){
+		for(final Metadatum value:values){
 			final String dcValue = value.schema + ". " + value.element + (value.qualifier==null?"":(". " + value.qualifier));
 			final Row row = table.addRow();
 			row.addCell().addContent(dcValue);
@@ -153,8 +153,8 @@ public class ConfirmItemForm extends AbstractDSpaceTransformer {
 	 */
 	static class DCValueComparator implements Comparator, Serializable {
 		public int compare(Object arg0, Object arg1) {
-			final DCValue o1 = (DCValue)arg0;
-			final DCValue o2 = (DCValue)arg1;
+			final Metadatum o1 = (Metadatum)arg0;
+			final Metadatum o2 = (Metadatum)arg1;
 			final String s1 = o1.schema + o1.element + (o1.qualifier==null?"":("." + o1.qualifier));
 			final  String s2 = o2.schema + o2.element + (o2.qualifier==null?"":("." + o2.qualifier));
 			return s1.compareTo(s2);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/EditItemMetadataForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/EditItemMetadataForm.java
@@ -34,7 +34,7 @@ import org.dspace.app.xmlui.wing.element.Text;
 import org.dspace.app.xmlui.wing.element.TextArea;
 import org.dspace.app.xmlui.wing.element.Value;
 import org.dspace.content.Collection;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataField;
 import org.dspace.content.MetadataSchema;
@@ -114,7 +114,7 @@ public class EditItemMetadataForm extends AbstractDSpaceTransformer {
                 // Get our parameters and state
                 int itemID = parameters.getParameterAsInteger("itemID",-1);
                 Item item = Item.find(context, itemID);
-                DCValue[] values = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+                Metadatum[] values = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
                 Arrays.sort(values, new DCValueComparator());
                 String baseURL = contextPath+"/admin/item?administrative-continue="+knot.getId();
 
@@ -221,7 +221,7 @@ public class EditItemMetadataForm extends AbstractDSpaceTransformer {
                 header.addCell().addContent(T_column4);
 
                 ChoiceAuthorityManager cmgr = ChoiceAuthorityManager.getManager();
-                for(DCValue value : values)
+                for(Metadatum value : values)
                 {
                         String name = value.schema + "_" + value.element;
                         if (value.qualifier != null)
@@ -312,8 +312,8 @@ public class EditItemMetadataForm extends AbstractDSpaceTransformer {
          */
         static class DCValueComparator implements Comparator, Serializable {
                 public int compare(Object arg0, Object arg1) {
-                        final DCValue o1 = (DCValue)arg0;
-                        final DCValue o2 = (DCValue)arg1;
+                        final Metadatum o1 = (Metadatum)arg0;
+                        final Metadatum o2 = (Metadatum)arg1;
                         final String s1 = o1.schema + o1.element + (o1.qualifier==null?"":("." + o1.qualifier));
                         final  String s2 = o2.schema + o2.element + (o2.qualifier==null?"":("." + o2.qualifier));
                         return s1.compareTo(s2);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/mapper/BrowseItemForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/mapper/BrowseItemForm.java
@@ -24,7 +24,7 @@ import org.dspace.app.xmlui.wing.element.Row;
 import org.dspace.app.xmlui.wing.element.Table;
 import org.dspace.authorize.AuthorizeManager;
 import org.dspace.content.Collection;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.content.ItemIterator;
 import org.dspace.core.Constants;
@@ -107,14 +107,14 @@ public class BrowseItemForm extends AbstractDSpaceTransformer {
 			Collection owningCollection = item.getOwningCollection();
 			String owning = owningCollection.getMetadata("name");
 			String author = "unknown";
-			DCValue[] dcAuthors = item.getDC("contributor",Item.ANY,Item.ANY);
+			Metadatum[] dcAuthors = item.getDC("contributor",Item.ANY,Item.ANY);
 			if (dcAuthors != null && dcAuthors.length >= 1)
             {
                 author = dcAuthors[0].value;
             }
 			
 			String title = "untitled";
-			DCValue[] dcTitles = item.getDC("title",null,Item.ANY);
+			Metadatum[] dcTitles = item.getDC("title",null,Item.ANY);
 			if (dcTitles != null && dcTitles.length >= 1)
             {
                 title = dcTitles[0].value;

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/mapper/SearchItemForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/mapper/SearchItemForm.java
@@ -23,7 +23,7 @@ import org.dspace.app.xmlui.wing.element.Para;
 import org.dspace.app.xmlui.wing.element.Row;
 import org.dspace.app.xmlui.wing.element.Table;
 import org.dspace.content.Collection;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.ConfigurationManager;
@@ -108,13 +108,13 @@ public class SearchItemForm extends AbstractDSpaceTransformer {
 			if (owningCollection != null)
 				owning = owningCollection.getMetadata("name");
 			String author = "unknown";
-			DCValue[] dcCreators = item.getDC("creator",Item.ANY,Item.ANY);
+			Metadatum[] dcCreators = item.getDC("creator",Item.ANY,Item.ANY);
 			if (dcCreators != null && dcCreators.length >= 1)
             {
                 author = dcCreators[0].value;
             } else {
             	// Do a fallback look for contributors
-				DCValue[] dcContributors = item.getDC("contributor",Item.ANY,Item.ANY);
+				Metadatum[] dcContributors = item.getDC("contributor",Item.ANY,Item.ANY);
 				if (dcContributors != null && dcContributors.length >= 1)
 	            {
 	                author = dcContributors[0].value;
@@ -122,7 +122,7 @@ public class SearchItemForm extends AbstractDSpaceTransformer {
 			}
 			
 			String title = "untitled";
-			DCValue[] dcTitles = item.getDC("title",null,Item.ANY);
+			Metadatum[] dcTitles = item.getDC("title",null,Item.ANY);
 			if (dcTitles != null && dcTitles.length >= 1)
             {
                 title = dcTitles[0].value;

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/metadataimport/MetadataImportConfirm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/metadataimport/MetadataImportConfirm.java
@@ -27,7 +27,7 @@ import org.dspace.app.xmlui.wing.element.Row;
 import org.dspace.app.xmlui.wing.element.Cell;
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.xml.sax.SAXException;
 
 import org.dspace.app.bulkedit.BulkEditChange;
@@ -106,8 +106,8 @@ public class MetadataImportConfirm extends AbstractDSpaceTransformer {
                     for (BulkEditChange change : changes)
                     {
                         // Get the changes
-                        List<DCValue> adds = change.getAdds();
-                        List<DCValue> removes = change.getRemoves();
+                        List<Metadatum> adds = change.getAdds();
+                        List<Metadatum> removes = change.getRemoves();
                         List<Collection> newCollections = change.getNewMappedCollections();
                         List<Collection> oldCollections = change.getOldMappedCollections();
 
@@ -207,7 +207,7 @@ public class MetadataImportConfirm extends AbstractDSpaceTransformer {
                         }
 
                         // Show additions
-                        for (DCValue dcv : adds)
+                        for (Metadatum dcv : adds)
                         {
                             Row mdrow = mdchanges.addRow("addition",Row.ROLE_DATA,"metadata-addition");
                             String md = dcv.schema + "." + dcv.element;
@@ -227,7 +227,7 @@ public class MetadataImportConfirm extends AbstractDSpaceTransformer {
                         }
 
                         // Show removals
-                        for (DCValue dcv : removes)
+                        for (Metadatum dcv : removes)
                         {
                             Row mdrow = mdchanges.addRow("deletion",Row.ROLE_DATA,"metadata-deletion");
                             String md = dcv.schema + "." + dcv.element;

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/metadataimport/MetadataImportUpload.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/metadataimport/MetadataImportUpload.java
@@ -27,7 +27,7 @@ import org.dspace.app.xmlui.wing.element.Row;
 import org.dspace.app.xmlui.wing.element.Cell;
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.xml.sax.SAXException;
 
 import org.dspace.app.bulkedit.BulkEditChange;
@@ -103,8 +103,8 @@ public class MetadataImportUpload extends AbstractDSpaceTransformer {
             for (BulkEditChange change : changes)
             {
                 // Get the changes
-                List<DCValue> adds = change.getAdds();
-                List<DCValue> removes = change.getRemoves();
+                List<Metadatum> adds = change.getAdds();
+                List<Metadatum> removes = change.getRemoves();
                 List<Collection> newCollections = change.getNewMappedCollections();
                 List<Collection> oldCollections = change.getOldMappedCollections();
 
@@ -204,7 +204,7 @@ public class MetadataImportUpload extends AbstractDSpaceTransformer {
                 }
 
                 // Show additions
-                for (DCValue dcv : adds)
+                for (Metadatum dcv : adds)
                 {
                     Row mdrow = mdchanges.addRow("addition",Row.ROLE_DATA,"metadata-addition");
                     String md = dcv.schema + "." + dcv.element;
@@ -224,7 +224,7 @@ public class MetadataImportUpload extends AbstractDSpaceTransformer {
                 }
 
                 // Show removals
-                for (DCValue dcv : removes)
+                for (Metadatum dcv : removes)
                 {
                     Row mdrow = mdchanges.addRow("deletion",Row.ROLE_DATA,"metadata-deletion");
                     String md = dcv.schema + "." + dcv.element;

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemRequestChangeStatusForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemRequestChangeStatusForm.java
@@ -31,7 +31,7 @@ import org.dspace.app.xmlui.wing.element.Radio;
 import org.dspace.app.xmlui.wing.element.Text;
 import org.dspace.app.xmlui.wing.element.TextArea;
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.xml.sax.SAXException;

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemRequestForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemRequestForm.java
@@ -31,7 +31,7 @@ import org.dspace.app.xmlui.wing.element.*;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.AuthorizeManager;
 import org.dspace.content.Bitstream;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.Constants;
@@ -192,7 +192,7 @@ public class ItemRequestForm extends AbstractDSpaceTransformer implements Cachea
 
         itemRequest.addPara(T_para1);
 
-		DCValue[] titleDC = item.getDC("title", null, Item.ANY);
+		Metadatum[] titleDC = item.getDC("title", null, Item.ANY);
 		if (titleDC != null && titleDC.length > 0)
 			itemRequest.addPara(titleDC[0].value);
 

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemRequestResponseAction.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemRequestResponseAction.java
@@ -21,7 +21,7 @@ import org.dspace.app.requestitem.RequestItemAuthorExtractor;
 import org.dspace.app.xmlui.utils.ContextUtil;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 import org.dspace.core.Email;
@@ -69,7 +69,7 @@ public class ItemRequestResponseAction extends AbstractAction
         RequestItem requestItem = RequestItem.findByToken(context, token);
         String title;
         Item item = Item.find(context, requestItem.getItemID());
-        DCValue[] titleDC = item.getDC("title", null, Item.ANY);
+        Metadatum[] titleDC = item.getDC("title", null, Item.ANY);
         if (titleDC != null || titleDC.length > 0) 
         	title=titleDC[0].value; 
         else

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemRequestResponseDecisionForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemRequestResponseDecisionForm.java
@@ -31,7 +31,7 @@ import org.dspace.app.xmlui.wing.element.Radio;
 import org.dspace.app.xmlui.wing.element.Text;
 import org.dspace.app.xmlui.wing.element.TextArea;
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.ConfigurationManager;

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemRequestResponseFalseForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemRequestResponseFalseForm.java
@@ -33,7 +33,7 @@ import org.dspace.app.xmlui.wing.element.Radio;
 import org.dspace.app.xmlui.wing.element.Text;
 import org.dspace.app.xmlui.wing.element.TextArea;
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
@@ -120,7 +120,7 @@ public class ItemRequestResponseFalseForm extends AbstractDSpaceTransformer impl
 
 		String title;
 		Item item = Item.find(context, requestItem.getItemID());
-		DCValue[] titleDC = item.getDC("title", null, Item.ANY);
+		Metadatum[] titleDC = item.getDC("title", null, Item.ANY);
 		if (titleDC != null || titleDC.length > 0)
 			title = titleDC[0].value;
 		else

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemRequestResponseTrueForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemRequestResponseTrueForm.java
@@ -31,7 +31,7 @@ import org.dspace.app.xmlui.wing.element.PageMeta;
 import org.dspace.app.xmlui.wing.element.Text;
 import org.dspace.app.xmlui.wing.element.TextArea;
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 import org.dspace.core.I18nUtil;
@@ -119,7 +119,7 @@ public class ItemRequestResponseTrueForm extends AbstractDSpaceTransformer imple
 
 		String title;
 		Item item = Item.find(context, requestItem.getItemID());
-		DCValue[] titleDC = item.getDC("title", null, Item.ANY);
+		Metadatum[] titleDC = item.getDC("title", null, Item.ANY);
 		if (titleDC != null || titleDC.length > 0)
 			title = titleDC[0].value;
 		else

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemRequestStatusChanged.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemRequestStatusChanged.java
@@ -30,7 +30,7 @@ import org.dspace.app.xmlui.wing.element.Radio;
 import org.dspace.app.xmlui.wing.element.Text;
 import org.dspace.app.xmlui.wing.element.TextArea;
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.xml.sax.SAXException;

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemViewer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemViewer.java
@@ -242,7 +242,7 @@ public class ItemViewer extends AbstractDSpaceTransformer implements CacheablePr
         */
         String identifierField = new DSpace().getConfigurationService()
                 .getPropertyAsType("altmetrics.field", "dc.identifier.uri");
-        for (DCValue uri : dso.getMetadataByMetadataString(identifierField))
+        for (Metadatum uri : dso.getMetadataByMetadataString(identifierField))
         {
             String idType, idValue;
             Matcher handleMatcher = handlePattern.matcher(uri.value);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemViewer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemViewer.java
@@ -38,7 +38,7 @@ import org.dspace.app.xmlui.wing.element.PageMeta;
 import org.dspace.app.xmlui.wing.element.Para;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Collection;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.app.util.GoogleMetadata;
@@ -433,7 +433,7 @@ public class ItemViewer extends AbstractDSpaceTransformer implements CacheablePr
      */
     public static String getItemTitle(Item item)
     {
-        DCValue[] titles = item.getDC("title", Item.ANY, Item.ANY);
+        Metadatum[] titles = item.getDC("title", Item.ANY, Item.ANY);
 
         String title;
         if (titles != null && titles.length > 0)

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/SendItemRequestAction.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/SendItemRequestAction.java
@@ -26,7 +26,7 @@ import org.dspace.app.requestitem.RequestItemAuthorExtractor;
 import org.dspace.app.xmlui.utils.ContextUtil;
 import org.dspace.app.xmlui.utils.HandleUtil;
 import org.dspace.content.Bitstream;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.ConfigurationManager;
@@ -102,7 +102,7 @@ public class SendItemRequestAction extends AbstractAction
         
         Item item = (Item) dso;
         String title = "";
-        DCValue[] titleDC = item.getDC("title", null, Item.ANY);
+        Metadatum[] titleDC = item.getDC("title", null, Item.ANY);
         if (titleDC == null || titleDC.length == 0) {
             titleDC = item.getDC("title", Item.ANY, Item.ANY); // dc.title with qualifier term
         }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/AbstractSearch.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/AbstractSearch.java
@@ -454,11 +454,11 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
                 itemName.append(item.getHandle()).append(":").append(metadataKey.toString());
 
 
-                DCValue[] itemMetadata = item.getMetadata(schema, metadataField.getElement(), metadataField.getQualifier(), Item.ANY);
+                Metadatum[] itemMetadata = item.getMetadata(schema, metadataField.getElement(), metadataField.getQualifier(), Item.ANY);
                 if(!ArrayUtils.isEmpty(itemMetadata))
                 {
                     org.dspace.app.xmlui.wing.element.List metadataFieldList = itemList.addList(itemName.toString());
-                    for (DCValue metadataValue : itemMetadata)
+                    for (Metadatum metadataValue : itemMetadata)
                     {
                         String value = metadataValue.value;
                         addMetadataField(highlightedResults, metadataKey.toString(), metadataFieldList, value);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/statisticsElasticSearch/CSVOutputter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/statisticsElasticSearch/CSVOutputter.java
@@ -22,7 +22,7 @@ import org.dspace.app.xmlui.utils.ContextUtil;
 import org.dspace.app.xmlui.utils.HandleUtil;
 import org.dspace.app.xmlui.wing.WingException;
 import org.dspace.content.Bitstream;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
@@ -199,10 +199,10 @@ public class CSVOutputter extends AbstractReader implements Recyclable
         }
     }
     
-    public String wrapInDelimitedString(DCValue[] metadataEntries) {
+    public String wrapInDelimitedString(Metadatum[] metadataEntries) {
         StringBuilder metadataString = new StringBuilder();
 
-        for(DCValue metadataEntry : metadataEntries) {
+        for(Metadatum metadataEntry : metadataEntries) {
             if(metadataString.length() > 0) {
                 // Delimit entries with the || double pipe character sequence.
                 metadataString.append("\\|\\|");

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/statisticsElasticSearch/ElasticSearchStatsViewer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/statisticsElasticSearch/ElasticSearchStatsViewer.java
@@ -409,7 +409,7 @@ public class ElasticSearchStatsViewer extends AbstractDSpaceTransformer {
     }
     
     private String getFirstMetadataValue(Item item, String metadataKey) {
-        DCValue[] dcValue = item.getMetadataByMetadataString(metadataKey);
+        Metadatum[] dcValue = item.getMetadataByMetadataString(metadataKey);
         if(dcValue.length > 0) {
             return dcValue[0].value;
         } else {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/Submissions.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/Submissions.java
@@ -29,7 +29,7 @@ import org.dspace.app.xmlui.wing.element.Row;
 import org.dspace.app.xmlui.wing.element.Table;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Collection;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.content.ItemIterator;
 import org.dspace.content.SupervisedItem;
@@ -223,7 +223,7 @@ public class Submissions extends AbstractDSpaceTransformer
         {
             for (WorkspaceItem workspaceItem : unfinishedItems) 
             {
-                DCValue[] titles = workspaceItem.getItem().getDC("title", null, Item.ANY);
+                Metadatum[] titles = workspaceItem.getItem().getDC("title", null, Item.ANY);
                 EPerson submitterEPerson = workspaceItem.getItem().getSubmitter();
 
                 int workspaceItemID = workspaceItem.getID();
@@ -267,7 +267,7 @@ public class Submissions extends AbstractDSpaceTransformer
         for (WorkspaceItem workspaceItem : supervisedItems) 
         {
 
-            DCValue[] titles = workspaceItem.getItem().getDC("title", null, Item.ANY);
+            Metadatum[] titles = workspaceItem.getItem().getDC("title", null, Item.ANY);
             EPerson submitterEPerson = workspaceItem.getItem().getSubmitter();
 
             int workspaceItemID = workspaceItem.getID();
@@ -394,9 +394,9 @@ public class Submissions extends AbstractDSpaceTransformer
             Item published = (Item) i.next();
             String collUrl = contextPath+"/handle/"+published.getOwningCollection().getHandle();
             String itemUrl = contextPath+"/handle/"+published.getHandle();
-            DCValue[] titles = published.getMetadata("dc", "title", null, Item.ANY);
+            Metadatum[] titles = published.getMetadata("dc", "title", null, Item.ANY);
             String collectionName = published.getOwningCollection().getMetadata("name");
-            DCValue[] ingestDate = published.getMetadata("dc", "date", "accessioned", Item.ANY);
+            Metadatum[] ingestDate = published.getMetadata("dc", "date", "accessioned", Item.ANY);
 
             Row row = table.addRow();
 

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/DescribeStep.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/DescribeStep.java
@@ -41,7 +41,7 @@ import org.dspace.content.Collection;
 import org.dspace.content.DCDate;
 import org.dspace.content.DCPersonName;
 import org.dspace.content.DCSeriesNumber;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.content.authority.MetadataAuthorityManager;
 import org.dspace.content.authority.ChoiceAuthorityManager;
@@ -213,7 +213,7 @@ public class DescribeStep extends AbstractSubmissionStep
                         String element = dcInput.getElement();
                         String qualifier = dcInput.getQualifier();
 
-                        DCValue[] dcValues = item.getMetadata(schema, element, qualifier, Item.ANY);
+                        Metadatum[] dcValues = item.getMetadata(schema, element, qualifier, Item.ANY);
 
                         String fieldName = FlowUtils.getFieldName(dcInput);
                         String inputType = dcInput.getInputType();
@@ -251,9 +251,9 @@ public class DescribeStep extends AbstractSubmissionStep
                                 // selected we need to search through all the metadata and see
                                 // if any match for another field, if not we assume that this field
                                 // should handle it.
-                                DCValue[] unfiltered = item.getMetadata(dcInput.getSchema(), dcInput.getElement(), Item.ANY, Item.ANY);
-                                ArrayList<DCValue> filtered = new ArrayList<DCValue>();
-                                for (DCValue dcValue : unfiltered)
+                                Metadatum[] unfiltered = item.getMetadata(dcInput.getSchema(), dcInput.getElement(), Item.ANY, Item.ANY);
+                                ArrayList<Metadatum> filtered = new ArrayList<Metadatum>();
+                                for (Metadatum dcValue : unfiltered)
                                 {
                                         String unfilteredFieldName = dcValue.element + "." + dcValue.qualifier;
                                         if ( ! inputSet.isFieldPresent(unfilteredFieldName) )
@@ -262,7 +262,7 @@ public class DescribeStep extends AbstractSubmissionStep
                                         }
                                 }
                                 
-                                renderQualdropField(form, fieldName, dcInput, filtered.toArray(new DCValue[filtered.size()]), readonly);
+                                renderQualdropField(form, fieldName, dcInput, filtered.toArray(new Metadatum[filtered.size()]), readonly);
                         }
                         else if (inputType.equals("textarea"))
                         {
@@ -343,7 +343,7 @@ public class DescribeStep extends AbstractSubmissionStep
 
             String inputType = input.getInputType();
             String pairsName = input.getPairsType();
-            DCValue[] values;
+            Metadatum[] values;
 
             if (inputType.equals("qualdrop_value"))
             {
@@ -356,7 +356,7 @@ public class DescribeStep extends AbstractSubmissionStep
 
             if (values != null && values.length > 0)
             {
-                for (DCValue value : values)
+                for (Metadatum value : values)
                 {
                     String displayValue = null;
                     if (inputType.equals("date"))
@@ -401,7 +401,7 @@ public class DescribeStep extends AbstractSubmissionStep
                             describeSection.addItem(displayValue);
                         }
                     }
-                } // For each DCValue
+                } // For each Metadatum
             } // If values exist
         } // For each input
         
@@ -424,7 +424,7 @@ public class DescribeStep extends AbstractSubmissionStep
          * @param dcValues
          *                      The field's pre-existing values.
          */
-        private void renderNameField(List form, String fieldName, DCInput dcInput, DCValue[] dcValues, boolean readonly) throws WingException
+        private void renderNameField(List form, String fieldName, DCInput dcInput, Metadatum[] dcValues, boolean readonly) throws WingException
         {
                 // The name field is a composite field containing two text fields, one
                 // for first name the other for last name.
@@ -486,7 +486,7 @@ public class DescribeStep extends AbstractSubmissionStep
                 // Setup the field's values
                 if (dcInput.isRepeatable() || dcValues.length > 1)
                 {
-                        for (DCValue dcValue : dcValues)
+                        for (Metadatum dcValue : dcValues)
                         {
                                 DCPersonName dpn = new DCPersonName(dcValue.value);
                 
@@ -541,7 +541,7 @@ public class DescribeStep extends AbstractSubmissionStep
          * @param dcValues
          *                      The field's pre-existing values.
          */
-        private void renderDateField(List form, String fieldName, DCInput dcInput, DCValue[] dcValues, boolean readonly) throws WingException
+        private void renderDateField(List form, String fieldName, DCInput dcInput, Metadatum[] dcValues, boolean readonly) throws WingException
         {
                 // The date field consists of three primitive fields: a text field
                 // for the year, followed by a select box of the months, follewed
@@ -604,7 +604,7 @@ public class DescribeStep extends AbstractSubmissionStep
                 // Setup the field's values
                 if (dcInput.isRepeatable() || dcValues.length > 1)
                 {
-                        for (DCValue dcValue : dcValues)
+                        for (Metadatum dcValue : dcValues)
                         {
                                 DCDate dcDate = new DCDate(dcValue.value);
 
@@ -651,7 +651,7 @@ public class DescribeStep extends AbstractSubmissionStep
          * @param dcValues
          *                      The field's pre-existing values.
          */
-        private void renderSeriesField(List form, String fieldName, DCInput dcInput, DCValue[] dcValues, boolean readonly) throws WingException
+        private void renderSeriesField(List form, String fieldName, DCInput dcInput, Metadatum[] dcValues, boolean readonly) throws WingException
         {
                 // The series field consists of two parts, a series name (text field)
                 // and report or paper number (also a text field).
@@ -699,7 +699,7 @@ public class DescribeStep extends AbstractSubmissionStep
                 // Setup the field's values
                 if (dcInput.isRepeatable() || dcValues.length > 1)
                 {
-                        for (DCValue dcValue : dcValues)
+                        for (Metadatum dcValue : dcValues)
                         {
                                 DCSeriesNumber dcSeriesNumber = new DCSeriesNumber(dcValue.value);
 
@@ -734,7 +734,7 @@ public class DescribeStep extends AbstractSubmissionStep
          * @param dcValues
          *                      The field's pre-existing values.
          */
-        private void renderQualdropField(List form, String fieldName, DCInput dcInput, DCValue[] dcValues, boolean readonly) throws WingException
+        private void renderQualdropField(List form, String fieldName, DCInput dcInput, Metadatum[] dcValues, boolean readonly) throws WingException
         {
                 Composite qualdrop = form.addItem().addComposite(fieldName,"submit-qualdrop");
                 Select qual = qualdrop.addSelect(fieldName+"_qualifier");
@@ -788,7 +788,7 @@ public class DescribeStep extends AbstractSubmissionStep
                 // Setup the field's values
                 if (dcInput.isRepeatable() || dcValues.length > 1)
                 {
-                        for (DCValue dcValue : dcValues)
+                        for (Metadatum dcValue : dcValues)
                         {
                                 qual.addInstance().setOptionSelected(dcValue.qualifier);
                                 value.addInstance().setValue(dcValue.value);
@@ -815,7 +815,7 @@ public class DescribeStep extends AbstractSubmissionStep
          * @param dcValues
          *                      The field's pre-existing values.
          */
-        private void renderTextArea(List form, String fieldName, DCInput dcInput, DCValue[] dcValues, boolean readonly) throws WingException
+        private void renderTextArea(List form, String fieldName, DCInput dcInput, Metadatum[] dcValues, boolean readonly) throws WingException
         {
                 // Plain old Textarea
                 TextArea textArea = form.addItem().addTextArea(fieldName,"submit-textarea");
@@ -868,7 +868,7 @@ public class DescribeStep extends AbstractSubmissionStep
                 // Setup the field's values
                 if (dcInput.isRepeatable() || dcValues.length > 1)
                 {
-                        for (DCValue dcValue : dcValues)
+                        for (Metadatum dcValue : dcValues)
                         {
                                 Instance ti = textArea.addInstance();
                                 ti.setValue(dcValue.value);
@@ -916,7 +916,7 @@ public class DescribeStep extends AbstractSubmissionStep
          * @param dcValues
          *                      The field's pre-existing values.
          */
-        private void renderChoiceSelectField(List form, String fieldName, Collection coll, DCInput dcInput, DCValue[] dcValues, boolean readonly) throws WingException
+        private void renderChoiceSelectField(List form, String fieldName, Collection coll, DCInput dcInput, Metadatum[] dcValues, boolean readonly) throws WingException
         {
                 String fieldKey = MetadataAuthorityManager.makeFieldKey(dcInput.getSchema(), dcInput.getElement(), dcInput.getQualifier());
                 if (MetadataAuthorityManager.getManager().isAuthorityControlled(fieldKey))
@@ -973,7 +973,7 @@ public class DescribeStep extends AbstractSubmissionStep
                 }
 
                 // Setup the field's pre-selected values
-                for (DCValue dcValue : dcValues)
+                for (Metadatum dcValue : dcValues)
                 {
                         select.setOptionSelected(dcValue.value);
                 }
@@ -992,7 +992,7 @@ public class DescribeStep extends AbstractSubmissionStep
          * @param dcValues
          *                      The field's pre-existing values.
          */
-        private void renderDropdownField(List form, String fieldName, DCInput dcInput, DCValue[] dcValues, boolean readonly) throws WingException
+        private void renderDropdownField(List form, String fieldName, DCInput dcInput, Metadatum[] dcValues, boolean readonly) throws WingException
         {
                 // Plain old select list.
                 Select select = form.addItem().addSelect(fieldName,"submit-select");
@@ -1039,7 +1039,7 @@ public class DescribeStep extends AbstractSubmissionStep
                 }
                 
                 // Setup the field's pre-selected values
-                for (DCValue dcValue : dcValues)
+                for (Metadatum dcValue : dcValues)
                 {
                         select.setOptionSelected(dcValue.value);
                 }
@@ -1063,7 +1063,7 @@ public class DescribeStep extends AbstractSubmissionStep
          * @param dcValues
          *                      The field's pre-existing values.
          */
-        private void renderSelectFromListField(List form, String fieldName, DCInput dcInput, DCValue[] dcValues, boolean readonly) throws WingException
+        private void renderSelectFromListField(List form, String fieldName, DCInput dcInput, Metadatum[] dcValues, boolean readonly) throws WingException
         {
                 Field listField = null;
                 
@@ -1120,7 +1120,7 @@ public class DescribeStep extends AbstractSubmissionStep
                 }
                 
                 // Setup the field's pre-selected values
-                for (DCValue dcValue : dcValues)
+                for (Metadatum dcValue : dcValues)
                 {
                         if(listField instanceof CheckBox)
                         {
@@ -1145,7 +1145,7 @@ public class DescribeStep extends AbstractSubmissionStep
          * @param dcValues
          *                      The field's pre-existing values.
          */
-        private void renderOneboxField(List form, String fieldName, DCInput dcInput, DCValue[] dcValues, boolean readonly) throws WingException
+        private void renderOneboxField(List form, String fieldName, DCInput dcInput, Metadatum[] dcValues, boolean readonly) throws WingException
         {
                 // Both onebox and twobox consist a free form text field
                 // that the user may enter any value. The difference between
@@ -1213,7 +1213,7 @@ public class DescribeStep extends AbstractSubmissionStep
                 // Setup the field's values
                 if (dcInput.isRepeatable() || dcValues.length > 1)
                 {
-                        for (DCValue dcValue : dcValues)
+                        for (Metadatum dcValue : dcValues)
                         {
                                 Instance ti = text.addInstance();
                                 ti.setValue(dcValue.value);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/InitialQuestionsStep.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/InitialQuestionsStep.java
@@ -20,7 +20,7 @@ import org.dspace.app.xmlui.wing.element.Division;
 import org.dspace.app.xmlui.wing.element.List;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Collection;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.xml.sax.SAXException;
 
@@ -93,11 +93,11 @@ public class InitialQuestionsStep extends AbstractSubmissionStep
 		Collection collection = submission.getCollection();
 		String actionURL = contextPath + "/handle/"+collection.getHandle() + "/submit/" + knot.getId() + ".continue";
 
-		DCValue[] titles = item.getDC("title", "alternative", Item.ANY);
+		Metadatum[] titles = item.getDC("title", "alternative", Item.ANY);
 		
-		DCValue[] dateIssued = item.getDC("date", "issued", Item.ANY);
-        DCValue[] citation = item.getDC("identifier", "citation", Item.ANY);
-        DCValue[] publisher = item.getDC("publisher", null, Item.ANY);
+		Metadatum[] dateIssued = item.getDC("date", "issued", Item.ANY);
+        Metadatum[] citation = item.getDC("identifier", "citation", Item.ANY);
+        Metadatum[] publisher = item.getDC("publisher", null, Item.ANY);
     	
     	
         // Generate a from asking the user two questions: multiple 

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/versioning/DeleteVersionsConfirm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/versioning/DeleteVersionsConfirm.java
@@ -14,7 +14,7 @@ import org.dspace.app.xmlui.wing.WingException;
 import org.dspace.app.xmlui.wing.element.*;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.DCDate;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.MetadataSchema;
 import org.dspace.eperson.EPerson;
 import org.dspace.utils.DSpace;
@@ -126,7 +126,7 @@ public class DeleteVersionsConfirm extends AbstractDSpaceTransformer {
     private void addItemIdentifier(Cell cell, org.dspace.content.Item item) throws WingException {
         String itemHandle = item.getHandle();
 
-        DCValue[] identifiers = item.getMetadata(MetadataSchema.DC_SCHEMA, "identifier", null, org.dspace.content.Item.ANY);
+        Metadatum[] identifiers = item.getMetadata(MetadataSchema.DC_SCHEMA, "identifier", null, org.dspace.content.Item.ANY);
         String itemIdentifier=null;
         if(identifiers!=null && identifiers.length > 0)
         {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/versioning/VersionHistoryForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/versioning/VersionHistoryForm.java
@@ -202,7 +202,7 @@ public class VersionHistoryForm extends AbstractDSpaceTransformer {
     {
         String itemHandle = version.getItem().getHandle();
 
-        DCValue[] identifiers = version.getItem().getMetadata(MetadataSchema.DC_SCHEMA, "identifier", null, Item.ANY);
+        Metadatum[] identifiers = version.getItem().getMetadata(MetadataSchema.DC_SCHEMA, "identifier", null, Item.ANY);
         String itemIdentifier=null;
         if(identifiers!=null && identifiers.length > 0)
         {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/workflow/Submissions.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/workflow/Submissions.java
@@ -175,7 +175,7 @@ public class Submissions extends AbstractDSpaceTransformer
         		int workflowItemID = owned.getID();
         		String collectionUrl = contextPath + "/handle/" + owned.getCollection().getHandle();
         		String ownedWorkflowItemUrl = contextPath + "/handle/" + owned.getCollection().getHandle() + "/workflow?workflowID=" + workflowItemID;
-        		DCValue[] titles = owned.getItem().getDC("title", null, Item.ANY);
+        		Metadatum[] titles = owned.getItem().getDC("title", null, Item.ANY);
         		String collectionName = owned.getCollection().getMetadata("name");
         		EPerson submitter = owned.getSubmitter();
         		String submitterName = submitter.getFullName();
@@ -248,7 +248,7 @@ public class Submissions extends AbstractDSpaceTransformer
         		int workflowItemID = pooled.getID();
         		String collectionUrl = contextPath + "/handle/" + pooled.getCollection().getHandle();
         		String pooledItemUrl = contextPath + "/handle/" + pooled.getCollection().getHandle() + "/workflow?workflowID=" + workflowItemID;
-        		DCValue[] titles = pooled.getItem().getDC("title", null, Item.ANY);
+        		Metadatum[] titles = pooled.getItem().getDC("title", null, Item.ANY);
         		String collectionName = pooled.getCollection().getMetadata("name");
         		EPerson submitter = pooled.getSubmitter();
         		String submitterName = submitter.getFullName();
@@ -347,7 +347,7 @@ public class Submissions extends AbstractDSpaceTransformer
 
         for (WorkflowItem workflowItem : inprogressItems)
         {
-        	DCValue[] titles = workflowItem.getItem().getDC("title", null, Item.ANY);
+        	Metadatum[] titles = workflowItem.getItem().getDC("title", null, Item.ANY);
         	String collectionName = workflowItem.getCollection().getMetadata("name");
         	Message state = getWorkflowStateMessage(workflowItem);
 

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/xmlworkflow/Submissions.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/xmlworkflow/Submissions.java
@@ -173,7 +173,7 @@ public class Submissions extends AbstractDSpaceTransformer
                     Step step = wf.getStep(stepID);
                     WorkflowActionConfig action = step.getActionConfig(actionID);
                     String url = contextPath+"/handle/"+item.getCollection().getHandle()+"/xmlworkflow?workflowID="+workflowItemID+"&stepID="+stepID+"&actionID="+actionID;
-                    DCValue[] titles = item.getItem().getDC("title", null, Item.ANY);
+                    Metadatum[] titles = item.getItem().getDC("title", null, Item.ANY);
                     String collectionName = item.getCollection().getMetadata("name");
                     EPerson submitter = item.getSubmitter();
                     String submitterName = submitter.getFullName();
@@ -266,7 +266,7 @@ public class Submissions extends AbstractDSpaceTransformer
                     item = XmlWorkflowItem.find(context, workflowItemID);
                     Workflow wf = WorkflowFactory.getWorkflow(item.getCollection());
                     String url = contextPath+"/handle/"+item.getCollection().getHandle()+"/xmlworkflow?workflowID="+workflowItemID+"&stepID="+stepID+"&actionID="+actionID;
-                    DCValue[] titles = item.getItem().getDC("title", null, Item.ANY);
+                    Metadatum[] titles = item.getItem().getDC("title", null, Item.ANY);
                     String collectionName = item.getCollection().getMetadata("name");
                     EPerson submitter = item.getSubmitter();
                     String submitterName = submitter.getFullName();
@@ -369,7 +369,7 @@ public class Submissions extends AbstractDSpaceTransformer
 
             for (XmlWorkflowItem workflowItem : inprogressItems)
             {
-                DCValue[] titles = workflowItem.getItem().getDC("title", null, Item.ANY);
+                Metadatum[] titles = workflowItem.getItem().getDC("title", null, Item.ANY);
                 String collectionName = workflowItem.getCollection().getMetadata("name");
                 java.util.List<PoolTask> pooltasks = PoolTask.find(context,workflowItem);
                 java.util.List<ClaimedTask> claimedtasks = ClaimedTask.find(context, workflowItem);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/ItemAdapter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/ItemAdapter.java
@@ -16,7 +16,7 @@ import org.dspace.authorize.AuthorizeManager;
 import org.dspace.content.Bitstream;
 import org.dspace.content.BitstreamFormat;
 import org.dspace.content.Bundle;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
 import org.dspace.content.authority.Choices;
 import org.dspace.content.crosswalk.CrosswalkException;
@@ -264,8 +264,8 @@ public class ItemAdapter extends AbstractAdapter
             }
             startElement(DIM,"dim",attributes);
                         
-                DCValue[] dcvs = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
-                for (DCValue dcv : dcvs)
+                Metadatum[] dcvs = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+                for (Metadatum dcv : dcvs)
                 {
                         if (!MetadataExposure.isHidden(context, dcv.schema, dcv.element, dcv.qualifier))
                         {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/DSpaceValidity.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/DSpaceValidity.java
@@ -17,7 +17,7 @@ import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.eperson.EPerson;
@@ -276,8 +276,8 @@ public class DSpaceValidity implements SourceValidity
             validityKey.append(item.getOwningCollection());
             validityKey.append(item.getLastModified());
             // Include all metadata values in the validity key.
-            DCValue[] dcvs = item.getDC(Item.ANY,Item.ANY,Item.ANY);
-            for (DCValue dcv : dcvs)
+            Metadatum[] dcvs = item.getDC(Item.ANY,Item.ANY,Item.ANY);
+            for (Metadatum dcv : dcvs)
             {
                 validityKey.append(dcv.schema).append(".");
                 validityKey.append(dcv.element).append(".");
@@ -298,8 +298,8 @@ public class DSpaceValidity implements SourceValidity
         	
         	validityKey.append("BrowseItem:");
         	validityKey.append(browseItem.getHandle());
-        	DCValue[] dcvs = browseItem.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
-            for (DCValue dcv : dcvs)
+        	Metadatum[] dcvs = browseItem.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+            for (Metadatum dcv : dcvs)
             {
                 validityKey.append(dcv.schema).append(".");
                 validityKey.append(dcv.element).append(".");

--- a/dspace-xmlui/src/main/java/org/dspace/springmvc/BibTexView.java
+++ b/dspace-xmlui/src/main/java/org/dspace/springmvc/BibTexView.java
@@ -8,7 +8,7 @@
 package org.dspace.springmvc;
 
 
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
@@ -131,7 +131,7 @@ public class BibTexView implements View {
 
     private String getMetadataValue(Item item, String metadatafield)
     {
-        for (DCValue value : item.getMetadataByMetadataString(metadatafield))
+        for (Metadatum value : item.getMetadataByMetadataString(metadatafield))
         {
             return value.value;
         }
@@ -152,7 +152,7 @@ public class BibTexView implements View {
 
     private String getYear(Item aItem)
     {
-        for (DCValue date : aItem.getMetadataByMetadataString("dc.date.issued"))
+        for (Metadatum date : aItem.getMetadataByMetadataString("dc.date.issued"))
         {
             return date.value.substring(0, 4);
         }
@@ -160,12 +160,12 @@ public class BibTexView implements View {
         return null;
     }
 
-    private List<String> getAuthors(DCValue[] aMetadata)
+    private List<String> getAuthors(Metadatum[] aMetadata)
     {
         ArrayList<String> authors = new ArrayList<String>();
         StringTokenizer tokenizer;
 
-        for (DCValue metadata : aMetadata)
+        for (Metadatum metadata : aMetadata)
         {
             StringBuilder builder = new StringBuilder();
 

--- a/dspace-xmlui/src/main/java/org/dspace/springmvc/RisView.java
+++ b/dspace-xmlui/src/main/java/org/dspace/springmvc/RisView.java
@@ -9,7 +9,7 @@
 package org.dspace.springmvc;
 
 
-import org.dspace.content.DCValue;
+import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
@@ -166,7 +166,7 @@ public class RisView implements View {
     {
         ArrayList<String> keywordList = new ArrayList<String>();
 
-        for (DCValue keyword : aItem.getMetadataByMetadataString("dc.subject"))
+        for (Metadatum keyword : aItem.getMetadataByMetadataString("dc.subject"))
         {
             if (keyword.value.length() < 255)
             {
@@ -174,7 +174,7 @@ public class RisView implements View {
             }
         }
 
-        for (DCValue keyword : aItem.getMetadataByMetadataString("dwc.ScientificName"))
+        for (Metadatum keyword : aItem.getMetadataByMetadataString("dwc.ScientificName"))
         {
             if (keyword.value.length() < 255)
             {
@@ -189,7 +189,7 @@ public class RisView implements View {
     {
         StringTokenizer tokenizer;
 
-        for (DCValue date : item.getMetadataByMetadataString("dc.date.issued"))
+        for (Metadatum date : item.getMetadataByMetadataString("dc.date.issued"))
         {
             tokenizer = new StringTokenizer(date.value, "-/ T");
             String[] dateParts = new String[tokenizer.countTokens()];
@@ -207,19 +207,19 @@ public class RisView implements View {
 
     private String getMetadataValue(Item item, String metadatafield)
     {
-        for (DCValue value : item.getMetadataByMetadataString(metadatafield))
+        for (Metadatum value : item.getMetadataByMetadataString(metadatafield))
         {
             return value.value;
         }
         return null;
     }
 
-    private List<String> getAuthors(DCValue[] aMetadata)
+    private List<String> getAuthors(Metadatum[] aMetadata)
     {
         ArrayList<String> authors = new ArrayList<String>();
         StringTokenizer tokenizer;
 
-        for (DCValue metadata : aMetadata)
+        for (Metadatum metadata : aMetadata)
         {
             StringBuilder builder = new StringBuilder();
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-1883

Un-deprecate DCValue and rename it.  It seems that the reason for deprecation was objection to the _name_, since it is not strictly for DC anymore.
