### PR TITLE
[DS-2295] Index authority script malfunctions

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authority/AuthorityValueFinder.java
+++ b/dspace-api/src/main/java/org/dspace/authority/AuthorityValueFinder.java
@@ -38,7 +38,8 @@ public class AuthorityValueFinder {
      * Item.ANY does not work here.
      */
     public AuthorityValue findByUID(Context context, String authorityID) {
-        String queryString = "id:" + authorityID;
+        //Ensure that if we use the full identifier to match on
+        String queryString = "id:\"" + authorityID + "\"";
         List<AuthorityValue> findings = find(context, queryString);
         return findings.size() > 0 ? findings.get(0) : null;
     }

--- a/dspace-api/src/main/java/org/dspace/authority/AuthorityValueGenerator.java
+++ b/dspace-api/src/main/java/org/dspace/authority/AuthorityValueGenerator.java
@@ -38,7 +38,11 @@ public class AuthorityValueGenerator {
 
 
         if (nextValue != null) {
-            nextValue.setId(UUID.randomUUID().toString());
+            //Only generate a new UUID if there isn't one offered OR if the identifier needs to be generated
+            if(StringUtils.isBlank(uid) || StringUtils.startsWith(uid, AuthorityValueGenerator.GENERATE)){
+                uid = UUID.randomUUID().toString();
+            }
+            nextValue.setId(uid);
             nextValue.updateLastModifiedDate();
             nextValue.setCreationDate(new Date());
             nextValue.setField(field);

--- a/dspace-api/src/main/java/org/dspace/authority/indexer/AuthorityConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/authority/indexer/AuthorityConsumer.java
@@ -75,6 +75,8 @@ public class AuthorityConsumer implements Consumer {
             for (Integer id : itemsToReindex) {
                 Item item = Item.find(ctx, id);
                 AuthorityIndexClient.indexItem(ctx, item);
+                //Commit our DB connection in case new UUID were generated.
+                ctx.getDBConnection().commit();
 
             }
         } catch (Exception e){

--- a/dspace-api/src/main/java/org/dspace/authority/indexer/AuthorityIndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/authority/indexer/AuthorityIndexClient.java
@@ -14,6 +14,7 @@ import org.dspace.core.Context;
 import org.dspace.kernel.ServiceManager;
 import org.dspace.utils.DSpace;
 
+import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +33,7 @@ public class AuthorityIndexClient {
     public static void main(String[] args) throws Exception {
 
         //Populate our solr
-        Context context = new Context();
+        Context context = new ContextNoCaching();
         //Ensure that we can update items if we are altering our authority control
         context.turnOffAuthorisationSystem();
         ServiceManager serviceManager = getServiceManager();
@@ -104,6 +105,19 @@ public class AuthorityIndexClient {
         //Retrieve our service
         DSpace dspace = new DSpace();
         return dspace.getServiceManager();
+    }
+
+    private static class ContextNoCaching extends Context
+    {
+
+        public ContextNoCaching() throws SQLException {
+            super();
+        }
+
+        @Override
+        public void cache(Object o, int id) {
+            //Do not cache any object
+        }
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/authority/indexer/AuthorityIndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/authority/indexer/AuthorityIndexClient.java
@@ -33,18 +33,19 @@ public class AuthorityIndexClient {
 
         //Populate our solr
         Context context = new Context();
+        //Ensure that we can update items if we are altering our authority control
+        context.turnOffAuthorisationSystem();
         ServiceManager serviceManager = getServiceManager();
 
 
         AuthorityIndexingService indexingService = serviceManager.getServiceByName(AuthorityIndexingService.class.getName(),AuthorityIndexingService.class);
         List<AuthorityIndexerInterface> indexers = serviceManager.getServicesByType(AuthorityIndexerInterface.class);
 
-        log.info("Cleaning the old index");
-        System.out.println("Cleaning the old index");
-        indexingService.cleanIndex();
+        System.out.println("Retrieving all data");
+        log.info("Retrieving all data");
 
         //Get all our values from the input forms
-        Map<String, AuthorityValue> toIndexValues = new HashMap<String, AuthorityValue>();
+        Map<String, AuthorityValue> toIndexValues = new HashMap<>();
         for (AuthorityIndexerInterface indexerInterface : indexers) {
             log.info("Initialize " + indexerInterface.getClass().getName());
             System.out.println("Initialize " + indexerInterface.getClass().getName());
@@ -59,14 +60,22 @@ public class AuthorityIndexClient {
             indexerInterface.close();
         }
 
+
+        log.info("Cleaning the old index");
+        System.out.println("Cleaning the old index");
+        indexingService.cleanIndex();
+        log.info("Writing new data");
+        System.out.println("Writing new data");
         for(String id : toIndexValues.keySet()){
             indexingService.indexContent(toIndexValues.get(id), true);
         }
 
+        context.commit();
         //In the end commit our server
         indexingService.commit();
         context.abort();
         System.out.println("All done !");
+        log.info("All done !");
     }
 
     public static void indexItem(Context context, Item item){


### PR DESCRIPTION
This pull request a number of issues with the index authority script: 
- When run multiple times the internal identifiers are recreated 
- When running the index authority script ORCID links to authority keys could get lost. 
- When running the script there would be authorization errors in the logs when updating updates. 
- Pre existing authors weren't properly imported.
