### PR TITLE
DS-2174 Metadata Export to CSV, fix bug with empty language []

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSV.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSV.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.app.bulkedit;
 
+import org.apache.commons.lang.StringUtils;
 import org.dspace.content.*;
 import org.dspace.content.Collection;
 import org.dspace.core.ConfigurationManager;
@@ -423,8 +424,7 @@ public class DSpaceCSV implements Serializable
             }
 
             // Add the language if there is one (schema.element.qualifier[langauge])
-            //if ((value.language != null) && (!"".equals(value.language)))
-            if (value.language != null)
+            if (StringUtils.isNotBlank(value.language))
             {
                 key = key + "[" + value.language + "]";
             }


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2174

Change MetadataExport to not spit out columns such as dc.date.submitted[], instead you will just get dc.date.submitted

I found what I believe is a bug, where if a metadata field had a non-null language value, such as empty string, it would add [] to the metadata field. Sometimes you get [], other times you don't.
