### PR TITLE
Fix DS-2427 for 5.1 by consolidating problematic schema code into DatabaseUtils...

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -66,14 +66,12 @@ db.password=dspace
 #db.username=dspace
 #db.password=dspace
 
-# Schema name - if your database contains multiple schemas, you can avoid problems with
-# retrieving the definitions of duplicate object names by specifying
-# the schema name here that is used for DSpace by uncommenting the following entry
-
-# NOTE: this configuration option is for PostgreSQL only. For Oracle, schema is equivalent
-# to user name. DSpace depends on the PostgreSQL understanding of schema. If you are using
-# Oracle, just leave this this value blank.
-
+# Schema name - if your database contains multiple schemas, you can avoid
+# problems with retrieving the definitions of duplicate object names by
+# specifying the schema name that is used for DSpace.
+# ORACLE USAGE NOTE: In Oracle, schema is equivalent to "username". This means
+# specifying a "db.schema" is often unnecessary (i.e. you can leave it blank),
+# UNLESS your Oracle DB Account (in db.username) has access to multiple schemas.
 db.schema = 
 
 # Maximum number of DB connections in pool

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseManager.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseManager.java
@@ -15,7 +15,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.sql.SQLWarning;
 import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -35,8 +34,6 @@ import javax.sql.DataSource;
 import org.apache.commons.lang.StringUtils;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
-import org.flywaydb.core.Flyway;
-import org.flywaydb.core.api.MigrationInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1237,10 +1234,6 @@ public class DatabaseManager
 
         try
         {
-            String schema = canonicalize(ConfigurationManager.getProperty("db.schema"));
-            if(StringUtils.isBlank(schema)){
-                schema = null;
-            }
             String catalog = null;
 
             int dotIndex = table.indexOf('.');
@@ -1254,6 +1247,9 @@ public class DatabaseManager
 
             connection = getConnection();
 
+            // Get current database schema name
+            String schema = DatabaseUtils.getSchemaName(connection);
+            
             DatabaseMetaData metadata = connection.getMetaData();
             Map<String, ColumnInfo> results = new HashMap<String, ColumnInfo>();
 

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -889,7 +889,7 @@ public class DatabaseUtils
         DatabaseMetaData meta = connection.getMetaData();
         
         // Check the configured "db.schema" FIRST for the value configured there
-        schema = ConfigurationManager.getProperty("db.schema");
+        schema = DatabaseManager.canonicalize(ConfigurationManager.getProperty("db.schema"));
         
         // If unspecified, determine "sane" defaults based on DB type
         if(StringUtils.isBlank(schema))

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -873,8 +873,10 @@ public class DatabaseUtils
      * Get the Database Schema Name in use by this Connection, so that it can
      * be used to limit queries in other methods (e.g. tableExists()).
      * <P>
-     * For PostgreSQL, schema is simply what is configured in db.schema or "public"
-     * For Oracle, schema is actually the database *USER* or owner.
+     * NOTE: Once we upgrade to using Apache Commons DBCP / Pool version 2.0,
+     * this method WILL BE REMOVED in favor of java.sql.Connection's new
+     * "getSchema()" method.
+     * http://docs.oracle.com/javase/7/docs/api/java/sql/Connection.html#getSchema()
      * 
      * @param connection 
      *            Current Database Connection
@@ -886,27 +888,29 @@ public class DatabaseUtils
         String schema = null;
         DatabaseMetaData meta = connection.getMetaData();
         
-        // Determine our DB type
-        String dbType = DatabaseManager.findDbKeyword(meta);
+        // Check the configured "db.schema" FIRST for the value configured there
+        schema = ConfigurationManager.getProperty("db.schema");
         
-        if(dbType.equals(DatabaseManager.DBMS_POSTGRES))
+        // If unspecified, determine "sane" defaults based on DB type
+        if(StringUtils.isBlank(schema))
         {
-            // Get the schema name from "db.schema"
-            schema = ConfigurationManager.getProperty("db.schema");
-            
-            // If unspecified, default schema is "public"
-            if(StringUtils.isBlank(schema)){
+            String dbType = DatabaseManager.findDbKeyword(meta);
+        
+            if(dbType.equals(DatabaseManager.DBMS_POSTGRES))
+            {
+                // For PostgreSQL, the default schema is named "public"
+                // See: http://www.postgresql.org/docs/9.0/static/ddl-schemas.html
                 schema = "public";
             }
+            else if (dbType.equals(DatabaseManager.DBMS_ORACLE))
+            {
+                // For Oracle, default schema is actually the user account
+                // See: http://stackoverflow.com/a/13341390
+                schema = meta.getUserName();
+            }
+            else
+                schema = null;
         }
-        else if (dbType.equals(DatabaseManager.DBMS_ORACLE))
-        {
-            // Schema is actually the user account
-            // See: http://stackoverflow.com/a/13341390
-            schema = meta.getUserName();
-        }
-        else
-            schema = null;
         
         return schema;
     }

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -63,9 +63,9 @@ db.password = ${db.password}
 # Schema name - if your database contains multiple schemas, you can avoid
 # problems with retrieving the definitions of duplicate object names by
 # specifying the schema name that is used for DSpace.
-# NOTE: this configuration option is for PostgreSQL only. For Oracle, schema
-# is equivalent to user name. DSpace depends on the PostgreSQL understanding
-# of schema. If you are using Oracle, just leave this this value blank.
+# ORACLE USAGE NOTE: In Oracle, schema is equivalent to "username". This means
+# specifying a "db.schema" is often unnecessary (i.e. you can leave it blank),
+# UNLESS your Oracle DB Account (in db.username) has access to multiple schemas.
 db.schema = ${db.schema}
 
 ## Connection pool parameters


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2427

While, ideally, we'd want to move to using "java.sql.Connection's" new "getSchema()" method, that's not available until we upgrade to Apache Commons DBCP and Pool versions 2.0. But, both of these are major upgrades, and would require code changes/refactoring that would need to wait for DSpace 6. See ticket for more info.

So, in order to "fix" DS-2427 in DSpace 5.1, I've simply consolidated the schema logic code into the `DatabaseUtils.getSchemaName()` method (and refactored that method slightly to allow Oracle users to also use "db.schema"). I've also updated the comments in dspace.cfg/build.properties to make it clear that Oracle users are able to use "db.schema", but that it's normally unnecessary.

This PR does need some more verification testing (especially on Oracle). I've done a little on PostgreSQL, and it passes all Unit Tests.
