### PR TITLE
[DS-2723] Delete collection broken if a review group is attached in basic workflow

### DIFF
--- a/dspace-api/src/main/java/org/dspace/workflowbasic/BasicWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/workflowbasic/BasicWorkflowServiceImpl.java
@@ -1018,6 +1018,9 @@ public class BasicWorkflowServiceImpl implements BasicWorkflowService
 
     @Override
     public void deleteCollection(Context context, Collection collection) throws SQLException, IOException, AuthorizeException {
+        collection.setWorkflowGroup(1, null);
+        collection.setWorkflowGroup(2, null);
+        collection.setWorkflowGroup(3, null);
         workflowItemService.deleteByCollection(context, collection);
     }
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2723

The review group isn't unlinked when we delete the collection. The pull request ensures that the linking is destroyed (the groups remain, since they COULD be used by for other collections).
