### PR TITLE
[DS-2423] Added possibility to create additional Filter for DSpace OAI-P...

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceAtLeastOneMetadataFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceAtLeastOneMetadataFilter.java
@@ -8,12 +8,10 @@
 
 package org.dspace.xoai.filter;
 
-import com.google.common.base.Function;
-import com.lyncode.builder.ListBuilder;
-import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.ParameterList;
-import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.ParameterMap;
-import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.ParameterValue;
-import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.SimpleType;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
@@ -28,9 +26,11 @@ import org.dspace.xoai.filter.results.SolrFilterResult;
 import org.dspace.xoai.services.api.database.FieldResolver;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
+import com.google.common.base.Function;
+import com.lyncode.builder.ListBuilder;
+import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.ParameterList;
+import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.ParameterValue;
+import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.SimpleType;
 
 /**
  * @author Lyncode Development Team <dspace@lyncode.com>
@@ -41,11 +41,6 @@ public class DSpaceAtLeastOneMetadataFilter extends DSpaceFilter {
     private String field;
     private DSpaceMetadataFilterOperator operator = DSpaceMetadataFilterOperator.UNDEF;
     private List<String> values;
-    private ParameterMap configuration;
-
-    public DSpaceAtLeastOneMetadataFilter(ParameterMap configuration) {
-        this.configuration = configuration;
-    }
 
     @Autowired
     FieldResolver fieldResolver;
@@ -249,7 +244,4 @@ public class DSpaceAtLeastOneMetadataFilter extends DSpaceFilter {
         }
     }
 
-    public ParameterMap getConfiguration() {
-        return configuration;
-    }
 }

--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceAtLeastOneMetadataFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceAtLeastOneMetadataFilter.java
@@ -23,8 +23,6 @@ import org.dspace.xoai.exceptions.InvalidMetadataFieldException;
 import org.dspace.xoai.filter.data.DSpaceMetadataFilterOperator;
 import org.dspace.xoai.filter.results.DatabaseFilterResult;
 import org.dspace.xoai.filter.results.SolrFilterResult;
-import org.dspace.xoai.services.api.database.FieldResolver;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import com.google.common.base.Function;
 import com.lyncode.builder.ListBuilder;
@@ -41,9 +39,6 @@ public class DSpaceAtLeastOneMetadataFilter extends DSpaceFilter {
     private String field;
     private DSpaceMetadataFilterOperator operator = DSpaceMetadataFilterOperator.UNDEF;
     private List<String> values;
-
-    @Autowired
-    FieldResolver fieldResolver;
 
     private String getField() {
         if (field == null) {

--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceAuthorizationFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceAuthorizationFilter.java
@@ -12,8 +12,6 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.PostConstruct;
-
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
@@ -26,9 +24,6 @@ import org.dspace.handle.HandleManager;
 import org.dspace.xoai.data.DSpaceItem;
 import org.dspace.xoai.filter.results.DatabaseFilterResult;
 import org.dspace.xoai.filter.results.SolrFilterResult;
-import org.dspace.xoai.services.api.context.ContextService;
-import org.dspace.xoai.services.api.context.ContextServiceException;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * 
@@ -37,24 +32,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class DSpaceAuthorizationFilter extends DSpaceFilter
 {
     private static Logger log = LogManager.getLogger(DSpaceAuthorizationFilter.class);
-
-    @Autowired
-    private ContextService contextService;
-    private Context context;
-
-    @PostConstruct
-    public void intializeContext()
-    {
-        try
-        {
-            this.context = contextService.getContext();
-        }
-        catch (ContextServiceException e)
-        {
-            log.error("Context could not be obtained from the ContextService",
-                    e);
-        }
-    }
 
     @Override
     public DatabaseFilterResult buildDatabaseQuery(Context context)

--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceAuthorizationFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceAuthorizationFilter.java
@@ -8,6 +8,12 @@
 
 package org.dspace.xoai.filter;
 
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
@@ -20,10 +26,9 @@ import org.dspace.handle.HandleManager;
 import org.dspace.xoai.data.DSpaceItem;
 import org.dspace.xoai.filter.results.DatabaseFilterResult;
 import org.dspace.xoai.filter.results.SolrFilterResult;
-
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
+import org.dspace.xoai.services.api.context.ContextService;
+import org.dspace.xoai.services.api.context.ContextServiceException;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * 
@@ -32,10 +37,23 @@ import java.util.List;
 public class DSpaceAuthorizationFilter extends DSpaceFilter
 {
     private static Logger log = LogManager.getLogger(DSpaceAuthorizationFilter.class);
+
+    @Autowired
+    private ContextService contextService;
     private Context context;
 
-    public DSpaceAuthorizationFilter (Context context) {
-        this.context = context;
+    @PostConstruct
+    public void intializeContext()
+    {
+        try
+        {
+            this.context = contextService.getContext();
+        }
+        catch (ContextServiceException e)
+        {
+            log.error("Context could not be obtained from the ContextService",
+                    e);
+        }
     }
 
     @Override

--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceFilter.java
@@ -9,6 +9,8 @@ package org.dspace.xoai.filter;
 
 import com.lyncode.xoai.dataprovider.data.Filter;
 import com.lyncode.xoai.dataprovider.data.ItemIdentifier;
+import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.ParameterMap;
+
 import org.dspace.core.Context;
 import org.dspace.xoai.data.DSpaceItem;
 import org.dspace.xoai.filter.results.DatabaseFilterResult;
@@ -20,6 +22,9 @@ import org.dspace.xoai.filter.results.SolrFilterResult;
  */
 public abstract class DSpaceFilter implements Filter
 {
+    /** The configuration from xoai.xml file */
+    private ParameterMap configuration;
+
     public abstract DatabaseFilterResult buildDatabaseQuery(Context context);
     public abstract SolrFilterResult buildSolrQuery();
     public abstract boolean isShown(DSpaceItem item);
@@ -32,5 +37,22 @@ public abstract class DSpaceFilter implements Filter
             return isShown((DSpaceItem) item);
         }
         return false;
