### PR TITLE
DS-2441 Add a bitstream column to item/browse list

### DIFF
--- a/dspace-api/src/main/java/org/dspace/browse/BrowseItem.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseItem.java
@@ -27,11 +27,11 @@ import java.util.List;
  * metadata handling has been further optimised for performance in both
  * reading and writing, and it does not deal with other objects related to
  * items
- * 
+ *
  * FIXME: this class violates some of the encapsulation of the Item, but there is
- * unfortunately no way around this until DAOs and an interface are provided 
+ * unfortunately no way around this until DAOs and an interface are provided
  * for the Item class.
- * 
+ *
  * @author Richard Jones
  *
  */
@@ -39,10 +39,10 @@ public class BrowseItem extends DSpaceObject
 {
 	/** Logger */
     private static Logger log = Logger.getLogger(BrowseItem.class);
-    
+
 	/** a List of all the metadata */
 	private List<Metadatum> metadata = new ArrayList<Metadatum>();
-	
+
 	/** database id of the item */
 	private int id = -1;
 
@@ -54,13 +54,13 @@ public class BrowseItem extends DSpaceObject
 
     /** is the item discoverable */
     private boolean discoverable = true;
-    
+
     /** item handle */
 	private String handle = null;
 
     /**
 	 * Construct a new browse item with the given ourContext and the database id
-	 * 
+	 *
 	 * @param context	the DSpace ourContext
      * @param id		the database id of the item
      * @param in_archive
@@ -76,7 +76,7 @@ public class BrowseItem extends DSpaceObject
 
 	/**
 	 * Get String array of metadata values matching the given parameters
-	 * 
+	 *
 	 * @param schema	metadata schema
 	 * @param element	metadata element
 	 * @param qualifier	metadata qualifier
@@ -157,11 +157,11 @@ public class BrowseItem extends DSpaceObject
             return null;
         }
     }
-	
+
 	/**
 	 * Get the type of object.  This object masquerades as an Item, so this
 	 * returns the value of Constants.ITEM
-	 * 
+	 *
 	 *@return Constants.ITEM
 	 */
 	public int getType()
@@ -184,10 +184,10 @@ public class BrowseItem extends DSpaceObject
 			return getType();
 		}
 	}
-	
+
 	/**
 	 * get the database id of the item
-	 * 
+	 *
 	 *	@return database id of item
 	 */
 	public int getID()
@@ -197,14 +197,14 @@ public class BrowseItem extends DSpaceObject
 
 	/**
 	 * Set the database id of the item
-	 * 
+	 *
 	 * @param id	the database id of the item
 	 */
 	public void setID(int id)
 	{
 		this.id = id;
 	}
-	
+
 	/**
      * Utility method for pattern-matching metadata elements.  This
      * method will return <code>true</code> if the given schema,
@@ -303,15 +303,15 @@ public class BrowseItem extends DSpaceObject
 		}
 		return this.handle;
 	}
-    
+
 	/**
 	 * Get a thumbnail object out of the item.
-	 * 
+	 *
 	 * Warning: using this method actually instantiates an Item, which has a
 	 * corresponding performance hit on the database during browse listing
 	 * rendering.  That's your own fault for wanting to put images on your
 	 * browse page!
-	 * 
+	 *
 	 * @throws SQLException
 	 */
     public Thumbnail getThumbnail()
