### PR TITLE
fix for sort fields in solr, now the value is stored without accents

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -36,7 +36,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.collections.Transformer;
 import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang.time.DateFormatUtils;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.apache.http.HttpHost;
@@ -1282,7 +1282,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                             log.warn("Error while indexing sort date field, item: " + item.getHandle() + " metadata field: " + field + " date value: " + date);
                         }
                     }else{
-                        doc.addField(field + "_sort", value);
+                        doc.addField(field + "_sort", StringUtils.stripAccents(value));
                     }
                     sortFieldsAdded.add(field);
                 }


### PR DESCRIPTION
If we have accents in sort fields when solr tries to order (by dc.title_sort for example) it doesn't do it well, so I think we don't need accents in this type of fields.
Replacing every letter with his non accent equivalent one could be a fix, this is done using the StringUtils function 'stripAccents' that does the job. 
