### PR TITLE
[DS-2042] Discovery/Solr is improperly indexing the "dc.description.provenance" field

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -971,6 +971,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                 }
             }
 
+            List<String> toIgnoreMetadataFields = SearchUtils.getIgnoredMetadataFields(item.getType());
             Metadatum[] mydc = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
             for (Metadatum meta : mydc)
             {
@@ -989,7 +990,6 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                     field += "." + meta.qualifier;
                 }
 
-                List<String> toIgnoreMetadataFields = SearchUtils.getIgnoredMetadataFields(item.getType());
                 //We are not indexing provenance, this is useless
                 if (toIgnoreMetadataFields != null && (toIgnoreMetadataFields.contains(field) || toIgnoreMetadataFields.contains(unqualifiedField + "." + Item.ANY)))
                 {

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceSpellIndexingPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceSpellIndexingPlugin.java
@@ -13,6 +13,8 @@ import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 
+import java.util.List;
+
 /**
  * Created with IntelliJ IDEA.
  * User: kevin
@@ -25,12 +27,29 @@ public class SolrServiceSpellIndexingPlugin implements SolrServiceIndexPlugin {
     @Override
     public void additionalIndex(Context context, DSpaceObject dso, SolrInputDocument document) {
         if(dso instanceof Item){
-            Metadatum[] dcValues = ((Item) dso).getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+            Item item = (Item) dso;
+            Metadatum[] dcValues = item.getMetadata(Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+            List<String> toIgnoreMetadataFields = SearchUtils.getIgnoredMetadataFields(item.getType());
             for (Metadatum dcValue : dcValues) {
-                document.addField("a_spell", dcValue.value);
+                String field = dcValue.schema + "." + dcValue.element;
+                String unqualifiedField = field;
 
+                String value = dcValue.value;
+
+                if (value == null)
+                {
+                    continue;
+                }
+
+                if (dcValue.qualifier != null && !dcValue.qualifier.trim().equals(""))
+                {
+                    field += "." + dcValue.qualifier;
+                }
+
+                if(!toIgnoreMetadataFields.contains(field)){
+                    document.addField("a_spell", dcValue.value);
+                }
             }
         }
-
     }
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfigurationService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfigurationService.java
@@ -9,6 +9,7 @@ package org.dspace.discovery.configuration;
 
 import org.dspace.utils.DSpace;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -18,7 +19,7 @@ import java.util.Map;
 public class DiscoveryConfigurationService {
 
     private Map<String, DiscoveryConfiguration> map;
-    private Map<Integer, List<String>> toIgnoreMetadataFields;
+    private Map<Integer, List<String>> toIgnoreMetadataFields = new HashMap<>();
 
     public Map<String, DiscoveryConfiguration> getMap() {
         return map;


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2042

Added the default configuration settings to the SpellIndexPlugin to ensure that the ignored metadata is not indexed in any way.
