### PR TITLE
[DS-2722] Login as broken on XMLUI

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/AuthenticationUtil.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/AuthenticationUtil.java
@@ -334,8 +334,8 @@ public class AuthenticationUtil
     	// Just to be double be sure, make sure the administrator
     	// is the one who actually authenticated himself.
 	    HttpSession session = request.getSession(false);
-	    Integer authenticatedID = (Integer) session.getAttribute(AUTHENTICATED_USER_ID); 
-	    if (context.getCurrentUser().getID().equals(authenticatedID))
+        UUID authenticatedID = (UUID) session.getAttribute(AUTHENTICATED_USER_ID);
+	    if (!context.getCurrentUser().getID().equals(authenticatedID))
         {
             throw new AuthorizeException("xmlui.utils.AuthenticationUtil.onlyAuthenticatedAdmins");
         }


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2722

Easy fix, the session attribute for an EPerson identifier is now a UUID instead of an integer.
