### PR TITLE
DS-2218: Unable to use command "update-handle-prefix"

### DIFF
--- a/dspace-api/src/main/java/org/dspace/handle/UpdateHandlePrefix.java
+++ b/dspace-api/src/main/java/org/dspace/handle/UpdateHandlePrefix.java
@@ -41,7 +41,8 @@ public class UpdateHandlePrefix
             Context context = new Context();
             System.out.println("If you continue, all handles in your repository with prefix " +
                                 oldH + " will be updated to have handle prefix " + newH + "\n");
-            String sql = "SELECT count(*) as count FROM handle " +
+            String sql = "SELECT count(*) as count " +
+                         "FROM handle " +
                          "WHERE handle LIKE '" + oldH + "%'";
             TableRow row = DatabaseManager.querySingle(context, sql, new Object[] {});
             long count = row.getLongColumn("count");
@@ -53,15 +54,21 @@ public class UpdateHandlePrefix
             {
                 // Make the changes
                 System.out.print("Updating handle table... ");
-                sql = "update handle set handle = '" + newH + "' || '/' || handle_id " +
-                      "where handle like '" + oldH + "/%'";
+                sql = "UPDATE handle " +
+                      "SET handle = '" + newH + "' || '/' || handle_id " +
+                      "WHERE handle like '" + oldH + "/%'";
                 int updated = DatabaseManager.updateQuery(context, sql, new Object[] {});
                 System.out.println(updated + " items updated");
 
                 System.out.print("Updating metadatavalues table... ");
-                sql = "UPDATE metadatavalue SET text_value= (SELECT 'http://hdl.handle.net/' || " +
-                      "handle FROM handle WHERE handle.resource_id=item_id AND " +
-                      "handle.resource_type_id=2) WHERE  text_value LIKE 'http://hdl.handle.net/%'";
+                sql = "UPDATE metadatavalue " +
+                      "SET text_value = " +
+                        "(" +
+                          "SELECT 'http://hdl.handle.net/' || handle " +
+                          "FROM handle " +
+                          "WHERE handle.resource_id = item_id AND handle.resource_type_id = 2" +
+                        ") " +
+                      "WHERE text_value LIKE 'http://hdl.handle.net/%'";
                 updated = DatabaseManager.updateQuery(context, sql, new Object[] {});
                 System.out.println(updated + " metadata values updated");
 

--- a/dspace-api/src/main/java/org/dspace/handle/UpdateHandlePrefix.java
+++ b/dspace-api/src/main/java/org/dspace/handle/UpdateHandlePrefix.java
@@ -75,7 +75,7 @@ public class UpdateHandlePrefix
                 // Commit the changes
                 context.complete();
 
-                System.out.print("Re-creating browse and search indexes... ");                
+                System.out.print("Re-creating browse and search indexes... ");
 
                 // Reinitialise the browse system
                 IndexBrowse.main(new String[] {"-i"});

--- a/dspace-api/src/main/java/org/dspace/handle/UpdateHandlePrefix.java
+++ b/dspace-api/src/main/java/org/dspace/handle/UpdateHandlePrefix.java
@@ -61,7 +61,7 @@ public class UpdateHandlePrefix
                 System.out.print("Updating metadatavalues table... ");
                 sql = "UPDATE metadatavalue SET text_value= (SELECT 'http://hdl.handle.net/' || " +
                       "handle FROM handle WHERE handle.resource_id=item_id AND " +
-                      "handle.resource_type_id=2) WHERE  text_value LIKE 'http://hdl.handle.net/%';";
+                      "handle.resource_type_id=2) WHERE  text_value LIKE 'http://hdl.handle.net/%'";
                 updated = DatabaseManager.updateQuery(context, sql, new Object[] {});
                 System.out.println(updated + " metadata values updated");
 

--- a/dspace-api/src/main/java/org/dspace/handle/UpdateHandlePrefix.java
+++ b/dspace-api/src/main/java/org/dspace/handle/UpdateHandlePrefix.java
@@ -9,96 +9,159 @@ package org.dspace.handle;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
-
+import java.sql.SQLException;
+import org.apache.log4j.Logger;
 import org.dspace.core.Context;
 import org.dspace.storage.rdbms.DatabaseManager;
 import org.dspace.storage.rdbms.TableRow;
-import org.dspace.search.DSIndexer;
-import org.dspace.browse.IndexBrowse;
+import org.dspace.discovery.IndexClient;
 
 /**
  * A script to update the handle values in the database. This is typically used
- * when moving from a test machine (handle = 123456789) to a production service.
+ * when moving from a test machine (handle = 123456789) to a production service
+ * or when make a test clone from production service.
  *
  * @author Stuart Lewis
+ * @author Ivo Prajer (Czech Technical University in Prague)
  */
 public class UpdateHandlePrefix
 {
+
+    private static final Logger log = Logger.getLogger(UpdateHandlePrefix.class);
+
+    /**
+     * When invoked as a command-line tool, updates handle prefix
+     *
+     * @param args the command-line arguments, none used
+     * @throws java.lang.Exception
+     *
+     */
     public static void main(String[] args) throws Exception
     {
-        // There should be two paramters
+        // There should be two parameters
         if (args.length < 2)
         {
             System.out.println("\nUsage: update-handle-prefix <old handle> <new handle>\n");
+            System.exit(1);
         }
         else
         {
-            // Confirm with the user that this is what they want to do
             String oldH = args[0];
             String newH = args[1];
 
-            BufferedReader input = new BufferedReader(new InputStreamReader(System.in));
+            // Get info about changes
+            System.out.println("\nGetting information about handles from database...");
             Context context = new Context();
-            System.out.println("If you continue, all handles in your repository with prefix " +
-                                oldH + " will be updated to have handle prefix " + newH + "\n");
             String sql = "SELECT count(*) as count " +
                          "FROM handle " +
                          "WHERE handle LIKE '" + oldH + "%'";
             TableRow row = DatabaseManager.querySingle(context, sql, new Object[] {});
             long count = row.getLongColumn("count");
-            System.out.println(count + " items will be updated.\n");
-            System.out.print("Have you taken a backup, and are you ready to continue? [y/n]: ");
-            String choiceString = input.readLine();
 
-            if (choiceString.equalsIgnoreCase("y"))
+            if (count > 0)
             {
-                // Make the changes
-                System.out.print("Updating handle table... ");
-                sql = "UPDATE handle " +
-                      "SET handle = '" + newH + "' || '/' || handle_id " +
-                      "WHERE handle like '" + oldH + "/%'";
-                int updated = DatabaseManager.updateQuery(context, sql, new Object[] {});
-                System.out.println(updated + " items updated");
+                // Print info text about changes
+                System.out.println(
+                  "All " + count + " handle" + ((count > 1) ? "s" : "") +
+                  " in your repository with prefix " + oldH +
+                  " will be updated to have handle prefix " + newH + "!"
+                );
 
-                System.out.print("Updating metadatavalues table... ");
-                sql = "UPDATE metadatavalue " +
-                      "SET text_value = " +
-                        "(" +
-                          "SELECT 'http://hdl.handle.net/' || handle " +
-                          "FROM handle " +
-                          "WHERE handle.resource_id = item_id AND handle.resource_type_id = 2" +
-                        ") " +
-                      "WHERE text_value LIKE 'http://hdl.handle.net/%'";
-                updated = DatabaseManager.updateQuery(context, sql, new Object[] {});
-                System.out.println(updated + " metadata values updated");
+                // Confirm with the user that this is what they want to do
+                System.out.print(
+                  "Servlet container (e.g. Apache Tomcat, Jetty, Caucho Resin) must be running.\n" +
+                  "If it is necessary, please make a backup of the database.\n" +
+                  "Are you ready to continue? [y/n]: "
+                );
+                BufferedReader input = new BufferedReader(new InputStreamReader(System.in));
+                String choiceString = input.readLine();
 
-                // Commit the changes
-                context.complete();
-
-                System.out.print("Re-creating browse and search indexes... ");
-
-                // Reinitialise the browse system
-                IndexBrowse.main(new String[] {"-i"});
-
-                // Reinitialise the browse system
-                try
+                if (choiceString.equalsIgnoreCase("y"))
                 {
-                    DSIndexer.main(new String[0]);
-                }
-                catch (Exception e)
-                {
-                    // Not a lot we can do
-                    System.out.println("Error re-indexing:");
-                    e.printStackTrace();
-                    System.out.println("\nPlease manually run [dspace]/bin/index-all");
-                }
+                    try {
+                        log.info("Updating handle prefix");
+                        
+                        // Make the changes
+                        System.out.print("\nUpdating handle table... ");
+                        sql = "UPDATE handle " +
+                              "SET handle = '" + newH + "' || '/' || handle_id " +
+                              "WHERE handle like '" + oldH + "/%'";
+                        int updHdl = DatabaseManager.updateQuery(context, sql, new Object[] {});
+                        System.out.println(
+                          updHdl + " item" + ((updHdl > 1) ? "s" : "") + " updated"
+                        );
 
-                // All done
-                System.out.println("\nHandles successfully updated.");
+                        System.out.print("Updating metadatavalues table... ");
+                        sql = "UPDATE metadatavalue " +
+                              "SET text_value = " +
+                                "(" +
+                                  "SELECT 'http://hdl.handle.net/' || handle " +
+                                  "FROM handle " +
+                                  "WHERE handle.resource_id = item_id AND handle.resource_type_id = 2" +
+                                ") " +
+                              "WHERE text_value LIKE 'http://hdl.handle.net/%'";
+                        int updMeta = DatabaseManager.updateQuery(context, sql, new Object[] {});
+                        System.out.println(
+                          updMeta + " metadata value" + ((updMeta > 1) ? "s" : "") + " updated"
+                        );
+
+                        // Commit the changes
+                        context.complete();
+
+                        log.info("Done with updating handle prefix");
+                        log.info(
+                          "It was changed " + updHdl + " handle" + ((updHdl > 1) ? "s" : "") +
+                          " and " + updMeta + " metadata record" + ((updMeta > 1) ? "s" : "")
+                        );
+
+                    }
+                    catch (SQLException sqle)
+                    {
+                        if ((context != null) && (context.isValid()))
+                        {
+                            context.abort();
+                            context = null;
+                        }
+                        System.out.println("\nError during SQL operations.");
+                        throw sqle;
+                    }
+
+                    System.out.println("Handles successfully updated in database.\n");
+                    System.out.println("Re-creating browse and search indexes...");
+
+                    try
+                    {
+                        // Reinitialise the search and browse system
+                        IndexClient.main(new String[] {"-b"});
+                        System.out.println("Browse and search indexes are ready now.");
+                        // All done
+                        System.out.println("\nAll done successfully. Please check the DSpace logs!\n");
+                    }
+                    catch (Exception e)
+                    {
+                        // Not a lot we can do
+                        System.out.println("Error during re-indexing.");
+                        System.out.println(
+                          "\n\nAutomatic re-indexing failed. Please perform it manually.\n" +
+                          "You should run one of the following commands:\n\n" +
+                          "  [dspace]/bin/dspace index-discovery -b\n\n" +
+                          "If you are using Solr for browse (this is the default setting).\n" +
+                          "When launching this command, your servlet container must be running.\n\n" +
+                          "  [dspace]/bin/dspace index-lucene-init\n\n" +
+                          "If you enabled Lucene for search.\n" +
+                          "When launching this command, your servlet container must be shutdown.\n"
+                        );
+                        throw e;
+                    }
+                }
+                else
+                {
+                    System.out.println("No changes have been made to your data.\n");
+                }
             }
             else
             {
-                System.out.println("No changes have been made to your data.");
+                System.out.println("Nothing to do! All handles are up-to-date.\n");
             }
         }
     }

--- a/dspace-api/src/main/java/org/dspace/handle/UpdateHandlePrefix.java
+++ b/dspace-api/src/main/java/org/dspace/handle/UpdateHandlePrefix.java
@@ -62,9 +62,9 @@ public class UpdateHandlePrefix
             {
                 // Print info text about changes
                 System.out.println(
-                  "All " + count + " handle" + ((count > 1) ? "s" : "") +
-                  " in your repository with prefix " + oldH +
-                  " will be updated to have handle prefix " + newH + "!"
+                  "In your repository will be updated " + count + " handle" +
+                  ((count > 1) ? "s" : "") + " to new prefix " + newH +
+                  " from original " + oldH + "!\n"
                 );
 
                 // Confirm with the user that this is what they want to do
@@ -79,8 +79,8 @@ public class UpdateHandlePrefix
                 if (choiceString.equalsIgnoreCase("y"))
                 {
                     try {
-                        log.info("Updating handle prefix");
-                        
+                        log.info("Updating handle prefix from " + oldH + " to " + newH);
+
                         // Make the changes
                         System.out.print("\nUpdating handle table... ");
                         sql = "UPDATE handle " +
@@ -97,9 +97,17 @@ public class UpdateHandlePrefix
                                 "(" +
                                   "SELECT 'http://hdl.handle.net/' || handle " +
                                   "FROM handle " +
-                                  "WHERE handle.resource_id = item_id AND handle.resource_type_id = 2" +
+                                  "WHERE handle.resource_id = metadatavalue.item_id " +
+                                    "AND handle.resource_type_id = 2" +
                                 ") " +
-                              "WHERE text_value LIKE 'http://hdl.handle.net/%'";
+                              "WHERE text_value LIKE 'http://hdl.handle.net/" + oldH + "/%'" +
+                                "AND EXISTS " +
+                                  "(" +
+                                    "SELECT 1 " +
+                                    "FROM handle " + 
+                                    "WHERE handle.resource_id = metadatavalue.item_id " +
+                                      "AND handle.resource_type_id = 2" +
+                                  ")";
                         int updMeta = DatabaseManager.updateQuery(context, sql, new Object[] {});
                         System.out.println(
                           updMeta + " metadata value" + ((updMeta > 1) ? "s" : "") + " updated"
@@ -108,8 +116,8 @@ public class UpdateHandlePrefix
                         // Commit the changes
                         context.complete();
 
-                        log.info("Done with updating handle prefix");
                         log.info(
+                          "Done with updating handle prefix. " +
                           "It was changed " + updHdl + " handle" + ((updHdl > 1) ? "s" : "") +
                           " and " + updMeta + " metadata record" + ((updMeta > 1) ? "s" : "")
                         );


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2218

Use the command "bin/dspace update-handle-prefix <old handle> <new handle>" ends with the "ORA-00911: invalid character". The problem is the extra semicolon in sql command.

I made changes in formatting SQL.
