### PR TITLE
resumptionToken link for other verbs; oai stylesheet

### DIFF
--- a/dspace-oai/src/main/webapp/static/style.xsl
+++ b/dspace-oai/src/main/webapp/static/style.xsl
@@ -500,7 +500,7 @@
             <div class="text-center">
                 <a class="btn btn-primary">
                 <xsl:attribute name="href">
-                    <xsl:value-of select="concat(/oai:OAI-PMH/oai:request/text(), '?verb=ListSets&amp;resumptionToken=', text())"></xsl:value-of>
+                    <xsl:value-of select="concat(/oai:OAI-PMH/oai:request/text(), '?verb=',/oai:OAI-PMH/oai:request/@verb,'&amp;resumptionToken=', text())"></xsl:value-of>
                 </xsl:attribute>
                     Show More
                 </a>


### PR DESCRIPTION
The "Show More" link in oai stylesheet has its verb fixed to "ListSets". When you are listing records, the link should have the verb set to "ListRecords" and similarly when listing identifiers
