### PR TITLE
Flyway fixes for Oracle (DS-2244, DS-2250, DS-2251)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -174,7 +174,7 @@ public class DatabaseUtils
                         System.out.println("Migrating database ONLY to version " + argv[1] + " ... (Check logs for details)");
                         System.out.println("\nWARNING: It is highly likely you will see errors in your logs when the Metadata or Bitstream Format Registry auto-update.");
                         System.out.println("This is because you are attempting to use an OLD version " + argv[1] + " Database with a newer DSpace API.");
-                        System.out.println("Obviously, NEVER do this in a Production scenario. The resulting old stlye database is only useful for DB migration testing.");
+                        System.out.println("Obviously, NEVER do this in a Production scenario. The resulting old style database is only useful for DB migration testing.");
                         Connection connection = dataSource.getConnection();
                         // Update the database, to the version specified.
                         updateDatabase(dataSource, connection, argv[1], false);

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -84,7 +84,7 @@ public class DatabaseUtils
 
             // Get configured DB URL for reporting below
             String url = ConfigurationManager.getProperty("db.url");
-            
+
             // Point Flyway API to our database
             Flyway flyway = setupFlyway(dataSource);
 
@@ -152,7 +152,7 @@ public class DatabaseUtils
             else if(argv[0].equalsIgnoreCase("migrate"))
             {
                 System.out.println("\nDatabase URL: " + url);
-                
+
                 // "migrate" allows for an OPTIONAL second argument:
                 //    - "ignored" = Also run any previously "ignored" migrations during the migration
                 //    - [version] = ONLY run migrations up to a specific DSpace version (ONLY FOR TESTING)
@@ -362,14 +362,14 @@ public class DatabaseUtils
             // Set whethe Flyway will run migrations "out of order". By default, this is false,
             // and Flyway ONLY runs migrations that have a higher version number.
             flyway.setOutOfOrder(outOfOrder);
-            
+
             // If a target version was specified, tell Flyway to ONLY migrate to that version
             // (i.e. all later migrations are left as "pending"). By default we always migrate to latest version.
             if(!StringUtils.isBlank(targetVersion))
             {
                 flyway.setTarget(targetVersion);
             }
-            
+
             // Does the necessary Flyway table ("schema_version") exist in this database?
             // If not, then this is the first time Flyway has run, and we need to initialize
             // NOTE: search is case sensitive, as flyway table name is ALWAYS lowercase,
@@ -421,7 +421,7 @@ public class DatabaseUtils
             throw new SQLException("Flyway migration error occurred", fe);
         }
     }
