### PR TITLE
DS-2275 XMLUI Error Page onclick errors

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/core/elements.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/core/elements.xsl
@@ -513,6 +513,10 @@
                 <xsl:attribute name="name"><xsl:value-of select="@n"/></xsl:attribute>
             </xsl:if>
 
+            <xsl:if test="@onclick">
+                <xsl:attribute name="onclick"><xsl:value-of select="@onclick"/></xsl:attribute>
+            </xsl:if>
+
             <xsl:apply-templates />
         </a>
     </xsl:template>

--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/core/page-structure.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/core/page-structure.xsl
@@ -295,31 +295,22 @@
                 <meta name="{@element}" content="{.}"></meta>
             </xsl:for-each>
 
-            <!-- Add MathJAX CDN to render scientific formulas -->
+            <!-- Add MathJAX JS library to render scientific formulas-->
             <xsl:if test="confman:getProperty('webui.browse.render-scientific-formulas') = 'true'">
                 <script type="text/x-mathjax-config">
                     MathJax.Hub.Config({
-                    tex2jax: {
-                    inlineMath: [['$','$'], ['\\(','\\)']],
-                    ignoreClass: "detail-field-data|detailtable"
-                    },
-                    TeX: {
-                    Macros: {
-                    AA: '{\\mathring A}'
-                    }
-                    }
+                      tex2jax: {
+                        inlineMath: [['$','$'], ['\\(','\\)']],
+                        ignoreClass: "detail-field-data|detailtable|exception"
+                      },
+                      TeX: {
+                        Macros: {
+                          AA: '{\\mathring A}'
+                        }
+                      }
                     });
                 </script>
-
-                <xsl:choose>
-
-                    <xsl:when test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='scheme']='https'">
-                        <script type="text/javascript" src="https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">&#160;</script>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">&#160;</script>
-                    </xsl:otherwise>
-                </xsl:choose>
+                <script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">&#160;</script>
             </xsl:if>
 
         </head>

--- a/dspace-xmlui/src/main/webapp/exception2dri.xslt
+++ b/dspace-xmlui/src/main/webapp/exception2dri.xslt
@@ -45,7 +45,7 @@ Created by Tim Donohue
           <p>
             <xref><xsl:attribute name="target"><xsl:value-of select="$contextPath"/>/contact</xsl:attribute><i18n:text>xmlui.error.contact</i18n:text></xref> ||  
             <!-- Create a link which lets users optionally display the error stacktrace (using JQuery) -->
-            <xref target="javascript:jQuery('#errorstack').toggleClass('hidden');"><i18n:text>xmlui.error.show_stack</i18n:text></xref>
+            <xref target="#" onclick="javascript:jQuery('#errorstack').toggleClass('hidden');"><i18n:text>xmlui.error.show_stack</i18n:text></xref>
           </p>
           <!-- Include the Java stacktrace on the page, but hide it from view by default. -->
           <p id="errorstack" rend="pre hidden">

--- a/dspace-xmlui/src/main/webapp/exception2dri.xslt
+++ b/dspace-xmlui/src/main/webapp/exception2dri.xslt
@@ -34,7 +34,7 @@ Created by Tim Donohue
   <xsl:template match="ex:exception-report">
     <document version="1.1">
       <body>
-        <div id="exception">
+        <div id="exception" rend="exception">
           <head><xsl:value-of select="$pageTitle"/></head>
           <p>
             <xref><xsl:attribute name="target"><xsl:value-of select="$contextPath"/>/</xsl:attribute><i18n:text>xmlui.general.go_home</i18n:text></xref>

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
@@ -311,31 +311,22 @@
                 <meta name="{@element}" content="{.}"></meta>
             </xsl:for-each>
 
-            <!-- Add MathJAX CDN, can do a local install, or possibly get SSL enabled-->
+            <!-- Add MathJAX JS library to render scientific formulas-->
             <xsl:if test="confman:getProperty('webui.browse.render-scientific-formulas') = 'true'">
                 <script type="text/x-mathjax-config">
                     MathJax.Hub.Config({
-                    tex2jax: {
-                    inlineMath: [['$','$'], ['\\(','\\)']],
-                    ignoreClass: "detail-field-data|detailtable"
-                    },
-                    TeX: {
-                    Macros: {
-                    AA: '{\\mathring A}'
-                    }
-                    }
+                      tex2jax: {
+                        inlineMath: [['$','$'], ['\\(','\\)']],
+                        ignoreClass: "detail-field-data|detailtable|exception"
+                      },
+                      TeX: {
+                        Macros: {
+                          AA: '{\\mathring A}'
+                        }
+                      }
                     });
                 </script>
-
-                <xsl:choose>
-
-                    <xsl:when test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='scheme']='https'">
-                        <script type="text/javascript" src="https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">&#160;</script>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">&#160;</script>
-                    </xsl:otherwise>
-                </xsl:choose>
+                <script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">&#160;</script>
             </xsl:if>
 
         </head>

--- a/dspace-xmlui/src/main/webapp/themes/dri2xhtml-alt/core/elements.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/dri2xhtml-alt/core/elements.xsl
@@ -646,6 +646,10 @@
                 <xsl:attribute name="name"><xsl:value-of select="@n"/></xsl:attribute>
             </xsl:if>
 
+            <xsl:if test="@onclick">
+                <xsl:attribute name="onclick"><xsl:value-of select="@onclick"/></xsl:attribute>
+            </xsl:if>
+
             <xsl:apply-templates />
         </a>
     </xsl:template>

--- a/dspace-xmlui/src/main/webapp/themes/dri2xhtml/structural.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/dri2xhtml/structural.xsl
@@ -1740,6 +1740,10 @@
                 <xsl:attribute name="name"><xsl:value-of select="@n"/></xsl:attribute>
             </xsl:if>
 
+            <xsl:if test="@onclick">
+                <xsl:attribute name="onclick"><xsl:value-of select="@onclick"/></xsl:attribute>
+            </xsl:if>
+
             <xsl:apply-templates />
         </a>
     </xsl:template>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2275

This PR changes the javascript link to show the stack trace on an error page to be `<a onclick="javascript...` instead of an `<a href="javascript...`. To add the xref onclick, I had to add that to the core/elements.xsl. Chrome is smart enough to execute the javascript in an a href, but firefox instead left the page, and opened a javascript console page or something...

Also, my early diagnosis of what this issue was, was that I thought MathJax was causing the issue. Nope. But MathJax did try to render the stack trace, since it had enough dollar signs. I made MathJax not render the exception page.
