### PR TITLE
DS-2418: Incompatible oracle sql method on collection.java

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/Collection.java
+++ b/dspace-api/src/main/java/org/dspace/content/Collection.java
@@ -28,6 +28,7 @@ import org.dspace.workflow.WorkflowItem;
 import org.dspace.xmlworkflow.storedcomponents.CollectionRole;
 import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 
+import java.io.Serializable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.PreparedStatement;
@@ -450,13 +451,20 @@ public class Collection extends DSpaceObject
      */
     public ItemIterator getItems(Integer limit, Integer offset) throws SQLException
     {
-        String myQuery = "SELECT item.* FROM item, collection2item WHERE "
-                + "item.item_id=collection2item.item_id AND "
-                + "collection2item.collection_id= ? "
-                + "AND item.in_archive='1' limit ? offset ?";
+        List<Serializable> params = new ArrayList<Serializable>();
+        StringBuffer myQuery = new StringBuffer(
+            "SELECT item.* " + 
+            "FROM item, collection2item " + 
+            "WHERE item.item_id = collection2item.item_id " +
+              "AND collection2item.collection_id = ? " +
+              "AND item.in_archive = '1'"
+        );
 
-        TableRowIterator rows = DatabaseManager.queryTable(ourContext, "item",
-                myQuery,getID(), limit, offset);
+        params.add(getID());
+        DatabaseManager.applyOffsetAndLimit(myQuery, params, offset, limit);
+
+        TableRowIterator rows = DatabaseManager.query(ourContext,
+                myQuery.toString(), params.toArray());
 
         return new ItemIterator(ourContext, rows);
     }


### PR DESCRIPTION
For example if **expand** parameter it used, RESTful API ends with _ORA-00933: SQL command not properly ended_ exception due to bug in DSpace API

```
https://base_dspace_url/rest/collections/_id_?expand=items
https://base_dspace_url/rest/collections/_id_?expand=items&limit=20&offset=1
```

```
2015-03-14 23:28:07,305 DEBUG org.dspace.storage.rdbms.DatabaseManager @ Running query "SELECT item.* FROM item, collection2item WHERE item.item_id=collection2item.item_id AND collection2item.collection_id= ? AND item.in_archive='1' limit ? offset ?"  with parameters: 2671,20,1
2015-03-14 23:28:07,306 ERROR org.dspace.rest.CollectionsResource @ ORA-00933: SQL command not properly ended
```

https://jira.duraspace.org/browse/DS-2418
