### PR TITLE
Mirage2 - fixed bug where clicking on a + or - in community-list made the browser jump to top of page

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/community-list.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/community-list.xsl
@@ -108,7 +108,7 @@
 
     <xsl:template match="dri:field[@rend = 'community-browser-toggle-button']">
         <p class="toggler-wrap">
-            <a class="btn btn-default btn-sm toggler collapsed" href="#" role="button"  data-target="{@value}">
+            <a class="btn btn-default btn-sm toggler collapsed" href="javascript:void(0)" role="button"  data-target="{@value}">
                 <i class="glyphicon glyphicon-minus open-icon hidden" aria-hidden="true"/>
                 <i class="glyphicon glyphicon-plus closed-icon" aria-hidden="true"/>
             </a>


### PR DESCRIPTION
Having a DSpace with lots of communities and/or collections makes you have to scroll down to go to the bottom of the list. If you click on a + or - for a collection or community at the bottom of the page, it will make the browser jump up to the top of the page because of href="#".

Changing it to a href="javascript:void(0)" fixes this issue without affecting functionality.
