### PR TITLE
DS-2274 Only report error if the log CAN'T be deleted

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/DailyFileAppender.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DailyFileAppender.java
@@ -299,7 +299,7 @@ public class DailyFileAppender extends FileAppender
 			        			if (curLog != null)
 			        			{
 			        				LogLog.debug("Deleting log " + curLog.getName());
-		        					if (curLog.delete())
+		        					if (! curLog.delete())
                                     {
                                         LogLog.error("Unable to delete log file");
                                     }


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2274

Ever seen this:

```
$ /dspace/bin/dspace
log4j:ERROR Unable to delete log file
You must provide at least one command argument
Usage: dspace [command-name] {parameters}
 - checker: Run the checksum checker
```

Unable to delete log file? It looks like the error was being reported when it successfully deleted the file, so this fix is an adjustment to the `if` logic.
