### PR TITLE
Revert "DS-1821 Internationalize the bitstream access icon alt text"

### DIFF
--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -2225,7 +2225,6 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">View</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">Description</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">View/<wbr/>Open</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-files-access-rights">Read access available for</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">There are no files associated with this item.</message>
 
 	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">bytes</message>

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -548,15 +548,11 @@
                   </xsl:otherwise>
               </xsl:choose>
         </xsl:variable>
-        <xsl:variable name="alt-text"><i18n:text>xmlui.dri2xhtml.METS-1.0.item-files-access-rights</i18n:text> <xsl:value-of select="$users"/></xsl:variable>
 
         <xsl:choose>
             <xsl:when test="(not ($rights_context/@CONTEXTCLASS = 'GENERAL PUBLIC') and ($rights_context/rights:Permissions/@DISPLAY = 'true')) or not ($rights_context)">
                 <a href="{mets:FLocat[@LOCTYPE='URL']/@xlink:href}">
-                    <img width="64" height="64" src="{concat($theme-path,'/images/Crystal_Clear_action_lock3_64px.png')}">
-                        <xsl:attribute name="title"><xsl:value-of select="$alt-text"/></xsl:attribute>
-                        <xsl:attribute name="alt"><xsl:value-of select="$alt-text"/></xsl:attribute>
-                    </img>
+                    <img width="64" height="64" src="{concat($theme-path,'/images/Crystal_Clear_action_lock3_64px.png')}" title="Read access available for {$users}"/>
                     <!-- icon source: http://commons.wikimedia.org/wiki/File:Crystal_Clear_action_lock3.png -->
                 </a>
             </xsl:when>

--- a/dspace-xmlui/src/main/webapp/themes/dri2xhtml/General-Handler.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/dri2xhtml/General-Handler.xsl
@@ -222,15 +222,11 @@
                 <xsl:if test="position() != last()">, </xsl:if>
             </xsl:for-each>
         </xsl:variable>
-        <xsl:variable name="alt-text"><i18n:text>xmlui.dri2xhtml.METS-1.0.item-files-access-rights</i18n:text> <xsl:value-of select="$users"/></xsl:variable>
 
         <xsl:choose>
             <xsl:when test="not ($rights_context/@CONTEXTCLASS = 'GENERAL PUBLIC') and ($rights_context/rights:Permissions/@DISPLAY = 'true')">
                 <a href="{mets:FLocat[@LOCTYPE='URL']/@xlink:href}">
-                    <img width="64" height="64" src="{concat($theme-path,'/images/Crystal_Clear_action_lock3_64px.png')}">
-                        <xsl:attribute name="title"><xsl:value-of select="$alt-text"/></xsl:attribute>
-                        <xsl:attribute name="alt"><xsl:value-of select="$alt-text"/></xsl:attribute>
-                    </img>
+                    <img width="64" height="64" src="{concat($theme-path,'/images/Crystal_Clear_action_lock3_64px.png')}" title="Read access available for {$users}"/>
                     <!-- icon source: http://commons.wikimedia.org/wiki/File:Crystal_Clear_action_lock3.png -->
                 </a>
             </xsl:when>


### PR DESCRIPTION
Reverts DSpace/DSpace#451

This change actually didn't work. i18n:text can't be used in xsl:attribute for some reason, not even indirectly via xsl:variable. i18n:attr won't work, either, because it will only localize static text. So at this time I see no way of having translated parametrized attributes.
