### PR TITLE
DS-2748: Reduce Cocoon 404 log noise and add URIs to messages

### DIFF
--- a/dspace-xmlui/pom.xml
+++ b/dspace-xmlui/pom.xml
@@ -120,6 +120,10 @@
                     <groupId>net.sf.ehcache</groupId>
                     <artifactId>ehcache</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.cocoon</groupId>
+                    <artifactId>cocoon-sitemap-impl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -148,6 +152,10 @@
                     <groupId>org.apache.cocoon</groupId>
                     <artifactId>cocoon-servlet-service-impl</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.cocoon</groupId>
+                    <artifactId>cocoon-sitemap-impl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -155,6 +163,12 @@
             <groupId>org.dspace.dependencies.cocoon</groupId>
             <artifactId>dspace-cocoon-servlet-service-impl</artifactId>
             <version>1.0.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.dspace.dependencies.cocoon</groupId>
+            <artifactId>dspace-cocoon-sitemap-impl</artifactId>
+            <version>1.0.0</version>
         </dependency>
 
         <dependency>

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/general/PageNotFoundTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/general/PageNotFoundTransformer.java
@@ -165,7 +165,7 @@ public class PageNotFoundTransformer extends AbstractDSpaceTransformer implement
 
             notFound.addPara().addXref(contextPath + "/",T_go_home);
 
-            throw new ResourceNotFoundException("Page cannot be found");
+            throw new ResourceNotFoundException("Page not found: " + sitemapURI);
 
 
         }


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2748

This switches to using a patched version of cocoon-sitemap-impl[1] which avoids putting lengthy ERROR level stack traces in the Cocoon logs when ResourceNotFoundExceptions are encountered. Instead, these are now logged at WARN level and do not include the stack trace -- only the sitemap URI.

Before testing this, you'll need to run the following:

```
git clone https://github.com/cwilper/dspace-cocoon-sitemap-impl.git
cd dspace-cocoon-sitemap-impl
mvn install
```

The above will put dspace-cocoon-sitemap-impl-1.0.0.jar in the right place under your local repository (~/.m2/repository/), and the dependency will be resolved correctly when you build DSpace.

[1] Patched version of cocoon-sitemap-impl:
https://github.com/cwilper/dspace-cocoon-sitemap-impl

If this PR is accepted, I'd advise moving this repository to the DSpace github organization and publishing the jar to Maven Central prior to merging this branch.
