### PR TITLE
DS-2358: Preserves custom policy rules during versioning (UPDATED)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/versioning/AbstractVersionProvider.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/AbstractVersionProvider.java
@@ -62,12 +62,18 @@ public abstract class AbstractVersionProvider {
             for(Bitstream nativeBitstream : nativeBundle.getBitstreams())
             {
                 Bitstream bitstreamNew = createBitstream(c, nativeBitstream);
-                // we need to copy the custom ressource policy rules for the 
-                // bitstream as well, like we did above for bundles
+
+                bundleNew.addBitstream(bitstreamNew);
+
+                // NOTE: bundle.addBitstream() causes Bundle policies to be inherited by default.
+                // So, we need to REMOVE any inherited TYPE_CUSTOM policies before copying over the correct ones.
+                AuthorizeManager.removeAllPoliciesByDSOAndType(c, bitstreamNew, ResourcePolicy.TYPE_CUSTOM);
+
+                // Now, we need to copy the TYPE_CUSTOM resource policies from old bitstream
+                // to the new bitstream, like we did above for bundles
                 List<ResourcePolicy> bitstreamPolicies = 
                         AuthorizeManager.findPoliciesByDSOAndType(c, nativeBitstream, ResourcePolicy.TYPE_CUSTOM);
                 AuthorizeManager.addPolicies(c, bitstreamPolicies, bitstreamNew);
-                bundleNew.addBitstream(bitstreamNew);
 
                 if(nativeBundle.getPrimaryBitstreamID() == nativeBitstream.getID())
                 {

--- a/dspace-api/src/main/java/org/dspace/versioning/DefaultItemVersionProvider.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/DefaultItemVersionProvider.java
@@ -17,6 +17,9 @@ import org.dspace.utils.DSpace;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.List;
+import org.dspace.authorize.AuthorizeManager;
+import org.dspace.authorize.ResourcePolicy;
 
 /**
  *
@@ -84,6 +87,15 @@ public class DefaultItemVersionProvider extends AbstractVersionProvider implemen
             } catch (IdentifierException e) {
                 throw new RuntimeException("Can't create Identifier!", e);
             }
+            // DSpace knows several types of resource policies (see the class
+            // org.dspace.authorize.ResourcePolicy): Submission, Workflow, Custom
+            // and inherited. Submission, Workflow and Inherited policies will be
+            // set automatically as neccessary. We need to copy the custom policies
+            // only to preserve customly set policies and embargos (which are
+            // realized by custom policies with a start date).
+            List<ResourcePolicy> policies = 
+                    AuthorizeManager.findPoliciesByDSOAndType(c, previousItem, ResourcePolicy.TYPE_CUSTOM);
+            AuthorizeManager.addPolicies(c, policies, itemNew);
             itemNew.update();
             return itemNew;
         }catch (SQLException e) {


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2358

This PR is nearly a copy of #973 , but with one minor bug fix applied (https://github.com/tdonohue/DSpace/commit/18f335bdf8ec4a208a9cb7c0471f972b95738327).

The bug fix ensures that any TYPE_CUSTOM policies which may be auto-inherited from Bundle to Bitstream are first removed before they are copied from the original Bitstream to the new-version Bitstream.

For more details see this comment on previous PR: https://github.com/DSpace/DSpace/pull/973#issuecomment-124577617

This PR makes #973 obsolete, as it includes the commit from that PR.

While I've done some thorough testing here, I'd appreciate a sanity check from another Committer/Developer.  

Here's how to test this:
1. Enable both Versioning and Embargo on your DSpace
2. Submit a new Item, adding a future Embargo date to it.
3. After submission, create a _new_ version of that Embargoed Item
4. Edit both the 1st and 2nd versions of the Embargoed Item, checking that the Authorization Policies are identical.  If they are identical, then this PR worked. Currently, on "master" they will not be identical, and Embargo policies will not be applied to the 2nd version.
