### PR TITLE
DS-2289: Keep NULL field language while importing items

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -1129,18 +1129,6 @@ public class ItemImport
             qualifier = null;
         }
 
-        // if language isn't set, use the system's default value
-        if (StringUtils.isEmpty(language))
-        {
-            language = ConfigurationManager.getProperty("default.language");
-        }
-
-        // a goofy default, but there it is
-        if (language == null)
-        {
-            language = "en";
-        }
-
         if (!isTest)
         {
             i.addMetadata(schema, element, qualifier, language, value);


### PR DESCRIPTION
Related JIRA: https://jira.duraspace.org/browse/DS-2289

@helix84 noticed that imported items get the default language (specified in dspace.cfg) if no language is specified. This is a problem when exporting items and then immediately import them again, since all metadata fields with NULL value in language, after the import, the get the default language.

This PR corrects this problem, however, I am not sure if, after removing these lines of code, something else is affected (i.e. what about the XMLUI?)
