### PR TITLE
DS-2583 Additional REST Verbs to Support Reporting Tools

### DIFF
--- a/dspace-rest/src/main/java/org/dspace/rest/FilteredCollectionsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/FilteredCollectionsResource.java
@@ -1,0 +1,115 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.rest;
+
+
+import org.apache.log4j.Logger;
+import org.dspace.authorize.AuthorizeManager;
+import org.dspace.content.DSpaceObject;
+import org.dspace.core.ConfigurationManager;
+import org.dspace.core.Constants;
+import org.dspace.rest.common.Collection;
+import org.dspace.usage.UsageEvent;
+import org.dspace.utils.DSpace;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.ServletContext;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import java.sql.SQLException;
+import java.util.ArrayList;
+
+/*
+The "Path" annotation indicates the URI this class will be available at relative to your base URL.  For
+example, if this web-app is launched at localhost using a context of "hello" and no URL pattern is defined
+in the web.xml servlet mapping section, then the web service will be available at:
+
+http://localhost:8080/<webapp>/collections
+ */
+@Path("/filtered-collections")
+public class FilteredCollectionsResource {
+    private static Logger log = Logger.getLogger(FilteredCollectionsResource.class);
+
+    @javax.ws.rs.core.Context ServletContext servletContext;
+    
+    private static final boolean writeStatistics;
+	
+	static{
+		writeStatistics=ConfigurationManager.getBooleanProperty("rest","stats",false);
+	}
+
+    @GET
+    @Path("/{collection_id}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    public org.dspace.rest.common.FilteredCollection getCollection(@PathParam("collection_id") Integer collection_id, @QueryParam("expand") String expand, 
+    		@QueryParam("limit") @DefaultValue("1000") Integer limit, @QueryParam("offset") @DefaultValue("0") Integer offset,
+    		@QueryParam("userIP") String user_ip, @QueryParam("userAgent") String user_agent, @QueryParam("xforwarderfor") String xforwarderfor,
+    		@QueryParam("filters") @DefaultValue("all") String filters,
+    		@Context HttpHeaders headers, @Context HttpServletRequest request) {
+        org.dspace.core.Context context = null;
+        try {
+            context = new org.dspace.core.Context();
+
+            org.dspace.content.Collection collection = org.dspace.content.Collection.find(context, collection_id);
+            if(AuthorizeManager.authorizeActionBoolean(context, collection, org.dspace.core.Constants.READ)) {
+            	if(writeStatistics){
+    				writeStats(context, collection_id, user_ip, user_agent, xforwarderfor, headers, request);
+    			}
+                return new org.dspace.rest.common.FilteredCollection(collection, filters, expand, context, limit, offset);
+            } else {
+                throw new WebApplicationException(Response.Status.UNAUTHORIZED);
+            }
+        } catch (SQLException e) {
+            log.error(e.getMessage());
+            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
+        } finally {
+            if(context != null) {
+                try {
+                    context.complete();
+                } catch (SQLException e) {
+                    log.error(e.getMessage() + " occurred while trying to close");
+                }
+            }
+        }
+    }
+    
+    private void writeStats(org.dspace.core.Context context, Integer collection_id, String user_ip, String user_agent,
+			String xforwarderfor, HttpHeaders headers,
+			HttpServletRequest request) {
+		
+    	try{
+    		DSpaceObject collection = DSpaceObject.find(context, Constants.COLLECTION, collection_id);
+    		
+    		if(user_ip==null || user_ip.length()==0){
+    			new DSpace().getEventService().fireEvent(
+	                     new UsageEvent(
+	                                     UsageEvent.Action.VIEW,
+	                                     request,
+	                                     context,
+	                                     collection));
+    		} else{
+	    		new DSpace().getEventService().fireEvent(
+	                     new UsageEvent(
+	                                     UsageEvent.Action.VIEW,
+	                                     user_ip,
+	                                     user_agent,
+	                                     xforwarderfor,
+	                                     context,
+	                                     collection));
+    		}
+    		log.debug("fired event");
+    		
+		} catch(SQLException ex){
+			log.error("SQL exception can't write usageEvent \n" + ex);
+		}
+    		
+	}
+}

