### PR TITLE
DS-2201: Unable to complete installation of DSpace with non-empty variable "db.schema" configuration file "build.properties"

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseManager.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseManager.java
@@ -868,22 +868,22 @@ public class DatabaseManager
     }
 
     /**
-     * Return the canonical name for a table.
+     * Return the canonical name for a database object.
      *
-     * @param table
-     *            The name of the table.
-     * @return The canonical name of the table.
+     * @param db_object
+     *            The name of the database object.
+     * @return The canonical name of the database object.
      */
-    static String canonicalize(String table)
+    static String canonicalize(String db_object)
     {
-        // Oracle expects upper-case table names
+        // Oracle expects upper-case table names, schemas, etc.
         if (isOracle)
         {
-            return (table == null) ? null : table.toUpperCase();
+            return (db_object == null) ? null : db_object.toUpperCase();
         }
 
         // default database postgres wants lower-case table names
-        return (table == null) ? null : table.toLowerCase();
+        return (db_object == null) ? null : db_object.toLowerCase();
     }
 
     ////////////////////////////////////////
@@ -1402,7 +1402,7 @@ public class DatabaseManager
 
         try
         {
-            String schema = ConfigurationManager.getProperty("db.schema");
+            String schema = canonicalize(ConfigurationManager.getProperty("db.schema"));
             if(StringUtils.isBlank(schema)){
                 schema = null;
             }


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2201

If the variable "db.schema" is not empty in the configuration file [dspace-source]/build.properties, installation ends with this error:

```
[java] 2014-10-17 00:30:14,649 FATAL org.dspace.administer.RegistryLoader @ anonymous::error_loading_registries:
[java] java.lang.NullPointerException
[java] at org.dspace.storage.rdbms.ColumnInfo.canonicalize(ColumnInfo.java:154)
[java] at org.dspace.storage.rdbms.TableRow.canonicalizeAndCheck(TableRow.java:579)
[java] at org.dspace.storage.rdbms.TableRow.setColumn(TableRow.java:437)
[java] at org.dspace.storage.rdbms.DatabaseManager.doInsertGeneric(DatabaseManager.java:1834)
[java] at org.dspace.storage.rdbms.DatabaseManager.insert(DatabaseManager.java:675)
[java] at org.dspace.storage.rdbms.DatabaseManager.create(DatabaseManager.java:447)
[java] at org.dspace.content.BitstreamFormat.create(BitstreamFormat.java:403)
[java] at org.dspace.administer.RegistryLoader.loadFormat(RegistryLoader.java:172)
[java] at org.dspace.administer.RegistryLoader.loadBitstreamFormats(RegistryLoader.java:138)
[java] at org.dspace.administer.RegistryLoader.main(RegistryLoader.java:75)
[java] Error:
[java] - null

BUILD FAILED
/opt/dspace-src-42/dspace/target/dspace-4.2-build/build.xml:858: Java returned: 1
```
