### PR TITLE
DS-2162: Per item configurable visual indicators for browse and search results (JSPUI only)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemmarking/ItemMarkingAvailabilityBitstreamStrategy.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemmarking/ItemMarkingAvailabilityBitstreamStrategy.java
@@ -10,6 +10,7 @@ package org.dspace.app.itemmarking;
 import java.io.UnsupportedEncodingException;
 import java.sql.SQLException;
 
+import org.dspace.app.util.Util;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.Item;
@@ -67,9 +68,9 @@ public class ItemMarkingAvailabilityBitstreamStrategy implements ItemMarkingExtr
                             + bitstream.getSequenceID() + "/";
                 
                 try {
-					bsLink = bsLink + encodeBitstreamName(bitstream.getName(),  Constants.DEFAULT_ENCODING);
+					bsLink = bsLink + Util.encodeBitstreamName(bitstream.getName(),  Constants.DEFAULT_ENCODING);
 				} catch (UnsupportedEncodingException e) {
-					// TODO Auto-generated catch block
+					
 					e.printStackTrace();
 				}
                 
@@ -86,68 +87,5 @@ public class ItemMarkingAvailabilityBitstreamStrategy implements ItemMarkingExtr
 
 	public void setNonAvailableImageName(String nonAvailableImageName) {
 		this.nonAvailableImageName = nonAvailableImageName;
-	}
-
-	public static String encodeBitstreamName(String stringIn, String encoding) throws java.io.UnsupportedEncodingException {
-        // FIXME: This should be moved elsewhere, as it is used outside the UI
-        StringBuffer out = new StringBuffer();
-    
-        final String[] pctEncoding = { "%00", "%01", "%02", "%03", "%04",
-                "%05", "%06", "%07", "%08", "%09", "%0a", "%0b", "%0c", "%0d",
-                "%0e", "%0f", "%10", "%11", "%12", "%13", "%14", "%15", "%16",
-                "%17", "%18", "%19", "%1a", "%1b", "%1c", "%1d", "%1e", "%1f",
-                "%20", "%21", "%22", "%23", "%24", "%25", "%26", "%27", "%28",
-                "%29", "%2a", "%2b", "%2c", "%2d", "%2e", "%2f", "%30", "%31",
-                "%32", "%33", "%34", "%35", "%36", "%37", "%38", "%39", "%3a",
-                "%3b", "%3c", "%3d", "%3e", "%3f", "%40", "%41", "%42", "%43",
-                "%44", "%45", "%46", "%47", "%48", "%49", "%4a", "%4b", "%4c",
-                "%4d", "%4e", "%4f", "%50", "%51", "%52", "%53", "%54", "%55",
-                "%56", "%57", "%58", "%59", "%5a", "%5b", "%5c", "%5d", "%5e",
-                "%5f", "%60", "%61", "%62", "%63", "%64", "%65", "%66", "%67",
-                "%68", "%69", "%6a", "%6b", "%6c", "%6d", "%6e", "%6f", "%70",
-                "%71", "%72", "%73", "%74", "%75", "%76", "%77", "%78", "%79",
-                "%7a", "%7b", "%7c", "%7d", "%7e", "%7f", "%80", "%81", "%82",
-                "%83", "%84", "%85", "%86", "%87", "%88", "%89", "%8a", "%8b",
-                "%8c", "%8d", "%8e", "%8f", "%90", "%91", "%92", "%93", "%94",
-                "%95", "%96", "%97", "%98", "%99", "%9a", "%9b", "%9c", "%9d",
-                "%9e", "%9f", "%a0", "%a1", "%a2", "%a3", "%a4", "%a5", "%a6",
-                "%a7", "%a8", "%a9", "%aa", "%ab", "%ac", "%ad", "%ae", "%af",
-                "%b0", "%b1", "%b2", "%b3", "%b4", "%b5", "%b6", "%b7", "%b8",
-                "%b9", "%ba", "%bb", "%bc", "%bd", "%be", "%bf", "%c0", "%c1",
-                "%c2", "%c3", "%c4", "%c5", "%c6", "%c7", "%c8", "%c9", "%ca",
-                "%cb", "%cc", "%cd", "%ce", "%cf", "%d0", "%d1", "%d2", "%d3",
-                "%d4", "%d5", "%d6", "%d7", "%d8", "%d9", "%da", "%db", "%dc",
-                "%dd", "%de", "%df", "%e0", "%e1", "%e2", "%e3", "%e4", "%e5",
-                "%e6", "%e7", "%e8", "%e9", "%ea", "%eb", "%ec", "%ed", "%ee",
-                "%ef", "%f0", "%f1", "%f2", "%f3", "%f4", "%f5", "%f6", "%f7",
-                "%f8", "%f9", "%fa", "%fb", "%fc", "%fd", "%fe", "%ff" };
-    
-        byte[] bytes = stringIn.getBytes(encoding);
-    
-        for (int i = 0; i < bytes.length; i++)
-        {
-            // Any unreserved char or "/" goes through unencoded
-            if ((bytes[i] >= 'A' && bytes[i] <= 'Z')
-                    || (bytes[i] >= 'a' && bytes[i] <= 'z')
-                    || (bytes[i] >= '0' && bytes[i] <= '9') || bytes[i] == '-'
-                    || bytes[i] == '.' || bytes[i] == '_' || bytes[i] == '~'
-                    || bytes[i] == '/')
-            {
-                out.append((char) bytes[i]);
-            }
-            else if (bytes[i] >= 0)
-            {
-                // encode other chars (byte code < 128)
-                out.append(pctEncoding[bytes[i]]);
-            }
-            else
-            {
-                // encode other chars (byte code > 127, so it appears as
-                // negative in Java signed byte data type)
-                out.append(pctEncoding[256 + bytes[i]]);
-            }
-        }
-    
-        return out.toString();
-    }
+	}	
 }