--- a/dspace-rest/src/main/java/org/dspace/rest/FilteredItemsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/FilteredItemsResource.java
@@ -1,0 +1,247 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.rest;
+
+
+import org.apache.log4j.Logger;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.AuthorizeManager;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.content.ItemIterator;
+import org.dspace.content.MetadataField;
+import org.dspace.content.MetadataSchema;
+import org.dspace.core.ConfigurationManager;
+import org.dspace.core.Constants;
+import org.dspace.rest.common.Collection;
+import org.dspace.rest.common.MetadataEntry;
+import org.dspace.rest.common.ItemFilter;
+import org.dspace.rest.common.ItemFilterQuery;
+import org.dspace.rest.filter.ItemFilterSet;
+import org.dspace.storage.rdbms.DatabaseManager;
+import org.dspace.storage.rdbms.TableRowIterator;
+import org.dspace.usage.UsageEvent;
+import org.dspace.utils.DSpace;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.ServletContext;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.HttpHeaders;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/*
+The "Path" annotation indicates the URI this class will be available at relative to your base URL.  For
+example, if this web-app is launched at localhost using a context of "hello" and no URL pattern is defined
+in the web.xml servlet mapping section, then the web service will be available at:
+
+http://localhost:8080/<webapp>/collections
+ */
+@Path("/filtered-items")
+public class FilteredItemsResource {
+    private static Logger log = Logger.getLogger(FilteredItemsResource.class);
+    
+    private enum OP {
+        equals("==",true,"="),
+        not_equals("!=",false,"="),
+        like("like",true," like "),
+        not_like("not like",false," like "),
+        contains("like",true," like ") {
+            public String prepareVal(String val) {
+                return "%" + val + "%";
+            }
+        },
+        doesnt_contain("not like",false," like "){
+            public String prepareVal(String val) {
+                return "%" + val + "%";
+            }
+        },
+        exists(true),
+        doesnt_exist(false),
+        matches("~",true, "~"),
+        doesnt_match("!~",false,"~");
+        String disp;
+        boolean bexists;
+        String valop;
+        
+        private OP(String disp, boolean exists, String valop) {
+            this.disp = disp;
+            this.bexists = exists;
+            this.valop = valop;
+        }
+        private OP(boolean exists) {
+            this.disp = name();
+            this.bexists = exists;
+            this.valop = null;
+        }
+        public String prepareVal(String val) {
+            return val;
+        }
+    }
+
+    @javax.ws.rs.core.Context ServletContext servletContext;
+    
+    private static final boolean writeStatistics;
+    
+	static{
+		writeStatistics=ConfigurationManager.getBooleanProperty("rest","stats",false);
+	}
+	
+	private void addOp(org.dspace.core.Context context, StringBuilder sb, List<Object> params, String field, OP op, String val) throws SQLException, AuthorizeException {
+	    sb.append(" and ");
+	    sb.append(op.bexists ? "exists " : "not exists ");
+	    sb.append("(select 1 from metadatavalue mv where item.item_id = mv.item_id and mv.metadata_field_id=?");
+
+	    String[] parts = field.split("\\.");
+	    String schema =  (parts.length > 0) ? parts[0] : ""; 
+        String element =  (parts.length > 1) ? parts[1] : ""; 
+        String qualifier =  (parts.length > 2) ? parts[2] : null; 
+	    MetadataSchema mds = MetadataSchema.find(context, schema);
+        if (mds == null)
+        {
+            throw new IllegalArgumentException("No such metadata schema: " + schema);
+        }
+        MetadataField mdf = MetadataField.findByElement(context, mds.getSchemaID(), element, qualifier);
+        if (mdf == null)
+        {
+            throw new IllegalArgumentException(
+                    "No such metadata field: schema=" + schema + ", element=" + element + ", qualifier=" + qualifier);
+        }
+        params.add(mdf.getFieldID());
+        
+        if (op.valop != null) {
+            sb.append(" and text_value ");
+            sb.append(op.valop);
+            sb.append(" ?");
+            params.add(op.prepareVal(val));
+        }
+        sb.append(")");
+	}
+	
+    @GET
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    public org.dspace.rest.common.ItemFilter getItemQuery(@PathParam("collection_id") Integer collection_id, @QueryParam("expand") String expand, 
+    		@QueryParam("limit") @DefaultValue("100") Integer limit, @QueryParam("offset") @DefaultValue("0") Integer offset,
+    		@QueryParam("userIP") String user_ip, @QueryParam("userAgent") String user_agent, @QueryParam("xforwarderfor") String xforwarderfor,
+    		@QueryParam("filters") @DefaultValue("all_filters") String filters,
+            @QueryParam("query_field[]") @DefaultValue("dc.title") List<String> query_field,
+            @QueryParam("query_op[]") @DefaultValue("exists") List<String> query_op,
+            @QueryParam("query_val[]") @DefaultValue("") List<String> query_val,
+            @QueryParam("show_fields[]") @DefaultValue("") List<String> show_fields,
+    		@Context HttpHeaders headers, @Context HttpServletRequest request) {
+        org.dspace.core.Context context = null;
+        try {
+            context = new org.dspace.core.Context();
+
+            ItemFilterSet itemFilterSet = new ItemFilterSet(filters, true);
+            ItemFilter result = itemFilterSet.getAllFiltersFilter();
+            
+            StringBuilder sb = new StringBuilder();
+            StringBuilder sql = new StringBuilder("select item.* from item where 1=1 ");
+            ArrayList<Object> params = new ArrayList<Object>();
+            
+            List<ItemFilterQuery> itemFilterQueries = new ArrayList<ItemFilterQuery>();
+            
+            try {                
+                for(int i=0; i<query_field.size(); i++) {
+                    if (i >= query_op.size()) break;
+                    String field = query_field.get(i);
+                    OP op = OP.valueOf(query_op.get(i));
+                    String val = (i >= query_val.size()) ? "" : query_val.get(i);
+                    if (sb.length() > 0) {
+                        sb.append(" AND ");
+                    }
+                    sb.append(op.bexists ? "(" : "!(");
+                    sb.append(query_field.get(i));
+                    sb.append(" ");
+                    sb.append(op.valop == null ? "exists" : op.valop);
+                    sb.append(" ");
+                    sb.append(op.prepareVal(val));
+                    sb.append(")");
+                    
+                    addOp(context, sql, params, field, op, val);
+                    itemFilterQueries.add(new ItemFilterQuery(field, op.disp, op.prepareVal(val)));
+                }
+                
+                sql.append(" limit ? offset ?");
+                params.add(limit);
+                params.add(offset);
+                
+                result.setQueryAnnotation(sb.toString());
+                result.setItemFilterQueries(itemFilterQueries);
+                if (show_fields != null) {
+                    List<MetadataEntry> returnFields = new ArrayList<MetadataEntry>();
+                    for(String field: show_fields) {
+                        returnFields.add(new MetadataEntry(field, null));
+                    }
+                    result.setMetadata(returnFields);                    
+                }
+                TableRowIterator rows = DatabaseManager.queryTable(context, "item", sql.toString(), params.toArray(new Object[0]));
+                
+                ItemIterator childItems = new ItemIterator(context, rows);
+                itemFilterSet.processSaveItems(context, childItems, true, expand);
+            } catch(IllegalArgumentException e) {
+                result.setQueryAnnotation(e.getMessage());                
+            }
+            
+            return result;
+        } catch (SQLException e) {
+            log.error(e.getMessage());
+            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
+        } catch (AuthorizeException e) {
+            log.error(e.getMessage());
+            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
+        } finally {
+            if(context != null) {
+                try {
+                    context.complete();
+                } catch (SQLException e) {
+                    log.error(e.getMessage() + " occurred while trying to close");
+                }
+            }
+        }
+    }
+    
+    private void writeStats(org.dspace.core.Context context, Integer collection_id, String user_ip, String user_agent,
+			String xforwarderfor, HttpHeaders headers,
+			HttpServletRequest request) {
+		
+    	try{
+    		DSpaceObject collection = DSpaceObject.find(context, Constants.COLLECTION, collection_id);
+    		
+    		if(user_ip==null || user_ip.length()==0){
+    			new DSpace().getEventService().fireEvent(
+	                     new UsageEvent(
+	                                     UsageEvent.Action.VIEW,
+	                                     request,
+	                                     context,
+	                                     collection));
+    		} else{
+	    		new DSpace().getEventService().fireEvent(
+	                     new UsageEvent(
+	                                     UsageEvent.Action.VIEW,
+	                                     user_ip,
+	                                     user_agent,
+	                                     xforwarderfor,
+	                                     context,
+	                                     collection));
+    		}
+    		log.debug("fired event");
+    		
+		} catch(SQLException ex){
+			log.error("SQL exception can't write usageEvent \n" + ex);
+		}
+    		
+	}
+}

