### PR TITLE
[DS-2438] fixed problem with immense metadata values for oai solr core

### DIFF
--- a/dspace/solr/oai/conf/schema.xml
+++ b/dspace/solr/oai/conf/schema.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <schema name="xoai" version="1.2">
   <types>
+    <fieldtype name="lengthfilter" class="solr.TextField">
+      <analyzer>
+        <tokenizer class="solr.KeywordTokenizerFactory"/>
+        <!-- ignore fields with more than 10000 chars because lucene doesn't swallow 
+        the MaxBytesLengthExceededException any longer. 
+        See https://issues.apache.org/jira/browse/LUCENE-5710  
+        This leads to an error if the content of a metadata field exceeds 32766 Bytes. -->
+        <filter class="solr.LengthFilterFactory" min="0" max="10000" />
+      </analyzer>
+    </fieldtype>
     <fieldType name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true"/>
     <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true" omitNorms="true"/>
     <fieldtype name="binary" class="solr.BinaryField"/>
@@ -158,7 +168,7 @@
    <field name="item.compile" type="string" indexed="false" stored="true" multiValued="false" />
 
    <!-- Item metadata -->
-   <dynamicField name="metadata.*" type="string" indexed="true" stored="true" multiValued="true" />
+   <dynamicField name="metadata.*" type="lengthfilter" indexed="true" stored="true" multiValued="true" />
  
    <!-- Dynamic fields (not used by default) -->
    <dynamicField name="*_i"  type="int"    indexed="true"  stored="true"/>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2438

Lucene changed the behaviour how it handles a immense term exception (https://issues.apache.org/jira/browse/LUCENE-5710). This leads to the termination of the indexing for the oai interface (like dspace oai import -c) if there is a metadata field with a rearly long text value (exceeding 32766 Bytes)

To reproduce the error: 
1. add metadata field with more than 32766 chars to an item
2. run [dspace]/bin/dspace oai import -c

The fixes changes the field type from string to text to make it possible to use the LengthFilterFactory. The KeywordTokenizer behaves like the old string field the only difference is that metadata fields exceeding 10000 chars are excluded from the index. 
