### PR TITLE
DS-2297: Auto upgrade Solr indexes

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/IndexVersion.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/IndexVersion.java
@@ -37,7 +37,7 @@ public class IndexVersion
         if (argv.length < 1)
         {
             System.out.println("\nRequired Solr/Lucene index directory is missing.");
-            System.out.println("Mimimally, pass in the full path of the Solr/Lucene Index directory to analyze");
+            System.out.println("Minimally, pass in the full path of the Solr/Lucene Index directory to analyze");
             System.out.println("Usage: IndexVersion [full-path-to-solr-index] ([version-to-compare])");
             System.out.println("  - [full-path-to-index] is REQUIRED (e.g. [dspace.dir]/solr/statistics/data/index/)");
             System.out.println("  - [version-to-compare] is optional. When specified, this command will return:");

--- a/dspace-api/src/main/java/org/dspace/app/util/IndexVersion.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/IndexVersion.java
@@ -1,0 +1,246 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Comparator;
+import org.apache.lucene.index.SegmentCommitInfo;
+import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.util.StringHelper;
+
+/**
+ * This utility class simply determines the version of a given Solr/Lucene index,
+ * so that they can be upgraded to the latest version.
+ * <p>
+ * You must pass it the full path of the index directory, e.g.
+ * [dspace]/solr/statistics/data/index/
+ * <p>
+ * The response is simply a version number (e.g. 4.4), as this is utilized by
+ * the "ant update_solr_indexes" target in [src]/dspace/src/main/config/build.xml
+ * 
+ * @author tdonohue
+ */
+public class IndexVersion
+{
+    public static void main(String[] argv)
+            throws IOException
+    {
+        // Usage checks
+        if (argv.length < 1)
+        {
+            System.out.println("\nRequired Solr/Lucene index directory is missing.");
+            System.out.println("Mimimally, pass in the full path of the Solr/Lucene Index directory to analyze");
+            System.out.println("Usage: IndexVersion [full-path-to-solr-index] ([version-to-compare])");
+            System.out.println("  - [full-path-to-index] is REQUIRED (e.g. [dspace.dir]/solr/statistics/data/index/)");
+            System.out.println("  - [version-to-compare] is optional. When specified, this command will return:");
+            System.out.println("       -1 if index dir version < version-to-compare");
+            System.out.println("        0 if index dir version = version-to-compare");
+            System.out.println("        1 if index dir version > version-to-compare");
+            System.exit(1);
+        }
+        
+        // First argument is the Index path. Determine its version
+        String indexVersion = getIndexVersion(argv[0]);
+        
+        // Second argumet is an optional version number to compare to
+        String compareToVersion = argv.length > 1 ? argv[1] : null;
+        
+        // If indexVersion comes back as null, then this is likely not a valid directory
+        if(indexVersion==null)
+        {
+            System.out.println("\nRequired Solr/Lucene index directory is invalid.");
+            System.out.println("The following path does NOT seem to be a valid index directory:");
+            System.out.println(argv[0]);
+            System.out.println("Please pass in the full path of the Solr/Lucene Index directory to analyze");
+            System.out.println("(e.g. [dspace.dir]/solr/statistics/data/index/)\n");
+            System.exit(1);
+        }
+        // If a compare-to-version was passed in, print the result of this comparison
+        else if(compareToVersion!=null && !compareToVersion.isEmpty())
+        {
+            System.out.println(compareSoftwareVersions(indexVersion,compareToVersion));
+        }
+        // Otherwise, we'll just print the version of this index directory
+        else
+        {
+            System.out.println(indexVersion);
+        }
+    }
+    
+    /**
+     * Determine the version of Solr/Lucene which was used to create a given index directory.
+     * 
+     * @param indexDirPath
+     *          Full path of the Solr/Lucene index directory
+     * @return version as a string (e.g. "4.4"), or null if directory doesn't exist
+     * @throws IOException 
+     */
+    public static String getIndexVersion(String indexDirPath)
+            throws IOException
+    {
+        String indexVersion = null;
+        
+        // Make sure this directory exists
+        File dir = new File(indexDirPath);
+        if(dir.exists() && dir.isDirectory())
+        {
+            Directory indexDir = FSDirectory.open(dir);
+
+            // Get info on the Lucene segment file(s) in Solr index directory
+            SegmentInfos sis = new SegmentInfos();
+            try
+            {
+                sis.read(indexDir);
+            }
+            catch(Throwable t)
+            {
+                throw new IOException("Could not read Lucene segments files in " + dir.getAbsolutePath(), t);
+            }
+
+            // Loop through our Lucene segment files to locate the OLDEST
+            // version. It is possible for individual segment files to be
+            // created by different versions of Lucene. So, we just need
+            // to find the oldest version of Lucene which created these
+            // index segment files. 
+            // This logic borrowed from Lucene v.4.9 CheckIndex class:
+            // https://github.com/apache/lucene-solr/blob/lucene_solr_4_9/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java#L407
+            // WARNING: It MAY require updating whenever we upgrade the 
+            // "lucene.version" in our DSpace Parent POM
+            String oldest = Integer.toString(Integer.MAX_VALUE);
+            String oldSegment = null;
+            Comparator<String> versionComparator = StringHelper.getVersionComparator();
+            for (SegmentCommitInfo si : sis) 
+            {
+                // Get the version of Lucene which created this segment file
+                String version = si.info.getVersion();
+                if(version == null)
+                {
+                    // If null, then this is a pre-3.1 segment file.
+                    // For our purposes, we will just assume it is "3.0", 
+                    // This lets us know we will need to upgrade it to 3.5
+                    // before upgrading to Solr/Lucene 4.x or above
+                    oldSegment = "3.0";
+                }
+                // else if this segment is older than our oldest thus far
+                else if(versionComparator.compare(version, oldest) < 0)
+                {
+                    // We have a new oldest segment version
+                    oldest = version;
+                }
+            }
+
+            // If we found a really old segment
+            if(oldSegment!=null)
+            {
+                // See if it really is older than any others, just for safety
+                if(versionComparator.compare(oldSegment, oldest) < 0)
+                {
+                    oldest = oldSegment;
+                }
+            }
+
+            // Verify we only have *one* decimal point. We want sub-minor
+            // versions to be dropped, so 4.10.2 becomes simply 4.10
+            String[] parts = oldest.split(".");
+            if(parts.length>2)
+            {
+                oldest = parts[0] + "." + parts[1];
+            }
+
+            // At this point, we know what version of Lucene created our
+            // oldest segment file. We will return this as the Index version
+            // as it's the oldest segment we will need to upgrade.
+            indexVersion = oldest;
+        }
+        
+        return indexVersion;
+    }
+    
+    /**
+     * Compare two software version numbers to see which is greater. ONLY does
+     * a comparison of *major* and *minor* versions (any sub-minor versions are
+     * stripped and ignored).
+     * <P>
+     * This method returns -1 if firstVersion is less than secondVersion,
+     * 1 if firstVersion is greater than secondVersion, and 0 if equal.
+     * <P>
+     * However, since we ignore sub-minor versions, versions "4.2.1" and "4.2.5"
+     * will be seen as EQUAL (as "4.2" = "4.2").
+     * <P>
+     * NOTE: In case it is not obvious, software version numbering does NOT 
+     * behave like normal decimal numbers. For example, in software versions
+     * the following statement is TRUE: 4.1 < 4.4 < 4.5 < 4.10 < 4.21 < 4.51
+     * 
+     * @param firstVersion
+     *          First version to compare, as a String
+     * @param secondVersion
+     *          Second version to compare as a String
+     * @return -1 if first < second, 1 if first > second, 0 if equal
+     * @throws IOException 
+     */
+    public static int compareSoftwareVersions(String firstVersion, String secondVersion)
+            throws IOException
+    {
+        // Constants which represent our various return values for this comparison
+        int GREATER_THAN = 1;
+        int EQUAL = 0;
+        int LESS_THAN = -1;
+        
+        // "null" is less than anything
+        if(firstVersion==null)
+            return LESS_THAN;
+        // Anything is newer than "null"
+        if(secondVersion==null)
+            return GREATER_THAN;
+            
+        //Split the first version into it's parts (i.e. major & minor versions)
+        String[] firstParts = firstVersion.split("\\.");
+        String[] secondParts = secondVersion.split("\\.");
+        
+        // Get major / minor version numbers. Default to "0" if unspecified
+        // NOTE: We are specifically IGNORING any sub-minor version numbers
+        int firstMajor = firstParts.length>=1 ? Integer.parseInt(firstParts[0]) : 0;
+        int firstMinor = firstParts.length>=2 ? Integer.parseInt(firstParts[1]) : 0;
+        int secondMajor = secondParts.length>=1 ? Integer.parseInt(secondParts[0]) : 0;
+        int secondMinor = secondParts.length>=2 ? Integer.parseInt(secondParts[1]) : 0;
+        
+        // Check for equality
+        if(firstMajor==secondMajor && firstMinor==secondMinor)
+        {
+            return EQUAL;
+        }
+        // If first major version is greater than second
+        else if(firstMajor > secondMajor)
+        {
+            return GREATER_THAN;
+        }
+        // If first major version is less than second
+        else if(firstMajor < secondMajor)
+        {
+            return LESS_THAN;
+        }
+        // If we get here, major versions must be EQUAL. Now, time to check our minor versions
+        else if(firstMinor > secondMinor)
+        {
+            return GREATER_THAN;
+        }
+        else if(firstMinor < secondMinor)
+        {
+            return LESS_THAN;
+        }
+        else
+        {
+            // This is an impossible scenario. 
+            // This 'else' should never be triggered since we've checked for equality above already
+            return EQUAL;
+        }
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -1068,9 +1068,11 @@ public class DatabaseUtils
 
                         log.info("Post database migration, reindexing all content in Discovery search and browse engine");
 
-                        // Reindex Discovery (just clean & update index)
-                        this.indexer.cleanIndex(true);
-                        this.indexer.updateIndex(context, true);
+                        // Reindex Discovery completely
+                        // Recreate the entire index (overwriting existing one)
+                        this.indexer.createIndex(context);
+                        // Rebuild spell checker (which is based on index)
+                        this.indexer.buildSpellCheck();
 
                         // Reset our indexing flag. Indexing is done.
                         DatabaseUtils.setReindexDiscovery(false);

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -1069,13 +1069,13 @@ public class DatabaseUtils
                         log.info("Post database migration, reindexing all content in Discovery search and browse engine");
 
                         // Reindex Discovery completely
+                        // Force clean all content
+                        this.indexer.cleanIndex(true);
                         // Recreate the entire index (overwriting existing one)
                         this.indexer.createIndex(context);
                         // Rebuild spell checker (which is based on index)
                         this.indexer.buildSpellCheck();
 
-                        // Reset our indexing flag. Indexing is done.
-                        DatabaseUtils.setReindexDiscovery(false);
                         log.info("Reindexing is complete");
                     }
                     catch(SearchServiceException sse)
@@ -1088,6 +1088,10 @@ public class DatabaseUtils
                     }
                     finally
                     {
+                        // Reset our indexing flag. Indexing is done or it threw an error,
+                        // Either way, we shouldn't try again.
+                        DatabaseUtils.setReindexDiscovery(false);
+
                         // Clean up our context, if it still exists
                         if(context!=null && context.isValid())
                             context.abort();

--- a/dspace-api/src/test/java/org/dspace/app/util/IndexVersionTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/IndexVersionTest.java
@@ -1,0 +1,69 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.util;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * @author Tim
+ */
+public class IndexVersionTest {
+    
+    @BeforeClass
+    public static void setUpClass() {
+    }
+    
+    @AfterClass
+    public static void tearDownClass() {
+    }
+    
+    @Before
+    public void setUp() {
+    }
+    
+    @After
+    public void tearDown() {
+    }
+
+    /**
+     * Test of compareSoftwareVersions method, of class IndexVersion.
+     */
+    @Test
+    public void testCompareSoftwareVersions() throws Exception {
+        
+        // Test various version comparisons. Remember, in software versions:
+        // 4.1 < 4.4 < 4.5 < 4.10 < 4.21 < 4.51
+        
+        // less than tests (return -1)
+        assertEquals(IndexVersion.compareSoftwareVersions("5", "6"), -1);
+        assertEquals(IndexVersion.compareSoftwareVersions("4.1", "6"), -1);
+        assertEquals(IndexVersion.compareSoftwareVersions("4.1", "4.4"), -1);
+        assertEquals(IndexVersion.compareSoftwareVersions("4.1", "4.10"), -1);
+        assertEquals(IndexVersion.compareSoftwareVersions("4.4", "4.10"), -1);
+        assertEquals(IndexVersion.compareSoftwareVersions("4.4", "5.1"), -1);
+        
+        // greater than tests (return 1)
+        assertEquals(IndexVersion.compareSoftwareVersions("6", "5"), 1);
+        assertEquals(IndexVersion.compareSoftwareVersions("6.10", "6.4"), 1);
+        assertEquals(IndexVersion.compareSoftwareVersions("6.10", "6.1"), 1);
+        assertEquals(IndexVersion.compareSoftwareVersions("5.3", "2.4"), 1);
+        
+        // equality tests (return 0)
+        assertEquals(IndexVersion.compareSoftwareVersions("5", "5.0"), 0);
+        assertEquals(IndexVersion.compareSoftwareVersions("6", "6"), 0);
+        assertEquals(IndexVersion.compareSoftwareVersions("4.2", "4.2"), 0);
+        // we ignore subminor versions, so these should be "equal"
+        assertEquals(IndexVersion.compareSoftwareVersions("4.2.1", "4.2"), 0);
+    }
+    
+}

--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -954,10 +954,16 @@ You may manually install this file by following these steps:
             For each index, this is currently a two step process:
              (1) Ensure the index is upgraded to Solr/Lucene 3.5.0
                  (really old indexes need upgrading to this version first)
-             (2) Then, we can upgrade from 3.5.0 to 4.9.1 (our current Lucene version)
-                 (NOTE: we can only upgrade to the latest version of LUCENE used, 
-                  as we use the Lucene API to do so)
+             (2) Then, we can upgrade from 3.5.0 to latest version of Lucene
         -->
+
+        <!-- Determine what version of Solr/Lucene is being used in DSpace. -->
+        <java classname="org.dspace.app.util.IndexVersion" classpathref="class.path" fork="yes" outputproperty="latest_version">
+            <sysproperty key="log4j.configuration" value="file:config/log4j-console.properties" />
+            <sysproperty key="dspace.log.init.disable" value="true" />
+            <arg value="-v" />
+        </java>
+        <echo>Current version of Solr/Lucene: ${latest_version}</echo>
 
         <!-- First, let's do the Solr Statistics index -->
         <property name="stats.index" value="${dspace.dir}/solr/statistics/data/index/"/>
@@ -968,11 +974,13 @@ You may manually install this file by following these steps:
                 <antcall target="check_solr_index">
                     <param name="indexDir" value="${stats.index}"/>
                     <param name="version" value="3.5.0"/>
+                    <param name="included" value="false"/>
                 </antcall>
-                <!-- Ensure Statistics index is upgraded to 4.9.1 -->
+                <!-- Ensure Statistics index is upgraded to latest version (included in DSpace) -->
                 <antcall target="check_solr_index">
                     <param name="indexDir" value="${stats.index}"/>
-                    <param name="version" value="4.9.1"/>
+                    <param name="version" value="${latest_version}"/>
+                    <param name="included" value="true"/>
                 </antcall>
             </then>
         </if>
@@ -986,11 +994,13 @@ You may manually install this file by following these steps:
                 <antcall target="check_solr_index">
                     <param name="indexDir" value="${oai.index}"/>
                     <param name="version" value="3.5.0"/>
+                    <param name="included" value="false"/>
                 </antcall>
-                <!-- Ensure OAI index is upgraded to 4.9.1 -->
+                <!-- Ensure OAI index is upgraded to latest version (included in DSpace) -->
                 <antcall target="check_solr_index">
                     <param name="indexDir" value="${oai.index}"/>
-                    <param name="version" value="4.9.1"/>
+                    <param name="version" value="${latest_version}"/>
+                    <param name="included" value="true"/>
                 </antcall>
             </then>
         </if>
@@ -1003,13 +1013,15 @@ You may manually install this file by following these steps:
         </delete>
     </target>
     
-    <!-- Target to check an existing Solr index to see if it -->
-    <!-- meets a particular version requirement.             -->
-    <!-- If the index is outdated, "upgrade_solr_index" is   -->
-    <!-- called to upgrade it to the specified version.      -->
-    <!-- REQUIRES these params:                              -->
-    <!--   * indexDir  = Full path to Index directory        -->
-    <!--   * version   = Version of Solr to check against.   -->
+    <!-- Target to check an existing Solr index to see if it            -->
+    <!-- meets a particular version requirement.                        -->
+    <!-- If the index is outdated, "upgrade_solr_index" is              -->
+    <!-- called to upgrade it to the specified version.                 -->
+    <!-- REQUIRES these params:                                         -->
+    <!--   * indexDir  = Full path to Index directory                   -->
+    <!--   * version   = Version of Solr to check against.              -->
+    <!--   * included  = Whether this version of Solr/Lucene is already -->
+    <!--                 included in DSpace classpath.                  -->
     <target name="check_solr_index">       
         <!-- Check if the Solr Statistics index is AT LEAST compatible with Solr/Lucene version 3.5 -->
         <echo>Checking if the Solr index at ${indexDir} is >= Solr ${version}</echo>
@@ -1044,6 +1056,7 @@ ${version_compare}
                 <antcall target="upgrade_solr_index">
                     <param name="indexDir" value="${indexDir}"/>
                     <param name="version" value="${version}"/>
+                    <param name="included" value="${included}"/>
                 </antcall>
             </then>
             <else>
@@ -1052,21 +1065,28 @@ ${version_compare}
         </if>
     </target>
     
-    <!-- Target to actually *upgrade* an existing Solr index -->
-    <!-- REQUIRES these params:                              -->
-    <!--   * indexDir   = Full path to Index directory       -->
-    <!--   * version    = Version of Solr to upgrade to      -->
+    <!-- Target to actually *upgrade* an existing Solr index            -->
+    <!-- REQUIRES these params:                                         -->
+    <!--   * indexDir  = Full path to Index directory                   -->
+    <!--   * version   = Version of Solr to upgrade to                  -->
+    <!--   * included  = Whether this version of Solr/Lucene is already -->
+    <!--                 included in DSpace classpath. If 'false', then -->
+    <!--                 the appropriate Lucene JAR will be downloaded. -->
     <target name="upgrade_solr_index">
         <echo>Upgrading Solr/Lucene Index at ${indexDir} to Solr/Lucene ${version}.</echo>
 
         <!-- Replace the "[version]" placeholders in ${lucene-core} with the actual ${version}-->
         <propertyregex property="lucene-core.jar" input="${lucene-core}" regexp="\[version\]" replace="${version}" global="true"/>
         
-        <!-- Download the appropriate version of the lucene-core.jar, if we haven't already. -->
+        <!-- Download the appropriate version of the lucene-core.jar, if we
+             haven't already AND it's not included on our DSpace classpath. -->
         <if>
-            <not>
-                <available file="./lucene-core-${version}.jar"/>
-            </not>
+            <and>
+                <not>
+                    <available file="./lucene-core-${version}.jar"/>
+                </not>
+                <equals arg1="${included}" arg2="false" casesensitive="false"/>
+            </and>
             <then>
                 <echo>Downloading ${lucene-core.jar}</echo>
                 <trycatch property="lucene.download.error">
@@ -1104,10 +1124,13 @@ For more information, please see the Upgrade Instructions.
             </then>
         </if>
   
-        <!-- At this point, we need the Lucene-core JAR to continue -->
-        <!-- NEXT, we'll actually upgrade the Solr index! -->
+        <!-- If we downloaded a "lucene-core-*.jar" in the previous step,
+             then use that downloaded JAR to upgrade the Solr/Lucene Index -->
         <if>
-            <available file="./lucene-core-${version}.jar"/>
+            <and>
+                <available file="./lucene-core-${version}.jar"/>
+                <equals arg1="${included}" arg2="false" casesensitive="false"/>
+            </and>
             <then>
                 <echo>Upgrading the Solr index in ${indexDir}. Depending on the index size, this may take a while (please be patient)...</echo>
                 <!-- Run the Lucene IndexUpgrader on this index. This will upgrade the index based on the version of "lucene-core.jar" -->
@@ -1117,7 +1140,22 @@ For more information, please see the Upgrade Instructions.
                     <arg value="${indexDir}" />
                 </java>
             </then>
-        </if>        
+        </if>
+
+        <!-- Otherwise, if "included=true" then use the Lucene JAR included
+             in the DSpace classpath to upgrade the Solr/Lucene Index -->
+        <if>
+            <equals arg1="${included}" arg2="true" casesensitive="false"/>
+            <then>
+                <echo>Upgrading the Solr index in ${indexDir}. Depending on the index size, this may take a while (please be patient)...</echo>
+                <!-- Run the Lucene IndexUpgrader on this index. This will upgrade the index based on the version of "lucene-core.jar" -->
+                <java classname="org.apache.lucene.index.IndexUpgrader" classpathref="class.path" fork="yes" failonerror="yes">
+                    <sysproperty key="log4j.configuration" value="file:config/log4j-console.properties" />
+                    <sysproperty key="dspace.log.init.disable" value="true" />
+                    <arg value="${indexDir}" />
+                </java>
+            </then>
+        </if>
     </target>
 
 </project>

--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -95,7 +95,7 @@ Common usage:
     <!-- Default location of GeoLiteCity.dat.gz to download. This may be overridden, if URL path changes. -->
     <property name="geolite" value="http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz" />
     
-    <!-- Default location of lucene-core JAR to download (for update-solr-indexes). This may be overridden, if URL path changes. -->
+    <!-- Default location of lucene-core JAR to download (for update_solr_indexes). This may be overridden, if URL path changes. -->
     <!-- NOTE: this URL should have the version of the JAR replaced with "[version]" -->
     <property name="lucene-core" value="http://search.maven.org/remotecontent?filepath=org/apache/lucene/lucene-core/[version]/lucene-core-[version].jar" />
     
@@ -137,6 +137,7 @@ Common usage:
     	<echo message="update_geolite  --> Dowload and install GeoCity database into ${dspace.dir}/config" />
         <echo message="update_code     --> Update compiled code (bin, lib, and etc directories)" />
         <echo message="update_webapps  --> Update web applications" />
+        <echo message="update_solr_indexes --> Checks if any Solr indexes need upgrading (to latest Solr), and if so, upgrades them." />
         <echo message="" />
         <echo message="init_configs    --> Write the configuration files to ${dspace.dir}/config" />
         <echo message="install_code    --> Install compiled code into ${dspace.dir}" />
@@ -1012,12 +1013,26 @@ You may manually install this file by following these steps:
     <target name="check_solr_index">       
         <!-- Check if the Solr Statistics index is AT LEAST compatible with Solr/Lucene version 3.5 -->
         <echo>Checking if the Solr index at ${indexDir} is >= Solr ${version}</echo>
-        <java classname="org.dspace.app.util.IndexVersion" classpathref="class.path" fork="yes" failonerror="yes" outputproperty="version_compare">
+        <java classname="org.dspace.app.util.IndexVersion" classpathref="class.path" fork="yes" resultproperty="version_returncode" outputproperty="version_compare">
             <sysproperty key="log4j.configuration" value="file:config/log4j-console.properties" />
             <sysproperty key="dspace.log.init.disable" value="true" />
             <arg value="${indexDir}" />
             <arg value="${version}" />
         </java>
+
+        <!-- Fail if the previous command returns a non-zero result, as this
+             means we couldn't determine the Solr index version.
+             We need this special error handling, since we are capturing the
+             output in ${version_compare}. -->
+        <fail>
+          <condition>
+              <not>
+                <equals arg1="${version_returncode}" arg2="0"/>
+              </not>
+          </condition>
+ERROR occurred while checking Solr index version:
+${version_compare}
+        </fail>
         
         <!-- If the above java command returned -1, that means this index is NOT yet
              upgraded to the specified Solr version. So, let's upgrade it! -->

--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -970,7 +970,7 @@ You may manually install this file by following these steps:
         <if>
             <available file="${stats.index}" type="dir"/>
             <then>
-                <!-- Ensure Statistics index is >= 3.5.0 -->
+                <!-- Ensure Statistics index is >= Solr/Lucene 3.5.0 -->
                 <antcall target="check_solr_index">
                     <param name="indexDir" value="${stats.index}"/>
                     <param name="version" value="3.5.0"/>
@@ -984,13 +984,35 @@ You may manually install this file by following these steps:
                 </antcall>
             </then>
         </if>
-        
+
+        <!-- Next, let's do the Discovery Solr index.
+             NOTE: Discovery will be reindexed post database migration, but this
+             is here as a safety measure for older versions of Solr/Lucene -->
+        <property name="discovery.index" value="${dspace.dir}/solr/search/data/index/"/>
+        <if>
+            <available file="${discovery.index}" type="dir"/>
+            <then>
+                <!-- Ensure Discovery index is >= Solr/Lucene 3.5.0 -->
+                <antcall target="check_solr_index">
+                    <param name="indexDir" value="${discovery.index}"/>
+                    <param name="version" value="3.5.0"/>
+                    <param name="included" value="false"/>
+                </antcall>
+                <!-- Ensure Discovery index is upgraded to latest version (included in DSpace) -->
+                <antcall target="check_solr_index">
+                    <param name="indexDir" value="${discovery.index}"/>
+                    <param name="version" value="${latest_version}"/>
+                    <param name="included" value="true"/>
+                </antcall>
+            </then>
+        </if>
+
         <!-- Next, let's do the OAI-PMH Solr index -->
         <property name="oai.index" value="${dspace.dir}/solr/oai/data/index/"/>
         <if>
             <available file="${oai.index}" type="dir"/>
             <then>
-                <!-- Ensure OAI index is >= 3.5.0 -->
+                <!-- Ensure OAI index is >= Solr/Lucene 3.5.0 -->
                 <antcall target="check_solr_index">
                     <param name="indexDir" value="${oai.index}"/>
                     <param name="version" value="3.5.0"/>
@@ -1004,7 +1026,22 @@ You may manually install this file by following these steps:
                 </antcall>
             </then>
         </if>
-        
+
+        <!-- Next, let's do the Authority Solr index. This index first appeared
+             in DSpace 5, so it will never be < Solr 3.5.0 -->
+        <property name="authority.index" value="${dspace.dir}/solr/authority/data/index/"/>
+        <if>
+            <available file="${authority.index}" type="dir"/>
+            <then>
+                <!-- Ensure Authority index is upgraded to latest version (included in DSpace) -->
+                <antcall target="check_solr_index">
+                    <param name="indexDir" value="${authority.index}"/>
+                    <param name="version" value="${latest_version}"/>
+                    <param name="included" value="true"/>
+                </antcall>
+            </then>
+        </if>
+
         <!-- Finally, cleanup any Lucene JARs that were downloaded into the Ant build directory -->
         <!-- (These JARs are automatically downloaded when an index needs an upgrade). -->
         <echo>Cleanup any downloaded lucene-core-*.jar files. We don't need them anymore.</echo>

--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -1027,21 +1027,6 @@ You may manually install this file by following these steps:
             </then>
         </if>
 
-        <!-- Next, let's do the Authority Solr index. This index first appeared
-             in DSpace 5, so it will never be < Solr 3.5.0 -->
-        <property name="authority.index" value="${dspace.dir}/solr/authority/data/index/"/>
-        <if>
-            <available file="${authority.index}" type="dir"/>
-            <then>
-                <!-- Ensure Authority index is upgraded to latest version (included in DSpace) -->
-                <antcall target="check_solr_index">
-                    <param name="indexDir" value="${authority.index}"/>
-                    <param name="version" value="${latest_version}"/>
-                    <param name="included" value="true"/>
-                </antcall>
-            </then>
-        </if>
-
         <!-- Finally, cleanup any Lucene JARs that were downloaded into the Ant build directory -->
         <!-- (These JARs are automatically downloaded when an index needs an upgrade). -->
         <echo>Cleanup any downloaded lucene-core-*.jar files. We don't need them anymore.</echo>

--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -94,6 +94,11 @@ Common usage:
 
     <!-- Default location of GeoLiteCity.dat.gz to download. This may be overridden, if URL path changes. -->
     <property name="geolite" value="http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz" />
+    
+    <!-- Default location of lucene-core JAR to download (for update-solr-indexes). This may be overridden, if URL path changes. -->
+    <!-- NOTE: this URL should have the version of the JAR replaced with "[version]" -->
+    <property name="lucene-core" value="http://search.maven.org/remotecontent?filepath=org/apache/lucene/lucene-core/[version]/lucene-core-[version].jar" />
+    
 
     <!-- ============================================================= -->
     <!-- The DSpace class path for executing installation targets      -->
@@ -180,7 +185,7 @@ Common usage:
     <!-- Update an installation                                        -->
     <!-- ============================================================= -->
 
-    <target name="update" depends="update_configs,update_code,update_webapps" description="Update installed code and web applications (without clobbering data/config)">
+    <target name="update" depends="update_configs,update_code,update_webapps,update_solr_indexes" description="Update installed code and web applications (without clobbering data/config)">
     </target>
 
     <!-- ============================================================= -->
@@ -938,6 +943,166 @@ You may manually install this file by following these steps:
 
     <target name="init_geolite" depends="check_geolite" if="need.geolite">
         <antcall target="update_geolite" />
+    </target>
+    
+    <!-- Check if any Solr indexes need updating to the version of Solr/Lucene we are using. -->
+    <target name="update_solr_indexes">
+        <echo>Checking if any Solr indexes (${dspace.dir}/solr/*) need upgrading...</echo>
+
+        <!-- 
+            For each index, this is currently a two step process:
+             (1) Ensure the index is upgraded to Solr/Lucene 3.5.0
+                 (really old indexes need upgrading to this version first)
+             (2) Then, we can upgrade from 3.5.0 to 4.9.1 (our current Lucene version)
+                 (NOTE: we can only upgrade to the latest version of LUCENE used, 
+                  as we use the Lucene API to do so)
+        -->
+
+        <!-- First, let's do the Solr Statistics index -->
+        <property name="stats.index" value="${dspace.dir}/solr/statistics/data/index/"/>
+        <if>
+            <available file="${stats.index}" type="dir"/>
+            <then>
+                <!-- Ensure Statistics index is >= 3.5.0 -->
+                <antcall target="check_solr_index">
+                    <param name="indexDir" value="${stats.index}"/>
+                    <param name="version" value="3.5.0"/>
+                </antcall>
+                <!-- Ensure Statistics index is upgraded to 4.9.1 -->
+                <antcall target="check_solr_index">
+                    <param name="indexDir" value="${stats.index}"/>
+                    <param name="version" value="4.9.1"/>
+                </antcall>
+            </then>
+        </if>
+        
+        <!-- Next, let's do the OAI-PMH Solr index -->
+        <property name="oai.index" value="${dspace.dir}/solr/oai/data/index/"/>
+        <if>
+            <available file="${oai.index}" type="dir"/>
+            <then>
+                <!-- Ensure OAI index is >= 3.5.0 -->
+                <antcall target="check_solr_index">
+                    <param name="indexDir" value="${oai.index}"/>
+                    <param name="version" value="3.5.0"/>
+                </antcall>
+                <!-- Ensure OAI index is upgraded to 4.9.1 -->
+                <antcall target="check_solr_index">
+                    <param name="indexDir" value="${oai.index}"/>
+                    <param name="version" value="4.9.1"/>
+                </antcall>
+            </then>
+        </if>
+        
+        <!-- Finally, cleanup any Lucene JARs that were downloaded into the Ant build directory -->
+        <!-- (These JARs are automatically downloaded when an index needs an upgrade). -->
+        <echo>Cleanup any downloaded lucene-core-*.jar files. We don't need them anymore.</echo>
+        <delete>
+            <fileset dir="." includes="lucene-core-*.jar"/>
+        </delete>
+    </target>
+    
+    <!-- Target to check an existing Solr index to see if it -->
+    <!-- meets a particular version requirement.             -->
+    <!-- If the index is outdated, "upgrade_solr_index" is   -->
+    <!-- called to upgrade it to the specified version.      -->
+    <!-- REQUIRES these params:                              -->
+    <!--   * indexDir  = Full path to Index directory        -->
+    <!--   * version   = Version of Solr to check against.   -->
+    <target name="check_solr_index">       
+        <!-- Check if the Solr Statistics index is AT LEAST compatible with Solr/Lucene version 3.5 -->
+        <echo>Checking if the Solr index at ${indexDir} is >= Solr ${version}</echo>
+        <java classname="org.dspace.app.util.IndexVersion" classpathref="class.path" fork="yes" failonerror="yes" outputproperty="version_compare">
+            <sysproperty key="log4j.configuration" value="file:config/log4j-console.properties" />
+            <sysproperty key="dspace.log.init.disable" value="true" />
+            <arg value="${indexDir}" />
+            <arg value="${version}" />
+        </java>
+        
+        <!-- If the above java command returned -1, that means this index is NOT yet
+             upgraded to the specified Solr version. So, let's upgrade it! -->
+        <if>
+            <equals arg1="${version_compare}" arg2="-1"/>
+            <then>
+                <echo message="The Solr index in ${indexDir} needs an upgrade to Solr ${version}"/>
+                <!-- Call 'upgrade_solr_index' to actually upgrade the index-->
+                <antcall target="upgrade_solr_index">
+                    <param name="indexDir" value="${indexDir}"/>
+                    <param name="version" value="${version}"/>
+                </antcall>
+            </then>
+            <else>
+                <echo message="The Solr index in ${indexDir} IS >= Solr ${version}. Looks good!"/>
+            </else>
+        </if>
+    </target>
+    
+    <!-- Target to actually *upgrade* an existing Solr index -->
+    <!-- REQUIRES these params:                              -->
+    <!--   * indexDir   = Full path to Index directory       -->
+    <!--   * version    = Version of Solr to upgrade to      -->
+    <target name="upgrade_solr_index">
+        <echo>Upgrading Solr/Lucene Index at ${indexDir} to Solr/Lucene ${version}.</echo>
+
+        <!-- Replace the "[version]" placeholders in ${lucene-core} with the actual ${version}-->
+        <propertyregex property="lucene-core.jar" input="${lucene-core}" regexp="\[version\]" replace="${version}" global="true"/>
+        
+        <!-- Download the appropriate version of the lucene-core.jar, if we haven't already. -->
+        <if>
+            <not>
+                <available file="./lucene-core-${version}.jar"/>
+            </not>
+            <then>
+                <echo>Downloading ${lucene-core.jar}</echo>
+                <trycatch property="lucene.download.error">
+                    <try>
+                        <get src="${lucene-core.jar}" dest="./lucene-core-${version}.jar" verbose="true"/>
+                    </try>
+                    <catch>
+                        <echo>
+====================================================================
+WARNING : FAILED TO DOWNLOAD LUCENE-CORE.JAR
+          (Needed to upgrade your existing Solr indexes)
+
+Underlying Error: ${lucene.download.error}
+
+In order to upgrade your Solr indexes to the latest version,
+you will need to do the following:
+
+(1) Manually download the lucene-core-${version}.jar at:
+
+    ${lucene-core.jar}
+
+(2) Place the JAR in the "[src]/dspace/target/dspace-installer" directory.
+
+    [src]/dspace/target/dspace-installer/${lucene-core}.jar
+
+(3) Manually re-run the following 'ant' upgrade command:
+
+    ant update_solr_indexes
+
+For more information, please see the Upgrade Instructions.
+====================================================================
+                        </echo>
+                    </catch>
+                </trycatch>
+            </then>
+        </if>
+  
+        <!-- At this point, we need the Lucene-core JAR to continue -->
+        <!-- NEXT, we'll actually upgrade the Solr index! -->
+        <if>
+            <available file="./lucene-core-${version}.jar"/>
+            <then>
+                <echo>Upgrading the Solr index in ${indexDir}. Depending on the index size, this may take a while (please be patient)...</echo>
+                <!-- Run the Lucene IndexUpgrader on this index. This will upgrade the index based on the version of "lucene-core.jar" -->
+                <java classname="org.apache.lucene.index.IndexUpgrader" classpath="./lucene-core-${version}.jar" fork="yes" failonerror="yes">
+                    <sysproperty key="log4j.configuration" value="file:config/log4j-console.properties" />
+                    <sysproperty key="dspace.log.init.disable" value="true" />
+                    <arg value="${indexDir}" />
+                </java>
+            </then>
+        </if>        
     </target>
 
 </project>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2297

This PR adds the following:
- A new Ant target (update_solr_indexes) which automatically upgrades Solr indexes as specified using a few other new targets
- A new "IndexVersion" java class (and unit tests) which can determine the Lucene version used to create a specific index directory, and also determine if that version of Lucene is older/newer than a specified version.

This needs further testing, but with these in place, simply running "ant update" will automatically check your Solr Statistics and OAI-PMH indexes (if they exist) and first upgrade them to Lucene 3.5.0 (if needed) followed by an upgrade to Lucene 4.9.1 (which is what we are using). This follows the strategy at: https://wiki.duraspace.org/display/DSPACE/DSpace+Release+5.0+Status#DSpaceRelease5.0Status-Solrupgrade(WIP)