--- a/dspace-rest/src/main/java/org/dspace/rest/FiltersResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/FiltersResource.java
@@ -1,0 +1,55 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.rest;
+
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
+import org.apache.log4j.Logger;
+import org.dspace.rest.common.ItemFilter;
+
+/**
+ * Class which provides read methods over the metadata registry.
+ * 
+ * @author Terry Brady, Georgetown University
+ * 
+ */
+@Path("/filters")
+//public class MetadataRegistryResource extends Resource
+public class FiltersResource 
+{
+    private static Logger log = Logger.getLogger(FiltersResource.class);
+
+    /**
+     * Return all metadata registry items in DSpace.
+     * 
+     * @return Return array of metadata schemas.
+     * @throws WebApplicationException
+     *             It can be caused by creating context or while was problem
+     *             with reading community from database(SQLException).
+     */
+    @GET
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+    public ItemFilter[] getFilters(@QueryParam("userIP") String user_ip, @QueryParam("userAgent") String user_agent,
+            @QueryParam("xforwarderfor") String xforwarderfor, @Context HttpHeaders headers, @Context HttpServletRequest request)
+            throws WebApplicationException
+    {
+
+        log.info("Reading all filters.");
+        return ItemFilter.getItemFilters(ItemFilter.ALL, false).toArray(new ItemFilter[0]);
+    }
+
+}

--- a/dspace-rest/src/main/java/org/dspace/rest/MetadataRegistryResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/MetadataRegistryResource.java
@@ -1,0 +1,102 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.rest;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.ArrayList;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.apache.log4j.Logger;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.AuthorizeManager;
+import org.dspace.rest.common.MetadataSchema;
+import org.dspace.rest.common.MetadataField;
+//import org.dspace.rest.exceptions.ContextException;
+import org.dspace.usage.UsageEvent;
+
+/**
+ * Class which provides read methods over the metadata registry.
+ * 
+ * @author Terry Brady, Georgetown University
+ * 
+ */
+@Path("/metadataregistry")
+//public class MetadataRegistryResource extends Resource
+public class MetadataRegistryResource 
+{
+    private static Logger log = Logger.getLogger(MetadataRegistryResource.class);
+
+    /**
+     * Return all metadata registry items in DSpace.
+     * 
+     * @return Return array of metadata schemas.
+     * @throws WebApplicationException
+     *             It can be caused by creating context or while was problem
+     *             with reading community from database(SQLException).
+     */
+    @GET
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+    public MetadataSchema[] getSchemas(@QueryParam("userIP") String user_ip, @QueryParam("userAgent") String user_agent,
+            @QueryParam("xforwarderfor") String xforwarderfor, @Context HttpHeaders headers, @Context HttpServletRequest request)
+            throws WebApplicationException
+    {
+
+        log.info("Reading all schemas.");
+        org.dspace.core.Context context = null;
+        ArrayList<MetadataSchema> metadataSchemas = null;
+
+        try
+        {
+            //context = createContext(getUser(headers));
+            context = new org.dspace.core.Context();
+
+            org.dspace.content.MetadataSchema[] schemas = org.dspace.content.MetadataSchema.findAll(context);
+            metadataSchemas = new ArrayList<MetadataSchema>();
+            for(org.dspace.content.MetadataSchema schema: schemas) {
+                metadataSchemas.add(new MetadataSchema(schema, context));
+            }
+
+            context.complete();
+        }
+        catch (SQLException e)
+        {
+            //processException("Could not read schemas, SQLException. Message:" + e, context);
+            log.error(e.getMessage());
+            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
+        }
+        //catch (ContextException e)
+        //{
+        //    processException("Could not read schemas, ContextException. Message:" + e.getMessage(), context);
+        //}
+        finally
+        {
+            //processFinally(context);
+        }
+
+        log.trace("All schemas successfully read.");
+        return metadataSchemas.toArray(new MetadataSchema[0]);
+    }
+
+}

