### PR TITLE
DS-2477 : Ensure distribution packages always get created with Unix (LF) line endings

### DIFF
--- a/dspace/src/main/assembly/release.xml
+++ b/dspace/src/main/assembly/release.xml
@@ -43,6 +43,8 @@
             <exclude>**/target/**</exclude>
             <exclude>.*</exclude>
          </excludes>
+         <!-- Ensure line endings in all files are Unix (LF) line endings-->
+         <lineEnding>unix</lineEnding>
       </fileSet>
    </fileSets>
 

--- a/dspace/src/main/assembly/src-release.xml
+++ b/dspace/src/main/assembly/src-release.xml
@@ -34,6 +34,8 @@
             <exclude>**/target/**</exclude>
             <exclude>.*</exclude>
          </excludes>
+         <!-- Ensure line endings in all files are Unix (LF) line endings-->
+         <lineEnding>unix</lineEnding>
       </fileSet>
    </fileSets>
 


### PR DESCRIPTION
PR should be pretty self explanatory and a tiny change. This should be backported to the 5.x, 4.x and 3.x branches, since all are still "under support".

https://jira.duraspace.org/browse/DS-2477

I've tested this on Windows. Distribution Zips now get created with Unix line endings even on Windows. As this is a tiny change, I'll get it merged as soon as Travis gives the OK.
