### PR TITLE
DS-2497: Keep version numbers stable.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/versioning/ItemVersionProvider.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/ItemVersionProvider.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.versioning;
 
+import java.sql.SQLException;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 
@@ -19,6 +20,6 @@ import org.dspace.core.Context;
  */
 public interface ItemVersionProvider {
     public Item createNewItemAndAddItInWorkspace(Context c, Item item);
-    public void deleteVersionedItem(Context c, Version versionToDelete, VersionHistory history);
+    public void deleteVersionedItem(Context c, Version versionToDelete, VersionHistory history) throws SQLException;
     public Item updateItemState(Context c, Item itemNew, Item previousItem);
 }

--- a/dspace-api/src/main/java/org/dspace/versioning/VersionHistory.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/VersionHistory.java
@@ -13,6 +13,7 @@ import org.hibernate.proxy.HibernateProxyHelper;
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.log4j.Logger;
 
 /**
  *
@@ -20,10 +21,13 @@ import java.util.List;
  * @author Fabio Bolognesi (fabio at atmire dot com)
  * @author Mark Diggory (markd at atmire dot com)
  * @author Ben Bosman (ben at atmire dot com)
+ * @author Pascal-Nicolas Becker (dspace at pascal dash becker dot de)
  */
 @Entity
 @Table(name="versionhistory")
 public class VersionHistory {
+    
+    private static final Logger log = Logger.getLogger(VersionHistory.class);
 
     @Id
     @Column(name="versionhistory_id")
@@ -50,7 +54,14 @@ public class VersionHistory {
         return id;
     }
 
-    public List<Version> getVersions() {
+    /**
+     * Please use {@link VersioningService#getVersionsByHistory(Context, VersionHistory)} instead.
+     * 
+     * To keep version number stables we keep information about deleted Versions.
+     * {@code VersioningService.getVersionsByHistory(Context, VersionHistory)} filters
+     * such versions and returns only active versions.
+     */
+    protected List<Version> getVersions() {
         return versions;
     }
 

--- a/dspace-api/src/main/java/org/dspace/versioning/VersionHistoryServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/VersionHistoryServiceImpl.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import org.dspace.versioning.service.VersioningService;
 
 /**
  *
@@ -24,11 +25,15 @@ import java.util.List;
  * @author Fabio Bolognesi (fabio at atmire dot com)
  * @author Mark Diggory (markd at atmire dot com)
  * @author Ben Bosman (ben at atmire dot com)
+ * @author Pascal-Nicolas Becker (dspace at pascal dash becker dot de)
  */
 public class VersionHistoryServiceImpl implements VersionHistoryService
 {
     @Autowired(required = true)
     protected VersionHistoryDAO versionHistoryDAO;
+    
+    @Autowired(required = true)
+    private VersioningService versioningService;
 
     protected VersionHistoryServiceImpl()
     {
@@ -57,58 +62,79 @@ public class VersionHistoryServiceImpl implements VersionHistoryService
 
     // LIST order: descending
     @Override
-    public Version getPrevious(VersionHistory versionHistory, Version version) {
-        List<Version> versions = versionHistory.getVersions();
+    public Version getPrevious(Context context, VersionHistory versionHistory, Version version)
+    throws SQLException
+    {
+        List<Version> versions = versioningService.getVersionsByHistory(context, versionHistory);
         int index = versions.indexOf(version);
-
-        if( (index+1)==versions.size()) return null;
-
-        return versions.get(index + 1);
+        if (index + 1 < versions.size())
+        {
+            return versions.get(index+1);
+        }
+        
+        return null;
     }
 
     // LIST order: descending
     @Override
-    public Version getNext(VersionHistory versionHistory, Version version)
+    public Version getNext(Context c, VersionHistory versionHistory, Version version)
+        throws SQLException
     {
-        List<Version> versions = versionHistory.getVersions();
-        int index = versionHistory.getVersions().indexOf(version);
+        List<Version> versions = versioningService.getVersionsByHistory(c, versionHistory);
+        int index = versions.indexOf(version);
 
-        if(index==0)
+        if (index -1 >= 0)
         {
-            return null;
+            return versions.get(index -1);
         }
-
-        return versions.get(index-1);
+        
+        return null;
     }
 
     @Override
-    public Version getVersion(VersionHistory versionHistory, Item item) {
-       List<Version> versions = versionHistory.getVersions();
-       for(Version v : versions)
-       {
-           if(v.getItem().getID()==item.getID())
-           {
-               return v;
-           }
-       }
-       return null;
-    }
-
-    @Override
-    public boolean hasNext(VersionHistory versionHistory, Item item)
+    public Version getVersion(Context context, VersionHistory versionHistory, Item item)
+            throws SQLException
     {
-        Version version = getVersion(versionHistory, item);
-        return hasNext(versionHistory, version);
+        Version v = versioningService.getVersion(context, item);
+        if (v != null);
+        {
+            if (versionHistory.equals(v.getVersionHistory()))
+            {
+                return v;
+            }
+        }
+        return null;
     }
-
+    
     @Override
-    public boolean hasNext(VersionHistory versionHistory, Version version)
+    public boolean hasNext(Context context, VersionHistory versionHistory, Item item)
+        throws SQLException
     {
-        return getNext(versionHistory, version)!=null;
+        Version version = getVersion(context, versionHistory, item);
+        if (version == null)
+        {
+            return false;
+        }
+        return hasNext(context, versionHistory, version);
     }
 
     @Override
-    public void add(VersionHistory versionHistory, Version version)
+    public boolean hasNext(Context context, VersionHistory versionHistory, Version version)
+            throws SQLException
+    {
+        return getNext(context, versionHistory, version)!=null;
+    }
+
+    @Override
+    public boolean hasVersionHistory(Context context, Item item)
+            throws SQLException
+    {
+        return findByItem(context, item) != null;
+    }
+    
+    @Override
+    public void add(Context context, VersionHistory versionHistory, Version version)
+            throws SQLException
     {
         List<Version> versions = versionHistory.getVersions();
         if(versions==null) versions=new ArrayList<Version>();
@@ -116,44 +142,72 @@ public class VersionHistoryServiceImpl implements VersionHistoryService
     }
 
     @Override
-    public Version getLatestVersion(VersionHistory versionHistory)
+    public Version getLatestVersion(Context context, VersionHistory versionHistory)
+            throws SQLException
     {
-        List<Version> versions = versionHistory.getVersions();
-        if(versions==null || versions.size()==0)
+        List<Version> versions = versioningService.getVersionsByHistory(context, versionHistory);
+        if(versions != null && !versions.isEmpty())
+        {
+            return versions.get(0);
+        }
+        return null;
+    }
+
+    @Override
+    public Version getFirstVersion(Context context, VersionHistory versionHistory)
+            throws SQLException
+    {
+        List<Version> versions = versioningService.getVersionsByHistory(context, versionHistory);
+
+        if (versions == null)
         {
             return null;
         }
-
-        return versions.get(0);
-    }
-
-    @Override
-    public Version getFirstVersion(VersionHistory versionHistory)
-    {
-        List<Version> versions = versionHistory.getVersions();
-        if(versions==null || versions.size()==0)
+        
+        if (versions.size()-1 >= 0)
         {
-            return null;
+            return versions.get(versions.size()-1);
         }
-
-        return versions.get(versions.size()-1);
-    }
-
-
-    @Override
-    public boolean isFirstVersion(VersionHistory versionHistory, Version version)
-    {
-        List<Version> versions = versionHistory.getVersions();
-        Version first = versions.get(versions.size()-1);
-        return first.equals(version);
+        
+        return null;
     }
 
     @Override
-    public boolean isLastVersion(VersionHistory versionHistory, Version version)
+    public boolean isFirstVersion(Context context, Item item) throws SQLException
     {
-        List<Version> versions = versionHistory.getVersions();
-        Version last = versions.get(0);
-        return last.equals(version);
+        VersionHistory vh = findByItem(context, item);
+        if (vh == null)
+        {
+            return true;
+        }
+        Version version = versioningService.getVersion(context, item);
+        return isFirstVersion(context, vh, version);
+    }
+    
+    @Override
+    public boolean isFirstVersion(Context context, VersionHistory versionHistory, Version version)
+            throws SQLException
+    {
+        return getFirstVersion(context, versionHistory).equals(version);
+    }
+    
+    @Override
+    public boolean isLastVersion(Context context, Item item) throws SQLException
+    {
+        VersionHistory vh = findByItem(context, item);
+        if (vh == null)
+        {
+            return true;
+        }
+        Version version = versioningService.getVersion(context, item);
+        return isLastVersion(context, vh, version);
+    }
+
+    @Override
+    public boolean isLastVersion(Context context, VersionHistory versionHistory, Version version)
+            throws SQLException
+    {
+        return getLatestVersion(context, versionHistory).equals(version);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/versioning/VersioningConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/VersioningConsumer.java
@@ -18,7 +18,6 @@ import org.dspace.versioning.factory.VersionServiceFactory;
 import org.dspace.versioning.service.VersionHistoryService;
 import org.dspace.versioning.service.VersioningService;
 
-import java.sql.SQLException;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -60,10 +59,10 @@ public class VersioningConsumer implements Consumer {
         if(st == Constants.ITEM && et == Event.INSTALL){
             Item item = (Item) event.getSubject(ctx);
             if (item != null && item.isArchived()) {
-                VersionHistory history = retrieveVersionHistory(ctx, item);
+                VersionHistory history = versionHistoryService.findByItem(ctx, item);
                 if (history != null) {
-                    Version latest = versionHistoryService.getLatestVersion(history);
-                    Version previous = versionHistoryService.getPrevious(history, latest);
+                    Version latest = versionHistoryService.getLatestVersion(ctx, history);
+                    Version previous = versionHistoryService.getPrevious(ctx, history, latest);
                     if(previous != null){
                         Item previousItem = previous.getItem();
                         if(previousItem != null){
@@ -98,8 +97,4 @@ public class VersioningConsumer implements Consumer {
         itemsToProcess = null;
     }
 
-
-    protected org.dspace.versioning.VersionHistory retrieveVersionHistory(Context c, Item item) throws SQLException {
-        return versioningService.findVersionHistory(c, item);
-    }
 }

--- a/dspace-api/src/main/java/org/dspace/versioning/VersioningServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/VersioningServiceImpl.java
@@ -22,7 +22,6 @@ import org.springframework.beans.factory.annotation.Required;
 import java.sql.SQLException;
 import java.util.Date;
 import java.util.List;
-import org.apache.log4j.Logger;
 
 /**
  *
@@ -30,7 +29,8 @@ import org.apache.log4j.Logger;
  * @author Fabio Bolognesi (fabio at atmire dot com)
  * @author Mark Diggory (markd at atmire dot com)
  * @author Ben Bosman (ben at atmire dot com)
- */
+ * @author Pascal-Nicolas Becker (dspace at pascal dash becker dot de)
+*/
 public class VersioningServiceImpl implements VersioningService {
 
     @Autowired(required = true)
@@ -41,6 +41,10 @@ public class VersioningServiceImpl implements VersioningService {
     private ItemService itemService;
     private DefaultItemVersionProvider provider;
 
+    @Required
+    public void setProvider(DefaultItemVersionProvider provider) {
+        this.provider = provider;
+    }
 
     protected VersioningServiceImpl()
     {
@@ -59,7 +63,7 @@ public class VersioningServiceImpl implements VersioningService {
             VersionHistory vh = versionHistoryService.findByItem(c, item);
             if(vh==null)
             {
-                // first time: create 2 versions, .1(old version) and .2(new version)
+                // first time: create 2 versions: old and new one
                 vh= versionHistoryService.create(c);
 
                 // get dc:date.accessioned to be set as first version date...
@@ -89,17 +93,40 @@ public class VersioningServiceImpl implements VersioningService {
     @Override
     public void removeVersion(Context c, Version version) throws SQLException {
         try{
+            // we will first delete the version and then the item
+            // after deletion of the version we cannot find the item anymore
+            // so we need to get the item now
+            Item item = version.getItem();
+
             VersionHistory history = version.getVersionHistory();
-            provider.deleteVersionedItem(c, version, history);
-            versionDAO.delete(c, version);
+            if (item != null)
+            {
+                // take care of the item identifiers
+                provider.deleteVersionedItem(c, version, history);
+            }
+            
+            // to keep version number stables, we do not delete versions,
+            // we set all fields null except versionnumber and versionhistory
+            version.setItem(null);
+            version.setSummary(null);
+            version.setVersionDate(null);
+            version.setePerson(null);
+            versionDAO.save(c, version);
 
-            history.removeVersion(version);
-
-            if(CollectionUtils.isEmpty(history.getVersions())){
+            // if all versions of a version history were deleted,
+            // we delete the version history.
+            if (this.getVersionsByHistory(c, history) == null
+                    || this.getVersionsByHistory(c, history).isEmpty())
+            {
+                // hard delete the previously soft deleted versions
+                for (Version v : history.getVersions())
+                {
+                    versionDAO.delete(c, v);
+                }
+                // delete the version history
                 versionHistoryService.delete(c, history);
             }
-            //Delete the item linked to the version
-            Item item = version.getItem();
+            
             // Completely delete the item
             if (item != null) {
                 itemService.delete(c, item);
@@ -135,11 +162,6 @@ public class VersioningServiceImpl implements VersioningService {
     }
 
     @Override
-    public VersionHistory findVersionHistory(Context c, Item item) throws SQLException {
-        return versionHistoryService.findByItem(c, item);
-    }
-
-    @Override
     public Version updateVersion(Context c, Item item, String summary) throws SQLException {
         Version version = versionDAO.findByItem(c, item);
         version.setSummary(summary);
@@ -157,34 +179,43 @@ public class VersioningServiceImpl implements VersioningService {
         try {
             Version version = versionDAO.create(context, new Version());
 
-            version.setVersionNumber(getNextVersionNumer(versionHistoryService.getLatestVersion(history)));
+            version.setVersionNumber(getNextVersionNumer(context, history));
             version.setVersionDate(date);
             version.setePerson(item.getSubmitter());
             version.setItem(item);
             version.setSummary(summary);
             version.setVersionHistory(history);
             versionDAO.save(context, version);
-            versionHistoryService.add(history, version);
+            versionHistoryService.add(context, history, version);
             return version;
         } catch (SQLException e) {
             throw new RuntimeException(e.getMessage(), e);
         }
     }
+    
+    @Override
+    public List<Version> getVersionsByHistory(Context c, VersionHistory vh) throws SQLException {
+        List<Version> versions = versionDAO.findVersionsWithItems(c, vh);
+        return versions;
+    }
+
 
 // **** PROTECTED METHODS!!
 
-    protected Version createVersion(Context c, VersionHistory vh, Item item, String summary, Date date) {
-        return createNewVersion(c, vh, item, summary, date, getNextVersionNumer(versionHistoryService.getLatestVersion(vh)));
+    protected Version createVersion(Context c, VersionHistory vh, Item item, String summary, Date date) throws SQLException {
+        return createNewVersion(c, vh, item, summary, date, getNextVersionNumer(c, vh));
     }
 
-    protected int getNextVersionNumer(Version latest){
-        if(latest==null) return 1;
+    protected int getNextVersionNumer(Context c, VersionHistory vh) throws SQLException{
+        int next = versionDAO.getNextVersionNumber(c, vh);
         
-        return latest.getVersionNumber()+1;
+        // check if we have uncommited versions in DSpace's cache
+        if (versionHistoryService.getLatestVersion(c, vh) != null 
+                && versionHistoryService.getLatestVersion(c, vh).getVersionNumber() >= next)
+        {
+            next = versionHistoryService.getLatestVersion(c, vh).getVersionNumber() + 1;
         }
         
-    @Required
-    public void setProvider(DefaultItemVersionProvider provider) {
-        this.provider = provider;
+        return next;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/versioning/dao/VersionDAO.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/dao/VersionDAO.java
@@ -13,6 +13,8 @@ import org.dspace.core.GenericDAO;
 import org.dspace.versioning.Version;
 
 import java.sql.SQLException;
+import java.util.List;
+import org.dspace.versioning.VersionHistory;
 
 /**
  * Database Access Object interface class for the Version object.
@@ -24,4 +26,17 @@ import java.sql.SQLException;
 public interface VersionDAO extends GenericDAO<Version>
 {
     public Version findByItem(Context context, Item item) throws SQLException;
+    
+    /**
+     * This method returns all versions of an version history that have items
+     * assigned. We do not delete versions to keep version numbers stable. To
+     * remove a version we set the item, date, summary and eperson null. This
+     * method returns only versions that aren't soft deleted and have items
+     * assigned.
+     */
+    public List<Version> findVersionsWithItems(Context context, VersionHistory versionHistory)
+            throws SQLException;
+
+    public int getNextVersionNumber(Context c, VersionHistory vh) throws SQLException;
+    
 }

--- a/dspace-api/src/main/java/org/dspace/versioning/dao/VersionHistoryDAO.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/dao/VersionHistoryDAO.java
@@ -13,6 +13,8 @@ import org.dspace.core.GenericDAO;
 import org.dspace.versioning.VersionHistory;
 
 import java.sql.SQLException;
+import java.util.List;
+import org.dspace.versioning.Version;
 
 /**
  * Database Access Object interface class for the VersionHistory object.

--- a/dspace-api/src/main/java/org/dspace/versioning/dao/impl/VersionDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/dao/impl/VersionDAOImpl.java
@@ -16,6 +16,10 @@ import org.hibernate.Criteria;
 import org.hibernate.criterion.Restrictions;
 
 import java.sql.SQLException;
+import java.util.List;
+import org.dspace.versioning.VersionHistory;
+import org.hibernate.Query;
+import org.hibernate.criterion.Order;
 
 /**
  * Hibernate implementation of the Database Access Object interface class for the Version object.
@@ -26,6 +30,7 @@ import java.sql.SQLException;
  * @author Mark Diggory (markd at atmire dot com)
  * @author Ben Bosman (ben at atmire dot com)
  * @author kevinvandevelde at atmire.com
+ * @author Pascal-Nicolas Becker (dspace at pascal dash becker dot de)
  */
 public class VersionDAOImpl extends AbstractHibernateDAO<Version> implements VersionDAO
 {
@@ -39,5 +44,27 @@ public class VersionDAOImpl extends AbstractHibernateDAO<Version> implements Ver
         Criteria criteria = createCriteria(context, Version.class);
         criteria.add(Restrictions.eq("item", item));
         return singleResult(criteria);
+    }
+
+    @Override
+    public int getNextVersionNumber(Context c, VersionHistory vh) throws SQLException {
+        Query q = this.createQuery(c, 
+                "SELECT (COALESCE(MAX(versionNumber), 0) + 1) "
+                        + "FROM Version WHERE versionHistory.id = :historyId");
+        q.setParameter("historyId", vh.getId());
+
+        int next = (Integer) q.uniqueResult();
+        return next;
+    }
+    
+    @Override
+    public List<Version> findVersionsWithItems(Context context, VersionHistory versionHistory)
+            throws SQLException
+    {
+        Criteria criteria = createCriteria(context, Version.class);
+        criteria.add(Restrictions.eq("versionHistory", versionHistory));
+        criteria.add(Restrictions.and(Restrictions.isNotNull("item")));
+        criteria.addOrder(Order.desc("versionNumber"));
+        return list(criteria);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/versioning/dao/impl/VersionHistoryDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/dao/impl/VersionHistoryDAOImpl.java
@@ -16,6 +16,9 @@ import org.hibernate.Criteria;
 import org.hibernate.criterion.Restrictions;
 
 import java.sql.SQLException;
+import java.util.List;
+import org.dspace.versioning.Version;
+import org.hibernate.criterion.Order;
 
 /**
  * Hibernate implementation of the Database Access Object interface class for the VersionHistory object.
@@ -39,6 +42,7 @@ public class VersionHistoryDAOImpl extends AbstractHibernateDAO<VersionHistory> 
         Criteria criteria = createCriteria(context, VersionHistory.class);
         criteria.createAlias("versions", "v");
         criteria.add(Restrictions.eq("v.item", item));
+        criteria.addOrder(Order.desc("v.versionNumber"));
         return singleResult(criteria);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/versioning/service/VersionHistoryService.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/service/VersionHistoryService.java
@@ -14,6 +14,7 @@ import org.dspace.versioning.Version;
 import org.dspace.versioning.VersionHistory;
 
 import java.sql.SQLException;
+import java.util.List;
 
 /**
  *
@@ -21,31 +22,52 @@ import java.sql.SQLException;
  * @author Fabio Bolognesi (fabio at atmire dot com)
  * @author Mark Diggory (markd at atmire dot com)
  * @author Ben Bosman (ben at atmire dot com)
+ * @author Pascal-Nicolas Becker (dspace at pascal dash becker dot de)
  */
 public interface VersionHistoryService extends DSpaceCRUDService<VersionHistory> {
+    
+    public void add(Context context, VersionHistory versionHistory, Version version)
+            throws SQLException;
+    
+    public VersionHistory findByItem(Context context, Item item)
+            throws SQLException;
+    
+    public Version getFirstVersion(Context context, VersionHistory versionHistory)
+            throws SQLException;
+    
+    public Version getLatestVersion(Context context, VersionHistory versionHistory)
+            throws SQLException;
+    
+    public Version getNext(Context context, VersionHistory versionHistory, Version version)
+            throws SQLException;
+    
+    public Version getPrevious(Context context, VersionHistory versionHistory, Version version)
+            throws SQLException;
+    
+    public Version getVersion(Context context, VersionHistory versionHistory, Item item)
+            throws SQLException;
+    
+    public boolean hasNext(Context context, VersionHistory versionHistory, Item item)
+            throws SQLException;
 
-    public Version getLatestVersion(VersionHistory versionHistory);
+    public boolean hasNext(Context context, VersionHistory versionHistory, Version version)
+            throws SQLException;
+    
+    public boolean hasVersionHistory(Context context, Item item)
+            throws SQLException;
+    
+    public boolean isFirstVersion(Context context, Item item)
+            throws SQLException;
 
-    public Version getFirstVersion(VersionHistory versionHistory);
+    public boolean isFirstVersion(Context context, VersionHistory versionHistory, Version version)
+            throws SQLException;
 
-    public Version getPrevious(VersionHistory versionHistory, Version version);
+    public boolean isLastVersion(Context context, Item item)
+            throws SQLException;
 
-    public Version getNext(VersionHistory versionHistory, Version version);
-
-    public boolean hasNext(VersionHistory versionHistory, Version version);
-
-    public void add(VersionHistory versionHistory, Version version);
-
-    public Version getVersion(VersionHistory versionHistory, Item item);
-
-    public boolean hasNext(VersionHistory versionHistory, Item item);
-
-    public boolean isFirstVersion(VersionHistory versionHistory, Version version);
-
-    public boolean isLastVersion(VersionHistory versionHistory, Version version);
+    public boolean isLastVersion(Context context, VersionHistory versionHistory, Version version)
+            throws SQLException;
 
     public void remove(VersionHistory versionHistory, Version version);
-
-    public VersionHistory findByItem(Context context, Item item) throws SQLException;
 
 }

--- a/dspace-api/src/main/java/org/dspace/versioning/service/VersioningService.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/service/VersioningService.java
@@ -14,6 +14,7 @@ import org.dspace.versioning.VersionHistory;
 
 import java.sql.SQLException;
 import java.util.Date;
+import java.util.List;
 
 /**
  *
@@ -27,6 +28,15 @@ public interface VersioningService {
     Version createNewVersion(Context c, Item itemId);
 
     Version createNewVersion(Context c, Item itemId, String summary);
+    
+    /**
+     * Returns all versions of a version history.
+     * To keep version numbers stable we do not delete versions, we do only set 
+     * the item, date, summary and eperson null. This methods returns only those
+     * versions that have an item assigned.
+     * @return All versions of a version history that have an item assigned.
+     */
+    List<Version> getVersionsByHistory(Context c, VersionHistory vh) throws SQLException;
 
     void removeVersion(Context c, Version version) throws SQLException;
 
@@ -37,8 +47,6 @@ public interface VersioningService {
     Version restoreVersion(Context c, Version version);
 
     Version restoreVersion(Context c, Version version, String summary);
-
-    VersionHistory findVersionHistory(Context c, Item itemId) throws SQLException;
 
     Version updateVersion(Context c, Item itemId, String summary) throws SQLException;
 

--- a/dspace-api/src/test/java/org/dspace/content/VersioningTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/VersioningTest.java
@@ -122,7 +122,7 @@ public class VersioningTest extends AbstractUnitTest {
     {
         VersionHistory versionHistory = versionHistoryService.findByItem(context, originalItem);
         assertThat("testFindVersionHistory", versionHistory, notNullValue());
-        Version version = versionHistoryService.getVersion(versionHistory, versionedItem);
+        Version version = versionHistoryService.getVersion(context, versionHistory, versionedItem);
         assertThat("testFindVersion", version, notNullValue());
     }
 
@@ -134,7 +134,7 @@ public class VersioningTest extends AbstractUnitTest {
     {
         //Start by creating a new item !
         VersionHistory versionHistory = versionHistoryService.findByItem(context, originalItem);
-        Version version = versionHistoryService.getVersion(versionHistory, versionedItem);
+        Version version = versionHistoryService.getVersion(context, versionHistory, versionedItem);
         assertThat("Test_version_summary", summary, equalTo(version.getSummary()));
     }
 

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/VersionHistoryServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/VersionHistoryServlet.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.app.webui.servlet;
 
+import com.hp.hpl.jena.sparql.vocabulary.DOAP;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.UUID;
@@ -29,6 +30,7 @@ import org.dspace.versioning.Version;
 import org.dspace.versioning.VersionHistory;
 import org.dspace.versioning.factory.VersionServiceFactory;
 import org.dspace.versioning.service.VersionHistoryService;
+import org.dspace.versioning.service.VersioningService;
 
 /**
  * Servlet for handling the operations in the version history page
@@ -47,6 +49,9 @@ public class VersionHistoryServlet extends DSpaceServlet
 
     private final transient VersionHistoryService versionHistoryService
              = VersionServiceFactory.getInstance().getVersionHistoryService();
+    
+    private final transient VersioningService versioningService
+            = VersionServiceFactory.getInstance().getVersionService();
 
     @Override
     protected void doDSGet(Context context, HttpServletRequest request,
@@ -75,11 +80,10 @@ public class VersionHistoryServlet extends DSpaceServlet
         }
 
         // manage if versionID is not came by request
-        VersionHistory history = VersionUtil.retrieveVersionHistory(context,
-                item);
+        VersionHistory history = versionHistoryService.findByItem(context, item);
         if (versionID == null || versionID.isEmpty())
         {
-            Version version = versionHistoryService.getVersion(history, item);
+            Version version = versionHistoryService.getVersion(context, history, item);
             if (version != null)
             {
                 versionID = String.valueOf(version.getId());
@@ -130,6 +134,7 @@ public class VersionHistoryServlet extends DSpaceServlet
         request.setAttribute("item", item);
         request.setAttribute("itemID", itemID);
         request.setAttribute("versionID", versionID);
+        request.setAttribute("allVersions", versioningService.getVersionsByHistory(context, history));
         JSPManager.showJSP(request, response, "/tools/version-history.jsp");
     }
 

--- a/dspace-jspui/src/main/webapp/display-item.jsp
+++ b/dspace-jspui/src/main/webapp/display-item.jsp
@@ -182,7 +182,7 @@
                 	<% if(hasVersionHistory) { %>			                
                 	<form method="get" action="<%= request.getContextPath() %>/tools/history">
                     	<input type="hidden" name="itemID" value="<%= item.getID() %>" />
-                    	<input type="hidden" name="versionID" value="<%= versionHistoryService.getVersion(history, item)!=null?versionHistoryService.getVersion(history, item).getId():null %>" />
+                    	<input type="hidden" name="versionID" value="<%= versionHistoryService.getVersion(context, history, item)!=null?versionHistoryService.getVersion(context, history, item).getId():null %>" />
                     	<input class="btn btn-info col-md-12" type="submit" name="submit" value="<fmt:message key="jsp.general.version.history.button"/>" />
                 	</form>         	         	
 					<% } %>

--- a/dspace-jspui/src/main/webapp/tools/version-history.jsp
+++ b/dspace-jspui/src/main/webapp/tools/version-history.jsp
@@ -7,6 +7,7 @@
     http://www.dspace.org/license/
 
 --%>
+<%@page import="java.util.List"%>
 <%--
   - Version history table with functionalities
   -
@@ -20,6 +21,7 @@
 <%@page import="org.dspace.versioning.Version"%>
 <%@page import="org.dspace.app.webui.util.VersionUtil"%>
 <%@page import="org.dspace.versioning.VersionHistory"%>
+<%@page import="org.dspace.versioning.factory.VersionServiceFactory"%>
 <%@ page import="java.util.UUID" %>
 <%@ page contentType="text/html;charset=UTF-8" %>
 
@@ -73,7 +75,7 @@ var j = jQuery.noConflict();
     <%-- Versioning table --%>
 <%
                 
-	VersionHistory history = VersionUtil.retrieveVersionHistory(context, item);
+        List<Version> allVersions = (List<Version>) request.getAttribute("allVersions");
 						 
 %>
 	<div id="versionHistory">
@@ -94,8 +96,7 @@ var j = jQuery.noConflict();
 				id="t5" class="oddRowEvenCol"><fmt:message key="jsp.version.history.column5"/> </th>
 		</tr>
 		
-		<% for(Version versRow : history.getVersions()) {  
-		
+                <% for(Version versRow : allVersions) {
 			EPerson versRowPerson = versRow.getEPerson();
 			String[] identifierPath = VersionUtil.addItemIdentifier(item, versRow);
 

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/versioning/Navigation.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/versioning/Navigation.java
@@ -51,6 +51,7 @@ import java.util.UUID;
  * @author Fabio Bolognesi (fabio at atmire dot com)
  * @author Mark Diggory (markd at atmire dot com)
  * @author Ben Bosman (ben at atmire dot com)
+ * @author Pascal-Nicolas Becker (dspace at pascal dash becker dot de)
  */
 public class Navigation extends AbstractDSpaceTransformer implements CacheableProcessingComponent
 {
@@ -172,14 +173,14 @@ public class Navigation extends AbstractDSpaceTransformer implements CacheablePr
             if(authorizeService.isAdmin(this.context, item.getOwningCollection()))
             {
                 boolean headAdded=false;
-                if(isLatest(item) && item.isArchived())
+                if(versionHistoryService.isLastVersion(this.context, item) && item.isArchived())
                 {
                     context.setHead(T_context_head);
                     headAdded=true;
                     context.addItem().addXref(contextPath+"/item/version?itemID="+item.getID(), T_context_create_version);
                 }
 
-                if(hasVersionHistory(item))
+                if(versionHistoryService.hasVersionHistory(this.context, item))
                 {
                     if(!headAdded)
                     {
@@ -211,19 +212,6 @@ public class Navigation extends AbstractDSpaceTransformer implements CacheablePr
     {
         this.validity = null;
         super.recycle();
-    }
-
-    private boolean isLatest(Item item) throws SQLException
-    {
-        org.dspace.versioning.VersionHistory history = versionHistoryService.findByItem(context, item);
-        return (history==null || versionHistoryService.getLatestVersion(history).getItem().equals(item));
-    }
-
-
-    private boolean hasVersionHistory(Item item) throws SQLException
-    {
-        org.dspace.versioning.VersionHistory history = versionHistoryService.findByItem(context, item);
-        return (history!=null);
     }
 
 }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/versioning/VersionItemForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/versioning/VersionItemForm.java
@@ -101,7 +101,7 @@ public class VersionItemForm extends AbstractDSpaceTransformer {
         Para actions = main.addPara();
 
         org.dspace.versioning.VersionHistory history = retrieveVersionHistory(item);
-        if(history!=null && versionHistoryService.hasNext(history ,item))
+        if(history!=null && versionHistoryService.hasNext(context, history ,item))
         {
             actions.addButton("submit_update_version").setValue(T_submit_update_version);
         }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/versioning/VersionManager.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/versioning/VersionManager.java
@@ -155,14 +155,14 @@ public class VersionManager {
 
             Item item = itemService.find(context, itemId);
 
-            VersionHistory versionHistory = versioningService.findVersionHistory(context, item);
+            VersionHistory versionHistory = versionHistoryService.findByItem(context, item);
 
             for (String id : versionIDs) {
                 versioningService.removeVersion(context, versioningService.getVersion(context, Integer.parseInt(id)));
             }
 
             //Retrieve the latest version of our history (IF any is even present)
-            Version latestVersion = versionHistoryService.getLatestVersion(versionHistory);
+            Version latestVersion = versionHistoryService.getLatestVersion(context, versionHistory);
             if(latestVersion == null){
                 result.setParameter("itemID", null);
             }else{

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/versioning/VersionNoticeTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/versioning/VersionNoticeTransformer.java
@@ -31,6 +31,7 @@ import org.xml.sax.SAXException;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
+import org.dspace.versioning.service.VersioningService;
 
 /**
  * Adds a notice to item page in the following conditions
@@ -51,6 +52,7 @@ public class VersionNoticeTransformer extends AbstractDSpaceTransformer {
 
     protected AuthorizeService authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();
     protected HandleService handleService = HandleServiceFactory.getInstance().getHandleService();
+    protected VersioningService versioningService = VersionServiceFactory.getInstance().getVersionService();
     protected VersionHistoryService versionHistoryService = VersionServiceFactory.getInstance().getVersionHistoryService();
 
     @Override
@@ -104,7 +106,7 @@ public class VersionNoticeTransformer extends AbstractDSpaceTransformer {
 
     private Version retrieveLatestVersion(VersionHistory history, Item item) throws SQLException {
         //Attempt to retrieve the latest version
-        List<Version> allVersions = history.getVersions();
+        List<Version> allVersions = versioningService.getVersionsByHistory(context, history);
         for (Version version : allVersions) {
             if (version.getItem().isArchived() || authorizeService.isAdmin(context, item.getOwningCollection()))
             {


### PR DESCRIPTION
As we use the version numbers to generate persistent identifiers, we
should keep them stable. If we generate some versions of an item, delete
the latest version and create a new version the deleted and the new
version should have different version numbers as they are different
versions.
