### PR TITLE
DS-2520: Modify XPath expression when retrieving a workflow step

### DIFF
--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowFactoryImpl.java
@@ -99,7 +99,7 @@ public class XmlWorkflowFactoryImpl implements XmlWorkflowFactory {
 
     protected Step createFirstStep(Workflow workflow, Node workflowNode) throws TransformerException, WorkflowConfigurationException {
         String firstStepID = workflowNode.getAttributes().getNamedItem("start").getTextContent();
-        Node stepNode = XPathAPI.selectSingleNode(workflowNode, "//step[@id='"+firstStepID+"']");
+        Node stepNode = XPathAPI.selectSingleNode(workflowNode, "step[@id='"+firstStepID+"']");
         if(stepNode == null){
             throw new WorkflowConfigurationException("First step does not exist for workflow: "+workflowNode.getAttributes().getNamedItem("id").getTextContent());
         }


### PR DESCRIPTION
When we have two workflows, W1 and W2, and W2 has a first
step with a ID equal to other step ID in W1, WorkflowFactory
retrieves erroneously the step in W1 when we ask about the
first step in W2.

To prevent this, the corresponding XPath expression was modified.

See [JIRA issue](https://jira.duraspace.org/browse/DS-2520) for more details.
