### PR TITLE
DS-2539: REST: Export Metadata Schema and Field Registries

### DIFF
--- a/dspace-rest/src/main/java/org/dspace/rest/MetadataRegistryResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/MetadataRegistryResource.java
@@ -1,0 +1,102 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.rest;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.ArrayList;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.apache.log4j.Logger;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.AuthorizeManager;
+import org.dspace.rest.common.MetadataSchema;
+import org.dspace.rest.common.MetadataField;
+//import org.dspace.rest.exceptions.ContextException;
+import org.dspace.usage.UsageEvent;
+
+/**
+ * Class which provides read methods over the metadata registry.
+ * 
+ * @author Terry Brady, Georgetown University
+ * 
+ */
+@Path("/metadataregistry")
+//public class MetadataRegistryResource extends Resource
+public class MetadataRegistryResource 
+{
+    private static Logger log = Logger.getLogger(MetadataRegistryResource.class);
+
+    /**
+     * Return all metadata registry items in DSpace.
+     * 
+     * @return Return array of metadata schemas.
+     * @throws WebApplicationException
+     *             It can be caused by creating context or while was problem
+     *             with reading community from database(SQLException).
+     */
+    @GET
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+    public MetadataSchema[] getSchemas(@QueryParam("userIP") String user_ip, @QueryParam("userAgent") String user_agent,
+            @QueryParam("xforwarderfor") String xforwarderfor, @Context HttpHeaders headers, @Context HttpServletRequest request)
+            throws WebApplicationException
+    {
+
+        log.info("Reading all schemas.");
+        org.dspace.core.Context context = null;
+        ArrayList<MetadataSchema> metadataSchemas = null;
+
+        try
+        {
+            //context = createContext(getUser(headers));
+            context = new org.dspace.core.Context();
+
+            org.dspace.content.MetadataSchema[] schemas = org.dspace.content.MetadataSchema.findAll(context);
+            metadataSchemas = new ArrayList<MetadataSchema>();
+            for(org.dspace.content.MetadataSchema schema: schemas) {
+                metadataSchemas.add(new MetadataSchema(schema, context));
+            }
+
+            context.complete();
+        }
+        catch (SQLException e)
+        {
+            //processException("Could not read schemas, SQLException. Message:" + e, context);
+            log.error(e.getMessage());
+            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
+        }
+        //catch (ContextException e)
+        //{
+        //    processException("Could not read schemas, ContextException. Message:" + e.getMessage(), context);
+        //}
+        finally
+        {
+            //processFinally(context);
+        }
+
+        log.trace("All schemas successfully read.");
+        return metadataSchemas.toArray(new MetadataSchema[0]);
+    }
+
+}

--- a/dspace-rest/src/main/java/org/dspace/rest/MetadataRegistryResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/MetadataRegistryResource.java
@@ -31,18 +31,34 @@ import javax.ws.rs.core.Response;
 import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.AuthorizeManager;
+import org.dspace.content.NonUniqueMetadataException;
+import org.dspace.content.Site;
 import org.dspace.rest.common.MetadataSchema;
-import org.dspace.rest.common.MetadataField;
 import org.dspace.rest.exceptions.ContextException;
 import org.dspace.usage.UsageEvent;
+import org.dspace.rest.common.MetadataField;
 
 /**
  * Class which provides read methods over the metadata registry.
+ * GUCODE[[twb27:custom module]]
  * 
  * @author Terry Brady, Georgetown University
  * 
+ * GET    /registries/schema - Return the list of schemas in the registry
+ * GET    /registries/schema/{schema_prefix} - Returns the specified schema
+ * GET    /registries/schema/{schema_prefix}/metadata-fields/{element} - Returns the metadata field within a schema with an unqualified element name
+ * GET    /registries/schema/{schema_prefix}/metadata-fields/{element}/{qualifier} - Returns the metadata field within a schema with a qualified element name
+ * POST   /registries/schema/ - Add a schema to the schema registry
+ * POST   /registries/schema/{schema_prefix}/metadata-fields - Add a metadata field to the specified schema
+ * GET    /registries/metadata-fields/{field_id} - Return the specified metadata field
+ * PUT    /registries/metadata-fields/{field_id} - Update the specified metadata field
+ * DELETE /registries/metadata-fields/{field_id} - Delete the specified metadata field from the metadata field registry
+ * DELETE /registries/schema/{schema_id} - Delete the specified schema from the schema registry
+ * 
+ * Note: intentionally not providing since there is no date to update other than the namespace
+ * PUT    /registries/schema/{schema_id}
  */
