### PR TITLE
[DS-2195] importing AIPs with DSpace:master throws an NPE

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/packager/RoleIngester.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/RoleIngester.java
@@ -215,6 +215,7 @@ public class RoleIngester implements PackageIngester
         {
             Element group = (Element) groups.item(groupx);
             String name = group.getAttribute(RoleDisseminator.NAME);
+            log.debug("Processing group {}", name);
 
             try
             {
@@ -234,6 +235,7 @@ public class RoleIngester implements PackageIngester
                          "If you are performing an AIP restore, you can ignore this warning as the Community/Collection AIP will likely create this group once it is processed.");
                 continue;
             }
+            log.debug("Translated group name:  {}", name);
 
             Group groupObj = null; // The group to restore
             Group collider = Group.findByName(context, name); // Existing group?
@@ -273,9 +275,11 @@ public class RoleIngester implements PackageIngester
             else
             { // No such group exists  -- so, we'll need to create it!
 
+                log.debug("Creating group for a {}", parent.getTypeText());
                 // First Check if this is a "typed" group (i.e. Community or Collection associated Group)
                 // If so, we'll create it via the Community or Collection
                 String type = group.getAttribute(RoleDisseminator.TYPE);
+                log.debug("Group type is {}", type);
                 if(type!=null && !type.isEmpty() && parent!=null)
                 {
                     //What type of dspace object is this group associated with
@@ -356,10 +360,12 @@ public class RoleIngester implements PackageIngester
         {
             Element group = (Element) groups.item(groupx);
             String name = group.getAttribute(RoleDisseminator.NAME);
+            log.debug("Processing group {}", name);
             try
             {
                 // Translate Group name back to internal ID format (e.g. COLLECTION_<ID>_ADMIN)
                 name = PackageUtils.translateGroupNameForImport(context, name);
+                log.debug("Translated group name:  {}", name);
             }
             catch(PackageException pe)
             {
@@ -373,6 +379,7 @@ public class RoleIngester implements PackageIngester
 
             // Find previously created group
             Group groupObj = Group.findByName(context, name);
+            log.debug("Looked up the group and found {}", groupObj);
             NodeList members = group
                     .getElementsByTagName(RoleDisseminator.MEMBER_GROUP);
             for (int memberx = 0; memberx < members.getLength(); memberx++)

--- a/dspace-api/src/main/java/org/dspace/eperson/Group.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/Group.java
@@ -729,6 +729,10 @@ public class Group extends DSpaceObject
             }
             else
             {
+                // Force the row to be a Group row, as it has all epersongroup
+                // columns but also some others, so could not be typed using
+                // querySingleTable.
+                row.setTable("epersongroup");
                 return new Group(context, row);
             }
         }


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2195

DatabaseManager.querySingle returns an untyped TableRow.  We can't use
querySingleTable because the row contains columns not found in the
required type.  Just force the row to have a type anyway, since it
does contain all of the columns required for that type.  Otherwise the
Group is not update()able.
