### PR TITLE
DS-3109: Introduce a VersionedHandleIdentifierProvider that creates new handles for each version

### DIFF
--- a/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
@@ -37,8 +37,6 @@ public class HandleIdentifierProvider extends IdentifierProvider {
     /** Prefix registered to no one */
     protected static final String EXAMPLE_PREFIX = "123456789";
 
-    protected String[] supportedPrefixes = new String[]{"info:hdl", "hdl", "http://"};
-
     @Autowired(required = true)
     protected HandleService handleService;
     @Autowired(required = true)
@@ -52,23 +50,21 @@ public class HandleIdentifierProvider extends IdentifierProvider {
     @Override
     public boolean supports(String identifier)
     {
-        for(String prefix : supportedPrefixes){
-            if(identifier.startsWith(prefix))
-            {
-                return true;
-            }
+        String prefix = handleService.getPrefix();
+        String handleResolver = ConfigurationManager.getProperty("handle.canonical.prefix");
+        if (identifier == null)
+        {
+            return false;
         }
-
-        try {
-            String outOfUrl = retrieveHandleOutOfUrl(identifier);
-            if(outOfUrl != null)
-            {
-                return true;
-            }
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
+        if (identifier.startsWith(prefix)
+                || identifier.startsWith(handleResolver)
+                || identifier.startsWith("http://hdl.handle.net/")
+                || identifier.startsWith("hdl:")
+                || identifier.startsWith("info:hdl"))
+        {
+            return true;
         }
-
+        
         return false;
     }
 

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
@@ -48,8 +48,6 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
 
     private static final char DOT = '.';
 
-    private String[] supportedPrefixes = new String[]{"info:hdl", "hdl", "http://"};
-
     @Autowired(required = true)
     private VersioningService versionService;
 
@@ -71,24 +69,21 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
     @Override
     public boolean supports(String identifier)
     {
-        for(String prefix : supportedPrefixes)
+        String prefix = handleService.getPrefix();
+        String handleResolver = ConfigurationManager.getProperty("handle.canonical.prefix");
+        if (identifier == null)
         {
-            if(identifier.startsWith(prefix))
-            {
-                return true;
-            }
+            return false;
         }
-
-        try {
-            String outOfUrl = retrieveHandleOutOfUrl(identifier);
-            if(outOfUrl != null)
-            {
-                return true;
-            }
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
+        if (identifier.startsWith(prefix)
+                || identifier.startsWith(handleResolver)
+                || identifier.startsWith("http://hdl.handle.net/")
+                || identifier.startsWith("hdl:")
+                || identifier.startsWith("info:hdl"))
+        {
+            return true;
         }
-
+        
         return false;
     }
 

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
@@ -428,9 +428,10 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
         return identifier;
     }
     
-    protected void populateHandleMetadata(Context context, Item item, String handleref)
+    protected void populateHandleMetadata(Context context, Item item, String handle)
             throws SQLException, IOException, AuthorizeException
     {
+        String handleref = getCanonicalForm(handle);
         // we want to remove the old handle and insert the new. To do so, we 
         // load all identifiers, clear the metadata field, re add all 
         // identifiers which are not from type handle and add the new handle.

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
@@ -1,0 +1,445 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.identifier;
+
+import org.apache.log4j.Logger;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.*;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.ConfigurationManager;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.core.LogManager;
+import org.dspace.handle.service.HandleService;
+import org.dspace.versioning.*;
+import org.dspace.versioning.service.VersionHistoryService;
+import org.dspace.versioning.service.VersioningService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Date;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ *
+ *
+ * @author Fabio Bolognesi (fabio at atmire dot com)
+ * @author Mark Diggory (markd at atmire dot com)
+ * @author Ben Bosman (ben at atmire dot com)
+ * @author Pascal-Nicolas Becker (dspace at pascal dash becker dot de)
+ */
+@Component
+public class VersionedHandleIdentifierProvider extends IdentifierProvider {
+    /** log4j category */
+    private static Logger log = Logger.getLogger(VersionedHandleIdentifierProvider.class);
+
+    /** Prefix registered to no one */
+    static final String EXAMPLE_PREFIX = "123456789";
+
+    private static final char DOT = '.';
+
+    private String[] supportedPrefixes = new String[]{"info:hdl", "hdl", "http://"};
+
+    @Autowired(required = true)
+    private VersioningService versionService;
+
+    @Autowired(required = true)
+    private VersionHistoryService versionHistoryService;
+
+    @Autowired(required = true)
+    private HandleService handleService;
+
+    @Autowired(required = true)
+    private ItemService itemService;
+
+    @Override
+    public boolean supports(Class<? extends Identifier> identifier)
+    {
+        return Handle.class.isAssignableFrom(identifier);
+    }
+
+    @Override
+    public boolean supports(String identifier)
+    {
+        for(String prefix : supportedPrefixes)
+        {
+            if(identifier.startsWith(prefix))
+            {
+                return true;
+            }
+        }
+
+        try {
+            String outOfUrl = retrieveHandleOutOfUrl(identifier);
+            if(outOfUrl != null)
+            {
+                return true;
+            }
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
+        }
+
+        return false;
+    }
+
+    @Override
+    public String register(Context context, DSpaceObject dso)
+    {
+        String id = mint(context, dso);
+        try
+        {
+            if (dso instanceof Item)
+            {
+                populateHandleMetadata(context, (Item) dso, id);
+            }
+        }catch (Exception e){
+            log.error(LogManager.getHeader(context, "Error while attempting to create handle", "Item id: " + (dso != null ? dso.getID() : "")), e);
+            throw new RuntimeException("Error while attempting to create identifier for Item id: " + (dso != null ? dso.getID() : ""));
+        }
+        return id;
+    }
+
+    @Override
+    public void register(Context context, DSpaceObject dso, String identifier)
+            throws IdentifierException
+    {
+        if (dso instanceof Item && identifier != null)
+        {
+            Item item = (Item) dso;
+
+            // if identifier == 1234.5/100.4 reinstate the version 4 in the 
+            // version table if absent
+            Matcher versionHandleMatcher = Pattern.compile("^.*/.*\\.(\\d+)$").matcher(identifier);
+            if(versionHandleMatcher.matches())
+            {
+                // parse the version number from the handle
+                int versionNumber = -1;
+                try {
+                    versionNumber = Integer.valueOf(versionHandleMatcher.group(1));
+                } catch (NumberFormatException ex) {
+                    throw new IllegalStateException("Cannot detect the interger value of a digit.", ex);
+                }
+                // get history
+                VersionHistory history = null;
+                try {
+                    history = versionHistoryService.findByItem(context, item);
+                } catch (SQLException ex) {
+                    throw new RuntimeException("Unable to create handle '" 
+                        + identifier + "' for " 
+                        + Constants.typeText[dso.getType()] + " " + dso.getID() 
+                        + " in cause of a problem with the database: ", ex);
+                }
+                
+                if (history != null)
+                {
+                    // get version
+                    Version version = null;
+                    try {
+                        versionHistoryService.getVersion(context, history, item);
+                    } catch (SQLException ex) {
+                        throw new RuntimeException("Problem with the database connection occurd.", ex);
+                    }
+                    if (version != null)
+                    {
+                        if (version.getVersionNumber() != versionNumber)
+                        {
+                            throw new IdentifierException("Trying to register a handle without matching its item's version number.");
+                        }
+                        // version numbers matches, just create the handle
+                        try {
+                            handleService.createHandle(context, dso, identifier);
+                            populateHandleMetadata(context, item, identifier);
+                            return;
+                        } catch (AuthorizeException ex) {
+                            throw new IdentifierException("Current user does not "
+                                    + "have the privileges to add the handle " 
+                                    + identifier + " to the item's (" 
+                                    + dso.getID() + ") metadata.", ex);
+                        } catch (SQLException | IOException ex) {
+                            throw new RuntimeException("Unable to create handle '"
+                            + identifier + "' for "
+                            + Constants.typeText[dso.getType()] + " " + dso.getID()
+                            + ".", ex);
+                        }
+                    }
+                } else {
+                    try {
+                        // either no VersionHistory or no Version exists.
+                        // Restore item with the appropriate version number.
+                        restoreItAsVersion(context, item, identifier, versionNumber);
+                    } catch (SQLException | IOException ex) {
+                        throw new RuntimeException("Unable to restore a versioned "
+                                + "handle as there was a problem in creating a "
+                                + "neccessary item version: ", ex);
+                    } catch (AuthorizeException ex) {
+                        throw new RuntimeException("Unable to restore a versioned "
+                                + "handle as the current user was not allowed to "
+                                + "create a neccessary item version: ", ex);
+                    }
+                    return;
+                }
+            }
+        }
+        try {
+            // either we have a DSO not of type object or the handle was not a
+            // versioned (e.g. 123456789/100) one
+            // just register it.
+            createNewIdentifier(context, dso, identifier);
+            if (dso instanceof Item) {
+                    populateHandleMetadata(context, (Item) dso, identifier);
+            }
+        } catch (SQLException ex) {
+            throw new RuntimeException("Unable to create handle '" 
+                            + identifier + "' for " 
+                            + Constants.typeText[dso.getType()] + " " + dso.getID() 
+                            + " in cause of a problem with the database: ", ex);
+        } catch (AuthorizeException ex) {
+                    throw new IdentifierException("Current user does not "
+                            + "have the privileges to add the handle " 
+                            + identifier + " to the item's (" 
+                            + dso.getID() + ") metadata.", ex);
+        } catch (IOException ex) {
+            throw new RuntimeException("Unable add the handle '"
+            + identifier + "' for "
+            + Constants.typeText[dso.getType()] + " " + dso.getID()
+            + " in the object's metadata.", ex);
+        }
+    }
+
+    // get VersionHistory by handle
+    protected VersionHistory getHistory(Context context, String identifier) throws SQLException {
+        DSpaceObject item = this.resolve(context, identifier);
+        if(item!=null){
+            VersionHistory history = versionHistoryService.findByItem(context, (Item) item);
+            return history;
+        }
+        return null;
+    }
+
+    protected void restoreItAsVersion(Context context, Item item, String identifier, int versionNumber)
+            throws SQLException, AuthorizeException, IOException
+    {
+        createNewIdentifier(context, item, identifier);
+        populateHandleMetadata(context, item, identifier);
+        
+        VersionHistory vh = versionHistoryService.findByItem(context, item);
+        if (vh == null)
+        {
+            vh = versionHistoryService.create(context);
+        }
+        Version version = versionHistoryService.getVersion(context, vh, item);
+        if (version == null)
+        {
+            version = versionService.createNewVersion(context, vh, item, "Restoring from AIP Service", new Date(), versionNumber);
+        }
+        versionHistoryService.update(context, vh);
+    }
+
+    @Override
+    public void reserve(Context context, DSpaceObject dso, String identifier)
+    {
+        try{
+            handleService.createHandle(context, dso, identifier);
+        }catch(Exception e){
+            log.error(LogManager.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
+            throw new RuntimeException("Error while attempting to create identifier for Item id: " + dso.getID());
+        }
+    }
+
+
+    /**
+     * Creates a new handle in the database.
+     *
+     * @param context DSpace context
+     * @param dso The DSpaceObject to create a handle for
+     * @return The newly created handle
+     */
+    @Override
+    public String mint(Context context, DSpaceObject dso)
+    {
+        if(dso.getHandle() != null)
+        {
+            return dso.getHandle();
+        }
+
+        try{
+            String handleId = null;
+            VersionHistory history = null;
+            if(dso instanceof Item)
+            {
+                history = versionHistoryService.findByItem(context, (Item) dso);
+            }
+
+            if(history!=null)
+            {
+                handleId = makeIdentifierBasedOnHistory(context, dso, history);
+            }else{
+                handleId = createNewIdentifier(context, dso, null);
+            }
+            return handleId;
+        }catch (Exception e){
+            log.error(LogManager.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
+            throw new RuntimeException("Error while attempting to create identifier for Item id: " + dso.getID());
+        }
+    }
+
+    @Override
+    public DSpaceObject resolve(Context context, String identifier, String... attributes)
+    {
+        // We can do nothing with this, return null
+        try{
+            return handleService.resolveToObject(context, identifier);
+        }catch (Exception e){
+            log.error(LogManager.getHeader(context, "Error while resolving handle to item", "handle: " + identifier), e);
+        }
+        return null;
+    }
+
+    @Override
+    public String lookup(Context context, DSpaceObject dso) throws IdentifierNotFoundException, IdentifierNotResolvableException {
+
+        try
+        {
+            return handleService.findHandle(context, dso);
+        }catch(SQLException sqe){
+            throw new IdentifierNotResolvableException(sqe.getMessage(),sqe);
+        }
+    }
+
+    @Override
+    public void delete(Context context, DSpaceObject dso, String identifier) throws IdentifierException {
+        delete(context, dso);
+    }
+
+    @Override
+    public void delete(Context context, DSpaceObject dso) throws IdentifierException {
+        try{
+            handleService.unbindHandle(context, dso);
+        } catch(SQLException sqe) {
+            throw new RuntimeException(sqe.getMessage(),sqe);
+        }
+    }
+
+    public static String retrieveHandleOutOfUrl(String url) throws SQLException
+    {
+        // We can do nothing with this, return null
+        if (!url.contains("/")) return null;
+
+        String[] splitUrl = url.split("/");
+
+        return splitUrl[splitUrl.length - 2] + "/" + splitUrl[splitUrl.length - 1];
+    }
+
+    /**
+     * Get the configured Handle prefix string, or a default
+     * @return configured prefix or "123456789"
+     */
+    public static String getPrefix()
+    {
+        String prefix = ConfigurationManager.getProperty("handle.prefix");
+        if (null == prefix)
+        {
+            prefix = EXAMPLE_PREFIX; // XXX no good way to exit cleanly
+            log.error("handle.prefix is not configured; using " + prefix);
+        }
+        return prefix;
+    }
+
+    protected static String getCanonicalForm(String handle)
+    {
+
+        // Let the admin define a new prefix, if not then we'll use the
+        // CNRI default. This allows the admin to use "hdl:" if they want to or
+        // use a locally branded prefix handle.myuni.edu.
+        String handlePrefix = ConfigurationManager.getProperty("handle.canonical.prefix");
+        if (handlePrefix == null || handlePrefix.length() == 0)
+        {
+            handlePrefix = "http://hdl.handle.net/";
+        }
+
+        return handlePrefix + handle;
+    }
+
+    protected String createNewIdentifier(Context context, DSpaceObject dso, String handleId) throws SQLException {
+        if(handleId == null)
+        {
+            return handleService.createHandle(context, dso);
+        }else{
+            return handleService.createHandle(context,  dso, handleId);
+        }
+    }
+
+    protected String makeIdentifierBasedOnHistory(Context context, DSpaceObject dso, VersionHistory history) throws AuthorizeException, SQLException
+    {
+        if (!(dso instanceof Item))
+        {
+            throw new IllegalStateException("Cannot create versioned handle for "
+                    + "objects other then item: Currently versioning supports "
+                    + "items only.");
+        }
+        Item item = (Item)dso;
+        
+        // The first version will have a handle like 12345/100 to be backward compatible
+        // to DSpace installation that started without versioning.
+        // Mint foreach new VERSION an identifier like: 12345/100.versionNumber.
+        
+        Version version = versionService.getVersion(context, item);
+        Version firstVersion = versionHistoryService.getFirstVersion(context, history);
+
+        String bareHandle = firstVersion.getItem().getHandle();
+        if(bareHandle.matches(".*/.*\\.\\d+"))
+        {
+            bareHandle = bareHandle.substring(0, bareHandle.lastIndexOf(DOT));
+        }
+
+        // add a new Identifier for new item: 12345/100.x
+        int versionNumber = version.getVersionNumber();
+        String identifier = bareHandle;
+
+        if (versionNumber > 1)
+        {
+            identifier = identifier.concat(String.valueOf(DOT)).concat(String.valueOf(versionNumber));
+        }
+
+        // Ensure this handle does not exist already.
+        if (handleService.resolveToObject(context, identifier) == null)
+        {
+             handleService.createHandle(context, dso, identifier);
+        }
+        else
+        {
+            throw new IllegalStateException("A versioned handle is used for another version already!");
+        }
+        return identifier;
+    }
+
+    protected void populateHandleMetadata(Context context, Item item, String handleref)
+            throws SQLException, IOException, AuthorizeException
+    {
+        // Add handle as identifier.uri DC value.
+        // First check that identifier doesn't already exist.
+        boolean identifierExists = false;
+        List<MetadataValue> identifiers = itemService.getMetadata(item, MetadataSchema.DC_SCHEMA, "identifier", "uri", Item.ANY);
+        for (MetadataValue identifier : identifiers)
+        {
+            if (handleref.equals(identifier.getValue()))
+            {
+                identifierExists = true;
+            }
+        }
+        if (!identifierExists)
+        {
+            itemService.addMetadata(context, item, MetadataSchema.DC_SCHEMA, "identifier", "uri", null, handleref);
+        }
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
@@ -35,9 +35,9 @@ import java.util.List;
  * @author Ben Bosman (ben at atmire dot com)
  */
 @Component
-public class VersionedHandleIdentifierProvider extends IdentifierProvider {
+public class VersionedHandleIdentifierProviderWithCanonicalHandles extends IdentifierProvider {
     /** log4j category */
-    private static Logger log = Logger.getLogger(VersionedHandleIdentifierProvider.class);
+    private static Logger log = Logger.getLogger(VersionedHandleIdentifierProviderWithCanonicalHandles.class);
 
     /** Prefix registered to no one */
     static final String EXAMPLE_PREFIX = "123456789";

--- a/dspace-api/src/test/java/org/dspace/content/InstallItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/InstallItemTest.java
@@ -118,7 +118,7 @@ public class InstallItemTest extends AbstractUnitTest
     public void testInstallItem_validHandle() throws Exception
     {
         context.turnOffAuthorisationSystem();
-        String handle = "1345/567";
+        String handle = "123456789/567";
         WorkspaceItem is = workspaceItemService.create(context, collection, false);
       
         //Test assigning a specified handle to an item
@@ -145,7 +145,7 @@ public class InstallItemTest extends AbstractUnitTest
                 authorizeService.isAdmin((Context) any); result = true;
         }};
 
-        String handle = "1345/567";
+        String handle = "123456789/567";
         WorkspaceItem is = workspaceItemService.create(context, collection, false);
         WorkspaceItem is2 = workspaceItemService.create(context, collection, false);
         
@@ -166,7 +166,7 @@ public class InstallItemTest extends AbstractUnitTest
     public void testRestoreItem() throws Exception
     {
         context.turnOffAuthorisationSystem();
-        String handle = "1345/567";
+        String handle = "123456789/567";
         WorkspaceItem is = workspaceItemService.create(context, collection, false);
 
         //get current date
@@ -236,7 +236,7 @@ public class InstallItemTest extends AbstractUnitTest
     {
         //create a dummy WorkspaceItem
         context.turnOffAuthorisationSystem();
-        String handle = "1345/567";
+        String handle = "123456789/567";
         WorkspaceItem is = workspaceItemService.create(context, collection, false);
 
         // Set "today" as "dc.date.issued"
@@ -267,7 +267,7 @@ public class InstallItemTest extends AbstractUnitTest
     {
         //create a dummy WorkspaceItem with no dc.date.issued
         context.turnOffAuthorisationSystem();
-        String handle = "1345/567";
+        String handle = "123456789/567";
         WorkspaceItem is = workspaceItemService.create(context, collection, false);
 
         Item result = installItemService.installItem(context, is, handle);
@@ -286,7 +286,7 @@ public class InstallItemTest extends AbstractUnitTest
     {
         //create a dummy WorkspaceItem
         context.turnOffAuthorisationSystem();
-        String handle = "1345/567";
+        String handle = "123456789/567";
         WorkspaceItem is = workspaceItemService.create(context, collection, false);
 
         // Set "today" as "dc.date.issued"

--- a/dspace-api/src/test/java/org/dspace/content/VersioningTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/VersioningTest.java
@@ -56,7 +56,7 @@ public class VersioningTest extends AbstractUnitTest {
     protected VersioningService versionService = VersionServiceFactory.getInstance().getVersionService();
     protected VersionHistoryService versionHistoryService = VersionServiceFactory.getInstance().getVersionHistoryService();
 
-    //A regex that can be used to see if a handle contains the format of handle created by the org.dspace.identifier.VersionedHandleIdentifierProvider
+    //A regex that can be used to see if a handle contains the format of handle created by the org.dspace.identifier.VersionedHandleIdentifierProvider*
     protected String versionedHandleRegex = ConfigurationManager.getProperty("handle.prefix") + "\\/[0-9]*\\.[0-9]";
 
     /**
@@ -147,13 +147,20 @@ public class VersioningTest extends AbstractUnitTest {
         assertThat("Test_version_handle 1", versionedItem.getHandle(), notNullValue());
         assertThat("Test_version_handle 2", originalItem.getHandle(), notNullValue());
         assertTrue("Test_version_handle 3 ", originalItem.getHandles().size() == 1);
-        assertTrue("Test_version_handle 4 ", versionedItem.getHandles().size() == 2);
-        assertTrue("Test_version_handle 5 ", originalItem.getHandle().matches(versionedHandleRegex));
-        assertTrue("Test_version_handle 6 ", originalItem.getHandle().startsWith(originalHandle + "."));
-        //The getHandle method should always return the original handle
-        assertTrue("Test_version_handle 7 ", versionedItem.getHandle().equals(originalHandle));
-        assertTrue("Test_version_handle 8 ", versionedItem.getHandles().get(1).getHandle().startsWith(originalHandle + "."));
-        assertTrue("Test_version_handle 9 ", versionedItem.getHandles().get(1).getHandle().matches(versionedHandleRegex));
+        
+        /* The following assertments are specific to the VersionHandleIdentifier 
+         * that use "canonical" handles that are moved from version to version.
+         * It would be good to create Tests for each IdentifierProvider, which
+         * would need to tell spring which one to use for which test.
+         *
+         * assertTrue("Test_version_handle 4 ", versionedItem.getHandles().size() == 2);
+         * assertTrue("Test_version_handle 5 ", originalItem.getHandle().matches(versionedHandleRegex));
+         * assertTrue("Test_version_handle 6 ", originalItem.getHandle().startsWith(originalHandle + "."));
+         * //The getHandle method should always return the original handle
+         * assertTrue("Test_version_handle 7 ", versionedItem.getHandle().equals(originalHandle));
+         * assertTrue("Test_version_handle 8 ", versionedItem.getHandles().get(1).getHandle().startsWith(originalHandle + "."));
+         * assertTrue("Test_version_handle 9 ", versionedItem.getHandles().get(1).getHandle().matches(versionedHandleRegex));
+         */
     }
 
     @Test

--- a/dspace/config/spring/api/identifier-service.xml
+++ b/dspace/config/spring/api/identifier-service.xml
@@ -21,9 +21,26 @@
           autowire="byType"
           scope="singleton"/>
 
-   <!-- provider for using the versioned handle identifier instead of the default one. -->
+      <!-- If you enabled versioning, you should use one of the versioned
+           handle identifier provider instead of the default one. 
+           The VersionedHandleIdentifierProvider creates a new versioned
+           handle for every new version.
+           -->
     <!--
     <bean id="org.dspace.identifier.HandleIdentifierProvider" class="org.dspace.identifier.VersionedHandleIdentifierProvider" scope="singleton">
+        <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
+    </bean>
+    -->
+    <!--
+           The VersionedHandleIdentifierProviderWithCanonicalHandles
+           preserves the first handle for every new version. Whenever
+           a new version is created the previous version gets a new
+           handle. This leads to a handle that points always to the
+           newest version, but there is no permanent handle, that
+           will always keep pointing to the acutal newest one.
+           -->
+    <!--
+    <bean id="org.dspace.identifier.HandleIdentifierProvider" class="org.dspace.identifier.VersionedHandleIdentifierProviderWithCanonicalHandles" scope="singleton">
         <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
     </bean>
     -->


### PR DESCRIPTION
This PR originally was written against ~~https://jira.duraspace.org/browse/DS-1348~~. DS-1348 was replaced by: https://jira.duraspace.org/browse/DS-3109
This PR also fixes https://jira.duraspace.org/browse/DS-2940

The VersionedHandleIdentifierProvider introduced the idea of an handle
that always refers the newest version (in the sense of an edition) of an
Item. This breaks persistence of handles. This commit changes the
VersionedHandleIdentifierProvider to still create handles containing the
version number, but it does not change the bare handle to always point
on the newest version. This PR does not include the idea of another
handle that always points to the newest version (see the ticket for
further explaination).
