### PR TITLE
DS-2204 Consolidate/Clean Batch Import UI code

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -2124,8 +2124,8 @@ public class ItemImport
      * @param context The context
      * @throws Exception
      */
-    public static void processUIImport(File file, Collection owningCollection, String[] collections, String resumeDir, 
-    		String bteInputType, Context context) throws Exception
+    public static void processBTEUIImport(File file, Collection owningCollection, String[] collections, String resumeDir,
+                                          String bteInputType, Context context) throws Exception
     {
         final EPerson eperson = context.getCurrentUser();
         final File myFile = file;
@@ -2273,7 +2273,7 @@ public class ItemImport
      * @param context The context
      * @throws Exception
      */
-    public static void processUIImport(String url, Collection owningCollection, String[] collections, String resumeDir, Context context) throws Exception
+    public static void processSAFUIImport(String url, Collection owningCollection, String[] collections, String resumeDir, Context context) throws Exception
 	{
 		final EPerson eperson = context.getCurrentUser();
 		final String[] otherCollections2 = collections;

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -2344,56 +2344,8 @@ public class ItemImport
 
 					is.close();
 					os.close();
-					
-					
-					
-					ZipFile zf = new ZipFile(dataZipPath);
-                    ZipEntry entry;
-                    Enumeration<? extends ZipEntry> entries = zf.entries();
-                    while (entries.hasMoreElements())
-                    {
-                        entry = entries.nextElement();
-                        if (entry.isDirectory())
-                        {
-                            if (!new File(dataZipDir + entry.getName()).mkdir())
-                            {
-                                log.error("Unable to create contents directory");
-                            }
-                        }
-                        else
-                        {
-                            //System.out.println("Extracting file: " + entry.getName());
-                            int index = entry.getName().lastIndexOf('/');
-                            if (index == -1)
-                            {
-                                // Was it created on Windows instead?
-                                index = entry.getName().lastIndexOf('\\');
-                            }
-                            if (index > 0)
-                            {
-                                File dir = new File(dataZipDir + entry.getName().substring(0, index));
-                                if (!dir.mkdirs())
-                                {
-                                    log.error("Unable to create directory");
-                                }
-                            }
-                            byte[] buffer = new byte[1024];
-                            int len;
-                            InputStream in = zf.getInputStream(entry);
-                            BufferedOutputStream out = new BufferedOutputStream(
-                                new FileOutputStream(dataZipDir + entry.getName()));
-                            while((len = in.read(buffer)) >= 0)
-                            {
-                                out.write(buffer, 0, len);
-                            }
-                            in.close();
-                            out.close();
-                        }
-                    }
-                    zf.close();
-                    
-					
-					String sourcePath = dataZipDir;
+
+					String sourcePath = unzip(new File(dataZipPath));
 					String mapFilePath = importDirFile + File.separator + "mapfile";
 					
 					

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/BatchImportServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/BatchImportServlet.java
@@ -181,23 +181,14 @@ public class BatchImportServlet extends DSpaceServlet
     			}
 
     			try {
-    				//Decide if it is a new upload or a resume one!
-    				if (uploadId != null){ //resume upload
-    					if (f==null){
-    						ItemImport.processSAFUIImport(zipurl, owningCollection, reqCollections, uploadId, context);
-    					}
-    					else {
-    						ItemImport.processBTEUIImport(f, owningCollection, reqCollections, uploadId, inputType, context);
-    					}
+    				String finalInputType = "saf";
+    				String filePath = zipurl;
+    				if (f!=null){
+    					finalInputType = inputType;
+        				filePath = f.getAbsolutePath();
     				}
-    				else { //New upload
-    					if (f==null){
-    						ItemImport.processSAFUIImport(zipurl, owningCollection, reqCollections, null, context);
-    					}
-    					else {
-    						ItemImport.processBTEUIImport(f, owningCollection, reqCollections, null, inputType, context);
-    					}
-    				}
+    				
+    				ItemImport.processUIImport(filePath, owningCollection, reqCollections, uploadId, finalInputType, context);
     				
     				request.setAttribute("has-error", "false");
     				request.setAttribute("uploadId", null);

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/BatchImportServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/BatchImportServlet.java
@@ -19,7 +19,6 @@ import java.util.ResourceBundle;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.jsp.jstl.fmt.LocaleSupport;
 
 import org.apache.commons.fileupload.FileUploadBase.FileSizeLimitExceededException;
 import org.apache.commons.lang3.StringUtils;
@@ -32,7 +31,6 @@ import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Collection;
 import org.dspace.core.*;
 import org.dspace.utils.DSpace;
-import org.elasticsearch.common.collect.Lists;
 
 /**
  * Servlet to batch import metadata via the BTE
@@ -186,18 +184,18 @@ public class BatchImportServlet extends DSpaceServlet
     				//Decide if it is a new upload or a resume one!
     				if (uploadId != null){ //resume upload
     					if (f==null){
-    						ItemImport.processUIImport(zipurl, owningCollection, reqCollections, uploadId, context);
+    						ItemImport.processSAFUIImport(zipurl, owningCollection, reqCollections, uploadId, context);
     					}
     					else {
-    						ItemImport.processUIImport(f, owningCollection, reqCollections, uploadId, inputType, context);
+    						ItemImport.processBTEUIImport(f, owningCollection, reqCollections, uploadId, inputType, context);
     					}
     				}
     				else { //New upload
     					if (f==null){
-    						ItemImport.processUIImport(zipurl, owningCollection, reqCollections, null, context);
+    						ItemImport.processSAFUIImport(zipurl, owningCollection, reqCollections, null, context);
     					}
     					else {
-    						ItemImport.processUIImport(f, owningCollection, reqCollections, null, inputType, context);
+    						ItemImport.processBTEUIImport(f, owningCollection, reqCollections, null, inputType, context);
     					}
     				}
     				


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2204

There were two Batch Import UI PR's recently, that each added duplication of code to ItemImport. Since they are both in, we can clean up the ItemImport code to reuse methods and clean up the code.

Peter's XMLUI:  https://github.com/DSpace/DSpace/pull/591
Kostas' JSPUI: https://github.com/DSpace/DSpace/pull/675

Primarily the unzip(File) method and other SAF and BTE methods can be consolidated.