--- a/dspace-api/src/main/java/org/dspace/app/itemmarking/ItemMarkingAvailabilityBitstreamStrategy.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemmarking/ItemMarkingAvailabilityBitstreamStrategy.java
@@ -1,0 +1,152 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.itemmarking;
+
+import java.io.UnsupportedEncodingException;
+import java.sql.SQLException;
+
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Item;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+
+/**
+ * Try to look to an item signing via the collection it bellongs
+ * 
+ * @author Kostas Stamatis
+ * 
+ */
+public class ItemMarkingAvailabilityBitstreamStrategy implements ItemMarkingExtractor {
+
+	private String availableImageName;
+	private String nonAvailableImageName;
+	
+	public ItemMarkingAvailabilityBitstreamStrategy() {
+	
+	}
+
+	@Override
+	public ItemMarkingInfo getItemMarkingInfo(Context context, Item item)
+			throws SQLException {
+		
+		Bundle[] bundles = item.getBundles("ORIGINAL");
+		if (bundles.length == 0){
+			ItemMarkingInfo markInfo = new ItemMarkingInfo();
+			markInfo.setImageName(nonAvailableImageName);	
+			
+			return markInfo;
+		}
+		else {
+			Bundle originalBundle = bundles[0];
+			if (originalBundle.getBitstreams().length == 0){
+				ItemMarkingInfo markInfo = new ItemMarkingInfo();
+				markInfo.setImageName(nonAvailableImageName);
+				
+				return markInfo;
+			}
+			else {
+				Bitstream bitstream = originalBundle.getBitstreams()[0];
+				
+				ItemMarkingInfo signInfo = new ItemMarkingInfo();
+				signInfo.setImageName(availableImageName);
+				signInfo.setTooltip(bitstream.getName());
+				
+				
+				
+				String bsLink = "";
+
+                bsLink = bsLink + "bitstream/"
+                            + item.getHandle() + "/"
+                            + bitstream.getSequenceID() + "/";
+                
+                try {
+					bsLink = bsLink + encodeBitstreamName(bitstream.getName(),  Constants.DEFAULT_ENCODING);
+				} catch (UnsupportedEncodingException e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
+                
+				signInfo.setLink(bsLink);
+				
+				return signInfo;
+			}
+		}
+	}
+
+	public void setAvailableImageName(String availableImageName) {
+		this.availableImageName = availableImageName;
+	}
+
+	public void setNonAvailableImageName(String nonAvailableImageName) {
+		this.nonAvailableImageName = nonAvailableImageName;
+	}
+
+	public static String encodeBitstreamName(String stringIn, String encoding) throws java.io.UnsupportedEncodingException {
+        // FIXME: This should be moved elsewhere, as it is used outside the UI
+        StringBuffer out = new StringBuffer();
+    
+        final String[] pctEncoding = { "%00", "%01", "%02", "%03", "%04",
+                "%05", "%06", "%07", "%08", "%09", "%0a", "%0b", "%0c", "%0d",
+                "%0e", "%0f", "%10", "%11", "%12", "%13", "%14", "%15", "%16",
+                "%17", "%18", "%19", "%1a", "%1b", "%1c", "%1d", "%1e", "%1f",
+                "%20", "%21", "%22", "%23", "%24", "%25", "%26", "%27", "%28",
+                "%29", "%2a", "%2b", "%2c", "%2d", "%2e", "%2f", "%30", "%31",
+                "%32", "%33", "%34", "%35", "%36", "%37", "%38", "%39", "%3a",
+                "%3b", "%3c", "%3d", "%3e", "%3f", "%40", "%41", "%42", "%43",
+                "%44", "%45", "%46", "%47", "%48", "%49", "%4a", "%4b", "%4c",
+                "%4d", "%4e", "%4f", "%50", "%51", "%52", "%53", "%54", "%55",
+                "%56", "%57", "%58", "%59", "%5a", "%5b", "%5c", "%5d", "%5e",
+                "%5f", "%60", "%61", "%62", "%63", "%64", "%65", "%66", "%67",
+                "%68", "%69", "%6a", "%6b", "%6c", "%6d", "%6e", "%6f", "%70",
+                "%71", "%72", "%73", "%74", "%75", "%76", "%77", "%78", "%79",
+                "%7a", "%7b", "%7c", "%7d", "%7e", "%7f", "%80", "%81", "%82",
+                "%83", "%84", "%85", "%86", "%87", "%88", "%89", "%8a", "%8b",
+                "%8c", "%8d", "%8e", "%8f", "%90", "%91", "%92", "%93", "%94",
+                "%95", "%96", "%97", "%98", "%99", "%9a", "%9b", "%9c", "%9d",
+                "%9e", "%9f", "%a0", "%a1", "%a2", "%a3", "%a4", "%a5", "%a6",
+                "%a7", "%a8", "%a9", "%aa", "%ab", "%ac", "%ad", "%ae", "%af",
+                "%b0", "%b1", "%b2", "%b3", "%b4", "%b5", "%b6", "%b7", "%b8",
+                "%b9", "%ba", "%bb", "%bc", "%bd", "%be", "%bf", "%c0", "%c1",
+                "%c2", "%c3", "%c4", "%c5", "%c6", "%c7", "%c8", "%c9", "%ca",
+                "%cb", "%cc", "%cd", "%ce", "%cf", "%d0", "%d1", "%d2", "%d3",
+                "%d4", "%d5", "%d6", "%d7", "%d8", "%d9", "%da", "%db", "%dc",
+                "%dd", "%de", "%df", "%e0", "%e1", "%e2", "%e3", "%e4", "%e5",
+                "%e6", "%e7", "%e8", "%e9", "%ea", "%eb", "%ec", "%ed", "%ee",
+                "%ef", "%f0", "%f1", "%f2", "%f3", "%f4", "%f5", "%f6", "%f7",
+                "%f8", "%f9", "%fa", "%fb", "%fc", "%fd", "%fe", "%ff" };
+    
+        byte[] bytes = stringIn.getBytes(encoding);
+    
+        for (int i = 0; i < bytes.length; i++)
+        {
+            // Any unreserved char or "/" goes through unencoded
+            if ((bytes[i] >= 'A' && bytes[i] <= 'Z')
+                    || (bytes[i] >= 'a' && bytes[i] <= 'z')
+                    || (bytes[i] >= '0' && bytes[i] <= '9') || bytes[i] == '-'
+                    || bytes[i] == '.' || bytes[i] == '_' || bytes[i] == '~'
+                    || bytes[i] == '/')
+            {
+                out.append((char) bytes[i]);
+            }
+            else if (bytes[i] >= 0)
+            {
+                // encode other chars (byte code < 128)
+                out.append(pctEncoding[bytes[i]]);
+            }
+            else
+            {
+                // encode other chars (byte code > 127, so it appears as
+                // negative in Java signed byte data type)
+                out.append(pctEncoding[256 + bytes[i]]);
+            }
+        }
+    
+        return out.toString();
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/app/itemmarking/ItemMarkingAvailabilityBitstreamStrategy.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemmarking/ItemMarkingAvailabilityBitstreamStrategy.java
@@ -17,7 +17,8 @@ import org.dspace.core.Constants;
 import org.dspace.core.Context;
 
 /**
- * Try to look to an item signing via the collection it bellongs
+ * This is an item marking Strategy class that tries to mark an item availability
+ * based on the existence of bitstreams within the ORIGINAL bundle.
  * 
  * @author Kostas Stamatis
  * 

--- a/dspace-api/src/main/java/org/dspace/app/itemmarking/ItemMarkingCollectionStrategy.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemmarking/ItemMarkingCollectionStrategy.java
@@ -1,0 +1,49 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.itemmarking;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+
+/**
+ * Try to look to an item signing via the collection it bellongs
+ * 
+ * @author Kostas Stamatis
+ * 
+ */
+public class ItemMarkingCollectionStrategy implements ItemMarkingExtractor {
+
+	Map<String, ItemMarkingInfo> mapping = new HashMap<String, ItemMarkingInfo>();
+	
+	public ItemMarkingCollectionStrategy() {
+	}
+
+	@Override
+	public ItemMarkingInfo getItemMarkingInfo(Context context, Item item)
+			throws SQLException {
+		
+		if (mapping!=null){
+			for (Collection collection : item.getCollections()){
+				if (mapping.containsKey(collection.getHandle())){
+					return mapping.get(collection.getHandle());
+				}
+			}
+		}
+		
+		return null;
+	}
+
+	public void setMapping(Map<String, ItemMarkingInfo> mapping) {
+		this.mapping = mapping;
+	}
+}

--- a/dspace-api/src/main/java/org/dspace/app/itemmarking/ItemMarkingCollectionStrategy.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemmarking/ItemMarkingCollectionStrategy.java
@@ -16,7 +16,8 @@ import org.dspace.content.Item;
 import org.dspace.core.Context;
 
 /**
- * Try to look to an item signing via the collection it bellongs
+ * This is an item marking Strategy class that tries to mark an item
+ * based on the collection the items belong to
  * 
  * @author Kostas Stamatis
  * 

--- a/dspace-api/src/main/java/org/dspace/app/itemmarking/ItemMarkingExtractor.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemmarking/ItemMarkingExtractor.java
@@ -1,0 +1,24 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.itemmarking;
+
+import java.sql.SQLException;
+
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+
+/**
+ * Interface to abstract the strategy for item signing
+ * 
+ * @author Kostas Stamatis
+ * 
+ */
+public interface ItemMarkingExtractor {
+	public ItemMarkingInfo getItemMarkingInfo(Context context, Item item)
+			throws SQLException;
+}

--- a/dspace-api/src/main/java/org/dspace/app/itemmarking/ItemMarkingInfo.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemmarking/ItemMarkingInfo.java
@@ -8,8 +8,7 @@
 package org.dspace.app.itemmarking;
 
 /**
- * Simple DTO to transfer data about the signing info for the item
- * Copy feature
+ * Simple DTO to transfer data about the marking info for an item
  * 
  * @author Kostas Stamatis
  * 

--- a/dspace-api/src/main/java/org/dspace/app/itemmarking/ItemMarkingInfo.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemmarking/ItemMarkingInfo.java
@@ -1,0 +1,58 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.itemmarking;
+
+/**
+ * Simple DTO to transfer data about the signing info for the item
+ * Copy feature
+ * 
+ * @author Kostas Stamatis
+ * 
+ */
+public class ItemMarkingInfo {
+	private String imageName;
+	private String classInfo;
+	private String tooltip;
+	private String link;
+
+	public ItemMarkingInfo() {
+		super();
+	}
+
+	public String getImageName() {
+		return imageName;
+	}
+
+	public void setImageName(String imageName) {
+		this.imageName = imageName;
+	}
+
+	public String getTooltip() {
+		return tooltip;
+	}
+
+	public void setTooltip(String tooltip) {
+		this.tooltip = tooltip;
+	}
+	
+	public String getLink() {
+		return link;
+	}
+
+	public void setLink(String link) {
+		this.link = link;
+	}
+	
+	public String getClassInfo() {
+		return classInfo;
+	}
+
+	public void setClassInfo(String classInfo) {
+		this.classInfo = classInfo;
+	}
+}

--- a/dspace-api/src/main/java/org/dspace/app/itemmarking/ItemMarkingMetadataStrategy.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemmarking/ItemMarkingMetadataStrategy.java
@@ -1,0 +1,59 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.itemmarking;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.dspace.content.DCValue;
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+
+/**
+ * Try to look to an item signing via the collection it bellongs
+ * 
+ * @author Kostas Stamatis
+ * 
+ */
+public class ItemMarkingMetadataStrategy implements ItemMarkingExtractor {
+
+	private String metadataField;
+	Map<String, ItemMarkingInfo> mapping = new HashMap<String, ItemMarkingInfo>();
+	
+	public ItemMarkingMetadataStrategy() {
+	}
+
+	@Override
+	public ItemMarkingInfo getItemMarkingInfo(Context context, Item item)
+			throws SQLException {
+		
+		if (metadataField != null && mapping!=null)
+		{
+			DCValue[] vals = item.getMetadata(metadataField);
+			if (vals.length > 0)
+			{
+				for (DCValue value : vals){
+					String type = value.value;
+					if (mapping.containsKey(type)){
+						return mapping.get(type);
+					}
+				}
+			}
+		}
+		return null;
+	}
+
+	public void setMetadataField(String metadataField) {
+		this.metadataField = metadataField;
+	}
+
+	public void setMapping(Map<String, ItemMarkingInfo> mapping) {
+		this.mapping = mapping;
+	}
+}

--- a/dspace-api/src/main/java/org/dspace/app/itemmarking/ItemMarkingMetadataStrategy.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemmarking/ItemMarkingMetadataStrategy.java
@@ -35,7 +35,7 @@ public class ItemMarkingMetadataStrategy implements ItemMarkingExtractor {
 		
 		if (metadataField != null && mapping!=null)
 		{
-			DCValue[] vals = item.getMetadata(metadataField);
+			DCValue[] vals = item.getMetadataByMetadataString(metadataField);
 			if (vals.length > 0)
 			{
 				for (DCValue value : vals){

--- a/dspace-api/src/main/java/org/dspace/app/itemmarking/ItemMarkingMetadataStrategy.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemmarking/ItemMarkingMetadataStrategy.java
@@ -16,7 +16,9 @@ import org.dspace.content.Item;
 import org.dspace.core.Context;
 
 /**
- * Try to look to an item signing via the collection it bellongs
+ * This is an item marking Strategy class that tries to mark an item
+ * based on the existence of a specific value within the values of a specific
+ * metadata field
  * 
  * @author Kostas Stamatis
  * 

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/BrowseListTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/BrowseListTag.java
@@ -485,7 +485,7 @@ public class BrowseListTag extends TagSupport
                     }
                     else  if (field.startsWith("mark_"))
                     {
-                        metadata = getMarkingMarkup(hrq, items[i], field);
+                        metadata = UIUtil.getMarkingMarkup(hrq, items[i], field);
                     }
                     else if (metadataArray.length > 0)
                     {
@@ -916,78 +916,6 @@ public class BrowseListTag extends TagSupport
         catch (UnsupportedEncodingException e)
         {
             throw new JspException("Server does not support DSpace's default encoding. ", e);
-        }
-    }
-    
-    /* generate the (X)HTML required to show the item signing */
-    private String getMarkingMarkup(HttpServletRequest hrq, BrowseItem item, String markType)
-            throws JspException
-    {
-    	try
-    	{
-            Context c = UIUtil.obtainContext(hrq);
-            
-            String mark = markType.replace("mark_", "");
-            
-            ItemMarkingInfo markInfo = new DSpace()
-				.getServiceManager()
-				.getServiceByName(
-					ItemMarkingExtractor.class.getName()+"."+mark,
-					ItemMarkingExtractor.class)
-					.getItemMarkingInfo(c, Item.find(c, item.getID()));
-            
-            StringBuffer markFrag = new StringBuffer();
-            
-            if (markInfo!=null && markInfo.getImageName()!=null){
-            	
-            	//Link
-            	if (markInfo.getLink()!=null && !markInfo.getLink().trim().equals("")){
-            		markFrag.append("<a href=\"")
-            			.append(((HttpServletRequest)pageContext.getRequest()).getContextPath()+"/" + markInfo.getLink())
-            			.append("\">");
-            	}
-            	
-            	markFrag.append("<img class=\""+markType+"_img\" src=\""+ ((HttpServletRequest)pageContext.getRequest()).getContextPath()+"/")
-            		.append(markInfo.getImageName()).append("\"");
-            	if (markInfo.getTooltip()!=null){
-            		markFrag.append(" title=\"")
-            			.append(LocaleSupport.getLocalizedMessage(pageContext, markInfo.getTooltip()))
-            			.append("\"");
-            	}
-            	markFrag.append("/>");
-            	
-            	//Link
-            	if (markInfo.getLink()!=null && !markInfo.getLink().trim().equals("")){
-            		markFrag.append("</a>");
-            	}
-            }
-            else  if (markInfo!=null && markInfo.getClassInfo()!=null){
-            	//Link
-            	if (markInfo.getLink()!=null && !markInfo.getLink().trim().equals("")){
-            		markFrag.append("<a href=\"")
-            			.append(((HttpServletRequest)pageContext.getRequest()).getContextPath()+"/" + markInfo.getLink())
-            			.append("\">");
-            	}
-
-            	markFrag.append("<div class=\""+markType+"_class" + " " + markInfo.getClassInfo() + "\" ");
-            	if (markInfo.getTooltip()!=null){
-            		markFrag.append(" title=\"")
-            		.append(LocaleSupport.getLocalizedMessage(pageContext, markInfo.getTooltip()))
-            		.append("\"");
-            	}
-            	markFrag.append("/>");
-
-            	//Link
-            	if (markInfo.getLink()!=null && !markInfo.getLink().trim().equals("")){
-            		markFrag.append("</a>");
-            	}
-            }
-            
-        	return markFrag.toString();
-        }
-        catch (SQLException sqle)
-        {
-        	throw new JspException(sqle.getMessage(), sqle);
         }
     }
 }

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/BrowseListTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/BrowseListTag.java
@@ -10,6 +10,8 @@ package org.dspace.app.webui.jsptag;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
+import org.dspace.app.itemmarking.ItemMarkingExtractor;
+import org.dspace.app.itemmarking.ItemMarkingInfo;
 import org.dspace.app.webui.util.UIUtil;
 import org.dspace.browse.*;
 import org.dspace.content.Bitstream;
@@ -24,6 +26,7 @@ import org.dspace.core.Context;
 import org.dspace.core.Utils;
 import org.dspace.storage.bitstore.BitstreamStorageManager;
 import org.dspace.sort.SortOption;
+import org.dspace.utils.DSpace;
 
 import javax.imageio.ImageIO;
 import javax.servlet.http.HttpServletRequest;
@@ -388,8 +391,14 @@ public class BrowseListTag extends TagSupport
                 String css = "oddRow" + cOddOrEven[colIdx] + "Col";
                 String message = "itemlist." + field;
 
+                String markClass = "";
+                if (field.startsWith("mark_"))
+                {
+                	markClass = " "+field+"_th";
+                }
+                
                 // output the header
-                out.print("<th id=\"" + id +  "\" class=\"" + css + "\">"
+                out.print("<th id=\"" + id +  "\" class=\"" + css + markClass +"\">"
                         + (emph[colIdx] ? "<strong>" : "")
                         + LocaleSupport.getLocalizedMessage(pageContext, message)
                         + (emph[colIdx] ? "</strong>" : "") + "</th>");
@@ -473,6 +482,10 @@ public class BrowseListTag extends TagSupport
                     if (field.equals("thumbnail"))
                     {
                         metadata = getThumbMarkup(hrq, items[i]);
+                    }
+                    else  if (field.startsWith("mark_"))
+                    {
+                        metadata = getMarkingMarkup(hrq, items[i], field);
                     }
                     else if (metadataArray.length > 0)
                     {
@@ -594,10 +607,16 @@ public class BrowseListTag extends TagSupport
                     {
                         extras = "nowrap=\"nowrap\" align=\"right\"";
                     }
+                    
+                    String markClass = "";
+                    if (field.startsWith("mark_"))
+                    {
+                    	markClass = " "+field+"_tr";
+                    }
 
                     String id = "t" + Integer.toString(colIdx + 1);
                     out.print("<td headers=\"" + id + "\" class=\""
-                    	+ rOddOrEven + "Row" + cOddOrEven[colIdx] + "Col\" " + extras + ">"
+                    		+ rOddOrEven + "Row" + cOddOrEven[colIdx] + "Col" + markClass + "\" " + extras + ">"
                     	+ (emph[colIdx] ? "<strong>" : "") + metadata + (emph[colIdx] ? "</strong>" : "")
                     	+ "</td>");
                 }
@@ -897,6 +916,78 @@ public class BrowseListTag extends TagSupport
         catch (UnsupportedEncodingException e)
         {
             throw new JspException("Server does not support DSpace's default encoding. ", e);
+        }
+    }
+    
+    /* generate the (X)HTML required to show the item signing */
+    private String getMarkingMarkup(HttpServletRequest hrq, BrowseItem item, String markType)
+            throws JspException
+    {
+    	try
+    	{
+            Context c = UIUtil.obtainContext(hrq);
+            
+            String mark = markType.replace("mark_", "");
+            
+            ItemMarkingInfo markInfo = new DSpace()
+				.getServiceManager()
+				.getServiceByName(
+					ItemMarkingExtractor.class.getName()+"."+mark,
+					ItemMarkingExtractor.class)
+					.getItemMarkingInfo(c, Item.find(c, item.getID()));
+            
+            StringBuffer markFrag = new StringBuffer();
+            
+            if (markInfo!=null && markInfo.getImageName()!=null){
+            	
+            	//Link
+            	if (markInfo.getLink()!=null && !markInfo.getLink().trim().equals("")){
+            		markFrag.append("<a href=\"")
+            			.append(((HttpServletRequest)pageContext.getRequest()).getContextPath()+"/" + markInfo.getLink())
+            			.append("\">");
+            	}
+            	
+            	markFrag.append("<img class=\""+markType+"_img\" src=\""+ ((HttpServletRequest)pageContext.getRequest()).getContextPath()+"/")
+            		.append(markInfo.getImageName()).append("\"");
+            	if (markInfo.getTooltip()!=null){
+            		markFrag.append(" title=\"")
+            			.append(LocaleSupport.getLocalizedMessage(pageContext, markInfo.getTooltip()))
+            			.append("\"");
+            	}
+            	markFrag.append("/>");
+            	
+            	//Link
+            	if (markInfo.getLink()!=null && !markInfo.getLink().trim().equals("")){
+            		markFrag.append("</a>");
+            	}
+            }
+            else  if (markInfo!=null && markInfo.getClassInfo()!=null){
+            	//Link
+            	if (markInfo.getLink()!=null && !markInfo.getLink().trim().equals("")){
+            		markFrag.append("<a href=\"")
+            			.append(((HttpServletRequest)pageContext.getRequest()).getContextPath()+"/" + markInfo.getLink())
+            			.append("\">");
+            	}
+
+            	markFrag.append("<div class=\""+markType+"_class" + " " + markInfo.getClassInfo() + "\" ");
+            	if (markInfo.getTooltip()!=null){
+            		markFrag.append(" title=\"")
+            		.append(LocaleSupport.getLocalizedMessage(pageContext, markInfo.getTooltip()))
+            		.append("\"");
+            	}
+            	markFrag.append("/>");
+
+            	//Link
+            	if (markInfo.getLink()!=null && !markInfo.getLink().trim().equals("")){
+            		markFrag.append("</a>");
+            	}
+            }
+            
+        	return markFrag.toString();
+        }
+        catch (SQLException sqle)
+        {
+        	throw new JspException(sqle.getMessage(), sqle);
         }
     }
 }

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemListTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemListTag.java
@@ -450,7 +450,7 @@ public class ItemListTag extends TagSupport
                     }
                     else  if (field.startsWith("mark_"))
                     {
-                        metadata = getMarkingMarkup(hrq, items[i], field);
+                        metadata = UIUtil.getMarkingMarkup(hrq, items[i], field);
                     }
                     if (metadataArray.length > 0)
                     {
@@ -893,76 +893,4 @@ public class ItemListTag extends TagSupport
             throw new JspException("Server does not support DSpace's default encoding. ", e);
         }
 	}
-    
-    /* generate the (X)HTML required to show the item signing */
-    private String getMarkingMarkup(HttpServletRequest hrq, Item item, String markType)
-            throws JspException
-    {
-    	try
-    	{
-            Context c = UIUtil.obtainContext(hrq);
-            
-            String mark = markType.replace("mark_", "");
-            
-            ItemMarkingInfo markInfo = new DSpace()
-				.getServiceManager()
-				.getServiceByName(
-					ItemMarkingExtractor.class.getName()+"."+mark,
-					ItemMarkingExtractor.class)
-					.getItemMarkingInfo(c, Item.find(c, item.getID()));
-            
-            StringBuffer markFrag = new StringBuffer();
-            
-            if (markInfo!=null && markInfo.getImageName()!=null){
-            	
-            	//Link
-            	if (markInfo.getLink()!=null && !markInfo.getLink().trim().equals("")){
-            		markFrag.append("<a href=\"")
-            			.append(((HttpServletRequest)pageContext.getRequest()).getContextPath()+"/" + markInfo.getLink())
-            			.append("\">");
-            	}
-            	
-            	markFrag.append("<img class=\""+markType+"_img\" src=\""+ ((HttpServletRequest)pageContext.getRequest()).getContextPath()+"/")
-                	.append(markInfo.getImageName()).append("\"");
-            	if (markInfo.getTooltip()!=null){
-            		markFrag.append(" title=\"")
-                		.append(LocaleSupport.getLocalizedMessage(pageContext, markInfo.getTooltip()))
-                		.append("\"");
-            	}
-            	markFrag.append("/>");
-            	
-            	//Link
-            	if (markInfo.getLink()!=null && !markInfo.getLink().trim().equals("")){
-            		markFrag.append("</a>");
-            	}
-            }
-            else  if (markInfo!=null && markInfo.getClassInfo()!=null){
-            	//Link
-            	if (markInfo.getLink()!=null && !markInfo.getLink().trim().equals("")){
-            		markFrag.append("<a href=\"")
-            			.append(((HttpServletRequest)pageContext.getRequest()).getContextPath()+"/" + markInfo.getLink())
-            			.append("\">");
-            	}
-
-            	markFrag.append("<div class=\""+markType+"_class" + " " + markInfo.getClassInfo() + "\" ");
-            	if (markInfo.getTooltip()!=null){
-            		markFrag.append(" title=\"")
-            		.append(LocaleSupport.getLocalizedMessage(pageContext, markInfo.getTooltip()))
-            		.append("\"");
-            	}
-            	markFrag.append("/>");
-
-            	//Link
-            	if (markInfo.getLink()!=null && !markInfo.getLink().trim().equals("")){
-            		markFrag.append("</a>");
-            	}
-            }
-            
-        	return markFrag.toString();
-        }
-        catch (SQLException sqle)
-        {
-        	throw new JspException(sqle.getMessage(), sqle);
-        }
-    }
 }

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/util/UIUtil.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/util/UIUtil.java
@@ -22,21 +22,28 @@ import javax.mail.internet.MimeUtility;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.jstl.core.Config;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
+import org.dspace.app.itemmarking.ItemMarkingExtractor;
+import org.dspace.app.itemmarking.ItemMarkingInfo;
 import org.dspace.app.util.Util;
 import org.dspace.authenticate.AuthenticationManager;
+import org.dspace.browse.BrowseItem;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.DCDate;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.Email;
 import org.dspace.core.I18nUtil;
 import org.dspace.eperson.EPerson;
+import org.dspace.utils.DSpace;
 
 /**
  * Miscellaneous UI utility methods
@@ -470,4 +477,105 @@ public class UIUtil extends Util
 			response.setHeader("Content-Disposition", "attachment;filename=" + name);
 		}
 	}
+	
+	/**
+	 * Generate the (X)HTML required to show the item marking. Based on the markType it tries to find
+	 * the corresponding item marking Strategy on the iem_marking.xml Spring configuration file in order
+	 * to apply it to the item.
+	 * This method is used in BrowseListTag and ItemListTag to du the actual item marking in browse
+	 * and search results
+	 * 
+	 * @param hrq The servlet request
+	 * @param dso The DSpaceObject to mark (it can be a BrowseItem or an Item)
+	 * @param markType the type of the mark.
+	 * @return
+	 * @throws JspException
+	 */
+    public static String getMarkingMarkup(HttpServletRequest hrq, DSpaceObject dso, String markType)
+            throws JspException
+    {
+    	try
+    	{
+    		String contextPath = hrq.getContextPath();
+    		
+            Context c = UIUtil.obtainContext(hrq);
+            
+            Item item = null;
+    		if (dso instanceof BrowseItem){
+    			item = Item.find(c, dso.getID());
+    		}
+    		else if (dso instanceof Item){
+    			item = (Item)dso;
+    		}
+    		
+            String mark = markType.replace("mark_", "");
+            
+            ItemMarkingInfo markInfo = new DSpace()
+				.getServiceManager()
+				.getServiceByName(
+					ItemMarkingExtractor.class.getName()+"."+mark,
+					ItemMarkingExtractor.class)
+					.getItemMarkingInfo(c, item);
+            
+            StringBuffer markFrag = new StringBuffer();
+            
+            String localizedTooltip = null;
+            if (markInfo.getTooltip()!=null){
+            	localizedTooltip = org.dspace.core.I18nUtil.getMessage(markInfo.getTooltip(), hrq.getLocale());
+            }
+            		
+            String markLink = markInfo.getLink();
+            
+            if (markInfo!=null && markInfo.getImageName()!=null){
+            	
+            	//Link
+            	if (StringUtils.isNotEmpty(markLink)){
+            		markFrag.append("<a href=\"")
+            			.append(contextPath+"/" + markLink)
+            			.append("\">");
+            	}
+            	
+            	markFrag.append("<img class=\""+markType+"_img\" src=\""+ contextPath+"/")
+            		.append(markInfo.getImageName()).append("\"");
+            	if (StringUtils.isNotEmpty(localizedTooltip)){
+            		markFrag.append(" title=\"")
+            			.append(localizedTooltip)
+            			.append("\"");
+            	}
+            	markFrag.append("/>");
+            	
+            	//Link
+            	if (StringUtils.isNotEmpty(markLink)){
+            		markFrag.append("</a>");
+            	}
+            }
+            else  if (markInfo!=null && markInfo.getClassInfo()!=null){
+            	//Link
+            	if (StringUtils.isNotEmpty(markLink)){
+            		markFrag.append("<a href=\"")
+            			.append(contextPath+"/" + markLink)
+            			.append("\">");
+            	}
+
+            	markFrag.append("<div class=\""+markType+"_class" + " " + markInfo.getClassInfo() + "\" ");
+            	if (StringUtils.isNotEmpty(localizedTooltip)){
+            		markFrag.append(" title=\"")
+            		.append(localizedTooltip)
+            		.append("\"");
+            	}
+            	markFrag.append("/>");
+
+            	//Link
+            	if (StringUtils.isNotEmpty(markLink)){
+            		markFrag.append("</a>");
+            	}
+            }
+            
+        	return markFrag.toString();
+        }
+        catch (SQLException sqle)
+        {
+        	throw new JspException(sqle.getMessage(), sqle);
+        }
+    }
 }

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/util/UIUtil.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/util/UIUtil.java
@@ -510,12 +510,21 @@ public class UIUtil extends Util
     		
             String mark = markType.replace("mark_", "");
             
-            ItemMarkingInfo markInfo = new DSpace()
+            ItemMarkingExtractor markingExtractor = new DSpace()
 				.getServiceManager()
 				.getServiceByName(
-					ItemMarkingExtractor.class.getName()+"."+mark,
-					ItemMarkingExtractor.class)
-					.getItemMarkingInfo(c, item);
+						ItemMarkingExtractor.class.getName()+"."+mark,
+						ItemMarkingExtractor.class);
+            
+            if (markingExtractor == null){ // In case we cannot find the corresponding extractor (strategy) in xml beans
+            	return "";
+            }
+            
+            ItemMarkingInfo markInfo = markingExtractor.getItemMarkingInfo(c, item);
+            
+            if (markInfo == null){
+            	return "";
+            }
             
             StringBuffer markFrag = new StringBuffer();
             
