### PR TITLE
DS-1959 Upgraded xoai dependency version to 3.2.9

### DIFF
--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -16,7 +16,7 @@
         <!-- This is the path to the root [dspace-src] directory. -->
         <root.basedir>${basedir}/..</root.basedir>
         <spring.version>3.2.5.RELEASE</spring.version>
-        <xoai.version>3.2.7</xoai.version>
+        <xoai.version>3.2.9</xoai.version>
         <jtwig.version>2.0.1</jtwig.version>
     </properties>
 


### PR DESCRIPTION
This basically fixes https://jira.duraspace.org/browse/DS-1959
