### PR TITLE
DS-2250: Incorrect detection of user sequences

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -793,7 +793,10 @@ public class DatabaseUtils
                 // If results are non-zero, then this sequence exists!
                 if(results!=null && results.next())
                 {
-                   exists = true;
+                   if(results.getInt(1) > 0)
+                   {
+                       exists = true;
+                   }
                 }
             }
         }


### PR DESCRIPTION
This construct returns TRUE, even if the count of sequences is equal to zero = sequence doesn't exists (explanation in https://jira.duraspace.org/browse/DS-2250 and https://jira.duraspace.org/browse/DS-2244).

```
if(results!=null && results.next())
{
   exists = true;
}
```
