### PR TITLE
[DS-1702] XSS injection possible on recent submission (JSPUI)

### DIFF
--- a/dspace-jspui/src/main/webapp/collection-home.jsp
+++ b/dspace-jspui/src/main/webapp/collection-home.jsp
@@ -377,7 +377,7 @@
 			{
 				if (dcv.length > 0)
 				{
-					displayTitle = dcv[0].value;
+					displayTitle = Utils.addEntities(dcv[0].value);
 				}
 			}
 			%><p class="recentItem"><a href="<%= request.getContextPath() %>/handle/<%= items[i].getHandle() %>"><%= displayTitle %></a></p><%

--- a/dspace-jspui/src/main/webapp/community-home.jsp
+++ b/dspace-jspui/src/main/webapp/community-home.jsp
@@ -157,7 +157,7 @@
 			{
 				if (dcv.length > 0)
 				{
-					displayTitle = dcv[0].value;
+					displayTitle = Utils.addEntities(dcv[0].value);
 				}
 			}
 			%>

--- a/dspace-jspui/src/main/webapp/home.jsp
+++ b/dspace-jspui/src/main/webapp/home.jsp
@@ -15,6 +15,7 @@
   -    recent.submissions - RecetSubmissions
   --%>
 
+<%@page import="org.dspace.core.Utils"%>
 <%@page import="org.dspace.content.Bitstream"%>
 <%@ page contentType="text/html;charset=UTF-8" %>
 
@@ -113,13 +114,13 @@ if (submissions != null && submissions.count() > 0)
 		        String displayTitle = "Untitled";
 		        if (dcv != null & dcv.length > 0)
 		        {
-		            displayTitle = dcv[0].value;
+		            displayTitle = Utils.addEntities(dcv[0].value);
 		        }
 		        dcv = item.getMetadata("dc", "description", "abstract", Item.ANY);
 		        String displayAbstract = "";
 		        if (dcv != null & dcv.length > 0)
 		        {
-		            displayAbstract = dcv[0].value;
+		            displayAbstract = Utils.addEntities(dcv[0].value);
 		        }
 		%>
 		    <div style="padding-bottom: 50px; min-height: 200px;" class="item <%= first?"active":""%>">

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1304,8 +1304,8 @@ webui.browse.link.1 = author:dc.contributor.*
 recent.submissions.sort-option = dateaccessioned
 
 # how many recent submissions should be displayed at any one time
-# Set to 0 since discovery uses a separate configuration for this
-recent.submissions.count = 0
+# setting that applies only to JSPUI (for XMLUI set to 0 since discovery uses a separate configuration for this)
+recent.submissions.count = 5
 
 # name of the browse index to display collection's items.
 # You can set a "item" type of browse index only.                      


### PR DESCRIPTION
This PR addresses the resolution for the possible XSS injection in the "recent submissions" excerpt (in homepage, collection home and community home) as mentioned in https://jira.duraspace.org/browse/DS-1702

The PR contains also a change on configuration (see dspace.cfg). Now the default for "how many recent submission should be displayed" is set to 5. Also I have modified the comment above the line to clarify that is only for JSPUI. I have seen in XMLUI code and i think that this configuration is not used. But i need a double check from a XMLUI developer.
