### PR TITLE
[Ds-2099] Request correction

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -102,6 +102,9 @@ mail.feedback.recipient = dspace-help@myu.edu
 # General site administration (Webmaster) e-mail
 mail.admin = dspace-help@myu.edu
 
+# Adress for Request correction emails
+mail.requestCorrection.recipient = dspace-help@myu.edu
+
 # Recipient for server errors and alerts
 #mail.alert.recipient = email-address-here
 mail.alert.recipient=

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/RequestCorrectionForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/RequestCorrectionForm.java
@@ -1,0 +1,119 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.xmlui.aspect.artifactbrowser;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.sql.SQLException;
+
+import org.apache.cocoon.caching.CacheableProcessingComponent;
+import org.apache.cocoon.util.HashUtil;
+import org.apache.excalibur.source.SourceValidity;
+import org.apache.excalibur.source.impl.validity.NOPValidity;
+import org.dspace.app.xmlui.cocoon.AbstractDSpaceTransformer;
+import org.dspace.app.xmlui.utils.UIException;
+import org.dspace.app.xmlui.wing.Message;
+import org.dspace.app.xmlui.wing.WingException;
+import org.dspace.app.xmlui.wing.element.Body;
+import org.dspace.app.xmlui.wing.element.Division;
+import org.dspace.app.xmlui.wing.element.List;
+import org.dspace.app.xmlui.wing.element.PageMeta;
+import org.dspace.app.xmlui.wing.element.TextArea;
+import org.dspace.authorize.AuthorizeException;
+import org.xml.sax.SAXException;
+
+/**
+ * Display to the user a simple form letting the user give an item error report.
+ * 
+ * @author Scott Phillips
+ * @author AdÃ¡n RomÃ¡n Ruiz at arvo.es
+ */
+public class RequestCorrectionForm extends AbstractDSpaceTransformer implements CacheableProcessingComponent
+{
+    /** Language Strings */
+    private static final Message T_title =
+        message("xmlui.ArtifactBrowser.RequestCorrectionForm.title");
+    
+    private static final Message T_dspace_home =
+        message("xmlui.general.dspace_home");
+    
+    private static final Message T_trail =
+        message("xmlui.ArtifactBrowser.RequestCorrectionForm.trail");
+    
+    private static final Message T_head = 
+        message("xmlui.ArtifactBrowser.RequestCorrectionForm.head");
+    
+    private static final Message T_para1 =
+        message("xmlui.ArtifactBrowser.RequestCorrectionForm.para1");
+    
+    private static final Message T_email =
+        message("xmlui.ArtifactBrowser.RequestCorrectionForm.email");
+
+    private static final Message T_email_help =
+        message("xmlui.ArtifactBrowser.RequestCorrectionForm.email_help");
+    
+    private static final Message T_comments = 
+        message("xmlui.ArtifactBrowser.RequestCorrectionForm.comments");
+    
+    private static final Message T_submit =
+        message("xmlui.ArtifactBrowser.RequestCorrectionForm.submit");
+    
+    /**
+     * Generate the unique caching key.
+     * This key must be unique inside the space of this component.
+     */
+    public Serializable getKey() {
+        
+        String comments = parameters.getParameter("comments","");
+        String page = parameters.getParameter("page","unknown");
+        String handle = parameters.getParameter("handle","unknown");
+        
+       return HashUtil.hash(/*email + "-" + */comments + "-" + page + "-" + handle);
+    }
+
+    /**
+     * Generate the cache validity object.
+     */
+    public SourceValidity getValidity() 
+    {
+        return NOPValidity.SHARED_INSTANCE;
+    }
+    
+    
+    public void addPageMeta(PageMeta pageMeta) throws SAXException,
+            WingException, UIException, SQLException, IOException,
+            AuthorizeException
+    {       
+        pageMeta.addMetadata("title").addContent(T_title);
+ 
+        pageMeta.addTrailLink(contextPath + "/",T_dspace_home);
+        pageMeta.addTrail().addContent(T_trail);
+    }
+
+    public void addBody(Body body) throws SAXException, WingException,
+            UIException, SQLException, IOException, AuthorizeException
+    {
+        // Build the item viewer division.
+        Division feedback = body.addInteractiveDivision("RequestCorrection-form",
+                contextPath+"/requestCorrection/"+parameters.getParameter("handle","unknown"),Division.METHOD_POST,"primary");
+        
+        feedback.setHead(T_head);
+        
+        feedback.addPara(T_para1.parameterize(parameters.getParameter("handle","unknown")));
+        
+        List form = feedback.addList("form",List.TYPE_FORM);
+               
+        TextArea comments = form.addItem().addTextArea("comments");
+        comments.setLabel(T_comments);
+        comments.setValue(parameters.getParameter("comments",""));
+        
+        form.addItem().addButton("submit").setValue(T_submit);
+        
+        feedback.addHidden("page").setValue(parameters.getParameter("page","unknown"));
+    }
+}

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/RequestCorrectionSent.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/RequestCorrectionSent.java
@@ -1,0 +1,90 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.xmlui.aspect.artifactbrowser;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.sql.SQLException;
+
+import org.apache.cocoon.caching.CacheableProcessingComponent;
+import org.apache.excalibur.source.SourceValidity;
+import org.apache.excalibur.source.impl.validity.NOPValidity;
+import org.dspace.app.xmlui.cocoon.AbstractDSpaceTransformer;
+import org.dspace.app.xmlui.utils.UIException;
+import org.dspace.app.xmlui.wing.Message;
+import org.dspace.app.xmlui.wing.WingException;
+import org.dspace.app.xmlui.wing.element.Body;
+import org.dspace.app.xmlui.wing.element.Division;
+import org.dspace.app.xmlui.wing.element.PageMeta;
+import org.dspace.authorize.AuthorizeException;
+import org.xml.sax.SAXException;
+
+/**
+ * Simple page to let the user know their error report has been sent.
+ * 
+ * @author Scott Phillips
+ * @author AdÃ¡n RomÃ¡n Ruiz at arvo.es
+ */
+public class RequestCorrectionSent extends AbstractDSpaceTransformer implements CacheableProcessingComponent
+{
+    /** language strings */
+    public static final Message T_title =
+        message("xmlui.ArtifactBrowser.RequestCorrectionSent.title");
+    
+    public static final Message T_dspace_home =
+        message("xmlui.general.dspace_home");
+    
+    public static final Message T_trail = 
+        message("xmlui.ArtifactBrowser.RequestCorrectionSent.trail");
+    
+    public static final Message T_head =
+        message("xmlui.ArtifactBrowser.RequestCorrectionSent.head");
+    
+    public static final Message T_para1 = 
+        message("xmlui.ArtifactBrowser.RequestCorrectionSent.para1");
+    
+    
+    /**
+     * Generate the unique caching key.
+     */
+    public Serializable getKey() {
+        return "1";
+    }
+
+    /**
+     * Generate the cache validity object.
+     */
+    public SourceValidity getValidity() 
+    {
+       return NOPValidity.SHARED_INSTANCE;
+    }
+    
+    
+    public void addPageMeta(PageMeta pageMeta) throws SAXException,
+            WingException, UIException, SQLException, IOException,
+            AuthorizeException
+    {
+        
+        pageMeta.addMetadata("title").addContent(T_title);
+       
+        pageMeta.addTrailLink(contextPath + "/",T_dspace_home);
+        pageMeta.addTrail().addContent(T_trail);
+    }
+
+  
+    public void addBody(Body body) throws SAXException, WingException,
+            UIException, SQLException, IOException, AuthorizeException
+    {
+        Division feedback = body.addDivision("requestCorrection-sent","primary");
+     
+        feedback.setHead(T_head);
+        
+        feedback.addPara(T_para1);
+        
+    }
+}

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/SendRequestCorrectionAction.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/SendRequestCorrectionAction.java
@@ -1,0 +1,103 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.xmlui.aspect.artifactbrowser;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.avalon.framework.parameters.Parameters;
+import org.apache.cocoon.acting.AbstractAction;
+import org.apache.cocoon.environment.ObjectModelHelper;
+import org.apache.cocoon.environment.Redirector;
+import org.apache.cocoon.environment.Request;
+import org.apache.cocoon.environment.SourceResolver;
+import org.dspace.app.xmlui.utils.ContextUtil;
+import org.dspace.core.ConfigurationManager;
+import org.dspace.core.Context;
+import org.dspace.core.Email;
+import org.dspace.core.I18nUtil;
+import org.dspace.eperson.EPerson;
+
+/**
+ * @author Scott Phillips
+ * @author AdÃ¡n RomÃ¡n Ruiz at arvo.es
+ */
+
+public class SendRequestCorrectionAction extends AbstractAction
+{
+
+    /**
+     *
+     */
+    public Map act(Redirector redirector, SourceResolver resolver, Map objectModel,
+            String source, Parameters parameters) throws Exception
+    {
+        Request request = ObjectModelHelper.getRequest(objectModel);
+
+        String page = request.getParameter("page");
+       // String address = request.getParameter("email");
+        String agent = request.getHeader("User-Agent");
+        String session = request.getSession().getId();
+        String comments = request.getParameter("comments");
+        String handle = parameters.getParameter("handle");
+        
+        // Obtain information from request
+        // The page where the user came from
+        String fromPage = request.getHeader("Referer");
+
+        // User email from context
+        Context context = ContextUtil.obtainContext(objectModel);
+        EPerson loggedin = context.getCurrentUser();
+        String eperson = null;
+        if (loggedin != null)
+        {
+            eperson = loggedin.getEmail();
+        }
+
+        if (page == null || page.equals(""))
+        {
+            page = fromPage;
+        }
+
+        // Check all data is there
+        if ( (comments == null) || comments.equals("") 
+                || (handle == null) || handle.equals(""))
+        {
+            // Either the user did not fill out the form or this is the
+            // first time they are visiting the page.
+            Map<String,String> map = new HashMap<String,String>();
+            map.put("page",page);
+            map.put("comments",comments);
+            map.put("handle",handle);
+            
+            return map;
+        }
+
+        // All data is there, send the email
+        Email email = Email.getEmail(I18nUtil.getEmailFilename(context.getCurrentLocale(), "requestCorrection"));
+        email.addRecipient(ConfigurationManager.getProperty("requestCorrection.recipient"));
+
+        email.addArgument(new Date()); // Date
+        email.addArgument(eperson);    // Logged in as
+        email.addArgument(page.replace("/requestCorrection/", "/handle/"));       // Referring page
+        email.addArgument(agent);      // User agent
+        email.addArgument(session);    // Session ID
+        email.addArgument(comments);   // The feedback itself
+
+        // Replying to feedback will reply to email on form
+        email.setReplyTo(eperson);
+
+        // May generate MessageExceptions.
+        email.send();
+
+        // Finished, allow to pass.
+        return null;
+    }
+
+}

