### PR TITLE
Adding CSS classes identifying each field by its metadata type

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemTag.java
@@ -485,6 +485,19 @@ public class ItemTag extends TagSupport
                 }
                 
                 out.print(label);
+                
+		// Create CSS class to identify fields by their metadata name.
+		// We use underscore as separator and no wildcard qualifier
+		// because dots and asterisks are forbidden as CSS class names.
+		String metadataNameClass = "";
+		if (qualifier == null || qualifier == Item.ANY
+				|| qualifier.isEmpty()) {
+			metadataNameClass = schema + "_" + element;
+		} else {
+			metadataNameClass = schema + "_" + element + "_"
+					+ qualifier;
+		} 
+                
                 out.print(":&nbsp;</td><td class=\"metadataFieldValue\">");
                 
                 //If the values are in controlled vocabulary and the display value should be shown


### PR DESCRIPTION
Adding CSS classes identifying each field by its metadata type. This allows unique layout changes for each metadata type in the detail view.
