### PR TITLE
DS-2313 - Revert to compiling Mirage2 styles with SASS 3.3.14 for better IE compatibility

### DIFF
--- a/dspace-xmlui-mirage2/readme.md
+++ b/dspace-xmlui-mirage2/readme.md
@@ -4,9 +4,9 @@ Mirage 2 is a responsive XMLUI theme for DSpace 4. It is based on the responsive
 
 Like the original Mirage theme, we started from [HTML5 boilerplate](http://h5bp.com) for the basic structure of each page and best practices with regards to cross browser compatibility, accessibility and performance.
 
-We used [Bootstrap 3](http://getbootstrap.com/) to have a sturdy responsive grid to base everything on. We chose the SASS version because that allows us to use it in conjunction with the [Compass](http://compass-style.org/) framework, which provides a great library of SASS classes and mixins. Compass also comes with a custom version of the SASS preprocessor we can use to concatenate and minify all stylesheets. We also included the [Handlebars](http://handlebarsjs.com/) templating framework to create more robust Javascript views.
+We used [Bootstrap 3](http://getbootstrap.com/) to have a sturdy responsive grid to base everything on. We chose the SASS version ([bootstrap-sass](https://github.com/twbs/bootstrap-sass)) because that allows us to use it in conjunction with the [Compass](http://compass-style.org/) framework, which provides a great library of SASS classes and mixins. Compass also comes with a custom version of the [SASS preprocessor](http://sass-lang.com/) we can use to concatenate and minify all stylesheets. We also included the [Handlebars](http://handlebarsjs.com/) templating framework to create more robust Javascript views.
 
-All these extra dependencies made us reconsider the way front-end dependencies were managed in Mirage 2. A common problem with themes based on the first Mirage was that its dependencies (jQuery, Modernizr, …) were outdated. The versions that came with the theme kept on being used because no-one remembered to update them when creating a new Mirage based theme. So we decided to no longer include 3d party dependencies with the theme and instead go for a combination of [Bower](http://bower.io/) and [Grunt](http://gruntjs.com/) to fetch and combine dependencies at build time.
+All these extra dependencies made us reconsider the way front-end dependencies were managed in Mirage 2. A common problem with themes based on the first Mirage was that its dependencies (jQuery, Modernizr, …) were outdated. The versions that came with the theme kept on being used because no-one remembered to update them when creating a new Mirage based theme. So we decided to no longer include 3rd party dependencies with the theme and instead go for a combination of [Bower](http://bower.io/) and [Grunt](http://gruntjs.com/) to fetch and combine dependencies at build time.
 
 These new technologies are put in place to make it easier for the theme developer to produce great themes, but they come with a few new dependencies: node js and ruby. In order to make it easier to get started customizing Mirage2 we added a way to install them automatically durng a maven build.
 
@@ -18,7 +18,7 @@ Mirage 2 has been integrated into the standard maven build as an optional featur
     mvn package -Dmirage2.on=true
 ```
 
-All extra tools in the Mirage 2 build process run on either Node js or Ruby, so you'll need both to be able to build the theme. By default, the maven build will assume you don't have either installed and install them in a temporary sandbox every time you build the project. That's convenient, but also quite a bit slower than installing them natively. So we recommend you only use that feature to try out the theme. Afterwards, install the prerequisites and build DSpace with the `mirage2.deps.included` property set to `false`:
+All extra tools in the Mirage 2 build process run on either Node.js or Ruby, so you'll need both to be able to build the theme. By default, the maven build will assume you don't have either installed and install them in a temporary sandbox every time you build the project. That's convenient, but also quite a bit slower than installing them natively. So we recommend you only use that feature to try out the theme. Afterwards, install the prerequisites and build DSpace with the `mirage2.deps.included` property set to `false`:
 
 ```bash
     mvn package -Dmirage2.on=true -Dmirage2.deps.included=false
@@ -28,7 +28,7 @@ All extra tools in the Mirage 2 build process run on either Node js or Ruby, so 
 
 ### Node ###
 
-We recommend using [nvm](https://github.com/creationix/nvm)  (Node Version Manager), because it makes it easy to install, use and upgrade node without super user rights.
+We recommend using [nvm](https://github.com/creationix/nvm) (Node Version Manager) to install [Node.js](http://nodejs.org/), because it makes it easy to install, use and upgrade node without super user rights.
 
 First download and install nvm:
 
@@ -36,22 +36,22 @@ First download and install nvm:
     curl https://raw.githubusercontent.com/creationix/nvm/v0.5.1/install.sh | sh 
 ```
 
-Then, close and reopen your terminal, and install a node version. We’ve been using 0.10.17 during the development of the theme, but it may very well work on other versions
+Then, close and reopen your terminal, and install a node version. We’ve been using v0.10.31 during the development of the theme, but it may very well work on other versions
 
 ```bash
-    nvm install 0.10.17 
+    nvm install 0.10.31 
 ```
 
 Set the node version you installed as the default version.
 
 ```bash
-    nvm alias default 0.10.17
+    nvm alias default 0.10.31
 ```
 
 
 ### Bower ###
 
-You can install bower using the node package manager. The `-g` means install it globally, not as part of a specific project.
+You can install [Bower](http://bower.io/) using the node package manager. The `-g` means install it globally, not as part of a specific project.
 
 ```bash
     npm install -g bower
@@ -60,7 +60,7 @@ Afterwards the command `bower` should show a help message.
 
 ### Grunt ###
 
-Grunt should also be installed globally using the node package manager:
+[Grunt](http://gruntjs.com/) should also be installed globally using the node package manager:
 
 ```bash
     npm install -g grunt && npm install -g grunt-cli 
@@ -70,11 +70,11 @@ Afterwards the command `grunt --version` should show the grunt-cli version numbe
 
 ### Ruby ###
 
-For the same reasons as with Node, we’d advise using ruby via [RVM](http://rvm.io/)  (Ruby Version Manager). Even on OS X, which comes with a version of ruby preinstalled, you can save yourself a lot of hassle by using RVM instead. (In most cases there is no need to uninstall the system ruby first). Note that `you need sudo rights to perform the RVM installation`. You won't need sudo again to use RVM, ruby or gem later on
+For the same reasons as with Node, we’d advise using ruby via [RVM](http://rvm.io/)  (Ruby Version Manager). Even on OSX, which comes with a version of ruby preinstalled, you can save yourself a lot of hassle by using RVM instead. (In most cases there is no need to uninstall the system ruby first). Note that **you need sudo rights to perform the RVM installation**. You won't need sudo again to use RVM, ruby or gem later on
 
 
-### Note: ###
-On OS X you need to have the XCode command line tools installed. To test if they're installed try to type `make` in your terminal, if it says “command not found” follow [these instructions](http://www.computersnyou.com/2025/2013/06/install-command-line-tools-in-osx-10-9-mavericks-how-to/) to install them  
+#### OSX Ruby Note ####
+On OSX, you need to have the XCode command line tools installed. To test if they're installed try to type `make` in your terminal, if it says "command not found" follow [these instructions](http://www.computersnyou.com/2025/2013/06/install-command-line-tools-in-osx-10-9-mavericks-how-to/) to install them  
 (If this should fail, then you can find and download the Xcode command line tools directly from [Apple Developer site](https://developer.apple.com/downloads/index.action) - You will need an Apple id for this)
 
 Install RVM and ruby:
@@ -85,29 +85,33 @@ Install RVM and ruby:
 
 ### Compass ###
 
-Compass is built on the SASS CSS preprocessor, and at the time of writing there is an issue with the latest version of SASS (v3.3), so first you'll have to install the last known stable version using ruby's package manager:
+:warning: **Make sure you are using compatible versions of SASS and Compass.** For example, [Compass v0.12.0 was incompatible with SASS v3.3](https://github.com/Compass/compass/issues/1544). But, Compass v1.0.0 is compatible with SASS v3.3
+
+:warning: At this time, _we do NOT recommend using SASS v3.4_. Mirage2 is based on [bootstrap-sass](https://github.com/twbs/bootstrap-sass), which currently has a [minor Internet Explorer breadcrumb display bug when using SASS v3.4](https://github.com/twbs/bootstrap-sass/issues/803)
+
+[Compass](http://compass-style.org/) is built on the [SASS CSS preprocessor](http://sass-lang.com/). At the time of writing, we recommend using SASS v3.3.14 with Compass v1.0.1 (see warnings above):
 
 ```bash
-    gem install sass -v 3.2.10
+    gem install sass -v 3.3.14
 ```
 
 Then you can install compass:
 
 ```bash
-    gem install compass
+    gem install compass -v 1.0.1
 ```
 
 Afterwards the command `compass` should show a help message.
 
-### Prerequisites for Windows ###
+## Prerequisites for Windows ##
 
-### Node ###
+### Node on Windows ###
 
-Download and install NodeJs: [NodeJS](http://nodejs.org/)
+Download and install [Node.js](http://nodejs.org/) using the Windows installer version.
 
-### Bower ###
+### Bower on Windows ###
 
-You can install bower using the node package manager. The `-g` means install it globally, not as part of a specific project.
+You can install [Bower](http://bower.io/) using the node package manager. The `-g` means install it globally, not as part of a specific project.
 
 Execute following command in Windows command prompt:
 (Open a Windows command prompt by pressing cmd-R, then type 'cmd' and enter.)
@@ -117,9 +121,9 @@ Execute following command in Windows command prompt:
 ```
 Afterwards the command `bower` should show a help message.
 
-### Grunt ###
+### Grunt on Windows ###
 
-Grunt should also be installed globally using the node package manager:
+[Grunt](http://gruntjs.com/) should also be installed globally using the node package manager:
 
 Perform the following in a Windows command prompt:
 
@@ -129,7 +133,8 @@ Perform the following in a Windows command prompt:
 
 Afterwards the command `grunt --version` should show the grunt-cli version number
 
-### Ruby ###
+### Ruby on Windows ###
+
 Download and install: [Ruby Installer](http://rubyinstaller.org/)
 
 Make sure its environment variables are set in system variables
@@ -138,29 +143,30 @@ Open computer properties:
 
 ![Step 1](documentation/sysvars1.png)
 
-
 Open "advanced sytem settings". Open "Advanced" tab, and click "environment variables":
 
 ![Step 2](documentation/sysvars2.png)
 
-
-
 Add new variables `GEM_HOME` and `GEM_PATH` pointing to your Ruby gems directory.
 
-### Compass ###
+### Compass on Windows ###
 
-Compass is built on the SASS CSS preprocessor, and at the time of writing there is an issue with the latest version of SASS (v3.3), so first you'll have to install the last known stable version using ruby's package manager:
+:warning: **Make sure you are using compatible versions of SASS and Compass.** For example, [Compass v0.12.0 was incompatible with SASS v3.3](https://github.com/Compass/compass/issues/1544). But, Compass v1.0.0 is compatible with SASS v3.3
+
+:warning: At this time, _we do NOT recommend using SASS v3.4_. Mirage2 is based on [bootstrap-sass](https://github.com/twbs/bootstrap-sass), which currently has a [minor Internet Explorer breadcrumb display bug when using SASS v3.4](https://github.com/twbs/bootstrap-sass/issues/803)
+
+[Compass](http://compass-style.org/) is built on the [SASS CSS preprocessor](http://sass-lang.com/). At the time of writing, we recommend using SASS v3.3.14 with Compass v1.0.1 (see warnings above):
 
 Perform the following in a Windows command prompt:
 
 ```bash
-    gem install sass -v 3.2.10
+    gem install sass -v 3.3.14
 ```
 
 Then you can install compass:
 
 ```bash
-    gem install compass
+    gem install compass -v 1.0.1
 ```
 
 Afterwards the command `compass` should show a help message.
@@ -173,9 +179,7 @@ Add the following to the `<themes>` section of  `src/dspace/config/xmlui.xconf`,
     <theme name="Mirage 2" regex=".*" path="Mirage2/" /> 
 ```
 
-
-
-Now, if you run `mvn package -Dmirage2.on=true` in the dspace project root, bower will download all Mirage 2 dependencies, and grunt will trigger a number of plugins to preprocess, concatenate and minify all the theme's resources. 
+Now, if you run `mvn package -Dmirage2.on=true` in the dspace project root, bower will download all Mirage 2 dependencies, and Grunt will trigger a number of plugins to preprocess, concatenate and minify all the theme's resources. 
 
 
 # Customizing the theme #
@@ -186,16 +190,17 @@ To get you started the module already contains a Mirage 2 folder containing noth
 
 # Production and development builds #
 
-You can use maven profiles to have grunt build the theme in production or development mode.
+You can use Maven profiles to have Grunt build the theme in production or development mode.
 
-In production mode, grunt will concatenate and minify all javascript files referenced in the `Mirage2/scripts.xml` file (for more details see the javascript section of this document) in to a single `theme.js` file, to improve the performance of the theme. In development mode all javascript files will be separate and untouched, to make debugging easier.
+In production mode, Grunt will concatenate and minify all javascript files referenced in the `Mirage2/scripts.xml` file (for more details see the javascript section of this document) in to a single `theme.js` file, to improve the performance of the theme. In development mode all javascript files will be separate and untouched, to make debugging easier.
 
-Similarly for CSS, compass will compile the CSS either using `Mirage2/config-dev.rb` or `Mirage2/config-prod.rb`. Both will yield a single css file: `main.css`, but the dev version won't be minified and will contain the scss file name and line number as a comment above each CSS rule.
+Similarly for CSS, Compass will compile the CSS either using `Mirage2/config-dev.rb` or `Mirage2/config-prod.rb`. Both will yield a single css file: `main.css`, but the dev version won't be minified and will contain the scss file name and line number as a comment above each CSS rule.
 
-By default grunt will build the javascript and CSS in production mode. Use the `mirage2_dev` maven profile, or run grunt with the `dev` task to build the theme in development mode.
+By default, Grunt will build the javascript and CSS in production mode. Use the `mirage2_dev` maven profile, or run Grunt with the `dev` task to build the theme in development mode.
 
 ### Note: ###
-The dspace.cfg property `xmlui.minifiedjs` used in the alpha version of the theme to switch between development and production modes has been deprecated. Because we've moved the javascript declarations to a separate file: `scripts.xml` we no longer need to know which mode you're using in the theme XSLs at runtime but instead can let grunt handle it at build time.
+
+The dspace.cfg property `xmlui.minifiedjs` used in the alpha version of the theme to switch between development and production modes has been deprecated. Because we've moved the javascript declarations to a separate file: `scripts.xml` we no longer need to know which mode you're using in the theme XSLs at runtime but instead can let Grunt handle it at build time.
 
 # DRI Pre-Processing #
 
@@ -203,16 +208,17 @@ One of the goals for this theme was that changes outside the theme’s directory
 
 For example, if you want to add an extra class to div, you’d copy the default div template, change the copy's matcher to match the div you want to target, and then add your class to that template. That adds about 10 lines of XSL, only to add a simple CSS class. It makes the theme XSL files much harder to read and to modify; because if you wanted to change the default div template afterwards, you'd also have to change every template that overrides it.
 
-So we added an additional XSL transformation step in the theme’s sitemap: preprocess.xsl. This transformation is added right after the DRI generator, and it transforms DRI to DRI. By default it will simply copy the input to the output, and if you want to do something that is perfectly possible in DRI, like adding an extra CSS class to a div, you can now add your exception to the preprocess XSL, and simply let the default div template of the theme XSL render it afterwards. 
+So we added an additional XSL transformation step in the theme’s sitemap: `preprocess.xsl`. This transformation is added right after the DRI generator, and it transforms DRI to DRI. By default it will simply copy the input to the output, and if you want to do something that is perfectly possible in DRI, like adding an extra CSS class to a div, you can now add your exception to the preprocess XSL, and simply let the default div template of the theme XSL render it afterwards. 
 
 ### Tip: ###
+
 When working with a DRI that has been changed by the preprocess XSLs, it is often useful to see the differences between the original DRI and the version after preprocessing. To see the original DRI you can add `DRI/` after the contextpath in a page’s URL, to see the preprocessed DRI add `?XML` after the page’s URL
 
 # Style #
 
-Mirage 2 contains two color schemes to choose from. The classic Mirage color scheme or the standard Bootstrap color scheme. By default grunt will build CSS to get the classic Mirage color scheme. However, by activating the `mirage2_bootstrap_color_scheme` maven profile, this can be changed to get the standard Bootstrap color scheme. 
+Mirage 2 contains two color schemes to choose from. The classic Mirage color scheme or the standard Bootstrap color scheme. By default, Grunt will build CSS to get the classic Mirage color scheme. However, by activating the `mirage2_bootstrap_color_scheme` maven profile, this can be changed to get the standard Bootstrap color scheme. 
 
-The stylesheets are written in [SASS](http://sass-lang.com/). You can find them in the folder `Mirage2/styles`. Each color scheme has its own subfolder, and a `_main.scss`  file that imports all others. These files will import the Compass library first. Next, all Bootstrap scss files and finally the DSpace specific files. Both color schemes also import the file `_style.scss`. It contains some example SCSS by default, and is meant to add your own style. Note that CSS is also valid SCSS, so if you don't want to learn SASS, just add plain old CSS to that file and it will work just fine.   
+The stylesheets are written in [SASS](http://sass-lang.com/). You can find them in the folder `Mirage2/styles`. Each color scheme has its own subfolder, and a `_main.scss` file that imports all others. These files will import the Compass library first. Next, all Bootstrap scss files and finally the DSpace specific files. Both color schemes also import the file `_style.scss`. It contains some example SCSS by default, and is meant to add your own style. Note that CSS is also valid SCSS, so if you don't want to learn SASS, just add plain old CSS to that file and it will work just fine.   
 
 The goal of the standard Bootstrap color scheme was to add as little extra style on top of Bootstrap as possible and instead force ourselves to solve most issues in XSL; by creating the right HTML structure and adding the right bootstrap CSS classes. But try as we might, a few additional style rules were still needed. Those can be found in `shared/_dspace-bootstrap-tweaks.scss`, most of it is limited to styles to improve the sidebar behavior on mobile devices.
 
@@ -235,7 +241,7 @@ with an import of just its `_variables.sccs` file (those variables need to be de
 Then import the the css file(s) of your Bootstrap theme of choice below it. Depending on the theme you may also need to update the `twbs-font-path` function right above that import statement.
 
 ### Tip: ###
-During development it is a hassle to always have to run `mvn package` to re-compile the style and see the result of a CSS change. Luckily compass comes with a “watch” feature that automatically recompiles when the scss files change. If your editor can update the running webapp when you save an scss file, and you run `compass watch` in that webapp's `xmlui/themes/Mirage2` folder, changes to the style will show up nearly instantaneous.
+During development it is a hassle to always have to run `mvn package` to re-compile the style and see the result of a CSS change. Luckily Compass comes with a `watch` feature that automatically recompiles when the scss files change. If your editor can update the running webapp when you save an scss file, and you run `compass watch` in that webapp's `xmlui/themes/Mirage2` folder, changes to the style will show up nearly instantaneous.
 
 
 # Scripts #
@@ -246,13 +252,13 @@ The advantage of having all the site’s javascript in a minified single file is
 
 To keep global javascript variables to a minimum, we’ve created a namespace object called `DSpace` to contain all other global variables. For example `DSpace.context_path` and `DSpace.theme_path` contain the context and theme paths, `DSpace.templates` contains compiled handlebars templates, and `DSpace.i18n` contains i18n strings used by those templates (take a look at the object in your browser’s dev-tools on a discovery page to see that in action). We advise you to put your own global javascript objects in the `DSpace` namespace as well.
 
-If you create your own handlebars templates, put them in `Mirage2/templates`. They will be precompiled and added to `theme.js` by grunt. To access a template in your javascript code, use the function `DSpace.getTemplate(file-name)` (where `file-name` is the name of your handlebars file, without the extension). That function will return a precompiled version of the template if it exists, and download and compile it if it doesn't. That ensures your templates work both when you’re in development mode or using the production `theme.js` file.
+If you create your own handlebars templates, put them in `Mirage2/templates`. They will be precompiled and added to `theme.js` by Grunt. To access a template in your javascript code, use the function `DSpace.getTemplate(file-name)` (where `file-name` is the name of your handlebars file, without the extension). That function will return a precompiled version of the template if it exists, and download and compile it if it doesn't. That ensures your templates work both when you’re in development mode or using the production `theme.js` file.
 
 The theme also comes with built in support for [CoffeeScript](http://coffeescript.org/). If you put `.coffee` files in the `Mirage2/scripts` folder, they will be converted to javascript. Make sure to add the correct reference to `Mirage2/scripts.xml` i.e. with an `.js` extension instead of `.coffee`.
 
 # Managing dependencies #
 
-Mirage 2’s dependencies are specified in the file `Mirage2/bower.json`. Dependencies in this file should be specified according to the rules in the [Bower documentation](http://bower.io/|). Note that Bower only downloads the dependencies, nothing more. So if you add other dependencies, you'll still have to reference them. That means if it’s a CSS file, import it in `Mirage2/styles/_style.scss`, if it's a javascript file, add it to `Mirage2/scripts.xml`.
+Mirage 2's dependencies are specified in the file `Mirage2/bower.json`. Dependencies in this file should be specified according to the rules in the [Bower documentation](http://bower.io/|). Note that Bower only downloads the dependencies, nothing more. So if you add other dependencies, you'll still have to reference them. That means if it’s a CSS file, import it in `Mirage2/styles/_style.scss`, if it's a javascript file, add it to `Mirage2/scripts.xml`.
 
 We've used the the `latest` keyword to specify dependency versions in `bower.json` wherever possible because that ensures you're starting with up to date versions when creating a new theme. However once your theme is going in to production, we strongly recommend replacing `latest` with the actual version numbers being used at that moment. That way your production build won't break when a version of a dependency is released that isn't backwards compatible.
 

--- a/dspace-xmlui-mirage2/readme.md
+++ b/dspace-xmlui-mirage2/readme.md
@@ -85,9 +85,9 @@ Install RVM and ruby:
 
 ### Compass ###
 
-:warning: **Make sure you are using compatible versions of SASS and Compass.** For example, [Compass v0.12.0 was incompatible with SASS v3.3](https://github.com/Compass/compass/issues/1544). But, Compass v1.0.0 is compatible with SASS v3.3
+> *WARNING:* **Make sure you are using compatible versions of SASS and Compass.** For example, [Compass v0.12.0 was incompatible with SASS v3.3](https://github.com/Compass/compass/issues/1544). But, Compass v1.0.0 is compatible with SASS v3.3
 
-:warning: At this time, _we do NOT recommend using SASS v3.4_. Mirage2 is based on [bootstrap-sass](https://github.com/twbs/bootstrap-sass), which currently has a [minor Internet Explorer breadcrumb display bug when using SASS v3.4](https://github.com/twbs/bootstrap-sass/issues/803)
+> *WARNING:* At this time, we do NOT recommend using SASS v3.4.x. The Mirage2 theme is based on [bootstrap-sass](https://github.com/twbs/bootstrap-sass), which currently has a [minor Internet Explorer breadcrumb display bug when using SASS v3.4](https://github.com/twbs/bootstrap-sass/issues/803)
 
 [Compass](http://compass-style.org/) is built on the [SASS CSS preprocessor](http://sass-lang.com/). At the time of writing, we recommend using SASS v3.3.14 with Compass v1.0.1 (see warnings above):
 
@@ -151,9 +151,9 @@ Add new variables `GEM_HOME` and `GEM_PATH` pointing to your Ruby gems directory
 
 ### Compass on Windows ###
 
-:warning: **Make sure you are using compatible versions of SASS and Compass.** For example, [Compass v0.12.0 was incompatible with SASS v3.3](https://github.com/Compass/compass/issues/1544). But, Compass v1.0.0 is compatible with SASS v3.3
+> *WARNING:* **Make sure you are using compatible versions of SASS and Compass.** For example, [Compass v0.12.0 was incompatible with SASS v3.3](https://github.com/Compass/compass/issues/1544). But, Compass v1.0.0 is compatible with SASS v3.3
 
-:warning: At this time, _we do NOT recommend using SASS v3.4_. Mirage2 is based on [bootstrap-sass](https://github.com/twbs/bootstrap-sass), which currently has a [minor Internet Explorer breadcrumb display bug when using SASS v3.4](https://github.com/twbs/bootstrap-sass/issues/803)
+> *WARNING:* At this time, we do NOT recommend using SASS v3.4.x. The Mirage2 theme is based on [bootstrap-sass](https://github.com/twbs/bootstrap-sass), which currently has a [minor Internet Explorer breadcrumb display bug when using SASS v3.4](https://github.com/twbs/bootstrap-sass/issues/803)
 
 [Compass](http://compass-style.org/) is built on the [SASS CSS preprocessor](http://sass-lang.com/). At the time of writing, we recommend using SASS v3.3.14 with Compass v1.0.1 (see warnings above):
 

--- a/dspace/modules/xmlui-mirage2/pom.xml
+++ b/dspace/modules/xmlui-mirage2/pom.xml
@@ -23,7 +23,7 @@
         <grunt.color.scheme>classic_mirage_color_scheme</grunt.color.scheme>
         <mirage2.deps.included>true</mirage2.deps.included>
         <!-- Versions of build dependencies to be auto-installed when "mirage2.deps.included=true" -->
-        <sass.version>3.4.3</sass.version>
+        <sass.version>3.3.14</sass.version>
         <compass.version>1.0.1</compass.version>
         <node.version>0.10.31</node.version>
         <npm.version>1.4.23</npm.version>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2313

Fixes the Internet Explorer 10 or 11 breadcrumb display issue by simply reverting to compiling our CSS files using SASS 3.3.14.  Compiling with SASS 3.3.x seems to work fine with all major browsers (including Internet Explorer).

It seems that 'bootstrap-sass' (which Mirage2 uses) has a minor IE breadcrumb incompatibility with SASS 3.4.x.  I've logged a ticket with the 'bootstrap-sass' team:
- https://github.com/twbs/bootstrap-sass/issues/803

This is all related to a new behavior introduced in SASS 3.4, which is described in much detail in this SASS ticket: https://github.com/sass/sass/issues/1395
