### PR TITLE
DS-2628: Use Travis container environment & enable caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,18 @@
 language: java
 
+# Use container build env
+sudo: false
+
 env: 
   # Give Maven 1GB of memory to work with
   - MAVEN_OPTS=-Xmx1024M
+
+cache:
+  directories:
+    # Cache the local Maven repo
+    - '$HOME/.m2/repository'
+    # Cache Node.js modules (for Mirage2)
+    - node_modules
 
 # Install prerequisites for building Mirage2 more rapidly
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
     # Cache the local Maven repo
     - '$HOME/.m2/repository'
     # Cache Node.js modules (for Mirage2)
-    - node_modules
+    - '$HOME/.nvm'
 
 # Install prerequisites for building Mirage2 more rapidly
 before_install:


### PR DESCRIPTION
An alternative version of PR #971, which also enables caching for both Maven and Node.js (Mirage2).

Let's see what Travis thinks about this.
