### PR TITLE
[DS-2184] RSS section header style doesn't match the rest in Mirage 2

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/core/navigation.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/core/navigation.xsl
@@ -126,9 +126,9 @@
             <!-- DS-984 Add RSS Links to Options Box -->
             <xsl:if test="count(/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='feed']) != 0">
                 <div>
-                    <h6 class="ds-option-set-head">
+                    <h2 class="ds-option-set-head h6">
                         <i18n:text>xmlui.feed.header</i18n:text>
-                    </h6>
+                    </h2>
                     <div id="ds-feed-option" class="ds-option-set list-group">
                         <xsl:call-template name="addRSSLinks"/>
                     </div>


### PR DESCRIPTION
Fixes https://jira.duraspace.org/browse/DS-2184