@@ -319,21 +319,21 @@ public class BrowseItem extends DSpaceObject
     {
     	// instantiate an item for this one.  Not nice.
         Item item = Item.find(ourContext, id);
-    	
+
     	if (item == null)
     	{
     		return null;
     	}
-    	
+
     	// now go sort out the thumbnail
-    	
+
     	// if there's no original, there is no thumbnail
     	Bundle[] original = item.getBundles("ORIGINAL");
         if (original.length == 0)
         {
         	return null;
         }
-        
+
         // if multiple bitstreams, check if the primary one is HTML
         boolean html = false;
         if (original[0].getBitstreams().length > 1)
@@ -351,14 +351,14 @@ public class BrowseItem extends DSpaceObject
 
         // now actually pull out the thumbnail (ouch!)
         Bundle[] thumbs = item.getBundles("THUMBNAIL");
-        
+
         // if there are thumbs and we're not dealing with an HTML item
         // then show the thumbnail
         if ((thumbs.length > 0) && !html)
         {
         	Bitstream thumbnailBitstream;
         	Bitstream originalBitstream;
-        	
+
         	if ((original[0].getBitstreams().length > 1) && (original[0].getPrimaryBitstreamID() > -1))
         	{
         		originalBitstream = Bitstream.find(ourContext, original[0].getPrimaryBitstreamID());
@@ -369,7 +369,7 @@ public class BrowseItem extends DSpaceObject
         		originalBitstream = original[0].getBitstreams()[0];
         		thumbnailBitstream = thumbs[0].getBitstreams()[0];
         	}
-        	
+
         	if ((thumbnailBitstream != null)
         			&& (AuthorizeManager.authorizeActionBoolean(ourContext, thumbnailBitstream, Constants.READ)))
         	{
@@ -405,8 +405,17 @@ public class BrowseItem extends DSpaceObject
     {
         return withdrawn;
     }
-    
+
     public boolean isDiscoverable() {
     	return discoverable;
+	}
+
+	public static BitstreamList toBitstreamList(BrowseItem[] items){
+		if(items.length == 0) // items should has at least one element.
+			return new BitstreamList();
+		int[] item_ids = new int[items.length];
+		for (int i = 0; i < items.length ; i++)
+			item_ids[i] = items[i].getID();
+		return new BitstreamList(item_ids,"ORIGINAL",items[0].context);
 	}
 }

--- a/dspace-api/src/main/java/org/dspace/content/BitstreamList.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamList.java
@@ -1,0 +1,184 @@
+/**
+* The contents of this file are subject to the license and copyright
+* detailed in the LICENSE and NOTICE files at the root of the source
+* tree and available online at
+*
+* http://www.dspace.org/license/
+*/
+package org.dspace.content;
+
+import java.lang.StringBuilder;
+import org.apache.log4j.Logger;
+import org.dspace.core.Context;
+import org.dspace.storage.rdbms.DatabaseManager;
+import org.dspace.storage.rdbms.TableRow;
+import org.dspace.storage.rdbms.TableRowIterator;
+
+/**
+* This is a class is to get the first bitstream of every item in the array, null is given if not found
+* See the constructor for more detailed info
+*
+* @author PastLeo 2015/2/2
+*
+*/
+public class BitstreamList
+{
+	/** Logger */
+	private static Logger log = Logger.getLogger(BitstreamList.class);
+
+	/** DSpace context */
+	private Context context;
+
+	/** bitstream list */
+	private Bitstream[] bit_list;
+
+	/** bitstream list cursor */
+	private int cursor;
+
+	/** bitstream list length */
+	public final int length;
+
+	public BitstreamList(){
+		this.length = 0;
+		this.bit_list = new Bitstream[length];
+		this.cursor = 0;
+	}
+
+	/* Get the first bitstream of every item in the array, null is given if not found
+	*  index | parameter item | returned bitstream
+	*  ------+----------------+---------------------
+	*  0     | item_a_has_bs  | first_bs_of_item_a
+	*  1     | item_b_no_bs   | null
+	*  2     | item_c_has_bs  | first_bs_of_item_c
+	* ...
+	*/
+	public BitstreamList(int[] item_ids,String bundle_name,Context context){
+		this.length = item_ids.length;
+		this.bit_list = new Bitstream[length];
+		this.context = context;
+		this.cursor = 0;
+
+		TableRowIterator tri = null;
+		StringBuilder debugMsg = new StringBuilder();
+		try{
+			/*
+			===================================
+			Code below will build a query like this:
+			SELECT g.*
+			FROM (VALUES (6709,0),(6710,1),(6708,2),(6707,3),(6723,4),(6722,5),(6719,6)) AS a (item_id,i)
+			LEFT JOIN (
+				SELECT b.item_id,MAX(b.bundle_id),MAX(c.primary_bitstream_id) FROM item2bundle AS b
+				LEFT JOIN bundle AS c ON b.bundle_id = c.bundle_id WHERE c.name = 'ORIGINAL' GROUP BY b.item_id
+			) AS d (item_id,bundle_id,primary_bitstream_id) ON a.item_id = d.item_id
+			LEFT JOIN (
+				SELECT e.bundle_id,MAX(e.bitstream_id) FROM bundle2bitstream AS e GROUP BY e.bundle_id
+			) AS f (bundle_id,bitstream_id) ON d.bundle_id = f.bundle_id
+			LEFT JOIN bitstream AS g
+			ON ((d.primary_bitstream_id IS NULL AND f.bitstream_id = g.bitstream_id) OR d.primary_bitstream_id = g.bitstream_id) AND g.deleted = 'f'
+			ORDER BY a.i;
+
+			===================================
+			An alike query for debuging:
+			SELECT a.item_id, d.*, f.* , g.bitstream_id, g.name, g.deleted
+			FROM (VALUES (6709,0),(6710,1),(6708,2),(6707,3),(6723,4),(6722,5),(6719,6)) AS a (item_id,i)
+			LEFT JOIN (
+				SELECT b.item_id,MAX(b.bundle_id),MAX(c.primary_bitstream_id) FROM item2bundle AS b
+				LEFT JOIN bundle AS c ON b.bundle_id = c.bundle_id WHERE c.name = 'ORIGINAL' GROUP BY b.item_id
+			) AS d (item_id,bundle_id,primary_bitstream_id) ON a.item_id = d.item_id
+			LEFT JOIN (
+				SELECT e.bundle_id,MAX(e.bitstream_id) FROM bundle2bitstream AS e GROUP BY e.bundle_id
+			) AS f (bundle_id,bitstream_id) ON d.bundle_id = f.bundle_id
+			LEFT JOIN bitstream AS g
+			ON ((d.primary_bitstream_id IS NULL AND f.bitstream_id = g.bitstream_id) OR d.primary_bitstream_id = g.bitstream_id) AND g.deleted = 'f'
+			ORDER BY a.i;
+			*/
+
+			StringBuilder query = new StringBuilder();
+			int lastItemIndex = length - 1;
+			query.append("SELECT g.* FROM (VALUES ");
+			for (int i = 0 ; i < lastItemIndex ; i++) {
+				query.append("(");
+				query.append(item_ids[i]);
+				query.append(",");
+				query.append(i);
+				query.append("),");
+			}
+			query.append("(");
+			query.append(item_ids[lastItemIndex]);
+			query.append(",");
+			query.append(lastItemIndex);
+			query.append(")) AS a (item_id,i) LEFT JOIN (SELECT b.item_id,MAX(b.bundle_id),MAX(c.primary_bitstream_id) FROM item2bundle AS b LEFT JOIN bundle AS c ON b.bundle_id = c.bundle_id WHERE c.name = '");
+			query.append(bundle_name);
+			query.append("' GROUP BY b.item_id) AS d (item_id,bundle_id,primary_bitstream_id) ON a.item_id = d.item_id LEFT JOIN (SELECT e.bundle_id,MAX(e.bitstream_id) FROM bundle2bitstream AS e GROUP BY e.bundle_id) AS f (bundle_id,bitstream_id) ON d.bundle_id = f.bundle_id LEFT JOIN bitstream AS g ON ((d.primary_bitstream_id IS NULL AND f.bitstream_id = g.bitstream_id) OR d.primary_bitstream_id = g.bitstream_id) AND g.deleted = 'f' ORDER BY a.i;");
+			String query_str = query.toString();
+
+			debugMsg.append("Using '");
+			debugMsg.append(query_str);
+			debugMsg.append("' to for items to BitstreamList.\n");
+
+			tri = DatabaseManager.query(context,query.toString());
+
+			if(!tri.hasNext())
+				log.warn("There is an empty response from db when query items to BitstreamList");
+
+			debugMsg.append("bitstream: ");
+			TableRow r;
+			Bitstream fromCache;
+			int bitstream_id;
+			for (int i = 0 ; i <= lastItemIndex && tri.hasNext() ; i++) {
+				try{
+					r = tri.next();
+					bitstream_id = r.getIntColumn("bitstream_id");
+
+					debugMsg.append("[");
+					debugMsg.append(bitstream_id);
+					debugMsg.append("]: ");
+
+					if(bitstream_id == -1)
+						continue;
+					// First check the cache
+					fromCache = (Bitstream) context.fromCache(
+							Bitstream.class, r.getIntColumn("bitstream_id"));
+					if (fromCache != null){
+						bit_list[i] = fromCache;
+						fromCache = null;
+					}
+					else{
+						r.setTable("bitstream");
+						bit_list[i] = new Bitstream(context, r);
+					}
+					debugMsg.append(bit_list[i].getName() + ", ");
+				}catch(Exception e){
+					log.error("Error on item to bitstreamList iteration: " + e.getMessage());
+				}
+			}
+			log.debug(debugMsg.toString());
+		}catch(Exception e){
+			log.error(debugMsg.toString());
+			log.error("Error on item to bitstreamList: " + e.getMessage());
+		}finally{
+			// close the TableRowIterator to free up resources
+			if (tri != null)
+				tri.close();
+		}
+	}
+
+	/**
+	* Get the next Bitstream
+	*
+	*/
+	public Bitstream getNextBS()
+	{
+		if(cursor == length)
+			return null;
+		return bit_list[cursor++];
+	}
+
+	/**
+	* Get current cursor
+	*
+	*/
+	public int getCursor(){
+		return cursor;
+	}
+}

--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -77,6 +77,10 @@ itemlist.dc.type.course        = Course
 itemlist.dc.type.degree        = Degree
 itemlist.et-al                 = et al
 itemlist.thumbnail             = Preview
+itemlist.bitstream             = File
+itemlist.bitstream.yes         = <span class="glyphicon glyphicon-file" aria-hidden="true"></span>
+itemlist.bitstream.yes.full    = <a href="{0}" alt={1}" target="_blank" class="has-bitstream"><span class="glyphicon glyphicon-file" aria-hidden="true"></span></a>
+itemlist.bitstream.no          = -
 
 itemlist.title.undefined	   = Undefined
 

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/BrowseListTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/BrowseListTag.java
@@ -429,6 +429,7 @@ public class BrowseListTag extends TagSupport
 			BitstreamList bss = null;
 			if(hasBitstream){
 				bss = BrowseItem.toBitstreamList(items);
+				hrq.setAttribute("itemlist.bitstream", bss);
 			}
 
             // now output each item row

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/BrowseListTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/BrowseListTag.java
@@ -13,8 +13,10 @@ import org.apache.log4j.Logger;
 import org.dspace.app.itemmarking.ItemMarkingExtractor;
 import org.dspace.app.itemmarking.ItemMarkingInfo;
 import org.dspace.app.webui.util.UIUtil;
+import org.dspace.app.webui.util.BitstreamDisplayStrategy;
 import org.dspace.browse.*;
 import org.dspace.content.Bitstream;
+import org.dspace.content.BitstreamList;
 import org.dspace.content.DCDate;
 import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
@@ -287,6 +289,7 @@ public class BrowseListTag extends TagSupport
         boolean viewFull[] = new boolean[fieldArr.length];
         String[] browseType = new String[fieldArr.length];
         String[] cOddOrEven = new String[fieldArr.length];
+		Boolean hasBitstream = false;
 
         try
         {
@@ -386,6 +389,11 @@ public class BrowseListTag extends TagSupport
                 	emph[colIdx] = true;
                 }
 
+				if (field.equals("bitstream"))
+				{
+					hasBitstream = true;
+				}
+
                 // prepare the strings for the header
                 String id = "t" + Integer.toString(colIdx + 1);
                 String css = "oddRow" + cOddOrEven[colIdx] + "Col";
@@ -396,7 +404,7 @@ public class BrowseListTag extends TagSupport
                 {
                 	markClass = " "+field+"_th";
                 }
-                
+
                 // output the header
                 out.print("<th id=\"" + id +  "\" class=\"" + css + markClass +"\">"
                         + (emph[colIdx] ? "<strong>" : "")
@@ -418,10 +426,15 @@ public class BrowseListTag extends TagSupport
 
             out.print("</tr>");
 
+			BitstreamList bss = null;
+			if(hasBitstream){
+				bss = BrowseItem.toBitstreamList(items);
+			}
+
             // now output each item row
             for (int i = 0; i < items.length; i++)
             {
-            	out.print("<tr>"); 
+            	out.print("<tr>");
                 // now prepare the XHTML frag for this division
                 String rOddOrEven;
                 if (i == highlightRow)
@@ -487,6 +500,13 @@ public class BrowseListTag extends TagSupport
                     {
                         metadata = UIUtil.getMarkingMarkup(hrq, items[i], field);
                     }
+					else if (field.equals("bitstream"))
+					{
+						metadata = (new BitstreamDisplayStrategy()).getMetadataDisplay(hrq, 0,
+                            viewFull[colIdx], browseType[colIdx], colIdx,
+                            field, metadataArray, items[i], disableCrossLinks,
+                            emph[colIdx], pageContext);
+					}
                     else if (metadataArray.length > 0)
                     {
                         // format the date field correctly
@@ -600,14 +620,14 @@ public class BrowseListTag extends TagSupport
                             + "</a>";
                         }
                     }
-                    
+
                     // prepare extra special layout requirements for dates
                     String extras = "";
                     if (isDate[colIdx])
                     {
                         extras = "nowrap=\"nowrap\" align=\"right\"";
                     }
-                    
+
                     String markClass = "";
                     if (field.startsWith("mark_"))
                     {

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemListTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemListTag.java
@@ -13,12 +13,14 @@ import org.apache.log4j.Logger;
 import org.dspace.app.itemmarking.ItemMarkingExtractor;
 import org.dspace.app.itemmarking.ItemMarkingInfo;
 import org.dspace.app.webui.util.UIUtil;
+import org.dspace.app.webui.util.BitstreamDisplayStrategy;
 
 import org.dspace.browse.BrowseException;
 import org.dspace.browse.BrowseIndex;
 import org.dspace.browse.CrossLinks;
 
 import org.dspace.content.Bitstream;
+import org.dspace.content.BitstreamList;
 import org.dspace.content.DCDate;
 import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
@@ -254,6 +256,7 @@ public class ItemListTag extends TagSupport
         boolean viewFull[] = new boolean[fieldArr.length];
         String[] browseType = new String[fieldArr.length];
         String[] cOddOrEven = new String[fieldArr.length];
+        Boolean hasBitstream = false;
 
         try
         {
@@ -351,6 +354,11 @@ public class ItemListTag extends TagSupport
                     emph[colIdx] = true;
                 }
 
+                if (field.equals("bitstream"))
+                {
+                    hasBitstream = true;
+                }
+
                 // prepare the strings for the header
                 String id = "t" + Integer.toString(colIdx + 1);
                 String css = "oddRow" + cOddOrEven[colIdx] + "Col";
@@ -383,11 +391,16 @@ public class ItemListTag extends TagSupport
 
             out.print("</tr>");
 
+            BitstreamList bss = null;
+            if(hasBitstream){
+                bss = Item.toBitstreamList(items);
+            }
+
             // now output each item row
             for (int i = 0; i < items.length; i++)
             {
                 // now prepare the XHTML frag for this division
-            	out.print("<tr>"); 
+            	out.print("<tr>");
                 String rOddOrEven;
                 if (i == highlightRow)
                 {
@@ -451,6 +464,13 @@ public class ItemListTag extends TagSupport
                     else  if (field.startsWith("mark_"))
                     {
                         metadata = UIUtil.getMarkingMarkup(hrq, items[i], field);
+                    }
+                    else if (field.equals("bitstream"))
+                    {
+                        metadata = (new BitstreamDisplayStrategy()).getMetadataDisplay(hrq, 0,
+                            viewFull[colIdx], browseType[colIdx], colIdx,
+                            field, metadataArray, items[i], disableCrossLinks,
+                            emph[colIdx], pageContext);
                     }
                     if (metadataArray.length > 0)
                     {
@@ -579,7 +599,7 @@ public class ItemListTag extends TagSupport
                     	markClass = " "+field+"_tr";
                     }
 
-                    
+
                     String id = "t" + Integer.toString(colIdx + 1);
                     out.print("<td headers=\"" + id + "\" class=\""
                     	+ rOddOrEven + "Row" + cOddOrEven[colIdx] + "Col" + markClass + "\" " + extras + ">"

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemListTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemListTag.java
@@ -394,6 +394,7 @@ public class ItemListTag extends TagSupport
             BitstreamList bss = null;
             if(hasBitstream){
                 bss = Item.toBitstreamList(items);
+                hrq.setAttribute("itemlist.bitstream", bss);
             }
 
             // now output each item row

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/util/BitstreamDisplayStrategy.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/util/BitstreamDisplayStrategy.java
@@ -1,0 +1,158 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.webui.util;
+
+import java.lang.StringBuilder;
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.PageContext;
+import javax.servlet.jsp.jstl.fmt.LocaleSupport;
+
+import org.apache.log4j.Logger;
+import org.dspace.browse.BrowseItem;
+import org.dspace.content.DCValue;
+import org.dspace.content.Item;
+import org.dspace.content.BitstreamFormat;
+import org.dspace.content.Bitstream;
+import org.dspace.content.BitstreamList;
+import org.dspace.core.SelfNamedPlugin;
+import org.dspace.core.ConfigurationManager;
+import org.dspace.core.Constants;
+
+public class BitstreamDisplayStrategy extends SelfNamedPlugin implements
+        IDisplayMetadataValueStrategy
+{
+    /** log4j category */
+    private static final Logger log = Logger.getLogger(BitstreamDisplayStrategy.class);
+
+    private static final boolean showFullBitstream;
+    static
+    {
+        showFullBitstream = ConfigurationManager
+                .getBooleanProperty("webui.browse.bitstream.showfull");
+    }
+
+    public String getMetadataDisplay(HttpServletRequest hrq,
+            int limit, boolean viewFull, String browseType, int colIdx,
+            String field, DCValue[] metadataArray, boolean disableCrossLinks,
+            boolean emph, PageContext pageContext) throws JspException
+    {
+        // StringBuilder debugMsg = new StringBuilder();
+        BitstreamList bss = (BitstreamList) hrq.getAttribute("itemlist.bitstream");
+        // debugMsg.append("Bitstream list using simple version ...\nitemlist.bitstream.length = ");
+        // debugMsg.append(bss.length);
+        Bitstream bs = bss.getNextBS();
+
+        if(bs != null){
+            BitstreamFormat bsFormat = bs.getFormat();
+            if((!bsFormat.isInternal()) || bsFormat.getMIMEType().equals("text/html"))
+                return LocaleSupport.getLocalizedMessage(pageContext,"itemlist.bitstream.yes");
+            log.debug("\nbitstream " + bs.getName() + " not null but format " + bsFormat.getMIMEType() + " is internal or not equal to text/html\n");
+            // debugMsg.append("\nbitstream " + bs.getName() + " not null but format " + bsFormat.getMIMEType() + " is internal or not equal to text/html\n");
+        }
+        // debugMsg.append("\nbitstream[");
+        // debugMsg.append(bss.getCursor());
+        // debugMsg.append("] is null");
+        // log.debug(debugMsg.toString());
+
+        return LocaleSupport.getLocalizedMessage(pageContext,"itemlist.bitstream.no");
+    }
+
+    public String getMetadataDisplay(HttpServletRequest hrq, int limit,
+            boolean viewFull, String browseType, int colIdx, String field,
+            DCValue[] metadataArray, BrowseItem item,
+            boolean disableCrossLinks, boolean emph, PageContext pageContext)
+            throws JspException
+    {
+        return getMetadataDisplay(hrq, limit, viewFull, browseType, colIdx,
+                field, metadataArray, disableCrossLinks, emph, pageContext);
+    }
+
+    public String getMetadataDisplay(HttpServletRequest hrq, int limit,
+            boolean viewFull, String browseType, int colIdx, String field,
+            DCValue[] metadataArray, Item item, boolean disableCrossLinks,
+            boolean emph, PageContext pageContext) throws JspException
+    {
+        if(!showFullBitstream)
+            return getMetadataDisplay(hrq, limit, viewFull, browseType, colIdx,
+                field, metadataArray, disableCrossLinks, emph, pageContext);
+        // StringBuilder debugMsg = new StringBuilder();
+        BitstreamList bss = (BitstreamList) hrq.getAttribute("itemlist.bitstream");
+        // debugMsg.append("Bitstream list using full version ...\nitemlist.bitstream.length = ");
+        // debugMsg.append(bss.length);
+        Bitstream bs = bss.getNextBS();
+
+        if(bs == null)
+            return LocaleSupport.getLocalizedMessage(pageContext,"itemlist.bitstream.no");
+
+        String bsLink;
+        String itemHandle = item.getHandle();
+        BitstreamFormat bsFormat = bs.getFormat();
+        Object[] bsData;
+
+        try{
+            if(bsFormat.getMIMEType().equals("text/html"))
+                bsLink =
+                    hrq.getContextPath() + "/html/" +
+                    (itemHandle == null ? "db-id/" + item.getID() : itemHandle) +
+                    "/" + UIUtil.encodeBitstreamName(bs.getName(), Constants.DEFAULT_ENCODING);
+            else if(!bsFormat.isInternal()){
+                if ((itemHandle != null) && (bs.getSequenceID() > 0))
+                    bsLink =
+                        hrq.getContextPath() + "/bitstream/" +
+                        item.getHandle() + "/" + bs.getSequenceID() + "/";
+                else
+                    bsLink = hrq.getContextPath() + "/retrieve/" + bs.getID() + "/";
+
+                bsLink = bsLink + UIUtil.encodeBitstreamName(bs.getName(), Constants.DEFAULT_ENCODING);
+            }
+            else{
+                log.debug("\nbitstream " + bs.getName() + " not null but format " + bsFormat.getMIMEType() + " is internal or not equal to text/html\n");
+                return LocaleSupport.getLocalizedMessage(pageContext,"itemlist.bitstream.no");
+            }
+        }catch(IOException ie){
+            throw new JspException(ie);
+        }
+
+        bsData = new Object[2];
+        bsData[0] = bsLink;
+        bsData[1] = bs.getName();
+        // debugMsg.append("\nbitstream " + bs.getName() + " not null and format " + bsFormat.getMIMEType() + "bitstream returning full info{link: '" + bsLink + "', name: '" + bs.getName() + "'");
+        // log.debug(debugMsg.toString());
+        return LocaleSupport.getLocalizedMessage(pageContext,"itemlist.bitstream.yes.full",bsData);
+    }
+
+    public String getExtraCssDisplay(HttpServletRequest hrq, int limit,
+            boolean b, String browseType, int colIdx, String field,
+            DCValue[] metadataArray, boolean disableCrossLinks, boolean emph,
+            PageContext pageContext) throws JspException
+    {
+        return null;
+    }
+
+    public String getExtraCssDisplay(HttpServletRequest hrq, int limit,
+            boolean b, String browseType, int colIdx, String field,
+            DCValue[] metadataArray, BrowseItem browseItem,
+            boolean disableCrossLinks, boolean emph, PageContext pageContext)
+            throws JspException
+    {
+        return getExtraCssDisplay(hrq, limit, b, browseType, colIdx, field,
+                metadataArray, disableCrossLinks, emph, pageContext);
+    }
+
+    public String getExtraCssDisplay(HttpServletRequest hrq, int limit,
+            boolean b, String browseType, int colIdx, String field,
+            DCValue[] metadataArray, Item item, boolean disableCrossLinks,
+            boolean emph, PageContext pageContext) throws JspException
+    {
+        return getExtraCssDisplay(hrq, limit, b, browseType, colIdx, field,
+                metadataArray, disableCrossLinks, emph, pageContext);
+    }
+
+}

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -39,7 +39,7 @@ dspace.baseUrl = ${dspace.baseUrl}
 dspace.url = ${dspace.url}
 
 # Optional: DSpace URL for mobile access
-# This 
+# This
 #dspace.mobileUrl = http://mobile.example.com
 
 # Name of the site
@@ -236,7 +236,7 @@ log.dir = ${dspace.dir}/log
 # To mint DOIs you have to use a DOI registration agency like DataCite. Several
 # DataCite members offers services as DOI registration agency, so f.e. EZID or
 # TIB Hannover. To mint DOIs with DSpace you have to get an agreement with an
-# DOI registration agency. You have to edit 
+# DOI registration agency. You have to edit
 # [dspace]/config/spring/api/identifier-service.xml and to configure the following
 # properties.
 
@@ -274,7 +274,7 @@ search.max-clauses = 2048
 
 # Non-Stemming analyzer.  Does not "stem" words/terms. When using this analyzer,
 # a search for "wellness" will always return items matching "wellness" and not "well".
-# However, similarly a search for "experiments" will only return objects matching 
+# However, similarly a search for "experiments" will only return objects matching
 # "experiments" and not "experiment" or "experimenting".
 # search.analyzer = org.dspace.search.DSNonStemmingAnalyzer
 
@@ -301,7 +301,7 @@ search.maxfieldlength = 10000
 # DC metadata elements.qualifiers to be indexed for search
 # format: - search.index.[number] = [search field]:element.qualifier
 #       - * used as wildcard
-#	- inputform -> In case we have different input-forms for different repository supported locales (e.g input-forms_el.xml, input-forms_pt.xml etc). In this case, the 
+#	- inputform -> In case we have different input-forms for different repository supported locales (e.g input-forms_el.xml, input-forms_pt.xml etc). In this case, the
 #		stored and the displayed value from all input-forms are indexed. If the stored value is not found in input-forms, it is indexed anyway.
 #		e.g.:search.index.12 = language:dc.language:inputform
 #
@@ -348,13 +348,13 @@ handle.prefix = ${handle.prefix}
 # Directory for installing Handle server files
 handle.dir = ${dspace.dir}/handle-server
 
-# List any additional prefixes that need to be managed by this handle server 
-# (as for examle handle prefix coming from old dspace repository merged in 
+# List any additional prefixes that need to be managed by this handle server
+# (as for examle handle prefix coming from old dspace repository merged in
 # that repository)
-# handle.additional.prefixes = prefix1[, prefix2]  
+# handle.additional.prefixes = prefix1[, prefix2]
 
-# By default we hide the list handles method in the JSON endpoint as it could 
-# produce heavy load for large repository 
+# By default we hide the list handles method in the JSON endpoint as it could
+# produce heavy load for large repository
 # handle.hide.listhandles = false
 
 ##### Authorization system configuration - Delegate ADMIN #####
@@ -444,8 +444,8 @@ filter.plugins = PDF Text Extractor, HTML Text Extractor, \
 # [To enable Branded Preview]: uncomment and insert the following into the plugin list
 #                Branded Preview JPEG, \
 
-# [To enable ImageMagick Thumbnail]: 
-#    remove "JPEG Thumbnail" from the plugin list 
+# [To enable ImageMagick Thumbnail]:
+#    remove "JPEG Thumbnail" from the plugin list
 #    uncomment and insert the following line into the plugin list
 #                ImageMagick Image Thumbnail, ImageMagick PDF Thumbnail, \
 
@@ -589,7 +589,7 @@ plugin.named.org.dspace.content.crosswalk.DisseminationCrosswalk = \
   org.dspace.content.crosswalk.OREDisseminationCrosswalk = ore, \
   org.dspace.content.crosswalk.DIMDisseminationCrosswalk = dim, \
   org.dspace.content.crosswalk.RoleCrosswalk = DSPACE-ROLES
-  
+
 
 # regarding the XSLTDisseminationCrosswalk see the section were it is
 # configured to avoid error logs! Disable it if you remove its configuration.
@@ -916,7 +916,7 @@ cc.api.rooturl = http://api.creativecommons.org/rest/1.5
 
 # Metadata field to hold CC license URI of selected license
 # NB: XMLUI presentation code expects 'dc.rights.uri' to hold CC data. If you change
-# this to another field, please consult documentation on how to update UI configuration 
+# this to another field, please consult documentation on how to update UI configuration
 cc.license.uri = dc.rights.uri
 
 # Metadata field to hold CC license name of selected license (if defined)
@@ -989,6 +989,9 @@ thumbnail.blurring = true
 # image quality, but it takes longer to create thumbnails.
 thumbnail.hqscaling = true
 
+#### Bitstream full toggle ####
+# After you enable this, you can use the 'itemlist.bitstream.yes.full' to show full info ({0} for link, {1} for name) of the bitstream
+webui.browse.bitstream.showfull = true
 
 #### Settings for Item Preview ####
 
@@ -1025,7 +1028,7 @@ webui.preview.brand.fontpoint = 12
 
 # whether to display collection and community strengths
 # (Since DSpace 4.0, this config option is used by XMLUI, too.
-# XMLUI only makes strengths available to themes if this is set to true! 
+# XMLUI only makes strengths available to themes if this is set to true!
 # To show strengths in the XMLUI, you also need to create a theme which displays them)
 webui.strengths.show = false
 
@@ -1034,7 +1037,7 @@ webui.strengths.show = false
 #
 # Counts fetched in real time will perform an actual count of the
 # database contents every time a page with this feature is requested,
-# which will not scale.  The default behaviour is to use a cache (see 
+# which will not scale.  The default behaviour is to use a cache (see
 # ItemCounter configuration)
 #
 # The default is to use a cache
@@ -1045,11 +1048,11 @@ webui.strengths.show = false
 ###### ItemCounter Configuration ######
 #
 # Define the DAO class to use. This must correspond to your choice of
-# storage for the browse system (RDBMS: PostgreSQL or Oracle, Solr). 
+# storage for the browse system (RDBMS: PostgreSQL or Oracle, Solr).
 # By default, since DSpace 4.0, the Solr implementation is used.
 #
-# Only if you use a DBMS implementation and want to use the cache 
-# (recommended!), you must run the following command periodically 
+# Only if you use a DBMS implementation and want to use the cache
+# (recommended!), you must run the following command periodically
 # to update the count:
 #
 # [dspace]/bin/itemcounter	(NOT required if you use the Solr implementation)
@@ -1067,8 +1070,8 @@ webui.strengths.show = false
 
 ###### Browse Configuration ######
 #
-# Define the DAO class to use this must meet your storage choice for 
-# the browse system (RDBMS: PostgreSQL or Oracle, Solr). 
+# Define the DAO class to use this must meet your storage choice for
+# the browse system (RDBMS: PostgreSQL or Oracle, Solr).
 # By default, since DSpace 4.0, the Solr implementation is used
 #
 # PostgreSQL:
@@ -1308,7 +1311,7 @@ recent.submissions.sort-option = dateaccessioned
 recent.submissions.count = 0
 
 # name of the browse index to display collection's items.
-# You can set a "item" type of browse index only.                      
+# You can set a "item" type of browse index only.
 #   default = title
 #webui.collectionhome.browse-name = title
 
@@ -1359,7 +1362,7 @@ plugin.single.org.dspace.app.xmlui.aspect.administrative.mapper.SearchRequestPro
 # to show facets on the site home page, community, collection
 # comment out the following lines if you disable Discovery or don't want
 # to show facets on side bars
-# TagCloudProcessor is responsible for displaying a tag-cloud facet on the 
+# TagCloudProcessor is responsible for displaying a tag-cloud facet on the
 # site home page, community or collection home page
 plugin.sequence.org.dspace.plugin.CommunityHomeProcessor = \
         org.dspace.app.webui.components.RecentCommunitySubmissions,\
@@ -1474,7 +1477,7 @@ webui.feed.item.author = dc.contributor.author
 # Add all the communities / collections, separated by commas (no spaces) that should
 # have the iTunes podcast metadata added to their RSS feed.
 # Default: Disabled, No collections or communities have iTunes Podcast enhanced metadata in their feed.
-# webui.feed.podcast.collections =123456789/2,123456789/3 
+# webui.feed.podcast.collections =123456789/2,123456789/3
 # webui.feed.podcast.communities =123456789/1
 
 # Which MIMETypes of Bitstreams would you like to have podcastable in your item?
@@ -1482,8 +1485,8 @@ webui.feed.item.author = dc.contributor.author
 #webui.feed.podcast.mimetypes=audio/x-mpeg
 
 # For the iTunes Podcast Feed, if you would like to specify an external media file,
-# not on your DSpace server to be enclosed within the entry for each item, 
-# specify which metadata field will hold the URI to the external media file. 
+# not on your DSpace server to be enclosed within the entry for each item,
+# specify which metadata field will hold the URI to the external media file.
 # This is useful if you store the metadata in DSpace, and a separate streaming server to host the media.
 # Default: dc.source.uri
 #webui.feed.podcast.sourceuri = dc.source.uri
@@ -1573,7 +1576,7 @@ sitemap.engineurls = http://www.google.com/webmasters/sitemaps/ping?sitemap=
 sherpa.romeo.url = http://www.sherpa.ac.uk/romeo/api29.php
 
 # to disable the sherpa/romeo integration
-# uncomment the follow line 
+# uncomment the follow line
 # webui.submission.sherparomeo-policy-enabled = false
 
 # please register for a free api access key to get many benefits
@@ -1698,9 +1701,9 @@ google-metadata.enable = true
 # These configs are only used by the JSP User Interface         #
 #---------------------------------------------------------------#
 ##### JSPUI Layout #####
-# set this value if you want to use a diffent main template. 
+# set this value if you want to use a diffent main template.
 # The value must match the name of a subfolder of dspace-jspui/src/main/webapp/layout
-# jspui.template.name = 
+# jspui.template.name =
 
 ##### Show community or collection logo in list #####
 # jspui.home-page.logos = true
@@ -1748,10 +1751,10 @@ report.dir = ${dspace.dir}/reports/
 #                             (any or no qualifier)
 #    dc.identifier.uri(link) = DC identifier.uri, render as a link
 #    dc.date.issued(date)   = DC date.issued, render as a date
-#    dc.subject(nobreakline)   = DC subject.keyword, rendered as separated values 
+#    dc.subject(nobreakline)   = DC subject.keyword, rendered as separated values
 #                               (see also webui.itemdisplay.nobreakline.separator option)
 #    dc.language(inputform)   = If the dc.language is in a controlled vocabulary, then the displayed value will be shown based on the stored value from the value-pairs-name in input forms.
-#			      The input-forms will be loaded based on the session locale. If the displayed value is not found, then the value will be shown as is. 	
+#			      The input-forms will be loaded based on the session locale. If the displayed value is not found, then the value will be shown as is.
 #    "link/date" options can be combined with "nobreakline" option using a space among them i.e "dc.identifier.uri(link nobreakline)"
 #
 # If an item has no value for a particular field, it won't be displayed.
@@ -1790,7 +1793,7 @@ report.dir = ${dspace.dir}/reports/
 # already, it is simply rendered as a link with no other manipulation.
 
 # If nobreakline option is applied for a field in itemdisplay then the following option defines the separator string.
-# If a non-breaking space is needed before or after the separator, this can be included using &nbsp; 
+# If a non-breaking space is needed before or after the separator, this can be included using &nbsp;
 # (i.e. webui.itemdisplay.separator = ;&nbsp;)
 # If ommitted, the default separator is ';&nbsp;'
 webui.itemdisplay.nobreakline.separator = ;
@@ -1826,15 +1829,20 @@ plugin.single.org.dspace.app.webui.util.StyleSelection = \
 #
 # If you have enabled thumbnails (webui.browse.thumbnail.show), you must also
 # include a 'thumbnail' entry in your columns - this is where the thumbnail will be displayed
+
 #
-# If you want to mark each item include a 'mark_[value]' (without the brackets - replace the word 'value' with anything that 
+# If you want to mark each item include a 'mark_[value]' (without the brackets - replace the word 'value' with anything that
 # has a meaning for your mark) entry in your columns - this is where the icon will be displayed.
-# Do not forget to add a Spring bean with id = "org.dspace.app.itemmarking.ItemMarkingExtractor.[value]" 
+# Do not forget to add a Spring bean with id = "org.dspace.app.itemmarking.ItemMarkingExtractor.[value]"
 # in file 'config/spring/api/item-marking.xml'. This bean is responsible for drawing the appropriate mark for each item.
 # You can add more than one 'mark_[value]' options (with different value) in case you need to mark items more than one time for
 # different purposes. Remember to add the respective beans in file 'config/spring/api/item-marking.xml'.
 #
 # webui.itemlist.columns = thumbnail, dc.date.issued(date), dc.title, dc.contributor.*
+#
+# You can add a bitstream column in your itemlist or browsing list by adding the 'bitstream' like below (by default this is not enabled)
+#
+# webui.itemlist.columns = thumbnail, dc.date.issued(date), dc.title, dc.contributor.*, bitstream
 #
 # You can customise the width of each column with the following line - you can have numbers (pixels)
 # or percentages. For the 'thumbnail' column, a setting of '*' will use the max width specified
@@ -1971,7 +1979,7 @@ webui.suggest.enable = false
 
 # Check if the user has a consistent ip address from the start of the login process
 # to the end of the login process. Disabling this check is not recommended unless
-# absolutely necessary as the ip check can be helpful for preventing session 
+# absolutely necessary as the ip check can be helpful for preventing session
 # hijacking. Possible reasons to set this to false: many-to-many wireless networks
 # that prevent consistent ip addresses or complex proxying of requests.
 # The default value is set to true.


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2441

In the IR of our university, not all items have file (full text like pdf or we call 全文) , just some of them.
We want a function to show if there is a file in the item at the list view so I write (or maybe hack) some code into the core of dspace.  
My code may not be great, but at least this will work.  
If someone want this function too, they can add 'bitstream' to `webui.itemlist.columns` like line 1845 in `dspace.cfg` and the full version (with the file name and its link) can be enabled by `webui.browse.bitstream.showfull = true` on line 994 in `dspace.cfg`
