### PR TITLE
DS-1925: Remove odd default Google Analytics key from dspace-services API 

### DIFF
--- a/dspace-services/src/main/resources/config/dspace-defaults.cfg
+++ b/dspace-services/src/main/resources/config/dspace-defaults.cfg
@@ -17,7 +17,3 @@ caching.use.clustering = false
 # note that the mapping service must be called "default.MappingService"
 #activator.class.default.MappingService = org.dspace.services.mapping.DatabaseIdEidMapping;default.MappingService
 #activator.class.default.MappingService = org.dspace.services.mapping.MemoryMappingService;default.MappingService
-
-### Default Activators
-
-xmlui.google.analytics.key = UA-554232-12


### PR DESCRIPTION
As reported in comments of DS-1925, this default key seems to cause issues in loading JSPUI

https://jira.duraspace.org/browse/DS-1925?focusedCommentId=41812&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-41812

I can see no purpose for having a default XMLUI Google Analytics key in this file.
