### PR TITLE
DS-635 Render scientific formulas in XMLUI using MathJax

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/core/page-structure.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/core/page-structure.xsl
@@ -295,6 +295,33 @@
                 <meta name="{@element}" content="{.}"></meta>
             </xsl:for-each>
 
+            <!-- Add MathJAX CDN to render scientific formulas -->
+            <xsl:if test="confman:getProperty('webui.browse.render-scientific-formulas') = 'true'">
+                <script type="text/x-mathjax-config">
+                    MathJax.Hub.Config({
+                    tex2jax: {
+                    inlineMath: [['$','$'], ['\\(','\\)']],
+                    ignoreClass: "detail-field-data|detailtable"
+                    },
+                    TeX: {
+                    Macros: {
+                    AA: '{\\mathring A}'
+                    }
+                    }
+                    });
+                </script>
+
+                <xsl:choose>
+
+                    <xsl:when test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='scheme']='https'">
+                        <script type="text/javascript" src="https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">&#160;</script>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">&#160;</script>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:if>
+
         </head>
     </xsl:template>
 

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
@@ -311,6 +311,33 @@
                 <meta name="{@element}" content="{.}"></meta>
             </xsl:for-each>
 
+            <!-- Add MathJAX CDN, can do a local install, or possibly get SSL enabled-->
+            <xsl:if test="confman:getProperty('webui.browse.render-scientific-formulas') = 'true'">
+                <script type="text/x-mathjax-config">
+                    MathJax.Hub.Config({
+                    tex2jax: {
+                    inlineMath: [['$','$'], ['\\(','\\)']],
+                    ignoreClass: "detail-field-data|detailtable"
+                    },
+                    TeX: {
+                    Macros: {
+                    AA: '{\\mathring A}'
+                    }
+                    }
+                    });
+                </script>
+
+                <xsl:choose>
+
+                    <xsl:when test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='scheme']='https'">
+                        <script type="text/javascript" src="https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">&#160;</script>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">&#160;</script>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:if>
+
         </head>
     </xsl:template>
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1226,6 +1226,10 @@ plugin.named.org.dspace.sort.OrderFormatDelegate= \
 #
 webui.browse.link.1 = author:dc.contributor.*
 
+### Render scientific formulas symbols in view/browse
+# Use MathJax to render properly encoded text formulas to be visual for people
+#webui.browse.render-scientific-formulas = true
+
 #### Display browse frequencies
 #
 # webui.browse.metadata.show-freq.<n> = true | false


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-635 - Rendering MathML code in abstracts

Include MathJax Javascript to render scientific formulas, that are wrapped in dollar signs, to display in human readable format.

This work was sponsored by [The Ohio State University Libraries](http://library.osu.edu/)
![osu-universitylibraries](https://cloud.githubusercontent.com/assets/58014/4421119/ca6f5c9a-4580-11e4-92b9-88c48fe0550e.png)

The raw formula for the title is: 
`THE $1 ^{1}B^{+}_{u} \leftarrow 1 ^{1}A^{-}_{g}$ ABSORPTION OF JET-COOLED TRANS,TRANS-1,3,5,7-OCTATETRAENE`
An example of what this looks like is below.

![screen shot 2014-10-05 at 11 36 41 am](https://cloud.githubusercontent.com/assets/58014/4518904/710a53d6-4ca5-11e4-8419-44909e4e36e1.png)

The MathJax renders on browse lists, and item view, but not for the show-full-metadata page. It is assumed that on the full metadata view, a user should be able to access the "raw" text, not get rendered symbols from MathJax.