@@ -526,7 +535,7 @@ public class UIUtil extends Util
             		
             String markLink = markInfo.getLink();
             
-            if (markInfo!=null && markInfo.getImageName()!=null){
+            if (markInfo.getImageName()!=null){
             	
             	//Link
             	if (StringUtils.isNotEmpty(markLink)){
@@ -549,7 +558,7 @@ public class UIUtil extends Util
             		markFrag.append("</a>");
             	}
             }
-            else  if (markInfo!=null && markInfo.getClassInfo()!=null){
+            else  if (markInfo.getClassInfo()!=null){
             	//Link
             	if (StringUtils.isNotEmpty(markLink)){
             		markFrag.append("<a href=\"")

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1788,6 +1788,13 @@ plugin.single.org.dspace.app.webui.util.StyleSelection = \
 # If you have enabled thumbnails (webui.browse.thumbnail.show), you must also
 # include a 'thumbnail' entry in your columns - this is where the thumbnail will be displayed
 #
+# If you want to mark each item include a 'mark_[value]' (without the brackets - replace the word 'value' with anything that 
+# has a meaning for your mark) entry in your columns - this is where the icon will be displayed.
+# Do not forget to add a Spring bean with id = "org.dspace.app.itemmarking.ItemMarkingExtractor.[value]" 
+# in file 'config/sping/api/item-marking.xml'. This bean is responsible for drawing the appropriate mark for each item.
+# You can add more than one 'mark_[value]' options (with different value) in case yu need to mark items more than one item for
+# different purposes. Remember to add the respecive beans in file 'config/sping/api/item-marking.xml'.
+#
 # webui.itemlist.columns = thumbnail, dc.date.issued(date), dc.title, dc.contributor.*
 #
 # You can customise the width of each column with the following line - you can have numbers (pixels)

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1791,9 +1791,9 @@ plugin.single.org.dspace.app.webui.util.StyleSelection = \
 # If you want to mark each item include a 'mark_[value]' (without the brackets - replace the word 'value' with anything that 
 # has a meaning for your mark) entry in your columns - this is where the icon will be displayed.
 # Do not forget to add a Spring bean with id = "org.dspace.app.itemmarking.ItemMarkingExtractor.[value]" 
-# in file 'config/sping/api/item-marking.xml'. This bean is responsible for drawing the appropriate mark for each item.
-# You can add more than one 'mark_[value]' options (with different value) in case yu need to mark items more than one item for
-# different purposes. Remember to add the respecive beans in file 'config/sping/api/item-marking.xml'.
+# in file 'config/spring/api/item-marking.xml'. This bean is responsible for drawing the appropriate mark for each item.
+# You can add more than one 'mark_[value]' options (with different value) in case you need to mark items more than one time for
+# different purposes. Remember to add the respective beans in file 'config/spring/api/item-marking.xml'.
 #
 # webui.itemlist.columns = thumbnail, dc.date.issued(date), dc.title, dc.contributor.*
 #

--- a/dspace/config/spring/api/item-marking.xml
+++ b/dspace/config/spring/api/item-marking.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+           http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+           http://www.springframework.org/schema/context
+           http://www.springframework.org/schema/context/spring-context-2.5.xsd"
+    default-autowire-candidates="*Service,*DAO,javax.sql.DataSource">
+
+    <context:annotation-config /> <!-- allows us to use spring annotations in beans -->
+
+	<!-- Enable this strategy in order to mark item based on the value of a metadata field -->
+	<bean class="org.dspace.app.itemmarking.ItemMarkingMetadataStrategy"
+		id="org.dspace.app.itemmarking.ItemMarkingExtractor.type">
+		<property name="metadataField" value="dc.type" />
+		<property name="mapping" ref="typeMap"/>
+	</bean>
+	
+	<!-- Enable this strategy in order to mark items based on the collection the item belongs to -->
+	<!-- <bean class="org.dspace.app.itemmarking.ItemMarkingCollectionStrategy"
+		id="org.dspace.app.itemmarking.ItemMarkingExtractor.type">
+		<property name="mapping" ref="collectionMap"/>
+	</bean> -->
+
+	<!-- Enable this strategy in order to mark items based on the availability of their bitstreams -->
+	<bean class="org.dspace.app.itemmarking.ItemMarkingAvailabilityBitstreamStrategy"
+		id="org.dspace.app.itemmarking.ItemMarkingExtractor.availability">
+		<property name="availableImageName" value="image/available.png" />
+		<property name="nonAvailableImageName" value="image/nonavailable.png" />
+	</bean>
+	
+	<bean class="java.util.HashMap" id="typeMap">
+	    <constructor-arg>
+		    <map>
+		        <!-- <entry>
+		            <key>
+		                <value>image</value>
+		            </key>
+					<ref bean="type1MarkingInfo"/>
+		        </entry>
+		        <entry>
+		            <key>
+		                <value>video</value>
+		            </key>
+					<ref bean="type2MarkingInfo"/>
+		        </entry> -->
+		    </map> 
+		</constructor-arg>
+	</bean>
+	
+	<bean class="java.util.HashMap" id="collectionMap">
+	    <constructor-arg>
+		    <map>
+		        <!-- <entry>
+		            <key>
+		                <value>123456789/2</value>
+		            </key>
+					<ref bean="type1MarkingInfo"/>
+		        </entry> -->
+		    </map> 
+		</constructor-arg>
+	</bean>
+	
+	<!-- <bean class="org.dspace.app.itemmarking.ItemMarkingInfo" id="type1MarkingInfo">
+		<property name="classInfo" value="glyphicon glyphicon-picture"/>
+		<property name="tooltip" value="itemlist.mark.type1MarkingInfo"/>
+	</bean>
+	
+	<bean class="org.dspace.app.itemmarking.ItemMarkingInfo" id="type2MarkingInfo">
+		<property name="imageName" value="image/type2.png"/>
+		<property name="tooltip" value="itemlist.mark.type2MarkingInfo"/>
+	</bean> -->
+	
+</beans>


### PR DESCRIPTION
This is a rebase of #659 on master. Please, check #659 for some comments on previous PR.

JIRA Issue: https://jira.duraspace.org/browse/DS-2162

This PR adds per item visual indicators for browse and search results.

The extended functionality has the following specs:

1) Multiple marks can be added per item (i.e. mark the type of the item and the availability of the bitstreams) 
2) Easy configuration of the strategy of what mark to display in every item 
3) Marks based on images or a generic class (i.e. a glyphicon icon for bootstrap) 
4) Display tooltip when hovering the mark + localization of the tooltip 
5) Easy addtion of new strategies for any type of mark the user desires 
6) Add css styles for the user to configure the position of the marks in the list row

Documentation to follow!
