### PR TITLE
DS-2381 sitemap generator skip unreadable items

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
+++ b/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
@@ -52,10 +52,6 @@ public class GenerateSitemaps
     /** Logger */
     private static Logger log = Logger.getLogger(GenerateSitemaps.class);
 
-    private static final int COMM = 1;
-    private static final int COLL = 2;
-    private static final int ITEM = 3;
-
     public static void main(String[] args) throws Exception
     {
         final String usage = GenerateSitemaps.class.getCanonicalName();
@@ -125,7 +121,7 @@ public class GenerateSitemaps
                     DSpaceObject obj = DSpaceObject.fromString(c, id);
                     if (obj != null)
                     {
-                        System.out.println("Will exclude " + obj.toString() + " " + obj.getHandle());
+                        System.out.println("Will exclude\t" + obj.toString() + "\t"  + obj.getHandle() + "\t" + obj.getName());
                         switch (obj.getType())
                         {
                             case Constants.COMMUNITY:
@@ -273,7 +269,8 @@ public class GenerateSitemaps
                 excludeReason = "On Collection Exclude List";
             } else if (excludeList[Constants.COMMUNITY].contains(colls[i].getParentObject()))
             {
-                excludeReason = "In Excluded " + Constants.typeText[colls[i].getParentObject().getType()] + " " + colls[i].getParentObject().getHandle();
+                excludeReason = "In Excluded " + Constants.typeText[colls[i].getParentObject().getType()] +
+                        " " + colls[i].getParentObject().getHandle();
             }
             if (excludeReason != null)
             {

--- a/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
+++ b/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
@@ -217,7 +217,7 @@ public class GenerateSitemaps
         if (makeHTMLMap)
         {
             html = new HTMLSitemapGenerator(outputDir, htmlMapStem + "?map=", null);
-            log.info("Generate HTLM map");
+            log.info("Generate HTML map");
         }
 
         if (makeSitemapOrg)

--- a/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
+++ b/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
@@ -304,7 +304,7 @@ public class GenerateSitemaps
                         if (excludeList[Constants.ITEM].contains(itm))
                         {
                             excludeReason = "On Item Exclude List";
-                        } else if (!AuthorizeManager.authorizeActionBoolean(c, itm, org.dspace.core.Constants.READ))
+                        } else if (!AuthorizeManager.authorizeActionBoolean(c, itm, Constants.READ))
                         {
                             excludeReason = "Not Readable by Anonymous";
                         } else if (!doItemsWithoutBiistreams && !hasReadableBitstream(c, itm))
@@ -316,7 +316,7 @@ public class GenerateSitemaps
                             log.info("Excluding Item\t" + itm.getHandle() +
                                     "\tin\t" + itm.getOwningCollection().getHandle() +
                                     "\t" + excludeReason +
-                                    "\t" + itm.getName());
+                                    "\t" + itm.getName().replaceAll("\\s+", " ").trim());
                         } else
                         {
                             url = handleURLStem + itm.getHandle();

--- a/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
+++ b/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
@@ -7,17 +7,15 @@
  */
 package org.dspace.app.sitemap;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
+import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Date;
+<<<<<<< HEAD
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -26,247 +24,253 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PosixParser;
 import org.apache.commons.lang.StringUtils;
+=======
+import org.apache.commons.cli.*;
+>>>>>>> 1e8c07f... add -x and -S options
 import org.apache.log4j.Logger;
-import org.dspace.content.Collection;
-import org.dspace.content.Community;
-import org.dspace.content.Item;
-import org.dspace.content.Bundle;
-import org.dspace.content.Bitstream;
-import org.dspace.content.ItemIterator;
+import org.dspace.authorize.AuthorizeManager;
+import org.dspace.content.*;
 import org.dspace.core.ConfigurationManager;
+import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.LogManager;
-import org.dspace.authorize.AuthorizeManager;
-import org.dspace.core.Constants;
+
 /**
  * Command-line utility for generating HTML and Sitemaps.org protocol Sitemaps.
- * 
+ *
  * @author Robert Tansley
  * @author Stuart Lewis
  */
-public class GenerateSitemaps
-{
-    /** Logger */
+public class GenerateSitemaps {
+    /**
+     * Logger
+     */
     private static Logger log = Logger.getLogger(GenerateSitemaps.class);
 
-    public static void main(String[] args) throws Exception
-    {
+    public static void main(String[] args) throws Exception {
         final String usage = GenerateSitemaps.class.getCanonicalName();
-
         CommandLineParser parser = new PosixParser();
         HelpFormatter hf = new HelpFormatter();
 
         Options options = new Options();
-
         options.addOption("h", "help", false, "help");
-        options.addOption("s", "no_sitemaps", false,
-                "do not generate sitemaps.org protocol sitemap");
-        options.addOption("b", "no_htmlmap", false,
-                "do not generate a basic HTML sitemap");
-        options.addOption("a", "ping_all", false,
-                "ping configured search engines");
-        options
-                .addOption("p", "ping", true,
-                        "ping specified search engine URL");
+        options.addOption("s", "no_sitemaps", false, "do not generate sitemaps.org protocol sitemap");
+        options.addOption("b", "no_htmlmap", false, "do not generate a basic HTML sitemap");
+        options.addOption("a", "ping_all", false, "ping configured search engines");
+        options.addOption("x", "exclude", true, "exclude items from list of communities, collections, and items, given as comma separated list of  TYPE.id, or handle");
+        options.addOption("S", "scholar", false, "exclude items without bitstreams readable by anonymous users");
+        options.addOption("p", "ping", true, "ping specified search engine URL");
 
         CommandLine line = null;
-
-        try
-        {
-            line = parser.parse(options, args);
-        }
-        catch (ParseException pe)
-        {
-            hf.printHelp(usage, options);
-            System.exit(1);
-        }
-
-        if (line.hasOption('h'))
-        {
-            hf.printHelp(usage, options);
-            System.exit(0);
-        }
-
-        if (line.getArgs().length != 0)
-        {
-            hf.printHelp(usage, options);
-            System.exit(1);
-        }
-
-        /*
-         * Sanity check -- if no sitemap generation or pinging to do, print
-         * usage
-         */
-        if (line.getArgs().length != 0 || line.hasOption('b')
-                && line.hasOption('s') && !line.hasOption('g')
-                && !line.hasOption('m') && !line.hasOption('y')
-                && !line.hasOption('p'))
-        {
-            System.err
-                    .println("Nothing to do (no sitemap to generate, no search engines to ping)");
-            hf.printHelp(usage, options);
-            System.exit(1);
-        }
-
-        // Note the negation (CLI options indicate NOT to generate a sitemap)
-        if (!line.hasOption('b') || !line.hasOption('s'))
-        {
-            generateSitemaps(!line.hasOption('b'), !line.hasOption('s'));
-        }
-
-        if (line.hasOption('a'))
-        {
-            pingConfiguredSearchEngines();
-        }
-
-        if (line.hasOption('p'))
-        {
-            try
-            {
-                pingSearchEngine(line.getOptionValue('p'));
-            }
-            catch (MalformedURLException me)
-            {
-                System.err
-                        .println("Bad search engine URL (include all except sitemap URL)");
-                System.exit(1);
-            }
-        }
-
-        System.exit(0);
-    }
-
-    /**
-     * Generate sitemap.org protocol and/or basic HTML sitemaps.
-     * 
-     * @param makeHTMLMap
-     *            if {@code true}, generate an HTML sitemap.
-     * @param makeSitemapOrg
-     *            if {@code true}, generate an sitemap.org sitemap.
-     * @throws SQLException
-     *             if a database error occurs.
-     * @throws IOException
-     *             if IO error occurs.
-     */
-    public static void generateSitemaps(boolean makeHTMLMap,
-            boolean makeSitemapOrg) throws SQLException, IOException
-    {
-        String sitemapStem = ConfigurationManager.getProperty("dspace.url")
-                + "/sitemap";
-        String htmlMapStem = ConfigurationManager.getProperty("dspace.url")
-                + "/htmlmap";
-        String handleURLStem = ConfigurationManager.getProperty("dspace.url")
-                + "/handle/";
-
-        File outputDir = new File(ConfigurationManager.getProperty("sitemap.dir"));
-        if (!outputDir.exists() && !outputDir.mkdir())
-        {
-            log.error("Unable to create output directory");
-        }
-        
-        AbstractGenerator html = null;
-        AbstractGenerator sitemapsOrg = null;
-
-        if (makeHTMLMap)
-        {
-            html = new HTMLSitemapGenerator(outputDir, htmlMapStem + "?map=",
-                    null);
-        }
-
-        if (makeSitemapOrg)
-        {
-            sitemapsOrg = new SitemapsOrgGenerator(outputDir, sitemapStem
-                    + "?map=", null);
-        }
-
+        Boolean error = false;
         Context c = new Context();
+        try {
+            ArrayList<DSpaceObject> excludeComm = new ArrayList<DSpaceObject>();
+            ArrayList<DSpaceObject> excludeColl = new ArrayList<DSpaceObject>();
+            ArrayList<DSpaceObject> excludeItem = new ArrayList<DSpaceObject>();
+            line = parser.parse(options, args);
 
-        Community[] comms = Community.findAll(c);
-
-        for (int i = 0; i < comms.length; i++)
-        {
-            if (AuthorizeManager.authorizeActionBoolean(c, comms[i], org.dspace.core.Constants.READ)) {
-                String url = handleURLStem + comms[i].getHandle();
-
-                if (makeHTMLMap) {
-                    html.addURL(url, null);
-                }
-                if (makeSitemapOrg) {
-                    sitemapsOrg.addURL(url, null);
-                }
+            if (line.hasOption('h')) {
+                hf.printHelp(usage, options);
+                return;
             }
-        }
 
-        Collection[] colls = Collection.findAll(c);
-
-        for (int i = 0; i < colls.length; i++)
-        {
-            if (AuthorizeManager.authorizeActionBoolean(c, colls[i], org.dspace.core.Constants.READ)) {
-                String url = handleURLStem + colls[i].getHandle();
-
-                if (makeHTMLMap) {
-                    html.addURL(url, null);
+            if (line.hasOption('x')) {
+                String excludes = line.getOptionValue('x');
+                String[] excludeIds = excludes.split(",");
+                if (excludeIds.length == 0) {
+                    System.err.println("must provide id list to exclude");
+                    error = true;
                 }
-                if (makeSitemapOrg) {
-                    sitemapsOrg.addURL(url, null);
-                }
-            }
-        }
-
-        ItemIterator allItems = Item.findAll(c);
-        try
-        {
-            int itemCount = 0;
-
-            while (allItems.hasNext())
-            {
-                Item i = allItems.next();
-                if (AuthorizeManager.authorizeActionBoolean(c, i, org.dspace.core.Constants.READ)) {
-                    if (hasReadableBitstream(c, i)) {
-                        String url = handleURLStem + i.getHandle();
-                        Date lastMod = i.getLastModified();
-
-                        if (makeHTMLMap) {
-                            html.addURL(url, lastMod);
+                for (String id : excludeIds) {
+                    DSpaceObject obj = DSpaceObject.fromString(c, id);
+                    if (obj == null) {
+                        error = true;
+                    } else {
+                        System.out.println("Will exclude " + obj.toString() + " " + obj.getHandle());
+                        switch (obj.getType()) {
+                            case Constants.COMMUNITY:
+                                excludeComm.add(obj);
+                                break;
+                            case Constants.COLLECTION:
+                                excludeColl.add(obj);
+                                break;
+                            case Constants.ITEM:
+                                excludeItem.add(obj);
+                                break;
+                            default:
+                                System.err.println("'" + id + " ' not a community, collection or item");
+                                error = true;
                         }
-                        if (makeSitemapOrg) {
-                            sitemapsOrg.addURL(url, lastMod);
-                        }
-                        i.decache();
-
-                        itemCount++;
                     }
                 }
             }
 
-            if (makeHTMLMap)
-            {
-                int files = html.finish();
-                log.info(LogManager.getHeader(c, "write_sitemap",
-                        "type=html,num_files=" + files + ",communities="
-                                + comms.length + ",collections=" + colls.length
-                                + ",items=" + itemCount));
+            /*
+             * Sanity check -- error if no sitemap generation or pinging to do
+             */
+            if (line.hasOption('b') &&
+                    line.hasOption('s') && !line.hasOption('g') &&
+                    !line.hasOption('m') && !line.hasOption('y') &&
+                    !line.hasOption('p')) {
+                System.err.println("Nothing to do (no sitemap to generate, no search engines to ping)");
+                error = true;
             }
 
-            if (makeSitemapOrg)
-            {
-                int files = sitemapsOrg.finish();
-                log.info(LogManager.getHeader(c, "write_sitemap",
-                        "type=html,num_files=" + files + ",communities="
-                                + comms.length + ",collections=" + colls.length
-                                + ",items=" + itemCount));
+            if (error)
+                return;
+
+            // Note the negation (CLI options indicate NOT to generate a sitemap)
+            if (!line.hasOption('b') || !line.hasOption('s')) {
+                if (!line.hasOption('b')) {
+                    System.out.println("Generate HTLM map");
+                }
+                if (!line.hasOption('s')) {
+                    System.out.println("Generate Sitemap.org map");
+                }
+                if (line.hasOption('S')) {
+                    System.out.println("Exclude Items without READable Bitstreams");
+                }
+                generateSitemaps(!line.hasOption('b'), !line.hasOption('s'), !line.hasOption('S'),
+                        c, excludeComm, excludeColl, excludeItem);
+            }
+
+            if (line.hasOption('a')) {
+                pingConfiguredSearchEngines();
+            }
+
+            if (line.hasOption('p')) {
+                try {
+                    pingSearchEngine(line.getOptionValue('p'));
+                } catch (MalformedURLException me) {
+                    System.err.println("Bad search engine URL (include all except sitemap URL)");
+                    System.exit(1);
+                }
+            }
+
+        } catch (ParseException pe) {
+            System.err.println("Could not parse arguments");
+            error = true;
+        } finally {
+            c.complete();
+            if (error) {
+                hf.printHelp(usage, options);
+                System.exit(1);
+            } else {
+                System.exit(0);
             }
         }
-        finally
-        {
-            if (allItems != null)
-            {
-                allItems.close();
-            }
-        }
-        
-        c.abort();
     }
+
+    /**
+     * Generate sitemap.org protocol and/or basic HTML sitemaps.
+     *
+     * @param makeHTMLMap    if {@code true}, generate an HTML sitemap.
+     * @param makeSitemapOrg if {@code true}, generate an sitemap.org sitemap.
+     * @throws SQLException if a database error occurs.
+     * @throws IOException  if IO error occurs.
+     */
+    public static void generateSitemaps(boolean makeHTMLMap, boolean makeSitemapOrg, boolean doItemsWithoutBiistreams,
+                                        Context c, ArrayList<DSpaceObject> excludeComm, ArrayList<DSpaceObject> excludeColl, ArrayList<DSpaceObject> excludeItem) throws SQLException, IOException {
+        String sitemapStem = ConfigurationManager.getProperty("dspace.url") + "/sitemap";
+        String htmlMapStem = ConfigurationManager.getProperty("dspace.url") + "/htmlmap";
+        String handleURLStem = ConfigurationManager.getProperty("dspace.url") + "/handle/";
+
+        File outputDir = new File(ConfigurationManager.getProperty("sitemap.dir"));
+        if (!outputDir.exists() && !outputDir.mkdir()) {
+            log.error("Unable to create output directory");
+        }
+
+        AbstractGenerator html = null;
+        AbstractGenerator sitemapsOrg = null;
+
+        if (makeHTMLMap) {
+            html = new HTMLSitemapGenerator(outputDir, htmlMapStem + "?map=", null);
+        }
+
+        if (makeSitemapOrg) {
+            sitemapsOrg = new SitemapsOrgGenerator(outputDir, sitemapStem + "?map=", null);
+        }
+
+
+        Community[] comms = Community.findAll(c);
+        int commCount = 0;
+        for (int i = 0; i < comms.length; i++) {
+            if (excludeComm.contains(comms[i])) {
+                System.out.println("Skipping Community " + comms[i].getHandle() + "\t" + ((Community) comms[i]).getName());
+            } else {
+                if (AuthorizeManager.authorizeActionBoolean(c, comms[i], org.dspace.core.Constants.READ)) {
+                    System.out.println("Doing    Community " + comms[i].getHandle() + "\t" + ((Community) comms[i]).getName());
+                    String url = handleURLStem + comms[i].getHandle();
+
+                    if (makeHTMLMap) {
+                        html.addURL(url, null);
+                    }
+                    if (makeSitemapOrg) {
+                        sitemapsOrg.addURL(url, null);
+                    }
+                }
+                commCount++;
+            }
+        }
+
+        Collection[] colls = Collection.findAll(c);
+        int itemCount = 0;
+        int collCount = 0;
+        for (int i = 0; i < colls.length; i++) {
+            if (excludeColl.contains(colls[i]) || excludeComm.contains(colls[i].getParentObject())) {
+                System.out.println("Skipping Collection " + colls[i].getHandle() + " in " + colls[i].getParentObject().getHandle() + "\t" + ((Collection) colls[i]).getName());
+            } else {
+                if (AuthorizeManager.authorizeActionBoolean(c, colls[i], org.dspace.core.Constants.READ)) {
+                    System.out.println("Doing    Collection " + colls[i].getHandle() + " in " + colls[i].getParentObject().getHandle() + "\t" + ((Collection) colls[i]).getName());
+                    String url = handleURLStem + colls[i].getHandle();
+
+                    if (makeHTMLMap) {
+                        html.addURL(url, null);
+                    }
+                    if (makeSitemapOrg) {
+                        sitemapsOrg.addURL(url, null);
+                    }
+                    collCount++;
+                    ItemIterator collItens = colls[i].getItems();
+                    while (collItens.hasNext()) {
+                        Item itm = collItens.next();
+                        if (itm.getOwningCollection() == colls[i] &&
+                                !excludeItem.contains(itm) &&
+                                AuthorizeManager.authorizeActionBoolean(c, itm, org.dspace.core.Constants.READ) &&
+                                (doItemsWithoutBiistreams || hasReadableBitstream(c, itm))) {
+                            url = handleURLStem + itm.getHandle();
+                            Date lastMod = itm.getLastModified();
+
+                            if (makeHTMLMap) {
+                                html.addURL(url, lastMod);
+                            }
+                            if (makeSitemapOrg) {
+                                sitemapsOrg.addURL(url, lastMod);
+                            }
+                            itm.decache();
+
+                            itemCount++;
+
+                        } else {
+                            System.out.println("Skipping Item      " + itm.getHandle() + " in " + colls[i].getHandle() + "\t" + itm.getName());
+                        }
+                    }
+                }
+            }
+        }
+
+        if (makeHTMLMap) {
+            int files = html.finish();
+            log.info(LogManager.getHeader(c, "write_sitemap", "type=html,num_files=" + files + ",communities=" + commCount + ",collections=" + collCount + ",items=" + itemCount));
+        }
+
+        if (makeSitemapOrg) {
+            int files = sitemapsOrg.finish();
+            log.info(LogManager.getHeader(c, "write_sitemap", "type=html,num_files=" + files + ",communities=" + commCount + ",collections=" + collCount + ",items=" + itemCount));
+        }
+    }
+
 
     private static boolean hasReadableBitstream(Context c, Item item) throws SQLException {
         Bundle bundles[] = item.getBundles();
@@ -279,103 +283,74 @@ public class GenerateSitemaps
         }
         return false;
     }
+
     /**
      * Ping all search engines configured in {@code dspace.cfg}.
-     * 
-     * @throws UnsupportedEncodingException
-     *             theoretically should never happen
+     *
+     * @throws UnsupportedEncodingException theoretically should never happen
      */
-    public static void pingConfiguredSearchEngines()
-            throws UnsupportedEncodingException
-    {
-        String engineURLProp = ConfigurationManager
-                .getProperty("sitemap.engineurls");
+    public static void pingConfiguredSearchEngines() throws UnsupportedEncodingException {
+        String engineURLProp = ConfigurationManager.getProperty("sitemap.engineurls");
         String engineURLs[] = null;
 
-        if (engineURLProp != null)
-        {
+        if (engineURLProp != null) {
             engineURLs = engineURLProp.trim().split("\\s*,\\s*");
         }
 
-        if (engineURLProp == null || engineURLs == null
-                || engineURLs.length == 0 || engineURLs[0].trim().equals(""))
-        {
+        if (engineURLProp == null || engineURLs == null || engineURLs.length == 0 || engineURLs[0].trim().equals("")) {
             log.warn("No search engine URLs configured to ping");
             return;
         }
 
-        for (int i = 0; i < engineURLs.length; i++)
-        {
-            try
-            {
+        for (int i = 0; i < engineURLs.length; i++) {
+            try {
                 pingSearchEngine(engineURLs[i]);
-            }
-            catch (MalformedURLException me)
-            {
-                log.warn("Bad search engine URL in configuration: "
-                        + engineURLs[i]);
+            } catch (MalformedURLException me) {
+                log.warn("Bad search engine URL in configuration: " + engineURLs[i]);
             }
         }
     }
 
     /**
      * Ping the given search engine.
-     * 
-     * @param engineURL
-     *            Search engine URL minus protocol etc, e.g.
-     *            {@code www.google.com}
-     * @throws MalformedURLException
-     *             if the passed in URL is malformed
-     * @throws UnsupportedEncodingException
-     *             theoretically should never happen
+     *
+     * @param engineURL Search engine URL minus protocol etc, e.g.
+     *                  {@code www.google.com}
+     * @throws MalformedURLException        if the passed in URL is malformed
+     * @throws UnsupportedEncodingException theoretically should never happen
      */
-    public static void pingSearchEngine(String engineURL)
-            throws MalformedURLException, UnsupportedEncodingException
-    {
+    public static void pingSearchEngine(String engineURL) throws MalformedURLException, UnsupportedEncodingException {
         // Set up HTTP proxy
         if ((StringUtils.isNotBlank(ConfigurationManager.getProperty("http.proxy.host")))
                 && (StringUtils.isNotBlank(ConfigurationManager.getProperty("http.proxy.port"))))
         {
             System.setProperty("proxySet", "true");
-            System.setProperty("proxyHost", ConfigurationManager
-                    .getProperty("http.proxy.host"));
-            System.getProperty("proxyPort", ConfigurationManager
-                    .getProperty("http.proxy.port"));
+            System.setProperty("proxyHost", ConfigurationManager.getProperty("http.proxy.host"));
+            System.getProperty("proxyPort", ConfigurationManager.getProperty("http.proxy.port"));
         }
 
-        String sitemapURL = ConfigurationManager.getProperty("dspace.url")
-                + "/sitemap";
+        String sitemapURL = ConfigurationManager.getProperty("dspace.url") + "/sitemap";
 
         URL url = new URL(engineURL + URLEncoder.encode(sitemapURL, "UTF-8"));
 
-        try
-        {
-            HttpURLConnection connection = (HttpURLConnection) url
-                    .openConnection();
+        try {
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
 
-            BufferedReader in = new BufferedReader(new InputStreamReader(
-                    connection.getInputStream()));
+            BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
 
             String inputLine;
             StringBuffer resp = new StringBuffer();
-            while ((inputLine = in.readLine()) != null)
-            {
+            while ((inputLine = in.readLine()) != null) {
                 resp.append(inputLine).append("\n");
             }
             in.close();
 
-            if (connection.getResponseCode() == 200)
-            {
+            if (connection.getResponseCode() == 200) {
                 log.info("Pinged " + url.toString() + " successfully");
+            } else {
+                log.warn("Error response pinging " + url.toString() + ":\n" + resp);
             }
-            else
-            {
-                log.warn("Error response pinging " + url.toString() + ":\n"
-                        + resp);
-            }
-        }
-        catch (IOException e)
-        {
+        } catch (IOException e) {
             log.warn("Error pinging " + url.toString(), e);
         }
     }

--- a/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
+++ b/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
@@ -238,20 +238,14 @@ public class GenerateSitemaps
         int commCount = 0;
         for (int i = 0; i < comms.length; i++)
         {
-            String excludeReason = null;
             if (excludeList[Constants.COMMUNITY].contains(comms[i]))
             {
-                excludeReason = "On Community Exclude List";
-            } else if (false && AuthorizeManager.authorizeActionBoolean(c, comms[i], org.dspace.core.Constants.READ))
-            {
-                excludeReason = "Not Readable by Anonymous";
-            }
-            if (excludeReason != null)
-            {
+                String excludeReason = "On Community Exclude List";
                 log.info("Excluding Community\t" + comms[i].getHandle() +
                         "\t" + excludeReason +
                         "\t" + ((Community) comms[i]).getName());
-            } else
+            }
+            else
             {
                 log.debug("Doing Community\t" + comms[i].getHandle() + "\t" + ((Community) comms[i]).getName());
                 String url = handleURLStem + comms[i].getHandle();
@@ -280,9 +274,6 @@ public class GenerateSitemaps
             } else if (excludeList[Constants.COMMUNITY].contains(colls[i].getParentObject()))
             {
                 excludeReason = "In Excluded " + Constants.typeText[colls[i].getParentObject().getType()] + " " + colls[i].getParentObject().getHandle();
-            } else if (false && !AuthorizeManager.authorizeActionBoolean(c, colls[i], org.dspace.core.Constants.READ))
-            {
-                excludeReason = "Not Readable by Anonymous";
             }
             if (excludeReason != null)
             {

--- a/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
+++ b/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
@@ -85,9 +85,10 @@ public class GenerateSitemaps
 
             line = parser.parse(options, args);
 
-            if (line.hasOption('h'))
-                return;  /* print help and exit in finally block
-
+            if (line.hasOption('h')) {
+                hf.printHelp(usage, options);
+                return;  /* print help and exit in finally block */
+            }
             /*
              * Sanity check -- if no sitemap generation or pinging to do, print
              * error message - print help and exit in finally block
@@ -182,7 +183,6 @@ public class GenerateSitemaps
                 System.exit(1);
             } else
             {
-                hf.printHelp(usage, options);
                 System.exit(0);
             }
         }

--- a/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
+++ b/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
@@ -195,7 +195,7 @@ public class GenerateSitemaps {
             String excludeReason = null;
             if (excludeList[Constants.COMMUNITY].contains(comms[i])) {
                 excludeReason = "On Community Exclude List";
-            } else if (AuthorizeManager.authorizeActionBoolean(c, comms[i], org.dspace.core.Constants.READ)) {
+            } else if (false && AuthorizeManager.authorizeActionBoolean(c, comms[i], org.dspace.core.Constants.READ)) {
                 excludeReason = "Not Readable by Anonymous";
             }
             if (excludeReason != null) {
@@ -225,7 +225,7 @@ public class GenerateSitemaps {
                 excludeReason = "On Collection Exclude List";
             } else if (excludeList[Constants.COMMUNITY].contains(colls[i].getParentObject())) {
                 excludeReason = "In Excluded " + Constants.typeText[colls[i].getParentObject().getType()] + " " + colls[i].getParentObject().getHandle();
-            } else if (!AuthorizeManager.authorizeActionBoolean(c, colls[i], org.dspace.core.Constants.READ)) {
+            } else if (false && !AuthorizeManager.authorizeActionBoolean(c, colls[i], org.dspace.core.Constants.READ)) {
                 excludeReason = "Not Readable by Anonymous";
             }
             if (excludeReason != null) {

--- a/dspace-api/src/main/java/org/dspace/authorize/AuthorizeManager.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/AuthorizeManager.java
@@ -276,6 +276,7 @@ public class AuthorizeManager
         // is authorization disabled for this context?
         if (c.ignoreAuthorization())
         {
+            System.out.println("Ignore author");
             return true;
         }
 
@@ -294,7 +295,7 @@ public class AuthorizeManager
                 return true;
             }
         }
-
+        System.out.println("userid " + userid  + "obj: " + o.getHandle());
         for (ResourcePolicy rp : getPoliciesActionFilter(c, o, action))
         {
             // check policies for date validity

--- a/dspace-api/src/main/java/org/dspace/authorize/AuthorizeManager.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/AuthorizeManager.java
@@ -276,7 +276,6 @@ public class AuthorizeManager
         // is authorization disabled for this context?
         if (c.ignoreAuthorization())
         {
-            System.out.println("Ignore author");
             return true;
         }
 
@@ -295,6 +294,7 @@ public class AuthorizeManager
                 return true;
             }
         }
+
         for (ResourcePolicy rp : getPoliciesActionFilter(c, o, action))
         {
             // check policies for date validity

--- a/dspace-api/src/main/java/org/dspace/authorize/AuthorizeManager.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/AuthorizeManager.java
@@ -295,7 +295,6 @@ public class AuthorizeManager
                 return true;
             }
         }
-        System.out.println("userid " + userid  + "obj: " + o.getHandle());
         for (ResourcePolicy rp : getPoliciesActionFilter(c, o, action))
         {
             // check policies for date validity

--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
@@ -1383,7 +1383,7 @@ public abstract class DSpaceObject
                 return new String[]{null, null, null};
         }
     }
-    
+
     /**
      * expects a two part string as parameter:
      *   * TYPE.ID, where TYPE is a DSpaceObject type and ID is the object id
@@ -1434,4 +1434,11 @@ public abstract class DSpaceObject
                     }
                     case Constants.GROUP:
                         return Group.findByName(c, right);
+                    default:
+                        return null;
+                }
+            }
+        }
+    }
+
 }

--- a/dspace-api/src/main/java/org/dspace/core/Constants.java
+++ b/dspace-api/src/main/java/org/dspace/core/Constants.java
@@ -40,6 +40,9 @@ public class Constants
     /** Type of individual eperson objects */
     public static final int EPERSON = 7;
 
+    /** number of DSPACE object Types  */
+    public static final int NOBJECT_TYPES = 8;
+
     /**
      * lets you look up type names from the type IDs
      */

--- a/dspace/config/log4j.properties
+++ b/dspace/config/log4j.properties
@@ -102,7 +102,7 @@ log4j.appender.A3.layout.ConversionPattern=%d %-5p %c %x - %m%n
 ###########################################################################
 # A4 is the name of the appender for dspace.app programs
 ###########################################################################
-# These lines sets the logging level for dspace.app programs
+# These lines set the logging level for dspace.app programs
 # Set these to DEBUG to see extra detailed logging.
 log4j.logger.org.dspace.app=DEBU, A4
 # Do not change this line

--- a/dspace/config/log4j.properties
+++ b/dspace/config/log4j.properties
@@ -99,6 +99,18 @@ log4j.appender.A3.MaxLogs=14
 log4j.appender.A3.layout=org.apache.log4j.PatternLayout
 log4j.appender.A3.layout.ConversionPattern=%d %-5p %c %x - %m%n
 
+###########################################################################
+# A4 is the name of the appender for dspace.app programs
+###########################################################################
+# These lines sets the logging level for dspace.app programs
+# Set these to DEBUG to see extra detailed logging.
+log4j.logger.org.dspace.app=DEBU, A4
+# Do not change this line
+log4j.additivity.org.dspace.app=true
+# The name of the file appender
+log4j.appender.A4=org.apache.log4j.ConsoleAppender
+log4j.appender.A4.layout=org.apache.log4j.PatternLayout
+log4j.appender.A4.layout.ConversionPattern=%-5p %c @ %m%n
 
 ###########################################################################
 # A4 is the name of the appender for Solr


### PR DESCRIPTION
see [DS 2381](https://jira.duraspace.org/browse/DS-2381)

added a new Console appender in log4j.properties such that all log DEBUG calls from org.dspace/app appear on the console as well as  dspace.log 

personally I find the standard command line utilities rather quiet - I like tracing to assure me that what is happening is actually what I think should be happening 
