### PR TITLE
DS-2698 Use all result info in browse page cache validity

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ConfigurableBrowse.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ConfigurableBrowse.java
@@ -212,7 +212,7 @@ public class ConfigurableBrowse extends AbstractDSpaceTransformer implements
                     // Add the metadata to the validity
                     for (String[] singleEntry : browseInfo.getStringResults())
                     {
-                        validity.add(singleEntry[0]+"#"+singleEntry[1]);
+                        validity.add(StringUtils.join(singleEntry,"#"));
                     }
                 }
 


### PR DESCRIPTION
Stepping through the code in a debugger showed that the singleEntry arrays
typically hold three entries: the metadata value in [0], the authority key (if
present) in [1] and the frequency of this metadata value in the current browse
in [2]. The validity used to take into account only [0] and [1], probably from
the old lucene browse (which didn't include frequencies).

This change ensures that the cache validity object includes all entries in the
singleEntry arrays by avoiding to pick out individual array entries.
