### PR TITLE
DS-2384: Guard automatic flyway migration with a config property

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -92,6 +92,10 @@ db.statementpool = true
 # If not specified, defaults to 'dspacepool'
 db.poolname = dspacepool
 
+#Specify if the database schema should be automatically updated on every dspace start.
+#Defaults to false
+db.migration.automatic = false
+
 #######################
 # EMAIL CONFIGURATION #
 #######################

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseManager.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseManager.java
@@ -1374,7 +1374,8 @@ public class DatabaseManager
             // FINALLY, ensure database schema is up-to-date.
             // If not, upgrade/migrate database. (NOTE: This needs to run LAST
             // as it may need some of the initialized variables set above)
-            DatabaseUtils.updateDatabase(dataSource, connection);
+            if (ConfigurationManager.getBooleanProperty("db.migration.automatic", false))
+                DatabaseUtils.updateDatabase(dataSource, connection);
 
             connection.close();
         }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -188,7 +188,9 @@ public class DatabaseUtils
                     // NOTE: This looks odd, but all we really need to do is ensure the
                     // DatabaseManager auto-initializes. It'll take care of the migration itself.
                     // Asking for our DB Name will ensure DatabaseManager.initialize() is called.
-                    DatabaseManager.getDbName();
+                    Connection connection = dataSource.getConnection();
+                    DatabaseUtils.updateDatabase(dataSource, connection);
+                    connection.close();
                 }
                 System.out.println("Done.");
             }

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -94,6 +94,10 @@ db.poolname = ${db.poolname}
 # pool.
 #db.jndi = jdbc/dspace
 
+#Specify if the database schema should be automatically updated on every dspace start.
+#Defaults to false
+db.migration.automatic = ${db.migration.automatic}
+
 ##### Email settings ######
 
 # SMTP mail server

--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -133,6 +133,8 @@ Common usage:
         <echo message="" />
         <echo message="update          --> Update ${dspace.dir} config, etc, lib and web applications without " />
         <echo message="                    touching your data" />
+        <echo message="upgrade          --> Upgrade ${dspace.dir} config, etc, lib and web applications without " />
+        <echo message="                    touching your data but migrate the database schema: for upgrading to a new DSpace version" />
     	<echo message="update_configs  --> Update your configs directory with new configuration files"/>
     	<echo message="update_geolite  --> Dowload and install GeoCity database into ${dspace.dir}/config" />
         <echo message="update_code     --> Update compiled code (bin, lib, and etc directories)" />
@@ -187,6 +189,9 @@ Common usage:
     <!-- ============================================================= -->
 
     <target name="update" depends="update_configs,update_code,update_webapps,update_solr_indexes" description="Update installed code and web applications (without clobbering data/config)">
+    </target>
+
+    <target name="upgrade" depends="update_configs,update_code,migrate_database,update_webapps,update_solr_indexes" description="Update installed code and web applications (without clobbering data/config) and migrate the database">
     </target>
 
     <!-- ============================================================= -->
@@ -799,6 +804,19 @@ Common usage:
             <sysproperty key="dspace.log.init.disable" value="true" />
             <sysproperty key="dspace.configuration" value="${config}" />
             <arg value="test" />
+        </java>
+    </target>
+    <!-- ============================================================= -->
+    <!-- Migrate database                                              -->
+    <!-- ============================================================= -->
+
+    <!-- Test the connection to the database -->
+    <target name="migrate_database">
+        <java classname="org.dspace.storage.rdbms.DatabaseUtils" classpathref="class.path" fork="yes" failonerror="yes">
+            <sysproperty key="log4j.configuration" value="file:config/log4j-console.properties" />
+            <sysproperty key="dspace.log.init.disable" value="true" />
+            <sysproperty key="dspace.configuration" value="${config}" />
+            <arg value="migrate" />
         </java>
     </target>
 

--- a/src/main/filters/testEnvironment.properties
+++ b/src/main/filters/testEnvironment.properties
@@ -81,6 +81,10 @@ db.statementpool = true
 # If not specified, defaults to 'dspacepool'
 db.poolname = dspacepool
 
+#Specify if the database schema should be automatically updated on every dspace start.
+#Defaults to false
+db.migration.automatic = true
+
 #######################
 # EMAIL CONFIGURATION #
 #######################


### PR DESCRIPTION
Added upgrade target in build.xml to easily upgrade but don't require it to run automatically.
Added db.migration.automatic in both dspace.cfg and build.properties. Set it to false in build.properties.

https://jira.duraspace.org/browse/DS-2384
