### PR TITLE
DS-2554: fix the oai index issue when submitter is null

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -244,7 +244,9 @@ public class XOAI {
         String handle = item.getHandle();
         doc.addField("item.handle", handle);
         doc.addField("item.lastmodified", item.getLastModified());
-        doc.addField("item.submitter", item.getSubmitter().getEmail());
+        if (item.getSubmitter() != null) {
+            doc.addField("item.submitter", item.getSubmitter().getEmail());
+        }
         doc.addField("item.deleted", item.isWithdrawn() ? "true" : "false");
         for (Collection col : item.getCollections())
             doc.addField("item.collections",


### PR DESCRIPTION
when submitter is null, it will cause NPE exception, so it will stop the OAI index process. eg. if using harvest, the submitter probably will be null in db.
