### PR TITLE
DS-2172 Mirage 2: grunt-contrib-handlebars set to latest version

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/package.json
+++ b/dspace-xmlui-mirage2/src/main/webapp/package.json
@@ -10,7 +10,7 @@
     "load-grunt-tasks": "~0.1.0",
     "time-grunt": "~0.1.1",
     "grunt-contrib-coffee": "~0.7.0",
-    "grunt-contrib-handlebars": "~0.5.12",
+    "grunt-contrib-handlebars": "latest",
     "grunt-usemin": "~2.1.0",
     "grunt-contrib-uglify": "~0.4.0",
     "grunt-contrib-concat": "~0.3.0",


### PR DESCRIPTION
Changed the grunt-contrib-handlebars version to 'latest'. This will use grunt-contrib-handlebars version 0.9.0 which is able to compile handlebars version 2.0.0. 

https://jira.duraspace.org/browse/DS-2172