-    
+
     /**
      * Clean the existing database, permanently removing all data and tables
      * <P>
@@ -625,7 +625,7 @@ public class DatabaseUtils
             // Get the name of the Schema that the DSpace Database is using
             // (That way we can search the right schema)
             String schema = getSchemaName(connection);
-            
+
             // Get information about our database.
             DatabaseMetaData meta = connection.getMetaData();
 
@@ -686,12 +686,12 @@ public class DatabaseUtils
             // Get the name of the Schema that the DSpace Database is using
             // (That way we can search the right schema)
             String schema = getSchemaName(connection);
-            
+
             // Canonicalize everything to the proper case based on DB type
             schema = canonicalize(connection, schema);
             tableName = canonicalize(connection, tableName);
             columnName = canonicalize(connection, columnName);
-            
+
             // Get information about our database.
             DatabaseMetaData meta = connection.getMetaData();
 
@@ -745,8 +745,11 @@ public class DatabaseUtils
             // Get the name of the Schema that the DSpace Database is using
             // (That way we can search the right schema)
             String schema = getSchemaName(connection);
+
+            // Canonicalize everything to the proper case based on DB type
             schema = canonicalize(connection, schema);
-            
+            sequenceName = canonicalize(connection, sequenceName);
+
             // Different database types store sequence information in different tables
             String dbtype = DatabaseManager.findDbKeyword(connection.getMetaData());
             String sequenceSQL = null;
@@ -788,10 +791,10 @@ public class DatabaseUtils
             {
                 // Run the query, passing it our parameters
                 statement = connection.prepareStatement(sequenceSQL);
-                statement.setString(1, StringUtils.upperCase(sequenceName));
+                statement.setString(1, sequenceName);
                 if(schemaFilter)
                 {
-                    statement.setString(2, StringUtils.upperCase(schema));
+                    statement.setString(2, schema);
                 }
                 results = statement.executeQuery();
 

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -70,8 +70,8 @@ public class DatabaseUtils
         if (argv.length < 1)
         {
             System.out.println("\nDatabase action argument is missing.");
-            System.out.println("Valid actions include: 'test', 'info', 'migrate', 'migrate-ignored, 'repair' or 'clean'");
-            System.out.println("Or, type 'database help' for more information.\n");
+            System.out.println("Valid actions: 'test', 'info', 'migrate', 'repair' or 'clean'");
+            System.out.println("\nOr, type 'database help' for more information.\n");
             System.exit(1);
         }
 
@@ -142,8 +142,8 @@ public class DatabaseUtils
                     if (dbVersion!=null)
                     {
                         System.out.println("\nYour database looks to be compatible with DSpace version " + dbVersion);
-                        System.out.println("All upgrades *after* version " + dbVersion + " will be automatically run during the next migration.");
-                        System.out.println("If you'd like to upgrade now, simply run 'dspace database migrate'.");
+                        System.out.println("All upgrades *after* version " + dbVersion + " will be run during the next migration.");
+                        System.out.println("\nIf you'd like to upgrade now, simply run 'dspace database migrate'.");
                     }
                 }
                 connection.close();
@@ -172,9 +172,10 @@ public class DatabaseUtils
                         // Otherwise, we assume "argv[1]" is a valid migration version number
                         // This is only for testing! Never specify for Production!
                         System.out.println("Migrating database ONLY to version " + argv[1] + " ... (Check logs for details)");
-                        System.out.println("\nWARNING: It is highly likely you will see errors in your logs when the Metadata or Bitstream Format Registry auto-update.");
-                        System.out.println("This is because you are attempting to use an OLD version " + argv[1] + " Database with a newer DSpace API.");
-                        System.out.println("Obviously, NEVER do this in a Production scenario. The resulting old style database is only useful for DB migration testing.");
+                        System.out.println("\nWARNING: It is highly likely you will see errors in your logs when the Metadata");
+                        System.out.println("or Bitstream Format Registry auto-update. This is because you are attempting to");
+                        System.out.println("use an OLD version " + argv[1] + " Database with a newer DSpace API. NEVER do this in a");
+                        System.out.println("PRODUCTION scenario. The resulting old DB is only useful for migration testing.\n");
                         Connection connection = dataSource.getConnection();
                         // Update the database, to the version specified.
                         updateDatabase(dataSource, connection, argv[1], false);
@@ -204,10 +205,10 @@ public class DatabaseUtils
             {
                 BufferedReader input = new BufferedReader(new InputStreamReader(System.in));
                 System.out.println("\nDatabase URL: " + url);
-                System.out.println("\nIf you continue, ALL DATA AND TABLES IN YOUR DATABASE WILL BE PERMANENTLY DELETED.\n");
-                System.out.println("There is NO turning back from this action. You should backup your database before continuing.");
+                System.out.println("\nWARNING: ALL DATA AND TABLES IN YOUR DATABASE WILL BE PERMANENTLY DELETED.\n");
+                System.out.println("There is NO turning back from this action. Backup your DB before continuing.");
                 System.out.println("If you are using Oracle, your RECYCLEBIN will also be PURGED.\n");
-                System.out.print("Are you sure you want to PERMANENTLY DELETE everything from your database? [y/n]: ");
+                System.out.print("Do you want to PERMANENTLY DELETE everything from your database? [y/n]: ");
                 String choiceString = input.readLine();
                 input.close();
 
@@ -221,13 +222,13 @@ public class DatabaseUtils
             else
             {
                 System.out.println("\nUsage: database [action]");
-                System.out.println("Valid actions include: 'test', 'info', 'migrate', 'migrate-ignored, 'repair' or 'clean'");
-                System.out.println(" - test             = Test database connection is OK");
-                System.out.println(" - info             = Describe basic info about database (type, version, driver, migrations run)");
-                System.out.println(" - migrate          = Migrate the Database to the latest version");
-                System.out.println("                      Optionally, specify \"ignored\" to also run \"Ignored\" migrations");
-                System.out.println(" - repair           = Attempt to repair any previously failed database migrations");
-                System.out.println(" - clean            = Destroy all data and tables in Database (WARNING there is no going back!)");
+                System.out.println("Valid actions: 'test', 'info', 'migrate', 'repair' or 'clean'");
+                System.out.println(" - test    = Test database connection is OK");
+                System.out.println(" - info    = Describe basic info about database, including migrations run");
+                System.out.println(" - migrate = Migrate the Database to the latest version");
+                System.out.println("             Optionally, specify \"ignored\" to also run \"Ignored\" migrations");
+                System.out.println(" - repair  = Attempt to repair any previously failed database migrations");
+                System.out.println(" - clean   = DESTROY all data and tables in Database (WARNING there is no going back!)");
                 System.out.println("");
             }
 

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -141,8 +141,9 @@ public class DatabaseUtils
                     String dbVersion = determineDBVersion(connection);
                     if (dbVersion!=null)
                     {
-                        System.out.println("Your database looks to be compatible with DSpace version " + dbVersion);
+                        System.out.println("\nYour database looks to be compatible with DSpace version " + dbVersion);
                         System.out.println("All upgrades *after* version " + dbVersion + " will be automatically run during the next migration.");
+                        System.out.println("If you'd like to upgrade now, simply run 'dspace database migrate'.");
                     }
                 }
                 connection.close();
@@ -171,6 +172,9 @@ public class DatabaseUtils
                         // Otherwise, we assume "argv[1]" is a valid migration version number
                         // This is only for testing! Never specify for Production!
                         System.out.println("Migrating database ONLY to version " + argv[1] + " ... (Check logs for details)");
+                        System.out.println("\nWARNING: It is highly likely you will see errors in your logs when the Metadata or Bitstream Format Registry auto-update.");
+                        System.out.println("This is because you are attempting to use an OLD version " + argv[1] + " Database with a newer DSpace API.");
+                        System.out.println("Obviously, NEVER do this in a Production scenario. The resulting old stlye database is only useful for DB migration testing.");
                         Connection connection = dataSource.getConnection();
                         // Update the database, to the version specified.
                         updateDatabase(dataSource, connection, argv[1], false);
@@ -792,12 +796,9 @@ public class DatabaseUtils
                 results = statement.executeQuery();
 
                 // If results are non-zero, then this sequence exists!
-                if(results!=null && results.next())
+                if(results!=null && results.next() && results.getInt(1)>0)
                 {
-                   if(results.getInt(1) > 0)
-                   {
-                      exists = true;
-                   }
+                    exists = true;
                 }
             }
         }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/MigrationUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/MigrationUtils.java
@@ -5,14 +5,14 @@
  *
  * http://www.dspace.org/license/
  */
