### PR TITLE
Export Metadata Schema/Field Reg as JSON

### DIFF
--- a/dspace-rest/src/main/java/org/dspace/rest/MetadataRegistry.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/MetadataRegistry.java
@@ -1,0 +1,66 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.rest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.ServletContext;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.dspace.content.MetadataField;
+import org.dspace.content.MetadataSchema;
+import org.dspace.core.Context;
+import org.dspace.rest.common.Field;
+import org.dspace.rest.common.Schema;
+
+import com.google.gson.Gson;
+
+/*
+Export the DSpace Metadata Schema and Field Registries as JSON using the GSON library.
+This exported file can be used in conjunction with the FileAnalyzer to validate metadata field while generating DSpace Ingest Folders.
+* https://github.com/Georgetown-University-Libraries/File-Analyzer/wiki/Create-Ingest-Folders-for-a-Set-of-Files
+The FileAnalyzer is a desktop application containing a number of automation tasks for library and digitization projects.  
+A set of DSpace related tasks are included in the code base.
+ */
+@Path("/metadataregistry")
+public class MetadataRegistry {
+    @javax.ws.rs.core.Context public static ServletContext servletContext;
+
+    /*
+    The "GET" annotation indicates this method will respond to HTTP Get requests.
+    The "Produces" annotation indicates the MIME response the method will return.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public String getMetadataRegistry() {
+        try {
+            Context context = new Context();
+            List<Schema> mySchemas = new ArrayList<Schema>();
+            MetadataSchema[] schemas = MetadataSchema.findAll(context);
+            for(MetadataSchema schema: schemas) {
+                Schema mySchema = new Schema(schema.getName(), schema.getNamespace());
+                mySchemas.add(mySchema);
+                MetadataField[] fields = MetadataField.findAllInSchema(context, schema.getSchemaID());
+                for(MetadataField field: fields){
+                    String fname = Field.makeName(mySchema.prefix(), field.getElement(), field.getQualifier());
+                    mySchema.addField(fname, field.getElement(), field.getQualifier(), field.getScopeNote());
+                }
+            }
+            Gson gson = new Gson();
+            String s = gson.toJson(mySchemas);
+            return s;
+        } catch (Exception e) {
+            return "{\"error\":\""+e.getMessage()+"\"}";
+        }
+        
+    }
+}

--- a/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
@@ -115,6 +115,10 @@ public class RestIndex {
                   		"<li>DELETE /bitstreams/{bitstream id} - Delete the specified bitstream from DSpace.</li>" +
                   		"<li>DELETE /bitstreams/{bitstream id}/policy/{policy_id} - Delete the specified bitstream policy.</li>" +
                   	"</ul>" +
+                    "<h2>Metadata Registry</h2>" +
+                    "<ul>" +
+                      "<li>GET /metadataregistry - Return the metadata schema and field registry as JSON</li>" +
+                    "</ul>" +
                 "</body></html> ";
     }
     

--- a/dspace-rest/src/main/java/org/dspace/rest/common/Field.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/common/Field.java
@@ -1,0 +1,53 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.rest.common;
+
+/**
+ * Use GSON to export the metadata field registry to JSON
+ * @author terry.brady@georgetown.edu
+ */
+public class Field {
+    public static String makeName(String prefix, String element, String qualifier) {
+        StringBuilder sb = new StringBuilder(prefix);
+        sb.append(".");
+        sb.append(element);
+        if (qualifier != null) {
+            sb.append(".");
+            sb.append(qualifier);
+        }
+        return sb.toString();
+    }
+
+    private String name;
+    private String element;
+    private String qualifier;
+    private String description;
+    
+    public String name() {return name;}
+    public String element() {return element;}
+    public String qualifier() {return qualifier;}
+    public String description() {return description;}
+    
+    public void setName(String name) {this.name = name;}
+    public void setElement(String element) {this.name = element;}
+    public void setQualifier(String qualifier) {this.name = qualifier;}
+    public void setDescription(String description) {this.name = description;}
+
+    public Field() {
+    }
+    public Field(String name, String element, String qualifier, String description) {
+        this.name = name;
+        this.element = element;
+        this.qualifier = qualifier;
+        this.description = description;
+    }
+    
+    public String toString() {
+        return String.format("name:%s,element:%s,qualifier:%s,description:%s", name, element, qualifier, description == null ? null : description.replaceAll("\\s+", " "));
+    }
+}

--- a/dspace-rest/src/main/java/org/dspace/rest/common/Schema.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/common/Schema.java
@@ -1,0 +1,60 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.rest.common;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Use GSON to export the metadata schema registry to JSON
+ * @author terry.brady@georgetown.edu
+ */
+public class Schema {
+    private String prefix;
+    private String namespace;
+    private List<Field> fields;
+
+    public String prefix() {return prefix;}
+    public String namespace() {return namespace;}
+    public List<Field> getFields() {return fields;}
+
+    public void setPrefix(String prefix) {this.prefix = prefix;}
+    public void setNamespace(String namespace) {this.namespace = namespace;}
+    public void setFields(List<Field> fields) {this.fields = fields;}
+    
+    public Schema() {
+    }
+    public Schema(String prefix, String namespace) {
+        this.prefix = prefix;
+        this.namespace = namespace;
+        this.fields = new ArrayList<Field>();
+    }
+    public void addField(String name, String element, String qualifier, String description) {
+        fields.add(new Field(name, element, qualifier, description));
+    }
+    
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("prefix:%s,namespace:%s", prefix, namespace));
+        for(Field f: fields) {
+            sb.append(String.format("%n\t%s",f));
+        }
+        return sb.toString();
+    }
+    
+    static public HashMap<String,Field> getFields(Schema[] schemas) {
+        HashMap<String,Field> fields = new HashMap<String,Field>();
+        for(Schema schema: schemas) {
+            for(Field field: schema.getFields()) {
+                fields.put(field.name(), field);
+            }
+        }
+        return fields;
+    }
+}


### PR DESCRIPTION
Export the DSpace Metadata Schema and Field Registries as JSON. 

This exported file can be used in conjunction with the FileAnalyzer to validate metadata field while generating DSpace Ingest Folders. 

https://github.com/Georgetown-University-Libraries/File-Analyzer/wiki/Create-Ingest-Folders-for-a-Set-of-Files 

The FileAnalyzer is a desktop application containing a number of automation tasks for library and digitization projects. A set of DSpace related tasks are included in the code base. 
