### PR TITLE
[DS-2502] Correct some dependencies to prevent pulling in servlet-api

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -604,12 +604,20 @@
             <artifactId>google-api-services-analytics</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.api-client</groupId>
+            <artifactId>google-api-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.http-client</groupId>
+            <artifactId>google-http-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.http-client</groupId>
             <artifactId>google-http-client-jackson2</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.oauth-client</groupId>
-            <artifactId>google-oauth-client-jetty</artifactId>
+            <artifactId>google-oauth-client</artifactId>
         </dependency>
         <!-- FindBugs -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1260,13 +1260,23 @@
               <version>v3-rev103-1.19.0</version>
           </dependency>
           <dependency>
+            <groupId>com.google.api-client</groupId>
+            <artifactId>google-api-client</artifactId>
+            <version>1.19.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.http-client</groupId>
+            <artifactId>google-http-client</artifactId>
+            <version>1.19.0</version>
+        </dependency>
+        <dependency>
               <groupId>com.google.http-client</groupId>
               <artifactId>google-http-client-jackson2</artifactId>
               <version>1.19.0</version>
           </dependency>
           <dependency>
               <groupId>com.google.oauth-client</groupId>
-              <artifactId>google-oauth-client-jetty</artifactId>
+              <artifactId>google-oauth-client</artifactId>
               <version>1.19.0</version>
           </dependency>
           <!-- Findbugs annotations -->


### PR DESCRIPTION
This needs some testing.  It leaves servlet-api.jar out of all webapp.s but includes it in [DSpace]/lib.
