### PR TITLE
[DS-2697] 'dspace curate --id all' crashes with NPE

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/Site.java
+++ b/dspace-api/src/main/java/org/dspace/content/Site.java
@@ -28,13 +28,16 @@ public class Site extends DSpaceObject
     // cache for Handle that is persistent ID for entire site.
     private static String handle = null;
 
-    private static Site theSite = null;
+    private Site() { super(); }
+
+    private Site(Context ctx) { super(ctx); }
 
     /**
      * Get the type of this object, found in Constants
      *
      * @return type of the object
      */
+    @Override
     public int getType()
     {
         return Constants.SITE;
@@ -45,6 +48,7 @@ public class Site extends DSpaceObject
      *
      * @return internal ID of object
      */
+    @Override
     public int getID()
     {
         return SITE_ID;
@@ -56,6 +60,7 @@ public class Site extends DSpaceObject
      * @return Handle of the object, or <code>null</code> if it doesn't have
      *         one
      */
+    @Override
     public String getHandle()
     {
         return getSiteHandle();
@@ -75,7 +80,9 @@ public class Site extends DSpaceObject
     }
 
     /**
-     * Get Site object corresponding to db id (which is ignored).
+     * Get Site object corresponding to db id (which is ignored).  Essentially
+     * this is a factory method for a fresh instance of Site.
+     *
      * @param context the context.
      * @param id integer database id, ignored.
      * @return Site object.
@@ -83,11 +90,7 @@ public class Site extends DSpaceObject
     public static DSpaceObject find(Context context, int id)
         throws SQLException
     {
-        if (theSite == null)
-        {
-            theSite = new Site();
-        }
-        return theSite;
+        return new Site(context);
     }
 
     void delete()
@@ -95,11 +98,13 @@ public class Site extends DSpaceObject
     {
     }
 
+    @Override
     public void update()
         throws SQLException, AuthorizeException
     {
     }
 
+    @Override
     public String getName()
     {
         return ConfigurationManager.getProperty("dspace.name");

--- a/dspace-api/src/main/java/org/dspace/rdf/RDFizer.java
+++ b/dspace-api/src/main/java/org/dspace/rdf/RDFizer.java
@@ -219,7 +219,7 @@ public class RDFizer {
             throws SQLException
     {
         report("Starting conversion of all DSpaceItems, this may take a while...");
-        this.convert(new Site(), true);
+        this.convert(Site.find(context, Site.SITE_ID), true);
         report("Conversion ended.");
     }
     

--- a/dspace-api/src/test/java/org/dspace/content/SiteTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/SiteTest.java
@@ -122,7 +122,6 @@ public class SiteTest extends AbstractUnitTest
         int id = 0;
         Site found = (Site)Site.find(context, id);
         assertThat("testSiteFind 0",found, notNullValue());
-        assertThat("testSiteFind 1",found, equalTo(s));
     }
 
     /**


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2697
Site.find() did not return a properly initialized Site, making subsequent metadata access throw NPE.
