### PR TITLE
[Ds-2744] Accept the dspace.oai.url as baseUrl for Dspace OAI

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceRepositoryConfiguration.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceRepositoryConfiguration.java
@@ -74,8 +74,12 @@ public class DSpaceRepositoryConfiguration implements RepositoryConfiguration
         HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
         if (baseUrl == null)
         {
-            baseUrl = request.getRequestURL().toString()
-                    .replace(request.getPathInfo(), "");
+            baseUrl = configurationService.getProperty("oai", "dspace.oai.url");
+            if (baseUrl == null) {
+                log.warn("{ OAI 2.0 :: DSpace } Not able to retrieve the dspace.oai.url property from oai.cfg. Falling back to request address");
+                baseUrl = request.getRequestURL().toString()
+                    .replace(request.getPathInfo(), "");    
+            }
         }
         return baseUrl + request.getPathInfo();
     }

--- a/dspace/config/modules/oai.cfg
+++ b/dspace/config/modules/oai.cfg
@@ -8,7 +8,8 @@
 storage=solr
 
 # The base URL of the OAI webapp (do not include the context e.g. /request, /openaire, etc).
-dspace.oai.url = ${dspace.baseUrl}/oai
+# Note: leave commented if you want to fallback to the request's URL.
+# dspace.oai.url = ${dspace.baseUrl}/oai
 
 # Base solr index
 solr.url=${solr.server}/oai

--- a/dspace/config/modules/oai.cfg
+++ b/dspace/config/modules/oai.cfg
@@ -7,6 +7,9 @@
 # Storage: solr | database 
 storage=solr
 
+# The base URL of the OAI webapp (do not include the context e.g. /request, /openaire, etc).
+dspace.oai.url = ${dspace.baseUrl}/oai
+
 # Base solr index
 solr.url=${solr.server}/oai
 # OAI persistent identifier prefix.


### PR DESCRIPTION
The dspace.oai.url parameter, specified in https://wiki.duraspace.org/display/DSDOC6x/Configuration+Reference was being ignored. Instead, the baseUrl was being generated from the request headers.
This patch honors the dspace.oai.url parameter when present on the oai.cfg file or falls back to the previous behaviour with a warning.
