### PR TITLE
[DS-2465] Removed property not used in constructor

### DIFF
--- a/dspace-api/src/main/java/org/dspace/browse/BrowseIndex.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseIndex.java
@@ -117,7 +117,6 @@ public final class BrowseIndex
         try
         {
             boolean valid = true;
-            this.defaultOrder = SortOption.ASCENDING;
             this.number = number;
 
             String rx = "(\\w+):(\\w+):([\\w\\.\\*,]+):?(\\w*):?(\\w*)";


### PR DESCRIPTION
variable defaultOrder - Removed line in constructor method because value has been setted in variable definition on line 59.
 https://github.com/DSpace/DSpace/blob/master/dspace-api/src/main/java/org/dspace/browse/BrowseIndex.java#L59