--- a/dspace-xmlui/src/main/resources/aspects/ViewArtifacts/sitemap.xmap
+++ b/dspace-xmlui/src/main/resources/aspects/ViewArtifacts/sitemap.xmap
@@ -45,6 +45,8 @@ and searching the repository.
 			<map:transformer name="ItemRequestStatusChanged" src="org.dspace.app.xmlui.aspect.artifactbrowser.ItemRequestStatusChanged" />
 
             <map:transformer name="Statistics" src="org.dspace.app.xmlui.aspect.artifactbrowser.StatisticsViewer"/>
+			<map:transformer name="RequestCorrectionForm" src="org.dspace.app.xmlui.aspect.artifactbrowser.RequestCorrectionForm" />
+			<map:transformer name="RequestCorrectionSent" 	src="org.dspace.app.xmlui.aspect.artifactbrowser.RequestCorrectionSent" />
         </map:transformers>
 
 
@@ -62,6 +64,7 @@ and searching the repository.
 			<map:action name="UsageLoggerAction" src="org.dspace.app.xmlui.cocoon.UsageLoggerAction" />
 			<map:action name="NotModifiedAction" src="org.dspace.app.xmlui.aspect.general.NotModifiedAction" />
 			<map:action name="ItemRequestResponseAction" src="org.dspace.app.xmlui.aspect.artifactbrowser.ItemRequestResponseAction" />
