### PR TITLE
DS-2343 OAI interface Response Header is missing character encoding (UTF-8)

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/controller/DSpaceOAIDataProvider.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/controller/DSpaceOAIDataProvider.java
@@ -95,6 +95,7 @@ public class DSpaceOAIDataProvider
             OAIRequestParameters parameters = new OAIRequestParameters(buildParametersMap(request));
 
             response.setContentType("application/xml");
+            response.setCharacterEncoding("UTF-8");
 
             String identification = xoaiContext + parameters.requestID();
 

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/opensearch/AbstractOpenSearchGenerator.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/opensearch/AbstractOpenSearchGenerator.java
@@ -70,8 +70,8 @@ public abstract class AbstractOpenSearchGenerator extends AbstractGenerator
     /** results per page */
     protected int rpp = 0;
 
-    /** first result index */
-    protected int start = 0;
+    /** first result index is 1 because OpenSearch starts counting at 1 */
+    protected int start = 1;
 
     /** the results document (cached) */
     protected Document resultsDoc = null;
@@ -209,17 +209,17 @@ public abstract class AbstractOpenSearchGenerator extends AbstractGenerator
                     SortOption.ASCENDING : SortOption.DESCENDING;
         }
 
-        // Start index param
+        // Start index param (has to be >= 1)
         String st = request.getParameter("start");
         try
         {
             this.start = (st == null || st.length() == 0) ? 0 : Integer.valueOf(st);
-            if(this.start < 0)
-                this.start = 0;
+            if (this.start < 1)
+                this.start = 1;
         }
         catch (NumberFormatException e)
         {
-            this.start = 0;
+            this.start = 1;
         }
 
 
@@ -248,7 +248,7 @@ public abstract class AbstractOpenSearchGenerator extends AbstractGenerator
         this.scope = null;
         this.sort = null;
         this.rpp = 0;
-        this.start = 0;
+        this.start = 1;
         this.sortOrder = null;
         this.resultsDoc = null;
         this.validity = null;

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/opensearch/DiscoveryOpenSearchGenerator.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/opensearch/DiscoveryOpenSearchGenerator.java
@@ -92,7 +92,9 @@ public class DiscoveryOpenSearchGenerator extends AbstractOpenSearchGenerator
                 
             	// Sets the query
                 queryArgs.setQuery(query);
-                queryArgs.setStart(start);
+                // start -1 because Solr indexing starts at 0 and OpenSearch
+                // indexing starts at 1.
+                queryArgs.setStart(start - 1);
                 queryArgs.setMaxResults(rpp);
 
                 // we want Items only


### PR DESCRIPTION
Fixes DS-2343 for DSpace 5.X. Maybe someone can check if line 83 is a typo and should be **response**.setCharacterEncoding("UTF-8");

In this case the new line 98 would not be needed. 

https://jira.duraspace.org/browse/DS-2343
