### PR TITLE
[DS-2345] Fixes wrong start index starting at 0 instead of 1 for OpenSearch

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/opensearch/AbstractOpenSearchGenerator.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/opensearch/AbstractOpenSearchGenerator.java
@@ -70,8 +70,8 @@ public abstract class AbstractOpenSearchGenerator extends AbstractGenerator
     /** results per page */
     protected int rpp = 0;
 
-    /** first result index */
-    protected int start = 0;
+    /** first result index is 1 because OpenSearch starts counting at 1 */
+    protected int start = 1;
 
     /** the results document (cached) */
     protected Document resultsDoc = null;
@@ -209,17 +209,17 @@ public abstract class AbstractOpenSearchGenerator extends AbstractGenerator
                     SortOption.ASCENDING : SortOption.DESCENDING;
         }
 
-        // Start index param
+        // Start index param (has to be >= 1)
         String st = request.getParameter("start");
         try
         {
             this.start = (st == null || st.length() == 0) ? 0 : Integer.valueOf(st);
-            if(this.start < 0)
-                this.start = 0;
+            if (this.start < 1)
+                this.start = 1;
         }
         catch (NumberFormatException e)
         {
-            this.start = 0;
+            this.start = 1;
         }
 
 
@@ -248,7 +248,7 @@ public abstract class AbstractOpenSearchGenerator extends AbstractGenerator
         this.scope = null;
         this.sort = null;
         this.rpp = 0;
-        this.start = 0;
+        this.start = 1;
         this.sortOrder = null;
         this.resultsDoc = null;
         this.validity = null;

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/opensearch/DiscoveryOpenSearchGenerator.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/opensearch/DiscoveryOpenSearchGenerator.java
@@ -92,7 +92,9 @@ public class DiscoveryOpenSearchGenerator extends AbstractOpenSearchGenerator
                 
             	// Sets the query
                 queryArgs.setQuery(query);
-                queryArgs.setStart(start);
+                // start -1 because Solr indexing starts at 0 and OpenSearch
+                // indexing starts at 1.
+                queryArgs.setStart(start - 1);
                 queryArgs.setMaxResults(rpp);
 
                 // we want Items only


### PR DESCRIPTION
This fixes the bug for the Discovery implementation. I think for the StandardOpenSearchGenerator (old Lucene based) implemenatation there are 2 lines which should be changed too. 
Line 72 and Line 114. But we are using Discovery which makes it harder to test it. 

https://jira.duraspace.org/browse/DS-2345