--- a/dspace-rest/src/main/java/org/dspace/rest/common/FilteredCollection.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/common/FilteredCollection.java
@@ -1,0 +1,142 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.rest.common;
+
+import org.apache.log4j.Logger;
+import org.dspace.authorize.AuthorizeManager;
+import org.dspace.content.ItemIterator;
+import org.dspace.core.Context;
+import org.dspace.rest.filter.ItemFilterDefs;
+import org.dspace.rest.filter.ItemFilterSet;
+import org.dspace.rest.filter.ItemFilterTest;
+
+import javax.ws.rs.WebApplicationException;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: peterdietz
+ * Date: 5/22/13
+ * Time: 9:41 AM
+ * To change this template use File | Settings | File Templates.
+ */
+@XmlRootElement(name = "filtered-collection")
+public class FilteredCollection extends DSpaceObject {
+    Logger log = Logger.getLogger(FilteredCollection.class);
+
+    //Relationships
+    private Community parentCommunity;
+    private List<Community> parentCommunityList = new ArrayList<Community>();
+
+    private List<Item> items = new ArrayList<Item>();
+    
+    private List<ItemFilter> itemFilters = new ArrayList<ItemFilter>();
+    
+    //Calculated
+    private Integer numberItems;
+
+    public FilteredCollection(){}
+
+    public FilteredCollection(org.dspace.content.Collection collection, String filters, String expand, Context context, Integer limit, Integer offset) throws SQLException, WebApplicationException{
+        super(collection);
+        setup(collection, expand, context, limit, offset, filters);
+    }
+
+    private void setup(org.dspace.content.Collection collection, String expand, Context context, Integer limit, Integer offset, String filters) throws SQLException{
+        List<String> expandFields = new ArrayList<String>();
+        if(expand != null) {
+            expandFields = Arrays.asList(expand.split(","));
+        }
+
+        if(expandFields.contains("parentCommunityList") || expandFields.contains("all")) {
+            org.dspace.content.Community[] parentCommunities = collection.getCommunities();
+            for(org.dspace.content.Community parentCommunity : parentCommunities) {
+                this.addParentCommunityList(new Community(parentCommunity, null, context));
+            }
+        } else {
+            this.addExpand("parentCommunityList");
+        }
+
+        if(expandFields.contains("parentCommunity") | expandFields.contains("all")) {
+            org.dspace.content.Community parentCommunity = (org.dspace.content.Community) collection.getParentObject();
+            this.setParentCommunity(new Community(parentCommunity, null, context));
+        } else {
+            this.addExpand("parentCommunity");
+        }
+
+        boolean reportItems = expandFields.contains("items") || expandFields.contains("all");
+        ItemFilterSet itemFilterSet = new ItemFilterSet(filters, reportItems);
+        itemFilters = itemFilterSet.getItemFilters();
+        
+        if (itemFilters.size() > 0) {
+            //TODO: Item paging. limit, offset/page
+            ItemIterator childItems;
+            if(limit != null && limit >= 0 && offset != null && offset >= 0) {
+                childItems = collection.getItems(limit, offset);
+            } else {
+                childItems = collection.getAllItems();
+            }
+
+            items = itemFilterSet.processSaveItems(context, childItems, true, expand);            
+        }       
+        
+        if(!expandFields.contains("all")) {
+            this.addExpand("all");
+        }
+        this.setNumberItems(collection.countItems());
+    }
+
+    public Integer getNumberItems() {
+        return numberItems;
+    }
+
+    public void setNumberItems(Integer numberItems) {
+        this.numberItems = numberItems;
+    }
+
+    public Community getParentCommunity() {
+        return parentCommunity;
+    }
+
+    public void setParentCommunity(Community parentCommunity) {
+        this.parentCommunity = parentCommunity;
+    }
+
+    public List<Item> getItems() {
+		return items;
+	}
+
+	public void setItems(List<Item> items) {
+		this.items = items;
+	}
+
+	public void setParentCommunityList(List<Community> parentCommunityList) {
+		this.parentCommunityList = parentCommunityList;
+	}
+
+	public List<Community> getParentCommunityList() {
+        return parentCommunityList;
+    }
+
+    public void addParentCommunityList(Community parentCommunity) {
+        this.parentCommunityList.add(parentCommunity);
+    }
+
+	public List<ItemFilter> getItemFilters() {
+	    return itemFilters;
+	}
+	
+	public void setItemFilters(List<ItemFilter> itemFilters) {
+	    this.itemFilters = itemFilters;
+	}
+}

