### PR TITLE
DS-2593 : Ensure a "tombstone" is left for withdrawn items in OAI-PMH. Fix other minor, obvious OAI bugs.

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -167,10 +167,11 @@ public class XOAI {
         System.out
                 .println("Incremental import. Searching for documents modified after: "
                         + last.toString());
-
-        String sqlQuery = "SELECT item_id FROM item WHERE in_archive=TRUE AND discoverable=TRUE AND last_modified > ?";
+        // Index both in_archive items AND withdrawn items. Withdrawn items will be flagged withdrawn
+        // (in order to notify external OAI harvesters of their new status)
+        String sqlQuery = "SELECT item_id FROM item WHERE (in_archive=TRUE OR withdrawn=TRUE) AND discoverable=TRUE AND last_modified > ?";
         if(DatabaseManager.isOracle()){
-                sqlQuery = "SELECT item_id FROM item WHERE in_archive=1 AND discoverable=1 AND last_modified > ?";
+                sqlQuery = "SELECT item_id FROM item WHERE (in_archive=1 OR withdrawn=1) AND discoverable=1 AND last_modified > ?";
         }
 
         try {
@@ -187,10 +188,11 @@ public class XOAI {
     private int indexAll() throws DSpaceSolrIndexerException {
         System.out.println("Full import");
         try {
-
-            String sqlQuery = "SELECT item_id FROM item WHERE in_archive=TRUE AND discoverable=TRUE";
+            // Index both in_archive items AND withdrawn items. Withdrawn items will be flagged withdrawn
+            // (in order to notify external OAI harvesters of their new status)
+            String sqlQuery = "SELECT item_id FROM item WHERE (in_archive=TRUE OR withdrawn=TRUE) AND discoverable=TRUE";
             if(DatabaseManager.isOracle()){
-                sqlQuery = "SELECT item_id FROM item WHERE in_archive=1 AND discoverable=1";
+                sqlQuery = "SELECT item_id FROM item WHERE (in_archive=1 OR withdrawn=1) AND discoverable=1";
             }
 
             TableRowIterator iterator = DatabaseManager.query(context,
@@ -287,17 +289,14 @@ public class XOAI {
     }
 
     private boolean isPublic(Item item) {
+        boolean pub = false;
         try {
-            AuthorizeManager.authorizeAction(context, item, Constants.READ);
-            for (Bundle b : item.getBundles())
-                AuthorizeManager.authorizeAction(context, b, Constants.READ);
-            return true;
-        } catch (AuthorizeException ex) {
-            log.debug(ex.getMessage());
+            //Check if READ access allowed on this Item
+            pub = AuthorizeManager.authorizeActionBoolean(context, item, Constants.READ);
         } catch (SQLException ex) {
             log.error(ex.getMessage());
         }
-        return false;
+        return pub;
     }
 
 
@@ -355,6 +354,8 @@ public class XOAI {
         XOAICacheService cacheService = applicationContext.getBean(XOAICacheService.class);
         XOAIItemCacheService itemCacheService = applicationContext.getBean(XOAIItemCacheService.class);
 
+        Context ctx = null;
+
         try {
             CommandLineParser parser = new PosixParser();
             Options options = new Options();
@@ -394,7 +395,7 @@ public class XOAI {
                 String command = line.getArgs()[0];
 
                 if (COMMAND_IMPORT.equals(command)) {
-                    Context ctx = new Context();
+                    ctx = new Context();
                     XOAI indexer = new XOAI(ctx,
                             line.hasOption('o'),
                             line.hasOption('c'),
@@ -404,21 +405,17 @@ public class XOAI {
 
                     int imported = indexer.index();
                     if (imported > 0) cleanCache(itemCacheService, cacheService);
-
-                    ctx.abort();
                 } else if (COMMAND_CLEAN_CACHE.equals(command)) {
                     cleanCache(itemCacheService, cacheService);
                 } else if (COMMAND_COMPILE_ITEMS.equals(command)) {
 
-                    Context ctx = new Context();
+                    ctx = new Context();
                     XOAI indexer = new XOAI(ctx, line.hasOption('v'));
                     applicationContext.getAutowireCapableBeanFactory().autowireBean(indexer);
 
                     indexer.compile();
 
                     cleanCache(itemCacheService, cacheService);
-
-                    ctx.abort();
                 } else if (COMMAND_ERASE_COMPILED_ITEMS.equals(command)) {
                     cleanCompiledItems(itemCacheService);
                     cleanCache(itemCacheService, cacheService);
@@ -435,6 +432,12 @@ public class XOAI {
                 ex.printStackTrace();
             }
             log.error(ex.getMessage(), ex);
+        }
+        finally
+        {
+            // Abort our context, if still open
+            if(ctx!=null && ctx.isValid())
+                ctx.abort();
         }
     }
 

--- a/dspace-oai/src/main/java/org/dspace/xoai/controller/DSpaceOAIDataProvider.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/controller/DSpaceOAIDataProvider.java
@@ -145,7 +145,7 @@ public class DSpaceOAIDataProvider
     }
 
     private void closeContext(Context context) {
-        if (context != null)
+        if (context != null && context.isValid())
             context.abort();
     }
 

--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceAuthorizationFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceAuthorizationFilter.java
@@ -14,9 +14,7 @@ import java.util.List;
 
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
-import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.AuthorizeManager;
-import org.dspace.content.Bundle;
 import org.dspace.content.Item;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
@@ -52,14 +50,6 @@ public class DSpaceAuthorizationFilter extends DSpaceFilter
         boolean pub = false;
         try
         {
-            // For DSpace, if an Item is withdrawn, "isDeleted()" will be true.
-            // In this scenario, we want a withdrawn item to be *shown* so that
-            // we can properly respond with a "deleted" status via OAI-PMH.
-            // Don't worry, this does NOT make the metadata public for withdrawn items,
-            // it merely provides an item "tombstone" via OAI-PMH.
-            if (item.isDeleted())
-                return true;
-
             // If Handle or Item are not found, return false
             String handle = DSpaceItem.parseHandle(item.getIdentifier());
             if (handle == null)

--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceWithdrawnFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceWithdrawnFilter.java
@@ -1,0 +1,64 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xoai.filter;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.dspace.core.Context;
+import org.dspace.storage.rdbms.DatabaseManager;
+import org.dspace.xoai.data.DSpaceItem;
+import org.dspace.xoai.filter.results.DatabaseFilterResult;
+import org.dspace.xoai.filter.results.SolrFilterResult;
+
+/**
+ * Filter for Withdrawn items. Enabling this filter allows tombstones for
+ * withdrawn items to be accessible via OAI-PMH. This allows us to properly
+ * flag withdrawn items with a "deleted" status. For more info on OAI-PMH
+ * "deleted" status, see:
+ * http://www.openarchives.org/OAI/openarchivesprotocol.html#deletion
+ * <P>
+ * (Don't worry, a tombstone doesn't display the withdrawn item's metadata or files.)
+ * 
+ * @author Tim Donohue
+ */
+public class DSpaceWithdrawnFilter extends DSpaceFilter {
+
+    @Override
+    public DatabaseFilterResult buildDatabaseQuery(Context context)
+    {
+        List<Object> params = new ArrayList<Object>();
+
+        String filter = "i.withdrawn=TRUE";
+        if(DatabaseManager.isOracle())
+            filter = "i.withdrawn=1";
+
+        return new DatabaseFilterResult(filter, params);
+    }
+
+    @Override
+    public boolean isShown(DSpaceItem item)
+    {
+        // For DSpace, if an Item is withdrawn, "isDeleted()" will be true.
+        // In this scenario, we want a withdrawn item to be *shown* so that
+        // we can properly respond with a "deleted" status via OAI-PMH.
+        // Don't worry, this does NOT make the metadata public for withdrawn items,
+        // it merely provides an item "tombstone" via OAI-PMH.
+        if (item.isDeleted())
+            return true;
+        else
+            return false;
+    }
+
+    @Override
+    public SolrFilterResult buildSolrQuery()
+    {
+        // In Solr, we store withdrawn items as "deleted".
+        // See org.dspace.xoai.app.XOAI, index(Item) method.
+        return new SolrFilterResult("item.deleted:true");
+    }
+}

--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/NotFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/NotFilter.java
@@ -28,7 +28,7 @@ public class NotFilter extends DSpaceFilter {
 
     @Override
     public SolrFilterResult buildSolrQuery() {
-        return new SolrFilterResult("NOT("+inFilter.buildSolrQuery()+")");
+        return new SolrFilterResult("NOT("+inFilter.buildSolrQuery().getQuery()+")");
     }
 
     @Override

--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/OrFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/OrFilter.java
@@ -36,7 +36,7 @@ public class OrFilter extends DSpaceFilter {
 
     @Override
     public SolrFilterResult buildSolrQuery() {
-        return new SolrFilterResult("("+left.buildSolrQuery()+") OR ("+right.buildSolrQuery()+")");
+        return new SolrFilterResult("("+left.buildSolrQuery().getQuery()+") OR ("+right.buildSolrQuery().getQuery()+")");
     }
 
     @Override

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/database/DSpaceDatabaseQueryResolver.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/database/DSpaceDatabaseQueryResolver.java
@@ -52,12 +52,18 @@ public class DSpaceDatabaseQueryResolver implements DatabaseQueryResolver {
         }
         countParameters.addAll(parameters);
 
+        String whereInArchive = "WHERE i.in_archive=true";
+        if(DatabaseManager.isOracle())
+        {
+            whereInArchive = "WHERE i.in_archive=1";
+        }
+
         if (!where.equals("")) {
-            query += " WHERE i.in_archive=true AND " + where;
-            countQuery += " WHERE i.in_archive=true AND " + where;
+            query += " " + whereInArchive + " AND " + where;
+            countQuery += " " + whereInArchive + " AND " + where;
         } else {
-            query += " WHERE i.in_archive=true";
-            countQuery += " WHERE i.in_archive=true";
+            query += " " + whereInArchive;
+            countQuery += " " + whereInArchive;
         }
 
         query += " ORDER BY i.item_id";

--- a/dspace-oai/src/main/webapp/static/style.xsl
+++ b/dspace-oai/src/main/webapp/static/style.xsl
@@ -290,6 +290,10 @@
                     </div>
                 </div>
                 <div class="panel-body">
+                    <!-- If this record has a "status", display it as a warning -->
+                    <xsl:if test="oai:header/@status">
+                      <div class="alert alert-warning">Record Status: <xsl:value-of select="oai:header/@status"/></div>
+                    </xsl:if>
                     <div class="panel panel-success">
                         <a data-toggle="collapse">
                             <xsl:attribute name="href">#sets<xsl:value-of select="translate(oai:header/oai:identifier/text(), ':/.', '')"></xsl:value-of></xsl:attribute>
@@ -427,6 +431,10 @@
                     </div>
                 </div>
                 <div class="panel-body">
+                    <!-- If this record has a "status", display it as a warning -->
+                    <xsl:if test="@status">
+                      <div class="alert alert-warning">Record Status: <xsl:value-of select="@status"/></div>
+                    </xsl:if>
                     <div class="panel panel-success">
                         <a data-toggle="collapse">
                             <xsl:attribute name="href">#sets<xsl:value-of select="translate(oai:identifier/text(), ':/.', '')"></xsl:value-of></xsl:attribute>

--- a/dspace-oai/src/main/webapp/static/style.xsl
+++ b/dspace-oai/src/main/webapp/static/style.xsl
@@ -285,7 +285,7 @@
                             <h5>Identifier <small><xsl:value-of select="oai:header/oai:identifier/text()"></xsl:value-of></small></h5>
                         </div>
                         <div class="col-lg-6">
-                            <h5>Last Modfied <small><xsl:value-of select="translate(oai:header/oai:datestamp/text(), 'TZ', ' ')"></xsl:value-of></small></h5>
+                            <h5>Last Modified <small><xsl:value-of select="translate(oai:header/oai:datestamp/text(), 'TZ', ' ')"></xsl:value-of></small></h5>
                         </div>
                     </div>
                 </div>
@@ -350,11 +350,15 @@
                             <h5>Identifier <small><xsl:value-of select="oai:header/oai:identifier/text()"></xsl:value-of></small></h5>
                         </div>
                         <div class="col-lg-6">
-                            <h5>Last Modfied <small><xsl:value-of select="translate(oai:header/oai:datestamp/text(), 'TZ', ' ')"></xsl:value-of></small></h5>
+                            <h5>Last Modified <small><xsl:value-of select="translate(oai:header/oai:datestamp/text(), 'TZ', ' ')"></xsl:value-of></small></h5>
                         </div>
                     </div>
                 </div>
                 <div class="panel-body">
+                    <!-- If this record has a "status", display it as a warning -->
+                    <xsl:if test="oai:header/@status">
+                      <div class="alert alert-warning">Record Status: <xsl:value-of select="oai:header/@status"/></div>
+                    </xsl:if>
                     <div class="panel panel-success">
                             <div class="panel-heading">
                                 <h5 class="panel-title">
@@ -410,7 +414,7 @@
                             <h5>Identifier <small><xsl:value-of select="oai:identifier/text()"></xsl:value-of></small></h5>
                         </div>
                         <div class="col-lg-4">
-                            <h5>Last Modfied <small><xsl:value-of select="translate(oai:datestamp/text(), 'TZ', ' ')"></xsl:value-of></small></h5>
+                            <h5>Last Modified <small><xsl:value-of select="translate(oai:datestamp/text(), 'TZ', ' ')"></xsl:value-of></small></h5>
                         </div>
                         <div class="col-lg-4">
                             <a class="btn btn-default pull-right">

--- a/dspace/config/crosswalks/oai/xoai.xml
+++ b/dspace/config/crosswalks/oai/xoai.xml
@@ -32,7 +32,7 @@
             <Format ref="uketd_dc"/>
             <!--<Format ref="junii2" />-->
             <Description>
-                This is the default context of the DSpace data provider.
+                This is the default context of the DSpace OAI-PMH data provider.
             </Description>
         </Context>
 
@@ -62,7 +62,7 @@
         <!--
             OpenAIRE Guidelines 1.1:
 
-            - http://www.openaire.eu/en/component/attachments/download/79%E2%8C%A9=en
+            - https://guidelines.openaire.eu/en/latest/
 
             There is a limitation over the embargoedEndDate parameter:
 
@@ -180,6 +180,14 @@
 
 
     <Filters>
+        <!-- DRIVER filter for records returned by OAI-PMH.
+             By default, return an Item record:
+               * If a Title & Author field both exist
+               * AND a valid DRIVER Document Type exists
+               * AND Item is either publicly accessible OR Withdrawn (for tombstones)
+               * AND Driver "open access" condition is specified
+             This filter is only used in the DRIVER context ([oai]/driver)
+        -->
         <Filter id="driverFilter">
             <Definition>
                 <And>
@@ -201,7 +209,14 @@
                             <RightCondition>
                                 <And>
                                     <LeftCondition>
-                                        <Custom ref="bitstreamAccessCondition"/>
+                                        <Or>
+                                            <LeftCondition>
+                                                <Custom ref="itemAccessCondition"/>
+                                            </LeftCondition>
+                                            <RightCondition>
+                                                <Custom ref="itemWithdrawnCondition"/>
+                                            </RightCondition>
+                                        </Or>
                                     </LeftCondition>
                                     <RightCondition>
                                         <Custom ref="driverAccessCondition"/>
@@ -214,6 +229,14 @@
             </Definition>
         </Filter>
 
+        <!-- OpenAIRE filter for records returned by OAI-PMH.
+             By default, return an Item record:
+               * If a Title & Author field both exist
+               * AND a valid DRIVER Document Type exists
+               * AND Item is either publicly accessible OR Withdrawn (for tombstones)
+               * AND the OpenAIRE "dc.relation" is specified
+             This filter is only used in the OpenAIRE context ([oai]/openaire).
+        -->
         <Filter id="openAireFilter">
             <Definition>
                 <And>
@@ -233,7 +256,21 @@
                                 <Custom ref="driverDocumentTypeCondition"/>
                             </LeftCondition>
                             <RightCondition>
-                                <Custom ref="openaireRelationCondition"/>
+                                <And>
+                                    <LeftCondition>
+                                        <Or>
+                                            <LeftCondition>
+                                                <Custom ref="itemAccessCondition"/>
+                                            </LeftCondition>
+                                            <RightCondition>
+                                                <Custom ref="itemWithdrawnCondition"/>
+                                            </RightCondition>
+                                        </Or>
+                                    </LeftCondition>
+                                    <RightCondition>
+                                        <Custom ref="openaireRelationCondition"/>
+                                    </RightCondition>
+                                </And>
                             </RightCondition>
                         </And>
                     </RightCondition>
@@ -241,18 +278,40 @@
             </Definition>
         </Filter>
 
+        <!-- UKETD Filter for records returned by OAI-PMH.
+             By default, return an Item record:
+                * If it is a "thesis"
+
+             This filter is appended to any existing filter
+             when "metadataPrefix=uketd_dc" is specified.
+        -->
         <Filter id="uketdDcFilter">
             <Definition>
                 <Custom ref="thesisDocumentTypeCondition"/>
             </Definition>
         </Filter>
 
+        <!-- Default filter for records returned by OAI-PMH. 
+             By default, return an Item record:
+                * If it is publicly accessible
+                * OR it has been withdrawn (in order to display a tombstone record).
+             This filter is used by the default context ([oai]/request).
+        -->
         <Filter id="defaultFilter">
             <Definition>
-                <Custom ref="bitstreamAccessCondition"/>
+                <Or>
+                    <LeftCondition>
+                        <Custom ref="itemAccessCondition"/>
+                    </LeftCondition>
+                    <RightCondition>
+                        <Custom ref="itemWithdrawnCondition"/>
+                    </RightCondition>
+                </Or>
             </Definition>
         </Filter>
 
+        <!-- This condition determines if an Item has a "dc.type" field
+             which contains "Thesis". -->
         <CustomCondition id="thesisDocumentTypeCondition">
             <Class>org.dspace.xoai.filter.DSpaceAtLeastOneMetadataFilter</Class>
             <Configuration>
@@ -262,6 +321,7 @@
             </Configuration>
         </CustomCondition>
 
+        <!-- This condition determines if an Item has a "dc.contributor.author" -->
         <CustomCondition id="authorExistsCondition">
             <Class>org.dspace.xoai.filter.DSpaceMetadataExistsFilter</Class>
             <Configuration>
@@ -269,6 +329,7 @@
             </Configuration>
         </CustomCondition>
 
+        <!-- This condition determines if an Item has a "dc.title" -->
         <CustomCondition id="titleExistsCondition">
             <Class>org.dspace.xoai.filter.DSpaceMetadataExistsFilter</Class>
             <Configuration>
@@ -276,6 +337,8 @@
             </Configuration>
         </CustomCondition>
 
+        <!-- This condition determines if an Item has a "dc.type" field
+             specifying one of the valid DRIVER document types. -->
         <CustomCondition id="driverDocumentTypeCondition">
             <Class>org.dspace.xoai.filter.DSpaceAtLeastOneMetadataFilter</Class>
             <Configuration>
@@ -302,6 +365,9 @@
             </Configuration>
         </CustomCondition>
 
+        <!-- This condition determines if an Item has a "dc.rights" field
+             specifying "open access", which is required for DRIVER
+             OR "openAccess", which is required by OpenAIRE. -->
         <CustomCondition id="driverAccessCondition">
             <Class>org.dspace.xoai.filter.DSpaceAtLeastOneMetadataFilter</Class>
             <Configuration>
@@ -314,10 +380,21 @@
             </Configuration>
         </CustomCondition>
 
-        <CustomCondition id="bitstreamAccessCondition">
+        <!-- This condition determines if an Item is publicly accessible. -->
+        <CustomCondition id="itemAccessCondition">
             <Class>org.dspace.xoai.filter.DSpaceAuthorizationFilter</Class>
         </CustomCondition>
 
+        <!-- This condition determines if an Item is withdrawn. This condition
+             ensures a basic "tombstone" record is shown for withdrawn items,
+             as recommended by OAI-PMH spec. This "tombstone" doesn't display
+             any metadata or content files.  -->
+        <CustomCondition id="itemWithdrawnCondition">
+            <Class>org.dspace.xoai.filter.DSpaceWithdrawnFilter</Class>
+        </CustomCondition>
+
+        <!-- This condition determines if an Item has a "dc.relation" field
+             which specifies the openAIRE project ID. -->
         <CustomCondition id="openaireRelationCondition">
             <Class>org.dspace.xoai.filter.DSpaceAtLeastOneMetadataFilter</Class>
             <Configuration>


### PR DESCRIPTION
Fix for https://jira.duraspace.org/browse/DS-2593 along with some necessary code cleanup.

This PR does the following:
- Ensures running `./dspace oai import` will update OAI index for withdrawn items. Essentially, withdrawn items are now indexed.
- Ensures a "tombstone" is retained in OAI-PMH for any withdrawn items. Once an Item is withdrawn, and `./dspace oai import` is run, accessing that item in OAI-PMH results in a "tombstone" page which reports `<header status="deleted">` as recommended by OAI-PMH.  NO METADATA is available in the tombstone.  (NOTE: The "tombstone" is only show if you request the item directly via "GetRecord". Withdrawn items are not listed in "ListRecords" requests.)
- Cleans up some mismanaged `Context` objects in several OAI classes. There were `Context` objects that may not have been properly closed if an error occurred, and other which were being "aborted" multiple times (which results in a logged warning).
- Corrected some improper authorization logic (in `XOAI.isPublic()` and `DSpaceAuthorizationFilter.isShown()` which previously was just logging `AuthorizationExceptions` if an Item was not publicly READable. Both now properly use `AuthorizeManager.authorizeActionBoolean()` to simply return true/false based on whether Item has public READ permissions.

Please note, this PR simply fixes the bugs in DS-2593 (for possible inclusion in 5.3).  It does NOT add a new EventConsumer to auto-update the OAI index (that would need to wait for 6.0), so you still must run `./dspace oai import` via `cron` in order for your OAI index to be updated.
