### PR TITLE
DS-1798: Reenabling the XSLTDissemination crosswalk.

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -527,6 +527,11 @@ crosswalk.qdc.schemaLocation.qdc  = \
   http://purl.org/dc/elements/1.1/ http://dublincore.org/schemas/xmls/qdc/2006/01/06/dc.xsd
 crosswalk.qdc.properties.qdc = crosswalks/QDC.properties
 
+#### XSLTDisseminationCrosswalks ####
+# XSLTDisseminationCrosswalks uses the selfnamed plugin
+# org.dspace.content.crosswalk.XSLTDisseminationCrosswalk configured above.
+# If you remove all XSLTDisseminationCrosswalk you should disable this plugin
+# to avoid an error log message every time you load DSpace!
 ##
 ## Configure XSLT-driven submission crosswalk for MARC21
 ##
@@ -535,7 +540,6 @@ crosswalk.dissemination.marc.schemaLocation = \
     http://www.loc.gov/MARC21/slim \
     http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd
 crosswalk.dissemination.marc.preferList = true
-
 ##
 ## Configure XSLT-driven submission crosswalk for DataCite
 ##
@@ -583,11 +587,13 @@ plugin.named.org.dspace.content.crosswalk.DisseminationCrosswalk = \
   org.dspace.content.crosswalk.RoleCrosswalk = DSPACE-ROLES
   
 
+# regarding the XSLTDisseminationCrosswalk see the section were it is
+# configured to avoid error logs! Disable it if you remove its configuration.
 plugin.selfnamed.org.dspace.content.crosswalk.DisseminationCrosswalk = \
   org.dspace.content.crosswalk.MODSDisseminationCrosswalk , \
   org.dspace.content.crosswalk.QDCCrosswalk, \
-  org.dspace.content.crosswalk.XHTMLHeadDisseminationCrosswalk
-#  org.dspace.content.crosswalk.XSLTDisseminationCrosswalk
+  org.dspace.content.crosswalk.XHTMLHeadDisseminationCrosswalk, \
+  org.dspace.content.crosswalk.XSLTDisseminationCrosswalk
 
 plugin.named.org.dspace.content.crosswalk.StreamDisseminationCrosswalk = \
   org.dspace.content.crosswalk.CreativeCommonsRDFStreamDisseminationCrosswalk = DSPACE_CCRDF, \


### PR DESCRIPTION
We should re-enable the XSLTDissemination crosswalk as it is used. The DSpace default configuration is correct and does not produces the error messages that leeds to DS-1798. I added warnings in dspace.cfg and the DSpace documentation to prevent users to run in those error messages. I think this PR fixes DS-1798.
