### PR TITLE
[DS-2679] Retain ordering of authors for Google Scholar metatags.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
@@ -30,6 +30,7 @@ import org.dspace.core.ConfigurationManager;
 import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
@@ -759,16 +760,17 @@ public class GoogleMetadata
     }
 
     /**
-     * Fetch all metadata mappings
-     * 
+     * Fetch retaining the order of the values for any given key in which they
+     * where added (like authors).
+     *
      * Usage: GoogleMetadata gmd = new GoogleMetadata(item); for(Entry<String,
      * String> mapping : googlemd.getMappings()) { ... }
      * 
      * @return Iterable of metadata fields mapped to Google-formatted values
      */
-    public Set<Entry<String, String>> getMappings()
+    public Collection<Entry<String, String>> getMappings()
     {
-        return new HashSet<>(metadataMappings.entries());
+        return metadataMappings.entries();
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
@@ -759,16 +759,20 @@ public class GoogleMetadata
     }
 
     /**
-     * Fetch all metadata mappings
+     * Fetch metadata mappings retaining the order of the values for any given
+     * key in which they where added (like authors).
      * 
-     * Usage: GoogleMetadata gmd = new GoogleMetadata(item); for(Entry<String,
-     * String> mapping : googlemd.getMappings()) { ... }
+     * Usage: GoogleMetadata gmd = new GoogleMetadata(item); for (Entry<String,
+     * java.util.Collection<String>> m :
+     * gmd.getOrderedMappings().asMap().entrySet()) { for(String curValue :
+     * m.getValue()) { pageMeta.addMetadata(m.getKey()).addContent(curValue); }
+     * }
      * 
      * @return Iterable of metadata fields mapped to Google-formatted values
      */
-    public Set<Entry<String, String>> getMappings()
+    public ListMultimap<String, String> getMappings()
     {
-        return new HashSet<>(metadataMappings.entries());
+        return metadataMappings;
     }
 
     /**
@@ -778,13 +782,17 @@ public class GoogleMetadata
     {
         List<Element> metas = new ArrayList<Element>();
 
-        for (Entry<String, String> m : getMappings())
+        for (Entry<String, java.util.Collection<String>> m : getMappings()
+                .asMap().entrySet())
         {
-            Element e = new Element("meta");
-            e.setNamespace(null);
-            e.setAttribute("name", m.getKey());
-            e.setAttribute("content", m.getValue());
-            metas.add(e);
+            for (String curValue : m.getValue())
+            {
+                Element e = new Element("meta");
+                e.setNamespace(null);
+                e.setAttribute("name", m.getKey());
+                e.setAttribute("content", curValue);
+                metas.add(e);
+            }
         }
         return metas;
     }

--- a/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
@@ -759,20 +759,16 @@ public class GoogleMetadata
     }
 
     /**
-     * Fetch metadata mappings retaining the order of the values for any given
-     * key in which they where added (like authors).
+     * Fetch all metadata mappings
      * 
-     * Usage: GoogleMetadata gmd = new GoogleMetadata(item); for (Entry<String,
-     * java.util.Collection<String>> m :
-     * gmd.getOrderedMappings().asMap().entrySet()) { for(String curValue :
-     * m.getValue()) { pageMeta.addMetadata(m.getKey()).addContent(curValue); }
-     * }
+     * Usage: GoogleMetadata gmd = new GoogleMetadata(item); for(Entry<String,
+     * String> mapping : googlemd.getMappings()) { ... }
      * 
      * @return Iterable of metadata fields mapped to Google-formatted values
      */
