### PR TITLE
DS-2411: Fix memory issues by storing just a reference to ingested objects' handles

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/packager/Packager.java
+++ b/dspace-api/src/main/java/org/dspace/app/packager/Packager.java
@@ -512,12 +512,12 @@ public class Packager
             System.out.println("This may take a while, please check your logs for ongoing status while we process each package.");
 
             //ingest first package & recursively ingest anything else that package references (child packages, etc)
-            List<DSpaceObject> dsoResults = sip.ingestAll(context, parent, pkgFile, pkgParams, null);
+            List<String> hdlResults = sip.ingestAll(context, parent, pkgFile, pkgParams, null);
 
-            if(dsoResults!=null)
+            if(hdlResults!=null)
             {
                 //Report total objects created
-                System.out.println("\nCREATED a total of " + dsoResults.size() + " DSpace Objects.");
+                System.out.println("\nCREATED a total of " + hdlResults.size() + " DSpace Objects.");
 
                 String choiceString = null;
                 //Ask if user wants full list printed to command line, as this may be rather long.
@@ -538,17 +538,22 @@ public class Packager
                 if (choiceString.equalsIgnoreCase("y"))
                 {
                     System.out.println("\n\n");
-                    for(DSpaceObject result : dsoResults)
+                    for(String result : hdlResults)
                     {
-                        if(pkgParams.restoreModeEnabled())
+                        DSpaceObject dso = HandleManager.resolveToObject(context, result);
+                        
+                        if(dso!=null)
                         {
-                            System.out.println("RESTORED DSpace " + Constants.typeText[result.getType()] +
-                                    " [ hdl=" + result.getHandle() + ", dbID=" + result.getID() + " ] ");
-                        }
-                        else
-                        {
-                            System.out.println("CREATED new DSpace " + Constants.typeText[result.getType()] +
-                                    " [ hdl=" + result.getHandle() + ", dbID=" + result.getID() + " ] ");
+                            if(pkgParams.restoreModeEnabled())
+                            {
+                                System.out.println("RESTORED DSpace " + Constants.typeText[dso.getType()] +
+                                        " [ hdl=" + dso.getHandle() + ", dbID=" + dso.getID() + " ] ");
+                            }
+                            else
+                            {
+                                System.out.println("CREATED new DSpace " + Constants.typeText[dso.getType()] +
+                                        " [ hdl=" + dso.getHandle() + ", dbID=" + dso.getID() + " ] ");
+                            }
                         }
                     }
                 }
@@ -724,12 +729,12 @@ public class Packager
         if(pkgParams.recursiveModeEnabled())
         {
             //ingest first object using package & recursively replace anything else that package references (child objects, etc)
-            List<DSpaceObject> dsoResults = sip.replaceAll(context, objToReplace, pkgFile, pkgParams);
+            List<String> hdlResults = sip.replaceAll(context, objToReplace, pkgFile, pkgParams);
 
-            if(dsoResults!=null)
+            if(hdlResults!=null)
             {
                 //Report total objects replaced
-                System.out.println("\nREPLACED a total of " + dsoResults.size() + " DSpace Objects.");
+                System.out.println("\nREPLACED a total of " + hdlResults.size() + " DSpace Objects.");
 
                 String choiceString = null;
                 //Ask if user wants full list printed to command line, as this may be rather long.
@@ -750,10 +755,15 @@ public class Packager
                 if (choiceString.equalsIgnoreCase("y"))
                 {
                     System.out.println("\n\n");
-                    for(DSpaceObject result : dsoResults)
+                    for(String result : hdlResults)
                     {
-                        System.out.println("REPLACED DSpace " + Constants.typeText[result.getType()] +
-                                    " [ hdl=" + result.getHandle() + " ] ");
+                        DSpaceObject dso = HandleManager.resolveToObject(context, result);
+                        
+                        if(dso!=null)
+                        {
+                            System.out.println("REPLACED DSpace " + Constants.typeText[dso.getType()] +
+                                        " [ hdl=" + dso.getHandle() + " ] ");
+                        }
                     }
                 }
 

--- a/dspace-api/src/main/java/org/dspace/content/packager/PDFPackager.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/PDFPackager.java
@@ -180,7 +180,7 @@ public class PDFPackager
     /**
      * IngestAll() cannot be implemented for a PDF ingester, because there's only one PDF to ingest
      */
-    public List<DSpaceObject> ingestAll(Context context, DSpaceObject parent, File pkgFile,
+    public List<String> ingestAll(Context context, DSpaceObject parent, File pkgFile,
                                 PackageParameters params, String license)
         throws PackageException, UnsupportedOperationException,
                CrosswalkException, AuthorizeException,
@@ -205,7 +205,7 @@ public class PDFPackager
     /**
      * ReplaceAll() cannot be implemented for a PDF ingester, because there's only one PDF to ingest
      */
-    public List<DSpaceObject> replaceAll(Context context, DSpaceObject dso,
+    public List<String> replaceAll(Context context, DSpaceObject dso,
                                 File pkgFile, PackageParameters params)
         throws PackageException, UnsupportedOperationException,
                CrosswalkException, AuthorizeException,

--- a/dspace-api/src/main/java/org/dspace/content/packager/PackageIngester.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/PackageIngester.java
@@ -86,7 +86,8 @@ public interface PackageIngester
      * collection-level package, and also create an Item for every item-level
      * package referenced by the collection-level package.
      * <p>
-     * The output of this method is one or more newly created <code>DspaceObject<code>s.
+     * The output of this method is one or more newly created DSpaceObject Identifiers
+     * (i.e. Handles).
      * <p>
      * The packager <em>may</em> choose not to implement <code>ingestAll</code>,
      * or simply forward the call to <code>ingest</code> if it is unable to support
@@ -104,14 +105,14 @@ public interface PackageIngester
      * @param pkgFile  The initial package file to ingest
      * @param params Properties-style list of options (interpreted by each packager).
      * @param license  may be null, which takes default license.
-     * @return List of DSpaceObjects created
+     * @return List of Identifiers of DSpaceObjects created
      *
      * @throws PackageValidationException if initial package (or any referenced package)
      *          is unacceptable or there is a fatal error in creating a DSpaceObject
      * @throws UnsupportedOperationException if this packager does not
      *  implement <code>ingestAll</code>
      */
-    List<DSpaceObject> ingestAll(Context context, DSpaceObject parent, File pkgFile,
+    List<String> ingestAll(Context context, DSpaceObject parent, File pkgFile,
                                 PackageParameters params, String license)
         throws PackageException, UnsupportedOperationException,
                CrosswalkException, AuthorizeException,
@@ -158,7 +159,8 @@ public interface PackageIngester
      * initial object to replace, any additional objects to replace must be
      * determined based on the referenced packages (or initial package itself).
      * <p>
-     * The output of this method is one or more replaced <code>DspaceObject<code>s.
+     * The output of this method is one or more replaced DSpaceObject Identifiers
+     * (i.e. Handles).
      * <p>
      * The packager <em>may</em> choose not to implement <code>replaceAll</code>,
      * since it somewhat contradicts the archival nature of DSpace. It also
@@ -170,14 +172,14 @@ public interface PackageIngester
      *            if object to replace can be determined from package
      * @param pkgFile  The package file to ingest.
      * @param params Properties-style list of options specific to this packager
-     * @return List of DSpaceObjects replaced
+     * @return List of Identifiers of DSpaceObjects replaced
      *
      * @throws PackageValidationException if initial package (or any referenced package)
      *          is unacceptable or there is a fatal error in creating a DSpaceObject
      * @throws UnsupportedOperationException if this packager does not
      *  implement <code>replaceAll</code>
      */
-    List<DSpaceObject> replaceAll(Context context, DSpaceObject dso,
+    List<String> replaceAll(Context context, DSpaceObject dso,
                                 File pkgFile, PackageParameters params)
         throws PackageException, UnsupportedOperationException,
                CrosswalkException, AuthorizeException,

--- a/dspace-api/src/main/java/org/dspace/content/packager/RoleIngester.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/RoleIngester.java
@@ -490,7 +490,7 @@ public class RoleIngester implements PackageIngester
      * org.dspace.content.packager.PackageParameters, java.lang.String)
      */
     @Override
-    public List<DSpaceObject> ingestAll(Context context, DSpaceObject parent,
+    public List<String> ingestAll(Context context, DSpaceObject parent,
             File pkgFile, PackageParameters params, String license)
             throws PackageException, UnsupportedOperationException,
             CrosswalkException, AuthorizeException, SQLException, IOException
@@ -526,7 +526,7 @@ public class RoleIngester implements PackageIngester
      * org.dspace.content.packager.PackageParameters)
      */
     @Override
-    public List<DSpaceObject> replaceAll(Context context, DSpaceObject dso,
+    public List<String> replaceAll(Context context, DSpaceObject dso,
             File pkgFile, PackageParameters params) throws PackageException,
             UnsupportedOperationException, CrosswalkException,
             AuthorizeException, SQLException, IOException


### PR DESCRIPTION
See https://jira.duraspace.org/browse/DS-2411

This PR simply refactors the existing AIP Ingest code to store a String Handle reference to all successfully ingested objects, instead of the _entire_ DSpaceObject.

The refactor passes all AIP Integration Tests. It also seems to speed up the ingest process by as much as 10 times (previously AIP Integration Tests took around 40 seconds to complete, and they now take about 4 seconds to run the same tests)