-@Path("/metadataregistry")
+@Path("/registries")
 public class MetadataRegistryResource extends Resource
 {
     private static Logger log = Logger.getLogger(MetadataRegistryResource.class);
@@ -50,19 +66,24 @@ public class MetadataRegistryResource extends Resource
     /**
      * Return all metadata registry items in DSpace.
      * 
+     * @param expand
+     *            String in which is what you want to add to returned instance
+     *            of metadata schema. Options are: "all", "fields".  Default value "fields".
      * @return Return array of metadata schemas.
      * @throws WebApplicationException
      *             It can be caused by creating context or while was problem
-     *             with reading community from database(SQLException).
+     *             with reading schema from database(SQLException).
      */
     @GET
+    @Path("/schema")
     @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
-    public MetadataSchema[] getSchemas(@QueryParam("userIP") String user_ip, @QueryParam("userAgent") String user_agent,
+    public MetadataSchema[] getSchemas(@QueryParam("expand") @DefaultValue("fields") String expand, 
+    		@QueryParam("userIP") String user_ip, @QueryParam("userAgent") String user_agent,
             @QueryParam("xforwarderfor") String xforwarderfor, @Context HttpHeaders headers, @Context HttpServletRequest request)
             throws WebApplicationException
     {
 
-        log.info("Reading all schemas.");
+        log.info("Reading all metadata schemas.");
         org.dspace.core.Context context = null;
         ArrayList<MetadataSchema> metadataSchemas = null;
 
@@ -73,26 +94,669 @@ public class MetadataRegistryResource extends Resource
             org.dspace.content.MetadataSchema[] schemas = org.dspace.content.MetadataSchema.findAll(context);
             metadataSchemas = new ArrayList<MetadataSchema>();
             for(org.dspace.content.MetadataSchema schema: schemas) {
-                metadataSchemas.add(new MetadataSchema(schema, context));
+                metadataSchemas.add(new MetadataSchema(schema, expand, context));
             }
 
             context.complete();
         }
         catch (SQLException e)
         {
-            processException("Could not read schemas, SQLException. Message:" + e, context);
+            processException("Could not read metadata schemas, SQLException. Message:" + e, context);
+            log.error(e.getMessage());
+            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
         }
         catch (ContextException e)
         {
-            processException("Could not read schemas, ContextException. Message:" + e.getMessage(), context);
+            processException("Could not read metadata schemas, ContextException. Message:" + e.getMessage(), context);
         }
         finally
         {
             processFinally(context);
         }
 
-        log.trace("All schemas successfully read.");
+        log.trace("All metadata schemas successfully read.");
         return metadataSchemas.toArray(new MetadataSchema[0]);
+    }
+
+    /**
+     * Returns metadata schema with basic properties. If you want more, use expand
+     * parameter or method for metadata fields.
+     * 
+     * @param schemaPrefix
+     *            Prefix for schema in DSpace.
+     * @param expand
+     *            String in which is what you want to add to returned instance
+     *            of metadata schema. Options are: "all", "fields".  Default value "fields".
+     * @param headers
+     *            If you want to access to metadata schema under logged user into
+     *            context. In headers must be set header "rest-dspace-token"
+     *            with passed token from login method.
+     * @return Return instance of org.dspace.rest.common.MetadataSchema.
+     * @throws WebApplicationException
+     *             It is throw when was problem with creating context or problem
+     *             with database reading. Also if id/prefix of schema is incorrect
+     *             or logged user into context has no permission to read.
+     */
+    @GET
+    @Path("/schema/{schema_prefix}")
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+    public MetadataSchema getSchema(@PathParam("schema_prefix") String schemaPrefix, @QueryParam("expand") @DefaultValue("fields") String expand,
+    		@QueryParam("userIP") String user_ip, @QueryParam("userAgent") String user_agent,
+            @QueryParam("xforwarderfor") String xforwarderfor, @Context HttpHeaders headers, @Context HttpServletRequest request)
+            throws WebApplicationException
+    {
+
+        log.info("Reading metadata schemas.");
+        org.dspace.core.Context context = null;
+        MetadataSchema metadataSchema = null;
+
+        try
+        {
+            context = createContext(getUser(headers));
+
+            org.dspace.content.MetadataSchema schema = org.dspace.content.MetadataSchema.find(context, schemaPrefix);
+            metadataSchema = new MetadataSchema(schema, expand, context);
+            if (schema == null) {
+                log.error(String.format("Schema not found for index %s", schemaPrefix));
+                throw new WebApplicationException(Response.Status.NOT_FOUND);
+            }
+
+            context.complete();
+        }
+        catch (SQLException e)
+        {
+            processException("Could not read metadata schema, SQLException. Message:" + e, context);
+            log.error(e.getMessage());
+            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
+        }
+        catch (ContextException e)
+        {
+            processException("Could not read metadata schema, ContextException. Message:" + e.getMessage(), context);
+        }
+        finally
+        {
+            processFinally(context);
+        }
+
+        log.trace("Metadata schemas successfully read.");
+        return metadataSchema;
+    }
+    
+    /**
+     * Returns metadata field with basic properties. 
+     * 
+     * @param schemaPreix
+     *            Prefix for schema in DSpace.
+     * @param element
+     *            Unqualified element name for field in the metadata registry.
+     * @param expand
+     *            String in which is what you want to add to returned instance
+     *            of the metadata field. Options are: "all", "parentSchema".  Default value "".
+     * @param headers
+     *            If you want to access to community under logged user into
+     *            context. In headers must be set header "rest-dspace-token"
+     *            with passed token from login method.
+     * @return Return instance of org.dspace.rest.common.MetadataField.
+     * @throws WebApplicationException
+     *             It is throw when was problem with creating context or problem
+     *             with database reading. Also if id of field is incorrect
+     *             or logged user into context has no permission to read.
+     */
+    @GET
+    @Path("/schema/{schema_prefix}/metadata-fields/{element}")
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+    public MetadataField getMetadataFieldUnqualified(@PathParam("schema_prefix") String schemaPrefix,
+    		@PathParam("element") String element,
+    		@QueryParam("expand") String expand,
+    		@QueryParam("userIP") String user_ip, @QueryParam("userAgent") String user_agent,
+            @QueryParam("xforwarderfor") String xforwarderfor, @Context HttpHeaders headers, @Context HttpServletRequest request)
+            throws WebApplicationException
+    {
+    	return getMetadataFieldQualified(schemaPrefix, element, "", expand, user_ip, user_agent, xforwarderfor, headers, request);
+    }
+    
+    /**
+     * Returns metadata field with basic properties. 
+     * 
+     * @param schemaPreix
+     *            Prefix for schema in DSpace.
+     * @param element
+     *            Element name for field in the metadata registry.
+     * @param qualifier
+     *            Element name qualifier for field in the metadata registry.
+     * @param expand
+     *            String in which is what you want to add to returned instance
+     *            of the metadata field. Options are: "all", "parentSchema".  Default value "".
+     * @param headers
+     *            If you want to access to community under logged user into
+     *            context. In headers must be set header "rest-dspace-token"
+     *            with passed token from login method.
+     * @return Return instance of org.dspace.rest.common.MetadataField.
+     * @throws WebApplicationException
+     *             It is throw when was problem with creating context or problem
+     *             with database reading. Also if id of field is incorrect
+     *             or logged user into context has no permission to read.
+     */
+    @GET
+    @Path("/schema/{schema_prefix}/metadata-fields/{element}/{qualifier}")
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+    public MetadataField getMetadataFieldQualified(@PathParam("schema_prefix") String schemaPrefix,
+    		@PathParam("element") String element,
+    		@PathParam("qualifier") @DefaultValue("") String qualifier,
+    		@QueryParam("expand") String expand,
+    		@QueryParam("userIP") String user_ip, @QueryParam("userAgent") String user_agent,
+            @QueryParam("xforwarderfor") String xforwarderfor, @Context HttpHeaders headers, @Context HttpServletRequest request)
+            throws WebApplicationException
+    {
+
+        log.info("Reading metadata field.");
+        org.dspace.core.Context context = null;
+        MetadataField metadataField = null;
+
+        try
+        {
+            context = createContext(getUser(headers));
+
+            org.dspace.content.MetadataSchema schema = org.dspace.content.MetadataSchema.find(context, schemaPrefix);
+            
+            if (schema == null) {
+                log.error(String.format("Schema not found for prefix %s", schemaPrefix));
+                throw new WebApplicationException(Response.Status.NOT_FOUND);
+            }
+            
+            org.dspace.content.MetadataField field = org.dspace.content.MetadataField.findByElement(context, schema.getSchemaID(), element, qualifier);
+            if (field == null) {
+                log.error(String.format("Field %s.%s.%s not found", schemaPrefix, element, qualifier));
+                throw new WebApplicationException(Response.Status.NOT_FOUND);
+            }
+            metadataField = new MetadataField(schema, field, expand, context);
+
+            context.complete();
+        }
+        catch (SQLException e)
+        {
+            processException("Could not read metadata field, SQLException. Message:" + e, context);
+            log.error(e.getMessage());
+            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
+        }
+        catch (ContextException e)
+        {
+            processException("Could not read metadata field, ContextException. Message:" + e.getMessage(), context);
+        }
+        finally
+        {
+            processFinally(context);
+        }
+
+        log.trace("Metadata field successfully read.");
+        return metadataField;
+    }
+
+    /**
+     * Returns metadata field with basic properties. 
+     * 
+     * @param fieldId
+     *            Id of metadata field in DSpace.
+     * @param expand
+     *            String in which is what you want to add to returned instance
+     *            of the metadata field. Options are: "all", "parentSchema".  Default value "parentSchema".
+     * @param headers
+     *            If you want to access to community under logged user into
+     *            context. In headers must be set header "rest-dspace-token"
+     *            with passed token from login method.
+     * @return Return instance of org.dspace.rest.common.MetadataField.
+     * @throws WebApplicationException
+     *             It is throw when was problem with creating context or problem
+     *             with database reading. Also if id of field is incorrect
+     *             or logged user into context has no permission to read.
+     */
+    @GET
+    @Path("/metadata-fields/{field_id}")
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+    public MetadataField getMetadataField(@PathParam("field_id") Integer fieldId,  
+    		@QueryParam("expand") @DefaultValue("parentSchema") String expand,
+    		@QueryParam("userIP") String user_ip, @QueryParam("userAgent") String user_agent,
+            @QueryParam("xforwarderfor") String xforwarderfor, @Context HttpHeaders headers, @Context HttpServletRequest request)
+            throws WebApplicationException
+    {
+
+        log.info("Reading metadata field.");
+        org.dspace.core.Context context = null;
+        MetadataField metadataField = null;
+
+        try
+        {
+            context = createContext(getUser(headers));
+
+            org.dspace.content.MetadataField field = org.dspace.content.MetadataField.find(context, fieldId);
+            if (field == null) {
+                log.error(String.format("Metadata Field %d not found", fieldId));
+                throw new WebApplicationException(Response.Status.NOT_FOUND);
+            }
+            org.dspace.content.MetadataSchema schema = org.dspace.content.MetadataSchema.find(context, field.getSchemaID());
+            if (schema == null) {
+                log.error(String.format("Parent Schema %d for Metadata Field %d not found", field.getSchemaID(), fieldId));
+                throw new WebApplicationException(Response.Status.NOT_FOUND);
+            }
+            metadataField = new MetadataField(schema, field, expand, context);
+
+            context.complete();
+        }
+        catch (SQLException e)
+        {
+            processException("Could not read metadata field, SQLException. Message:" + e, context);
+            log.error(e.getMessage());
+            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
+        }
+        catch (ContextException e)
+        {
+            processException("Could not read metadata field, ContextException. Message:" + e.getMessage(), context);
+        }
+        finally
+        {
+            processFinally(context);
+        }
+
+        log.trace("Metadata field successfully read.");
+        return metadataField;
+    }
+
+    /**
+     * Create schema in the schema registry. Creating a schema is restricted to admin users.
+     * 
+     * @param schema
+     *            Schema that will be added to the metadata registry.
+     * @param headers
+     *            If you want to access to schema under logged user into
+     *            context. In headers must be set header "rest-dspace-token"
+     *            with passed token from login method.
+     * @return Return response 200 if was everything all right. Otherwise 400
+     *         when id of community was incorrect or 401 if was problem with
+     *         permission to write into collection.
+     *         Returns the schema (schemaId), if was all ok.
+     * @throws WebApplicationException
+     *             It can be thrown by SQLException, AuthorizeException and
+     *             ContextException.
+     */
+    @POST
+    @Path("/schema")
+    @Consumes({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+    public MetadataSchema createSchema(MetadataSchema schema, @QueryParam("userIP") String user_ip,
+            @QueryParam("userAgent") String user_agent, @QueryParam("xforwardedfor") String xforwardedfor,
+            @Context HttpHeaders headers, @Context HttpServletRequest request) throws WebApplicationException
+    {
+
+        log.info("Creating a schema.");
+        org.dspace.core.Context context = null;
+        MetadataSchema retSchema = null;
+
+        try
+        {
+            context = createContext(getUser(headers));
+
+            if (!AuthorizeManager.isAdmin(context))
+            {
+                context.abort();
+                String user = "anonymous";
+                if (context.getCurrentUser() != null)
+                {
+                    user = context.getCurrentUser().getEmail();
+                }
+                log.error("User(" + user + ") does not have permission to create a metadata schema!");
+                throw new WebApplicationException(Response.Status.UNAUTHORIZED);
+            }
+
+            log.debug(String.format("Admin user creating schema with namespace %s and prefix %s", schema.getNamespace(), schema.getPrefix()));
+
+            org.dspace.content.MetadataSchema dspaceSchema = new org.dspace.content.MetadataSchema(schema.getNamespace(), schema.getPrefix());
+            log.debug(String.format("Saving schema %s : %s. ", dspaceSchema.getName(), dspaceSchema.getNamespace()));
+            dspaceSchema.create(context);
+            log.debug("Creating return object.");
+            retSchema = new MetadataSchema(dspaceSchema, "", context);
+            
+            writeStats(Site.find(context, 0), UsageEvent.Action.CREATE, user_ip, user_agent, xforwardedfor,
+                   headers, request, context);
+
+            context.complete();
+            log.info("Schema created" + retSchema.getPrefix());
+
+        }
+        catch (SQLException e)
+        {
+            processException("Could not create new metadata schema, SQLException. Message: " + e, context);
+        }
+        catch (ContextException e)
+        {
+            processException("Could not create new metadata schema, ContextException. Message: " + e.getMessage(), context);
+        }
+        catch (AuthorizeException e)
+        {
+            processException("Could not create new metadata schema, AuthorizeException. Message: " + e.getMessage(), context);
+        } 
+        catch (NonUniqueMetadataException e) {
+            processException("Could not create new metadata schema, NonUniqueMetadataException. Message: " + e.getMessage(), context);
+		}
+        catch (Exception e)
+        {
+            processException("Could not create new metadata schema, Exception. Class: " + e.getClass(), context);
+        } 
+        finally
+        {
+            processFinally(context);
+        }
+
+        return retSchema;
+    }
+
+
+    /**
+     * Create a new metadata field within a schema. 
+     * Creating a metadata field is restricted to admin users.
+     * 
+     * @param field
+     *            Field that will be added to the metadata registry for a schema.
+     * @param headers
+     *            If you want to access to schema under logged user into
+     *            context. In headers must be set header "rest-dspace-token"
+     *            with passed token from login method.
+     * @return Return response 200 if was everything all right. Otherwise 400
+     *         when id of community was incorrect or 401 if was problem with
+     *         permission to write into collection.
+     *         Returns the field (with fieldId), if was all ok.
+     * @throws WebApplicationException
+     *             It can be thrown by SQLException, AuthorizeException and
+     *             ContextException.
+     */
+    @POST
+    @Path("/schema/{schema_prefix}/metadata-fields")
+    @Consumes({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+    public MetadataField createMetadataField(@PathParam("schema_prefix") String schemaPrefix,
+    		MetadataField field, @QueryParam("userIP") String user_ip,
+            @QueryParam("userAgent") String user_agent, @QueryParam("xforwardedfor") String xforwardedfor,
+            @Context HttpHeaders headers, @Context HttpServletRequest request) throws WebApplicationException
+    {
+
+        log.info(String.format("Creating metadataField within schema %s.", schemaPrefix));
+        org.dspace.core.Context context = null;
+        MetadataField retField = null;
+
+        try
+        {
+            context = createContext(getUser(headers));
+
+            if (!AuthorizeManager.isAdmin(context))
+            {
+                context.abort();
+                String user = "anonymous";
+                if (context.getCurrentUser() != null)
+                {
+                    user = context.getCurrentUser().getEmail();
+                }
+                log.error("User(" + user + ") does not have permission to create a metadata field!");
+                throw new WebApplicationException(Response.Status.UNAUTHORIZED);
+            }
+
+            org.dspace.content.MetadataSchema schema = org.dspace.content.MetadataSchema.find(context, schemaPrefix);
+            if (schema == null) {
+                log.error(String.format("Schema not found for prefix %s", schemaPrefix));
+                throw new WebApplicationException(Response.Status.NOT_FOUND);
+            }
+            org.dspace.content.MetadataField dspaceField = new org.dspace.content.MetadataField(schema, field.getElement(), field.getQualifier(), field.getDescription());
+            writeStats(Site.find(context, 0), UsageEvent.Action.CREATE, user_ip, user_agent, xforwardedfor,
+                    headers, request, context);
+
+            log.debug(String.format("Creating metadataField %s.%s within schema %s.", field.getElement(), field.getQualifier(),schemaPrefix));
+            dspaceField.create(context);
+            
+            retField = new MetadataField(schema, dspaceField, "", context);
+            context.complete();
+            log.info("Metadata field created within schema" + retField.getName());
+
+        }
+        catch (IOException e)
+        {
+            processException("Could not create new metadata field, IOException. Message: " + e, context);
+        }
+        catch (SQLException e)
+        {
+            processException("Could not create new metadata field, SQLException. Message: " + e, context);
+        }
+        catch (ContextException e)
+        {
+            processException("Could not create new metadata field, ContextException. Message: " + e.getMessage(), context);
+        }
+        catch (AuthorizeException e)
+        {
+            processException("Could not create new metadata field, AuthorizeException. Message: " + e.getMessage(), context);
+        } 
+        catch (NonUniqueMetadataException e) {
+           processException("Could not create new metadata field, NonUniqueMetadataException. Message: " + e.getMessage(), context);
+		}
+        catch (Exception e)
+        {
+            processException("Could not create new metadata field, Exception. Message: " + e.getMessage(), context);
+        } 
+        finally
+        {
+            processFinally(context);
+        }
+
+        return retField;
+    }
+
+    //@PUT
+    //@Path("/schema/{schema_prefix}")
+    //Assumption - there are no meaningful fields to update for a schema
+
+    /**
+     * Update metadata field. Replace all information about community except the id and the containing schema.
+     * 
+     * @param fieldId
+     *            Id of the field in the DSpace metdata registry.
+     * @param field
+     *            Instance of the metadata field which will replace actual metadata field in
+     *            DSpace.
+     * @param headers
+     *            If you want to access to metadata field under logged user into
+     *            context. In headers must be set header "rest-dspace-token"
+     *            with passed token from login method.
+     * @return Response 200 if was all ok. Otherwise 400 if was id incorrect or
+     *         401 if logged user has no permission to update the metadata field.
+     * @throws WebApplicationException
+     *             It is throw when was problem with creating context or problem
+     *             with database reading or writing. Or problem with writing to
+     *             community caused by authorization.
+     */
+    @PUT
+    @Path("/metadata-fields/{field_id}")
+    @Consumes({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+    public Response updateMetadataField(@PathParam("field_id") Integer fieldId, MetadataField field,
+            @QueryParam("userIP") String user_ip, @QueryParam("userAgent") String user_agent,
+            @QueryParam("xforwardedfor") String xforwardedfor, @Context HttpHeaders headers, @Context HttpServletRequest request)
+            throws WebApplicationException
+    {
+
+        log.info("Updating metadata field(id=" + fieldId + ").");
+        org.dspace.core.Context context = null;
+
+        try
+        {
+            context = createContext(getUser(headers));
+
+            org.dspace.content.MetadataField dspaceField = org.dspace.content.MetadataField.find(context, fieldId);
+            if (field == null) {
+                log.error(String.format("Metadata Field %d not found", fieldId));
+                throw new WebApplicationException(Response.Status.NOT_FOUND);
+            }
+
+            writeStats(Site.find(context, 0), UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor,
+                    headers, request, context);
+
+            dspaceField.setElement(field.getElement());
+            dspaceField.setQualifier(field.getQualifier());
+            dspaceField.setScopeNote(field.getDescription());
+            dspaceField.update(context);
+
+            context.complete();
+
+        }
+        catch (SQLException e)
+        {
+            processException("Could not update metadata field(id=" + fieldId + "), AuthorizeException. Message:" + e, context);
+        }
+        catch (ContextException e)
+        {
+            processException("Could not update metadata field(id=" + fieldId + "), ContextException Message:" + e, context);
+        }
+        catch (AuthorizeException e)
+        {
+            processException("Could not update metadata field(id=" + fieldId + "), AuthorizeException. Message:" + e, context);
+        } 
+        catch (NonUniqueMetadataException e) {
+            processException("Could not update metadata field(id=" + fieldId + "), NonUniqueMetadataException. Message:" + e, context);
+		} 
+        catch (IOException e) {
+            processException("Could not update metadata field(id=" + fieldId + "), IOException. Message:" + e, context);
+		}
+        finally
+        {
+            processFinally(context);
+        }
+
+        log.info("Metadata Field(id=" + fieldId + ") has been successfully updated.");
+        return Response.ok().build();
+    }
+
+    /**
+     * Delete metadata field from the DSpace metadata registry
+     * 
+     * @param fieldId
+     *            Id of the metadata field in DSpace.
+     * @param headers
+     *            If you want to access to metadata field under logged user into
+     *            context. In headers must be set header "rest-dspace-token"
+     *            with passed token from login method.
+     * @return Return response code OK(200) if was everything all right.
+     *         Otherwise return NOT_FOUND(404) if was id of metadata field is incorrect.
+     *         Or (UNAUTHORIZED)401 if was problem with permission to metadata field.
+     * @throws WebApplicationException
+     *             It is throw when was problem with creating context or problem
+     *             with database reading or deleting. Or problem with deleting
+     *             metadata field caused by IOException or authorization.
+     */
+    @DELETE
+    @Path("/metadata-fields/{field_id}")
+    public Response deleteMetadataField(@PathParam("field_id") Integer fieldId, @QueryParam("userIP") String user_ip,
+            @QueryParam("userAgent") String user_agent, @QueryParam("xforwardedfor") String xforwardedfor,
+            @Context HttpHeaders headers, @Context HttpServletRequest request) throws WebApplicationException
+    {
+
+        log.info("Deleting metadata field(id=" + fieldId + ").");
+        org.dspace.core.Context context = null;
+
+        try
+        {
+            context = createContext(getUser(headers));
+
+            org.dspace.content.MetadataField dspaceField = org.dspace.content.MetadataField.find(context, fieldId);
+            if (dspaceField == null) {
+                log.error(String.format("Metadata Field %d not found", fieldId));
+                throw new WebApplicationException(Response.Status.NOT_FOUND);
+            }
+            writeStats(Site.find(context, 0), UsageEvent.Action.DELETE, user_ip, user_agent, xforwardedfor, headers,
+                    request, context);
+
+            dspaceField.delete(context);
+            context.complete();
+
+        }
+        catch (SQLException e)
+        {
+            processException("Could not delete metadata field(id=" + fieldId + "), SQLException. Message:" + e, context);
+        }
+        catch (AuthorizeException e)
+        {
+            processException("Could not delete metadata field(id=" + fieldId + "), AuthorizeException. Message:" + e, context);
+        }
+        catch (ContextException e)
+        {
+            processException("Could not delete metadata field(id=" + fieldId + "), ContextException. Message:" + e.getMessage(),
+                    context);
+        }
+        finally
+        {
+            processFinally(context);
+        }
+
+
+        log.info("Metadata field(id=" + fieldId + ") was successfully deleted.");
+        return Response.status(Response.Status.OK).build();
+    }
+
+    /**
+     * Delete metadata schema from the DSpace metadata registry
+     * 
+     * @param schemaId
+     *            Id of the metadata schema in DSpace.
+     * @param headers
+     *            If you want to access to metadata schema under logged user into
+     *            context. In headers must be set header "rest-dspace-token"
+     *            with passed token from login method.
+     * @return Return response code OK(200) if was everything all right.
+     *         Otherwise return NOT_FOUND(404) if was id of metadata schema is incorrect.
+     *         Or (UNAUTHORIZED)401 if was problem with permission to metadata schema.
+     * @throws WebApplicationException
+     *             It is throw when was problem with creating context or problem
+     *             with database reading or deleting. Or problem with deleting
+     *             metadata schema caused by IOException or authorization.
+     */
+    @DELETE
+    @Path("/schema/{schema_id}")
+    public Response deleteSchema(@PathParam("schema_id") Integer schemaId, @QueryParam("userIP") String user_ip,
+            @QueryParam("userAgent") String user_agent, @QueryParam("xforwardedfor") String xforwardedfor,
+            @Context HttpHeaders headers, @Context HttpServletRequest request) throws WebApplicationException
+    {
+
+        log.info("Deleting metadata schema(id=" + schemaId + ").");
+        org.dspace.core.Context context = null;
+
+        try
+        {
+            context = createContext(getUser(headers));
+
+            org.dspace.content.MetadataSchema dspaceSchema = org.dspace.content.MetadataSchema.find(context, schemaId);
+            if (dspaceSchema == null) {
+                log.error(String.format("Metadata Schema %d not found", schemaId));
+                throw new WebApplicationException(Response.Status.NOT_FOUND);
+            }
+           writeStats(Site.find(context, 0), UsageEvent.Action.DELETE, user_ip, user_agent, xforwardedfor, headers,
+                    request, context);
+
+            dspaceSchema.delete(context);
+            context.complete();
+
+        }
+        catch (SQLException e)
+        {
+            processException("Could not delete metadata schema(id=" + schemaId + "), SQLException. Message:" + e, context);
+        }
+        catch (AuthorizeException e)
+        {
+            processException("Could not delete metadata schema(id=" + schemaId + "), AuthorizeException. Message:" + e, context);
+        }
+        catch (ContextException e)
+        {
+            processException("Could not delete metadata schema(id=" + schemaId + "), ContextException. Message:" + e.getMessage(),
+                    context);
+        }
+        finally
+        {
+            processFinally(context);
+        }
+
+
+        log.info("Metadata schema(id=" + schemaId + ") was successfully deleted.");
+        return Response.status(Response.Status.OK).build();
     }
 
 }

--- a/dspace-rest/src/main/java/org/dspace/rest/MetadataRegistryResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/MetadataRegistryResource.java
@@ -43,8 +43,7 @@ import org.dspace.usage.UsageEvent;
  * 
  */
 @Path("/metadataregistry")
-//public class MetadataRegistryResource extends Resource
-public class MetadataRegistryResource 
+public class MetadataRegistryResource extends Resource
 {
     private static Logger log = Logger.getLogger(MetadataRegistryResource.class);
 

--- a/dspace-rest/src/main/java/org/dspace/rest/MetadataRegistryResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/MetadataRegistryResource.java
@@ -33,7 +33,7 @@ import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.AuthorizeManager;
 import org.dspace.rest.common.MetadataSchema;
 import org.dspace.rest.common.MetadataField;
-//import org.dspace.rest.exceptions.ContextException;
+import org.dspace.rest.exceptions.ContextException;
 import org.dspace.usage.UsageEvent;
 
 /**
@@ -69,8 +69,7 @@ public class MetadataRegistryResource
 
         try
         {
-            //context = createContext(getUser(headers));
-            context = new org.dspace.core.Context();
+            context = createContext(getUser(headers));
 
             org.dspace.content.MetadataSchema[] schemas = org.dspace.content.MetadataSchema.findAll(context);
             metadataSchemas = new ArrayList<MetadataSchema>();
@@ -82,17 +81,15 @@ public class MetadataRegistryResource
         }
         catch (SQLException e)
         {
-            //processException("Could not read schemas, SQLException. Message:" + e, context);
-            log.error(e.getMessage());
-            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
+            processException("Could not read schemas, SQLException. Message:" + e, context);
         }
-        //catch (ContextException e)
-        //{
-        //    processException("Could not read schemas, ContextException. Message:" + e.getMessage(), context);
-        //}
+        catch (ContextException e)
+        {
+            processException("Could not read schemas, ContextException. Message:" + e.getMessage(), context);
+        }
         finally
         {
-            //processFinally(context);
+            processFinally(context);
         }
 
         log.trace("All schemas successfully read.");

--- a/dspace-rest/src/main/java/org/dspace/rest/MetadataRegistryResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/MetadataRegistryResource.java
@@ -40,7 +40,6 @@ import org.dspace.rest.common.MetadataField;
 
 /**
  * Class which provides read methods over the metadata registry.
- * GUCODE[[twb27:custom module]]
  * 
  * @author Terry Brady, Georgetown University
  * 

--- a/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
@@ -35,7 +35,6 @@ import org.dspace.rest.exceptions.ContextException;
  * 
  * @author Rostislav Novak (Computing and Information Centre, CTU in Prague)
  * 
- * GUCODE[[twb27:add additional verbs]]
  */
 @Path("/")
 public class RestIndex {

--- a/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
@@ -35,6 +35,7 @@ import org.dspace.rest.exceptions.ContextException;
  * 
  * @author Rostislav Novak (Computing and Information Centre, CTU in Prague)
  * 
+ * GUCODE[[twb27:add additional verbs]]
  */
 @Path("/")
 public class RestIndex {
@@ -115,9 +116,18 @@ public class RestIndex {
                   		"<li>DELETE /bitstreams/{bitstream id} - Delete the specified bitstream from DSpace.</li>" +
                   		"<li>DELETE /bitstreams/{bitstream id}/policy/{policy_id} - Delete the specified bitstream policy.</li>" +
                   	"</ul>" +
-                    "<h2>Metadata Registry</h2>" +
+                    "<h2>Metadata and Schema Registry</h2>" +
                     "<ul>" +
-                        "<li>GET /metadataregistry - Return metadata schema and field registry.</li>" +
+                        "<li>GET /registries/schema - Return the list of metadata schemas in the registry</li>" +
+                        "<li>GET /registries/schema/{schema_prefix} - Returns the specified metadata schema</li>" +
+                        "<li>GET /registries/schema/{schema_prefix}/metadata-fields/{element} - Returns the metadata field within a schema with an unqualified element name</li>" +
+                        "<li>GET /registries/schema/{schema_prefix}/metadata-fields/{element}/{qualifier} - Returns the metadata field within a schema with a qualified element name</li>" +
+                        "<li>POST /registries/schema/ - Add a schema to the schema registry</li>" +
+                        "<li>POST /registries/schema/{schema_prefix}/metadata-fields - Add a metadata field to the specified schema</li>" +
+                        "<li>GET /registries/metadata-fields/{field_id} - Return the specified metadata field</li>" +
+                        "<li>PUT /registries/metadata-fields/{field_id} - Update the specified metadata field</li>" +
+                        "<li>DELETE /registries/metadata-fields/{field_id} - Delete the specified metadata field from the metadata field registry</li>" +
+                        "<li>DELETE /registries/schema/{schema_id} - Delete the specified schema from the schema registry</li>" +
                     "</ul>" +
                 "</body></html> ";
     }
@@ -131,6 +141,7 @@ public class RestIndex {
     @Path("/test")
     public String test()
     {
+        log.info("REST TEST");
         return "REST api is running.";
     }
 

--- a/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
@@ -115,6 +115,10 @@ public class RestIndex {
                   		"<li>DELETE /bitstreams/{bitstream id} - Delete the specified bitstream from DSpace.</li>" +
                   		"<li>DELETE /bitstreams/{bitstream id}/policy/{policy_id} - Delete the specified bitstream policy.</li>" +
                   	"</ul>" +
+                    "<h2>Metadata Registry</h2>" +
+                    "<ul>" +
+                        "<li>GET /metadataregistry - Return metadata schema and field registry.</li>" +
+                    "</ul>" +
                 "</body></html> ";
     }
     

--- a/dspace-rest/src/main/java/org/dspace/rest/common/MetadataField.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/common/MetadataField.java
@@ -1,0 +1,83 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.rest.common;
+
+import org.apache.log4j.Logger;
+import org.dspace.authorize.AuthorizeManager;
+import org.dspace.core.Context;
+
+import javax.ws.rs.WebApplicationException;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Terry Brady, Georgetown University.
+ * Metadata field representation
+ */
+@XmlRootElement(name = "field")
+public class MetadataField {
+    private static Logger log = Logger.getLogger(MetadataField.class);
+
+    private String name;
+    private String element;
+    private String qualifier;
+    private String description;
+
+    public MetadataField(){}
+
+    public MetadataField(org.dspace.content.MetadataSchema schema, org.dspace.content.MetadataField field, Context context) throws SQLException, WebApplicationException{
+        setup(schema, field, context);
+    }
+
+    private void setup(org.dspace.content.MetadataSchema schema, org.dspace.content.MetadataField field, Context context) throws SQLException{
+        StringBuilder sb = new StringBuilder();
+        sb.append(schema.getName());
+        sb.append(".");
+        sb.append(field.getElement());
+        if (field.getQualifier()!=null) {
+            sb.append(".");
+            sb.append(field.getQualifier());            
+        }
+        
+        this.setName(sb.toString());
+        this.setElement(field.getElement());
+        this.setQualifier(field.getQualifier());
+        this.setDescription(field.getScopeNote());
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+    public void setElement(String element) {
+        this.element = element;
+    }
+    public void setQualifier(String qualifier) {
+        this.qualifier = qualifier;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+    
+    public String getName() {
+        return name;
+    }
+    
+    public String getQualifier() {
+        return qualifier;
+    }
+    public String getElement() {
+        return element;
+    }
+    public String getDescription() {
+        return description;
+    }
+}

--- a/dspace-rest/src/main/java/org/dspace/rest/common/MetadataField.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/common/MetadataField.java
@@ -7,8 +7,6 @@
  */
 package org.dspace.rest.common;
 
-import org.apache.log4j.Logger;
-import org.dspace.authorize.AuthorizeManager;
 import org.dspace.core.Context;
 
 import javax.ws.rs.WebApplicationException;
@@ -20,25 +18,33 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Terry Brady, Georgetown University.
  * Metadata field representation
+ * @author Terry Brady, Georgetown University.
  */
 @XmlRootElement(name = "field")
 public class MetadataField {
-    private static Logger log = Logger.getLogger(MetadataField.class);
-
+	private int fieldId;
     private String name;
     private String element;
     private String qualifier;
     private String description;
+    
+    private MetadataSchema parentSchema;
+
+    @XmlElement(required = true)
+    private ArrayList<String> expand = new ArrayList<String>();
 
     public MetadataField(){}
 
-    public MetadataField(org.dspace.content.MetadataSchema schema, org.dspace.content.MetadataField field, Context context) throws SQLException, WebApplicationException{
-        setup(schema, field, context);
+    public MetadataField(org.dspace.content.MetadataSchema schema, org.dspace.content.MetadataField field, String expand, Context context) throws SQLException, WebApplicationException{
+        setup(schema, field, expand, context);
     }
 
-    private void setup(org.dspace.content.MetadataSchema schema, org.dspace.content.MetadataField field, Context context) throws SQLException{
+    private void setup(org.dspace.content.MetadataSchema schema, org.dspace.content.MetadataField field, String expand, Context context) throws SQLException{
+        List<String> expandFields = new ArrayList<String>();
+        if(expand != null) {
+            expandFields = Arrays.asList(expand.split(","));
+        }
         StringBuilder sb = new StringBuilder();
         sb.append(schema.getName());
         sb.append(".");
@@ -49,11 +55,28 @@ public class MetadataField {
         }
         
         this.setName(sb.toString());
+        this.setFieldId(field.getFieldID());
         this.setElement(field.getElement());
         this.setQualifier(field.getQualifier());
         this.setDescription(field.getScopeNote());
+        
+        if (expandFields.contains("parentSchema") || expandFields.contains("all")) {
+        	this.addExpand("parentSchema");
+        	parentSchema = new MetadataSchema(schema, "", context);
+        }
     }
 
+    public void setParentSchema(MetadataSchema schema) {
+    	this.parentSchema = schema;
+    }
+    
+    public MetadataSchema getParentSchema() {
+    	return this.parentSchema;
+    }
+    
+    public void setFieldId(int fieldId) {
+        this.fieldId = fieldId;
+    }
     public void setName(String name) {
         this.name = name;
     }
@@ -67,6 +90,9 @@ public class MetadataField {
         this.description = description;
     }
     
+    public int getFieldId() {
+        return fieldId;
+    }
     public String getName() {
         return name;
     }
@@ -79,5 +105,16 @@ public class MetadataField {
     }
     public String getDescription() {
         return description;
+    }
+    public List<String> getExpand() {
+        return expand;
+    }
+
+    public void setExpand(ArrayList<String> expand) {
+        this.expand = expand;
+    }
+
+    public void addExpand(String expandableAttribute) {
+        this.expand.add(expandableAttribute);
     }
 }

--- a/dspace-rest/src/main/java/org/dspace/rest/common/MetadataSchema.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/common/MetadataSchema.java
@@ -1,0 +1,68 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.rest.common;
+
+import org.apache.log4j.Logger;
+import org.dspace.authorize.AuthorizeManager;
+import org.dspace.core.Context;
+
+import javax.ws.rs.WebApplicationException;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Terry Brady, Georgetown University.
+ * Metadata schema representation
+ */
+@XmlRootElement(name = "schema")
+public class MetadataSchema {
+    private static Logger log = Logger.getLogger(MetadataField.class);
+
+    private String prefix;
+    private String namespace;
+    
+    @XmlElement(name = "fields", required = true)
+    private List<MetadataField> fields = new ArrayList<MetadataField>();
+
+    public MetadataSchema(){}
+
+    public MetadataSchema(org.dspace.content.MetadataSchema schema, Context context) throws SQLException, WebApplicationException{
+        setup(schema, context);
+    }
+
+    private void setup(org.dspace.content.MetadataSchema schema, Context context) throws SQLException{
+        this.setPrefix(schema.getName());
+        this.setNamespace(schema.getNamespace());
+        org.dspace.content.MetadataField[] fields = org.dspace.content.MetadataField.findAllInSchema(context, schema.getSchemaID());
+        for(org.dspace.content.MetadataField field: fields) {
+            this.fields.add(new MetadataField(schema, field, context));
+        }
+    
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
+    }
+    
+    public String getPrefix() {
+        return prefix;
+    }    
+    public String getNamespace() {
+        return namespace;
+    }
+    public List<MetadataField> getMetadataFields() {
+        return fields;
+    }
+}

--- a/dspace-rest/src/main/java/org/dspace/rest/common/MetadataSchema.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/common/MetadataSchema.java
@@ -4,7 +4,6 @@
  * tree and available online at
  *
  * http://www.dspace.org/license/
- * GUDOE[[twb27:custom module]]
  */
 package org.dspace.rest.common;
 

--- a/dspace-rest/src/main/java/org/dspace/rest/common/MetadataSchema.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/common/MetadataSchema.java
@@ -4,11 +4,10 @@
  * tree and available online at
  *
  * http://www.dspace.org/license/
+ * GUDOE[[twb27:custom module]]
  */
 package org.dspace.rest.common;
 
-import org.apache.log4j.Logger;
-import org.dspace.authorize.AuthorizeManager;
 import org.dspace.core.Context;
 
 import javax.ws.rs.WebApplicationException;
@@ -20,33 +19,43 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Terry Brady, Georgetown University.
  * Metadata schema representation
+ * @author Terry Brady, Georgetown University.
  */
 @XmlRootElement(name = "schema")
 public class MetadataSchema {
-    private static Logger log = Logger.getLogger(MetadataField.class);
 
+	private int schemaID;
     private String prefix;
     private String namespace;
     
+    @XmlElement(required = true)
+    private ArrayList<String> expand = new ArrayList<String>();
+
     @XmlElement(name = "fields", required = true)
     private List<MetadataField> fields = new ArrayList<MetadataField>();
 
     public MetadataSchema(){}
 
-    public MetadataSchema(org.dspace.content.MetadataSchema schema, Context context) throws SQLException, WebApplicationException{
-        setup(schema, context);
+    public MetadataSchema(org.dspace.content.MetadataSchema schema, String expand, Context context) throws SQLException, WebApplicationException{
+        setup(schema, expand, context);
     }
 
-    private void setup(org.dspace.content.MetadataSchema schema, Context context) throws SQLException{
+    private void setup(org.dspace.content.MetadataSchema schema, String expand, Context context) throws SQLException{
+        List<String> expandFields = new ArrayList<String>();
+        if(expand != null) {
+            expandFields = Arrays.asList(expand.split(","));
+        }
+        this.setSchemaID(schema.getSchemaID());
         this.setPrefix(schema.getName());
         this.setNamespace(schema.getNamespace());
-        org.dspace.content.MetadataField[] fields = org.dspace.content.MetadataField.findAllInSchema(context, schema.getSchemaID());
-        for(org.dspace.content.MetadataField field: fields) {
-            this.fields.add(new MetadataField(schema, field, context));
+        if (expandFields.contains("fields") || expandFields.contains("all")) {
+            org.dspace.content.MetadataField[] fields = org.dspace.content.MetadataField.findAllInSchema(context, schema.getSchemaID());
+            this.addExpand("fields");
+            for(org.dspace.content.MetadataField field: fields) {
+                this.fields.add(new MetadataField(schema, field, "", context));
+            }        	
         }
-    
     }
 
     public void setPrefix(String prefix) {
@@ -62,7 +71,27 @@ public class MetadataSchema {
     public String getNamespace() {
         return namespace;
     }
+    public int getSchemaID()
+    {
+        return this.schemaID;
+    }
+
+    public void setSchemaID(int schemaID)
+    {
+        this.schemaID = schemaID;
+    }
     public List<MetadataField> getMetadataFields() {
         return fields;
+    }
+    public List<String> getExpand() {
+        return expand;
+    }
+
+    public void setExpand(ArrayList<String> expand) {
+        this.expand = expand;
+    }
+
+    public void addExpand(String expandableAttribute) {
+        this.expand.add(expandableAttribute);
     }
 }


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2539

Export the DSpace Metadata Schema and Field Registries.

This exported file can be used in conjunction with the FileAnalyzer to validate metadata field while generating DSpace Ingest Folders.

https://github.com/Georgetown-University-Libraries/File-Analyzer/wiki/Create-Ingest-Folders-for-a-Set-of-Files

The FileAnalyzer is a desktop application containing a number of automation tasks for library and digitization projects. A set of DSpace related tasks are included in the code base.
