### PR TITLE
DS-2645: teach IPMatcher to deal with  IpAddrs like  0:0:0:0:0:0:0:1

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/IPMatcher.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/IPMatcher.java
@@ -279,7 +279,11 @@ public class IPMatcher
             }
             catch (UnknownHostException e)
             {
-                throw new IPMatcherException("Malformed IPv6 address ",e);
+                throw new IPMatcherException("Malformed IPv6 address: " + ipIn,e);
+            }
+            catch (IllegalArgumentException ia)
+            {
+                throw new IPMatcherException("Very Malformed IPv6 address: " + ipIn , ia);
             }
 
         for (int i = 0; i < netmask.length; i++)


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2645
