### PR TITLE
[DS-2400] Item validity in XMLUI only uses dublin core metadata schema

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/DSpaceValidity.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/DSpaceValidity.java
@@ -276,7 +276,7 @@ public class DSpaceValidity implements SourceValidity
             validityKey.append(item.getOwningCollection());
             validityKey.append(item.getLastModified());
             // Include all metadata values in the validity key.
-            Metadatum[] dcvs = item.getDC(Item.ANY,Item.ANY,Item.ANY);
+            Metadatum[] dcvs = item.getMetadata(Item.ANY, Item.ANY,Item.ANY,Item.ANY);
             for (Metadatum dcv : dcvs)
             {
                 validityKey.append(dcv.schema).append(".");


### PR DESCRIPTION
For more information see: https://jira.duraspace.org/browse/DS-2400
