### PR TITLE
DS-2600: Choose how the filename of a bitstream is generated when is requested for download

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/BitstreamReader.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/BitstreamReader.java
@@ -397,100 +397,77 @@ public class BitstreamReader extends AbstractReader implements Recyclable
                 }
             }
 
+
             // Set the filename of the requested bitstream depending of 'xmlui.content_disposition_filename' configuration.
-            // Calculate file extension
-            String bitstreamExtension = "";
-		    int finalDotIndex = -1;
-		    if(bitstream.getName() != null)
-		    {
-		    	finalDotIndex = bitstream.getName().lastIndexOf('.');
-		    }
-            if(finalDotIndex > -1)
-		    { 
-			    bitstreamExtension = bitstream.getName().substring(finalDotIndex);
-		    }
-            String bitstreamNameSource = ConfigurationManager.getProperty("xmlui.content_disposition_filename");
+           String bitstreamNameSource = ConfigurationManager.getProperty("xmlui.content_disposition_filename");
             // If no configuration is specified, defaults to 'handle'.
             if(bitstreamNameSource == null)
             {
             	bitstreamNameSource = "handle";
-            }else if(!bitstreamNameSource.equals("title") && !bitstreamNameSource.equals("description") && !bitstreamNameSource.equals("parameter") && !bitstreamNameSource.equals("handle"))
-            {
-            	log.error("xmlui.content_disposition_filenameSource property in dspace.cfg is misconfigured.");
             }
-            
-            bitstreamName = null;
             // Generate the fileName without extension. Subsequently, the extension is concatenated.
             // Checks if at least least one of the previous options can be executed.
-            if((name != null && name.length() > 0) || (bitstream.getName() != null && bitstream.getName().length() > 0) || (bitstream.getDescription() != null && bitstream.getDescription().length() > 0) || (item != null && item.getHandle() != null))
-            {
-            	if(bitstreamNameSource.equals("title"))
-            	{
-            		if(bitstream.getName() != null && bitstream.getName().length() > 0)
-                    {
-                    	// filename is taken from the Bitstream instance (if exists).
-                		bitstreamName = bitstream.getName();
-                        // Trim any path information from the bitstream
-                		int finalSlashIndex = bitstreamName.lastIndexOf('/');
-                        if(finalSlashIndex > 0)
-                        {
-                        	bitstreamName = bitstreamName.substring(finalSlashIndex+1);
-                        }
-                        // Trim the file extension.
-                        if(finalDotIndex > -1)
-                        {
-                        	bitstreamName = bitstreamName.substring(0,finalDotIndex);
-                        }
-                    }else{
-                    	log.warn("The bitstream with ID "+ bitstream.getID() +" hasn't no 'name' attribute, or is empty.");
-                    }
-            	}
-            	if(bitstreamNameSource.equals("description"))
-            	{
-            		if(bitstream.getDescription() != null && bitstream.getDescription().length() > 0)
-            		{
-            			bitstreamName = bitstream.getDescription();
-            		}else
-            		{
-            			log.warn("The bitstream with ID "+ bitstream.getID() +" hasn't no 'description' attribute, or is empty.");
-            		}
-            	}
-            	if(bitstreamNameSource.equals("parameter"))
-            	{
-            		if(name != null && name.length() > 0)
-                    {
-                    	// filename is taken from the cocoon parameter called "name" (if exists). 
-            			int nameExtensionIndex = name.lastIndexOf('.');
-            			String parameterName = name; 
-            			if (nameExtensionIndex > -1)
-            			{
-            				parameterName = parameterName.substring(0, nameExtensionIndex); 
-            			}
-            			bitstreamName = parameterName;
-                    }else
-                    {
-                    	log.warn("The URL "+ request.getRequestURI() +" has no 'name' as a parameter, or is empty.");
-                    }
-            		
-            	}
-            	if(bitstreamNameSource.equals("handle"))
-            	{
-            		if(item != null && item.getHandle() != null)
+            bitstreamName = null;
+        	switch (bitstreamNameSource) {
+        		case "title":
+        			bitstreamName = bitstream.getName();
+        			break;
+        		case "description":
+        			bitstreamName = bitstream.getDescription();
+        			break;
+        		case "parameter":
+        			bitstreamName = name;
+        			break;
+        		case "handle":
+        			if(item != null && item.getHandle() != null)
                     {
                     	bitstreamName = item.getHandle().replace("/", "_") + "_" + bitstream.getSequenceID();
-                    }else
-                    {
-                    	log.warn("The bitstream with ID "+bitstream.getID()+" has no associated item, or the item doesn't have a 'handle' configured.");
                     }
-            	}
-            }
-            // if the configuration specified cannot be applied, then a generic filename is set.
-            if(bitstreamName == null)
+        			break;
+        		default:
+        			log.error("xmlui.content_disposition_filename property expects title, description, handle or parameter. But '"+ bitstreamNameSource +"' given.");
+			}
+            
+       
+            if(bitstreamName == null || bitstreamName.length() == 0)
             {
-            	bitstreamName = "bitstream";
+            	// If the configuration specified cannot be applied, then a generic filename is set.
+            	bitstreamName = "bitstream_" + bitstream.getID();
             }
