### PR TITLE
DS-2180 Fix sorting by date accessioned in xmlui My Archived Submissions

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/Item.java
+++ b/dspace-api/src/main/java/org/dspace/content/Item.java
@@ -254,23 +254,14 @@ public class Item extends DSpaceObject
      */
     public static ItemIterator findBySubmitterDateSorted(Context context, EPerson eperson, Integer limit) throws SQLException
     {
-        String querySorted =    "SELECT \n" +
-                "  item.item_id, \n" +
-                "  item.submitter_id, \n" +
-                "  item.in_archive, \n" +
-                "  item.withdrawn, \n" +
-                "  item.owning_collection, \n" +
-                "  item.last_modified, \n" +
-                "  metadatavalue.text_value\n" +
-                "FROM \n" +
-                "  public.item, \n" +
-                "  public.metadatafieldregistry, \n" +
-                "  public.metadatavalue\n" +
-                "WHERE \n" +
-                "  metadatafieldregistry.metadata_field_id = metadatavalue.metadata_field_id AND\n" +
-                "  metadatavalue.item_id = item.item_id AND\n" +
-                "  metadatafieldregistry.element = 'date' AND \n" +
-                "  metadatafieldregistry.qualifier = 'accessioned' AND \n" +
+        String querySorted =    "SELECT item.item_id, item.submitter_id, item.in_archive, item.withdrawn, " +
+                "item.owning_collection, item.last_modified, metadatavalue.text_value " +
+                "FROM item, metadatafieldregistry, metadatavalue " +
+                "WHERE metadatafieldregistry.metadata_field_id = metadatavalue.metadata_field_id AND " +
+                "  metadatavalue.resource_id = item.item_id AND " +
+                "  metadatavalue.resource_type_id = ? AND " +
+                "  metadatafieldregistry.element = 'date' AND " +
+                "  metadatafieldregistry.qualifier = 'accessioned' AND " +
                 "  item.submitter_id = ? AND \n" +
                 "  item.in_archive = true\n" +
                 "ORDER BY\n" +
@@ -280,10 +271,10 @@ public class Item extends DSpaceObject
 
         if(limit != null && limit > 0) {
             querySorted += " limit ? ;";
-            rows = DatabaseManager.query(context, querySorted, eperson.getID(), limit);
+            rows = DatabaseManager.query(context, querySorted, Constants.ITEM, eperson.getID(), limit);
         } else {
             querySorted += ";";
-            rows = DatabaseManager.query(context, querySorted, eperson.getID());
+            rows = DatabaseManager.query(context, querySorted, Constants.ITEM, eperson.getID());
         }
 
         return new ItemIterator(context, rows);

--- a/dspace-api/src/main/java/org/dspace/content/Item.java
+++ b/dspace-api/src/main/java/org/dspace/content/Item.java
@@ -245,6 +245,52 @@ public class Item extends DSpaceObject
     }
 
     /**
+     * Retrieve the list of Items submitted by eperson, ordered by recently submitted, optionally limitable
+     * @param context
+     * @param eperson
+     * @param limit a positive integer to limit, -1 or null for unlimited
+     * @return
+     * @throws SQLException
+     */
+    public static ItemIterator findBySubmitterDateSorted(Context context, EPerson eperson, Integer limit) throws SQLException
+    {
+        String querySorted =    "SELECT \n" +
+                "  item.item_id, \n" +
+                "  item.submitter_id, \n" +
+                "  item.in_archive, \n" +
+                "  item.withdrawn, \n" +
+                "  item.owning_collection, \n" +
+                "  item.last_modified, \n" +
+                "  metadatavalue.text_value\n" +
+                "FROM \n" +
+                "  public.item, \n" +
+                "  public.metadatafieldregistry, \n" +
+                "  public.metadatavalue\n" +
+                "WHERE \n" +
+                "  metadatafieldregistry.metadata_field_id = metadatavalue.metadata_field_id AND\n" +
+                "  metadatavalue.item_id = item.item_id AND\n" +
+                "  metadatafieldregistry.element = 'date' AND \n" +
+                "  metadatafieldregistry.qualifier = 'accessioned' AND \n" +
+                "  item.submitter_id = ? AND \n" +
+                "  item.in_archive = true\n" +
+                "ORDER BY\n" +
+                "  metadatavalue.text_value desc";
+
+        TableRowIterator rows;
+
+        if(limit != null && limit > 0) {
+            querySorted += " limit ? ;";
+            rows = DatabaseManager.query(context, querySorted, eperson.getID(), limit);
+        } else {
+            querySorted += ";";
+            rows = DatabaseManager.query(context, querySorted, eperson.getID());
+        }
+
+        return new ItemIterator(context, rows);
+
+    }
+
+    /**
      * Get the internal ID of this item. In general, this shouldn't be exposed
      * to users
      *

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/Submissions.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/Submissions.java
@@ -334,7 +334,16 @@ public class Submissions extends AbstractDSpaceTransformer
     {
         // Turn the iterator into a list (to get size info, in order to put in a table)
         List subList = new LinkedList();
-        ItemIterator subs = Item.findBySubmitter(context, context.getCurrentUser());
+
+        Integer limit;
+
+        if(displayAll) {
+            limit = -1;
+        } else {
+            //Set a default limit of 50
+            limit = 50;
+        }
+        ItemIterator subs = Item.findBySubmitterDateSorted(context, context.getCurrentUser(), limit);
 
         //NOTE: notice we are adding each item to this list in *reverse* order...
         // this is a very basic attempt at making more recent submissions float 
@@ -344,7 +353,7 @@ public class Submissions extends AbstractDSpaceTransformer
         {
             while (subs.hasNext())
             {
-                subList.add(0, subs.next());
+                subList.add(subs.next());
             }
         }
         finally
@@ -371,7 +380,6 @@ public class Submissions extends AbstractDSpaceTransformer
         //Limit to showing just 50 archived submissions, unless overridden
         //(This is a saftey measure for Admins who may have submitted 
         // thousands of items under their account via bulk ingest tools, etc.)
-        int limit = 50;
         int count = 0;
 
         // Populate table
@@ -420,7 +428,7 @@ public class Submissions extends AbstractDSpaceTransformer
         }//end while
 
         //Display limit text & link to allow user to override this default limit
-        if(!displayAll && count>limit)
+        if(!displayAll && count == limit)
         {
             Para limitedList = completedSubmissions.addPara();
             limitedList.addContent(T_c_limit);


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2180 - My Archived Submissions in XMLUI not actually sorting by date

This work was sponsored by [The Ohio State University Libraries](http://library.osu.edu/)
![osu-universitylibraries](https://cloud.githubusercontent.com/assets/58014/4421119/ca6f5c9a-4580-11e4-92b9-88c48fe0550e.png)

The My Archived Submissions in XMLUI was not really being sorted properly. It was doing something where it would add entries to an array, the approach I'm taking is to just use the DB to sort the item's this user has submitted by date accessioned.
