### PR TITLE
DS-2232 Update Oracle pom to latest: 11.2.0.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1082,7 +1082,7 @@
          <dependency>
             <groupId>com.oracle</groupId>
             <artifactId>ojdbc6</artifactId>
-            <version>11.2.0.2.0</version>
+            <version>11.2.0.4.0</version>
          </dependency>
          <dependency>
             <groupId>com.sun.media</groupId>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2232
Oracle version mismatch between our docs, and this pom. 11.2.0.4.0 is the latest from Oracle.
