### PR TITLE
[DS-2546] fixes problem in DateUtils parsing

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/util/DateUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/DateUtils.java
@@ -59,8 +59,8 @@ public class DateUtils
         catch (ParseException ex)
         {
             // 2008-01-01T00:00:00Z
-            format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'",
-                    Locale.getDefault());
+            format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+            format.setTimeZone(TimeZone.getTimeZone("ZULU"));
             try
             {
                 return format.parse(date);
@@ -112,7 +112,8 @@ public class DateUtils
     public static Date parseFromSolrDate(String date)
     {
         SimpleDateFormat format = new SimpleDateFormat(
-                "yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.getDefault());
+                "yyyy-MM-dd'T'HH:mm:ss'Z'");
+        format.setTimeZone(TimeZone.getTimeZone("ZULU"));
         Date ret;
         try
         {

--- a/dspace-oai/src/main/java/org/dspace/xoai/util/DateUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/DateUtils.java
@@ -35,7 +35,9 @@ public class DateUtils
         SimpleDateFormat sdf = new SimpleDateFormat(
                 "yyyy-MM-dd'T'HH:mm:ss.'000Z'");
         if (!init)
+        {
             sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.'999Z'");
+        }
         // We indicate that the returned date is in Zulu time (UTC) so we have
         // to set the time zone of sdf correct.
         sdf.setTimeZone(TimeZone.getTimeZone("ZULU"));

--- a/dspace-oai/src/main/java/org/dspace/xoai/util/DateUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/DateUtils.java
@@ -29,10 +29,13 @@ public class DateUtils
     {
         return format(date, true);
     }
+
     public static String format(Date date, boolean init)
     {
-    	SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.'000Z'");
-    	if (!init) sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.'999Z'");
+        SimpleDateFormat sdf = new SimpleDateFormat(
+                "yyyy-MM-dd'T'HH:mm:ss.'000Z'");
+        if (!init)
+            sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.'999Z'");
         // We indicate that the returned date is in Zulu time (UTC) so we have
         // to set the time zone of sdf correct.
         sdf.setTimeZone(TimeZone.getTimeZone("ZULU"));
@@ -42,50 +45,62 @@ public class DateUtils
 
     public static Date parse(String date)
     {
-        // 2008-01-01T00:00:00Z
+        // in org.dspace.xoai.util.DateUtils.format(Date, boolean) we format all
+        // dates with trailing milliseconds so we have to use them when parsing
         SimpleDateFormat format = new SimpleDateFormat(
-                "yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.getDefault());
-        // format.setTimeZone(TimeZone.getTimeZone("ZULU"));
+                "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        format.setTimeZone(TimeZone.getTimeZone("ZULU"));
         Date ret;
         try
         {
             ret = format.parse(date);
             return ret;
         }
-        catch (ParseException e)
+        catch (ParseException ex)
         {
-            format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss",
+            // 2008-01-01T00:00:00Z
+            format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'",
                     Locale.getDefault());
             try
             {
                 return format.parse(date);
             }
-            catch (ParseException e1)
+            catch (ParseException e)
             {
-                format = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault());
+                format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss",
+                        Locale.getDefault());
                 try
                 {
                     return format.parse(date);
                 }
-                catch (ParseException e2)
+                catch (ParseException e1)
                 {
-                    format = new SimpleDateFormat("yyyy-MM",
+                    format = new SimpleDateFormat("yyyy-MM-dd",
                             Locale.getDefault());
                     try
                     {
                         return format.parse(date);
                     }
-                    catch (ParseException e3)
+                    catch (ParseException e2)
                     {
-                        format = new SimpleDateFormat("yyyy",
+                        format = new SimpleDateFormat("yyyy-MM",
                                 Locale.getDefault());
                         try
                         {
                             return format.parse(date);
                         }
-                        catch (ParseException e4)
+                        catch (ParseException e3)
                         {
-                            log.error(e4.getMessage(), e);
+                            format = new SimpleDateFormat("yyyy",
+                                    Locale.getDefault());
+                            try
+                            {
+                                return format.parse(date);
+                            }
+                            catch (ParseException e4)
+                            {
+                                log.error(e4.getMessage(), e);
+                            }
                         }
                     }
                 }
@@ -96,7 +111,8 @@ public class DateUtils
 
     public static Date parseFromSolrDate(String date)
     {
-        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.getDefault());
+        SimpleDateFormat format = new SimpleDateFormat(
+                "yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.getDefault());
         Date ret;
         try
         {


### PR DESCRIPTION
The class org.dspace.xoai.util.DateUtils formats a Date to a String and vice versa. During formating it adds milliseconds to the String but the parser currently isn't able to parse it back to the original Date. 
Try this peace of code in the DateUtils class to see the problem: 

 public static void main(String[] args) 
    { 
       Date date = new Date(); 
       String formatted = ""; 

```
   for(int i = 0; i<10; i++){ 
       formatted = format(date, true); 
       System.out.println(formatted); 
       date = parse(formatted); 
   } 

}
```
