### PR TITLE
[DS-1810] prevent exception for XMLUI language switch and loss of Query ...

### DIFF
--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
@@ -798,5 +798,56 @@
                 </script>
 
     </xsl:template>
+    
+    <!-- Display language selection if more than 1 language is supported (overides buggy dir2xhtml-alt). 
+    Uses a page metadata curRequestURI which was introduced by in /xmlui/src/main/webapp/themes/Mirage/sitemap.xmap-->
+    <xsl:template name="languageSelection">
+        <xsl:variable name="curRequestURI">
+            <xsl:value-of select="substring-after(/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='curRequestURI'],/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='URI'])"/>
+        </xsl:variable>
+        <xsl:if test="count(/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='page'][@qualifier='supportedLocale']) &gt; 1">
+            <div id="ds-language-selection">
+                <xsl:for-each select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='page'][@qualifier='supportedLocale']">
+                    <xsl:variable name="locale" select="."/>
+                    <a>
+                        <xsl:attribute name="href">
+                            <xsl:value-of select="$curRequestURI"/>
+                            <xsl:call-template name="getLanguageURL"/>
+                            <xsl:value-of select="$locale"/>
+                        </xsl:attribute>
+                        <xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='supportedLocale'][@qualifier=$locale]"/>
+                    </a>
+                </xsl:for-each>
+            </div>
+        </xsl:if>
+    </xsl:template>
+    <!-- Builds the Query String part of the language URL. If there allready is an excisting query string 
+    like: ?filtertype=subject&filter_relational_operator=equals&filter=keyword1 it appends the locale parameter with the ampersand (&) symbol -->
+    <xsl:template name="getLanguageURL">
+        <xsl:variable name="queryString" select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='queryString']"/>
+        <xsl:choose>
+            <!-- There allready is a query string so append it and the language argument -->
+            <xsl:when test="$queryString != ''">
+                <xsl:text>?</xsl:text>
+                <xsl:choose>
+                    <xsl:when test="contains($queryString, '&amp;locale-attribute')">
+                        <xsl:value-of select="substring-before($queryString, '&amp;locale-attribute')"/>
+                        <xsl:text>&amp;locale-attribute=</xsl:text>
+                    </xsl:when>
+                    <!-- the query string is only the locale-attribute so remove it to append the correct one -->
+                    <xsl:when test="starts-with($queryString, 'locale-attribute')">
+                        <xsl:text>locale-attribute=</xsl:text>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="$queryString"/>
+                        <xsl:text>&amp;locale-attribute=</xsl:text>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:text>?locale-attribute=</xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
 
 </xsl:stylesheet>

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/sitemap.xmap
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/sitemap.xmap
@@ -84,6 +84,7 @@
                 <map:parameter name="javascript" value="lib/js/jquery-ui-1.8.15.custom.min.js"/>
                 <map:parameter name="theme.path" value="{global:theme-path}"/>
                 <map:parameter name="theme.name" value="{global:theme-path}"/>
+                <map:parameter name="curRequestURI" value="{1}"/>
             </map:transform>
 
             <!-- Debugging output (this is only called when ?XML is passed on querystring) -->


### PR DESCRIPTION
...String in Mirage theme.

This fix is only for the Mirage theme. 

**Steps to reproduce the exception**
1. Set supported locales in dspace.cfg line 1391 to support at least two languages like:
   `webui.supported.locales = en, de`
2. log in
3. start a new submission
4. change the language during submission

**Steps to reproduce the loss of the Query String**
1. Set supported locales in dspace.cfg line 1391 to support at least two languages like:
   `webui.supported.locales = en, de`
2. Click on an Author of the author facete (like http://demo.dspace.org/xmlui/discover?filtertype=author&filter_relational_operator=equals&filter=Cat%2C+Lily)
3. Change language

**Important Note**

This is not a perfect solution (only the Query String part handled by getLanguageURL is completely working as expected).
The problem with this solution is that it jumps to the page before the current page if there is a continuation. Thats because I found no way (maybe it is somehow possible in the sitemap but I think it needs major changes to the java code) to get the continuation id of the current site. 

https://jira.duraspace.org/browse/DS-1810
