### PR TITLE
Fix for DS-2577 : Flyway Migration Error (constraint "metadatavalue_item_id_fkey" doesn't exist)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/MigrationUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/MigrationUtils.java
@@ -23,18 +23,17 @@ import org.apache.commons.lang.StringUtils;
 public class MigrationUtils
 {
     /**
-     * Drop a given Database Constraint (based on the current database type).
+     * Drop a given Database Column Constraint (based on the current database type).
      * Returns a "checksum" for this migration which can be used as part of
      * a Flyway Java migration
      *
      * @param connection the current Database connection
      * @param tableName the name of the table the constraint applies to
      * @param columnName the name of the column the constraint applies to
-     * @param constraintSuffix Only used for PostgreSQL, whose constraint naming convention depends on a suffix (key, fkey, etc)
      * @return migration checksum as an Integer
      * @throws SQLException if a database error occurs
      */
-    public static Integer dropDBConstraint(Connection connection, String tableName, String columnName, String constraintSuffix)
+    public static Integer dropDBConstraint(Connection connection, String tableName, String columnName)
             throws SQLException
     {
         Integer checksum = -1;
@@ -48,13 +47,17 @@ public class MigrationUtils
         String dbtype = DatabaseManager.findDbKeyword(meta);
         String constraintName = null;
         String constraintNameSQL = null;
+        String schemaName = null;
         switch(dbtype)
         {
             case DatabaseManager.DBMS_POSTGRES:
-                // In Postgres, constraints are always named:
-                // {tablename}_{columnname(s)}_{suffix}
-                // see: http://stackoverflow.com/a/4108266/3750035
-                constraintName = StringUtils.lowerCase(tableName) + "_" + StringUtils.lowerCase(columnName) + "_" + StringUtils.lowerCase(constraintSuffix);
+                // In Postgres, column constraints are listed in the "information_schema.key_column_usage" view
+                // See: http://www.postgresql.org/docs/9.4/static/infoschema-key-column-usage.html
+                constraintNameSQL = "SELECT DISTINCT CONSTRAINT_NAME " +
+                                    "FROM information_schema.key_column_usage " +
+                                    "WHERE TABLE_NAME = ? AND COLUMN_NAME = ? AND TABLE_SCHEMA = ?";
+                // For Postgres, we need to limit by the schema as well
+                schemaName = DatabaseUtils.getSchemaName(connection);
                 break;
             case DatabaseManager.DBMS_ORACLE:
                 // In Oracle, constraints are listed in the USER_CONS_COLUMNS table
@@ -72,35 +75,46 @@ public class MigrationUtils
                 throw new SQLException("DBMS " + dbtype + " is unsupported in this migration.");
         }
 
-        // If we have a SQL query to run for the constraint name, then run it
-        if (constraintNameSQL!=null)
+        // Run the query to obtain the constraint name, passing it the parameters
+        PreparedStatement statement = connection.prepareStatement(constraintNameSQL);
+        statement.setString(1, DatabaseUtils.canonicalize(connection, tableName));
+        statement.setString(2, DatabaseUtils.canonicalize(connection, columnName));
+        // Also limit by database schema, if a schemaName has been set (only needed for PostgreSQL)
+        if(schemaName!=null && !schemaName.isEmpty())
         {
-            // Run the query to obtain the constraint name, passing it the parameters
-            PreparedStatement statement = connection.prepareStatement(constraintNameSQL);
-            statement.setString(1, StringUtils.upperCase(tableName));
-            statement.setString(2, StringUtils.upperCase(columnName));
-            try
+            statement.setString(3, DatabaseUtils.canonicalize(connection, schemaName));
+        }
+        try
+        {
+            ResultSet results = statement.executeQuery();
+            if(results.next())
             {
-                ResultSet results = statement.executeQuery();
-                if(results.next())
-                {
-                    constraintName = results.getString("CONSTRAINT_NAME");
-                }
-                results.close();
+                constraintName = results.getString("CONSTRAINT_NAME");
             }
-            finally
-            {
-                statement.close();
-            }
+            results.close();
+        }
+        finally
+        {
+            statement.close();
         }
 
         // As long as we have a constraint name, drop it
         if (constraintName!=null && !constraintName.isEmpty())
         {
-            // This drop constaint SQL should be the same in all databases
-            String dropConstraintSQL = "ALTER TABLE " + tableName + " DROP CONSTRAINT " + constraintName;
+            // Canonicalize the constraintName
+            constraintName = DatabaseUtils.canonicalize(connection, constraintName);
+            // If constraintName starts with a $, surround with double quotes
+            // (This is mostly for PostgreSQL, which sometimes names constraints $1, $2, etc)
+            if(constraintName.startsWith("$"))
+            {
+                constraintName = "\"" + constraintName + "\"";
+            }
 
-            PreparedStatement statement = connection.prepareStatement(dropConstraintSQL);
+            // This drop constaint SQL should be the same in all databases
+            String dropConstraintSQL = "ALTER TABLE " + DatabaseUtils.canonicalize(connection, tableName) +
+                                       " DROP CONSTRAINT " + constraintName;
+
+            statement = connection.prepareStatement(dropConstraintSQL);
             try
             {
                 statement.execute();

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V1_3_9__Drop_constraint_for_DSpace_1_4_schema.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V1_3_9__Drop_constraint_for_DSpace_1_4_schema.java
@@ -13,8 +13,6 @@ import java.sql.SQLException;
 import org.dspace.storage.rdbms.MigrationUtils;
 import org.flywaydb.core.api.migration.MigrationChecksumProvider;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class is in support of the "V1.4__Upgrade_to_DSpace_1.4_schema.sql"
@@ -42,9 +40,6 @@ import org.slf4j.LoggerFactory;
 public class V1_3_9__Drop_constraint_for_DSpace_1_4_schema
     implements JdbcMigration, MigrationChecksumProvider
 {
-    /** logging category */
-    private static final Logger log = LoggerFactory.getLogger(V1_3_9__Drop_constraint_for_DSpace_1_4_schema.class);
-
     /* The checksum to report for this migration (when successful) */
     private int checksum = -1;
 
@@ -57,7 +52,7 @@ public class V1_3_9__Drop_constraint_for_DSpace_1_4_schema
             throws IOException, SQLException
     {
         // Drop the constraint associated with "name" column of "community"
-        checksum = MigrationUtils.dropDBConstraint(connection, "community", "name", "key");
+        checksum = MigrationUtils.dropDBConstraint(connection, "community", "name");
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V1_5_9__Drop_constraint_for_DSpace_1_6_schema.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V1_5_9__Drop_constraint_for_DSpace_1_6_schema.java
@@ -13,8 +13,6 @@ import java.sql.SQLException;
 import org.dspace.storage.rdbms.MigrationUtils;
 import org.flywaydb.core.api.migration.MigrationChecksumProvider;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class is in support of the "V1.6__Upgrade_to_DSpace_1.6_schema.sql"
@@ -42,9 +40,6 @@ import org.slf4j.LoggerFactory;
 public class V1_5_9__Drop_constraint_for_DSpace_1_6_schema
     implements JdbcMigration, MigrationChecksumProvider
 {
-    /** logging category */
-    private static final Logger log = LoggerFactory.getLogger(V1_5_9__Drop_constraint_for_DSpace_1_6_schema.class);
-
     /* The checksum to report for this migration (when successful) */
     private int checksum = -1;
 
@@ -57,11 +52,11 @@ public class V1_5_9__Drop_constraint_for_DSpace_1_6_schema
             throws IOException, SQLException
     {
         // Drop the constraint associated with "collection_id" column of "community2collection" table
-        int return1 = MigrationUtils.dropDBConstraint(connection, "community2collection", "collection_id", "fkey");
+        int return1 = MigrationUtils.dropDBConstraint(connection, "community2collection", "collection_id");
         // Drop the constraint associated with "child_comm_id" column of "community2community" table
-        int return2 = MigrationUtils.dropDBConstraint(connection, "community2community", "child_comm_id", "fkey");
+        int return2 = MigrationUtils.dropDBConstraint(connection, "community2community", "child_comm_id");
         // Drop the constraint associated with "item_id" column of "collection2item" table
-        int return3 = MigrationUtils.dropDBConstraint(connection, "collection2item", "item_id", "fkey");
+        int return3 = MigrationUtils.dropDBConstraint(connection, "collection2item", "item_id");
 
 	// Checksum will just be the sum of those three return values
 	checksum = return1 + return2 + return3;

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V5_0_2014_09_25__DS_1582_Metadata_For_All_Objects_drop_constraint.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V5_0_2014_09_25__DS_1582_Metadata_For_All_Objects_drop_constraint.java
@@ -13,8 +13,6 @@ import java.sql.SQLException;
 import org.dspace.storage.rdbms.MigrationUtils;
 import org.flywaydb.core.api.migration.MigrationChecksumProvider;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class is in support of the DS-1582 Metadata for All Objects feature.
@@ -37,30 +35,27 @@ import org.slf4j.LoggerFactory;
  * <P>
  * This class represents a Flyway DB Java Migration
  * http://flywaydb.org/documentation/migration/java.html
- * 
+ *
  * @author Tim Donohue
  */
 public class V5_0_2014_09_25__DS_1582_Metadata_For_All_Objects_drop_constraint
     implements JdbcMigration, MigrationChecksumProvider
 {
-    /** logging category */
-    private static final Logger log = LoggerFactory.getLogger(V5_0_2014_09_25__DS_1582_Metadata_For_All_Objects_drop_constraint.class);
-    
     /* The checksum to report for this migration (when successful) */
     private int checksum = -1;
-    
+
     /**
      * Actually migrate the existing database
-     * @param connection 
+     * @param connection
      */
     @Override
     public void migrate(Connection connection)
             throws IOException, SQLException
     {
         // Drop the constraint associated with "item_id" column of "metadatavalue"
-        checksum = MigrationUtils.dropDBConstraint(connection, "metadatavalue", "item_id", "fkey");
+        checksum = MigrationUtils.dropDBConstraint(connection, "metadatavalue", "item_id");
     }
-    
+
     /**
      * Return the checksum to be associated with this Migration
      * in the Flyway database table (schema_version).


### PR DESCRIPTION
As noted in the related ticket, this bug is the result of our own code assuming that PostgreSQL column constraints are named in a standard fashion. 
https://jira.duraspace.org/browse/DS-2577

Now, rather than making that assumption, this PR ensures we instead query for the constraint name in PostgreSQL (which is what we already do for Oracle and H2). 

Some minor code refactoring was also necessary to make this all work properly.  I also had to add in some missing calls to "canonicalize()" to ensure all table names and column names are properly cased (either upper or lowercase) for Postgres vs Oracle.

I have thoroughly tested this PR, by taking a DSpace 4.0 Postgres DB, renaming the "metadatavalue_item_id_fkey" constraint to be "$1", and running the upgrade to 5.x. A fresh install also works perfectly.

I'll wait on Travis CI to confirm and then get this merged, as it solves one of the most common upgrade issues we've encountered with the 5.x flyway-based database upgrade process.
