### PR TITLE
DS-2301 Bump Lucene to 4.10.2 and ElasticSearch to 1.4.0

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -540,7 +540,7 @@
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>1.3.4</version>
+            <version>1.4.0</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.7</java.version>
-        <lucene.version>4.9.1</lucene.version>
+        <lucene.version>4.10.2</lucene.version>
         <solr.version>4.10.2</solr.version>
         <jena.version>2.12.0</jena.version>
         <slf4j.version>1.6.1</slf4j.version>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2301

Bump Lucene to 4.10.2 and ElasticSearch to 1.4.0
We don't need to have inconsistent lucene versions lying around.

This completes what we started, when we previously bumped SOLR, but didn't bump Lucene and ES all the way. https://github.com/DSpace/DSpace/pull/732
