### PR TITLE
DS-2602 : Fix Title/Date browsing, also properly escape special characters in Solr

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SearchService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SearchService.java
@@ -113,4 +113,11 @@ public interface SearchService {
      * @return the indexed field
      */
     String toSortFieldIndex(String metadataField, String type);
+
+    /**
+     * Utility method to escape any special characters in a user's query
+     * @param query
+     * @return query with any special characters escaped
+     */
+    String escapeQueryChars(String query);
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -2320,4 +2320,13 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 			throw new SearchServiceException(e.getMessage(), e);
 		}
 	}
+
+    @Override
+    public String escapeQueryChars(String query) {
+        // Use Solr's built in query escape tool
+        // WARNING: You should only escape characters from user entered queries,
+        // otherwise you may accidentally BREAK field-based queries (which often
+        // rely on special characters to separate the field from the query value)
+        return ClientUtils.escapeQueryChars(query);
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -1617,14 +1617,6 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         if(discoveryQuery.getQuery() != null)
         {
         	query = discoveryQuery.getQuery();
-            if (query.contains(": "))
-            {
-                query = StringUtils.replace(query, ": ", "\\: ");
-            }
-            else if (query.endsWith(":"))
-            {
-                query = StringUtils.removeEnd(query, ":") + "\\:";
-            }
 		}
 
         solrQuery.setQuery(query);

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/discovery/DiscoverUtility.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/discovery/DiscoverUtility.java
@@ -225,6 +225,8 @@ public class DiscoverUtility
         String query = request.getParameter("query");
         if (StringUtils.isNotBlank(query))
         {
+            // Escape any special characters in this user-entered query
+            query = SearchUtils.getSearchService().escapeQueryChars(query);
             queryArgs.setQuery(query);
         }
 

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/AbstractSearch.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/AbstractSearch.java
@@ -723,11 +723,11 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
         {
             return;
         }
-        
 
         String query = getQuery();
 
-        //DSpaceObject scope = getScope();
+        // Escape any special characters in this user-entered query
+        query = DiscoveryUIUtils.escapeQueryChars(query);
 
         int page = getParameterPage();
 

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/DiscoveryUIUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/DiscoveryUIUtils.java
@@ -96,4 +96,20 @@ public class DiscoveryUIUtils {
         }
         return new ArrayList<String>(result.values());
     }
+
+    /**
+     * Escape special characters in a user-entered query, based on the
+     * underlying search service.
+     * <P>
+     * WARNING: This likely shouldn't be used in field-based queries
+     * (e.g. search/browse by title) as it may unintentionally escape the
+     * special characters used to denote fields (e.g. ":").
+     *
+     * @param query
+     * @return query with special characters escaped
+     */
+    public static String escapeQueryChars(String query)
+    {
+        return searchService.escapeQueryChars(query);
+    }
 }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SidebarFacetsTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SidebarFacetsTransformer.java
@@ -157,6 +157,8 @@ public class SidebarFacetsTransformer extends AbstractDSpaceTransformer implemen
         //If we are on a search page performing a search a query may be used
         String query = request.getParameter("query");
         if(query != null && !"".equals(query)){
+            // Escape any special characters in this user-entered query
+            query = DiscoveryUIUtils.escapeQueryChars(query);
             queryArgs.setQuery(query);
         }
 


### PR DESCRIPTION
This PR resolves several issues with regards to special characters that are entered into queries:
- Reverts the changes in PR #944 as they caused DS-2602
- Update Discovery SearchService to include a method that escapes special characters in user-entered queries
- Add an implementation for Solr which uses Solr's own ClientUtils.escapeQueryChars() http://lucene.apache.org/solr/4_2_1/solr-solrj/org/apache/solr/client/solrj/util/ClientUtils.html#escapeQueryChars%28java.lang.String%29
- Update XMLUI to call this method right after obtaining a user query off the request

This PR fixes all three of these Solr special character related issues:
- https://jira.duraspace.org/browse/DS-2602
- https://jira.duraspace.org/browse/DS-2461
- https://jira.duraspace.org/browse/DS-2339

I will note that, while searching on ":" won't throw an error, it also doesn't seem to match any documents (even if you have a ":" in a title for example). I suspect it's because these special characters are also not being indexed.

I did NOT dig into changing our indexing setup. I simply fixed the bugs and ensured that Solr doesn't throw a SyntaxError within our DSpace logs.