+    }
+
+    /**
+     * @return the configuration map if defined in xoai.xml, otherwise null.
+     */
+    public ParameterMap getConfiguration()
+    {
+        return configuration;
+    }
+
+    /**
+     * @param configuration
+     *            the configuration map to set
+     */
+    public void setConfiguration(ParameterMap configuration)
+    {
+        this.configuration = configuration;
     }
 }

--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceFilter.java
@@ -15,6 +15,7 @@ import org.dspace.core.Context;
 import org.dspace.xoai.data.DSpaceItem;
 import org.dspace.xoai.filter.results.DatabaseFilterResult;
 import org.dspace.xoai.filter.results.SolrFilterResult;
+import org.dspace.xoai.services.api.database.FieldResolver;
 
 /**
  * 
@@ -23,7 +24,13 @@ import org.dspace.xoai.filter.results.SolrFilterResult;
 public abstract class DSpaceFilter implements Filter
 {
     /** The configuration from xoai.xml file */
-    private ParameterMap configuration;
+    protected ParameterMap configuration;
+
+    /** The configuration from xoai.xml file */
+    protected FieldResolver fieldResolver;
+
+    /** The oai context */
+    protected Context context;
 
     public abstract DatabaseFilterResult buildDatabaseQuery(Context context);
     public abstract SolrFilterResult buildSolrQuery();
@@ -54,5 +61,39 @@ public abstract class DSpaceFilter implements Filter
     public void setConfiguration(ParameterMap configuration)
     {
         this.configuration = configuration;
+    }
+
+    /**
+     * @return the fieldResolver
+     */
+    public FieldResolver getFieldResolver()
+    {
+        return fieldResolver;
+    }
+
+    /**
+     * @param fieldResolver
+     *            the fieldResolver to set
+     */
+    public void setFieldResolver(FieldResolver fieldResolver)
+    {
+        this.fieldResolver = fieldResolver;
+    }
+
+    /**
+     * @return the context
+     */
+    public Context getContext()
+    {
+        return context;
+    }
+
+    /**
+     * @param context
+     *            the context to set
+     */
+    public void setContext(Context context)
+    {
+        this.context = context;
     }
 }

