### PR TITLE
DS-2352 : Fix for when Solr index files exist, but index has no content

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/IndexVersion.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/IndexVersion.java
@@ -141,6 +141,13 @@ public class IndexVersion
                 throw new IOException("Could not read Lucene segments files in " + dir.getAbsolutePath(), ie);
             }
 
+            // If we have a valid Solr index dir, but it has no existing segments
+            // then just return an empty string. It's a valid but empty index.
+            if(sis!=null && sis.size()==0)
+            {
+                return "";
+            }
+            
             // Loop through our Lucene segment files to locate the OLDEST
             // version. It is possible for individual segment files to be
             // created by different versions of Lucene. So, we just need


### PR DESCRIPTION
Ensure we check for a valid index (with segment files) but which actually has no content in it.

Fixes latest issue noted in https://jira.duraspace.org/browse/DS-2352
