### PR TITLE
DS-2330 bug fix: lost authors when using ORCID column

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSV.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSV.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.app.bulkedit;
 
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.authority.AuthorityValue;
 import org.dspace.app.bulkedit.DSpaceCSVLine;
 import org.dspace.app.bulkedit.MetadataImport;
@@ -14,6 +15,7 @@ import org.dspace.app.bulkedit.MetadataImportInvalidHeadingException;
 import org.dspace.content.Collection;
 import org.dspace.content.*;
 import org.dspace.content.Collection;
+import org.dspace.content.authority.Choices;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 
@@ -185,7 +187,7 @@ public class DSpaceCSV implements Serializable
             StringBuilder lineBuilder = new StringBuilder();
             String lineRead;
 
-            while ((lineRead = input.readLine()) != null)
+            while (StringUtils.isNotBlank(lineRead = input.readLine()))
             {
                 if (lineBuilder.length() > 0) {
                     // Already have a previously read value - add this line
@@ -449,7 +451,7 @@ public class DSpaceCSV implements Serializable
                 String mdValue = value.value;
                 if (value.authority != null && !"".equals(value.authority))
                 {
-                    mdValue += authoritySeparator + value.authority + authoritySeparator + value.confidence;
+                    mdValue += authoritySeparator + value.authority + authoritySeparator +  (value.confidence != -1 ? value.confidence : Choices.CF_ACCEPTED);
                 }
                 line.add(key, mdValue);
                 if (!headings.contains(key))
@@ -610,8 +612,9 @@ public class DSpaceCSV implements Serializable
         // Create the headings line
         String[] csvLines = new String[counter + 1];
         csvLines[0] = "id" + fieldSeparator + "collection";
-        Collections.sort(headings);
-        for (String value : headings)
+        List<String> headingsCopy = new ArrayList<String>(headings);
+        Collections.sort(headingsCopy);
+        for (String value : headingsCopy)
         {
             csvLines[0] = csvLines[0] + fieldSeparator + value;
         }
@@ -620,7 +623,7 @@ public class DSpaceCSV implements Serializable
         int c = 1;
         while (i.hasNext())
         {
-            csvLines[c++] = i.next().toCSV(headings);
+            csvLines[c++] = i.next().toCSV(headingsCopy);
         }
 
         return csvLines;


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2330

org/dspace/app/bulkedit/MetadataImport.java:489 -> a metadata with confidence -1 will never be matched as constant, which means it will be deleted+added.
-> so we changed the export to give them 600 instead of -1

The core issue was the second column for the same metadata field.
When comparing the existing metadata to the provided metadata, DSpace would notice that the existing authors were not present in the ORCID:dc.contributor.author column and would remove all of them.
-> Fixed it by disabling removing metadata for columns with an external authority source prefix like "ORCID:".
Metadata can still be removed by omitting them from the regular dc.contributor.author column.

There was still a bug when removing an author like that an reimporting it with the "ORCID:"-column. (Which would be the way to virtually add the orcid to the existing metadata)
Depending on the order of the columns it may delete and reimport it or not, but it would not report correctly on what it has done.
-> I fixed it by putting an comparator on the DSpaceCSVLine headers ("ORCID:"-like columns should come last)
- -> when recording changes from the "ORCID:"-column, the changes are compared to the regular "dc.contributor.author" column instead of comparing with the existing item's metadata (because they should be replaced by the other column's values by the time this column gets processed)
