### PR TITLE
[DS-2701-service-api] Initial bugfixing for the JSPUI

### DIFF
--- a/dspace-api/src/main/java/org/dspace/eperson/service/GroupService.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/service/GroupService.java
@@ -26,8 +26,6 @@ import org.dspace.eperson.Group;
 public interface GroupService extends DSpaceObjectService<Group>, DSpaceObjectLegacySupportService<Group> {
 
     public static final int NAME = 1; // sort by NAME (default)
-	public static final int ANONYMOUS_ID = 0;
-	public static final int ID = 0;
 
 
     /**

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V6.0_2015.03.07__hibernate_migration.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V6.0_2015.03.07__hibernate_migration.sql
@@ -19,7 +19,7 @@ CREATE TABLE site
 
 );
 
-ALTER TABLE eperson ADD COLUMN uuid UUID UNIQUE;
+ALTER TABLE eperson ADD COLUMN uuid UUID DEFAULT gen_random_uuid() UNIQUE;
 INSERT INTO dspaceobject  (uuid) SELECT uuid FROM eperson;
 ALTER TABLE eperson ADD FOREIGN KEY (uuid) REFERENCES dspaceobject;
 ALTER TABLE eperson ALTER COLUMN uuid SET NOT NULL;
@@ -31,7 +31,7 @@ UPDATE eperson SET self_registered = false WHERE self_registered IS NULL;
 
 
 
-ALTER TABLE epersongroup ADD COLUMN uuid UUID UNIQUE;
+ALTER TABLE epersongroup ADD COLUMN uuid UUID DEFAULT gen_random_uuid() UNIQUE;
 INSERT INTO dspaceobject  (uuid) SELECT uuid FROM epersongroup;
 ALTER TABLE epersongroup ADD FOREIGN KEY (uuid) REFERENCES dspaceobject;
 ALTER TABLE epersongroup ALTER COLUMN uuid SET NOT NULL;
@@ -39,7 +39,7 @@ ALTER TABLE epersongroup ADD CONSTRAINT epersongroup_id_unique UNIQUE(uuid);
 ALTER TABLE epersongroup ADD PRIMARY KEY (uuid);
 ALTER TABLE epersongroup ALTER COLUMN eperson_group_id DROP NOT NULL;
 
-ALTER TABLE item ADD COLUMN uuid UUID UNIQUE;
+ALTER TABLE item ADD COLUMN uuid UUID DEFAULT gen_random_uuid() UNIQUE;
 INSERT INTO dspaceobject  (uuid) SELECT uuid FROM item;
 ALTER TABLE item ADD FOREIGN KEY (uuid) REFERENCES dspaceobject;
 ALTER TABLE item ALTER COLUMN uuid SET NOT NULL;
@@ -47,7 +47,7 @@ ALTER TABLE item ADD CONSTRAINT item_id_unique UNIQUE(uuid);
 ALTER TABLE item ADD PRIMARY KEY (uuid);
 ALTER TABLE item ALTER COLUMN item_id DROP NOT NULL;
 
-ALTER TABLE community ADD COLUMN uuid UUID UNIQUE;
+ALTER TABLE community ADD COLUMN uuid UUID DEFAULT gen_random_uuid() UNIQUE;
 INSERT INTO dspaceobject  (uuid) SELECT uuid FROM community;
 ALTER TABLE community ADD FOREIGN KEY (uuid) REFERENCES dspaceobject;
 ALTER TABLE community ALTER COLUMN uuid SET NOT NULL;
@@ -56,7 +56,7 @@ ALTER TABLE community ADD PRIMARY KEY (uuid);
 ALTER TABLE community ALTER COLUMN community_id DROP NOT NULL;
 
 
-ALTER TABLE collection ADD COLUMN uuid UUID UNIQUE;
+ALTER TABLE collection ADD COLUMN uuid UUID DEFAULT gen_random_uuid() UNIQUE;
 INSERT INTO dspaceobject  (uuid) SELECT uuid FROM collection;
 ALTER TABLE collection ADD FOREIGN KEY (uuid) REFERENCES dspaceobject;
 ALTER TABLE collection ALTER COLUMN uuid SET NOT NULL;
@@ -64,7 +64,7 @@ ALTER TABLE collection ADD CONSTRAINT collection_id_unique UNIQUE(uuid);
 ALTER TABLE collection ADD PRIMARY KEY (uuid);
 ALTER TABLE collection ALTER COLUMN collection_id DROP NOT NULL;
 
-ALTER TABLE bundle ADD COLUMN uuid UUID UNIQUE;
+ALTER TABLE bundle ADD COLUMN uuid UUID DEFAULT gen_random_uuid() UNIQUE;
 INSERT INTO dspaceobject  (uuid) SELECT uuid FROM bundle;
 ALTER TABLE bundle ADD FOREIGN KEY (uuid) REFERENCES dspaceobject;
 ALTER TABLE bundle ALTER COLUMN uuid SET NOT NULL;
@@ -72,7 +72,7 @@ ALTER TABLE bundle ADD CONSTRAINT bundle_id_unique UNIQUE(uuid);
 ALTER TABLE bundle ADD PRIMARY KEY (uuid);
 ALTER TABLE bundle ALTER COLUMN bundle_id DROP NOT NULL;
 
-ALTER TABLE bitstream ADD COLUMN uuid UUID UNIQUE;
+ALTER TABLE bitstream ADD COLUMN uuid UUID DEFAULT gen_random_uuid() UNIQUE;
 INSERT INTO dspaceobject  (uuid) SELECT uuid FROM bitstream;
 ALTER TABLE bitstream ADD FOREIGN KEY (uuid) REFERENCES dspaceobject;
 ALTER TABLE bitstream ALTER COLUMN uuid SET NOT NULL;
@@ -318,7 +318,7 @@ UPDATE metadatavalue SET dspace_object_id = (SELECT bundle.uuid FROM bundle WHER
 UPDATE metadatavalue SET dspace_object_id = (SELECT bitstream.uuid FROM bitstream WHERE metadatavalue.resource_id = bitstream.bitstream_id AND metadatavalue.resource_type_id = 0) WHERE metadatavalue.resource_type_id= 0;
 DROP INDEX metadatavalue_item_idx;
 DROP INDEX metadatavalue_item_idx2;
-ALTER TABLE metadatavalue DROP COLUMN resource_id;
+ALTER TABLE metadatavalue DROP COLUMN IF EXISTS resource_id;
 ALTER TABLE metadatavalue DROP COLUMN resource_type_id;
 UPDATE MetadataValue SET confidence = -1 WHERE confidence IS NULL;
 

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/AuthorityChooseServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/AuthorityChooseServlet.java
@@ -15,12 +15,12 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.Properties;
 import java.sql.SQLException;
+import java.util.UUID;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.dspace.content.Collection;
-import org.dspace.content.authority.ChoiceAuthorityServiceImpl;
 import org.xml.sax.SAXException;
 import org.dspace.app.webui.util.UIUtil;
 import org.dspace.authorize.AuthorizeException;
@@ -83,10 +83,10 @@ public class AuthorityChooseServlet extends DSpaceServlet {
 
         String query = request.getParameter("query");
         String format = request.getParameter("format");
-        int collectionID = UIUtil.getIntParameter(request, "collection");
+        UUID collectionID = UIUtil.getUUIDParameter(request, "collection");
         int start = UIUtil.getIntParameter(request, "start");
         int limit = UIUtil.getIntParameter(request, "limit");
-        Collection collection = collectionService.findByLegacyId(context, collectionID);
+        Collection collection = collectionService.find(context, collectionID);
         
         Choices result = choiceAuthorityService.getMatches(field, query, collection, start, limit, null);
 //        Choice[] testValues = {

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/FeedServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/FeedServlet.java
@@ -360,7 +360,7 @@ public class FeedServlet extends DSpaceServlet
                 checkAccess:
                     for (Group group : authorizeService.getAuthorizedGroups(context, result, Constants.READ))
                         {
-                        if ((group.getLegacyId() != null && group.getLegacyId() == GroupService.ANONYMOUS_ID))
+                        if ((group.getName() != null && group.getName().equals(Group.ANONYMOUS)))
                         {
                             items.add(result);
                             break checkAccess;

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/AuthorizeAdminServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/AuthorizeAdminServlet.java
@@ -190,7 +190,7 @@ public class AuthorizeAdminServlet extends DSpaceServlet
 
             AuthorizeUtil.authorizeManageItemPolicy(c, item);
 			ResourcePolicy policy = authorizeService.createResourcePolicy(c, item,
-					groupService.findByLegacyId(c, GroupService.ANONYMOUS_ID), null, -1, null);
+					groupService.findByName(c, Group.ANONYMOUS), null, -1, null);
 
             List<Group> groups = groupService.findAll(c, GroupService.NAME);
             List<EPerson> epeople = personService.findAll(c, EPerson.EMAIL);
@@ -242,7 +242,7 @@ public class AuthorizeAdminServlet extends DSpaceServlet
 
             AuthorizeUtil.authorizeManageBundlePolicy(c, bundle);
 			ResourcePolicy policy = authorizeService.createResourcePolicy(c, bundle,
-					groupService.findByLegacyId(c, GroupService.ANONYMOUS_ID), null, -1, null);
+					groupService.findByName(c, Group.ANONYMOUS), null, -1, null);
 
             List<Group> groups = groupService.findAll(c, GroupService.NAME);
             List<EPerson> epeople = personService.findAll(c, EPerson.EMAIL);
@@ -270,7 +270,7 @@ public class AuthorizeAdminServlet extends DSpaceServlet
 
             AuthorizeUtil.authorizeManageBitstreamPolicy(c, bitstream);
 			ResourcePolicy policy = authorizeService.createResourcePolicy(c, bitstream,
-					groupService.findByLegacyId(c, GroupService.ANONYMOUS_ID), null, -1, null);
+					groupService.findByName(c, Group.ANONYMOUS), null, -1, null);
 
             List<Group> groups = groupService.findAll(c, GroupService.NAME);
             List<EPerson> epeople = personService.findAll(c, EPerson.EMAIL);
@@ -316,7 +316,7 @@ public class AuthorizeAdminServlet extends DSpaceServlet
 
             AuthorizeUtil.authorizeManageCollectionPolicy(c, collection);
 			ResourcePolicy policy = authorizeService.createResourcePolicy(c, collection,
-					groupService.findByLegacyId(c, GroupService.ANONYMOUS_ID), null, -1, null);
+					groupService.findByName(c, Group.ANONYMOUS), null, -1, null);
 
 
             List<Group> groups = groupService.findAll(c, GroupService.NAME);
@@ -405,7 +405,7 @@ public class AuthorizeAdminServlet extends DSpaceServlet
             {
                 // create new policy
     			policy = authorizeService.createResourcePolicy(c, collection,
-    					groupService.findByLegacyId(c, GroupService.ANONYMOUS_ID), null, -1, null);
+    					groupService.findByName(c, Group.ANONYMOUS), null, -1, null);
             }
             else
             {
@@ -441,7 +441,7 @@ public class AuthorizeAdminServlet extends DSpaceServlet
             {
                 // create new policy
     			policy = authorizeService.createResourcePolicy(c, community,
-    					groupService.findByLegacyId(c, GroupService.ANONYMOUS_ID), null, -1, null);
+    					groupService.findByName(c, Group.ANONYMOUS), null, -1, null);
 
             }
             else
@@ -472,7 +472,7 @@ public class AuthorizeAdminServlet extends DSpaceServlet
 
             AuthorizeUtil.authorizeManageCollectionPolicy(c, collection);
 			ResourcePolicy policy = authorizeService.createResourcePolicy(c, collection,
-					groupService.findByLegacyId(c, GroupService.ANONYMOUS_ID), null, -1, null);
+					groupService.findByName(c, Group.ANONYMOUS), null, -1, null);
 
 
             List<Group> groups = groupService.findAll(c, GroupService.NAME);
@@ -499,7 +499,7 @@ public class AuthorizeAdminServlet extends DSpaceServlet
 
             AuthorizeUtil.authorizeManageCommunityPolicy(c, community);
 			ResourcePolicy policy = authorizeService.createResourcePolicy(c, community,
-					groupService.findByLegacyId(c, GroupService.ANONYMOUS_ID), null, -1, null);
+					groupService.findByName(c, Group.ANONYMOUS), null, -1, null);
 
 
             List<Group> groups = groupService.findAll(c, GroupService.NAME);
@@ -698,12 +698,12 @@ public class AuthorizeAdminServlet extends DSpaceServlet
 
             // if it's to bitstreams, do it to bundles too
             PolicySet.setPolicies(c, Constants.COLLECTION, collectionId,
-                    resourceType, 0, groupService.findByLegacyId(c, GroupService.ANONYMOUS_ID).getID(), false, true);
+                    resourceType, 0, groupService.findByName(c, Group.ANONYMOUS).getID(), false, true);
 
             if (resourceType == Constants.BITSTREAM)
             {
                 PolicySet.setPolicies(c, Constants.COLLECTION, collectionId,
-                        Constants.BUNDLE, 0, groupService.findByLegacyId(c, GroupService.ANONYMOUS_ID).getID(), false, true);
+                        Constants.BUNDLE, 0, groupService.findByName(c, Group.ANONYMOUS).getID(), false, true);
             }
 
             // return to the main page

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/CollectionWizardServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/CollectionWizardServlet.java
@@ -763,7 +763,7 @@ public class CollectionWizardServlet extends DSpaceServlet
                 EditCommunitiesServlet.storeAuthorizeAttributeCollectionEdit(context, request, collection);
             }
 
-            JSPManager.showJSP(request, response, "/tools/edit-collectionService.jsp");
+            JSPManager.showJSP(request, response, "/tools/edit-collection.jsp");
 
             break;
         }

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EPersonAdminServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EPersonAdminServlet.java
@@ -349,7 +349,7 @@ public class EPersonAdminServlet extends DSpaceServlet
                 }
                 
                 // You may not assume the login of another super administrator
-                Group administrators = groupService.findByLegacyId(context,1);
+                Group administrators = groupService.findByName(context,Group.ADMIN);
                 if (groupService.isDirectMember(administrators, e))
                 {                    
                     JSPManager.showJSP(request, response,

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/GroupListServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/GroupListServlet.java
@@ -49,14 +49,7 @@ public class GroupListServlet extends DSpaceServlet
 		
 		// What are we sorting by?  Name is default
 		int sortBy = GroupService.NAME;
-		
-		String sbParam = request.getParameter("sortby");
 
-		if (sbParam != null && sbParam.equals("id"))
-		{
-			sortBy = GroupService.ID;
-		}
-		
 		// What's the index of the first group to show?  Default is 0
 		int first = UIUtil.getIntParameter(request, "first");
 		if (first == -1)


### PR DESCRIPTION
This branch addresses some of the initial issues that showed up during the JSPUI review, these include:
- Usage of the old 0 & 1 identifiers to retrieve groups. On new installations these identifiers will not be present, best to use findByName().
- Reenabling the "gen_random_uuid()", this function is only available from postgres 9.4 but is required to generate UUID for the DSpace objects. (We should change the postgres version in the docs as soon as this pull request is merged in master).
- Over eager search & replace that altered the path of a jsp file
