### PR TITLE
DS-2278 : Fix two issues in XMLUI which block proper 404 error pages from displaying for some URL patterns

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/springmvc/ResourceIdentifierController.java
+++ b/dspace-xmlui/src/main/java/org/dspace/springmvc/ResourceIdentifierController.java
@@ -66,7 +66,7 @@ public class ResourceIdentifierController {
 
             DSpaceObject dso = dis.resolve(context, prefix);
 
-            if (dso == null) throw new RuntimeException("Cannot find Item!");
+            if (dso == null) throw new IdentifierNotFoundException("Cannot find Item " + prefix + "!");
 
             request.setAttribute(DSPACE_OBJECT, dso);
 

--- a/dspace-xmlui/src/main/webapp/sitemap.xmap
+++ b/dspace-xmlui/src/main/webapp/sitemap.xmap
@@ -646,6 +646,14 @@
                         <map:read src="static/{1}/{2}"/>
                     </map:match>
 
+                    <!-- DSpace does not have any paths beginning with numbers (0-9). If one is accessed,
+                         assume that it is an identifier & redirect it. This also avoids an internal
+                         error, where the XMLUI AspectMatcher wrongly assumes numbers at beginning
+                         of path are direct references to individual Aspects in the aspect chain.-->
+                    <map:match type="regexp" pattern="(^[0-9]+\/?.*$)">
+                        <map:redirect-to uri="{request:contextPath}/handle/{1}" permanent="yes"/>
+                    </map:match>
+
                 </map:pipeline>
                 
                 <!-- pipline to run external handle server -->


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2278

This PR fixes two bugs in the XMLUI which accidentally block 404 error pages from displaying for certain URL patterns.
- **Issue 1:** When accessing the "/handle" path, DSpace seems to assume that you'll always send a [prefix]/[suffix]. So, if you don't pass a [suffix], then it causes errors. For example: http://demo.dspace.org/xmlui/handle/1234
  - This issue is fixed by a minor change to the `org.dspace.springmvc.ResourceIdentifierController`. When an invalid Handle was passed on the URL path, it was throwing a "RuntimeException" behind the scenes (which killed all XMLUI processing & caused a blank screen).  Instead, it should throw an "IdentifierNotFoundException" which will trigger a proper 404 error
- **Issue 2:**  Paths that begin with a number (0-9) do NOT work properly in the XMLUI. It seems that the XMLUI forwards those paths on to its `AspectMatcher`, which wrongly assumes that the number references the index of an Aspect in the configured aspect chain (in `xmlui.xconf`).
  - This issue is fixed by an addition to the root `sitemap.xmap` which _redirects_ any URLs beginning with a number (0-9) to the "/handle/" path.  Because the [`AspectGenerator` prepends numbers to the URL path](https://github.com/DSpace/DSpace/blob/master/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/AspectGenerator.java#L75) to "step" through the Aspect chain (in conjunction with the `AspectMatcher`), we need to "catch" any paths starting with numbers prior to passing them along to the Theme & Aspects.  By default, no pages in DSpace start with a number, so I decided to simply "assume" the user may be attempting to access an object by its identifier and redirect them to "/handle/[identifier]".

Comments welcome! I also will note that while the fix for _Issue 2_ may seem odd (putting in a redirect), I could find no other way to patch the underlying code since the Aspect chain _relies on_ prepending integers to the existing path. So, I made the decision to simply catch those URLs when entered by a user, and redirect them before the Aspect chain attempts to process them.