-package org.dspace.storage.rdbms.migration;
+package org.dspace.storage.rdbms;
 
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import org.apache.commons.lang3.StringUtils;
-import org.dspace.storage.rdbms.DatabaseManager;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * This Utility class offers utility methods which may be of use to perform
@@ -42,7 +42,10 @@ public class MigrationUtils
         // First, in order to drop the appropriate Database constraint, we
         // must determine the unique name of the constraint. As constraint
         // naming is DB specific, this is dependent on our DB Type
-        String dbtype = DatabaseManager.getDbKeyword();
+        DatabaseMetaData meta = connection.getMetaData();
+        // NOTE: We use "findDbKeyword()" here as it won't cause
+        // DatabaseManager.initialize() to be called (which in turn re-calls Flyway)
+        String dbtype = DatabaseManager.findDbKeyword(meta);
         String constraintName = null;
         String constraintNameSQL = null;
         switch(dbtype)

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V1_3_9__Drop_constraint_for_DSpace_1_4_schema.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V1_3_9__Drop_constraint_for_DSpace_1_4_schema.java
@@ -10,7 +10,7 @@ package org.dspace.storage.rdbms.migration;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
-import org.dspace.storage.rdbms.migration.MigrationUtils;
+import org.dspace.storage.rdbms.MigrationUtils;
 import org.flywaydb.core.api.migration.MigrationChecksumProvider;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
 import org.slf4j.Logger;

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V1_5_9__Drop_constraint_for_DSpace_1_6_schema.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V1_5_9__Drop_constraint_for_DSpace_1_6_schema.java
@@ -10,7 +10,7 @@ package org.dspace.storage.rdbms.migration;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
-import org.dspace.storage.rdbms.migration.MigrationUtils;
+import org.dspace.storage.rdbms.MigrationUtils;
 import org.flywaydb.core.api.migration.MigrationChecksumProvider;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
 import org.slf4j.Logger;

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V5_0_2014_09_25__DS_1582_Metadata_For_All_Objects_drop_constraint.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V5_0_2014_09_25__DS_1582_Metadata_For_All_Objects_drop_constraint.java
@@ -10,6 +10,7 @@ package org.dspace.storage.rdbms.migration;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
+import org.dspace.storage.rdbms.MigrationUtils;
 import org.flywaydb.core.api.migration.MigrationChecksumProvider;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
 import org.slf4j.Logger;


### PR DESCRIPTION
- Refactor Flyway DatabaseUtils to properly search by Oracle "Schema" (i.e. User), see getSchemaName()
- Also add a (hidden) ability to initialize an _older_ version of a DSpace DB for testing purposes (`./dspace database migrate [version]`, e.g. `./dspace database migrate 1.7`)

I believe this may fix most, if not all of these tickets:
- https://jira.duraspace.org/browse/DS-2244
- https://jira.duraspace.org/browse/DS-2250
- https://jira.duraspace.org/browse/DS-2251

This also replicates the tiny change in PR #727 for easier testing.

Needs more testing on both Oracle & PostgreSQL (to ensure the refactoring doesn't hinder PostgreSQL in any way)

To clarify the usage of `./dspace database migrate [version]`, it can be used to test DB version identification as follows:
1. Clean existing DB: `./dspace database clean`
2. Create a specific version of a new DB: `./dspace database migrate 1.4`
3. Remove the Flyway table: `DROP TABLE schema_version;`
   - For Oracle: `DROP TABLE "schema_version";`
4. Test if we can identify the version of the DB correctly: `./dspace database info`
   - Should say "Your database looks to be compatible with DSpace version ___"
