### PR TITLE
DS-2265 Publisher information header in uploadstep

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/UploadStep.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/UploadStep.java
@@ -377,12 +377,12 @@ public class UploadStep extends AbstractSubmissionStep
 
 
         if (ConfigurationManager.getBooleanProperty("webui.submission.sherparomeo-policy-enabled", true)){
-            List div = divIn.addList("submit-upload-new", List.TYPE_FORM);
-            div.setHead(T_sherpa_title);
 
             SHERPASubmitService sherpaSubmitService = new DSpace().getSingletonService(SHERPASubmitService.class);
 
             if(sherpaSubmitService.hasISSNs(context, item)) {
+                List div = divIn.addList("submit-upload-new", List.TYPE_FORM);
+                div.setHead(T_sherpa_title);
 
                 //Since sherpa web service doesn't work reliable with more than 1 issn, perform the service for each issn
                 Set<String> issns = sherpaSubmitService.getISSNs(context, item);


### PR DESCRIPTION
The publisher information header in the upload step will now only be shown when there is information available to show.

Jira:
https://jira.duraspace.org/browse/DS-2265
