### PR TITLE
[DS-2527] Disable collection authorisation enumeration optimisation by default

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/Collection.java
+++ b/dspace-api/src/main/java/org/dspace/content/Collection.java
@@ -1564,7 +1564,7 @@ public class Collection extends DSpaceObject
 
     public static Collection[] findAuthorizedOptimized(Context context, int actionID) throws java.sql.SQLException
     {
-        if(! ConfigurationManager.getBooleanProperty("org.dspace.content.Collection.findAuthorizedPerformanceOptimize", true)) {
+        if(! ConfigurationManager.getBooleanProperty("org.dspace.content.Collection.findAuthorizedPerformanceOptimize", false)) {
             // Fallback to legacy query if config says so. The rationale could be that a site found a bug.
             return findAuthorized(context, null, actionID);
         }

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -841,9 +841,10 @@ org.dspace.app.itemexport.max.size = 200
 org.dspace.app.batchitemimport.work.dir = ${dspace.dir}/imports
 
 # Enable performance optimization for select-collection-step collection query
-# The only reason you might opt-out is in case the optimized algorithm missed a policy
-# default = true, (enabled)
-#org.dspace.content.Collection.findAuthorizedPerformanceOptimize = false
+# Enable when having 
+# a large number of collections and no Shibboleth or LDAP authentication.
+# default = false, (disabled)
+#org.dspace.content.Collection.findAuthorizedPerformanceOptimize = true
 
 # For backwards compatibility, the subscription emails by default include any modified items
 # uncomment the following entry for only new items to be emailed
@@ -2092,6 +2093,4 @@ mail.helpdesk = ${mail.admin}
 request.item.helpdesk.override = false
 
 #------------END REQUEST ITEM CONFIGURATION---------------------#
-#Optimizes collection enumeration in submission. Enable when having 
-#a large number of collections and no Shibboleth or LDAP authentication.
-org.dspace.content.Collection.findAuthorizedPerformanceOptimize=false
+

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -2092,3 +2092,6 @@ mail.helpdesk = ${mail.admin}
 request.item.helpdesk.override = false
 
 #------------END REQUEST ITEM CONFIGURATION---------------------#
+#Optimizes collection enumeration in submission. Enable when having 
+#a large number of collections and no Shibboleth or LDAP authentication.
+org.dspace.content.Collection.findAuthorizedPerformanceOptimize=false


### PR DESCRIPTION
Disable collection authorisation enumeration optimisation by default so LDAP and Shibboleth may work out of the box.
