### PR TITLE
DS-2248 XMLUI Delete Community doesn't work

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -469,6 +469,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/dspace-api/src/main/java/org/dspace/content/Bitstream.java
+++ b/dspace-api/src/main/java/org/dspace/content/Bitstream.java
@@ -39,11 +39,11 @@ import org.dspace.storage.rdbms.TableRowIterator;
 public class Bitstream extends DSpaceObject
 {
     /** log4j logger */
-    private static Logger log = Logger.getLogger(Bitstream.class);
+    private static final Logger log = Logger.getLogger(Bitstream.class);
 
 
     /** The row in the table representing this bitstream */
-    private TableRow bRow;
+    private final TableRow bRow;
 
     /** The bitstream format corresponding to this bitstream */
     private BitstreamFormat bitstreamFormat;
@@ -64,6 +64,11 @@ public class Bitstream extends DSpaceObject
     Bitstream(Context context, TableRow row) throws SQLException
     {
         super(context);
+
+        // Ensure that my TableRow is typed.
+        if (null == row.getTable())
+            row.setTable("bitstream");
+
         bRow = row;
 
         // Get the bitstream format

--- a/dspace-api/src/main/java/org/dspace/content/Bundle.java
+++ b/dspace-api/src/main/java/org/dspace/content/Bundle.java
@@ -40,10 +40,10 @@ import org.dspace.storage.rdbms.TableRowIterator;
 public class Bundle extends DSpaceObject
 {
     /** log4j logger */
-    private static Logger log = Logger.getLogger(Bundle.class);
+    private static final Logger log = Logger.getLogger(Bundle.class);
 
     /** The table row corresponding to this bundle */
-    private TableRow bundleRow;
+    private final TableRow bundleRow;
 
     /** The bitstreams in this bundle */
     private List<Bitstream> bitstreams;
@@ -62,6 +62,11 @@ public class Bundle extends DSpaceObject
     Bundle(Context context, TableRow row) throws SQLException
     {
         super(context);
+
+        // Ensure that my TableRow is typed.
+        if (null == row.getTable())
+            row.setTable("bundle");
+
         bundleRow = row;
         bitstreams = new ArrayList<Bitstream>();
         String bitstreamOrderingField  = ConfigurationManager.getProperty("webui.bitstream.order.field");

--- a/dspace-api/src/main/java/org/dspace/content/Collection.java
+++ b/dspace-api/src/main/java/org/dspace/content/Collection.java
@@ -52,10 +52,10 @@ import java.util.*;
 public class Collection extends DSpaceObject
 {
     /** log4j category */
-    private static Logger log = Logger.getLogger(Collection.class);
+    private static final Logger log = Logger.getLogger(Collection.class);
 
     /** The table row corresponding to this item */
-    private TableRow collectionRow;
+    private final TableRow collectionRow;
 
     /** The logo bitstream */
     private Bitstream logo;
@@ -73,7 +73,7 @@ public class Collection extends DSpaceObject
      * Groups corresponding to workflow steps - NOTE these start from one, so
      * workflowGroups[0] corresponds to workflow_step_1.
      */
-    private Group[] workflowGroup;
+    private final Group[] workflowGroup;
 
     /** The default group of submitters */
     private Group submitters;
@@ -100,6 +100,11 @@ public class Collection extends DSpaceObject
     Collection(Context context, TableRow row) throws SQLException
     {
         super(context);
+
+        // Ensure that my TableRow is typed.
+        if (null == row.getTable())
+            row.setTable("collection");
+
         collectionRow = row;
 
         // Get the logo bitstream
@@ -1083,6 +1088,7 @@ public class Collection extends DSpaceObject
      * @throws IOException
      * @throws AuthorizeException
      */
+    @Override
     public void update() throws SQLException, AuthorizeException
     {
         // Check authorisation
@@ -1168,9 +1174,6 @@ public class Collection extends DSpaceObject
 
         ourContext.addEvent(new Event(Event.DELETE, Constants.COLLECTION, 
                 getID(), getHandle(), getIdentifiers(ourContext)));
-
-        // Remove from cache
-        ourContext.removeCached(this, getID());
 
         // remove subscriptions - hmm, should this be in Subscription.java?
         DatabaseManager.updateQuery(ourContext,
@@ -1289,6 +1292,9 @@ public class Collection extends DSpaceObject
                 collectionRole.delete();
             }
         }
+
+        // Remove from cache
+        ourContext.removeCached(this, getID());
 
         // Delete collection row
         DatabaseManager.delete(ourContext, collectionRow);

--- a/dspace-api/src/main/java/org/dspace/content/Community.java
+++ b/dspace-api/src/main/java/org/dspace/content/Community.java
@@ -42,10 +42,10 @@ import java.util.*;
 public class Community extends DSpaceObject
 {
     /** log4j category */
-    private static Logger log = Logger.getLogger(Community.class);
+    private static final Logger log = Logger.getLogger(Community.class);
 
     /** The table row corresponding to this item */
-    private TableRow communityRow;
+    private final TableRow communityRow;
 
     /** The logo bitstream */
     private Bitstream logo;
@@ -76,6 +76,11 @@ public class Community extends DSpaceObject
     Community(Context context, TableRow row) throws SQLException
     {
         super(context);
+
+        // Ensure that my TableRow is typed.
+        if (null == row.getTable())
+            row.setTable("community");
+
         communityRow = row;
 
         // Get the logo bitstream

--- a/dspace-api/src/main/java/org/dspace/content/Item.java
+++ b/dspace-api/src/main/java/org/dspace/content/Item.java
@@ -66,7 +66,7 @@ public class Item extends DSpaceObject
     private static final Logger log = Logger.getLogger(Item.class);
 
     /** The table row corresponding to this item */
-    private TableRow itemRow;
+    private final TableRow itemRow;
 
     /** The e-person who submitted this item */
     private EPerson submitter;
@@ -96,6 +96,11 @@ public class Item extends DSpaceObject
     Item(Context context, TableRow row) throws SQLException
     {
         super(context);
+
+        // Ensure that my TableRow is typed.
+        if (null == row.getTable())
+            row.setTable("item");
+
         itemRow = row;
         modified = false;
         clearDetails();

--- a/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
@@ -77,6 +77,11 @@ public class EPerson extends DSpaceObject
      */
     EPerson(Context context, TableRow row) throws SQLException {
         super(context);
+
+        // Ensure that my TableRow is typed.
+        if (null == row.getTable())
+            row.setTable("eperson");
+
         myRow = row;
 
         // Cache ourselves

--- a/dspace-api/src/main/java/org/dspace/eperson/Group.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/Group.java
@@ -78,6 +78,11 @@ public class Group extends DSpaceObject
     Group(Context context, TableRow row) throws SQLException
     {
         super(context);
+
+        // Ensure that my TableRow is typed.
+        if (null == row.getTable())
+            row.setTable("epersongroup");
+
         myRow = row;
 
         // Cache ourselves

--- a/pom.xml
+++ b/pom.xml
@@ -1131,7 +1131,7 @@
              <artifactId>slf4j-log4j12</artifactId>
              <version>${slf4j.version}</version>
          </dependency>
-         <!-- JMockit and JUnit are used for Unit/Integration tests -->
+         <!-- JMockit, JUnit and Hamcrest are used for Unit/Integration tests -->
          <dependency> <!-- Keep jmockit before junit -->
             <groupId>org.jmockit</groupId>
             <artifactId>jmockit</artifactId>
@@ -1142,6 +1142,12 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>
+            <scope>test</scope>
+         </dependency>
+         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.3</version>
             <scope>test</scope>
          </dependency>
          <!-- H2 is an in-memory database used for Unit/Integration tests -->


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2248

This fixes two things:  (1) have DSO subclass constructors ensure that the embedded TableRow has a table name, to prevent NPE later; (2) decache Collection much later in delete() to prevent the object reappearing in the Context cache and causing spurious test failures.  Plus some tidying-up of surrounding code.
