### PR TITLE
DS-2269 Move Elastic Search schema to a resources file, and out of java

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/ElasticSearchLogger.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/ElasticSearchLogger.java
@@ -8,6 +8,8 @@
 package org.dspace.statistics;
 
 
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
 import com.maxmind.geoip.Location;
 import com.maxmind.geoip.LookupService;
 import org.apache.commons.lang.exception.ExceptionUtils;
@@ -21,10 +23,9 @@ import org.dspace.eperson.EPerson;
 import org.dspace.statistics.util.DnsLookup;
 import org.dspace.statistics.util.LocationUtils;
 import org.dspace.statistics.util.SpiderDetector;
-import org.elasticsearch.action.ActionFuture;
 
-import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequest;
-import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsResponse;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequestBuilder;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
@@ -34,6 +35,7 @@ import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.node.Node;
@@ -42,10 +44,9 @@ import org.elasticsearch.node.NodeBuilder;
 import javax.servlet.http.HttpServletRequest;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URL;
 import java.sql.SQLException;
 import java.util.*;
-
-import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 
 public class ElasticSearchLogger {
 
@@ -125,111 +126,42 @@ public class ElasticSearchLogger {
 
         //Initialize the connection to Elastic Search, and ensure our index is available.
         client = getClient();
+            boolean hasIndex = false;
+            try {
+                log.info("Checking Elastic Search cluster health...");
+                ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth(indexName).setWaitForYellowStatus()
+                        .setTimeout(TimeValue.timeValueSeconds(30)).execute()
+                        .actionGet();
 
-        IndicesExistsRequest indicesExistsRequest = new IndicesExistsRequest();
-        indicesExistsRequest.indices(new String[] {indexName});
+                if (healthResponse.isTimedOut() || healthResponse.getStatus() == ClusterHealthStatus.RED) {
+                    throw new IllegalStateException("cluster not ready due to health: " + healthResponse.toString());
+                }
 
-        ActionFuture<IndicesExistsResponse> actionFutureIndicesExist = client.admin().indices().exists(indicesExistsRequest);        
-        log.info("DS ES Checking if index exists");
-        if(! actionFutureIndicesExist.actionGet().isExists() ) {
+                log.info("DS ES Checking if index exists");
+                hasIndex = client.admin().indices().prepareExists(indexName).execute().actionGet().isExists();
+            } catch (Exception e) {
+                log.error("Exception during health check, likely have to create index and put mapping still. Exception:" + e.getMessage());
+                hasIndex = false;
+            }
+
+        if(! hasIndex) {
             //If elastic search index exists, then we are good to go, otherwise, we need to create that index. Should only need to happen once ever.
             log.info("DS ES index didn't exist, we need to create it.");
 
-            Settings settings = ImmutableSettings.settingsBuilder()
-                    .put("number_of_replicas", 1)
-                    .put("number_of_shards", 5)
-                    .put("cluster.name", clusterName)
-                    .build();
-            
-            String stringMappingJSON = "{\""+indexType+"\" : { \"properties\" : {\n" +
-                    "   \"userAgent\":{\n" +
-                    "      \"type\":\"string\"\n" +
-                    "   },\n" +
-                    "   \"countryCode\":{\n" +
-                    "      \"type\":\"string\",\n" +
-                    "      \"index\":\"not_analyzed\",\n" +
-                    "      \"omit_norms\":true\n" +
-                    "   },\n" +
-                    "   \"dns\":{\n" +
-                    "      \"type\":\"multi_field\",\n" +
-                    "      \"fields\": {\n" +
-                    "        \"dns\": {\"type\":\"string\",\"index\":\"analyzed\"},\n" +
-                    "        \"untouched\":{\"type\":\"string\",\"index\":\"not_analyzed\"}\n" +
-                    "      }\n" +
-                    "   },\n" +
-                    "   \"isBot\":{\n" +
-                    "      \"type\":\"boolean\"\n" +
-                    "   },\n" +
-                    "   \"owningColl\":{\n" +
-                    "      \"type\":\"integer\",\n" +
-                    "      \"index\":\"not_analyzed\"\n" +
-                    "   },\n" +
-                    "   \"type\":{\n" +
-                    "      \"type\":\"string\",\n" +
-                    "      \"index\":\"not_analyzed\",\n" +
-                    "      \"omit_norms\":true\n" +
-                    "   },\n" +
-                    "   \"owningComm\":{\n" +
-                    "      \"type\":\"integer\",\n" +
-                    "      \"index\":\"not_analyzed\"\n" +
-                    "   },\n" +
-                    "   \"city\":{\n" +
-                    "      \"type\":\"multi_field\",\n" +
-                    "      \"fields\": {\n" +
-                    "        \"city\": {\"type\":\"string\",\"index\":\"analyzed\"},\n" +
-                    "        \"untouched\":{\"type\":\"string\",\"index\":\"not_analyzed\"}\n" +
-                    "      }\n" +
-                    "   },\n" +
-                    "   \"country\":{\n" +
-                    "      \"type\":\"multi_field\",\n" +
-                    "      \"fields\": {\n" +
-                    "         \"country\": {\"type\":\"string\",\"index\":\"analyzed\"},\n" +
-                    "         \"untouched\":{\"type\":\"string\",\"index\":\"not_analyzed\"}\n" +
-                    "       }\n" +
-                    "   },\n" +
-                    "   \"ip\":{\n" +
-                    "      \"type\":\"multi_field\",\n" +
-                    "       \"fields\": {\n" +
-                    "         \"ip\": {\"type\":\"string\",\"index\":\"analyzed\"},\n" +
-                    "         \"untouched\":{\"type\":\"string\",\"index\":\"not_analyzed\"}\n" +
-                    "       }\n" +
-                    "   },\n" +
-                    "   \"id\":{\n" +
-                    "      \"type\":\"integer\",\n" +
-                    "      \"index\":\"not_analyzed\"\n" +
-                    "   },\n" +
-                    "   \"time\":{\n" +
-                    "      \"type\":\"date\"\n" +
-                    "   },\n" +
-                    "   \"owningItem\":{\n" +
-                    "      \"type\":\"string\",\n" +
-                    "      \"index\":\"not_analyzed\"\n" +
-                    "   },\n" +
-                    "   \"continent\":{\n" +
-                    "      \"type\":\"string\",\n" +
-                    "      \"index\":\"not_analyzed\"\n" +
-                    "   },\n" +
-                    "   \"geo\":{\n" +
-                    "      \"type\":\"geo_point\"\n" +
-                    "   },\n" +
-                    "   \"bundleName\":{\n" +
-                    "      \"type\":\"string\",\n" +
-                    "      \"index\":\"not_analyzed\"\n" +
-                    "   },\n" +
-                    "   \"epersonid\":{\n" +
-                    "      \"type\":\"string\",\n" +
-                    "      \"index\":\"not_analyzed\"\n" +
-                    "   }\n" +
-                    "} } }";
+            String mappingPath = ElasticSearchLogger.class.getPackage().getName().replaceAll("\\.", "/") ;
+            URL url = Resources.getResource(mappingPath + "/elasticsearch-statistics-mapping.json");
+            String stringMappingJSON = Resources.toString(url, Charsets.UTF_8);
+            stringMappingJSON = stringMappingJSON.replace("stats", indexType);
 
+            //Necessary to post, in order for index/type to be created.
             client.prepareIndex(indexName, indexType, "1")
                     .setSource(XContentFactory.jsonBuilder()
-                                .startObject()
+                                    .startObject()
                                     .field("user", "kimchy")
                                     .field("postDate", new Date())
                                     .field("message", "trying out Elastic Search")
-                                .endObject()
-                              )
+                                    .endObject()
+                    )
                     .execute()
                     .actionGet();
 
@@ -258,7 +190,7 @@ public class ElasticSearchLogger {
         log.info("DSpace ElasticSearchLogger Initialized Successfully (I suppose)");
 
         } catch (Exception e) {
-            log.info("Elastic Search crashed during init. " + e.getMessage());
+            log.error("Elastic Search crashed during init. " + e.getMessage(), e);
         }
     }
 
@@ -652,7 +584,7 @@ public class ElasticSearchLogger {
     public Client createNodeClient(ClientType clientType) {
         String dspaceDir = ConfigurationManager.getProperty("dspace.dir");
         Settings settings = ImmutableSettings.settingsBuilder().put("path.data", dspaceDir + "/elasticsearch/").build();
-        
+
         NodeBuilder nodeBuilder = NodeBuilder.nodeBuilder().clusterName(clusterName).data(true).settings(settings);
 
         if(clientType == ClientType.LOCAL) {

--- a/dspace-api/src/main/resources/org/dspace/statistics/elasticsearch-statistics-mapping.json
+++ b/dspace-api/src/main/resources/org/dspace/statistics/elasticsearch-statistics-mapping.json
@@ -1,0 +1,163 @@
+{
+    "stats": {
+        "properties": {
+            "bundleName": {
+                "type": "string",
+                "index": "not_analyzed",
+                "norms": {
+                    "enabled": false
+                },
+                "index_options": "docs"
+            },
+            "city": {
+                "type": "multi_field",
+                "fields": {
+                    "city": {
+                        "type": "string"
+                    },
+                    "untouched": {
+                        "type": "string",
+                        "index": "not_analyzed",
+                        "norms": {
+                            "enabled": false
+                        },
+                        "index_options": "docs",
+                        "include_in_all": false
+                    }
+                }
+            },
+            "continent": {
+                "type": "string",
+                "index": "not_analyzed",
+                "norms": {
+                    "enabled": false
+                },
+                "index_options": "docs"
+            },
+            "country": {
+                "type": "multi_field",
+                "fields": {
+                    "country": {
+                        "type": "string"
+                    },
+                    "untouched": {
+                        "type": "string",
+                        "index": "not_analyzed",
+                        "norms": {
+                            "enabled": false
+                        },
+                        "index_options": "docs",
+                        "include_in_all": false
+                    }
+                }
+            },
+            "countryCode": {
+                "type": "string",
+                "index": "not_analyzed",
+                "norms": {
+                    "enabled": false
+                },
+                "index_options": "docs"
+            },
+            "dns": {
+                "type": "multi_field",
+                "fields": {
+                    "dns": {
+                        "type": "string"
+                    },
+                    "untouched": {
+                        "type": "string",
+                        "index": "not_analyzed",
+                        "norms": {
+                            "enabled": false
+                        },
+                        "index_options": "docs",
+                        "include_in_all": false
+                    }
+                }
+            },
+            "epersonid": {
+                "type": "string",
+                "index": "not_analyzed",
+                "norms": {
+                    "enabled": false
+                },
+                "index_options": "docs"
+            },
+            "geo": {
+                "type": "geo_point"
+            },
+            "id": {
+                "type": "integer"
+            },
+            "ip": {
+                "type": "multi_field",
+                "fields": {
+                    "ip": {
+                        "type": "string"
+                    },
+                    "untouched": {
+                        "type": "string",
+                        "index": "not_analyzed",
+                        "norms": {
+                            "enabled": false
+                        },
+                        "index_options": "docs",
+                        "include_in_all": false
+                    }
+                }
+            },
+            "isBot": {
+                "type": "boolean"
+            },
+            "latitude": {
+                "type": "double"
+            },
+            "longitude": {
+                "type": "double"
+            },
+            "message": {
+                "type": "string"
+            },
+            "owningColl": {
+                "type": "integer"
+            },
+            "owningComm": {
+                "type": "integer"
+            },
+            "owningItem": {
+                "type": "string",
+                "index": "not_analyzed",
+                "norms": {
+                    "enabled": false
+                },
+                "index_options": "docs"
+            },
+            "postDate": {
+                "type": "date",
+                "format": "dateOptionalTime"
+            },
+            "time": {
+                "type": "date",
+                "format": "dateOptionalTime"
+            },
+            "type": {
+                "type": "string",
+                "index": "not_analyzed",
+                "norms": {
+                    "enabled": false
+                },
+                "index_options": "docs"
+            },
+            "typeIndex": {
+                "type": "long"
+            },
+            "user": {
+                "type": "string"
+            },
+            "userAgent": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/dspace/config/modules/elastic-search-statistics.cfg
+++ b/dspace/config/modules/elastic-search-statistics.cfg
@@ -5,4 +5,4 @@
 
 ## Elastic Search can connect via TransportClient, for external ES service.
 #address = 127.0.0.1
-#statistics.elasticsearch.port = 9300
+#port = 9300


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2269

ElasticSearchLogger has a giant section of hardcoded java string which is the elasticsearch schema / mapping. This PR moves that to a resources file. This is also minor cleanup to ElasticSearch index checking in here too.