--- a/dspace-rest/src/main/java/org/dspace/rest/common/ItemFilter.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/common/ItemFilter.java
@@ -1,0 +1,202 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.rest.common;
+
+import org.apache.log4j.Logger;
+import org.dspace.core.Context;
+import org.dspace.rest.filter.ItemFilterDefs;
+import org.dspace.rest.filter.ItemFilterTest;
+
+import javax.ws.rs.WebApplicationException;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Filtered list of items that match a specific set of criteria.
+ */
+@XmlRootElement(name = "item-filter")
+public class ItemFilter {
+    Logger log = Logger.getLogger(ItemFilter.class);
+
+    private ItemFilterTest itemFilterTest = null;
+    private String filterName = "";
+    private String title;
+    private String description;
+    private String queryAnnotation;
+    private List<Item> items = new ArrayList<Item>();
+    private List<ItemFilterQuery> itemFilterQueries = new ArrayList<ItemFilterQuery>();
+    private List<MetadataEntry> metadata = new ArrayList<MetadataEntry>();
+    private Integer itemCount;
+    private boolean saveItems = false;
+
+    public ItemFilter(){}
+
+    public static final String ALL_FILTERS = "all_filters";
+    public static final String ALL = "all";
+    
+    public static List<ItemFilter> getItemFilters(String filters, boolean saveItems) {
+        List<ItemFilter> itemFilters = new ArrayList<ItemFilter>();
+        ItemFilter allFilters = new ItemFilter(ItemFilter.ALL_FILTERS, "Matches all specified filters", "This filter includes all items that matched ALL specified filters", saveItems);
+
+        if (filters.equals(ALL)) {
+            for(ItemFilterDefs itemFilterDef: ItemFilterDefs.values()) {
+                itemFilters.add(new ItemFilter(itemFilterDef, saveItems));
+            }                
+            itemFilters.add(allFilters);
+        } else {
+            for(String filter: Arrays.asList(filters.split(","))) {
+                if (filter.equals(ItemFilter.ALL_FILTERS)) {
+                    itemFilters.add(allFilters);
+                    continue;
+                }
+                
+                ItemFilterDefs itemFilterDef;
+                try {
+                    itemFilterDef = ItemFilterDefs.valueOf(filter);
+                } catch (IllegalArgumentException e) {
+                    continue;
+                }
+                itemFilters.add(new ItemFilter(itemFilterDef, saveItems));
+            }
+        }
+        return itemFilters;
+    }
+    
+    public static ItemFilter getAllFiltersFilter(List<ItemFilter> itemFilters) {
+        for(ItemFilter itemFilter: itemFilters) {
+            if (itemFilter.getFilterName().equals(ALL_FILTERS)) {
+                itemFilter.initCount();
+                return itemFilter;
+            }
+        }
+        return null;
+    }
+    
+    public ItemFilter(ItemFilterTest itemFilterTest, boolean saveItems) throws WebApplicationException{
+        this.itemFilterTest = itemFilterTest;
+        this.saveItems = saveItems;
+        setup(itemFilterTest.getName(), itemFilterTest.getTitle(), itemFilterTest.getDescription());
+    }
+    
+    public ItemFilter(String name, String title, String description, boolean saveItems) throws WebApplicationException{
+        this.saveItems = saveItems;
+        setup(name, title, description);
+    }
+
+    private void setup(String name, String title, String description) {
+        this.setFilterName(name);
+        this.setTitle(title);
+        this.setDescription(description);
+    }
+
+    private void initCount() {
+        if (itemCount == null) {
+            itemCount = 0;
+        }        
+    }    
+    
+    public boolean hasItemTest() {
+        return itemFilterTest != null;
+    }
+    
+    public void addItem(Item restItem) {
+        initCount();
+        if (saveItems){
+            items.add(restItem);            
+        }
+        itemCount++;
+    }
+    
+    public boolean testItem(Context context, org.dspace.content.Item item, Item restItem) {
+        initCount();
+        if (itemFilterTest == null) {
+            return false;
+        }
+        if (itemFilterTest.testItem(context, item)) {
+            addItem(restItem);
+            return true;
+        }
+        return false;
+    }
+
+
+    @XmlAttribute(name="filter-name")
+    public String getFilterName() {
+        return filterName;
+    }
+
+    public void setFilterName(String name) {
+        this.filterName = name;
+    }
+    
+    @XmlAttribute(name="title")
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    @XmlAttribute(name="description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @XmlAttribute(name="query-annotation")
+    public String getQueryAnnotation() {
+        return queryAnnotation;
+    }
+
+    public void setQueryAnnotation(String queryAnnotation) {
+        this.queryAnnotation = queryAnnotation;
+    }
+
+    @XmlAttribute(name="item-count")
+    public Integer getItemCount() {
+        return itemCount;
+    }
+
+    public void setItemCount(Integer itemCount) {
+        this.itemCount = itemCount;
+    }
+
+    public List<Item> getItems() {
+        return items;
+    }
+
+	public void setItems(List<Item> items) {
+		this.items = items;
+	}
+
+    public List<ItemFilterQuery> getItemFilterQueries() {
+        return itemFilterQueries;
+    }
+
+    public void setItemFilterQueries(List<ItemFilterQuery> itemFilterQueries) {
+        this.itemFilterQueries = itemFilterQueries;
+    }
+
+    public List<MetadataEntry> getMetadata() {
+        return metadata;
+    }
+
+    @XmlElement(required = true)
+    public void setMetadata(List<MetadataEntry> metadata) {
+        this.metadata = metadata;
+    }
+}

--- a/dspace-rest/src/main/java/org/dspace/rest/common/ItemFilterQuery.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/common/ItemFilterQuery.java
@@ -1,0 +1,72 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.rest.common;
+
+import org.apache.log4j.Logger;
+import org.dspace.core.Context;
+import org.dspace.rest.filter.ItemFilterDefs;
+import org.dspace.rest.filter.ItemFilterTest;
+
+import javax.ws.rs.WebApplicationException;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Filtered list of items that match a specific set of criteria.
+ */
+@XmlRootElement(name = "item-filter-query")
+public class ItemFilterQuery {
+    Logger log = Logger.getLogger(ItemFilterQuery.class);
+
+    private String field = "";
+    private String operation = "";
+    private String value = "";
+
+    public ItemFilterQuery(){}
+
+    public ItemFilterQuery(String field, String operation, String value) throws WebApplicationException{
+        setup(field, operation, value);
+    }
+
+    private void setup(String field, String operation, String value) {
+        this.setField(field);
+        this.setOperation(operation);
+        this.setValue(value);
+    }
+
+    @XmlAttribute(name="field")
+    public String getField() {
+        return field;
+    }
+
+    public void setField(String field) {
+        this.field = field;
+    }
+    
+    @XmlAttribute(name="operation")
+    public String getOperation() {
+        return operation;
+    }
+
+    public void setOperation(String operation) {
+        this.operation = operation;
+    }
+    @XmlAttribute(name="value")
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/dspace-rest/src/main/java/org/dspace/rest/common/MetadataField.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/common/MetadataField.java
@@ -1,0 +1,83 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.rest.common;
+
+import org.apache.log4j.Logger;
+import org.dspace.authorize.AuthorizeManager;
+import org.dspace.core.Context;
+
+import javax.ws.rs.WebApplicationException;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Terry Brady, Georgetown University.
+ * Metadata field representation
+ */
+@XmlRootElement(name = "field")
+public class MetadataField {
+    private static Logger log = Logger.getLogger(MetadataField.class);
+
+    private String name;
+    private String element;
+    private String qualifier;
+    private String description;
+
+    public MetadataField(){}
+
+    public MetadataField(org.dspace.content.MetadataSchema schema, org.dspace.content.MetadataField field, Context context) throws SQLException, WebApplicationException{
+        setup(schema, field, context);
+    }
+
+    private void setup(org.dspace.content.MetadataSchema schema, org.dspace.content.MetadataField field, Context context) throws SQLException{
+        StringBuilder sb = new StringBuilder();
+        sb.append(schema.getName());
+        sb.append(".");
+        sb.append(field.getElement());
+        if (field.getQualifier()!=null) {
+            sb.append(".");
+            sb.append(field.getQualifier());            
+        }
+        
+        this.setName(sb.toString());
+        this.setElement(field.getElement());
+        this.setQualifier(field.getQualifier());
+        this.setDescription(field.getScopeNote());
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+    public void setElement(String element) {
+        this.element = element;
+    }
+    public void setQualifier(String qualifier) {
+        this.qualifier = qualifier;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+    
+    public String getName() {
+        return name;
+    }
+    
+    public String getQualifier() {
+        return qualifier;
+    }
+    public String getElement() {
+        return element;
+    }
+    public String getDescription() {
+        return description;
+    }
+}

--- a/dspace-rest/src/main/java/org/dspace/rest/common/MetadataSchema.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/common/MetadataSchema.java
@@ -1,0 +1,68 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.rest.common;
+
+import org.apache.log4j.Logger;
+import org.dspace.authorize.AuthorizeManager;
+import org.dspace.core.Context;
+
+import javax.ws.rs.WebApplicationException;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Terry Brady, Georgetown University.
+ * Metadata schema representation
+ */
+@XmlRootElement(name = "schema")
+public class MetadataSchema {
+    private static Logger log = Logger.getLogger(MetadataField.class);
+
+    private String prefix;
+    private String namespace;
+    
+    @XmlElement(name = "fields", required = true)
+    private List<MetadataField> fields = new ArrayList<MetadataField>();
+
+    public MetadataSchema(){}
+
+    public MetadataSchema(org.dspace.content.MetadataSchema schema, Context context) throws SQLException, WebApplicationException{
+        setup(schema, context);
+    }
+
+    private void setup(org.dspace.content.MetadataSchema schema, Context context) throws SQLException{
+        this.setPrefix(schema.getName());
+        this.setNamespace(schema.getNamespace());
+        org.dspace.content.MetadataField[] fields = org.dspace.content.MetadataField.findAllInSchema(context, schema.getSchemaID());
+        for(org.dspace.content.MetadataField field: fields) {
+            this.fields.add(new MetadataField(schema, field, context));
+        }
+    
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
+    }
+    
+    public String getPrefix() {
+        return prefix;
+    }    
+    public String getNamespace() {
+        return namespace;
+    }
+    public List<MetadataField> getMetadataFields() {
+        return fields;
+    }
+}

--- a/dspace-rest/src/main/java/org/dspace/rest/filter/ItemFilterDefs.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/filter/ItemFilterDefs.java
@@ -1,0 +1,154 @@
+package org.dspace.rest.filter;
+
+import java.sql.SQLException;
+
+import org.dspace.authorize.AuthorizeManager;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+
+public enum ItemFilterDefs implements ItemFilterTest {
+    is_not_withdrawn("Withdrawn Items") {
+        public boolean testItem(Context context, Item item) {
+            return !item.isWithdrawn();
+        }        
+    },
+    is_withdrawn("Available Items - Not Withdrawn") {
+        public boolean testItem(Context context, Item item) {
+            return item.isWithdrawn();
+        }        
+    },
+    is_discoverable("Discoverable Items - Not Private") {
+        public boolean testItem(Context context, Item item) {
+            return item.isDiscoverable();
+        }        
+    },
+    is_not_discoverable("Private Items - Not Discoverable") {
+        public boolean testItem(Context context, Item item) {
+            return !item.isDiscoverable();
+        }        
+    },
+    has_multiple_originals("Item has Multiple Originals") {
+        public boolean testItem(Context context, Item item) {
+            int count = 0;
+            try {
+                for(Bundle bundle: item.getBundles("ORIGINAL")){
+                    count += bundle.getBitstreams().length;
+                }
+            } catch (SQLException e) {
+            }
+            return count > 1;
+        }        
+    },
+    has_no_originals("Item has No Original Bitstreams") {
+        public boolean testItem(Context context, Item item) {
+            int count = 0;
+            try {
+                for(Bundle bundle: item.getBundles("ORIGINAL")){
+                    count += bundle.getBitstreams().length;
+                }
+            } catch (SQLException e) {
+            }
+            return count == 0;
+        }        
+    },
+    has_one_original("Item has One Original Bitstream") {
+        public boolean testItem(Context context, Item item) {
+            int count = 0;
+            try {
+                for(Bundle bundle: item.getBundles("ORIGINAL")){
+                    count += bundle.getBitstreams().length;
+                }
+            } catch (SQLException e) {
+            }
+            return count == 1;
+        }        
+    },
+    has_restricted_original("Item has Restricted Original", "Item has at least one original bitstream that is not accessible to Anonymous user") {
+        public boolean testItem(Context context, Item item) {
+            try {
+                for(Bundle bundle: item.getBundles("ORIGINAL")){
+                    for(Bitstream bit: bundle.getBitstreams()) {
+                        if (!AuthorizeManager.authorizeActionBoolean(context, bit, org.dspace.core.Constants.READ)) {
+                            return true;
+                        }
+                    }
+                }
+            } catch (SQLException e) {
+            }
+            return false;
+        }        
+    },
+    has_pdf_original("Item has PDF Original") {
+        public boolean testItem(Context context, Item item) {
+            try {
+                for(Bundle bundle: item.getBundles("ORIGINAL")){
+                    for(Bitstream bit: bundle.getBitstreams()) {
+                        if (bit.getFormat().getMIMEType().equals("application/pdf")) {
+                            return true;
+                        }
+                    }
+                }
+            } catch (SQLException e) {
+            }
+            return false;
+        }        
+    },
+    has_image_original("Item has Image Original") {
+        public boolean testItem(Context context, Item item) {
+            try {
+                for(Bundle bundle: item.getBundles("ORIGINAL")){
+                    for(Bitstream bit: bundle.getBitstreams()) {
+                        if (bit.getFormat().getMIMEType().startsWith("image")) {
+                            return true;
+                        }
+                    }
+                }
+            } catch (SQLException e) {
+            }
+            return false;
+        }        
+    },
+    has_jpg_original("Item has JPG Original") {
+        public boolean testItem(Context context, Item item) {
+            try {
+                for(Bundle bundle: item.getBundles("ORIGINAL")){
+                    for(Bitstream bit: bundle.getBitstreams()) {
+                        if (bit.getFormat().getMIMEType().equals("image/jpeg")) {
+                            return true;
+                        }
+                    }
+                }
+            } catch (SQLException e) {
+            }
+            return false;
+        }        
+    },
+    ;
+    
+    private String title = null;
+    private String description = null;
+    private ItemFilterDefs(String title, String description) {
+        this.title = title;
+        this.description = description;
+    }
+    
+    private ItemFilterDefs(String title) {
+        this(title, null);
+    }
+    
+    private ItemFilterDefs() {
+        this(null, null);
+    }
+    
+    public String getName() {
+        return name();
+    }
+    public String getTitle() {
+        return title;
+    }
+    public String getDescription() {
+        return description;
+    }
+}

--- a/dspace-rest/src/main/java/org/dspace/rest/filter/ItemFilterSet.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/filter/ItemFilterSet.java
@@ -1,0 +1,62 @@
+package org.dspace.rest.filter;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.ws.rs.WebApplicationException;
+
+import org.dspace.authorize.AuthorizeManager;
+import org.dspace.content.ItemIterator;
+import org.dspace.core.Context;
+import org.dspace.rest.common.Item;
+import org.dspace.rest.common.ItemFilter;
+
+public class ItemFilterSet {
+    private List<ItemFilter> itemFilters;
+    private ItemFilter allFiltersFilter; 
+
+    public ItemFilterSet(String filterList, boolean reportItems) {
+        itemFilters = ItemFilter.getItemFilters(filterList, reportItems);
+        allFiltersFilter = ItemFilter.getAllFiltersFilter(itemFilters);
+    }
+    
+    public ItemFilter getAllFiltersFilter() {
+        return allFiltersFilter;
+    }
+
+    public void testItem(Context context, org.dspace.content.Item item, Item restItem) {
+        boolean bAllTrue = true;
+        for(ItemFilter itemFilter: itemFilters) {
+            if (itemFilter.hasItemTest()) {
+                bAllTrue &= itemFilter.testItem(context, item, restItem);                            
+            }
+        }
+        if (bAllTrue && allFiltersFilter != null) {
+            allFiltersFilter.addItem(restItem);
+        }
+    }
+    
+    public List<ItemFilter> getItemFilters() {
+        return itemFilters;
+    }
+    
+    public void processItems(Context context, ItemIterator childItems) throws WebApplicationException, SQLException {
+        processSaveItems(context, childItems, false, null);
+    }
+
+    public List<Item> processSaveItems(Context context, ItemIterator childItems, boolean save, String expand) throws WebApplicationException, SQLException {
+        List<Item> items = new ArrayList<Item>();
+        while(childItems.hasNext()) {
+            org.dspace.content.Item item = childItems.next();
+            if(AuthorizeManager.authorizeActionBoolean(context, item, org.dspace.core.Constants.READ)) {
+                Item restItem = new Item(item, expand, context); 
+                if(save) {
+                    items.add(restItem);
+                }
+               testItem(context, item, restItem);
+            }
+        }
+        return items;
+    }
+}

--- a/dspace-rest/src/main/java/org/dspace/rest/filter/ItemFilterTest.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/filter/ItemFilterTest.java
@@ -1,0 +1,11 @@
+package org.dspace.rest.filter;
+
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+
+public interface ItemFilterTest {
+    public String getName();
+    public String getTitle();
+    public String getDescription();
+    public boolean testItem(Context context, Item i);
+}


### PR DESCRIPTION
# Notes about this PR
- See https://jira.duraspace.org/browse/DS-2583
- This code was built for DSpace 4.3.  Submitting 4.3 compatible code which will fail in the build
- Hardy Pottinger suggested submitting as is.
- This code contains code also present in https://github.com/DSpace/DSpace/pull/916
- **Question**: Should the sample client code be included in this PR?
- **Question**: If client code is included, should it be served up from /xmlui/... or from /rest/...?
- **Question**: Can Jersey be configured to return html/css/js files?
# Proposed REST API based reporting tool for DSpace

A proposed reporting tool for DSpace based on the DSpace 4.x REST api.
## Demonstration Video

[![Demonstration Video of Possible Report Tools](https://cloud.githubusercontent.com/assets/1111057/7463526/f3e34b22-f26e-11e4-9946-fe034c4cda51.png)](http://www.youtube.com/watch?v=1Lxzqpq_3x4)
## Collections Filters

_ItemsFilterDefs.java_ contains a set of filter definitions that match specific item use cases.

```
public enum ItemFilterDefs implements ItemFilterTest {
    is_not_withdrawn("Withdrawn Items") {
        public boolean testItem(Context context, Item item) {
            return !item.isWithdrawn();
        }        
    },
    is_withdrawn("Available Items - Not Withdrawn") {
        public boolean testItem(Context context, Item item) {
            return item.isWithdrawn();
        }        
    },
    is_discoverable("Discoverable Items - Not Private") {
        public boolean testItem(Context context, Item item) {
            return item.isDiscoverable();
        }        
    },
    is_not_discoverable("Private Items - Not Discoverable") {
        public boolean testItem(Context context, Item item) {
            return !item.isDiscoverable();
        }        
    },
    has_multiple_originals("Item has Multiple Originals") {
        public boolean testItem(Context context, Item item) {
            int count = 0;
            try {
                for(Bundle bundle: item.getBundles("ORIGINAL")){
                    count += bundle.getBitstreams().length;
                }
            } catch (SQLException e) {
            }
            return count > 1;
        }        
    },
    ...
```

This code illustrates a mechanism to filter DSpace items by use case and item properties.
### Sample Collections Filter Client

_The purpose of this client code is to illustrate how quickly a useful client application could be built by extending the REST API to support the ability to filter collections._
- [Sample Filter Client Page](https://github.com/Georgetown-University-Libraries/DSpaceRestQCReports/tree/master/sampleClient/index.html)
- [Sample Filter Client JS](https://github.com/Georgetown-University-Libraries/DSpaceRestQCReports/tree/master/sampleClient/restCommon.js)
- [Sample Client Screen Shots](https://github.com/Georgetown-University-Libraries/DSpaceRestQCReports/releases/tag/v0.1)
## Metadata Query Tool

This tool allows a user to query for items based on the presence of one or more metadata fields within an item.  The tool supports 8 operators: exists, doesn't exist, equals, not equals, like, not like, matches, doesn't match.  More than one operation can be provided.
### Sample Metadata Query Tool Client

_The purpose of this client code is to illustrate how quickly a useful client application could be built by extending the REST API to support the ability to query item metadata._
- [Sample Query Tool Client Page](https://github.com/Georgetown-University-Libraries/DSpaceRestQCReports/tree/master/sampleClient/query.html)
- [Sample Query Tool Client JS](https://github.com/Georgetown-University-Libraries/DSpaceRestQCReports/tree/master/sampleClient/restQuery.js)
- [Sample Query Tool Client Screen Shots](https://github.com/Georgetown-University-Libraries/DSpaceRestQCReports/releases/tag/v0.2)
## New API Calls Needed to Support These Tools
- **/metadataregistry** - Return the Metadata Registry
- **/filters** - Return a set of pre-defined filters for items of interest
- **/filtered-collections** - Return items / item counts within a collection that satisfy a filter
- **/filtered-items** - Return items that match a metadata query
