### PR TITLE
Fix for DS-2419 JSP UI ignores authorization.admin.usage. 

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/DisplayStatisticsServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/DisplayStatisticsServlet.java
@@ -55,7 +55,7 @@ public class DisplayStatisticsServlet extends DSpaceServlet
     {
 
 	// is the statistics data publically viewable?
-	boolean privatereport = ConfigurationManager.getBooleanProperty("usage-statistics", "authorization.admin");
+	boolean privatereport = ConfigurationManager.getBooleanProperty("usage-statistics", "authorization.admin.usage");
 
         // is the user a member of the Administrator (1) group?
         boolean admin = Group.isMember(context, 1);


### PR DESCRIPTION
Just an incomplete name for the configuration parameter which determines the accessibility of usage statistics.

https://jira.duraspace.org/browse/DS-2419
