### PR TITLE
[DS-2590] Fix multiple issues with distributed archives.

### DIFF
--- a/dspace/src/main/assembly/release.xml
+++ b/dspace/src/main/assembly/release.xml
@@ -46,8 +46,10 @@
          <!-- Ensure line endings in all files are Unix (LF) line endings-->
          <lineEnding>unix</lineEnding>
       </fileSet>
-      <!-- Ensure the presence of "empty" directories for build steps
-           that need them. -->
+      <!-- Ensure the presence of "empty" overlay directories for build
+           steps that need them.
+           By default our ".gitignore" files are excluded by
+           "useDefaultExcludes=true". -->
       <fileSet>
          <directory>..</directory>
          <useDefaultExcludes>false</useDefaultExcludes>

--- a/dspace/src/main/assembly/release.xml
+++ b/dspace/src/main/assembly/release.xml
@@ -46,6 +46,19 @@
          <!-- Ensure line endings in all files are Unix (LF) line endings-->
          <lineEnding>unix</lineEnding>
       </fileSet>
+      <!-- Ensure the presence of "empty" directories for build steps
+           that need them. -->
+      <fileSet>
+         <directory>..</directory>
+         <useDefaultExcludes>false</useDefaultExcludes>
+         <includes>
+            <include>dspace/modules/**/.gitignore</include>
+         </includes>
+         <excludes>
+            <exclude>**/target/**</exclude>
+         </excludes>
+         <lineEnding>unix</lineEnding>
+      </fileSet>
    </fileSets>
 
 </assembly>

--- a/dspace/src/main/assembly/src-release.xml
+++ b/dspace/src/main/assembly/src-release.xml
@@ -38,7 +38,8 @@
          <!-- Ensure line endings in all files are Unix (LF) line endings-->
          <lineEnding>unix</lineEnding>
       </fileSet>
-      <!-- Do not destroy ZIP archives by changing "line" endings! -->
+      <!-- Do not destroy ZIP archives by changing "line" endings!
+           (e.g. SWORD's example.zip) -->
       <fileSet>
          <directory>..</directory>
          <useDefaultExcludes>true</useDefaultExcludes>
@@ -49,8 +50,10 @@
             <exclude>**/target/**</exclude>
          </excludes>
       </fileSet>
-      <!-- Ensure the presence of "empty" directories for build steps
-           that need them. -->
+      <!-- Ensure the presence of "empty" overlay directories for build
+           steps that need them.
+           By default our ".gitignore" files are excluded by
+           "useDefaultExcludes=true". -->
       <fileSet>
          <directory>..</directory>
          <useDefaultExcludes>false</useDefaultExcludes>

--- a/dspace/src/main/assembly/src-release.xml
+++ b/dspace/src/main/assembly/src-release.xml
@@ -33,8 +33,33 @@
          <excludes>
             <exclude>**/target/**</exclude>
             <exclude>.*</exclude>
+            <exclude>**/*.zip</exclude>
          </excludes>
          <!-- Ensure line endings in all files are Unix (LF) line endings-->
+         <lineEnding>unix</lineEnding>
+      </fileSet>
+      <!-- Do not destroy ZIP archives by changing "line" endings! -->
+      <fileSet>
+         <directory>..</directory>
+         <useDefaultExcludes>true</useDefaultExcludes>
+         <includes>
+            <include>**/*.zip</include>
+         </includes>
+         <excludes>
+            <exclude>**/target/**</exclude>
+         </excludes>
+      </fileSet>
+      <!-- Ensure the presence of "empty" directories for build steps
+           that need them. -->
+      <fileSet>
+         <directory>..</directory>
+         <useDefaultExcludes>false</useDefaultExcludes>
+         <includes>
+            <include>dspace/modules/**/.gitignore</include>
+         </includes>
+         <excludes>
+            <exclude>**/target/**</exclude>
+         </excludes>
          <lineEnding>unix</lineEnding>
       </fileSet>
    </fileSets>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
              </plugin>
              <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4.1</version>
+                <version>2.5.4</version>
              </plugin>
              <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
              </plugin>
              <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.5.4</version>
+                <version>2.4.1</version>
              </plugin>
              <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Include dspace/modules/*/src/main/webapps so build succeeds.
Avoid damaging a sample ZIP archive by munging "line endings".
Upgrade to maven-assembly-plugin 2.5.4 (which uncovered the line ending problem).
