### PR TITLE
[DS-2426] added possibility to use relative import in oai xslt transformations

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/resources/DSpaceResourceResolver.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/resources/DSpaceResourceResolver.java
@@ -7,29 +7,46 @@
  */
 package org.dspace.xoai.services.impl.resources;
 
-import com.lyncode.xoai.dataprovider.services.api.ResourceResolver;
-import org.dspace.core.ConfigurationManager;
-
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerConfigurationException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.stream.StreamSource;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-public class DSpaceResourceResolver implements ResourceResolver {
-    private static final TransformerFactory transformerFactory = TransformerFactory.newInstance();
-    private final String basePath = ConfigurationManager.getProperty("oai", "config.dir");
+import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamSource;
+
+import org.dspace.core.ConfigurationManager;
+
+import com.lyncode.xoai.dataprovider.services.api.ResourceResolver;
+
+public class DSpaceResourceResolver implements ResourceResolver
+{
+    private static final TransformerFactory transformerFactory = TransformerFactory
+            .newInstance();
+
+    private final String basePath = ConfigurationManager.getProperty("oai",
+            "config.dir");
 
     @Override
-    public InputStream getResource(String path) throws IOException {
+    public InputStream getResource(String path) throws IOException
+    {
         return new FileInputStream(new File(basePath, path));
     }
 
     @Override
-    public Transformer getTransformer(String path) throws IOException, TransformerConfigurationException {
-        return transformerFactory.newTransformer(new StreamSource(getResource(path)));
+    public Transformer getTransformer(String path) throws IOException,
+            TransformerConfigurationException
+    {
+        // construct a Source that reads from an InputStream
+        Source mySrc = new StreamSource(getResource(path));
+        // specify a system ID (the path to the XSLT-file on the filesystem)
+        // so the Source can resolve relative URLs that are encountered in
+        // XSLT-files (like <xsl:import href="utils.xsl"/>)
+        String systemId = basePath + "/" + path;
+        mySrc.setSystemId(systemId);
+        return transformerFactory.newTransformer(mySrc);
     }
 }


### PR DESCRIPTION
To test the pull request create an additional XSL-file like:
dspace/config/crosswalks/oai/transformers/utils.xsl 
and import in in driver.xsl (<xsl:import href="utils.xsl"/>)

without this pull request there will be an exception.

**Note**
 I accidentally formated the source code according to the DSpace rules. The  relevant code is in lines 40-50

https://jira.duraspace.org/browse/DS-2426
