### PR TITLE
DS-2598 Correct XPATH for available date in mets format xoai

### DIFF
--- a/dspace/config/crosswalks/oai/metadataFormats/mets.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/mets.xsl
@@ -67,7 +67,7 @@
 							<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='available']">
 							<mods:extension>
 								<mods:dateAvailable encoding="iso8601">
-									<xsl:value-of select="doc:field[@name='value']/text()" />
+									<xsl:value-of select="doc:element/doc:field[@name='value']/text()" />
 								</mods:dateAvailable>
 							</mods:extension>
 							</xsl:for-each>


### PR DESCRIPTION
This ensures that dc.date.available is shown when using the mets metadata
format in OAI-PMH. Previously, the dateAvailable element was present but empty.