-            // escape the 'unsafe' chars in the bitstreamName
-            bitstreamName = escapeAsFilename(bitstreamName,"_") + bitstreamExtension;
+            else
+            {
+            	// Filter bitstreamName
+            	
+            	// Trim any path information
+        		int finalSlashIndex = bitstreamName.lastIndexOf('/');
+                if(finalSlashIndex > -1)
+                {
+                	bitstreamName = bitstreamName.substring(finalSlashIndex+1);
+                }
+            	
+                // Trim file extension
+            	int finalDotIndex = bitstreamName.lastIndexOf('.');
+	            if(finalDotIndex > -1)
+			    { 
+	            	bitstreamName = bitstreamName.substring(0, finalDotIndex);
+			    }
+	            
+	            // escape the 'unsafe' chars
+	            bitstreamName = escapeAsFilename(bitstreamName);
+            }
+           
+            // Calculate file extension from bitstream.getName() 
+            String bitstreamExtension = "";
+		    if(bitstream.getName() != null)
+		    {
+		    	int finalDotIndex = bitstream.getName().lastIndexOf('.');
+	            if(finalDotIndex > -1)
+			    { 
+				    bitstreamExtension = bitstream.getName().substring(finalDotIndex);
+			    }
+		    }
+		    
+            bitstreamName = bitstreamName + bitstreamExtension;
             
             // Log that the bitstream has been viewed, this is non-cached and the complexity
             // of adding it to the sitemap for every possible bitstream uri is not very tractable
@@ -831,48 +808,30 @@ public class BitstreamReader extends AbstractReader implements Recyclable
     /**
      * 	Makes a replacement of a group of reserved chars. This allows to download a filename suitable for its use in many filesystems.
      *	@param filename - the string to escape
-     *	@param replacement - the string used to replace the reserved chars
-     *  @return a escaped string using the replacement specified, the original string if replacement is null, or null if filename is not specified.
+     *  @return a escaped string, or null if filename is not specified.
      */
