### PR TITLE
Minor comment cleanup in dspace.cfg

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -60,17 +60,15 @@ db.driver = ${db.driver}
 db.username = ${db.username}
 db.password = ${db.password}
 
-# Schema name - if your database contains multiple schemas, you can avoid problems with
-# retrieving the definitions of duplicate object names by specifying
-# the schema name here that is used for DSpace by uncommenting the following entry
-
-# NOTE: this configuration option is for PostgreSQL only. For Oracle, schema is equivalent
-# to user name. DSpace depends on the PostgreSQL understanding of schema. If you are using
-# Oracle, just leave this this value blank.
-
+# Schema name - if your database contains multiple schemas, you can avoid
+# problems with retrieving the definitions of duplicate object names by
+# specifying the schema name that is used for DSpace.
+# NOTE: this configuration option is for PostgreSQL only. For Oracle, schema
+# is equivalent to user name. DSpace depends on the PostgreSQL understanding
+# of schema. If you are using Oracle, just leave this this value blank.
 db.schema = ${db.schema}
 
-# Connection pool parameters
+## Connection pool parameters
 
 # Maximum number of DB connections in pool
 db.maxconnections = ${db.maxconnections}
@@ -150,7 +148,6 @@ mail.allowed.referrers = ${dspace.hostname}
 
 # Asset (bitstream) store number 0 (zero)
 assetstore.dir = ${dspace.dir}/assetstore
-
 
 # Specify extra asset stores like this, counting from 1 upwards:
 # assetstore.dir.1 = /second/assetstore


### PR DESCRIPTION
The comments regarding "db.schema" were separated by whitespace, which (at least to me) made them harder to read together. I've cleaned this up. 

Will merge this PR shortly.