+			<map:action name="SendRequestCorrectionAction" src="org.dspace.app.xmlui.aspect.artifactbrowser.SendRequestCorrectionAction" />
 		</map:actions>
 
 
@@ -271,6 +274,30 @@ and searching the repository.
 
 			</map:match> <!-- End match handle/*/** -->
 
+			<map:match pattern="requestCorrection/**">
+				<map:select type="AuthenticatedSelector"> 
+				    <map:when test="eperson"> 
+				     	<map:act type="SendRequestCorrectionAction">
+							<map:parameter name="handle" value="{1}" />
+							<map:transform type="RequestCorrectionForm">
+								<map:parameter name="handle" value="{handle}" />
+								<map:parameter name="comments" value="{comments}" />
+								<map:parameter name="email" value="{email}" />
+								<map:parameter name="page" value="{page}" />
+							</map:transform>
+						<map:serialize type="xml" />
+					</map:act>
+					<map:transform type="RequestCorrectionSent" />
+					<map:serialize type="xml" />
+				   </map:when> 
+				    <map:otherwise> 
+				     <map:transform type="RestrictedItem"/> 
+						<map:serialize type="xml"/> 
+				    </map:otherwise> 
+				  </map:select>
+				<map:transform type="RequestCorrectionSent" />
+				<map:serialize type="xml" />
+			</map:match>
 
 			<!-- A simple feedback utility that presents the user with a form to fill 
 				out, the results of which are emailed to the site administrator. -->

--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -2452,6 +2452,22 @@
     <message key="xmlui.aspect.sherpa.submission.yellow">yellow</message>
     <!-- End Versioning -->
 
+        <!-- Request correction -->
+	<message key="xmlui.ArtifactBrowser.RequestCorrectionForm.link">Request correction</message>
+	<message key="xmlui.ArtifactBrowser.RequestCorrectionForm.title">Request correction</message>
+	<message key="xmlui.ArtifactBrowser.RequestCorrectionForm.trail">Request correction</message>
+	<message key="xmlui.ArtifactBrowser.RequestCorrectionForm.head">Request correction</message>
+	<message key="xmlui.ArtifactBrowser.RequestCorrectionForm.para1">Thanks for reporting the error in the item: {0}. We will review it as soon as possible</message>
+	<message key="xmlui.ArtifactBrowser.RequestCorrectionForm.email">Your email</message>
+	<message key="xmlui.ArtifactBrowser.RequestCorrectionForm.email_help">This address will be used to track your suggestion.</message>
+	<message key="xmlui.ArtifactBrowser.RequestCorrectionForm.comments">Error description</message>
+	<message key="xmlui.ArtifactBrowser.RequestCorrectionForm.submit">Send</message>
+ 	
+	<message key="xmlui.ArtifactBrowser.RequestCorrectionSent.title">Request correction</message>
+	<message key="xmlui.ArtifactBrowser.RequestCorrectionSent.trail">Request correction</message>
+	<message key="xmlui.ArtifactBrowser.RequestCorrectionSent.head">Correction request sent</message>
+	<message key="xmlui.ArtifactBrowser.RequestCorrectionSent.para1">Your request has been received</message>
+ 	<!-- End Correction Request -->
 
     <message key="xmlui.mirage2.itemSummaryView.MetaData">Metadata</message>
     <message key="xmlui.mirage2.itemSummaryView.Collections">Collections</message>

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/css/style.css
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/css/style.css
@@ -1380,9 +1380,13 @@ table.discovery-filters th.new-filter-header
     padding-top: 5px;
 }
 
-
 .searchTime{
     color: #999999;
+}
+
+.InformarError{
+	margin-top:4em;
+	margin-left:20em;
 }
 
 .didYouMean{

--- a/dspace-xmlui/src/main/webapp/themes/dri2xhtml-alt/core/elements.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/dri2xhtml-alt/core/elements.xsl
@@ -72,6 +72,8 @@
                     <xsl:call-template name="cc-license">
                         <xsl:with-param name="metadataURL" select="./dri:referenceSet/dri:reference/@url"/>
                     </xsl:call-template>
+                    <xsl:call-template name="requestCorrection">
+                    </xsl:call-template>
                 </xsl:if>
         <xsl:apply-templates select="@pagination">
             <xsl:with-param name="position">bottom</xsl:with-param>
@@ -675,4 +677,19 @@
         </xsl:if>
     </xsl:template>
 
+	<xsl:template name="requestCorrection">
+		<xsl:if test="/dri:document/dri:meta/dri:userMeta/dri:metadata[@element='identifier'][@qualifier='email']">
+			<p class="InformarError">
+				<a>
+					<xsl:attribute name="href">
+						<xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='contextPath'][not(@qualifier)]"/>
+						<xsl:value-of select="substring-before(/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='URI'],'handle/')"/>
+						<xsl:text>/requestCorrection/</xsl:text>
+						<xsl:value-of select="substring-after(/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='URI'],'handle/')"/>
+					</xsl:attribute>
+					<i18n:text>xmlui.ArtifactBrowser.RequestCorrectionForm.link</i18n:text>
+				</a>
+			</p>
+		</xsl:if>
+  	</xsl:template>
 </xsl:stylesheet>

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -115,6 +115,9 @@ feedback.recipient = ${mail.feedback.recipient}
 # General site administration (Webmaster) e-mail
 mail.admin = ${mail.admin}
 
+# Adress for Request correction emails
+requestCorrection.recipient = ${mail.requestCorrection.recipient}
+ 
 # Recipient for server errors and alerts
 alert.recipient = ${mail.alert.recipient}
 

--- a/dspace/config/emails/requestCorrection
+++ b/dspace/config/emails/requestCorrection
@@ -1,0 +1,24 @@
+# E-mail sent with the information filled out in a solicitar correcicon form.
+#
+# Parameters: {0} current date
+#             {1} email address that the user provided
+#             {2} logged in as
+#             {3} page that the user was on when they selected feedback
+#             {4} User-Agent HTTP Header
+#             {5} Session Id
+#             {6} The user's comments
+#
+# See org.dspace.core.Email for information on the format of this file.
+#
+Subject: Request for correction
+
+Date: {0}
+
+registered as: {1}
+
+Refered page: {2}
+
+Error detected:
+   
+{5}
+


### PR DESCRIPTION
Suggest a change (buttom in item-summary-view)
https://jira.duraspace.org/browse/DS-2099

"The idea is that only logged users can send error messages of the items. 
These errors can reach other recipient responsible of data integrity. He does not have to be the repository administrator . 
This system allows authors or editors, thesis authors,etc, which are usually users, quickly deliver problems in items produced by them or whith knowledge about them. 
It is intended for systems that have restricted the creation of user accounts."

Replaces Pull Request - Request Correction to item #667 