-    private String escapeAsFilename(String filename, String replacement)
+    private static String escapeAsFilename(String filename)
     {
     	if(filename == null)
     	{
-    		return null;
+    		throw new IllegalArgumentException("Missing required 'filename' argument.");
     	}
-    	if(replacement == null)
-    	{
-    		return filename;
-    	}
-    	ArrayList<Pattern> patternList = new ArrayList<Pattern>();
-    	// Pattern that applies in many OS (Unix, Windows, etc). Represents the characters that will be escaped.
-    	patternList.add(Pattern.compile("[%\\.\"\\*/:<>\\?\\\\\\|\\+,\\.;=\\[\\]]"));
-		// Pattern to delete consecutive existences of the replacement character. P.e: replace "_____a_____b__c" to "_a_b_c".
-    	patternList.add(Pattern.compile(replacement+"+"));
 		
-		// Size restriction (127 characters) for filenames in Android. 123 + 4 --> filename_123.ext
-		int max_length = 123;
-		String encoded = filename; 
-	    for(int i = 0; i < patternList.size(); i++)
-	    {
-	    	StringBuffer sb = new StringBuffer();
-		    
-	    	// Apply the regex.
-		    Matcher m = patternList.get(i).matcher(encoded);
-	
-		    while (m.find())
-		    {		    	
-		        m.appendReplacement(sb,replacement);
-		    }
-		    m.appendTail(sb);
-		    encoded = sb.toString();
-	    }
-	    // Trim the string.
-	    encoded = encoded.trim();
-
-	    // Truncate the string.
-	    int end = Math.min(encoded.length(),max_length);
-	    return encoded.substring(0,end);
+		//Regular expression of the characters that will be escaped.
+		String regex = "[%\\.\"\\*/:<>\\?\\\\\\|\\+,\\.;=\\[\\]]+";
+		// Replace all invalid characters in string.
+		filename = filename.replaceAll(regex,"_");
+	    
+	    // Size restriction (127 characters) for filenames in Android (123 + 4 for extension)
+	 	int max_length = 123;
+	    if(filename.length() > max_length)
+	     {
+	    	 int end = Math.min(filename.length(),max_length);
+	    	 filename = filename.substring(0,end);
+	     }
+	     
+	    return filename;
+	   
 	}
     
     /**

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/BitstreamReader.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/BitstreamReader.java
@@ -623,28 +623,31 @@ public class BitstreamReader extends AbstractReader implements Recyclable
         
         // If this is a large bitstream then tell the browser it should treat it as a download.
         int threshold = ConfigurationManager.getIntProperty("xmlui.content_disposition_threshold");
+        String contentDispositionMode = "inline";
+        String name  = bitstreamName;
+        // Try and make the download file name formatted for each browser.
+        try {
+                String agent = request.getHeader("USER-AGENT");
+                if (agent != null && agent.contains("MSIE"))
+                {
+                    name = URLEncoder.encode(name, "UTF8");
+                }
+                else if (agent != null && agent.contains("Mozilla"))
+                {
+                    name = MimeUtility.encodeText(name, "UTF8", "B");
+                }
+        }
+        catch (UnsupportedEncodingException see)
+        {
+                // do nothing
+        }
         if (bitstreamSize > threshold && threshold != 0)
         {
-                String name  = bitstreamName;
-                
-                // Try and make the download file name formatted for each browser.
-                try {
-                        String agent = request.getHeader("USER-AGENT");
-                        if (agent != null && agent.contains("MSIE"))
-                        {
-                            name = URLEncoder.encode(name, "UTF8");
-                        }
-                        else if (agent != null && agent.contains("Mozilla"))
-                        {
-                            name = MimeUtility.encodeText(name, "UTF8", "B");
-                        }
-                }
-                catch (UnsupportedEncodingException see)
-                {
-                        // do nothing
-                }
-                response.setHeader("Content-Disposition", "attachment;filename=" + '"' + name + '"');
+                contentDispositionMode = "attachment";
         }
+        
+        //Content-Disposition setting
+        response.setHeader("Content-Disposition", contentDispositionMode + ";filename=" + '"' + name + '"');
 
         ByteRange byteRange = null;
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1499,6 +1499,19 @@ websvc.opensearch.formats = html,atom,rss
 webui.content_disposition_threshold = 8388608
 xmlui.content_disposition_threshold = 8388608
 
+#### Content-Disposition Filename ################
+#
+# Set the source of the property "filename" of the content-disposition in header.
+# There are 4 options
+# 	* title: set the filename with the bitstream original name (Bitstream.getName()).
+#	* description: set the filename with the bitstream description (Bitstream.getDescription())
+#	* parameter: set the filename with the parameter of the url. 
+#			P.e.: in <dspace.url>/handle/<prefix>/<sufix>/<filename_in_url>?<sequence>..., the filename value is
+#			<filename_in_url>.
+#	* handle: set the filename using the pattern <handlePrefix>_<handleSufix>_<bitstream_sequence>.
+# The default value is the 'handle' option.		     
+#xmlui.content_disposition_filename = [title | description | parameter | handle]
+xmlui.content_disposition_filename = title	
 
 #### Multi-file HTML document/site settings #####
 #


### PR DESCRIPTION
When a bitstream is downloaded, the original bitstream's name ('dc.title' metadata) is used to set the filename.
This new feature lets set, in four different ways, how the filename is generated, by defining the following configuration options:
- TITLE: set the filename with the bitstream original name (Bitstream.getName()).
- DESCRIPTION: set the filename with the bitstream description (Bitstream.getDescription())
- PARAMETER: set the filename with the parameter of the url. P.e.: in &lt;dspace.url&gt;/handle/&lt;prefix&gt;/&lt;sufix&gt;/&lt;filename_in_url&gt;?&lt;sequence&gt;..., the filename value is &lt;filename_in_url&gt;.
- HANDLE: set the filename using the pattern &lt;handlePrefix&gt;_&lt;handleSufix&gt;_&lt;bitstream_sequence&gt;. P.e.: 123456789_325_2.

If none of the previous options can be applied, then the generic name 'bitstream' is used.

Once the download request is processed, the filename will be set in the element "Content-Disposition" of the HTTP response header. To do this, a little modification was made to ensure that the "Content-Disposition" element be always generated. 
