### PR TITLE
DS-2730 link getName() to DSpaceServices

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/Bitstream.java
+++ b/dspace-api/src/main/java/org/dspace/content/Bitstream.java
@@ -121,17 +121,6 @@ public class Bitstream extends DSpaceObject implements DSpaceObjectLegacySupport
     }
 
     /**
-     * Get the name of this bitstream - typically the filename, without any path
-     * information
-     * 
-     * @return the name of the bitstream
-     */
-    @Override
-    public String getName(){
-        return getBitstreamService().getMetadataFirstValue(this, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
-    }
-
-    /**
      * Set the name of the bitstream
      * 
      * @param n

--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -365,7 +365,7 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
             List<BundleBitstream> bitstreams = bundle.getBitstreams();
             for (int j = 0; j < bitstreams.size(); j++) {
                 BundleBitstream bundleBitstream = bitstreams.get(j);
-                if(StringUtils.equals(bundleBitstream.getBitstream().getName(), bitstreamName))
+                if(StringUtils.equals(this.getName(bundleBitstream.getBitstream()), bitstreamName))
                 {
                     return bundleBitstream.getBitstream();
                 }

--- a/dspace-api/src/main/java/org/dspace/content/Bundle.java
+++ b/dspace-api/src/main/java/org/dspace/content/Bundle.java
@@ -66,17 +66,6 @@ public class Bundle extends DSpaceObject implements DSpaceObjectLegacySupport
     }
 
     /**
-     * Get the name of the bundle
-     * 
-     * @return name of the bundle (ORIGINAL, TEXT, THUMBNAIL) or NULL if not set
-     */
-    @Override
-    public String getName()
-    {
-        return getBundleService().getMetadataFirstValue(this, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
-    }
-
-    /**
      * Set the name of the bundle
      * 
      * @param name

--- a/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
@@ -120,7 +120,7 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
 
         for (BundleBitstream bundleBitstream : bundle.getBitstreams()) {
             Bitstream bitstream = bundleBitstream.getBitstream();
-            if (name.equals(bitstream.getName())) {
+            if (name.equals(bitstreamService.getName(bitstream))) {
                 target = bitstream;
                 break;
             }
@@ -412,7 +412,7 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
                 + bundle.getID()));
 
         context.addEvent(new Event(Event.DELETE, Constants.BUNDLE, bundle.getID(),
-                bundle.getName(), getIdentifiers(context, bundle)));
+                this.getName(bundle), getIdentifiers(context, bundle)));
 
         // Remove bitstreams
         Iterator<BundleBitstream> bundleBitstreams = bundle.getBitstreams().iterator();

--- a/dspace-api/src/main/java/org/dspace/content/Collection.java
+++ b/dspace-api/src/main/java/org/dspace/content/Collection.java
@@ -106,13 +106,6 @@ public class Collection extends DSpaceObject implements DSpaceObjectLegacySuppor
 
     }
 
-    @Override
-    public String getName()
-    {
-        String value = getCollectionService().getMetadataFirstValue(this, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
-        return value == null ? "" : value;
-    }
-
     /**
      * Get the logo for the collection. <code>null</code> is returned if the
      * collection does not have a logo.

--- a/dspace-api/src/main/java/org/dspace/content/Community.java
+++ b/dspace-api/src/main/java/org/dspace/content/Community.java
@@ -235,12 +235,6 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
     }
 
     @Override
-    public String getName() {
-        String value = getCommunityService().getMetadataFirstValue(this, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
-        return value == null ? "" : value;
-    }
-
-    @Override
     public Integer getLegacyId() {
         return legacyId;
     }

--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
@@ -15,6 +15,8 @@ import java.io.Serializable;
 import java.util.*;
 
 import javax.persistence.*;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.DSpaceObjectService;
 
 /**
  * Abstract base class for DSpace objects
@@ -108,7 +110,26 @@ public abstract class DSpaceObject implements Serializable
         return id;
     }
 
-    public abstract String getName();
+    /**
+     * Get a proper name for the object. This may return <code>null</code>.
+     * Name should be suitable for display in a user interface.
+     * 
+     * This method is linked to the same method of the DSpaceObjectService. If 
+     * this methods is overridden the method in the service class should be 
+     * overridden too so both methods always returns the same values.
+     *
+     * @return Name for the object, or <code>null</code> if it doesn't have
+     *         one
+     */
+    public String getName()
+    {
+        DSpaceObjectService service = ContentServiceFactory.getInstance().getDSpaceObjectService(this);
+        if (service == null)
+        {
+            return null;
+        }
+        return service.getName(this);
+    }
 
     /**
      * Get the Handle of the object. This may return <code>null</code>

--- a/dspace-api/src/main/java/org/dspace/content/Item.java
+++ b/dspace-api/src/main/java/org/dspace/content/Item.java
@@ -327,12 +327,6 @@ public class Item extends DSpaceObject implements DSpaceObjectLegacySupport
     }
 
     @Override
-    public String getName()
-    {
-        return getItemService().getMetadataFirstValue(this, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
-    }
-
-    @Override
     public Integer getLegacyId() {
         return legacyId;
     }

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -95,7 +95,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
                 return null;
             }
 
-            thumbBitstream = bitstreamService.getBitstreamByName(item, "THUMBNAIL", primaryBitstream.getName() + ".jpg");
+            thumbBitstream = bitstreamService.getBitstreamByName(item, "THUMBNAIL", bitstreamService.getName(primaryBitstream) + ".jpg");
 
         } else {
             if (requireOriginal) {
@@ -242,7 +242,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         // now only keep bundles with matching names
         List<Bundle> bunds = item.getBundles();
         for (Bundle bund : bunds) {
-            if (name.equals(bund.getName())) {
+            if (name.equals(bundleService.getName(bund))) {
                 matchingBundles.add(bund);
             }
         }
@@ -272,7 +272,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         bundle.addItem(item);
 
         context.addEvent(new Event(Event.ADD, Constants.ITEM, item.getID(),
-                Constants.BUNDLE, bundle.getID(), bundle.getName(),
+                Constants.BUNDLE, bundle.getID(), bundleService.getName(bundle),
                 getIdentifiers(context, item)));
     }
 
@@ -290,7 +290,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
 
 
         context.addEvent(new Event(Event.REMOVE, Constants.ITEM, item.getID(),
-                Constants.BUNDLE, bundle.getID(), bundle.getName(), getIdentifiers(context, item)));
+                Constants.BUNDLE, bundle.getID(), bundleService.getName(bundle), getIdentifiers(context, item)));
 
         if (CollectionUtils.isEmpty(bundle.getItems())) {
             bundleService.delete(context, bundle);
@@ -487,7 +487,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         List<Collection> colls = item.getCollections();
 
         for (Collection coll : colls) {
-            prov.append(coll.getName()).append(" (ID: ").append(coll.getID()).append(")\n");
+            prov.append(collectionService.getName(coll)).append(" (ID: ").append(coll.getID()).append(")\n");
         }
 
         // Set withdrawn flag. timestamp will be set; last_modified in update()
@@ -534,7 +534,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
                 .append("Item was in collections:\n");
 
         for (Collection coll : colls) {
-            prov.append(coll.getName()).append(" (ID: ").append(coll.getID()).append(")\n");
+            prov.append(collectionService.getName(coll)).append(" (ID: ").append(coll.getID()).append(")\n");
         }
 
         // Clear withdrawn flag
@@ -625,7 +625,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
 
        log.info(LogManager.getHeader(context, "remove_bundle", "item_id="
                + item.getID() + ",bundle_id=" + b.getID()));
-       context.addEvent(new Event(Event.REMOVE, Constants.ITEM, item.getID(), Constants.BUNDLE, b.getID(), b.getName()));
+       context.addEvent(new Event(Event.REMOVE, Constants.ITEM, item.getID(), Constants.BUNDLE, b.getID(), bundleService.getName(b)));
    }
 
     protected void removeVersion(Context context, Item item) throws AuthorizeException, SQLException
@@ -1096,7 +1096,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
                     return true;
                 }
             }
-            log.debug("item(" + item.getID() + ") " + item.getName() + " is unlisted.");
+            log.debug("item(" + item.getID() + ") " + this.getName(item) + " is unlisted.");
             return false;
         } catch (SQLException e) {
             log.error(e.getMessage());


### PR DESCRIPTION
I pulled getName(DSpaceObject) up into org.dspace.content.DSpaceObject, linked it to the DSpaceObjectService and added a comment to it about what to pay attention if it is overridden in a sublcass. I left out org.dspace.content.Site and SiteService as @KevinVdV did this in #1037.
