### PR TITLE
DS-2424 workaround for bug in xoai library. changed ref to red for Filter in Contexts

### DIFF
--- a/dspace/config/crosswalks/oai/xoai.xml
+++ b/dspace/config/crosswalks/oai/xoai.xml
@@ -16,7 +16,7 @@
     <Contexts>
         <Context baseurl="request" name="Default Context">
             <!-- Restrict access to hidden items by default -->
-            <Filter ref="defaultFilter" />
+            <Filter red="defaultFilter" />
 
             <Format ref="oaidc"/>
             <Format ref="mets"/>
@@ -47,7 +47,7 @@
             <!-- Date format, field prefixes, etc are ensured by the transformer -->
             <Transformer ref="driverTransformer"/>
             <!-- The driver filter -->
-            <Filter ref="driverFilter"/>
+            <Filter red="driverFilter"/>
             <!-- Just an alias, in fact it returns all items within the driver context -->
             <Set ref="driverSet"/>
             <!-- Metadata Formats -->
@@ -72,7 +72,7 @@
             <!-- Date format, field prefixes, etc are ensured by the transformer -->
             <Transformer ref="openaireTransformer"/>
             <!-- OpenAIRE filter -->
-            <Filter ref="openAireFilter"/>
+            <Filter red="openAireFilter"/>
             <!-- Just an alias, in fact it returns all items within the driver context -->
             <Set ref="openaireSet"/>
             <!-- Metadata Formats -->


### PR DESCRIPTION
This is a workaround for the bug in xoai library which prevents filters in contexts from beeing loaded. 

If there is a filter defined in a context in xoai.xml like in line 75: 
<Filter ref="openAireFilter"/> 
The Filter is not used because of a typo in the xoai library 
https://github.com/lyncode/xoai/blob/xoai-3.2.9/src/main/java/com/lyncode/xoai/dataprovider/xml/xoaiconfig/parse/ContextConfigurationParser.java#L25 

See the issue in xoai: 
https://github.com/lyncode/xoai/issues/32

Not sure if it should be used but for anyone having problems with this error this might fix it until XOAI is updated

https://jira.duraspace.org/browse/DS-2424
