### PR TITLE
fix typo in method name (forwarder -> forwarded)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerUsageEventListener.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerUsageEventListener.java
@@ -41,7 +41,7 @@ public class SolrLoggerUsageEventListener extends AbstractUsageEventListener {
                 	if(ue.getRequest()!=null){
                 		SolrLogger.postView(ue.getObject(), ue.getRequest(), currentUser);
                 	} else {
-                		SolrLogger.postView(ue.getObject(), ue.getIp(), ue.getUserAgent(), ue.getXforwarderfor(), currentUser);
+                		SolrLogger.postView(ue.getObject(), ue.getIp(), ue.getUserAgent(), ue.getXForwardedFor(), currentUser);
                 	}
                 }else
                 if(UsageEvent.Action.SEARCH == ue.getAction()){

--- a/dspace-api/src/main/java/org/dspace/usage/UsageEvent.java
+++ b/dspace-api/src/main/java/org/dspace/usage/UsageEvent.java
@@ -221,11 +221,11 @@ public class UsageEvent extends Event {
 		this.userAgent = userAgent;
 	}
 
-	public String getXforwarderfor() {
+	public String getXForwardedFor() {
 		return xforwardedfor;
 	}
 
-	public void setXforwarderfor(String xforwardedfor) {
+	public void setXForwardedFor(String xforwardedfor) {
 		this.xforwardedfor = xforwardedfor;
 	}
 


### PR DESCRIPTION
Minor change in method name and all its uses (1). Since we're already doing a large API break in DSpace 6, let's fix method names, too.
