### PR TITLE
[DS-2407] fixes wrong redirect if xmlui.force.ssl is enabled.

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/DSpaceCocoonServletFilter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/DSpaceCocoonServletFilter.java
@@ -264,8 +264,7 @@ public class DSpaceCocoonServletFilter implements Filter
                 {
                     StringBuffer location = new StringBuffer("https://");
                     location.append(ConfigurationManager.getProperty("dspace.hostname"))
-                            .append(realRequest.getContextPath())
-                            .append(realRequest.getServletPath())
+                        .append(realRequest.getRequestURI())
                             .append(realRequest.getQueryString() == null ? ""
                                     : ("?" + realRequest.getQueryString()));
                     realResponse.sendRedirect(location.toString());


### PR DESCRIPTION
Steps to reproduce the error: 
1. set xmlui.force.ssl = true in dspace.cfg (ssl has to be configured)
2. log in into DSpace
3. paste/click on a link in a new tab starting with http:// (like **http://yourdspace**/handle/123456789/1)
4. the redirect goes to _https://yourdspace/_ instead of _https://yourdspace/handle/123456789/1_

https://jira.duraspace.org/browse/DS-2407
