### PR TITLE
DS-2313: Mirage2 svg logo fix for ie10

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/images/DSpace-logo-line.svg
+++ b/dspace-xmlui-mirage2/src/main/webapp/images/DSpace-logo-line.svg
@@ -1,168 +1,47 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="241.7"
-   height="52.400002"
-   id="svg3053"
-   version="1.1"
-   inkscape:version="0.48.2 r9819"
-   sodipodi:docname="DSpace-logo-line.svg">
-  <metadata
-     id="metadata3081">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs
-     id="defs3079" />
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="2348"
-     inkscape:window-height="1049"
-     id="namedview3077"
-     showgrid="false"
-     inkscape:zoom="6.2769679"
-     inkscape:cx="101.91044"
-     inkscape:cy="31.629348"
-     inkscape:window-x="2128"
-     inkscape:window-y="295"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg3053" />
-  <style
-     type="text/css"
-     id="style3055">
-	.st0{fill:#FFFFFF;stroke:#808285;stroke-width:1.0563;}
-	.st1{fill:#808285;}
-	.st2{fill:#C0D028;}
-	.st3{fill:#FFFFFF;stroke:#808285;stroke-width:0.4225;}
-	.st4{fill:#FFFFFF;stroke:#808285;stroke-width:0.6338;}
-	.st5{fill:#FFFFFF;stroke:#808285;stroke-width:0.6761;}
-	.st6{fill:#FFFFFF;stroke:#808285;stroke-width:0.8451;}
-</style>
-  <g
-     id="g3057">
-    <title
-       id="title3059">Layer 1</title>
-    <g
-       id="svg_1">
-      <rect
-         x="19.1"
-         y="17.700001"
-         class="st2"
-         width="14.8"
-         height="14.8"
-         id="svg_2"
-         style="fill:#c0d028" />
-      <g
-         id="svg_3">
-        <rect
-           x="40.599998"
-           y="21.200001"
-           class="st3"
-           width="8.3000002"
-           height="8.3000002"
-           id="svg_4"
-           style="fill:#ffffff;stroke:#808285;stroke-width:0.42250001" />
-        <rect
-           x="21.200001"
-           y="0.5"
-           class="st5"
-           width="10.7"
-           height="10.7"
-           id="svg_5"
-           style="fill:#ffffff;stroke:#808285;stroke-width:0.67610002" />
-        <rect
-           x="0.60000002"
-           y="18.5"
-           class="st0"
-           width="13.2"
-           height="13.2"
-           id="svg_6"
-           style="fill:#ffffff;stroke:#808285;stroke-width:1.05630004" />
-        <rect
-           x="3.0999999"
-           y="37.200001"
-           class="st3"
-           width="8.1999998"
-           height="8.1999998"
-           id="svg_7"
-           style="fill:#ffffff;stroke:#808285;stroke-width:0.42250001" />
-        <rect
-           x="19.799999"
-           y="38.5"
-           class="st6"
-           width="13.4"
-           height="13.4"
-           id="svg_8"
-           style="fill:#ffffff;stroke:#808285;stroke-width:0.84509999" />
-        <rect
-           x="39.099998"
-           y="36.5"
-           class="st4"
-           width="11.3"
-           height="11.3"
-           id="svg_9"
-           style="fill:#ffffff;stroke:#808285;stroke-width:0.63380003" />
-      </g>
-      <g
-         id="svg_10">
-        <path
-           class="st1"
-           d="m 74.056438,10.372928 7.33561,0 c 7.71174,0 13.91856,6.959379 13.91856,15.611616 0,8.652239 -6.20682,15.611649 -13.91856,15.611649 -0.7524,0 -7.33561,0 -7.33561,0 l 0,-31.223259 0,-6e-6 z m 5.07848,25.956683 2.06903,0 c 4.51418,0 8.27603,-4.702285 8.27603,-10.345067 0,-5.642718 -3.76185,-10.345065 -8.27603,-10.345065 -0.7524,0 -2.06903,0 -2.06903,0 l 0,20.690132 z"
-           id="svg_11"
-           inkscape:connector-curvature="0"
-           style="fill:#808285" />
-        <path
-           class="st2"
-           d="m 112.23911,41.972381 c -3.38566,0 -5.83086,-1.128548 -8.84033,-3.385653 l 0.56428,-4.7023 c 3.19757,1.692831 5.64276,2.821382 8.27605,2.821382 2.2571,0 5.26657,-1.316644 5.26657,-3.761842 0,-5.830848 -14.67117,-3.573748 -14.67117,-14.106898 0,-5.454667 4.70231,-9.2165067 10.34506,-9.2165067 3.57374,0 5.83085,1.1285527 9.0284,3.7618397 l -1.69283,4.138024 c -2.25709,-1.504738 -4.89038,-2.633286 -7.33557,-2.633286 -3.19757,0 -5.07849,1.692828 -5.07849,3.573747 0,5.642758 14.67118,4.13802 14.67118,13.730712 0.37618,6.583218 -4.89038,9.780781 -10.53315,9.780781 z"
-           id="svg_12"
-           inkscape:connector-curvature="0"
-           style="fill:#c0d028" />
-        <path
-           class="st2"
-           d="m 152.86689,20.906061 c 0,5.642781 -4.70248,10.345067 -10.34483,10.345067 -0.37657,0 -6.20688,0 -6.20688,0 l 0,10.345066 -5.26702,0 0,-31.223259 11.4739,0 c 5.64235,0 10.34483,4.70231 10.34483,10.533126 l 0,0 z m -5.2664,0 c 0,-2.821357 -2.25693,-5.266582 -5.26639,-5.266582 -0.56455,0 -6.20752,0 -6.20752,0 l 0,10.345066 6.20752,0 c 3.00946,0 5.26639,-2.257062 5.26639,-5.078484 z"
-           id="svg_13"
-           inkscape:connector-curvature="0"
-           style="fill:#c0d028" />
-        <path
-           class="st2"
-           d="m 167.35006,41.596206 -5.26657,0 0,-19.749664 c 0,-7.711772 4.70229,-11.849793 10.34504,-11.849793 5.83086,0 10.34507,4.326115 10.34507,11.849793 l 0,19.749664 -5.26657,0 0,-10.345066 -10.34509,0 0,10.345066 0.18812,0 z m 10.34506,-19.749664 c 0,-4.514206 -2.2571,-6.771311 -5.26659,-6.771311 -2.82137,0 -5.26659,2.257105 -5.26659,6.771311 l 0,4.138026 10.34509,0 0,-4.138026 0.18809,0 z"
-           id="svg_14"
-           inkscape:connector-curvature="0"
-           style="fill:#c0d028" />
-        <path
-           class="st2"
-           d="m 205.90865,9.996749 c 3.76197,0 7.89991,2.445192 9.96888,6.018928 l -3.19743,2.821422 c -2.06898,-2.633323 -4.13792,-3.761854 -6.58284,-3.761854 -4.13857,0 -7.71193,4.137989 -7.71193,10.9093 0,6.771311 3.57336,10.909362 7.71193,10.909362 2.25694,0 4.51386,-1.12853 6.58284,-3.761852 l 3.19743,2.821357 c -2.25695,3.573755 -6.20691,6.018978 -9.96888,6.018978 -7.89929,0 -13.1663,-7.147511 -13.1663,-15.987846 0,-8.840275 5.2664,-15.987795 13.1663,-15.987795 l 0,0 z"
-           id="svg_15"
-           inkscape:connector-curvature="0"
-           style="fill:#c0d028" />
-        <path
-           class="st2"
-           d="m 224.34197,10.372928 15.61185,0 0,5.266551 -10.34546,0 0,6.207076 10.34546,0 0,5.266585 -10.34546,0 0,9.404567 10.34546,0 0,5.266583 -15.61185,0 0,-31.411356 0,-6e-6 z"
-           id="svg_16"
-           inkscape:connector-curvature="0"
-           style="fill:#c0d028" />
-      </g>
-    </g>
-  </g>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1"
+	 id="svg3053" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" sodipodi:docname="DSpace-logo-line.svg" inkscape:version="0.48.2 r9819"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="102px" height="23px"
+	 viewBox="69.35 14.7 102 23" enable-background="new 69.35 14.7 102 23" xml:space="preserve">
+<sodipodi:namedview  inkscape:cy="31.629348" inkscape:cx="101.91044" inkscape:zoom="6.2769679" showgrid="false" guidetolerance="10" gridtolerance="10" objecttolerance="10" bordercolor="#666666" pagecolor="#ffffff" borderopacity="1" id="namedview3077" inkscape:current-layer="svg3053" inkscape:window-maximized="0" inkscape:window-y="295" inkscape:window-x="2128" inkscape:window-height="1049" inkscape:window-width="2348" inkscape:pageshadow="2" inkscape:pageopacity="0">
+	</sodipodi:namedview>
+<g id="g3057">
+	<title  id="title3059">Layer 1</title>
+	<g id="svg_1">
+		<rect id="svg_2" x="77.583" y="22.613" fill="#C0D028" width="6.245" height="6.245"/>
+		<g id="svg_3">
+			<rect id="svg_4" x="86.656" y="24.09" fill="#FFFFFF" stroke="#808285" stroke-width="0.4225" width="3.502" height="3.502"/>
+			<rect id="svg_5" x="78.469" y="15.355" fill="#FFFFFF" stroke="#808285" stroke-width="0.6761" width="4.515" height="4.515"/>
+			<rect id="svg_6" x="69.777" y="22.95" fill="#FFFFFF" stroke="#808285" stroke-width="1.0563" width="5.569" height="5.571"/>
+			<rect id="svg_7" x="70.832" y="30.842" fill="#FFFFFF" stroke="#808285" stroke-width="0.4225" width="3.46" height="3.46"/>
+			<rect id="svg_8" x="77.878" y="31.39" fill="#FFFFFF" stroke="#808285" stroke-width="0.8451" width="5.654" height="5.654"/>
+			<rect id="svg_9" x="86.022" y="30.546" fill="#FFFFFF" stroke="#808285" stroke-width="0.6338" width="4.768" height="4.769"/>
+		</g>
+		<g id="svg_10">
+			<path id="svg_11" inkscape:connector-curvature="0" fill="#808285" d="M100.773,19.521h3.095c3.254,0,5.873,2.937,5.873,6.588
+				c0,3.651-2.619,6.588-5.873,6.588c-0.318,0-3.095,0-3.095,0V19.521L100.773,19.521z M102.916,30.474h0.873
+				c1.905,0,3.492-1.984,3.492-4.365c0-2.381-1.587-4.365-3.492-4.365c-0.317,0-0.873,0-0.873,0V30.474z"/>
+			<path id="svg_12" inkscape:connector-curvature="0" fill="#C0D028" d="M116.885,32.855c-1.428,0-2.46-0.477-3.73-1.429
+				l0.238-1.984c1.349,0.715,2.381,1.191,3.492,1.191c0.953,0,2.223-0.556,2.223-1.588c0-2.46-6.19-1.509-6.19-5.953
+				c0-2.301,1.984-3.889,4.365-3.889c1.508,0,2.46,0.476,3.809,1.588l-0.714,1.746c-0.953-0.635-2.063-1.111-3.095-1.111
+				c-1.35,0-2.143,0.714-2.143,1.508c0,2.381,6.19,1.747,6.19,5.794C121.489,31.507,119.267,32.855,116.885,32.855L116.885,32.855z"
+				/>
+			<path id="svg_13" inkscape:connector-curvature="0" fill="#C0D028" d="M134.029,23.966c0,2.382-1.983,4.366-4.365,4.366
+				c-0.159,0-2.619,0-2.619,0v4.365h-2.223V19.521h4.842C132.045,19.521,134.029,21.506,134.029,23.966L134.029,23.966z
+				 M131.806,23.966c0-1.19-0.951-2.222-2.222-2.222c-0.238,0-2.619,0-2.619,0v4.365h2.619
+				C130.855,26.109,131.806,25.157,131.806,23.966z"/>
+			<path id="svg_14" inkscape:connector-curvature="0" fill="#C0D028" d="M140.14,32.697h-2.223v-8.334c0-3.254,1.984-5,4.365-5
+				c2.461,0,4.365,1.826,4.365,5v8.334h-2.222v-4.365h-4.365v4.365H140.14L140.14,32.697z M144.506,24.363
+				c0-1.905-0.953-2.857-2.224-2.857c-1.189,0-2.222,0.953-2.222,2.857v1.746h4.365v-1.746H144.506L144.506,24.363z"/>
+			<path id="svg_15" inkscape:connector-curvature="0" fill="#C0D028" d="M156.411,19.363c1.588,0,3.334,1.032,4.207,2.54
+				l-1.35,1.19c-0.873-1.111-1.746-1.587-2.777-1.587c-1.746,0-3.254,1.746-3.254,4.604c0,2.856,1.508,4.604,3.254,4.604
+				c0.952,0,1.904-0.477,2.777-1.588l1.35,1.191c-0.952,1.508-2.619,2.539-4.207,2.539c-3.333,0-5.555-3.016-5.555-6.746
+				S153.078,19.363,156.411,19.363L156.411,19.363L156.411,19.363z"/>
+			<path id="svg_16" inkscape:connector-curvature="0" fill="#C0D028" d="M164.189,19.521h6.588v2.223h-4.365v2.619h4.365v2.222
+				h-4.365v3.968h4.365v2.223h-6.588V19.521L164.189,19.521z"/>
+		</g>
+	</g>
+</g>
 </svg>


### PR DESCRIPTION
This is a fix for the logo scaling issue in IE10, described in the ticket below.
The proposed solution in the ticket was to use a png fallback. We chose to fix this issue by changing the width and height of the svg file to the size used in dspace. This is a better solution than using a fallback because IE10 does not support conditional comments. This means we would have to rely on javascript to provide the fallback. 

https://jira.duraspace.org/browse/DS-2313
