### PR TITLE
DS-2701 dspace-rdf

### DIFF
--- a/dspace-rdf/src/main/java/org/dspace/rdf/providing/DataProviderServlet.java
+++ b/dspace-rdf/src/main/java/org/dspace/rdf/providing/DataProviderServlet.java
@@ -20,7 +20,8 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.dspace.content.DSpaceObject;
 import org.dspace.core.Context;
-import org.dspace.handle.HandleServiceImpl;
+import org.dspace.handle.factory.HandleServiceFactory;
+import org.dspace.handle.service.HandleService;
 import org.dspace.rdf.RDFUtil;
 import org.dspace.utils.DSpace;
 
@@ -33,6 +34,8 @@ public class DataProviderServlet extends HttpServlet {
     protected static final String DEFAULT_LANG = "TURTLE";
     
     private static final Logger log = Logger.getLogger(DataProviderServlet.class);
+    
+    protected HandleService handleService = HandleServiceFactory.getInstance().getHandleService();
     
     /**
      * Processes requests for both HTTP
@@ -85,7 +88,7 @@ public class DataProviderServlet extends HttpServlet {
         try
         {
             context = new Context(Context.READ_ONLY);
-            dso = HandleServiceImpl.resolveToObject(context, handle);
+            dso = handleService.resolveToObject(context, handle);
         }
         catch (SQLException ex)
         {
@@ -127,8 +130,8 @@ public class DataProviderServlet extends HttpServlet {
         if (identifier == null)
         {
             // cannot generate identifier for dso?!
-            log.error("Cannot generate identifier for " + dso.getTypeText() 
-                    + " " + dso.getID() + "!");
+            log.error("Cannot generate identifier for UUID " 
+                    + dso.getID().toString() + "!");
             context.abort();
             response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             return;

--- a/dspace-rdf/src/main/java/org/dspace/rdf/providing/LocalURIRedirectionServlet.java
+++ b/dspace-rdf/src/main/java/org/dspace/rdf/providing/LocalURIRedirectionServlet.java
@@ -17,7 +17,8 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.dspace.content.DSpaceObject;
 import org.dspace.core.Context;
-import org.dspace.handle.HandleServiceImpl;
+import org.dspace.handle.factory.HandleServiceFactory;
+import org.dspace.handle.service.HandleService;
 import org.dspace.rdf.negotiation.Negotiator;
 import org.dspace.utils.DSpace;
 
@@ -30,6 +31,8 @@ public class LocalURIRedirectionServlet extends HttpServlet
     public static final String ACCEPT_HEADER_NAME = "Accept";
     
     private final static Logger log = Logger.getLogger(LocalURIRedirectionServlet.class);
+    
+    protected HandleService handleService = HandleServiceFactory.getInstance().getHandleService();
     
     /**
      * Processes requests for both HTTP
@@ -70,7 +73,7 @@ public class LocalURIRedirectionServlet extends HttpServlet
         try
         {
             context = new Context(Context.READ_ONLY);
-            dso = HandleServiceImpl.resolveToObject(context, handle);
+            dso = handleService.resolveToObject(context, handle);
         }
         catch (SQLException ex)
         {


### PR DESCRIPTION
Small patch to make dspace-rdf compile cleanly. dspace-rdf does not have any tests.

Most of the code to support RDF is part of dspace-api (org.dspace.rdf). I will test if everything still works within the next days and submit more PRs if necessary.

@KevinVdV This should be easy to review and can be merged to the service API feature branch.
