### PR TITLE
DS-2042 Discovery/Solr is improperly indexing the "dc.description.provenance" field

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -970,6 +970,18 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                     toProjectionFields.add(projectionFieldsString);
                 }
             }
+            
+            List<String> toIgnoreMetadataFields = new ArrayList<String>();
+            String ignoreFieldsString = new DSpace().getConfigurationService().getProperty("discovery.index.ignore");
+            if (ignoreFieldsString != null) {
+                if (ignoreFieldsString.indexOf(",") != -1) {
+                    for (int i = 0; i < ignoreFieldsString.split(",").length; i++) {
+                        toIgnoreMetadataFields.add(ignoreFieldsString.split(",")[i].trim());
+                    }
+                } else {
+                    toIgnoreMetadataFields.add(ignoreFieldsString);
+                }
+            }
 
             Metadatum[] mydc = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
             for (Metadatum meta : mydc)
@@ -989,7 +1001,6 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                     field += "." + meta.qualifier;
                 }
 
-                List<String> toIgnoreMetadataFields = SearchUtils.getIgnoredMetadataFields(item.getType());
                 //We are not indexing provenance, this is useless
                 if (toIgnoreMetadataFields != null && (toIgnoreMetadataFields.contains(field) || toIgnoreMetadataFields.contains(unqualifiedField + "." + Item.ANY)))
                 {

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceSpellIndexingPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceSpellIndexingPlugin.java
@@ -7,11 +7,14 @@
  */
 package org.dspace.discovery;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.solr.common.SolrInputDocument;
-import org.dspace.content.Metadatum;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
+import org.dspace.content.Metadatum;
 import org.dspace.core.Context;
+import org.dspace.utils.DSpace;
 
 /**
  * Created with IntelliJ IDEA.
@@ -25,8 +28,35 @@ public class SolrServiceSpellIndexingPlugin implements SolrServiceIndexPlugin {
     @Override
     public void additionalIndex(Context context, DSpaceObject dso, SolrInputDocument document) {
         if(dso instanceof Item){
+            
+            List<String> toIgnoreMetadataFields = new ArrayList<String>();
+            String ignoreFieldsString = new DSpace().getConfigurationService().getProperty("discovery.index.ignore");
+            if (ignoreFieldsString != null) {
+                if (ignoreFieldsString.indexOf(",") != -1) {
+                    for (int i = 0; i < ignoreFieldsString.split(",").length; i++) {
+                        toIgnoreMetadataFields.add(ignoreFieldsString.split(",")[i].trim());
+                    }
+                } else {
+                    toIgnoreMetadataFields.add(ignoreFieldsString);
+                }
+            }
             Metadatum[] dcValues = ((Item) dso).getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
             for (Metadatum dcValue : dcValues) {
+                String field = dcValue.schema + "." + dcValue.element;
+                String unqualifiedField = field;
+
+                if (dcValue.value == null) {
+                    continue;
+                }
+
+                if (dcValue.qualifier != null && !dcValue.qualifier.trim().equals("")) {
+                    field += "." + dcValue.qualifier;
+                }
+                 //We are not indexing provenance, this is useless
+                if (toIgnoreMetadataFields != null && (toIgnoreMetadataFields.contains(field) 
+                        || toIgnoreMetadataFields.contains(unqualifiedField + "." + Item.ANY))) {
+                    continue;
+                }
                 document.addField("a_spell", dcValue.value);
 
             }

--- a/dspace/config/modules/discovery.cfg
+++ b/dspace/config/modules/discovery.cfg
@@ -18,6 +18,8 @@ search.server = ${solr.server}/search
 # index.ignore-authority = false
 index.projection=dc.title,dc.contributor.*,dc.date.issued
 
+index.ignore=dc.description.provenance
+
 # ONLY-FOR-JSPUI: 
 # 1) you need to set the DiscoverySearchRequestProcessor in the dspace.cfg 
 # 2) to show facet on Site/Community/etc. you need to add a Site/Community/Collection


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2042

Discovery is supposed to be ignoring the "dc.description.provenance" field, based on this Spring configuration:
https://github.com/DSpace/DSpace/blob/master/dspace/config/spring/api/discovery.xml#L84

However, if you search in any DSpace 4.x instance for a Submitter's email address or name, you will get a results listing of everything that submitter has deposited within DSpace. We are seeing this in _every_ DSpaceDIrect instance (all running on 4.x).

It's also can be replicated in the Demo site (both XMLUI and JSPUI), for example:

JSPUI search for "dspacedemo+admin@gmail.com": http://demo.dspace.org/jspui/simple-search?query=dspacedemo%2Badmin%40gmail.com

You can similarly search for "dspacedemo+admin@gmail.com" in XMLUI to get results which show all Items deposited by that user. The ONLY metadata field with that information is the "dc.description.provenance" field. 
