### PR TITLE
DS-2562, fix incorrect if statement.

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/general/HandleAuthorizedMatcher.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/general/HandleAuthorizedMatcher.java
@@ -28,6 +28,7 @@ import org.dspace.core.Context;
  * possible values are listed in the DSpace Constant class.
  * 
  * @author Scott Phillips
+ * @author Tim Van den Langenbergh
  */
 
 public class HandleAuthorizedMatcher extends AbstractLogEnabled implements Matcher
@@ -66,7 +67,7 @@ public class HandleAuthorizedMatcher extends AbstractLogEnabled implements Match
     	}
     	
     	// Is it a valid action?
-    	if (action > 0 || action >= Constants.actionText.length)
+    	if (action < 0 || action >= Constants.actionText.length)
     	{
     		getLogger().warn("Invalid action: '"+pattern+"'");
     		return null;


### PR DESCRIPTION
This reminds me of that OS X bug where they had two goto fail statements after one another in an if statement without curly braces, also a really small issue that was trivial to solve.
