### PR TITLE
DS-2111 Remove lucene index operation at end of media filter run

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterManager.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterManager.java
@@ -66,8 +66,6 @@ public class MediaFilterManager
     
     //suffix (in dspace.cfg) for input formats supported by each filter
     public static final String INPUT_FORMATS_SUFFIX = "inputFormats";
-    
-    static boolean updateIndex = true; // default to updating index
 
     static boolean isVerbose = false; // default to not verbose
 
@@ -123,8 +121,6 @@ public class MediaFilterManager
                 "do not print anything except in the event of errors.");
         options.addOption("f", "force", false,
                 "force all bitstreams to be processed");
-        options.addOption("n", "noindex", false,
-                "do NOT update the search index after filtering bitstreams");
         options.addOption("i", "identifier", true,
         		"ONLY process bitstreams belonging to identifier");
         options.addOption("m", "maximum", true,
@@ -181,11 +177,6 @@ public class MediaFilterManager
         }
 
         isQuiet = line.hasOption('q');
-
-        if (line.hasOption('n'))
-        {
-            updateIndex = false;
-        }
 
         if (line.hasOption('f'))
         {
@@ -369,24 +360,6 @@ public class MediaFilterManager
             						applyFiltersItem(c, (Item)dso);
             						break;
             	}
-            }
-          
-            // update search index?
-            if (updateIndex)
-            {
-                if (!isQuiet)
-                {
-                    System.out.println("Updating search index:");
-                }
-                DSIndexer.setBatchProcessingMode(true);
-                try
-                {
-                    DSIndexer.updateIndex(c);
-                }
-                finally
-                {
-                    DSIndexer.setBatchProcessingMode(false);
-                }
             }
 
             c.complete();


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2111

Lucene index is deprecated nowadays, so we don't need to maintain it. Running the media filter has had a call to reindex the lucene index after all of these bitstreams get generated. According to Terry/Tim, Discovery is going to automagically index changed files, so we don't need to trigger a manual index. So, this PR removes the reindexing at the end of media filter.