--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceMetadataExistsFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceMetadataExistsFilter.java
@@ -19,8 +19,6 @@ import org.dspace.xoai.data.DSpaceItem;
 import org.dspace.xoai.exceptions.InvalidMetadataFieldException;
 import org.dspace.xoai.filter.results.DatabaseFilterResult;
 import org.dspace.xoai.filter.results.SolrFilterResult;
-import org.dspace.xoai.services.api.database.FieldResolver;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.ParameterValue;
 import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.SimpleType;
@@ -39,8 +37,6 @@ public class DSpaceMetadataExistsFilter extends DSpaceFilter {
     private static Logger log = LogManager
             .getLogger(DSpaceMetadataExistsFilter.class);
 
-    @Autowired
-    private FieldResolver fieldResolver;
     private List<String> fields;
 
     private List<String> getFields() {

--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceMetadataExistsFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceMetadataExistsFilter.java
@@ -7,9 +7,10 @@
  */
 package org.dspace.xoai.filter;
 
-import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.ParameterMap;
-import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.ParameterValue;
-import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.SimpleType;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.dspace.core.Constants;
@@ -19,10 +20,10 @@ import org.dspace.xoai.exceptions.InvalidMetadataFieldException;
 import org.dspace.xoai.filter.results.DatabaseFilterResult;
 import org.dspace.xoai.filter.results.SolrFilterResult;
 import org.dspace.xoai.services.api.database.FieldResolver;
+import org.springframework.beans.factory.annotation.Autowired;
 
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
+import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.ParameterValue;
+import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.SimpleType;
 
 /**
  * This filter allows one to retrieve (from the data source) those items
@@ -38,14 +39,9 @@ public class DSpaceMetadataExistsFilter extends DSpaceFilter {
     private static Logger log = LogManager
             .getLogger(DSpaceMetadataExistsFilter.class);
 
+    @Autowired
     private FieldResolver fieldResolver;
     private List<String> fields;
-    private ParameterMap configuration;
-
-    public DSpaceMetadataExistsFilter(FieldResolver fieldResolver, ParameterMap configuration) {
-        this.fieldResolver = fieldResolver;
-        this.configuration = configuration;
-    }
 
     private List<String> getFields() {
         if (this.fields == null) {
@@ -114,7 +110,4 @@ public class DSpaceMetadataExistsFilter extends DSpaceFilter {
         return new SolrFilterResult(cond.toString());
     }
 
-    public ParameterMap getConfiguration() {
-        return configuration;
-    }
 }

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/BaseDSpaceFilterResolver.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/BaseDSpaceFilterResolver.java
@@ -83,16 +83,19 @@ public class BaseDSpaceFilterResolver implements DSpaceFilterResolver {
         try
         {
             result = filterClass.newInstance();
+            if (result instanceof DSpaceFilter)
+            {
+                // add the DSpace filter specific objects
+                ((DSpaceFilter) result).setConfiguration(configuration);
+                ((DSpaceFilter) result).setContext(contextService.getContext());
+                ((DSpaceFilter) result).setFieldResolver(fieldResolver);
+            }
         }
-        catch (InstantiationException | IllegalAccessException e)
+        catch (InstantiationException | IllegalAccessException
+                | ContextServiceException e)
         {
             LOGGER.error("Filter " + filterClass.getName()
                     + " could not be instantiated", e);
-        }
-        if (result instanceof DSpaceFilter)
-        {
-            // add the configuration to the implementing class if there is any.
-            ((DSpaceFilter) result).setConfiguration(configuration);
         }
         return result;
     }

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/BaseDSpaceFilterResolver.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/BaseDSpaceFilterResolver.java
@@ -79,20 +79,22 @@ public class BaseDSpaceFilterResolver implements DSpaceFilterResolver {
 
     @Override
     public Filter getFilter(Class<? extends Filter> filterClass, ParameterMap configuration) {
-        if (filterClass.isAssignableFrom(DSpaceAtLeastOneMetadataFilter.class)) {
-            return new DSpaceAtLeastOneMetadataFilter(configuration);
-        } else if (filterClass.isAssignableFrom(DSpaceAuthorizationFilter.class)) {
-            try {
-                return new DSpaceAuthorizationFilter(contextService.getContext());
-            } catch (ContextServiceException e) {
-                LOGGER.error(e.getMessage(), e);
-                return null;
-            }
-        } else if (filterClass.isAssignableFrom(DSpaceMetadataExistsFilter.class)) {
-            return new DSpaceMetadataExistsFilter(fieldResolver, configuration);
+        Filter result = null;
+        try
+        {
+            result = filterClass.newInstance();
         }
-        LOGGER.error("Filter "+filterClass.getName()+" unknown instantiation");
-        return null;
+        catch (InstantiationException | IllegalAccessException e)
+        {
+            LOGGER.error("Filter " + filterClass.getName()
+                    + " could not be instantiated", e);
+        }
+        if (result instanceof DSpaceFilter)
+        {
+            // add the configuration to the implementing class if there is any.
+            ((DSpaceFilter) result).setConfiguration(configuration);
+        }
+        return result;
     }
 
     @Override

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/services/impl/database/DSpaceDatabaseQueryResolverTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/services/impl/database/DSpaceDatabaseQueryResolverTest.java
@@ -110,10 +110,17 @@ public class DSpaceDatabaseQueryResolverTest extends AbstractQueryResolverTest {
                 .withValue(FIELD_1)
                 .withName("fields"));
 
-        scopedFilters.add(new ScopedFilter(new CustomCondition(getFilterResolver(),
-                DSpaceMetadataExistsFilter.class,
-                filterConfiguration),
-                Scope.Query));
+        final DSpaceMetadataExistsFilter metadataExistsFilter = new DSpaceMetadataExistsFilter();
+        metadataExistsFilter.setConfiguration(filterConfiguration);
+        autowire(metadataExistsFilter);
+        scopedFilters.add(new ScopedFilter(new Condition()
+        {
+            @Override
+            public Filter getFilter()
+            {
+                return metadataExistsFilter;
+            }
+        }, Scope.Query));
 
         DatabaseQuery result = underTest.buildQuery(scopedFilters, START, LENGTH);
 
@@ -134,10 +141,17 @@ public class DSpaceDatabaseQueryResolverTest extends AbstractQueryResolverTest {
                 )
                 .withName("fields"));
 
-        scopedFilters.add(new ScopedFilter(new CustomCondition(getFilterResolver(),
-                DSpaceMetadataExistsFilter.class,
-                filterConfiguration),
-                Scope.Query));
+        final DSpaceMetadataExistsFilter metadataExistsFilter = new DSpaceMetadataExistsFilter();
+        metadataExistsFilter.setConfiguration(filterConfiguration);
+        autowire(metadataExistsFilter);
+        scopedFilters.add(new ScopedFilter(new Condition()
+        {
+            @Override
+            public Filter getFilter()
+            {
+                return metadataExistsFilter;
+            }
+        }, Scope.Query));
 
         DatabaseQuery result = underTest.buildQuery(scopedFilters, START, LENGTH);
 

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/services/impl/database/DSpaceDatabaseQueryResolverTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/services/impl/database/DSpaceDatabaseQueryResolverTest.java
@@ -7,16 +7,13 @@
  */
 package org.dspace.xoai.tests.unit.services.impl.database;
 
-import com.lyncode.builder.DateBuilder;
-import com.lyncode.xoai.dataprovider.data.Filter;
-import com.lyncode.xoai.dataprovider.filter.Scope;
-import com.lyncode.xoai.dataprovider.filter.ScopedFilter;
-import com.lyncode.xoai.dataprovider.filter.conditions.AndCondition;
-import com.lyncode.xoai.dataprovider.filter.conditions.Condition;
-import com.lyncode.xoai.dataprovider.filter.conditions.CustomCondition;
-import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.ParameterList;
-import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.ParameterMap;
-import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.StringValue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
 import org.dspace.core.Constants;
 import org.dspace.xoai.filter.DSpaceMetadataExistsFilter;
 import org.dspace.xoai.filter.DSpaceSetSpecFilter;
@@ -29,12 +26,15 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import com.lyncode.builder.DateBuilder;
+import com.lyncode.xoai.dataprovider.data.Filter;
+import com.lyncode.xoai.dataprovider.filter.Scope;
+import com.lyncode.xoai.dataprovider.filter.ScopedFilter;
+import com.lyncode.xoai.dataprovider.filter.conditions.AndCondition;
+import com.lyncode.xoai.dataprovider.filter.conditions.Condition;
+import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.ParameterList;
+import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.ParameterMap;
+import com.lyncode.xoai.dataprovider.xml.xoaiconfig.parameters.StringValue;
 
 public class DSpaceDatabaseQueryResolverTest extends AbstractQueryResolverTest {
     private static final Date DATE = new Date();
@@ -112,7 +112,7 @@ public class DSpaceDatabaseQueryResolverTest extends AbstractQueryResolverTest {
 
         final DSpaceMetadataExistsFilter metadataExistsFilter = new DSpaceMetadataExistsFilter();
         metadataExistsFilter.setConfiguration(filterConfiguration);
-        autowire(metadataExistsFilter);
+        metadataExistsFilter.setFieldResolver(theFieldResolver());
         scopedFilters.add(new ScopedFilter(new Condition()
         {
             @Override
@@ -143,7 +143,7 @@ public class DSpaceDatabaseQueryResolverTest extends AbstractQueryResolverTest {
 
         final DSpaceMetadataExistsFilter metadataExistsFilter = new DSpaceMetadataExistsFilter();
         metadataExistsFilter.setConfiguration(filterConfiguration);
-        autowire(metadataExistsFilter);
+        metadataExistsFilter.setFieldResolver(theFieldResolver());
         scopedFilters.add(new ScopedFilter(new Condition()
         {
             @Override

--- a/dspace/bin/dspace
+++ b/dspace/bin/dspace
@@ -46,6 +46,8 @@
 
 BINDIR=`dirname $0`
 DSPACEDIR=`cd "$BINDIR/.." ; pwd`
+# Add the directory with all oai classes (original and overlay) needed by the 'dspace oai' launcher.xml
+OAICLASSES=$DSPACEDIR/webapps/oai/WEB-INF/classes/
 
 # Get the JARs in $DSPACEDIR/jsp/WEB-INF/lib, separated by ':'
 JARS=`echo $DSPACEDIR/lib/*.jar | sed 's/ /\:/g'`
@@ -55,9 +57,9 @@ JARS=`echo $DSPACEDIR/lib/*.jar | sed 's/ /\:/g'`
 #   The JARs (WEB-INF/lib/*.jar)
 #   The WEB-INF/classes directory
 if [ "$CLASSPATH" = "" ]; then
-    FULLPATH=$JARS:$DSPACEDIR/config
+    FULLPATH=$OAICLASSES:$JARS:$DSPACEDIR/config
 else
-    FULLPATH=$CLASSPATH:$JARS:$DSPACEDIR/config
+    FULLPATH=$CLASSPATH:$OAICLASSES:$JARS:$DSPACEDIR/config
 fi
 
 

--- a/dspace/bin/dspace.bat
+++ b/dspace/bin/dspace.bat
@@ -54,8 +54,8 @@ goto end
 :okExec
 echo Using DSpace installation in: %cd%
 
-REM Build a CLASSPATH
-set DSPACE_CLASSPATH=%CLASSPATH%;config
+REM Build a CLASSPATH including all classes in oai webapp, all libraries in [dspace]/lib and the config folder.
+set DSPACE_CLASSPATH=%CLASSPATH%;config;webapps\oai\WEB-INF\classes\
 for %%f in (lib\*.jar) DO CALL bin\buildpath.bat %%f
 
 REM If the user only wants the CLASSPATH, just give it now.


### PR DESCRIPTION
This pull request makes it possible to add additional filters for the OAI-PMH interface without touching BaseDSpaceFilterResolver. 
Currently the getFilter method of the BaseDSpaceFilterResolver only handles the 3 existing Filters. I removed the need for different constructors in the 3 Filters (by adding the dependencies with spring) and adding an additional property (ParameterMap configuration) in the abstract class DSpaceFilter to allow the 3 (and any other Filters) to make use of the configuration defined in xoai.xml. 

**Note** 
This improvement can only be tested if Bugs DS-2324 and DS-2325 are fixed. Otherwise there will be no filter loaded at all.

https://jira.duraspace.org/browse/DS-2423
