### PR TITLE
DS-2757 add left hand variable, 'fileDescription', to catch a value.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/submit/step/UploadWithEmbargoStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/UploadWithEmbargoStep.java
@@ -352,7 +352,7 @@ public class UploadWithEmbargoStep extends UploadStep
                 String fileDescription =  (String) request.getAttribute(param + "-description");
                 if(fileDescription==null ||fileDescription.length()==0)
                 {
-                    request.getParameter("description");
+                    fileDescription = request.getParameter("description");
                 }
 
                 // if information wasn't passed by User Interface, we had a problem


### PR DESCRIPTION
Without the variable assignment, the file description entered by the user is lost when upload with embargo is turned on.  Compare with UploadStep.java, line 475.

https://github.com/DSpace/DSpace/blob/dspace-5_x/dspace-api/src/main/java/org/dspace/submit/step/UploadStep.java#L475

https://jira.duraspace.org/browse/DS-2757
