### PR TITLE
[DS-2532] botness of a visit is not properly logged when a location cannot be determined

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLogger.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLogger.java
@@ -331,6 +331,7 @@ public class SolrLogger
 		    {
 		        doc1.addField("userAgent", request.getHeader("User-Agent"));
 		    }
+		    doc1.addField("isBot",isSpiderBot);
             // Save the location information if valid, save the event without
             // location information if not valid
             if(locationService != null)
@@ -354,7 +355,7 @@ public class SolrLogger
                     doc1.addField("city", location.city);
                     doc1.addField("latitude", location.latitude);
                     doc1.addField("longitude", location.longitude);
-                    doc1.addField("isBot",isSpiderBot);
+                    
 
 
                 }
@@ -416,6 +417,7 @@ public class SolrLogger
 		    {
 		        doc1.addField("userAgent", userAgent);
 		    }
+		    doc1.addField("isBot",isSpiderBot);
             // Save the location information if valid, save the event without
             // location information if not valid
             if(locationService != null)
@@ -439,7 +441,7 @@ public class SolrLogger
                     doc1.addField("city", location.city);
                     doc1.addField("latitude", location.latitude);
                     doc1.addField("longitude", location.longitude);
-                    doc1.addField("isBot",isSpiderBot);
+                    
 
 
                 }


### PR DESCRIPTION
Extract isBot from the location==null if in two places.
