### PR TITLE
[DS-2220] Always use SSL to fetch Google Analytics

### DIFF
--- a/dspace-jspui/src/main/webapp/layout/header-default.jsp
+++ b/dspace-jspui/src/main/webapp/layout/header-default.jsp
@@ -98,7 +98,7 @@
 
             (function() {
                 var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-                ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+                ga.src = 'https://ssl.google-analytics.com/ga.js';
                 var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
             })();
         </script>

--- a/dspace-jspui/src/main/webapp/layout/header-submission.jsp
+++ b/dspace-jspui/src/main/webapp/layout/header-submission.jsp
@@ -98,7 +98,7 @@
 
             (function() {
                 var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-                ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+                ga.src = 'https://ssl.google-analytics.com/ga.js';
                 var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
             })();
         </script>

--- a/dspace-jspui/src/main/webapp/layout/legacy/header-default.jsp
+++ b/dspace-jspui/src/main/webapp/layout/legacy/header-default.jsp
@@ -99,7 +99,7 @@
 
             (function() {
                 var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-                ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+                ga.src = 'https://ssl.google-analytics.com/ga.js';
                 var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
             })();
         </script>

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
@@ -791,7 +791,7 @@
 
                    (function() {
                        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-                       ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+                       ga.src = 'https://ssl.google-analytics.com/ga.js';
                        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
                    })();
            </xsl:text></script>

--- a/dspace-xmlui/src/main/webapp/themes/dri2xhtml-alt/core/page-structure.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/dri2xhtml-alt/core/page-structure.xsl
@@ -233,7 +233,7 @@
 
                        (function() {
                            var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-                           ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+                           ga.src = 'https://ssl.google-analytics.com/ga.js';
                            var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
                        })();
                </xsl:text></script>

--- a/dspace-xmlui/src/main/webapp/themes/dri2xhtml/structural.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/dri2xhtml/structural.xsl
@@ -282,7 +282,7 @@
 
                        (function() {
                            var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-                           ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+                           ga.src = 'https://ssl.google-analytics.com/ga.js';
                            var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
                        })();
                </xsl:text></script>


### PR DESCRIPTION
We benefit from fetching ga.js over SSL regardless of whether the current page is using SSL itself.
