### PR TITLE
[DS-2444] fixed wrong time zone for statistic events.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/ElasticSearchLogger.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/ElasticSearchLogger.java
@@ -242,7 +242,8 @@ public class ElasticSearchLogger {
             docBuilder.field("type", Constants.typeText[dspaceObject.getType()]);
 
             // Save the current time
-            docBuilder.field("time", DateFormatUtils.format(new Date(), DATE_FORMAT_8601));
+            docBuilder.field("time",
+                    DateFormatUtils.formatUTC(new Date(), DATE_FORMAT_8601));
             if (currentUser != null) {
                 docBuilder.field("epersonid", currentUser.getID());
             }
@@ -359,7 +360,8 @@ public class ElasticSearchLogger {
             docBuilder.field("type", Constants.typeText[dspaceObject.getType()]);
 
             // Save the current time
-            docBuilder.field("time", DateFormatUtils.format(new Date(), DATE_FORMAT_8601));
+            docBuilder.field("time",
+                    DateFormatUtils.formatUTC(new Date(), DATE_FORMAT_8601));
             if (currentUser != null) {
                 docBuilder.field("epersonid", currentUser.getID());
             }

--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLogger.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLogger.java
@@ -367,7 +367,8 @@ public class SolrLogger
             storeParents(doc1, dspaceObject);
         }
         // Save the current time
-        doc1.addField("time", DateFormatUtils.format(new Date(), DATE_FORMAT_8601));
+        doc1.addField("time",
+                DateFormatUtils.formatUTC(new Date(), DATE_FORMAT_8601));
         if (currentUser != null)
         {
             doc1.addField("epersonid", currentUser.getID());
@@ -452,7 +453,8 @@ public class SolrLogger
             storeParents(doc1, dspaceObject);
         }
         // Save the current time
-        doc1.addField("time", DateFormatUtils.format(new Date(), DATE_FORMAT_8601));
+        doc1.addField("time",
+                DateFormatUtils.formatUTC(new Date(), DATE_FORMAT_8601));
         if (currentUser != null)
         {
             doc1.addField("epersonid", currentUser.getID());


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2444

The statistic loggers didn't set a time zone for the formatter. So if the server has a time zone which ist not UTC/ZULU it logs a wrong time for an event. 

**To reproduce the error** 
1. Setup a Server with a time zone which is not UTC
2. Produce an event (like the view of an item)
3. Reload the solr core at the admin view (http://localhost:8080/solr/#/~cores/statistics) to make the event visible immediately
4. Query the solr core sorting by date desc: (http://localhost:8080/solr/statistics/select?q=_%3A_&sort=time+desc&wt=json&indent=true)
