### PR TITLE
Add a way to easily manage "LICENSES_THIRD_PARTY" using codehaus license-maven-plugin

### DIFF
--- a/LICENSES_THIRD_PARTY
+++ b/LICENSES_THIRD_PARTY
@@ -1,162 +1,376 @@
-DSpace uses third-party libraries which may be distributed under different 
-licenses. We have attempted to list all of these third party libraries and 
-their licenses below (however the most up-to-date information can be found
-via Maven, see NOTE #2 at bottom of this page). 
 
-You must agree to the terms of these licenses, in addition to the DSpace 
-source code license, in order to use this software.
+List of third-party dependencies grouped by their license type.
 
---------------------------------------------------
-Third party Java libraries listed by License type
-[Format: Name (Maven Project) - URL]
---------------------------------------------------
+    Apache Software License, Version 2.0:
 
-Apache Software License, Version 2.0 (http://opensource.org/licenses/apache2.0)
-  * Ant-Contrib Tasks (ant-contrib:*) - http://ant-contrib.sourceforge.net/
-  * Apache Abdera (org.apache.abdera::*) - http://projects.apache.org/projects/abdera.html
-  * Apache Ant (org.apache.ant:*) - http://ant.apache.org/
-  * Apache Axis (axis:*) - http://axis.apache.org/axis/
-  * Apache Cocoon (org.apache.cocoon:*) - http://cocoon.apache.org/2.2/license.html
-  * Apache Commons BeanUtils (commons-beanutils:*) - http://commons.apache.org/beanutils/
-  * Apache Commons CLI (commons-cli:*) - http://commons.apache.org/cli/license.html
-  * Apache Commons Codec (commons-codec:*) - http://commons.apache.org/codec/license.html
-  * Apache Commons Collections (commons-collections:*) - http://commons.apache.org/collections/license.html
-  * Apache Commons Configuration (commons-configuration:*) - http://commons.apache.org/configuration/license.html
-  * Apache Commons DBCP (commons-dbcp:*) - http://commons.apache.org/dbcp/license.html
-  * Apache Commons Digester (commons-digester:*) - http://commons.apache.org/digester/
-  * Apache Commons Discovery (commons-discovery:*) - http://commons.apache.org/discovery/license.html
-  * Apache Commons FileUpload (commons-fileupload:*) - http://commons.apache.org/fileupload/license.html
-  * Apache Commons HTTP Client (commons-httpclient:*) - http://commons.apache.org/httpclient/license.html
-  * Apache Commons IO (commons-io:*) - http://commons.apache.org/io/license.html
-  * Apache Commons JXPath (commons-jxpath:*) - http://commons.apache.org/jxpath/license.html
-  * Apache Commons Lang (commons-lang:*) - http://commons.apache.org/lang/license.html
-  * Apache Commons Logging (commons-logging:*) - http://commons.apache.org/logging/license.html
-  * Apache Commons Pool (commons-pool:*) - http://commons.apache.org/pool/license.html
-  * Apache Commons Validator (commons-validator:*) - http://commons.apache.org/validator/license.html
-  * Apache Geronimo (org.apache.geronimo.specs:*) - http://geronimo.apache.org/
-  * Apache HTTPComponents (org.apache.httpcomponents:*) - http://hc.apache.org/
-  * Apache Jakarta ORO (oro:*) - http://svn.apache.org/repos/asf/jakarta/oro/trunk/LICENSE
-  * Apache Jakarta Regexp (jakarta-regexp:*) - http://jakarta.apache.org/regexp/
-  * Apache JaxMe (jaxme:jaxme-api) - http://ws.apache.org/old/jaxme-old/license.html
-  * Apache Jena (com.hp.hpl.jena:*) - http://jena.apache.org/
-  * Apache log4j (log4j:*) : http://logging.apache.org/log4j/
-  * Apache Lucene (org.apache.lucene:*) - http://lucene.apache.org/
-  * Apache PDFBox (org.apache.pdfbox:*) - http://pdfbox.apache.org/
-  * Apache POI (org.apache.poi:*) - http://poi.apache.org/
-  * Apache Solr (org.apache.solr:*) - http://lucene.apache.org/solr/
-  * Apache Xerces (xerces:*) - http://xerces.apache.org/
-  * Apache XML Commons (xml-apis:*) - http://xerces.apache.org/xml-commons/licenses.html
-  * Apache XML Project (xalan:*) - http://xml.apache.org/xalan-j/#license
-  * Apache XMLBeans (org.apache.xmlbeans:*) - http://xmlbeans.apache.org/
-  * Apache ZooKeeper (org.apache.zookeeper:*) - http://zookeeper.apache.org/
-  * Databene ContiPerf (org.databene:contiperf) - http://databene.org/contiperf
-  * Ehcache (net.sf.ehcache:*) - http://ehcache.org/about/license
-  * ElasticSearch (org.elasticsearch:*) - http://www.elasticsearch.org/
-  * Evo Inflector (org.atteo:*) - http://www.atteo.org/evo-framework/inflector/
-  * flexjson (net.sf.flexjson:*) - http://sourceforge.net/projects/flexjson/
-  * Google GSON (com.google.code.gson:*) - http://code.google.com/p/google-gson/
-  * Google Guava (com.google.guava:*) - http://code.google.com/p/guava-libraries/
-  * Jackson (org.codehaus.jackson:*) - http://jackson.codehaus.org/
-  * Jettison (org.codejaus.jettison:*) - http://jettison.codehaus.org/
-  * Jetty (org.mortbay.jetty:*) - http://jetty.codehaus.org/jetty/license.html
-  * Lyncode XOAI (com.lyncode:xoai) - http://www.lyncode.com/
-  * noggit (org.noggit:noggit) - http://noggit.org/
-  * oai4j (se.kb:oai4j) - http://oai4j-client.sourceforge.net/
-  * OpenCSV (net.sf.opencsv:*) - http://opencsv.sourceforge.net/
-  * Rome (net.java.dev.rome:*, org.rometools:*, rome:*) - http://rometools.org/
-  * spatial4j (com.spatial4j:*) - http://spatial4j.com/
-  * Spring Framework  (org.springframework:*) - http://www.springsource.org/spring-framework
-  * SWORD Libraries (org.swordapp:*) - http://mvnrepository.com/artifact/org.swordapp/server/2.0
-  * Woodstox (org.codehaus.woodstox:*) - http://woodstox.codehaus.org/Download
+        * Ant-Contrib Tasks (ant-contrib:ant-contrib:1.0b3 - http://ant-contrib.sourceforge.net)
+        * Code Generation Library (cglib:cglib:3.1 - http://cglib.sourceforge.net/)
+        * HPPC Collections (com.carrotsearch:hppc:0.5.2 - http://labs.carrotsearch.com/hppc.html/hppc)
+        * metadata-extractor (com.drewnoakes:metadata-extractor:2.6.2 - http://code.google.com/p/metadata-extractor/)
+        * Jackson-annotations (com.fasterxml.jackson.core:jackson-annotations:2.3.0 - http://wiki.fasterxml.com/JacksonHome)
+        * Jackson-core (com.fasterxml.jackson.core:jackson-core:2.1.3 - http://wiki.fasterxml.com/JacksonHome)
+        * Jackson-core (com.fasterxml.jackson.core:jackson-core:2.3.3 - http://wiki.fasterxml.com/JacksonHome)
+        * jackson-databind (com.fasterxml.jackson.core:jackson-databind:2.3.3 - http://wiki.fasterxml.com/JacksonHome)
+        * Google APIs Client Library for Java (com.google.api-client:google-api-client:1.19.0 - http://code.google.com/p/google-api-java-client/google-api-client/)
+        * Google Analytics API v3-rev103-1.19.0 (com.google.apis:google-api-services-analytics:v3-rev103-1.19.0 - http://nexus.sonatype.org/oss-repository-hosting.html/google-api-services-analytics)
+        * FindBugs-jsr305 (com.google.code.findbugs:jsr305:3.0.0 - http://findbugs.sourceforge.net/)
+        * Gson (com.google.code.gson:gson:2.2.1 - http://code.google.com/p/google-gson/)
+        * Guava: Google Core Libraries for Java (com.google.guava:guava:13.0 - http://code.google.com/p/guava-libraries/guava)
+        * Guava: Google Core Libraries for Java (com.google.guava:guava:14.0.1 - http://code.google.com/p/guava-libraries/guava)
+        * Guava: Google Core Libraries for Java (com.google.guava:guava:18.0 - http://code.google.com/p/guava-libraries/guava)
+        * Guava: Google Core Libraries for Java (com.google.guava:guava-jdk5:13.0 - http://code.google.com/p/guava-libraries/guava-jdk5)
+        * Google HTTP Client Library for Java (com.google.http-client:google-http-client:1.19.0 - http://code.google.com/p/google-http-java-client/google-http-client/)
+        * Jackson 2 extensions to the Google HTTP Client Library for Java. (com.google.http-client:google-http-client-jackson2:1.19.0 - http://code.google.com/p/google-http-java-client/google-http-client-jackson2/)
+        * Google OAuth Client Library for Java (com.google.oauth-client:google-oauth-client:1.19.0 - http://code.google.com/p/google-oauth-java-client/google-oauth-client/)
+        * Java 6 (and higher) extensions to the Google OAuth Client Library for Java. (com.google.oauth-client:google-oauth-client-java6:1.19.0 - http://code.google.com/p/google-oauth-java-client/google-oauth-client-java6/)
+        * Jetty extensions to the Google OAuth Client Library for Java. (com.google.oauth-client:google-oauth-client-jetty:1.19.0 - http://code.google.com/p/google-oauth-java-client/google-oauth-client-jetty/)
+        * ConcurrentLinkedHashMap (com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.2 - http://code.google.com/p/concurrentlinkedhashmap)
+        * FORESITE :: Object Reuse and Exchange library (com.googlecode.foresite-toolkit:foresite:0.9 - http://www.openarchives.org/ore)
+        * ISO Parser (com.googlecode.mp4parser:isoparser:1.0-RC-1 - http://code.google.com/p/mp4parser/)
+        * builder-commons (com.lyncode:builder-commons:1.0.2 - http://nexus.sonatype.org/oss-repository-hosting.html/builder-commons)
+        * Jtwig Core (com.lyncode:jtwig-core:2.0.1 - http://www.lyncode.com/jtwig-core)
+        * Jtwig Core Functions (com.lyncode:jtwig-functions:2.0.1 - http://www.lyncode.com/jtwig-functions)
+        * Jtwig Spring (com.lyncode:jtwig-spring:2.0.1 - http://www.lyncode.com/jtwig-spring)
+        * Test Support (com.lyncode:test-support:1.0.3 - http://nexus.sonatype.org/oss-repository-hosting.html/test-support)
+        * XOAI : OAI-PMH Java Toolkit (com.lyncode:xoai:3.2.9 - http://www.lyncode.com)
+        * Spatial4J (com.spatial4j:spatial4j:0.4.1 - https://github.com/spatial4j/spatial4j)
+        * Commons BeanUtils (commons-beanutils:commons-beanutils:1.8.3 - http://commons.apache.org/beanutils/)
+        * Commons CLI (commons-cli:commons-cli:1.2 - http://commons.apache.org/cli/)
+        * Apache Commons Codec (commons-codec:commons-codec:1.9 - http://commons.apache.org/proper/commons-codec/)
+        * Collections (commons-collections:commons-collections:3.2 - http://jakarta.apache.org/commons/collections/)
+        * Commons Configuration (commons-configuration:commons-configuration:1.6 - http://commons.apache.org/${pom.artifactId.substring(8)}/)
+        * Commons Configuration (commons-configuration:commons-configuration:1.8 - http://commons.apache.org/configuration/)
+        * Commons DBCP (commons-dbcp:commons-dbcp:1.4 - http://commons.apache.org/dbcp/)
+        * Digester (commons-digester:commons-digester:1.8 - http://jakarta.apache.org/commons/digester/)
+        * Commons FileUpload (commons-fileupload:commons-fileupload:1.2.1 - http://commons.apache.org/fileupload/)
+        * HttpClient (commons-httpclient:commons-httpclient:3.1 - http://jakarta.apache.org/httpcomponents/httpclient-3.x/)
+        * Commons IO (commons-io:commons-io:2.3 - http://commons.apache.org/io/)
+        * commons-jexl (commons-jexl:commons-jexl:1.0 - no url defined)
+        * Commons JXPath (commons-jxpath:commons-jxpath:1.3 - http://commons.apache.org/jxpath/)
+        * Commons Lang (commons-lang:commons-lang:2.6 - http://commons.apache.org/lang/)
+        * Commons Logging (commons-logging:commons-logging:1.1.1 - http://commons.apache.org/logging)
+        * Commons Pool (commons-pool:commons-pool:1.4 - http://commons.apache.org/pool/)
+        * Commons Validator (commons-validator:commons-validator:1.4.0 - http://commons.apache.org/validator/)
+        * Boilerpipe -- Boilerplate Removal and Fulltext Extraction from HTML pages (de.l3s.boilerpipe:boilerpipe:1.1.0 - http://code.google.com/p/boilerpipe/)
+        * jakarta-regexp (jakarta-regexp:jakarta-regexp:1.4 - no url defined)
+        * javax.inject (javax.inject:javax.inject:1 - http://code.google.com/p/atinject/)
+        * jdbm (jdbm:jdbm:1.0 - no url defined)
+        * Joda time (joda-time:joda-time:2.2 - http://joda-time.sourceforge.net)
+        * Joda-Time (joda-time:joda-time:2.3 - http://www.joda.org/joda-time/)
+        * Apache Log4j (log4j:log4j:1.2.16 - http://logging.apache.org/log4j/1.2/)
+        * Apache Log4j (log4j:log4j:1.2.17 - http://logging.apache.org/log4j/1.2/)
+        * Ehcache Core (net.sf.ehcache:ehcache-core:1.7.2 - http://ehcache.sf.net/ehcache-core)
+        * opencsv (net.sf.opencsv:opencsv:2.0 - http://opencsv.sf.net)
+        * opencsv (net.sf.opencsv:opencsv:2.3 - http://opencsv.sf.net)
+        * Abdera Client (org.apache.abdera:abdera-client:1.1.1 - http://abdera.apache.org/abdera-client)
+        * Abdera Core (org.apache.abdera:abdera-core:1.1.1 - http://abdera.apache.org/abdera-core)
+        * I18N Libraries (org.apache.abdera:abdera-i18n:1.1.1 - http://abdera.apache.org)
+        * Abdera Parser (org.apache.abdera:abdera-parser:1.1.1 - http://abdera.apache.org/abdera-parser)
+        * org.apache.tools.ant (org.apache.ant:ant:1.7.0 - http://ant.apache.org/ant/)
+        * ant-launcher (org.apache.ant:ant-launcher:1.7.0 - http://ant.apache.org/ant-launcher/)
+        * Avalon Framework API (org.apache.avalon.framework:avalon-framework-api:4.3.1 - http://www.apache.org/excalibur/avalon-framework/avalon-framework-api/)
+        * Avalon Framework Implementation (org.apache.avalon.framework:avalon-framework-impl:4.3.1 - http://www.apache.org/excalibur/avalon-framework/avalon-framework-impl/)
+        * Cocoon Configuration API (org.apache.cocoon:cocoon-configuration-api:1.0.2 - http://cocoon.apache.org/subprojects/configuration/1.0/configuration-api/1.0/)
+        * Cocoon Core (org.apache.cocoon:cocoon-core:2.2.0 - http://cocoon.apache.org/2.2/core-modules/core/2.2/)
+        * Cocoon Expression Language API (org.apache.cocoon:cocoon-expression-language-api:1.0.0 - http://cocoon.apache.org/2.2/core-modules/expression-language-api/1.0/)
+        * Cocoon Expression Language Implementation. (org.apache.cocoon:cocoon-expression-language-impl:1.0.0 - http://cocoon.apache.org/2.2/core-modules/expression-language-impl/1.0/)
+        * Cocoon Flowscript Block Implementation (org.apache.cocoon:cocoon-flowscript-impl:1.0.0 - http://cocoon.apache.org/2.2/blocks/flowscript/1.0/)
+        * Cocoon Linkrewriter Block Implementation (org.apache.cocoon:cocoon-linkrewriter-impl:1.0.0 - http://cocoon.apache.org/2.2/blocks/linkrewriter/1.0/)
+        * Cocoon Pipeline API (org.apache.cocoon:cocoon-pipeline-api:1.0.0 - http://cocoon.apache.org/2.2/core-modules/pipeline-api/1.0/)
+        * Cocoon Pipeline Components (org.apache.cocoon:cocoon-pipeline-components:1.0.0 - http://cocoon.apache.org/2.2/core-modules/pipeline-components/1.0/)
+        * Cocoon Pipeline Implementation (org.apache.cocoon:cocoon-pipeline-impl:1.0.0 - http://cocoon.apache.org/2.2/core-modules/pipeline-impl/1.0/)
+        * Cocoon Servlet Service Components (org.apache.cocoon:cocoon-servlet-service-components:1.0.0 - http://cocoon.apache.org/subprojects/servlet-service/1.0/servlet-service-components/1.0/)
+        * Cocoon Sitemap API (org.apache.cocoon:cocoon-sitemap-api:1.0.0 - http://cocoon.apache.org/2.2/core-modules/sitemap-api/1.0/)
+        * Cocoon Sitemap Components (org.apache.cocoon:cocoon-sitemap-components:1.0.0 - http://cocoon.apache.org/2.2/core-modules/sitemap-components/1.0/)
+        * Cocoon Sitemap Implementation (org.apache.cocoon:cocoon-sitemap-impl:1.0.0 - http://cocoon.apache.org/2.2/core-modules/sitemap-impl/1.0/)
+        * Cocoon Spring Configurator (org.apache.cocoon:cocoon-spring-configurator:1.0.2 - http://cocoon.apache.org/cocoon-spring-configurator)
+        * Cocoon Store Implementation (org.apache.cocoon:cocoon-store-impl:1.0.0 - http://cocoon.apache.org/2.2/core-modules/store-impl/1.0/)
+        * Cocoon Template Framework Block Implementation (org.apache.cocoon:cocoon-template-impl:1.1.0 - http://cocoon.apache.org/2.2/blocks/template/1.0/)
+        * Cocoon Thread API (org.apache.cocoon:cocoon-thread-api:1.0.0 - http://cocoon.apache.org/2.2/core-modules/thread-api/1.0/)
+        * Cocoon Thread Implementation (org.apache.cocoon:cocoon-thread-impl:1.0.0 - http://cocoon.apache.org/2.2/core-modules/thread-impl/1.0/)
+        * Cocoon Util (org.apache.cocoon:cocoon-util:1.0.0 - http://cocoon.apache.org/2.2/core-modules/util/1.0/)
+        * Cocoon XML API (org.apache.cocoon:cocoon-xml-api:1.0.0 - http://cocoon.apache.org/2.2/core-modules/xml-api/1.0/)
+        * Cocoon XML Implementation (org.apache.cocoon:cocoon-xml-impl:1.0.0 - http://cocoon.apache.org/2.2/core-modules/xml-impl/1.0/)
+        * Cocoon XML Resolver (org.apache.cocoon:cocoon-xml-resolver:1.0.0 - http://cocoon.apache.org/2.2/core-modules/xml-resolver/1.0/)
+        * Cocoon XML Utilities (org.apache.cocoon:cocoon-xml-util:1.0.0 - http://cocoon.apache.org/2.2/core-modules/xml-util/1.0/)
+        * Apache Commons Compress (org.apache.commons:commons-compress:1.7 - http://commons.apache.org/proper/commons-compress/)
+        * Commons Lang (org.apache.commons:commons-lang3:3.1 - http://commons.apache.org/lang/)
+        * Excalibur Pool API (org.apache.excalibur.components:excalibur-pool-api:2.2.1 - http://www.apache.org/excalibur/excalibur-components-modules/excalibur-pool-modules/excalibur-pool-api/)
+        * Excalibur Sourceresolve (org.apache.excalibur.components:excalibur-sourceresolve:2.2.3 - http://www.apache.org/excalibur/excalibur-sourceresolve/)
+        * Excalibur Store (org.apache.excalibur.components:excalibur-store:2.2.1 - http://www.apache.org/excalibur/excalibur-components-modules/excalibur-store/)
+        * Excalibur XML Utilities (org.apache.excalibur.components:excalibur-xmlutil:2.2.1 - http://www.apache.org/excalibur/excalibur-components-modules/excalibur-xmlutil/)
+        * Excalibur Instrument API (org.apache.excalibur.containerkit:excalibur-instrument-api:2.2.1 - http://www.apache.org/excalibur/excalibur-containerkit/excalibur-instrument-modules/excalibur-instrument-api/)
+        * Excalibur Logger (org.apache.excalibur.containerkit:excalibur-logger:2.2.1 - http://www.apache.org/excalibur/excalibur-containerkit/excalibur-logger/)
+        * Activation (org.apache.geronimo.specs:geronimo-activation_1.0.2_spec:1.1 - http://geronimo.apache.org/geronimo-activation_1.0.2_spec)
+        * Activation 1.1 (org.apache.geronimo.specs:geronimo-activation_1.1_spec:1.0.2 - http://geronimo.apache.org/specs/geronimo-activation_1.1_spec)
+        * JavaMail 1.4 (org.apache.geronimo.specs:geronimo-javamail_1.4_spec:1.6 - http://geronimo.apache.org/maven/specs/geronimo-javamail_1.4_spec/1.6)
+        * Streaming API for XML (STAX API 1.0) (org.apache.geronimo.specs:geronimo-stax-api_1.0_spec:1.0 - http://geronimo.apache.org/specs/geronimo-stax-api_1.0_spec)
+        * Streaming API for XML (STAX API 1.0) (org.apache.geronimo.specs:geronimo-stax-api_1.0_spec:1.0.1 - http://geronimo.apache.org/specs/geronimo-stax-api_1.0_spec)
+        * Apache Hadoop Annotations (org.apache.hadoop:hadoop-annotations:2.2.0 - no url defined)
+        * Apache Hadoop Auth (org.apache.hadoop:hadoop-auth:2.2.0 - no url defined)
+        * Apache Hadoop Common (org.apache.hadoop:hadoop-common:2.2.0 - no url defined)
+        * Apache Hadoop HDFS (org.apache.hadoop:hadoop-hdfs:2.2.0 - no url defined)
+        * Apache HttpClient (org.apache.httpcomponents:httpclient:4.3.5 - http://hc.apache.org/httpcomponents-client)
+        * Apache HttpClient Cache (org.apache.httpcomponents:httpclient-cache:4.2.6 - http://hc.apache.org/httpcomponents-client)
+        * Apache HttpCore (org.apache.httpcomponents:httpcore:4.3.2 - http://hc.apache.org/httpcomponents-core-ga)
+        * Apache HttpClient Mime (org.apache.httpcomponents:httpmime:4.3.1 - http://hc.apache.org/httpcomponents-client)
+        * Apache JAMES Mime4j (Core) (org.apache.james:apache-mime4j-core:0.7.2 - http://james.apache.org/mime4j/apache-mime4j-core)
+        * Apache JAMES Mime4j (DOM) (org.apache.james:apache-mime4j-dom:0.7.2 - http://james.apache.org/mime4j/apache-mime4j-dom)
+        * Apache Jena - Libraries POM (org.apache.jena:apache-jena-libs:2.12.0 - http://jena.apache.org/apache-jena-libs/)
+        * Apache Jena - ARQ (SPARQL 1.1 Query Engine) (org.apache.jena:jena-arq:2.12.0 - http://jena.apache.org/jena-arq/)
+        * Apache Jena - Core (org.apache.jena:jena-core:2.12.0 - http://jena.apache.org/jena-core/)
+        * Apache Jena - IRI (org.apache.jena:jena-iri:1.1.0 - http://jena.apache.org/jena-iri/)
+        * Apache Jena - TDB (Native Triple Store) (org.apache.jena:jena-tdb:1.1.0 - http://jena.apache.org/jena-tdb/)
+        * Lucene Common Analyzers (org.apache.lucene:lucene-analyzers-common:4.10.2 - http://lucene.apache.org/lucene-parent/lucene-analyzers-common)
+        * Lucene ICU Analysis Components (org.apache.lucene:lucene-analyzers-icu:4.10.2 - http://lucene.apache.org/lucene-parent/lucene-analyzers-icu)
+        * Lucene Kuromoji Japanese Morphological Analyzer (org.apache.lucene:lucene-analyzers-kuromoji:4.10.2 - http://lucene.apache.org/lucene-parent/lucene-analyzers-kuromoji)
+        * Lucene Morfologik Polish Lemmatizer (org.apache.lucene:lucene-analyzers-morfologik:4.10.2 - http://lucene.apache.org/lucene-parent/lucene-analyzers-morfologik)
+        * Lucene Phonetic Filters (org.apache.lucene:lucene-analyzers-phonetic:4.10.2 - http://lucene.apache.org/lucene-parent/lucene-analyzers-phonetic)
+        * Lucene Smart Chinese Analyzer (org.apache.lucene:lucene-analyzers-smartcn:4.10.2 - http://lucene.apache.org/lucene-parent/lucene-analyzers-smartcn)
+        * Lucene Stempel Analyzer (org.apache.lucene:lucene-analyzers-stempel:4.10.2 - http://lucene.apache.org/lucene-parent/lucene-analyzers-stempel)
+        * Lucene codecs (org.apache.lucene:lucene-codecs:4.10.2 - http://lucene.apache.org/lucene-parent/lucene-codecs)
+        * Lucene Core (org.apache.lucene:lucene-core:4.10.2 - http://lucene.apache.org/lucene-parent/lucene-core)
+        * Lucene Expressions (org.apache.lucene:lucene-expressions:4.10.2 - http://lucene.apache.org/lucene-parent/lucene-expressions)
+        * Lucene Grouping (org.apache.lucene:lucene-grouping:4.10.2 - http://lucene.apache.org/lucene-parent/lucene-grouping)
+        * Lucene Highlighter (org.apache.lucene:lucene-highlighter:4.10.2 - http://lucene.apache.org/lucene-parent/lucene-highlighter)
+        * Lucene Join (org.apache.lucene:lucene-join:4.10.2 - http://lucene.apache.org/lucene-parent/lucene-join)
+        * Lucene Memory (org.apache.lucene:lucene-memory:4.10.2 - http://lucene.apache.org/lucene-parent/lucene-memory)
+        * Lucene Miscellaneous (org.apache.lucene:lucene-misc:4.10.2 - http://lucene.apache.org/lucene-parent/lucene-misc)
+        * Lucene Queries (org.apache.lucene:lucene-queries:4.10.2 - http://lucene.apache.org/lucene-parent/lucene-queries)
+        * Lucene QueryParsers (org.apache.lucene:lucene-queryparser:4.10.2 - http://lucene.apache.org/lucene-parent/lucene-queryparser)
+        * Lucene Sandbox (org.apache.lucene:lucene-sandbox:4.10.2 - http://lucene.apache.org/lucene-parent/lucene-sandbox)
+        * Lucene Spatial (org.apache.lucene:lucene-spatial:4.10.2 - http://lucene.apache.org/lucene-parent/lucene-spatial)
+        * Lucene Suggest (org.apache.lucene:lucene-suggest:4.10.2 - http://lucene.apache.org/lucene-parent/lucene-suggest)
+        * Apache FontBox (org.apache.pdfbox:fontbox:1.8.7 - http://pdfbox.apache.org/)
+        * Apache JempBox (org.apache.pdfbox:jempbox:1.8.7 - http://www.apache.org/pdfbox-parent/jempbox/)
+        * Apache PDFBox (org.apache.pdfbox:pdfbox:1.8.7 - http://www.apache.org/pdfbox-parent/pdfbox/)
+        * Apache POI (org.apache.poi:poi:3.6 - http://poi.apache.org/)
+        * Apache POI (org.apache.poi:poi-ooxml:3.6 - http://poi.apache.org/)
+        * Apache POI (org.apache.poi:poi-ooxml-schemas:3.10.1 - http://poi.apache.org/)
+        * Apache POI (org.apache.poi:poi-ooxml-schemas:3.6 - http://poi.apache.org/)
+        * Apache POI (org.apache.poi:poi-scratchpad:3.6 - http://poi.apache.org/)
+        * Apache Solr Search Server (org.apache.solr:solr:4.10.2 - http://lucene.apache.org/solr-parent/solr)
+        * Apache Solr Analysis Extras (org.apache.solr:solr-analysis-extras:4.10.2 - http://lucene.apache.org/solr-parent/solr-analysis-extras)
+        * Apache Solr Content Extraction Library (org.apache.solr:solr-cell:4.10.2 - http://lucene.apache.org/solr-parent/solr-cell)
+        * Apache Solr Core (org.apache.solr:solr-core:4.10.2 - http://lucene.apache.org/solr-parent/solr-core)
+        * Apache Solr Solrj (org.apache.solr:solr-solrj:4.10.2 - http://lucene.apache.org/solr-parent/solr-solrj)
+        * Apache Tika core (org.apache.tika:tika-core:1.5 - http://tika.apache.org/)
+        * Apache Tika parsers (org.apache.tika:tika-parsers:1.5 - http://tika.apache.org/)
+        * Apache Tika XMP (org.apache.tika:tika-xmp:1.5 - http://tika.apache.org/)
+        * Axiom API (org.apache.ws.commons.axiom:axiom-api:1.2.10 - http://ws.apache.org/axiom/axiom-api/)
+        * Axiom Impl (org.apache.ws.commons.axiom:axiom-impl:1.2.10 - http://ws.apache.org/axiom/axiom-impl/)
+        * XmlBeans (org.apache.xmlbeans:xmlbeans:2.3.0 - http://xmlbeans.apache.org)
+        * XmlBeans (org.apache.xmlbeans:xmlbeans:2.6.0 - http://xmlbeans.apache.org)
+        * zookeeper (org.apache.zookeeper:zookeeper:3.4.6 - no url defined)
+        * Evo Inflector (org.atteo:evo-inflector:1.0.1 - http://atteo.org/static/evo-inflector)
+        * TagSoup (org.ccil.cowan.tagsoup:tagsoup:1.2.1 - http://home.ccil.org/~cowan/XML/tagsoup/)
+        * Jackson (org.codehaus.jackson:jackson-core-asl:1.9.13 - http://jackson.codehaus.org)
+        * Jackson (org.codehaus.jackson:jackson-core-asl:1.9.2 - http://jackson.codehaus.org)
+        * JAX-RS provider for JSON content type (org.codehaus.jackson:jackson-jaxrs:1.9.2 - http://jackson.codehaus.org)
+        * Data Mapper for Jackson (org.codehaus.jackson:jackson-mapper-asl:1.9.13 - http://jackson.codehaus.org)
+        * Data Mapper for Jackson (org.codehaus.jackson:jackson-mapper-asl:1.9.2 - http://jackson.codehaus.org)
+        * Xml Compatibility extensions for Jackson (org.codehaus.jackson:jackson-xc:1.9.2 - http://jackson.codehaus.org)
+        * Jettison (org.codehaus.jettison:jettison:1.1 - no url defined)
+        * Woodstox (org.codehaus.woodstox:wstx-asl:3.2.0 - http://woodstox.codehaus.org)
+        * Woodstox (org.codehaus.woodstox:wstx-asl:3.2.7 - http://woodstox.codehaus.org)
+        * databene ContiPerf (org.databene:contiperf:2.2.0 - http://databene.org/contiperf)
+        * elasticsearch (org.elasticsearch:elasticsearch:1.4.0 - http://nexus.sonatype.org/oss-repository-hosting.html/elasticsearch)
+        * flyway-core (org.flywaydb:flyway-core:3.0 - http://flywaydb.org/flyway-core)
+        * Ogg and Vorbis for Java, Core (org.gagravarr:vorbis-java-core:0.1 - https://github.com/Gagravarr/VorbisJava)
+        * Apache Tika plugin for Ogg, Vorbis and FLAC (org.gagravarr:vorbis-java-tika:0.1 - https://github.com/Gagravarr/VorbisJava)
+        * Javassist (org.javassist:javassist:3.16.1-GA - http://www.javassist.org/)
+        * Jetty Server (org.mortbay.jetty:jetty:6.1.14 - http://jetty.mortbay.org/project/modules/jetty)
+        * Jetty Server (org.mortbay.jetty:jetty:6.1.26 - http://www.eclipse.org/jetty/jetty-parent/project/modules/jetty)
+        * Jetty Servlet Tester (org.mortbay.jetty:jetty-servlet-tester:6.1.14 - http://jetty.mortbay.org/project/jetty-servlet-tester)
+        * Jetty Utilities (org.mortbay.jetty:jetty-util:6.1.14 - http://jetty.mortbay.org/project/jetty-util)
+        * Jetty Utilities (org.mortbay.jetty:jetty-util:6.1.26 - http://www.eclipse.org/jetty/jetty-parent/project/jetty-util)
+        * Servlet Specification API (org.mortbay.jetty:servlet-api:2.5-20081211 - http://jetty.mortbay.org/servlet-api)
+        * Noggit (org.noggit:noggit:0.5 - http://noggit.org)
+        * parboiled-core (org.parboiled:parboiled-core:1.1.6 - http://parboiled.org)
+        * parboiled-java (org.parboiled:parboiled-java:1.1.6 - http://parboiled.org)
+        * Restlet Core - API and Engine (org.restlet.jee:org.restlet:2.1.1 - http://www.restlet.org/org.restlet)
+        * Restlet Extension - Servlet (org.restlet.jee:org.restlet.ext.servlet:2.1.1 - http://www.restlet.org/org.restlet.ext.servlet)
+        * rome-modules (org.rometools:rome-modules:1.0 - http://www.rometools.org)
+        * spring-aop (org.springframework:spring-aop:3.1.1.RELEASE - no url defined)
+        * Spring AOP (org.springframework:spring-aop:3.2.5.RELEASE - https://github.com/SpringSource/spring-framework)
+        * spring-asm (org.springframework:spring-asm:3.1.1.RELEASE - no url defined)
+        * spring-beans (org.springframework:spring-beans:3.1.1.RELEASE - no url defined)
+        * Spring Beans (org.springframework:spring-beans:3.2.5.RELEASE - https://github.com/SpringSource/spring-framework)
+        * spring-context (org.springframework:spring-context:3.1.1.RELEASE - no url defined)
+        * Spring Context (org.springframework:spring-context:3.2.5.RELEASE - https://github.com/SpringSource/spring-framework)
+        * spring-context-support (org.springframework:spring-context-support:3.1.1.RELEASE - no url defined)
+        * spring-core (org.springframework:spring-core:3.1.1.RELEASE - no url defined)
+        * Spring Core (org.springframework:spring-core:3.2.5.RELEASE - https://github.com/SpringSource/spring-framework)
+        * spring-expression (org.springframework:spring-expression:3.1.1.RELEASE - no url defined)
+        * Spring Expression Language (SpEL) (org.springframework:spring-expression:3.2.5.RELEASE - https://github.com/SpringSource/spring-framework)
+        * spring-jdbc (org.springframework:spring-jdbc:3.1.1.RELEASE - no url defined)
+        * Spring Framework: Mock (org.springframework:spring-mock:2.0.8 - http://www.springframework.org)
+        * Spring TestContext Framework (org.springframework:spring-test:3.2.5.RELEASE - https://github.com/SpringSource/spring-framework)
+        * spring-tx (org.springframework:spring-tx:3.1.1.RELEASE - no url defined)
+        * spring-web (org.springframework:spring-web:3.1.1.RELEASE - no url defined)
+        * Spring Web (org.springframework:spring-web:3.2.5.RELEASE - https://github.com/SpringSource/spring-framework)
+        * spring-webmvc (org.springframework:spring-webmvc:3.1.1.RELEASE - no url defined)
+        * Spring Web MVC (org.springframework:spring-webmvc:3.2.5.RELEASE - https://github.com/SpringSource/spring-framework)
+        * SWORD Java API, GUI and CLI (org.swordapp:sword-common:1.1 - http://nexus.sonatype.org/oss-repository-hosting.html/sword-common)
+        * SWORD v2 :: Common Server Library (org.swordapp:sword2-server:1.0 - http://www.swordapp.org/)
+        * xml-matchers (org.xmlmatchers:xml-matchers:0.10 - http://code.google.com/p/xml-matchers/)
+        * oro (oro:oro:2.0.8 - no url defined)
+        * JUnitParams (pl.pragmatists:JUnitParams:1.0.2 - http://junitparams.googlecode.com)
+        * Rome A9 OpenSearch (rome:opensearch:0.1 - http://wiki.java.net/bin/view/Javawsxml/OpenSearch)
+        * ROME, RSS and atOM utilitiEs for Java (rome:rome:1.0 - https://rome.dev.java.net/)
+        * oai4j (se.kb:oai4j:0.6b1 - http://oai4j-client.sourceforge.net/)
+        * StAX API (stax:stax-api:1.0.1 - http://stax.codehaus.org/)
+        * standard (taglibs:standard:1.1.2 - no url defined)
+        * xalan (xalan:xalan:2.7.0 - no url defined)
+        * Xerces2 Java Parser (xerces:xercesImpl:2.8.1 - http://xerces.apache.org/xerces2-j/)
+        * xmlParserAPIs (xerces:xmlParserAPIs:2.6.2 - no url defined)
+        * XML Commons External Components XML APIs (xml-apis:xml-apis:1.0.b2 - http://xml.apache.org/commons/#external)
+        * xml-apis (xml-apis:xml-apis:1.3.02 - http://xml.apache.org/commons/#external)
+        * xmlParserAPIs (xml-apis:xmlParserAPIs:2.0.2 - no url defined)
+        * XML Commons Resolver Component (xml-resolver:xml-resolver:1.2 - http://xml.apache.org/commons/components/resolver/)
 
-BSD License (http://www.opensource.org/licenses/BSD-3-Clause)
-  * asm (asm:*) - http://asm.ow2.org/
-  * Biblio Transformation Engine (gr.ekt:biblio-transformation-engine) - http://code.google.com/p/biblio-transformation-engine/
-  * DNSJava (org.dspace.dnsjava:dnsjava)- http://www.xbill.org/dnsjava/dnsjava-current/README
-  * dom4j (dom4j:*, maven:dom4j) - http://dom4j.sourceforge.net/dom4j-1.6.1/license.html
-  * Foresite Toolkit (com.googlecode.foresite-toolkit:*) - http://code.google.com/p/foresite-toolkit/
-  * jargon (org.dspace:jargon) - http://www.sdsc.edu/srb/index.php/Jargon
-  * Java BibTeX Parser (org.jbibtex:*) - https://code.google.com/p/java-bibtex/
-  * Jaxen (jaxen:*) -  http://jaxen.codehaus.org/license.html
-  * JLine (jline:*) - http://jline.sourceforge.net/
-  * JUnitPerf (junitperf:*) - http://www.clarkware.com/software/JUnitPerf.html#license
-  * MSV (msv:*) - http://msv.java.net/
-  * StAX (Streaming API for XML) (stax:*) - http://stax.codehaus.org/
-  * XMLUnit (xmlunit:*) - http://xmlunit.sourceforge.net/
-  * YUI (com.yahoo.platform.yui:*) - http://yuilibrary.com/license/
-  
-Common Development and Distribution License (CDDL) v1.0 (http://www.opensource.org/licenses/CDDL-1.0)
-  * JavaBeans Activation Framework (javax.activation:*) - http://www.opensource.org/licenses/CDDL-1.0  
-  * Java Mail (javax.mail:*) - http://www.opensource.org/licenses/CDDL-1.0
-  * JAX-RPC (javax.xml:jaxrpc-api) - http://java.net/projects/jax-rpc/
+    BSD License:
 
-Common Development and Distribution License (CDDL) v1.1 (http://glassfish.java.net/public/CDDL+GPL_1_1.html)
-  * JAXB (com.sun.xml.bind:*) - http://jaxb.java.net/
-  * Jersey (com.sun.jersey.*) - https://jersey.java.net/
+        * ASM Core (asm:asm:3.1 - http://asm.objectweb.org/asm/)
+        * XMP Library for Java (com.adobe.xmp:xmpcore:5.1.2 - http://www.adobe.com/devnet/xmp.html)
+        * coverity-escapers (com.coverity.security:coverity-escapers:1.1.1 - http://coverity.com/security)
+        * JSONLD Java :: Core (com.github.jsonld-java:jsonld-java:0.5.0 - http://github.com/jsonld-java/jsonld-java/jsonld-java/)
+        * Protocol Buffer Java API (com.google.protobuf:protobuf-java:2.5.0 - http://code.google.com/p/protobuf)
+        * Jena IRI (com.hp.hpl.jena:iri:0.8 - http://jena.sf.net/iri)
+        * Jena (com.hp.hpl.jena:jena:2.6.4 - http://www.openjena.org/)
+        * yui compressor (com.yahoo.platform.yui:yuicompressor:2.3.6 - http://developer.yahoo.com/yui/compressor/)
+        * dnsjava (dnsjava:dnsjava:2.1.1 - http://www.dnsjava.org)
+        * dom4j (dom4j:dom4j:1.6.1 - http://dom4j.org)
+        * Biblio Transformation Engine :: Core (gr.ekt.bte:bte-core:0.9.3.5 - http://github.com/EKT/Biblio-Transformation-Engine/bte-core)
+        * Biblio Transformation Engine :: Input/Output (gr.ekt.bte:bte-io:0.9.3.5 - http://github.com/EKT/Biblio-Transformation-Engine/bte-io)
+        * jaxen (jaxen:jaxen:1.1 - http://jaxen.codehaus.org/)
+        * ANTLR 3 Runtime (org.antlr:antlr-runtime:3.5 - http://www.antlr.org)
+        * Morfologik FSA (org.carrot2:morfologik-fsa:1.7.1 - http://morfologik.blogspot.com/morfologik-fsa/)
+        * Morfologik Stemming Dictionary for Polish (org.carrot2:morfologik-polish:1.7.1 - http://morfologik.blogspot.com/morfologik-polish/)
+        * Morfologik Stemming APIs (org.carrot2:morfologik-stemming:1.7.1 - http://morfologik.blogspot.com/morfologik-stemming/)
+        * databene ContiPerf (org.databene:contiperf:2.2.0 - http://databene.org/contiperf)
+        * DSpace Kernel :: API and Implementation (org.dspace:dspace-api:5.0-rc4-SNAPSHOT - https://github.com/dspace/DSpace/dspace-api)
+        * DSpace JSP-UI (org.dspace:dspace-jspui:5.0-rc4-SNAPSHOT - https://github.com/dspace/DSpace/dspace-jspui)
+        * DSpace OAI-PMH (org.dspace:dspace-oai:5.0-rc4-SNAPSHOT - https://github.com/dspace/DSpace/dspace-oai)
+        * DSpace RDF (org.dspace:dspace-rdf:5.0-rc4-SNAPSHOT - https://github.com/dspace/DSpace/dspace-rdf)
+        * DSpace REST :: API and Implementation (org.dspace:dspace-rest:5.0-rc4-SNAPSHOT - http://demo.dspace.org)
+        * DSpace Services Framework :: API and Implementation (org.dspace:dspace-services:5.0-rc4-SNAPSHOT - https://github.com/dspace/DSpace/dspace-services)
+        * Apache Solr Webapp (org.dspace:dspace-solr:5.0-rc4-SNAPSHOT - https://github.com/dspace/DSpace/dspace-solr)
+        * DSpace SWORD (org.dspace:dspace-sword:5.0-rc4-SNAPSHOT - https://github.com/dspace/DSpace/dspace-sword)
+        * DSpace SWORD v2 (org.dspace:dspace-swordv2:5.0-rc4-SNAPSHOT - https://github.com/dspace/DSpace/dspace-swordv2)
+        * DSpace XML-UI (Manakin) (org.dspace:dspace-xmlui:5.0-rc4-SNAPSHOT - https://github.com/dspace/DSpace/dspace-xmlui)
+        * handle (org.dspace:handle:6.2 - no url defined)
+        * jargon (org.dspace:jargon:1.4.25 - no url defined)
+        * mets (org.dspace:mets:1.5.2 - no url defined)
+        * oclc-harvester2 (org.dspace:oclc-harvester2:0.1.12 - no url defined)
+        * Repackaged Cocoon Servlet Service Implementation (org.dspace.dependencies.cocoon:dspace-cocoon-servlet-service-impl:1.0.3 - http://projects.dspace.org/dspace-pom/dspace-cocoon-servlet-service-impl)
+        * DSpace Kernel :: Additions and Local Customizations (org.dspace.modules:additions:5.0-rc4-SNAPSHOT - https://github.com/dspace/DSpace/modules/additions)
+        * Hamcrest All (org.hamcrest:hamcrest-all:1.3 - https://github.com/hamcrest/JavaHamcrest/hamcrest-all)
+        * Hamcrest Core (org.hamcrest:hamcrest-core:1.3 - https://github.com/hamcrest/JavaHamcrest/hamcrest-core)
+        * JBibTeX (org.jbibtex:jbibtex:1.0.10 - http://www.jbibtex.org)
+        * ASM Core (org.ow2.asm:asm:4.1 - http://asm.objectweb.org/asm/)
+        * ASM Core (org.ow2.asm:asm:4.2 - http://asm.objectweb.org/asm/)
+        * ASM Analysis (org.ow2.asm:asm-analysis:4.1 - http://asm.objectweb.org/asm-analysis/)
+        * ASM Commons (org.ow2.asm:asm-commons:4.1 - http://asm.objectweb.org/asm-commons/)
+        * ASM Tree (org.ow2.asm:asm-tree:4.1 - http://asm.objectweb.org/asm-tree/)
+        * ASM Util (org.ow2.asm:asm-util:4.1 - http://asm.objectweb.org/asm-util/)
+        * PostgreSQL JDBC Driver (postgresql:postgresql:9.1-901-1.jdbc4 - http://jdbc.postgresql.org)
+        * XMLUnit for Java (xmlunit:xmlunit:1.1 - http://xmlunit.sourceforge.net/)
+        * XMLUnit for Java (xmlunit:xmlunit:1.3 - http://xmlunit.sourceforge.net/)
 
-Common Public License v1.0 (http://www.opensource.org/licenses/cpl1.0)
-  * JUnit (junit:*) - http://junit.org/license   
-  * WSDL4J (wsdl4j:*) - http://sourceforge.net/projects/wsdl4j/
+    Common Development and Distribution License (CDDL):
 
-Lesser GPL (http://www.opensource.org/licenses/LGPL-2.1)
-  * JExcelAPI (net.sourceforge.jexcelapi:*) - http://sourceforge.net/projects/jexcelapi/
-  * MaxMind GeoIP (org.dspace.dependencies:dspace-geoip) - http://geoip.cvs.sourceforge.net/viewvc/geoip/java/LICENSE
-  * METS Java Toolkit (org.dspace.mets:*) - http://hul.harvard.edu/mets/
-  * Text-mining (org.dspace.dependencies:dspace-tm-extractors) - http://code.google.com/p/text-mining/
-  * XOM (xom:*) - http://www.xom.nu/
+        * jersey-core (com.sun.jersey:jersey-core:1.17.1 - https://jersey.java.net/jersey-core/)
+        * jersey-json (com.sun.jersey:jersey-json:1.17.1 - https://jersey.java.net/jersey-json/)
+        * jersey-server (com.sun.jersey:jersey-server:1.17.1 - https://jersey.java.net/jersey-server/)
+        * jersey-servlet (com.sun.jersey:jersey-servlet:1.17.1 - https://jersey.java.net/jersey-servlet/)
+        * jersey-spring (com.sun.jersey.contribs:jersey-spring:1.8 - http://maven.apache.org)
+        * JAXB RI (com.sun.xml.bind:jaxb-impl:2.2.3-1 - http://jaxb.java.net/)
+        * JAXB Reference Implementation (com.sun.xml.bind:jaxb-impl:2.2.5 - http://jaxb.java.net/)
+        * JHighlight (com.uwyn:jhighlight:1.0 - https://jhighlight.dev.java.net/)
+        * JavaBeans Activation Framework (JAF) (javax.activation:activation:1.1 - http://java.sun.com/products/javabeans/jaf/index.jsp)
+        * JavaMail API (javax.mail:mail:1.4 - https://glassfish.dev.java.net/javaee5/mail/)
+        * Java Servlet API (javax.servlet:javax.servlet-api:3.1.0 - http://servlet-spec.java.net)
+        * jsp-api (javax.servlet:jsp-api:2.0 - no url defined)
+        * jstl (javax.servlet:jstl:1.1.2 - no url defined)
+        * servlet-api (javax.servlet:servlet-api:2.5 - no url defined)
+        * JAXB API bundle for GlassFish V3 (javax.xml.bind:jaxb-api:2.2.2 - https://jaxb.dev.java.net/)
+        * Streaming API for XML (javax.xml.stream:stax-api:1.0-2 - no url defined)
+        * Servlet Specification 2.5 API (org.mortbay.jetty:servlet-api-2.5:6.1.14 - http://jetty.mortbay.org/project/modules/servlet-api-2.5)
+        * Restlet Core - API and Engine (org.restlet.jee:org.restlet:2.1.1 - http://www.restlet.org/org.restlet)
+        * Restlet Extension - Servlet (org.restlet.jee:org.restlet.ext.servlet:2.1.1 - http://www.restlet.org/org.restlet.ext.servlet)
 
-MIT / X11 License (or adaptations) (http://www.opensource.org/licenses/MIT)
-  * Bouncy Castle (org.bouncycastle:*) - http://www.bouncycastle.org/licence.html
-  * jmockit (org.dspace.dependencies.jmockit:dspace-jmockit) - http://code.google.com/p/jmockit/
-  * SLF4J (org.slf4j:*) - http://www.slf4j.org/license.html
-  
-Mozilla Public License (http://www.opensource.org/licenses/MPL-2.0)
-  * H2 database (com.h2database:*) - http://www.h2database.com/html/license.html
+    Eclipse Public License:
 
-New BSD License (http://opensource.org/licenses/bsd-license.php)
-  * Biblio-Transformation Engine (gr.ekt.bte:*) - http://github.com/EKT/Biblio-Transformation-Engine
-  
-Other Open Source Licenses:
-  * AOP Alliance (aopalliance:*) - Public Domain: http://aopalliance.sourceforge.net/
-  * coverity-escapers (com.coverity.security:*) - Modified BSD
-  * Handle API (org.dspace:handle) - Handle Public License Agreement: http://www.handle.net/HSj/hdlnet-2-LICENSE.pdf
-  * ICU4J (com.ibm.icu:icu4j) - ICU License : http://source.icu-project.org/repos/icu/icu/trunk/license.html
-  * JDOM  (jdom:*) - JDOM License : https://github.com/hunterhacker/jdom/blob/master/LICENSE.txt
-  * OCLC Harvester2 (org.dspace:oclc-harvester2) - OCLC Research Public License: http://www.oclc.org/research/activities/software/license/v2final.html
-  * PostgreSQL (postgresql:*) - PostgreSQL License (BSD-based): http://www.postgresql.org/about/licence/
-  * Pull-parser / XPP3 (pull-parser:*, xpp3:*) - Indiana University Extreme! Lab Software License (BSD-based): http://www.extreme.indiana.edu/xgws/xsoap/xpp/download/PullParser2/LICENSE.txt
-  
-----
-NOTE #1: Some individual web application files in DSpace (e.g. Javascript 
-libraries, CSS Frameworks) may have their own open source license. In that 
-scenario, we place a copy of the full text of the license alongside the 
-licensed files. You can locate these additional licenses in our codebase 
-by searching for files with a ".LICENSE" file extension.
+        * JUnit (junit:junit:4.11 - http://junit.org)
+        * AspectJ runtime (org.aspectj:aspectjrt:1.6.11 - http://www.aspectj.org)
+        * databene ContiPerf (org.databene:contiperf:2.2.0 - http://databene.org/contiperf)
+        * Jetty Server (org.mortbay.jetty:jetty:6.1.26 - http://www.eclipse.org/jetty/jetty-parent/project/modules/jetty)
+        * Jetty Utilities (org.mortbay.jetty:jetty-util:6.1.26 - http://www.eclipse.org/jetty/jetty-parent/project/jetty-util)
+        * Restlet Core - API and Engine (org.restlet.jee:org.restlet:2.1.1 - http://www.restlet.org/org.restlet)
+        * Restlet Extension - Servlet (org.restlet.jee:org.restlet.ext.servlet:2.1.1 - http://www.restlet.org/org.restlet.ext.servlet)
 
-For example, on Linux you can use the 'find' command from the source directory:
+    GNU General Public Library:
 
-find . -type f -name "*.LICENSE"
-----
+        * Streaming API for XML (javax.xml.stream:stax-api:1.0-2 - no url defined)
 
-----
-NOTE #2: Although we try to keep this libraries list current, the latest 
-information about DSpace third party libraries can be found by running the 
-following Maven command(s):
+    GNU Lesser General Public License (LGPL):
 
-mvn project-info-reports:dependencies
+        * Jackson-annotations (com.fasterxml.jackson.core:jackson-annotations:2.3.0 - http://wiki.fasterxml.com/JacksonHome)
+        * Jackson-core (com.fasterxml.jackson.core:jackson-core:2.3.3 - http://wiki.fasterxml.com/JacksonHome)
+        * jackson-databind (com.fasterxml.jackson.core:jackson-databind:2.3.3 - http://wiki.fasterxml.com/JacksonHome)
+        * FindBugs-Annotations (com.google.code.findbugs:annotations:3.0.0 - http://findbugs.sourceforge.net/)
+        * MaxMind GeoIP API (com.maxmind.geoip:geoip-api:1.2.11 - https://github.com/maxmind/geoip-api-java)
+        * JHighlight (com.uwyn:jhighlight:1.0 - https://jhighlight.dev.java.net/)
+        * JAX-RS provider for JSON content type (org.codehaus.jackson:jackson-jaxrs:1.9.2 - http://jackson.codehaus.org)
+        * Xml Compatibility extensions for Jackson (org.codehaus.jackson:jackson-xc:1.9.2 - http://jackson.codehaus.org)
+        * databene ContiPerf (org.databene:contiperf:2.2.0 - http://databene.org/contiperf)
+        * DSpace TM-Extractors Dependency (org.dspace.dependencies:dspace-tm-extractors:1.0.1 - http://projects.dspace.org/dspace-pom/dspace-tm-extractors)
+        * im4java (org.im4java:im4java:1.4.0 - http://sourceforge.net/projects/im4java/)
+        * Javassist (org.javassist:javassist:3.16.1-GA - http://www.javassist.org/)
+        * org.jdesktop - Swing Worker (org.jdesktop:swing-worker:1.1 - no url defined)
+        * Restlet Core - API and Engine (org.restlet.jee:org.restlet:2.1.1 - http://www.restlet.org/org.restlet)
+        * Restlet Extension - Servlet (org.restlet.jee:org.restlet.ext.servlet:2.1.1 - http://www.restlet.org/org.restlet.ext.servlet)
+        * xom (xom:xom:1.1 - http://www.xom.nu)
 
-This generates a "[project]/target/site/dependencies.html" report under every 
-DSpace project directory. This report lists all dependencies and their license
-(if it can be determined by Maven).
+    ICU License:
 
-Additionally, you may wish to run:
+        * ICU4J (com.ibm.icu:icu4j:51.1 - http://icu-project.org/)
 
-mvn project-info-reports:dependency-convergence
+    JDOM License:
 
-This generates a summary report at 
-"[dspace]/target/site/dependency-convergence.html" which lists all dependencies
-of all DSpace projects (though it does not list license information)
+        * jdom (jdom:jdom:1.0 - no url defined)
 
-For more information see the maven-project-info-reports-plugin:
-http://maven.apache.org/plugins/maven-project-info-reports-plugin/
-----
+    MIT License:
+
+        * Bouncy Castle CMS and S/MIME API (org.bouncycastle:bcmail-jdk15:1.44 - http://www.bouncycastle.org/java.html)
+        * Bouncy Castle Provider (org.bouncycastle:bcprov-jdk15:1.44 - http://www.bouncycastle.org/java.html)
+        * Main (org.jmockit:jmockit:1.10 - http://www.jmockit.org)
+        * OpenCloud (org.mcavallo:opencloud:0.3 - http://opencloud.mcavallo.org/)
+        * Mockito (org.mockito:mockito-all:1.9.5 - http://www.mockito.org)
+        * Mockito (org.mockito:mockito-core:1.9.5 - http://www.mockito.org)
+        * Objenesis (org.objenesis:objenesis:1.0 - http://objenesis.googlecode.com/svn/docs/index.html)
+        * JCL 1.1.1 implemented over SLF4J (org.slf4j:jcl-over-slf4j:1.6.1 - http://www.slf4j.org)
+        * JUL to SLF4J bridge (org.slf4j:jul-to-slf4j:1.6.1 - http://www.slf4j.org)
+        * SLF4J API Module (org.slf4j:slf4j-api:1.6.1 - http://www.slf4j.org)
+        * SLF4J JDK14 Binding (org.slf4j:slf4j-jdk14:1.6.1 - http://www.slf4j.org)
+        * SLF4J LOG4J-12 Binding (org.slf4j:slf4j-log4j12:1.6.1 - http://www.slf4j.org)
+
+    Mozilla Public License:
+
+        * juniversalchardet (com.googlecode.juniversalchardet:juniversalchardet:1.0.3 - http://juniversalchardet.googlecode.com/)
+        * H2 Database Engine (com.h2database:h2:1.4.180 - http://www.h2database.com)
+        * Javassist (org.javassist:javassist:3.16.1-GA - http://www.javassist.org/)
+        * Rhino (rhino:js:1.6R7 - http://www.mozilla.org/rhino/)
+
+    Public Domain:
+
+        * AOP alliance (aopalliance:aopalliance:1.0 - http://aopalliance.sourceforge.net)
+        * Dough Lea's util.concurrent package (concurrent:concurrent:1.3.4 - no url defined)
+        * Reflections (org.reflections:reflections:0.9.9-RC1 - http://code.google.com/p/reflections/reflections/)
+        * XZ for Java (org.tukaani:xz:1.4 - http://tukaani.org/xz/java.html)
+
+    Unknown license:
+
+        * DSpace I18N :: Language Packs (org.dspace:dspace-api-lang:5.0.2 - http://nexus.sonatype.org/oss-repository-hosting.html/dspace-api-lang)
+        * DSpace XML-UI (Manakin) I18N :: Language Packs (org.dspace:dspace-xmlui-lang:5.0.2 - http://nexus.sonatype.org/oss-repository-hosting.html/dspace-xmlui-lang)

--- a/pom.xml
+++ b/pom.xml
@@ -362,6 +362,87 @@
             </build>
         </profile>
 
+        <!-- 
+             Generate a list of all THIRD PARTY open source licenses for all DSpace dependencies.
+             This list is automatically written to the [src]/LICENSES_THIRD_PARTY file.
+             Third party tools whose licenses are unknown by Maven are maintained in
+             [src]/src/main/license/LICENSES_THIRD_PARTY.properties.
+             To update "LICENSES_THIRD_PARTY", just run:
+                 mvn clean verify "-Dthird.party.licenses=true"  
+        -->
+        <profile>
+            <id>third-party-licenses</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <!-- This profile should ONLY be active when user specifies
+                     -Dthird.party.licenses=true on command-line. -->
+                <property>
+                    <name>third.party.licenses</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>license-maven-plugin</artifactId>
+                        <version>1.8</version>
+                        <!-- This plugin only needs to be run on the Parent POM
+                             as it aggregates results from all child POMs. -->
+                        <inherited>false</inherited>
+                        <executions>
+                            <execution>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>aggregate-add-third-party</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${root.basedir}</outputDirectory>
+                                    <thirdPartyFilename>LICENSES_THIRD_PARTY</thirdPartyFilename>
+                                    <excludedGroups>org\.dspace</excludedGroups>
+                                    <!-- Use the template which groups all dependencies by their License type (easier to read!). -->
+                                    <!-- SEE: https://fisheye.codehaus.org/browse/mojo/trunk/mojo/license-maven-plugin/src/main/resources/org/codehaus/mojo/license -->
+                                    <fileTemplate>/org/codehaus/mojo/license/third-party-file-groupByLicense.ftl</fileTemplate>
+                                    <!-- License names that should all be merged into the *first* listed name -->
+                                    <licenseMerges>
+                                        <licenseMerge>Apache Software License, Version 2.0|The Apache Software License, Version 2.0|Apache License Version 2.0|Apache License, Version 2.0|Apache Public License 2.0|Apache License 2.0|Apache Software License - Version 2.0|Apache 2.0 License|Apache 2.0 license|Apache License V2.0|Apache 2|Apache License|Apache|ASF 2.0</licenseMerge>
+                                        <!-- Ant-contrib is an Apache License -->
+                                        <licenseMerge>Apache Software License, Version 2.0|http://ant-contrib.sourceforge.net/tasks/LICENSE.txt</licenseMerge>
+                                        <licenseMerge>BSD License|The BSD License|BSD licence|BSD license|BSD|BSD-style license|New BSD License|New BSD license|Revised BSD License</licenseMerge>
+                                        <!-- DuraSpace uses a BSD License for DSpace -->
+                                        <licenseMerge>BSD License|DuraSpace BSD License|DuraSpace Sourcecode License</licenseMerge>
+                                        <!-- Coverity uses modified BSD: https://github.com/coverity/coverity-security-library -->
+                                        <licenseMerge>BSD License|BSD style modified by Coverity</licenseMerge>
+                                        <licenseMerge>Common Development and Distribution License (CDDL)|Common Development and Distribution License (CDDL) v1.0|COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0|CDDL, v1.0|CDDL 1.0 license|CDDL 1.0|CDDL 1.1</licenseMerge>
+                                        <!-- Jersey / Java Servlet API claims this license, but is actually CDDL 1.0: http://servlet-spec.java.net -->
+                                        <licenseMerge>Common Development and Distribution License (CDDL)|CDDL + GPLv2 with classpath exception</licenseMerge>
+                                        <!-- Jersey claims this license, but it is dual licensed with CDDL 1.0 being one: https://jersey.java.net/license.html -->
+                                        <licenseMerge>Common Development and Distribution License (CDDL)|GPL2 w/ CPE</licenseMerge>
+                                        <licenseMerge>Eclipse Public License|Eclipse Public License - Version 1.0|Eclipse Public License - v 1.0|EPL 1.0 license</licenseMerge>
+                                        <!-- JUnit claims this license but is actually Eclipse Public License: http://junit.org/license.html -->
+                                        <licenseMerge>Eclipse Public License|Common Public License Version 1.0</licenseMerge>
+                                        <licenseMerge>GNU Lesser General Public License (LGPL)|GNU Lesser General Public License (LGPL), Version 2.1|GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1|GNU Lesser General Public License|GNU Lesser Public License|GNU Lesser General Public License, Version 2.1|Lesser General Public License (LGPL) v 2.1|LGPL 2.1|LGPL 2.1 license|LGPL 3.0 license|LGPL, v2.1 or later|LGPL</licenseMerge>
+                                        <licenseMerge>MIT License|The MIT License|MIT LICENSE</licenseMerge>
+                                        <!-- BouncyCastle uses a modified MIT License: http://www.bouncycastle.org/license.html -->
+                                        <licenseMerge>MIT License|Bouncy Castle Licence</licenseMerge>
+                                        <licenseMerge>Mozilla Public License|Mozilla Public License version 1.1|Mozilla Public License 1.1 (MPL 1.1)|MPL 1.1</licenseMerge>
+                                        <!-- H2 Database claims this license, but for our purposes it's MPL: http://www.h2database.com -->
+                                        <licenseMerge>Mozilla Public License|MPL 2.0, and EPL 1.0</licenseMerge>
+                                        <!-- "concurrent.concurrent" claims this license, but is actually Public Domain: http://mvnrepository.com/artifact/concurrent/concurrent/ -->
+                                        <licenseMerge>Public Domain|Public domain, Sun Microsoystems</licenseMerge>
+                                        <!-- WTFPL is essentially Public Domain: http://www.wtfpl.net/ ;) -->
+                                        <licenseMerge>Public Domain|WTFPL</licenseMerge>
+                                    </licenseMerges>
+                                    <!-- For Licenses which are "Unknown" by Maven, load them from a properties file -->
+                                    <useMissingFile>true</useMissingFile>
+                                    <missingFile>src/main/license/LICENSES_THIRD_PARTY.properties</missingFile>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
         <!-- Determine path to Java Tools JAR. This JAR contains the 'native2ascii' tool (required above by maven-antrun-plugin)-->
         <!-- In most platforms Unix/Windows it's named tools.jar. But, on Mac it's classes.jar (see next profile) -->
         <profile>

--- a/src/main/license/LICENSES_THIRD_PARTY.properties
+++ b/src/main/license/LICENSES_THIRD_PARTY.properties
@@ -1,0 +1,86 @@
+# LICENSES_THIRD_PARTY.properties
+#
+# This file is used by the 'license-maven-plugin' to generate the 
+# LICENSES_THIRD_PARTY file in the root source directory. 
+# See both the "third-party-licenses" profile in the PARENT POM and
+# http://mojo.codehaus.org/license-maven-plugin/SNAPSHOT/examples/example-thirdparty.html
+#
+# -----------------------------------------------------------------------------
+# The following Maven dependencies do NOT report their source code license
+# in their Maven POM.
+#
+# NOTES TO MAINTAINERS:
+# 1) PLEASE CHECK THE "[src]/LICENSES_THIRD_PARTY" FILE FOR SPECIFIC LICENSE NAMES!
+# 2) Also please add a link/URL to where you looked up the license
+
+# http://asm.ow2.org/
+asm--asm--3.1=BSD License
+
+# https://projects.apache.org/projects/commons_jexl.html
+commons-jexl--commons-jexl--1.0=Apache Software License, Version 2.0
+
+concurrent--concurrent--1.3.4=Public Domain
+
+# http://dom4j.sourceforge.net/dom4j-1.6.1/license.html
+dom4j--dom4j--1.6.1=BSD License
+
+# http://jakarta.apache.org/regexp/
+jakarta-regexp--jakarta-regexp--1.4=Apache Software License, Version 2.0
+
+# https://java.net/projects/servlet-spec/
+javax.servlet--jsp-api--2.0=Common Development and Distribution License (CDDL)
+javax.servlet--jstl--1.1.2=Common Development and Distribution License (CDDL)
+javax.servlet--servlet-api--2.5=Common Development and Distribution License (CDDL)
+
+# http://jaxen.codehaus.org/license.html
+jaxen--jaxen--1.1=BSD License
+
+# https://github.com/jankotek/JDBM3
+jdbm--jdbm--1.0=Apache Software License, Version 2.0
+
+# https://github.com/hunterhacker/jdom/blob/master/LICENSE.txt
+jdom--jdom--1.0=JDOM License
+
+# http://ant.apache.org/
+org.apache.ant--ant--1.7.0=Apache Software License, Version 2.0
+org.apache.ant--ant-launcher--1.7.0=Apache Software License, Version 2.0
+
+# http://zookeeper.apache.org/
+org.apache.zookeeper--zookeeper--3.4.6=Apache Software License, Version 2.0
+
+# http://jettison.codehaus.org/
+org.codehaus.jettison--jettison--1.1=Apache Software License, Version 2.0
+
+# DSpace Licenses are all BSD
+org.dspace--handle--6.2=BSD License
+org.dspace--jargon--1.4.25=BSD License
+org.dspace--mets--1.5.2=BSD License
+org.dspace--oclc-harvester2--0.1.12=BSD License
+
+# Swingworker: https://java.net/projects/swingworker
+org.jdesktop--swing-worker--1.1=GNU Lesser General Public License (LGPL)
+
+# http://swordapp.org/
+org.swordapp--sword-common--1.1=Apache Software License, Version 2.0
+
+# Apache Jakarta ORO: http://svn.apache.org/repos/asf/jakarta/oro/trunk/LICENSE
+oro--oro--2.0.8=Apache Software License, Version 2.0
+
+# http://rometools.org/
+rome--rome--1.0=Apache Software License, Version 2.0
+
+# https://tomcat.apache.org/taglibs/license.html
+taglibs--standard--1.1.2=Apache Software License, Version 2.0
+
+# Apache XML (xalan): http://xml.apache.org/xalan-j/#license
+xalan--xalan--2.7.0=Apache Software License, Version 2.0
+
+# Apache Xerces: http://xerces.apache.org/
+xerces--xmlParserAPIs--2.6.2=Apache Software License, Version 2.0
+
+# Apache XML Commons: http://xerces.apache.org/xml-commons/licenses.html
+xml-apis--xml-apis--1.3.02=Apache Software License, Version 2.0
+xml-apis--xmlParserAPIs--2.0.2=Apache Software License, Version 2.0
+
+# http://www.xom.nu/
+xom--xom--1.1=GNU Lesser General Public License (LGPL)


### PR DESCRIPTION
This PR adds a way to more easily automate the creation/update of the [src]/LICENSES_THIRD_PARTY file in the DSpace Sourcecode.
- Uses license-maven-plugin settings here: http://mojo.codehaus.org/license-maven-plugin/aggregate-add-third-party-mojo.html
- Adds a new POM profile. To execute, run `mvn clean verify -Dthird.party.licenses=true`.  This will overwrite the existing LICENSES_THIRD_PARTY with the latest info.
- Adds a new `src/main/license/LICENSES_THIRD_PARTY.properties` file where all licenses are manages which are unknown to Maven (this is because some folks fail to put their license info in their Maven POM)

This PR also includes an updated LICENSES_THIRD_PARTY file, which I generated by running  `mvn clean verify -Dthird.party.licenses=true` on latest master.