-    public ListMultimap<String, String> getMappings()
+    public Set<Entry<String, String>> getMappings()
     {
-        return metadataMappings;
+        return new HashSet<>(metadataMappings.entries());
     }
 
     /**
@@ -782,17 +778,13 @@ public class GoogleMetadata
     {
         List<Element> metas = new ArrayList<Element>();
 
-        for (Entry<String, java.util.Collection<String>> m : getMappings()
-                .asMap().entrySet())
+        for (Entry<String, String> m : getMappings())
         {
-            for (String curValue : m.getValue())
-            {
-                Element e = new Element("meta");
-                e.setNamespace(null);
-                e.setAttribute("name", m.getKey());
-                e.setAttribute("content", curValue);
-                metas.add(e);
-            }
+            Element e = new Element("meta");
+            e.setNamespace(null);
+            e.setAttribute("name", m.getKey());
+            e.setAttribute("content", m.getValue());
+            metas.add(e);
         }
         return metas;
     }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemViewer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemViewer.java
@@ -281,21 +281,9 @@ public class ItemViewer extends AbstractDSpaceTransformer implements CacheablePr
             // Add Google metadata field names & values to DRI
             GoogleMetadata gmd = new GoogleMetadata(context, item);
 
-            for (Entry<String, java.util.Collection<String>> m : gmd
-                    .getMappings()
-                    .asMap().entrySet())
+            for (Entry<String, String> m : gmd.getMappings())
             {
-                // Iterate over the Entries which looks like
-                // GoogleScholarLabel-> OrderdList<Google-formatted value>
-                // e.G. citation_author->[firstAuthor, secondAuthor, ...,
-                // nthAuthor]
-                for (String curValue : m.getValue())
-                {
-                    // create a single metadata field like
-                    // <meta content="Mustermann, Max"
-                    // name="citation_author" />
-                    pageMeta.addMetadata(m.getKey()).addContent(curValue);
-                }
+                pageMeta.addMetadata(m.getKey()).addContent(m.getValue());
             }
         }
 

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemViewer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemViewer.java
@@ -281,9 +281,21 @@ public class ItemViewer extends AbstractDSpaceTransformer implements CacheablePr
             // Add Google metadata field names & values to DRI
             GoogleMetadata gmd = new GoogleMetadata(context, item);
 
-            for (Entry<String, String> m : gmd.getMappings())
+            for (Entry<String, java.util.Collection<String>> m : gmd
+                    .getMappings()
+                    .asMap().entrySet())
             {
-                pageMeta.addMetadata(m.getKey()).addContent(m.getValue());
+                // Iterate over the Entries which looks like
+                // GoogleScholarLabel-> OrderdList<Google-formatted value>
+                // e.G. citation_author->[firstAuthor, secondAuthor, ...,
+                // nthAuthor]
+                for (String curValue : m.getValue())
+                {
+                    // create a single metadata field like
+                    // <meta content="Mustermann, Max"
+                    // name="citation_author" />
+                    pageMeta.addMetadata(m.getKey()).addContent(curValue);
+                }
             }
         }
 


### PR DESCRIPTION
This pull requests resolve an issue (for XMLUI and JSPUI) reported by the Google Scholar team where the ordering of authors was wrong. 

To see the problem look at the source code of an item page with multiple authors like: 
http://demo.dspace.org/jspui/handle/10673/44 or 
http://demo.dspace.org/xmlui/handle/10673/44 

on this pages the metatags look like: 

`````` xml
<meta name="citation_title" content="texto" /> 
<meta name="citation_abstract_html_url" content="http://demo.dspace.org/xmlui/handle/10673/44" /> 
**<meta name="citation_author" content="Vorname3, Nachname3" />** 
<meta name="citation_date" content="2015-07-28T10:59:59Z" /> 
**<meta name="citation_author" content="Vorname1, Nachname1" />** 
**<meta name="citation_author" content="Vorname2, Nachname2" />** 
**<meta name="citation_author" content="garcia, victor" />** 

but should look like: 

```xml
<meta name="citation_title" content="texto" /> 
<meta name="citation_abstract_html_url" content="http://demo.dspace.org/xmlui/handle/10673/44" /> 
**<meta name="citation_author" content="garcia, victor" />** 
**<meta name="citation_author" content="Vorname1, Nachname1" />** 
**<meta name="citation_author" content="Vorname2, Nachname2" />** 
**<meta name="citation_author" content="Vorname3, Nachname3" />** 
<meta name="citation_date" content="2015-07-28T10:59:59Z" /> 


``````
