### PR TITLE
Fixed problem in DS-2553 -'DCInputAuthority cannot return the label of a...

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/authority/DCInputAuthority.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/DCInputAuthority.java
@@ -151,7 +151,17 @@ public class DCInputAuthority extends SelfNamedPlugin implements ChoiceAuthority
 
     public String getLabel(String field, String key, String locale)
     {
-        init();
-        return labels[Integer.parseInt(key)];
+    	init();
+        int pos=-1;
+        for (int i = 0; i < values.length; i++) {
+            if (values[i].equals(key)){
+                 pos = i;
+                 break;
+            }
+        }
+        if (pos != -1)
+            return labels[pos];
+        else
+            return "UNKNOWN KEY "+key;
     }
 }


### PR DESCRIPTION
...n authority key that isn't a number'. The #getLabel() method now can receive a 'key' parameter that is not a number.

When doing a **[dspace-install]/bin/dspace index-discovery -bos**  a NumberFormatException occurs and the items cannot be indexed in the _search_ core. I've made a modifications to the #getLabel method to prevent this exception occurs.
