### PR TITLE
DS-2748: Reduce Cocoon 404 log noise

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/general/PageNotFoundTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/general/PageNotFoundTransformer.java
@@ -7,15 +7,14 @@
  */
 package org.dspace.app.xmlui.aspect.general;
 
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.Serializable;
 import java.sql.SQLException;
 
 import org.apache.cocoon.ResourceNotFoundException;
 import org.apache.cocoon.caching.CacheableProcessingComponent;
-import org.apache.cocoon.environment.ObjectModelHelper;
-import org.apache.cocoon.environment.Request;
-import org.apache.cocoon.util.HashUtil;
+import org.apache.cocoon.environment.http.HttpEnvironment;
 import org.apache.excalibur.source.SourceValidity;
 import org.apache.excalibur.source.impl.validity.NOPValidity;
 import org.dspace.app.xmlui.cocoon.AbstractDSpaceTransformer;
@@ -27,7 +26,6 @@ import org.dspace.app.xmlui.wing.element.Body;
 import org.dspace.app.xmlui.wing.element.Division;
 import org.dspace.app.xmlui.wing.element.PageMeta;
 import org.dspace.authorize.AuthorizeException;
-
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 
@@ -69,9 +67,8 @@ public class PageNotFoundTransformer extends AbstractDSpaceTransformer implement
      */
     public Serializable getKey() 
     {
-        Request request = ObjectModelHelper.getRequest(objectModel);
-        
-        return HashUtil.hash(request.getSitemapURI());
+        // Prevent caching; Cocoon won't send 404 response codes for cached responses
+        return null;
     }
 
     /**
@@ -158,16 +155,12 @@ public class PageNotFoundTransformer extends AbstractDSpaceTransformer implement
         if (this.bodyEmpty)
         {
             Division notFound = body.addDivision("page-not-found","primary");
-            
             notFound.setHead(T_head);
-            
-            notFound.addPara(T_para1); 
-
+            notFound.addPara(T_para1);
             notFound.addPara().addXref(contextPath + "/",T_go_home);
 
-            throw new ResourceNotFoundException("Page cannot be found");
-
-
+            final HttpServletResponse response = (HttpServletResponse) objectModel.get(HttpEnvironment.HTTP_RESPONSE_OBJECT);
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
         }
     }
 


### PR DESCRIPTION
This change uses a less noisy approach to making Cocoon send 404s when needed. When applied, the large traces will stop appear whenever a non-existing page is requested of DSpace, and 404s will be consistently returned for subsequent requests.

https://jira.duraspace.org/browse/DS-2748

Rather than throwing a ResourceNotFoundException, this goes back to setting the http response status directly. This alone isn't enough, however, because Cocoon will by default cache the response and begin providing it to subsequent requests with a 200 status code. To avoid that, this change also explicitly disables caching of such responses by returning null from getKey().

Note: This PR is compatible with PR #1050, but both are based on master and touch similar parts of PageNotFoundTransformer, so some minor manual merging may be required.
