### PR TITLE
DS-1187 Full-text indexing of right-to-left PDF files

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFFilter.java
@@ -78,6 +78,7 @@ public class PDFFilter extends MediaFilter
             // get input stream from bitstream
             // pass to filter, get string back
             PDFTextStripper pts = new PDFTextStripper();
+            pts.setSortByPosition(true);
             PDDocument pdfDoc = null;
             Writer writer = null;
             File tempTextFile = null;


### PR DESCRIPTION
Fixes https://jira.duraspace.org/browse/DS-1187

This fixes right-to-left full-text indexing for Arabic PDF documents. Already in production in multiple sites since DSpace 1.8.x.
