### PR TITLE
DS-2701: Fix license headers and DB migration naming convention

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V6_0_2015_03_06__DS_2701_Dso_Uuid_Migration.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V6_0_2015_03_06__DS_2701_Dso_Uuid_Migration.java
@@ -18,7 +18,7 @@ import java.sql.Connection;
  *
  * @author kevinvandevelde at atmire.com
  */
-public class V6_0_2015_03_06__Dso_Uuid_Migration implements JdbcMigration, MigrationChecksumProvider {
+public class V6_0_2015_03_06__DS_2701_Dso_Uuid_Migration implements JdbcMigration, MigrationChecksumProvider {
 
     private int checksum = -1;
 

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V6.0_2015.03.07__DS-2701_Hibernate_migration.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V6.0_2015.03.07__DS-2701_Hibernate_migration.sql
@@ -6,6 +6,9 @@
 -- http://www.dspace.org/license/
 --
 
+------------------------------------------------------
+-- DS-2701 Service based API / Hibernate integration
+------------------------------------------------------
 DROP VIEW community2item;
 
 CREATE TABLE dspaceobject

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V6.0_2015.03.07__DS-2701_Hibernate_migration.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V6.0_2015.03.07__DS-2701_Hibernate_migration.sql
@@ -6,221 +6,210 @@
 -- http://www.dspace.org/license/
 --
 
+------------------------------------------------------
+-- DS-2701 Service based API / Hibernate integration
+------------------------------------------------------
 DROP VIEW community2item;
 
 CREATE TABLE dspaceobject
 (
-    uuid            uuid NOT NULL  PRIMARY KEY
+    uuid            RAW(16) NOT NULL  PRIMARY KEY
 );
 
 CREATE TABLE site
 (
-    uuid            uuid NOT NULL PRIMARY KEY REFERENCES dspaceobject(uuid)
+    uuid            RAW(16) NOT NULL PRIMARY KEY REFERENCES dspaceobject(uuid)
 
 );
 
-ALTER TABLE eperson ADD COLUMN uuid UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE eperson ADD uuid RAW(16) DEFAULT SYS_GUID();
 INSERT INTO dspaceobject  (uuid) SELECT uuid FROM eperson;
 ALTER TABLE eperson ADD FOREIGN KEY (uuid) REFERENCES dspaceobject;
-ALTER TABLE eperson ALTER COLUMN uuid SET NOT NULL;
-ALTER TABLE eperson ADD CONSTRAINT eperson_id_unique UNIQUE(uuid);
-ALTER TABLE eperson ADD PRIMARY KEY (uuid);
-ALTER TABLE eperson ALTER COLUMN eperson_id DROP NOT NULL;
-UPDATE eperson SET require_certificate = false WHERE require_certificate IS NULL;
-UPDATE eperson SET self_registered = false WHERE self_registered IS NULL;
+ALTER TABLE eperson MODIFY uuid NOT NULL;
+ALTER TABLE eperson ADD CONSTRAINT eperson_id_unique PRIMARY KEY (uuid);
+UPDATE eperson SET require_certificate = '0' WHERE require_certificate IS NULL;
+UPDATE eperson SET self_registered = '0' WHERE self_registered IS NULL;
 
 
 
-ALTER TABLE epersongroup ADD COLUMN uuid UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE epersongroup ADD uuid RAW(16) DEFAULT SYS_GUID();
 INSERT INTO dspaceobject  (uuid) SELECT uuid FROM epersongroup;
 ALTER TABLE epersongroup ADD FOREIGN KEY (uuid) REFERENCES dspaceobject;
-ALTER TABLE epersongroup ALTER COLUMN uuid SET NOT NULL;
-ALTER TABLE epersongroup ADD CONSTRAINT epersongroup_id_unique UNIQUE(uuid);
-ALTER TABLE epersongroup ADD PRIMARY KEY (uuid);
-ALTER TABLE epersongroup ALTER COLUMN eperson_group_id DROP NOT NULL;
+ALTER TABLE epersongroup MODIFY uuid NOT NULL;
+ALTER TABLE epersongroup ADD CONSTRAINT epersongroup_id_unique PRIMARY KEY (uuid);
 
-ALTER TABLE item ADD COLUMN uuid UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE item ADD uuid RAW(16) DEFAULT SYS_GUID();
 INSERT INTO dspaceobject  (uuid) SELECT uuid FROM item;
 ALTER TABLE item ADD FOREIGN KEY (uuid) REFERENCES dspaceobject;
-ALTER TABLE item ALTER COLUMN uuid SET NOT NULL;
-ALTER TABLE item ADD CONSTRAINT item_id_unique UNIQUE(uuid);
-ALTER TABLE item ADD PRIMARY KEY (uuid);
-ALTER TABLE item ALTER COLUMN item_id DROP NOT NULL;
+ALTER TABLE item MODIFY uuid NOT NULL;
+ALTER TABLE item ADD CONSTRAINT item_id_unique PRIMARY KEY (uuid);
 
-ALTER TABLE community ADD COLUMN uuid UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE community ADD uuid RAW(16) DEFAULT SYS_GUID();
 INSERT INTO dspaceobject  (uuid) SELECT uuid FROM community;
 ALTER TABLE community ADD FOREIGN KEY (uuid) REFERENCES dspaceobject;
-ALTER TABLE community ALTER COLUMN uuid SET NOT NULL;
-ALTER TABLE community ADD CONSTRAINT community_id_unique UNIQUE(uuid);
-ALTER TABLE community ADD PRIMARY KEY (uuid);
-ALTER TABLE community ALTER COLUMN community_id DROP NOT NULL;
+ALTER TABLE community MODIFY uuid NOT NULL;
+ALTER TABLE community ADD CONSTRAINT community_id_unique PRIMARY KEY (uuid);
 
 
-ALTER TABLE collection ADD COLUMN uuid UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE collection ADD uuid RAW(16) DEFAULT SYS_GUID();
 INSERT INTO dspaceobject  (uuid) SELECT uuid FROM collection;
 ALTER TABLE collection ADD FOREIGN KEY (uuid) REFERENCES dspaceobject;
-ALTER TABLE collection ALTER COLUMN uuid SET NOT NULL;
-ALTER TABLE collection ADD CONSTRAINT collection_id_unique UNIQUE(uuid);
-ALTER TABLE collection ADD PRIMARY KEY (uuid);
-ALTER TABLE collection ALTER COLUMN collection_id DROP NOT NULL;
+ALTER TABLE collection MODIFY uuid NOT NULL;
+ALTER TABLE collection ADD CONSTRAINT collection_id_unique PRIMARY KEY (uuid);
 
-ALTER TABLE bundle ADD COLUMN uuid UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE bundle ADD uuid RAW(16) DEFAULT SYS_GUID();
 INSERT INTO dspaceobject  (uuid) SELECT uuid FROM bundle;
 ALTER TABLE bundle ADD FOREIGN KEY (uuid) REFERENCES dspaceobject;
-ALTER TABLE bundle ALTER COLUMN uuid SET NOT NULL;
-ALTER TABLE bundle ADD CONSTRAINT bundle_id_unique UNIQUE(uuid);
-ALTER TABLE bundle ADD PRIMARY KEY (uuid);
-ALTER TABLE bundle ALTER COLUMN bundle_id DROP NOT NULL;
+ALTER TABLE bundle MODIFY uuid NOT NULL;
+ALTER TABLE bundle ADD CONSTRAINT bundle_id_unique PRIMARY KEY (uuid);
 
-ALTER TABLE bitstream ADD COLUMN uuid UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE bitstream ADD uuid RAW(16) DEFAULT SYS_GUID();
 INSERT INTO dspaceobject  (uuid) SELECT uuid FROM bitstream;
 ALTER TABLE bitstream ADD FOREIGN KEY (uuid) REFERENCES dspaceobject;
-ALTER TABLE bitstream ALTER COLUMN uuid SET NOT NULL;
-ALTER TABLE bitstream ADD CONSTRAINT bitstream_id_unique UNIQUE(uuid);
-ALTER TABLE bitstream ADD PRIMARY KEY (uuid);
-ALTER TABLE bitstream ALTER COLUMN bitstream_id DROP NOT NULL;
+ALTER TABLE bitstream MODIFY uuid NOT NULL;
+ALTER TABLE bitstream ADD CONSTRAINT bitstream_id_unique PRIMARY KEY (uuid);
 
 -- Migrate EPersonGroup2EPerson table
 ALTER TABLE EPersonGroup2EPerson RENAME COLUMN eperson_group_id to eperson_group_legacy_id;
 ALTER TABLE EPersonGroup2EPerson RENAME COLUMN eperson_id to eperson_legacy_id;
-ALTER TABLE EPersonGroup2EPerson ADD COLUMN eperson_group_id UUID REFERENCES EpersonGroup(uuid);
-ALTER TABLE EPersonGroup2EPerson ADD COLUMN eperson_id UUID REFERENCES Eperson(uuid);
-UPDATE EPersonGroup2EPerson SET eperson_group_id = EPersonGroup.uuid FROM EpersonGroup WHERE EPersonGroup2EPerson.eperson_group_legacy_id = EPersonGroup.eperson_group_id;
-UPDATE EPersonGroup2EPerson SET eperson_id = eperson.uuid FROM eperson WHERE EPersonGroup2EPerson.eperson_legacy_id = eperson.eperson_id;
-ALTER TABLE EPersonGroup2EPerson ALTER COLUMN eperson_group_id SET NOT NULL;
-ALTER TABLE EPersonGroup2EPerson ALTER COLUMN eperson_id SET NOT NULL;
+ALTER TABLE EPersonGroup2EPerson ADD eperson_group_id RAW(16) REFERENCES EpersonGroup(uuid);
+ALTER TABLE EPersonGroup2EPerson ADD eperson_id RAW(16) REFERENCES Eperson(uuid);
+UPDATE EPersonGroup2EPerson SET eperson_group_id = (SELECT EPersonGroup.uuid FROM EpersonGroup WHERE EPersonGroup2EPerson.eperson_group_legacy_id = EPersonGroup.eperson_group_id);
+UPDATE EPersonGroup2EPerson SET eperson_id = (SELECT eperson.uuid FROM eperson WHERE EPersonGroup2EPerson.eperson_legacy_id = eperson.eperson_id);
+ALTER TABLE EPersonGroup2EPerson MODIFY eperson_group_id NOT NULL;
+ALTER TABLE EPersonGroup2EPerson MODIFY eperson_id NOT NULL;
 ALTER TABLE EPersonGroup2EPerson DROP COLUMN eperson_group_legacy_id;
 ALTER TABLE EPersonGroup2EPerson DROP COLUMN eperson_legacy_id;
 ALTER TABLE epersongroup2eperson DROP COLUMN id;
-ALTER TABLE EPersonGroup2EPerson add primary key (eperson_group_id,eperson_id);
+ALTER TABLE EPersonGroup2EPerson add CONSTRAINT EPersonGroup2EPerson_unique primary key (eperson_group_id,eperson_id);
 
 -- Migrate GROUP2GROUP table
 ALTER TABLE Group2Group RENAME COLUMN parent_id to parent_legacy_id;
 ALTER TABLE Group2Group RENAME COLUMN child_id to child_legacy_id;
-ALTER TABLE Group2Group ADD COLUMN parent_id UUID REFERENCES EpersonGroup(uuid);
-ALTER TABLE Group2Group ADD COLUMN child_id UUID REFERENCES EpersonGroup(uuid);
-UPDATE Group2Group SET parent_id = EPersonGroup.uuid FROM EpersonGroup WHERE Group2Group.parent_legacy_id = EPersonGroup.eperson_group_id;
-UPDATE Group2Group SET child_id = EpersonGroup.uuid FROM EpersonGroup WHERE Group2Group.child_legacy_id = EpersonGroup.eperson_group_id;
-ALTER TABLE Group2Group ALTER COLUMN parent_id SET NOT NULL;
-ALTER TABLE Group2Group ALTER COLUMN child_id SET NOT NULL;
+ALTER TABLE Group2Group ADD parent_id RAW(16) REFERENCES EpersonGroup(uuid);
+ALTER TABLE Group2Group ADD child_id RAW(16) REFERENCES EpersonGroup(uuid);
+UPDATE Group2Group SET parent_id = (SELECT EPersonGroup.uuid FROM EpersonGroup WHERE Group2Group.parent_legacy_id = EPersonGroup.eperson_group_id);
+UPDATE Group2Group SET child_id = (SELECT EpersonGroup.uuid FROM EpersonGroup WHERE Group2Group.child_legacy_id = EpersonGroup.eperson_group_id);
+ALTER TABLE Group2Group MODIFY parent_id NOT NULL;
+ALTER TABLE Group2Group MODIFY child_id NOT NULL;
 ALTER TABLE Group2Group DROP COLUMN parent_legacy_id;
 ALTER TABLE Group2Group DROP COLUMN child_legacy_id;
 ALTER TABLE Group2Group DROP COLUMN id;
-ALTER TABLE Group2Group add primary key (parent_id,child_id);
+ALTER TABLE Group2Group add CONSTRAINT Group2Group_unique primary key (parent_id,child_id);
 
 -- Migrate collection2item
 ALTER TABLE Collection2Item RENAME COLUMN collection_id to collection_legacy_id;
 ALTER TABLE Collection2Item RENAME COLUMN item_id to item_legacy_id;
-ALTER TABLE Collection2Item ADD COLUMN collection_id UUID REFERENCES Collection(uuid);
-ALTER TABLE Collection2Item ADD COLUMN item_id UUID REFERENCES Item(uuid);
-UPDATE Collection2Item SET collection_id = Collection.uuid FROM Collection WHERE Collection2Item.collection_legacy_id = Collection.collection_id;
-UPDATE Collection2Item SET item_id = Item.uuid FROM Item WHERE Collection2Item.item_legacy_id = Item.item_id;
-ALTER TABLE Collection2Item ALTER COLUMN collection_id SET NOT NULL;
-ALTER TABLE Collection2Item ALTER COLUMN item_id SET NOT NULL;
+ALTER TABLE Collection2Item ADD collection_id RAW(16) REFERENCES Collection(uuid);
+ALTER TABLE Collection2Item ADD item_id RAW(16) REFERENCES Item(uuid);
+UPDATE Collection2Item SET collection_id = (SELECT Collection.uuid FROM Collection WHERE Collection2Item.collection_legacy_id = Collection.collection_id);
+UPDATE Collection2Item SET item_id = (SELECT Item.uuid FROM Item WHERE Collection2Item.item_legacy_id = Item.item_id);
+ALTER TABLE Collection2Item MODIFY collection_id NOT NULL;
+ALTER TABLE Collection2Item MODIFY item_id NOT NULL;
 ALTER TABLE Collection2Item DROP COLUMN collection_legacy_id;
 ALTER TABLE Collection2Item DROP COLUMN item_legacy_id;
 ALTER TABLE Collection2Item DROP COLUMN id;
 -- Magic query that will delete all duplicate collection item_id references from the database (if we don't do this the primary key creation will fail)
-DELETE FROM collection2item WHERE ctid NOT IN (SELECT max(ctid) FROM collection2item GROUP BY collection_id,item_id);
-ALTER TABLE Collection2Item add primary key (collection_id,item_id);
+DELETE FROM collection2item WHERE rowid NOT IN (SELECT MIN(rowid) FROM collection2item GROUP BY collection_id,item_id);
+ALTER TABLE Collection2Item add CONSTRAINT collection2item_unique primary key (collection_id,item_id);
 
 -- Migrate Community2Community
 ALTER TABLE Community2Community RENAME COLUMN parent_comm_id to parent_legacy_id;
 ALTER TABLE Community2Community RENAME COLUMN child_comm_id to child_legacy_id;
-ALTER TABLE Community2Community ADD COLUMN parent_comm_id UUID REFERENCES Community(uuid);
-ALTER TABLE Community2Community ADD COLUMN child_comm_id UUID REFERENCES Community(uuid);
-UPDATE Community2Community SET parent_comm_id = Community.uuid FROM Community WHERE Community2Community.parent_legacy_id = Community.community_id;
-UPDATE Community2Community SET child_comm_id = Community.uuid FROM Community WHERE Community2Community.child_legacy_id = Community.community_id;
-ALTER TABLE Community2Community ALTER COLUMN parent_comm_id SET NOT NULL;
-ALTER TABLE Community2Community ALTER COLUMN child_comm_id SET NOT NULL;
+ALTER TABLE Community2Community ADD parent_comm_id RAW(16) REFERENCES Community(uuid);
+ALTER TABLE Community2Community ADD child_comm_id RAW(16) REFERENCES Community(uuid);
+UPDATE Community2Community SET parent_comm_id = (SELECT Community.uuid FROM Community WHERE Community2Community.parent_legacy_id = Community.community_id);
+UPDATE Community2Community SET child_comm_id = (SELECT Community.uuid FROM Community WHERE Community2Community.child_legacy_id = Community.community_id);
+ALTER TABLE Community2Community MODIFY parent_comm_id NOT NULL;
+ALTER TABLE Community2Community MODIFY child_comm_id NOT NULL;
 ALTER TABLE Community2Community DROP COLUMN parent_legacy_id;
 ALTER TABLE Community2Community DROP COLUMN child_legacy_id;
 ALTER TABLE Community2Community DROP COLUMN id;
-ALTER TABLE Community2Community add primary key (parent_comm_id,child_comm_id);
+ALTER TABLE Community2Community add CONSTRAINT Community2Community_unique primary key (parent_comm_id,child_comm_id);
 
 -- Migrate community2collection
 ALTER TABLE community2collection RENAME COLUMN collection_id to collection_legacy_id;
 ALTER TABLE community2collection RENAME COLUMN community_id to community_legacy_id;
-ALTER TABLE community2collection ADD COLUMN collection_id UUID REFERENCES Collection(uuid);
-ALTER TABLE community2collection ADD COLUMN community_id UUID REFERENCES Community(uuid);
-UPDATE community2collection SET collection_id = Collection.uuid FROM Collection WHERE community2collection.collection_legacy_id = Collection.collection_id;
-UPDATE community2collection SET community_id = Community.uuid FROM Community WHERE community2collection.community_legacy_id = Community.community_id;
-ALTER TABLE community2collection ALTER COLUMN collection_id SET NOT NULL;
-ALTER TABLE community2collection ALTER COLUMN community_id SET NOT NULL;
+ALTER TABLE community2collection ADD collection_id RAW(16) REFERENCES Collection(uuid);
+ALTER TABLE community2collection ADD community_id RAW(16) REFERENCES Community(uuid);
+UPDATE community2collection SET collection_id = (SELECT Collection.uuid FROM Collection WHERE community2collection.collection_legacy_id = Collection.collection_id);
+UPDATE community2collection SET community_id = (SELECT Community.uuid FROM Community WHERE community2collection.community_legacy_id = Community.community_id);
+ALTER TABLE community2collection MODIFY collection_id NOT NULL;
+ALTER TABLE community2collection MODIFY community_id NOT NULL;
 ALTER TABLE community2collection DROP COLUMN collection_legacy_id;
 ALTER TABLE community2collection DROP COLUMN community_legacy_id;
 ALTER TABLE community2collection DROP COLUMN id;
-ALTER TABLE community2collection add primary key (collection_id,community_id);
+ALTER TABLE community2collection add CONSTRAINT community2collection_unique primary key (collection_id,community_id);
 
 
 -- Migrate Group2GroupCache table
 ALTER TABLE Group2GroupCache RENAME COLUMN parent_id to parent_legacy_id;
 ALTER TABLE Group2GroupCache RENAME COLUMN child_id to child_legacy_id;
-ALTER TABLE Group2GroupCache ADD COLUMN parent_id UUID REFERENCES EpersonGroup(uuid);
-ALTER TABLE Group2GroupCache ADD COLUMN child_id UUID REFERENCES EpersonGroup(uuid);
-UPDATE Group2GroupCache SET parent_id = EPersonGroup.uuid FROM EpersonGroup WHERE Group2GroupCache.parent_legacy_id = EPersonGroup.eperson_group_id;
-UPDATE Group2GroupCache SET child_id = EpersonGroup.uuid FROM EpersonGroup WHERE Group2GroupCache.child_legacy_id = EpersonGroup.eperson_group_id;
-ALTER TABLE Group2GroupCache ALTER COLUMN parent_id SET NOT NULL;
-ALTER TABLE Group2GroupCache ALTER COLUMN child_id SET NOT NULL;
+ALTER TABLE Group2GroupCache ADD parent_id RAW(16) REFERENCES EpersonGroup(uuid);
+ALTER TABLE Group2GroupCache ADD child_id RAW(16) REFERENCES EpersonGroup(uuid);
+UPDATE Group2GroupCache SET parent_id = (SELECT EPersonGroup.uuid FROM EpersonGroup WHERE Group2GroupCache.parent_legacy_id = EPersonGroup.eperson_group_id);
+UPDATE Group2GroupCache SET child_id = (SELECT EpersonGroup.uuid FROM EpersonGroup WHERE Group2GroupCache.child_legacy_id = EpersonGroup.eperson_group_id);
+ALTER TABLE Group2GroupCache MODIFY parent_id NOT NULL;
+ALTER TABLE Group2GroupCache MODIFY child_id NOT NULL;
 ALTER TABLE Group2GroupCache DROP COLUMN parent_legacy_id;
 ALTER TABLE Group2GroupCache DROP COLUMN child_legacy_id;
 ALTER TABLE Group2GroupCache DROP COLUMN id;
-ALTER TABLE Group2GroupCache add primary key (parent_id,child_id);
+ALTER TABLE Group2GroupCache add CONSTRAINT Group2GroupCache_unique primary key (parent_id,child_id);
 
 -- Migrate Item2Bundle
 ALTER TABLE item2bundle RENAME COLUMN bundle_id to bundle_legacy_id;
 ALTER TABLE item2bundle RENAME COLUMN item_id to item_legacy_id;
-ALTER TABLE item2bundle ADD COLUMN bundle_id UUID REFERENCES Bundle(uuid);
-ALTER TABLE item2bundle ADD COLUMN item_id UUID REFERENCES Item(uuid);
-UPDATE item2bundle SET bundle_id = Bundle.uuid FROM Bundle WHERE item2bundle.bundle_legacy_id = Bundle.bundle_id;
-UPDATE item2bundle SET item_id = Item.uuid FROM Item WHERE item2bundle.item_legacy_id = Item.item_id;
-ALTER TABLE item2bundle ALTER COLUMN bundle_id SET NOT NULL;
-ALTER TABLE item2bundle ALTER COLUMN item_id SET NOT NULL;
+ALTER TABLE item2bundle ADD bundle_id RAW(16) REFERENCES Bundle(uuid);
+ALTER TABLE item2bundle ADD item_id RAW(16) REFERENCES Item(uuid);
+UPDATE item2bundle SET bundle_id = (SELECT Bundle.uuid FROM Bundle WHERE item2bundle.bundle_legacy_id = Bundle.bundle_id);
+UPDATE item2bundle SET item_id = (SELECT Item.uuid FROM Item WHERE item2bundle.item_legacy_id = Item.item_id);
+ALTER TABLE item2bundle MODIFY bundle_id NOT NULL;
+ALTER TABLE item2bundle MODIFY item_id NOT NULL;
 ALTER TABLE item2bundle DROP COLUMN bundle_legacy_id;
 ALTER TABLE item2bundle DROP COLUMN item_legacy_id;
 ALTER TABLE item2bundle DROP COLUMN id;
-ALTER TABLE item2bundle add primary key (bundle_id,item_id);
+ALTER TABLE item2bundle add CONSTRAINT item2bundle_unique primary key (bundle_id,item_id);
 
 --Migrate Bundle2Bitsteam
 ALTER TABLE bundle2bitstream RENAME COLUMN bundle_id to bundle_legacy_id;
 ALTER TABLE bundle2bitstream RENAME COLUMN bitstream_id to bitstream_legacy_id;
-ALTER TABLE bundle2bitstream ADD COLUMN bundle_id UUID REFERENCES Bundle(uuid);
-ALTER TABLE bundle2bitstream ADD COLUMN bitstream_id UUID REFERENCES Bitstream(uuid);
+ALTER TABLE bundle2bitstream ADD bundle_id RAW(16) REFERENCES Bundle(uuid);
+ALTER TABLE bundle2bitstream ADD bitstream_id RAW(16) REFERENCES Bitstream(uuid);
 UPDATE bundle2bitstream SET bundle_id = (SELECT bundle.uuid FROM bundle WHERE bundle2bitstream.bundle_legacy_id = bundle.bundle_id);
 UPDATE bundle2bitstream SET bitstream_id = (SELECT bitstream.uuid FROM bitstream WHERE bundle2bitstream.bitstream_legacy_id = bitstream.bitstream_id);
-ALTER TABLE bundle2bitstream ALTER COLUMN bundle_id SET NOT NULL;
-ALTER TABLE bundle2bitstream ALTER COLUMN bitstream_id SET NOT NULL;
+ALTER TABLE bundle2bitstream MODIFY bundle_id NOT NULL;
+ALTER TABLE bundle2bitstream MODIFY bitstream_id NOT NULL;
 ALTER TABLE bundle2bitstream DROP COLUMN bundle_legacy_id;
 ALTER TABLE bundle2bitstream DROP COLUMN bitstream_legacy_id;
 ALTER TABLE bundle2bitstream DROP COLUMN id;
-ALTER TABLE bundle2bitstream add primary key (bitstream_id,bundle_id);
+ALTER TABLE bundle2bitstream add CONSTRAINT bundle2bitstream_unique primary key (bitstream_id,bundle_id);
 
 
 -- Migrate item
 ALTER TABLE item RENAME COLUMN submitter_id to submitter_id_legacy_id;
-ALTER TABLE item ADD COLUMN submitter_id UUID REFERENCES EPerson(uuid);
-UPDATE item SET submitter_id = eperson.uuid FROM eperson WHERE item.submitter_id_legacy_id = eperson.eperson_id;
+ALTER TABLE item ADD submitter_id RAW(16) REFERENCES EPerson(uuid);
+UPDATE item SET submitter_id = (SELECT eperson.uuid FROM eperson WHERE item.submitter_id_legacy_id = eperson.eperson_id);
 ALTER TABLE item DROP COLUMN submitter_id_legacy_id;
 
 ALTER TABLE item RENAME COLUMN owning_collection to owning_collection_legacy;
-ALTER TABLE item ADD COLUMN owning_collection UUID REFERENCES Collection(uuid);
-UPDATE item SET owning_collection = Collection.uuid FROM Collection WHERE item.owning_collection_legacy = collection.collection_id;
+ALTER TABLE item ADD owning_collection RAW(16) REFERENCES Collection(uuid);
+UPDATE item SET owning_collection = (SELECT Collection.uuid FROM Collection WHERE item.owning_collection_legacy = collection.collection_id);
 ALTER TABLE item DROP COLUMN owning_collection_legacy;
 
 -- Migrate bundle
 ALTER TABLE bundle RENAME COLUMN primary_bitstream_id to primary_bitstream_legacy_id;
-ALTER TABLE bundle ADD COLUMN primary_bitstream_id UUID REFERENCES Bitstream(uuid);
+ALTER TABLE bundle ADD primary_bitstream_id RAW(16) REFERENCES Bitstream(uuid);
 UPDATE bundle SET primary_bitstream_id = (SELECT Bitstream.uuid FROM Bitstream WHERE bundle.primary_bitstream_legacy_id = Bitstream.bitstream_id);
 ALTER TABLE bundle DROP COLUMN primary_bitstream_legacy_id;
 
 
 -- Migrate community references
 ALTER TABLE Community RENAME COLUMN admin to admin_legacy;
-ALTER TABLE Community ADD COLUMN admin UUID REFERENCES EPersonGroup(uuid);
-UPDATE Community SET admin = EPersonGroup.uuid FROM EPersonGroup WHERE Community.admin_legacy = EPersonGroup.eperson_group_id;
+ALTER TABLE Community ADD admin RAW(16) REFERENCES EPersonGroup(uuid);
+UPDATE Community SET admin = (SELECT EPersonGroup.uuid FROM EPersonGroup WHERE Community.admin_legacy = EPersonGroup.eperson_group_id);
 ALTER TABLE Community DROP COLUMN admin_legacy;
 ALTER TABLE Community RENAME COLUMN logo_bitstream_id to logo_bitstream_legacy_id;
-ALTER TABLE Community ADD COLUMN logo_bitstream_id UUID REFERENCES Bitstream(uuid);
+ALTER TABLE Community ADD logo_bitstream_id RAW(16) REFERENCES Bitstream(uuid);
 UPDATE Community SET logo_bitstream_id = (SELECT Bitstream.uuid FROM Bitstream WHERE Community.logo_bitstream_legacy_id = Bitstream.bitstream_id);
 ALTER TABLE Community DROP COLUMN logo_bitstream_legacy_id;
 
@@ -233,20 +222,20 @@ ALTER TABLE Collection RENAME COLUMN submitter to submitter_legacy;
 ALTER TABLE Collection RENAME COLUMN template_item_id to template_item_legacy_id;
 ALTER TABLE Collection RENAME COLUMN logo_bitstream_id to logo_bitstream_legacy_id;
 ALTER TABLE Collection RENAME COLUMN admin to admin_legacy;
-ALTER TABLE Collection ADD COLUMN workflow_step_1 UUID REFERENCES EPersonGroup(uuid);
-ALTER TABLE Collection ADD COLUMN workflow_step_2 UUID REFERENCES EPersonGroup(uuid);
-ALTER TABLE Collection ADD COLUMN workflow_step_3 UUID REFERENCES EPersonGroup(uuid);
-ALTER TABLE Collection ADD COLUMN submitter UUID REFERENCES EPersonGroup(uuid);
-ALTER TABLE Collection ADD COLUMN template_item_id UUID;
-ALTER TABLE Collection ADD COLUMN logo_bitstream_id UUID;
-ALTER TABLE Collection ADD COLUMN admin UUID REFERENCES EPersonGroup(uuid);
-UPDATE Collection SET workflow_step_1 = EPersonGroup.uuid FROM EPersonGroup WHERE Collection.workflow_step_1_legacy = EPersonGroup.eperson_group_id;
-UPDATE Collection SET workflow_step_2 = EPersonGroup.uuid FROM EPersonGroup WHERE Collection.workflow_step_2_legacy = EPersonGroup.eperson_group_id;
-UPDATE Collection SET workflow_step_3 = EPersonGroup.uuid FROM EPersonGroup WHERE Collection.workflow_step_3_legacy = EPersonGroup.eperson_group_id;
-UPDATE Collection SET submitter = EPersonGroup.uuid FROM EPersonGroup WHERE Collection.submitter_legacy = EPersonGroup.eperson_group_id;
+ALTER TABLE Collection ADD workflow_step_1 RAW(16) REFERENCES EPersonGroup(uuid);
+ALTER TABLE Collection ADD workflow_step_2 RAW(16) REFERENCES EPersonGroup(uuid);
+ALTER TABLE Collection ADD workflow_step_3 RAW(16) REFERENCES EPersonGroup(uuid);
+ALTER TABLE Collection ADD submitter RAW(16) REFERENCES EPersonGroup(uuid);
+ALTER TABLE Collection ADD template_item_id RAW(16);
+ALTER TABLE Collection ADD logo_bitstream_id RAW(16);
+ALTER TABLE Collection ADD admin RAW(16) REFERENCES EPersonGroup(uuid);
+UPDATE Collection SET workflow_step_1 = (SELECT EPersonGroup.uuid FROM EPersonGroup WHERE Collection.workflow_step_1_legacy = EPersonGroup.eperson_group_id);
+UPDATE Collection SET workflow_step_2 = (SELECT EPersonGroup.uuid FROM EPersonGroup WHERE Collection.workflow_step_2_legacy = EPersonGroup.eperson_group_id);
+UPDATE Collection SET workflow_step_3 = (SELECT EPersonGroup.uuid FROM EPersonGroup WHERE Collection.workflow_step_3_legacy = EPersonGroup.eperson_group_id);
+UPDATE Collection SET submitter = (SELECT EPersonGroup.uuid FROM EPersonGroup WHERE Collection.submitter_legacy = EPersonGroup.eperson_group_id);
 UPDATE Collection SET template_item_id = (SELECT Item.uuid FROM Item WHERE Collection.template_item_legacy_id = Item.item_id);
 UPDATE Collection SET logo_bitstream_id = (SELECT Bitstream.uuid FROM Bitstream WHERE Collection.logo_bitstream_legacy_id = Bitstream.bitstream_id);
-UPDATE Collection SET admin = EPersonGroup.uuid FROM EPersonGroup WHERE Collection.admin_legacy = EPersonGroup.eperson_group_id;
+UPDATE Collection SET admin = (SELECT EPersonGroup.uuid FROM EPersonGroup WHERE Collection.admin_legacy = EPersonGroup.eperson_group_id);
 ALTER TABLE Collection DROP COLUMN workflow_step_1_legacy;
 ALTER TABLE Collection DROP COLUMN workflow_step_2_legacy;
 ALTER TABLE Collection DROP COLUMN workflow_step_3_legacy;
@@ -258,15 +247,15 @@ ALTER TABLE Collection DROP COLUMN admin_legacy;
 
 -- Migrate resource policy references
 ALTER TABLE ResourcePolicy RENAME COLUMN eperson_id to eperson_id_legacy_id;
-ALTER TABLE ResourcePolicy ADD COLUMN eperson_id UUID REFERENCES EPerson(uuid);
-UPDATE ResourcePolicy SET eperson_id = eperson.uuid FROM eperson WHERE ResourcePolicy.eperson_id_legacy_id = eperson.eperson_id;
+ALTER TABLE ResourcePolicy ADD eperson_id RAW(16) REFERENCES EPerson(uuid);
+UPDATE ResourcePolicy SET eperson_id = (SELECT eperson.uuid FROM eperson WHERE ResourcePolicy.eperson_id_legacy_id = eperson.eperson_id);
 ALTER TABLE ResourcePolicy DROP COLUMN eperson_id_legacy_id;
 ALTER TABLE ResourcePolicy RENAME COLUMN epersongroup_id to epersongroup_id_legacy_id;
-ALTER TABLE ResourcePolicy ADD COLUMN epersongroup_id UUID REFERENCES EPersonGroup(uuid);
-UPDATE ResourcePolicy SET epersongroup_id = epersongroup.uuid FROM epersongroup WHERE ResourcePolicy.epersongroup_id_legacy_id = epersongroup.eperson_group_id;
+ALTER TABLE ResourcePolicy ADD epersongroup_id RAW(16) REFERENCES EPersonGroup(uuid);
+UPDATE ResourcePolicy SET epersongroup_id = (SELECT epersongroup.uuid FROM epersongroup WHERE ResourcePolicy.epersongroup_id_legacy_id = epersongroup.eperson_group_id);
 ALTER TABLE ResourcePolicy DROP COLUMN epersongroup_id_legacy_id;
 
-ALTER TABLE ResourcePolicy ADD COLUMN dspace_object UUID REFERENCES dspaceobject(uuid);
+ALTER TABLE ResourcePolicy ADD dspace_object RAW(16) REFERENCES dspaceobject(uuid);
 UPDATE ResourcePolicy SET dspace_object = (SELECT eperson.uuid FROM eperson WHERE ResourcePolicy.resource_id = eperson.eperson_id AND ResourcePolicy.resource_type_id = 7) WHERE ResourcePolicy.resource_type_id = 7;
 UPDATE ResourcePolicy SET dspace_object = (SELECT epersongroup.uuid FROM epersongroup WHERE ResourcePolicy.resource_id = epersongroup.eperson_group_id AND ResourcePolicy.resource_type_id = 6)  WHERE ResourcePolicy.resource_type_id = 6;
 UPDATE ResourcePolicy SET dspace_object = (SELECT community.uuid FROM community WHERE ResourcePolicy.resource_id = community.community_id AND ResourcePolicy.resource_type_id = 4)  WHERE ResourcePolicy.resource_type_id = 4;
@@ -278,37 +267,37 @@ UPDATE ResourcePolicy SET dspace_object = (SELECT bitstream.uuid FROM bitstream 
 
 -- Migrate Subscription
 ALTER TABLE Subscription RENAME COLUMN eperson_id to eperson_legacy_id;
-ALTER TABLE Subscription ADD COLUMN eperson_id UUID REFERENCES EPerson(uuid);
-UPDATE Subscription SET eperson_id = eperson.uuid FROM eperson WHERE Subscription.eperson_legacy_id = eperson.eperson_id;
+ALTER TABLE Subscription ADD eperson_id RAW(16) REFERENCES EPerson(uuid);
+UPDATE Subscription SET eperson_id = (SELECT eperson.uuid FROM eperson WHERE Subscription.eperson_legacy_id = eperson.eperson_id);
 ALTER TABLE Subscription DROP COLUMN eperson_legacy_id;
 ALTER TABLE Subscription RENAME COLUMN collection_id to collection_legacy_id;
-ALTER TABLE Subscription ADD COLUMN collection_id UUID REFERENCES Collection(uuid);
+ALTER TABLE Subscription ADD collection_id RAW(16) REFERENCES Collection(uuid);
 UPDATE Subscription SET collection_id = (SELECT collection.uuid FROM collection WHERE Subscription.collection_legacy_id = collection.collection_id);
 ALTER TABLE Subscription DROP COLUMN collection_legacy_id;
 
 
 -- Migrate versionitem
 ALTER TABLE versionitem RENAME COLUMN eperson_id to eperson_legacy_id;
-ALTER TABLE versionitem ADD COLUMN eperson_id UUID REFERENCES EPerson(uuid);
-UPDATE versionitem SET eperson_id = eperson.uuid FROM eperson WHERE versionitem.eperson_legacy_id = eperson.eperson_id;
+ALTER TABLE versionitem ADD eperson_id RAW(16) REFERENCES EPerson(uuid);
+UPDATE versionitem SET eperson_id = (SELECT eperson.uuid FROM eperson WHERE versionitem.eperson_legacy_id = eperson.eperson_id);
 ALTER TABLE versionitem DROP COLUMN eperson_legacy_id;
 
 ALTER TABLE versionitem RENAME COLUMN item_id to item_legacy_id;
-ALTER TABLE versionitem ADD COLUMN item_id UUID REFERENCES Item(uuid);
+ALTER TABLE versionitem ADD item_id RAW(16) REFERENCES Item(uuid);
 UPDATE versionitem SET item_id = (SELECT item.uuid FROM item WHERE versionitem.item_legacy_id = item.item_id);
 ALTER TABLE versionitem DROP COLUMN item_legacy_id;
 
 -- Migrate handle table
 ALTER TABLE handle RENAME COLUMN resource_id to resource_legacy_id;
-ALTER TABLE handle ADD COLUMN resource_id UUID REFERENCES dspaceobject(uuid);
-UPDATE handle SET resource_id = community.uuid FROM community WHERE handle.resource_legacy_id = community.community_id AND handle.resource_type_id = 4;
-UPDATE handle SET resource_id = collection.uuid FROM collection WHERE handle.resource_legacy_id = collection.collection_id AND handle.resource_type_id = 3;
-UPDATE handle SET resource_id = item.uuid FROM item WHERE handle.resource_legacy_id = item.item_id AND handle.resource_type_id = 2;
+ALTER TABLE handle ADD resource_id RAW(16) REFERENCES dspaceobject(uuid);
+UPDATE handle SET resource_id = (SELECT community.uuid FROM community WHERE handle.resource_legacy_id = community.community_id AND handle.resource_type_id = 4);
+UPDATE handle SET resource_id = (SELECT collection.uuid FROM collection WHERE handle.resource_legacy_id = collection.collection_id AND handle.resource_type_id = 3);
+UPDATE handle SET resource_id = (SELECT item.uuid FROM item WHERE handle.resource_legacy_id = item.item_id AND handle.resource_type_id = 2);
 
 -- Migrate metadata value table
 DROP VIEW dcvalue;
 
-ALTER TABLE metadatavalue ADD COLUMN dspace_object_id UUID REFERENCES dspaceobject(uuid);
+ALTER TABLE metadatavalue ADD dspace_object_id RAW(16) REFERENCES dspaceobject(uuid);
 UPDATE metadatavalue SET dspace_object_id = (SELECT eperson.uuid FROM eperson WHERE metadatavalue.resource_id = eperson.eperson_id AND metadatavalue.resource_type_id = 7) WHERE metadatavalue.resource_type_id= 7;
 UPDATE metadatavalue SET dspace_object_id = (SELECT epersongroup.uuid FROM epersongroup WHERE metadatavalue.resource_id = epersongroup.eperson_group_id AND metadatavalue.resource_type_id = 6) WHERE metadatavalue.resource_type_id= 6;
 UPDATE metadatavalue SET dspace_object_id = (SELECT community.uuid FROM community WHERE metadatavalue.resource_id = community.community_id AND metadatavalue.resource_type_id = 4) WHERE metadatavalue.resource_type_id= 4;
@@ -318,58 +307,58 @@ UPDATE metadatavalue SET dspace_object_id = (SELECT bundle.uuid FROM bundle WHER
 UPDATE metadatavalue SET dspace_object_id = (SELECT bitstream.uuid FROM bitstream WHERE metadatavalue.resource_id = bitstream.bitstream_id AND metadatavalue.resource_type_id = 0) WHERE metadatavalue.resource_type_id= 0;
 DROP INDEX metadatavalue_item_idx;
 DROP INDEX metadatavalue_item_idx2;
-ALTER TABLE metadatavalue DROP COLUMN IF EXISTS resource_id;
+ALTER TABLE metadatavalue DROP COLUMN resource_id;
 ALTER TABLE metadatavalue DROP COLUMN resource_type_id;
 UPDATE MetadataValue SET confidence = -1 WHERE confidence IS NULL;
 
 -- Alter harvested item
 ALTER TABLE harvested_item RENAME COLUMN item_id to item_legacy_id;
-ALTER TABLE harvested_item ADD COLUMN item_id UUID REFERENCES item(uuid);
+ALTER TABLE harvested_item ADD item_id RAW(16) REFERENCES item(uuid);
 UPDATE harvested_item SET item_id = (SELECT item.uuid FROM item WHERE harvested_item.item_legacy_id = item.item_id);
 ALTER TABLE harvested_item DROP COLUMN item_legacy_id;
 
 -- Alter harvested collection
 ALTER TABLE harvested_collection RENAME COLUMN collection_id to collection_legacy_id;
-ALTER TABLE harvested_collection ADD COLUMN collection_id UUID REFERENCES Collection(uuid);
+ALTER TABLE harvested_collection ADD collection_id RAW(16) REFERENCES Collection(uuid);
 UPDATE harvested_collection SET collection_id = (SELECT collection.uuid FROM collection WHERE harvested_collection.collection_legacy_id = collection.collection_id);
 ALTER TABLE harvested_collection DROP COLUMN collection_legacy_id;
 
 
 --Alter workspaceitem
 ALTER TABLE workspaceitem RENAME COLUMN item_id to item_legacy_id;
-ALTER TABLE workspaceitem ADD COLUMN item_id UUID REFERENCES Item(uuid);
+ALTER TABLE workspaceitem ADD item_id RAW(16) REFERENCES Item(uuid);
 UPDATE workspaceitem SET item_id = (SELECT item.uuid FROM item WHERE workspaceitem.item_legacy_id = item.item_id);
 ALTER TABLE workspaceitem DROP COLUMN item_legacy_id;
 
 ALTER TABLE workspaceitem RENAME COLUMN collection_id to collection_legacy_id;
-ALTER TABLE workspaceitem ADD COLUMN collection_id UUID REFERENCES Collection(uuid);
-ALTER TABLE workspaceitem ADD CONSTRAINT workspaceitem_collection_id_fk FOREIGN KEY (collection_id) REFERENCES collection;
+ALTER TABLE workspaceitem ADD collection_id RAW(16) REFERENCES Collection(uuid);
 UPDATE workspaceitem SET collection_id = (SELECT collection.uuid FROM collection WHERE workspaceitem.collection_legacy_id = collection.collection_id);
 ALTER TABLE workspaceitem DROP COLUMN collection_legacy_id;
 
 ALTER TABLE epersongroup2workspaceitem RENAME COLUMN eperson_group_id to eperson_group_legacy_id;
-ALTER TABLE epersongroup2workspaceitem ADD COLUMN eperson_group_id UUID REFERENCES epersongroup(uuid);
+ALTER TABLE epersongroup2workspaceitem ADD eperson_group_id RAW(16) REFERENCES epersongroup(uuid);
 UPDATE epersongroup2workspaceitem SET eperson_group_id = (SELECT epersongroup.uuid FROM epersongroup WHERE epersongroup2workspaceitem.eperson_group_legacy_id = epersongroup.eperson_group_id);
 ALTER TABLE epersongroup2workspaceitem DROP COLUMN eperson_group_legacy_id;
 ALTER TABLE epersongroup2workspaceitem DROP COLUMN id;
-ALTER TABLE epersongroup2workspaceitem ALTER COLUMN workspace_item_id SET NOT NULL;
-ALTER TABLE epersongroup2workspaceitem ALTER COLUMN eperson_group_id SET NOT NULL;
-ALTER TABLE epersongroup2workspaceitem add primary key (workspace_item_id,eperson_group_id);
+ALTER TABLE epersongroup2workspaceitem MODIFY workspace_item_id NOT NULL;
+ALTER TABLE epersongroup2workspaceitem MODIFY eperson_group_id NOT NULL;
+ALTER TABLE epersongroup2workspaceitem add CONSTRAINT  epersongroup2wsitem_unqiue primary key (workspace_item_id,eperson_group_id);
 
 
 --Alter most_recent_checksum
 ALTER TABLE most_recent_checksum RENAME COLUMN bitstream_id to bitstream_legacy_id;
-ALTER TABLE most_recent_checksum ADD COLUMN bitstream_id UUID REFERENCES Bitstream(uuid);
+ALTER TABLE most_recent_checksum ADD bitstream_id RAW(16) REFERENCES Bitstream(uuid);
 UPDATE most_recent_checksum SET bitstream_id = (SELECT Bitstream.uuid FROM Bitstream WHERE most_recent_checksum.bitstream_legacy_id = Bitstream.bitstream_id);
 ALTER TABLE most_recent_checksum DROP COLUMN bitstream_legacy_id;
 
 ALTER TABLE checksum_history RENAME COLUMN bitstream_id to bitstream_legacy_id;
-ALTER TABLE checksum_history ADD COLUMN bitstream_id UUID REFERENCES Bitstream(uuid);
+ALTER TABLE checksum_history ADD bitstream_id RAW(16) REFERENCES Bitstream(uuid);
 UPDATE checksum_history SET bitstream_id = (SELECT Bitstream.uuid FROM Bitstream WHERE checksum_history.bitstream_legacy_id = Bitstream.bitstream_id);
 ALTER TABLE checksum_history DROP COLUMN bitstream_legacy_id;
+RENAME checksum_history_seq TO checksum_history_check_id_seq;
 
 --Alter table doi
-ALTER TABLE doi ADD COLUMN dspace_object UUID REFERENCES dspaceobject(uuid);
+ALTER TABLE doi ADD dspace_object RAW(16) REFERENCES dspaceobject(uuid);
 UPDATE doi SET dspace_object = (SELECT community.uuid FROM community WHERE doi.resource_id = community.community_id AND doi.resource_type_id = 4)  WHERE doi.resource_type_id = 4;
 UPDATE doi SET dspace_object = (SELECT collection.uuid FROM collection WHERE doi.resource_id = collection.collection_id AND doi.resource_type_id = 3)  WHERE doi.resource_type_id = 3;
 UPDATE doi SET dspace_object = (SELECT item.uuid FROM item WHERE doi.resource_id = item.item_id AND doi.resource_type_id = 2)  WHERE doi.resource_type_id = 2;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V6.0_2015.03.07__DS-2701_Hibernate_migration.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V6.0_2015.03.07__DS-2701_Hibernate_migration.sql
@@ -1,204 +1,229 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+------------------------------------------------------
+-- DS-2701 Service based API / Hibernate integration
+------------------------------------------------------
 DROP VIEW community2item;
 
 CREATE TABLE dspaceobject
 (
-    uuid            RAW(16) NOT NULL  PRIMARY KEY
+    uuid            uuid NOT NULL  PRIMARY KEY
 );
 
 CREATE TABLE site
 (
-    uuid            RAW(16) NOT NULL PRIMARY KEY REFERENCES dspaceobject(uuid)
+    uuid            uuid NOT NULL PRIMARY KEY REFERENCES dspaceobject(uuid)
 
 );
 
-ALTER TABLE eperson ADD uuid RAW(16) DEFAULT SYS_GUID();
+ALTER TABLE eperson ADD COLUMN uuid UUID DEFAULT gen_random_uuid() UNIQUE;
 INSERT INTO dspaceobject  (uuid) SELECT uuid FROM eperson;
 ALTER TABLE eperson ADD FOREIGN KEY (uuid) REFERENCES dspaceobject;
-ALTER TABLE eperson MODIFY uuid NOT NULL;
-ALTER TABLE eperson ADD CONSTRAINT eperson_id_unique PRIMARY KEY (uuid);
-UPDATE eperson SET require_certificate = '0' WHERE require_certificate IS NULL;
-UPDATE eperson SET self_registered = '0' WHERE self_registered IS NULL;
+ALTER TABLE eperson ALTER COLUMN uuid SET NOT NULL;
+ALTER TABLE eperson ADD CONSTRAINT eperson_id_unique UNIQUE(uuid);
+ALTER TABLE eperson ADD PRIMARY KEY (uuid);
+ALTER TABLE eperson ALTER COLUMN eperson_id DROP NOT NULL;
+UPDATE eperson SET require_certificate = false WHERE require_certificate IS NULL;
+UPDATE eperson SET self_registered = false WHERE self_registered IS NULL;
 
 
 
-ALTER TABLE epersongroup ADD uuid RAW(16) DEFAULT SYS_GUID();
+ALTER TABLE epersongroup ADD COLUMN uuid UUID DEFAULT gen_random_uuid() UNIQUE;
 INSERT INTO dspaceobject  (uuid) SELECT uuid FROM epersongroup;
 ALTER TABLE epersongroup ADD FOREIGN KEY (uuid) REFERENCES dspaceobject;
-ALTER TABLE epersongroup MODIFY uuid NOT NULL;
-ALTER TABLE epersongroup ADD CONSTRAINT epersongroup_id_unique PRIMARY KEY (uuid);
+ALTER TABLE epersongroup ALTER COLUMN uuid SET NOT NULL;
+ALTER TABLE epersongroup ADD CONSTRAINT epersongroup_id_unique UNIQUE(uuid);
+ALTER TABLE epersongroup ADD PRIMARY KEY (uuid);
+ALTER TABLE epersongroup ALTER COLUMN eperson_group_id DROP NOT NULL;
 
-ALTER TABLE item ADD uuid RAW(16) DEFAULT SYS_GUID();
+ALTER TABLE item ADD COLUMN uuid UUID DEFAULT gen_random_uuid() UNIQUE;
 INSERT INTO dspaceobject  (uuid) SELECT uuid FROM item;
 ALTER TABLE item ADD FOREIGN KEY (uuid) REFERENCES dspaceobject;
-ALTER TABLE item MODIFY uuid NOT NULL;
-ALTER TABLE item ADD CONSTRAINT item_id_unique PRIMARY KEY (uuid);
+ALTER TABLE item ALTER COLUMN uuid SET NOT NULL;
+ALTER TABLE item ADD CONSTRAINT item_id_unique UNIQUE(uuid);
+ALTER TABLE item ADD PRIMARY KEY (uuid);
+ALTER TABLE item ALTER COLUMN item_id DROP NOT NULL;
 
-ALTER TABLE community ADD uuid RAW(16) DEFAULT SYS_GUID();
+ALTER TABLE community ADD COLUMN uuid UUID DEFAULT gen_random_uuid() UNIQUE;
 INSERT INTO dspaceobject  (uuid) SELECT uuid FROM community;
 ALTER TABLE community ADD FOREIGN KEY (uuid) REFERENCES dspaceobject;
-ALTER TABLE community MODIFY uuid NOT NULL;
-ALTER TABLE community ADD CONSTRAINT community_id_unique PRIMARY KEY (uuid);
+ALTER TABLE community ALTER COLUMN uuid SET NOT NULL;
+ALTER TABLE community ADD CONSTRAINT community_id_unique UNIQUE(uuid);
+ALTER TABLE community ADD PRIMARY KEY (uuid);
+ALTER TABLE community ALTER COLUMN community_id DROP NOT NULL;
 
 
-ALTER TABLE collection ADD uuid RAW(16) DEFAULT SYS_GUID();
+ALTER TABLE collection ADD COLUMN uuid UUID DEFAULT gen_random_uuid() UNIQUE;
 INSERT INTO dspaceobject  (uuid) SELECT uuid FROM collection;
 ALTER TABLE collection ADD FOREIGN KEY (uuid) REFERENCES dspaceobject;
-ALTER TABLE collection MODIFY uuid NOT NULL;
-ALTER TABLE collection ADD CONSTRAINT collection_id_unique PRIMARY KEY (uuid);
+ALTER TABLE collection ALTER COLUMN uuid SET NOT NULL;
+ALTER TABLE collection ADD CONSTRAINT collection_id_unique UNIQUE(uuid);
+ALTER TABLE collection ADD PRIMARY KEY (uuid);
+ALTER TABLE collection ALTER COLUMN collection_id DROP NOT NULL;
 
-ALTER TABLE bundle ADD uuid RAW(16) DEFAULT SYS_GUID();
+ALTER TABLE bundle ADD COLUMN uuid UUID DEFAULT gen_random_uuid() UNIQUE;
 INSERT INTO dspaceobject  (uuid) SELECT uuid FROM bundle;
 ALTER TABLE bundle ADD FOREIGN KEY (uuid) REFERENCES dspaceobject;
-ALTER TABLE bundle MODIFY uuid NOT NULL;
-ALTER TABLE bundle ADD CONSTRAINT bundle_id_unique PRIMARY KEY (uuid);
+ALTER TABLE bundle ALTER COLUMN uuid SET NOT NULL;
+ALTER TABLE bundle ADD CONSTRAINT bundle_id_unique UNIQUE(uuid);
+ALTER TABLE bundle ADD PRIMARY KEY (uuid);
+ALTER TABLE bundle ALTER COLUMN bundle_id DROP NOT NULL;
 
-ALTER TABLE bitstream ADD uuid RAW(16) DEFAULT SYS_GUID();
+ALTER TABLE bitstream ADD COLUMN uuid UUID DEFAULT gen_random_uuid() UNIQUE;
 INSERT INTO dspaceobject  (uuid) SELECT uuid FROM bitstream;
 ALTER TABLE bitstream ADD FOREIGN KEY (uuid) REFERENCES dspaceobject;
-ALTER TABLE bitstream MODIFY uuid NOT NULL;
-ALTER TABLE bitstream ADD CONSTRAINT bitstream_id_unique PRIMARY KEY (uuid);
+ALTER TABLE bitstream ALTER COLUMN uuid SET NOT NULL;
+ALTER TABLE bitstream ADD CONSTRAINT bitstream_id_unique UNIQUE(uuid);
+ALTER TABLE bitstream ADD PRIMARY KEY (uuid);
+ALTER TABLE bitstream ALTER COLUMN bitstream_id DROP NOT NULL;
 
 -- Migrate EPersonGroup2EPerson table
 ALTER TABLE EPersonGroup2EPerson RENAME COLUMN eperson_group_id to eperson_group_legacy_id;
 ALTER TABLE EPersonGroup2EPerson RENAME COLUMN eperson_id to eperson_legacy_id;
-ALTER TABLE EPersonGroup2EPerson ADD eperson_group_id RAW(16) REFERENCES EpersonGroup(uuid);
-ALTER TABLE EPersonGroup2EPerson ADD eperson_id RAW(16) REFERENCES Eperson(uuid);
-UPDATE EPersonGroup2EPerson SET eperson_group_id = (SELECT EPersonGroup.uuid FROM EpersonGroup WHERE EPersonGroup2EPerson.eperson_group_legacy_id = EPersonGroup.eperson_group_id);
-UPDATE EPersonGroup2EPerson SET eperson_id = (SELECT eperson.uuid FROM eperson WHERE EPersonGroup2EPerson.eperson_legacy_id = eperson.eperson_id);
-ALTER TABLE EPersonGroup2EPerson MODIFY eperson_group_id NOT NULL;
-ALTER TABLE EPersonGroup2EPerson MODIFY eperson_id NOT NULL;
+ALTER TABLE EPersonGroup2EPerson ADD COLUMN eperson_group_id UUID REFERENCES EpersonGroup(uuid);
+ALTER TABLE EPersonGroup2EPerson ADD COLUMN eperson_id UUID REFERENCES Eperson(uuid);
+UPDATE EPersonGroup2EPerson SET eperson_group_id = EPersonGroup.uuid FROM EpersonGroup WHERE EPersonGroup2EPerson.eperson_group_legacy_id = EPersonGroup.eperson_group_id;
+UPDATE EPersonGroup2EPerson SET eperson_id = eperson.uuid FROM eperson WHERE EPersonGroup2EPerson.eperson_legacy_id = eperson.eperson_id;
+ALTER TABLE EPersonGroup2EPerson ALTER COLUMN eperson_group_id SET NOT NULL;
+ALTER TABLE EPersonGroup2EPerson ALTER COLUMN eperson_id SET NOT NULL;
 ALTER TABLE EPersonGroup2EPerson DROP COLUMN eperson_group_legacy_id;
 ALTER TABLE EPersonGroup2EPerson DROP COLUMN eperson_legacy_id;
 ALTER TABLE epersongroup2eperson DROP COLUMN id;
-ALTER TABLE EPersonGroup2EPerson add CONSTRAINT EPersonGroup2EPerson_unique primary key (eperson_group_id,eperson_id);
+ALTER TABLE EPersonGroup2EPerson add primary key (eperson_group_id,eperson_id);
 
 -- Migrate GROUP2GROUP table
 ALTER TABLE Group2Group RENAME COLUMN parent_id to parent_legacy_id;
 ALTER TABLE Group2Group RENAME COLUMN child_id to child_legacy_id;
-ALTER TABLE Group2Group ADD parent_id RAW(16) REFERENCES EpersonGroup(uuid);
-ALTER TABLE Group2Group ADD child_id RAW(16) REFERENCES EpersonGroup(uuid);
-UPDATE Group2Group SET parent_id = (SELECT EPersonGroup.uuid FROM EpersonGroup WHERE Group2Group.parent_legacy_id = EPersonGroup.eperson_group_id);
-UPDATE Group2Group SET child_id = (SELECT EpersonGroup.uuid FROM EpersonGroup WHERE Group2Group.child_legacy_id = EpersonGroup.eperson_group_id);
-ALTER TABLE Group2Group MODIFY parent_id NOT NULL;
-ALTER TABLE Group2Group MODIFY child_id NOT NULL;
+ALTER TABLE Group2Group ADD COLUMN parent_id UUID REFERENCES EpersonGroup(uuid);
+ALTER TABLE Group2Group ADD COLUMN child_id UUID REFERENCES EpersonGroup(uuid);
+UPDATE Group2Group SET parent_id = EPersonGroup.uuid FROM EpersonGroup WHERE Group2Group.parent_legacy_id = EPersonGroup.eperson_group_id;
+UPDATE Group2Group SET child_id = EpersonGroup.uuid FROM EpersonGroup WHERE Group2Group.child_legacy_id = EpersonGroup.eperson_group_id;
+ALTER TABLE Group2Group ALTER COLUMN parent_id SET NOT NULL;
+ALTER TABLE Group2Group ALTER COLUMN child_id SET NOT NULL;
 ALTER TABLE Group2Group DROP COLUMN parent_legacy_id;
 ALTER TABLE Group2Group DROP COLUMN child_legacy_id;
 ALTER TABLE Group2Group DROP COLUMN id;
-ALTER TABLE Group2Group add CONSTRAINT Group2Group_unique primary key (parent_id,child_id);
+ALTER TABLE Group2Group add primary key (parent_id,child_id);
 
 -- Migrate collection2item
 ALTER TABLE Collection2Item RENAME COLUMN collection_id to collection_legacy_id;
 ALTER TABLE Collection2Item RENAME COLUMN item_id to item_legacy_id;
-ALTER TABLE Collection2Item ADD collection_id RAW(16) REFERENCES Collection(uuid);
-ALTER TABLE Collection2Item ADD item_id RAW(16) REFERENCES Item(uuid);
-UPDATE Collection2Item SET collection_id = (SELECT Collection.uuid FROM Collection WHERE Collection2Item.collection_legacy_id = Collection.collection_id);
-UPDATE Collection2Item SET item_id = (SELECT Item.uuid FROM Item WHERE Collection2Item.item_legacy_id = Item.item_id);
-ALTER TABLE Collection2Item MODIFY collection_id NOT NULL;
-ALTER TABLE Collection2Item MODIFY item_id NOT NULL;
+ALTER TABLE Collection2Item ADD COLUMN collection_id UUID REFERENCES Collection(uuid);
+ALTER TABLE Collection2Item ADD COLUMN item_id UUID REFERENCES Item(uuid);
+UPDATE Collection2Item SET collection_id = Collection.uuid FROM Collection WHERE Collection2Item.collection_legacy_id = Collection.collection_id;
+UPDATE Collection2Item SET item_id = Item.uuid FROM Item WHERE Collection2Item.item_legacy_id = Item.item_id;
+ALTER TABLE Collection2Item ALTER COLUMN collection_id SET NOT NULL;
+ALTER TABLE Collection2Item ALTER COLUMN item_id SET NOT NULL;
 ALTER TABLE Collection2Item DROP COLUMN collection_legacy_id;
 ALTER TABLE Collection2Item DROP COLUMN item_legacy_id;
 ALTER TABLE Collection2Item DROP COLUMN id;
 -- Magic query that will delete all duplicate collection item_id references from the database (if we don't do this the primary key creation will fail)
-DELETE FROM collection2item WHERE rowid NOT IN (SELECT MIN(rowid) FROM collection2item GROUP BY collection_id,item_id);
-ALTER TABLE Collection2Item add CONSTRAINT collection2item_unique primary key (collection_id,item_id);
+DELETE FROM collection2item WHERE ctid NOT IN (SELECT max(ctid) FROM collection2item GROUP BY collection_id,item_id);
+ALTER TABLE Collection2Item add primary key (collection_id,item_id);
 
 -- Migrate Community2Community
 ALTER TABLE Community2Community RENAME COLUMN parent_comm_id to parent_legacy_id;
 ALTER TABLE Community2Community RENAME COLUMN child_comm_id to child_legacy_id;
-ALTER TABLE Community2Community ADD parent_comm_id RAW(16) REFERENCES Community(uuid);
-ALTER TABLE Community2Community ADD child_comm_id RAW(16) REFERENCES Community(uuid);
-UPDATE Community2Community SET parent_comm_id = (SELECT Community.uuid FROM Community WHERE Community2Community.parent_legacy_id = Community.community_id);
-UPDATE Community2Community SET child_comm_id = (SELECT Community.uuid FROM Community WHERE Community2Community.child_legacy_id = Community.community_id);
-ALTER TABLE Community2Community MODIFY parent_comm_id NOT NULL;
-ALTER TABLE Community2Community MODIFY child_comm_id NOT NULL;
+ALTER TABLE Community2Community ADD COLUMN parent_comm_id UUID REFERENCES Community(uuid);
+ALTER TABLE Community2Community ADD COLUMN child_comm_id UUID REFERENCES Community(uuid);
+UPDATE Community2Community SET parent_comm_id = Community.uuid FROM Community WHERE Community2Community.parent_legacy_id = Community.community_id;
+UPDATE Community2Community SET child_comm_id = Community.uuid FROM Community WHERE Community2Community.child_legacy_id = Community.community_id;
+ALTER TABLE Community2Community ALTER COLUMN parent_comm_id SET NOT NULL;
+ALTER TABLE Community2Community ALTER COLUMN child_comm_id SET NOT NULL;
 ALTER TABLE Community2Community DROP COLUMN parent_legacy_id;
 ALTER TABLE Community2Community DROP COLUMN child_legacy_id;
 ALTER TABLE Community2Community DROP COLUMN id;
-ALTER TABLE Community2Community add CONSTRAINT Community2Community_unique primary key (parent_comm_id,child_comm_id);
+ALTER TABLE Community2Community add primary key (parent_comm_id,child_comm_id);
 
 -- Migrate community2collection
 ALTER TABLE community2collection RENAME COLUMN collection_id to collection_legacy_id;
 ALTER TABLE community2collection RENAME COLUMN community_id to community_legacy_id;
-ALTER TABLE community2collection ADD collection_id RAW(16) REFERENCES Collection(uuid);
-ALTER TABLE community2collection ADD community_id RAW(16) REFERENCES Community(uuid);
-UPDATE community2collection SET collection_id = (SELECT Collection.uuid FROM Collection WHERE community2collection.collection_legacy_id = Collection.collection_id);
-UPDATE community2collection SET community_id = (SELECT Community.uuid FROM Community WHERE community2collection.community_legacy_id = Community.community_id);
-ALTER TABLE community2collection MODIFY collection_id NOT NULL;
-ALTER TABLE community2collection MODIFY community_id NOT NULL;
+ALTER TABLE community2collection ADD COLUMN collection_id UUID REFERENCES Collection(uuid);
+ALTER TABLE community2collection ADD COLUMN community_id UUID REFERENCES Community(uuid);
+UPDATE community2collection SET collection_id = Collection.uuid FROM Collection WHERE community2collection.collection_legacy_id = Collection.collection_id;
+UPDATE community2collection SET community_id = Community.uuid FROM Community WHERE community2collection.community_legacy_id = Community.community_id;
+ALTER TABLE community2collection ALTER COLUMN collection_id SET NOT NULL;
+ALTER TABLE community2collection ALTER COLUMN community_id SET NOT NULL;
 ALTER TABLE community2collection DROP COLUMN collection_legacy_id;
 ALTER TABLE community2collection DROP COLUMN community_legacy_id;
 ALTER TABLE community2collection DROP COLUMN id;
-ALTER TABLE community2collection add CONSTRAINT community2collection_unique primary key (collection_id,community_id);
+ALTER TABLE community2collection add primary key (collection_id,community_id);
 
 
 -- Migrate Group2GroupCache table
 ALTER TABLE Group2GroupCache RENAME COLUMN parent_id to parent_legacy_id;
 ALTER TABLE Group2GroupCache RENAME COLUMN child_id to child_legacy_id;
-ALTER TABLE Group2GroupCache ADD parent_id RAW(16) REFERENCES EpersonGroup(uuid);
-ALTER TABLE Group2GroupCache ADD child_id RAW(16) REFERENCES EpersonGroup(uuid);
-UPDATE Group2GroupCache SET parent_id = (SELECT EPersonGroup.uuid FROM EpersonGroup WHERE Group2GroupCache.parent_legacy_id = EPersonGroup.eperson_group_id);
-UPDATE Group2GroupCache SET child_id = (SELECT EpersonGroup.uuid FROM EpersonGroup WHERE Group2GroupCache.child_legacy_id = EpersonGroup.eperson_group_id);
-ALTER TABLE Group2GroupCache MODIFY parent_id NOT NULL;
-ALTER TABLE Group2GroupCache MODIFY child_id NOT NULL;
+ALTER TABLE Group2GroupCache ADD COLUMN parent_id UUID REFERENCES EpersonGroup(uuid);
+ALTER TABLE Group2GroupCache ADD COLUMN child_id UUID REFERENCES EpersonGroup(uuid);
+UPDATE Group2GroupCache SET parent_id = EPersonGroup.uuid FROM EpersonGroup WHERE Group2GroupCache.parent_legacy_id = EPersonGroup.eperson_group_id;
+UPDATE Group2GroupCache SET child_id = EpersonGroup.uuid FROM EpersonGroup WHERE Group2GroupCache.child_legacy_id = EpersonGroup.eperson_group_id;
+ALTER TABLE Group2GroupCache ALTER COLUMN parent_id SET NOT NULL;
+ALTER TABLE Group2GroupCache ALTER COLUMN child_id SET NOT NULL;
 ALTER TABLE Group2GroupCache DROP COLUMN parent_legacy_id;
 ALTER TABLE Group2GroupCache DROP COLUMN child_legacy_id;
 ALTER TABLE Group2GroupCache DROP COLUMN id;
-ALTER TABLE Group2GroupCache add CONSTRAINT Group2GroupCache_unique primary key (parent_id,child_id);
+ALTER TABLE Group2GroupCache add primary key (parent_id,child_id);
 
 -- Migrate Item2Bundle
 ALTER TABLE item2bundle RENAME COLUMN bundle_id to bundle_legacy_id;
 ALTER TABLE item2bundle RENAME COLUMN item_id to item_legacy_id;
-ALTER TABLE item2bundle ADD bundle_id RAW(16) REFERENCES Bundle(uuid);
-ALTER TABLE item2bundle ADD item_id RAW(16) REFERENCES Item(uuid);
-UPDATE item2bundle SET bundle_id = (SELECT Bundle.uuid FROM Bundle WHERE item2bundle.bundle_legacy_id = Bundle.bundle_id);
-UPDATE item2bundle SET item_id = (SELECT Item.uuid FROM Item WHERE item2bundle.item_legacy_id = Item.item_id);
-ALTER TABLE item2bundle MODIFY bundle_id NOT NULL;
-ALTER TABLE item2bundle MODIFY item_id NOT NULL;
+ALTER TABLE item2bundle ADD COLUMN bundle_id UUID REFERENCES Bundle(uuid);
+ALTER TABLE item2bundle ADD COLUMN item_id UUID REFERENCES Item(uuid);
+UPDATE item2bundle SET bundle_id = Bundle.uuid FROM Bundle WHERE item2bundle.bundle_legacy_id = Bundle.bundle_id;
+UPDATE item2bundle SET item_id = Item.uuid FROM Item WHERE item2bundle.item_legacy_id = Item.item_id;
+ALTER TABLE item2bundle ALTER COLUMN bundle_id SET NOT NULL;
+ALTER TABLE item2bundle ALTER COLUMN item_id SET NOT NULL;
 ALTER TABLE item2bundle DROP COLUMN bundle_legacy_id;
 ALTER TABLE item2bundle DROP COLUMN item_legacy_id;
 ALTER TABLE item2bundle DROP COLUMN id;
-ALTER TABLE item2bundle add CONSTRAINT item2bundle_unique primary key (bundle_id,item_id);
+ALTER TABLE item2bundle add primary key (bundle_id,item_id);
 
 --Migrate Bundle2Bitsteam
 ALTER TABLE bundle2bitstream RENAME COLUMN bundle_id to bundle_legacy_id;
 ALTER TABLE bundle2bitstream RENAME COLUMN bitstream_id to bitstream_legacy_id;
-ALTER TABLE bundle2bitstream ADD bundle_id RAW(16) REFERENCES Bundle(uuid);
-ALTER TABLE bundle2bitstream ADD bitstream_id RAW(16) REFERENCES Bitstream(uuid);
+ALTER TABLE bundle2bitstream ADD COLUMN bundle_id UUID REFERENCES Bundle(uuid);
+ALTER TABLE bundle2bitstream ADD COLUMN bitstream_id UUID REFERENCES Bitstream(uuid);
 UPDATE bundle2bitstream SET bundle_id = (SELECT bundle.uuid FROM bundle WHERE bundle2bitstream.bundle_legacy_id = bundle.bundle_id);
 UPDATE bundle2bitstream SET bitstream_id = (SELECT bitstream.uuid FROM bitstream WHERE bundle2bitstream.bitstream_legacy_id = bitstream.bitstream_id);
-ALTER TABLE bundle2bitstream MODIFY bundle_id NOT NULL;
-ALTER TABLE bundle2bitstream MODIFY bitstream_id NOT NULL;
+ALTER TABLE bundle2bitstream ALTER COLUMN bundle_id SET NOT NULL;
+ALTER TABLE bundle2bitstream ALTER COLUMN bitstream_id SET NOT NULL;
 ALTER TABLE bundle2bitstream DROP COLUMN bundle_legacy_id;
 ALTER TABLE bundle2bitstream DROP COLUMN bitstream_legacy_id;
 ALTER TABLE bundle2bitstream DROP COLUMN id;
-ALTER TABLE bundle2bitstream add CONSTRAINT bundle2bitstream_unique primary key (bitstream_id,bundle_id);
+ALTER TABLE bundle2bitstream add primary key (bitstream_id,bundle_id);
 
 
 -- Migrate item
 ALTER TABLE item RENAME COLUMN submitter_id to submitter_id_legacy_id;
-ALTER TABLE item ADD submitter_id RAW(16) REFERENCES EPerson(uuid);
-UPDATE item SET submitter_id = (SELECT eperson.uuid FROM eperson WHERE item.submitter_id_legacy_id = eperson.eperson_id);
+ALTER TABLE item ADD COLUMN submitter_id UUID REFERENCES EPerson(uuid);
+UPDATE item SET submitter_id = eperson.uuid FROM eperson WHERE item.submitter_id_legacy_id = eperson.eperson_id;
 ALTER TABLE item DROP COLUMN submitter_id_legacy_id;
 
 ALTER TABLE item RENAME COLUMN owning_collection to owning_collection_legacy;
-ALTER TABLE item ADD owning_collection RAW(16) REFERENCES Collection(uuid);
-UPDATE item SET owning_collection = (SELECT Collection.uuid FROM Collection WHERE item.owning_collection_legacy = collection.collection_id);
+ALTER TABLE item ADD COLUMN owning_collection UUID REFERENCES Collection(uuid);
+UPDATE item SET owning_collection = Collection.uuid FROM Collection WHERE item.owning_collection_legacy = collection.collection_id;
 ALTER TABLE item DROP COLUMN owning_collection_legacy;
 
 -- Migrate bundle
 ALTER TABLE bundle RENAME COLUMN primary_bitstream_id to primary_bitstream_legacy_id;
-ALTER TABLE bundle ADD primary_bitstream_id RAW(16) REFERENCES Bitstream(uuid);
+ALTER TABLE bundle ADD COLUMN primary_bitstream_id UUID REFERENCES Bitstream(uuid);
 UPDATE bundle SET primary_bitstream_id = (SELECT Bitstream.uuid FROM Bitstream WHERE bundle.primary_bitstream_legacy_id = Bitstream.bitstream_id);
 ALTER TABLE bundle DROP COLUMN primary_bitstream_legacy_id;
 
 
 -- Migrate community references
 ALTER TABLE Community RENAME COLUMN admin to admin_legacy;
-ALTER TABLE Community ADD admin RAW(16) REFERENCES EPersonGroup(uuid);
-UPDATE Community SET admin = (SELECT EPersonGroup.uuid FROM EPersonGroup WHERE Community.admin_legacy = EPersonGroup.eperson_group_id);
+ALTER TABLE Community ADD COLUMN admin UUID REFERENCES EPersonGroup(uuid);
+UPDATE Community SET admin = EPersonGroup.uuid FROM EPersonGroup WHERE Community.admin_legacy = EPersonGroup.eperson_group_id;
 ALTER TABLE Community DROP COLUMN admin_legacy;
 ALTER TABLE Community RENAME COLUMN logo_bitstream_id to logo_bitstream_legacy_id;
-ALTER TABLE Community ADD logo_bitstream_id RAW(16) REFERENCES Bitstream(uuid);
+ALTER TABLE Community ADD COLUMN logo_bitstream_id UUID REFERENCES Bitstream(uuid);
 UPDATE Community SET logo_bitstream_id = (SELECT Bitstream.uuid FROM Bitstream WHERE Community.logo_bitstream_legacy_id = Bitstream.bitstream_id);
 ALTER TABLE Community DROP COLUMN logo_bitstream_legacy_id;
 
@@ -211,20 +236,20 @@ ALTER TABLE Collection RENAME COLUMN submitter to submitter_legacy;
 ALTER TABLE Collection RENAME COLUMN template_item_id to template_item_legacy_id;
 ALTER TABLE Collection RENAME COLUMN logo_bitstream_id to logo_bitstream_legacy_id;
 ALTER TABLE Collection RENAME COLUMN admin to admin_legacy;
-ALTER TABLE Collection ADD workflow_step_1 RAW(16) REFERENCES EPersonGroup(uuid);
-ALTER TABLE Collection ADD workflow_step_2 RAW(16) REFERENCES EPersonGroup(uuid);
-ALTER TABLE Collection ADD workflow_step_3 RAW(16) REFERENCES EPersonGroup(uuid);
-ALTER TABLE Collection ADD submitter RAW(16) REFERENCES EPersonGroup(uuid);
-ALTER TABLE Collection ADD template_item_id RAW(16);
-ALTER TABLE Collection ADD logo_bitstream_id RAW(16);
-ALTER TABLE Collection ADD admin RAW(16) REFERENCES EPersonGroup(uuid);
-UPDATE Collection SET workflow_step_1 = (SELECT EPersonGroup.uuid FROM EPersonGroup WHERE Collection.workflow_step_1_legacy = EPersonGroup.eperson_group_id);
-UPDATE Collection SET workflow_step_2 = (SELECT EPersonGroup.uuid FROM EPersonGroup WHERE Collection.workflow_step_2_legacy = EPersonGroup.eperson_group_id);
-UPDATE Collection SET workflow_step_3 = (SELECT EPersonGroup.uuid FROM EPersonGroup WHERE Collection.workflow_step_3_legacy = EPersonGroup.eperson_group_id);
-UPDATE Collection SET submitter = (SELECT EPersonGroup.uuid FROM EPersonGroup WHERE Collection.submitter_legacy = EPersonGroup.eperson_group_id);
+ALTER TABLE Collection ADD COLUMN workflow_step_1 UUID REFERENCES EPersonGroup(uuid);
+ALTER TABLE Collection ADD COLUMN workflow_step_2 UUID REFERENCES EPersonGroup(uuid);
+ALTER TABLE Collection ADD COLUMN workflow_step_3 UUID REFERENCES EPersonGroup(uuid);
+ALTER TABLE Collection ADD COLUMN submitter UUID REFERENCES EPersonGroup(uuid);
+ALTER TABLE Collection ADD COLUMN template_item_id UUID;
+ALTER TABLE Collection ADD COLUMN logo_bitstream_id UUID;
+ALTER TABLE Collection ADD COLUMN admin UUID REFERENCES EPersonGroup(uuid);
+UPDATE Collection SET workflow_step_1 = EPersonGroup.uuid FROM EPersonGroup WHERE Collection.workflow_step_1_legacy = EPersonGroup.eperson_group_id;
+UPDATE Collection SET workflow_step_2 = EPersonGroup.uuid FROM EPersonGroup WHERE Collection.workflow_step_2_legacy = EPersonGroup.eperson_group_id;
+UPDATE Collection SET workflow_step_3 = EPersonGroup.uuid FROM EPersonGroup WHERE Collection.workflow_step_3_legacy = EPersonGroup.eperson_group_id;
+UPDATE Collection SET submitter = EPersonGroup.uuid FROM EPersonGroup WHERE Collection.submitter_legacy = EPersonGroup.eperson_group_id;
 UPDATE Collection SET template_item_id = (SELECT Item.uuid FROM Item WHERE Collection.template_item_legacy_id = Item.item_id);
 UPDATE Collection SET logo_bitstream_id = (SELECT Bitstream.uuid FROM Bitstream WHERE Collection.logo_bitstream_legacy_id = Bitstream.bitstream_id);
-UPDATE Collection SET admin = (SELECT EPersonGroup.uuid FROM EPersonGroup WHERE Collection.admin_legacy = EPersonGroup.eperson_group_id);
+UPDATE Collection SET admin = EPersonGroup.uuid FROM EPersonGroup WHERE Collection.admin_legacy = EPersonGroup.eperson_group_id;
 ALTER TABLE Collection DROP COLUMN workflow_step_1_legacy;
 ALTER TABLE Collection DROP COLUMN workflow_step_2_legacy;
 ALTER TABLE Collection DROP COLUMN workflow_step_3_legacy;
@@ -236,15 +261,15 @@ ALTER TABLE Collection DROP COLUMN admin_legacy;
 
 -- Migrate resource policy references
 ALTER TABLE ResourcePolicy RENAME COLUMN eperson_id to eperson_id_legacy_id;
-ALTER TABLE ResourcePolicy ADD eperson_id RAW(16) REFERENCES EPerson(uuid);
-UPDATE ResourcePolicy SET eperson_id = (SELECT eperson.uuid FROM eperson WHERE ResourcePolicy.eperson_id_legacy_id = eperson.eperson_id);
+ALTER TABLE ResourcePolicy ADD COLUMN eperson_id UUID REFERENCES EPerson(uuid);
+UPDATE ResourcePolicy SET eperson_id = eperson.uuid FROM eperson WHERE ResourcePolicy.eperson_id_legacy_id = eperson.eperson_id;
 ALTER TABLE ResourcePolicy DROP COLUMN eperson_id_legacy_id;
 ALTER TABLE ResourcePolicy RENAME COLUMN epersongroup_id to epersongroup_id_legacy_id;
-ALTER TABLE ResourcePolicy ADD epersongroup_id RAW(16) REFERENCES EPersonGroup(uuid);
-UPDATE ResourcePolicy SET epersongroup_id = (SELECT epersongroup.uuid FROM epersongroup WHERE ResourcePolicy.epersongroup_id_legacy_id = epersongroup.eperson_group_id);
+ALTER TABLE ResourcePolicy ADD COLUMN epersongroup_id UUID REFERENCES EPersonGroup(uuid);
+UPDATE ResourcePolicy SET epersongroup_id = epersongroup.uuid FROM epersongroup WHERE ResourcePolicy.epersongroup_id_legacy_id = epersongroup.eperson_group_id;
 ALTER TABLE ResourcePolicy DROP COLUMN epersongroup_id_legacy_id;
 
-ALTER TABLE ResourcePolicy ADD dspace_object RAW(16) REFERENCES dspaceobject(uuid);
+ALTER TABLE ResourcePolicy ADD COLUMN dspace_object UUID REFERENCES dspaceobject(uuid);
 UPDATE ResourcePolicy SET dspace_object = (SELECT eperson.uuid FROM eperson WHERE ResourcePolicy.resource_id = eperson.eperson_id AND ResourcePolicy.resource_type_id = 7) WHERE ResourcePolicy.resource_type_id = 7;
 UPDATE ResourcePolicy SET dspace_object = (SELECT epersongroup.uuid FROM epersongroup WHERE ResourcePolicy.resource_id = epersongroup.eperson_group_id AND ResourcePolicy.resource_type_id = 6)  WHERE ResourcePolicy.resource_type_id = 6;
 UPDATE ResourcePolicy SET dspace_object = (SELECT community.uuid FROM community WHERE ResourcePolicy.resource_id = community.community_id AND ResourcePolicy.resource_type_id = 4)  WHERE ResourcePolicy.resource_type_id = 4;
@@ -256,37 +281,37 @@ UPDATE ResourcePolicy SET dspace_object = (SELECT bitstream.uuid FROM bitstream 
 
 -- Migrate Subscription
 ALTER TABLE Subscription RENAME COLUMN eperson_id to eperson_legacy_id;
-ALTER TABLE Subscription ADD eperson_id RAW(16) REFERENCES EPerson(uuid);
-UPDATE Subscription SET eperson_id = (SELECT eperson.uuid FROM eperson WHERE Subscription.eperson_legacy_id = eperson.eperson_id);
+ALTER TABLE Subscription ADD COLUMN eperson_id UUID REFERENCES EPerson(uuid);
+UPDATE Subscription SET eperson_id = eperson.uuid FROM eperson WHERE Subscription.eperson_legacy_id = eperson.eperson_id;
 ALTER TABLE Subscription DROP COLUMN eperson_legacy_id;
 ALTER TABLE Subscription RENAME COLUMN collection_id to collection_legacy_id;
-ALTER TABLE Subscription ADD collection_id RAW(16) REFERENCES Collection(uuid);
+ALTER TABLE Subscription ADD COLUMN collection_id UUID REFERENCES Collection(uuid);
 UPDATE Subscription SET collection_id = (SELECT collection.uuid FROM collection WHERE Subscription.collection_legacy_id = collection.collection_id);
 ALTER TABLE Subscription DROP COLUMN collection_legacy_id;
 
 
 -- Migrate versionitem
 ALTER TABLE versionitem RENAME COLUMN eperson_id to eperson_legacy_id;
-ALTER TABLE versionitem ADD eperson_id RAW(16) REFERENCES EPerson(uuid);
-UPDATE versionitem SET eperson_id = (SELECT eperson.uuid FROM eperson WHERE versionitem.eperson_legacy_id = eperson.eperson_id);
+ALTER TABLE versionitem ADD COLUMN eperson_id UUID REFERENCES EPerson(uuid);
+UPDATE versionitem SET eperson_id = eperson.uuid FROM eperson WHERE versionitem.eperson_legacy_id = eperson.eperson_id;
 ALTER TABLE versionitem DROP COLUMN eperson_legacy_id;
 
 ALTER TABLE versionitem RENAME COLUMN item_id to item_legacy_id;
-ALTER TABLE versionitem ADD item_id RAW(16) REFERENCES Item(uuid);
+ALTER TABLE versionitem ADD COLUMN item_id UUID REFERENCES Item(uuid);
 UPDATE versionitem SET item_id = (SELECT item.uuid FROM item WHERE versionitem.item_legacy_id = item.item_id);
 ALTER TABLE versionitem DROP COLUMN item_legacy_id;
 
 -- Migrate handle table
 ALTER TABLE handle RENAME COLUMN resource_id to resource_legacy_id;
-ALTER TABLE handle ADD resource_id RAW(16) REFERENCES dspaceobject(uuid);
-UPDATE handle SET resource_id = (SELECT community.uuid FROM community WHERE handle.resource_legacy_id = community.community_id AND handle.resource_type_id = 4);
-UPDATE handle SET resource_id = (SELECT collection.uuid FROM collection WHERE handle.resource_legacy_id = collection.collection_id AND handle.resource_type_id = 3);
-UPDATE handle SET resource_id = (SELECT item.uuid FROM item WHERE handle.resource_legacy_id = item.item_id AND handle.resource_type_id = 2);
+ALTER TABLE handle ADD COLUMN resource_id UUID REFERENCES dspaceobject(uuid);
+UPDATE handle SET resource_id = community.uuid FROM community WHERE handle.resource_legacy_id = community.community_id AND handle.resource_type_id = 4;
+UPDATE handle SET resource_id = collection.uuid FROM collection WHERE handle.resource_legacy_id = collection.collection_id AND handle.resource_type_id = 3;
+UPDATE handle SET resource_id = item.uuid FROM item WHERE handle.resource_legacy_id = item.item_id AND handle.resource_type_id = 2;
 
 -- Migrate metadata value table
 DROP VIEW dcvalue;
 
-ALTER TABLE metadatavalue ADD dspace_object_id RAW(16) REFERENCES dspaceobject(uuid);
+ALTER TABLE metadatavalue ADD COLUMN dspace_object_id UUID REFERENCES dspaceobject(uuid);
 UPDATE metadatavalue SET dspace_object_id = (SELECT eperson.uuid FROM eperson WHERE metadatavalue.resource_id = eperson.eperson_id AND metadatavalue.resource_type_id = 7) WHERE metadatavalue.resource_type_id= 7;
 UPDATE metadatavalue SET dspace_object_id = (SELECT epersongroup.uuid FROM epersongroup WHERE metadatavalue.resource_id = epersongroup.eperson_group_id AND metadatavalue.resource_type_id = 6) WHERE metadatavalue.resource_type_id= 6;
 UPDATE metadatavalue SET dspace_object_id = (SELECT community.uuid FROM community WHERE metadatavalue.resource_id = community.community_id AND metadatavalue.resource_type_id = 4) WHERE metadatavalue.resource_type_id= 4;
@@ -296,58 +321,58 @@ UPDATE metadatavalue SET dspace_object_id = (SELECT bundle.uuid FROM bundle WHER
 UPDATE metadatavalue SET dspace_object_id = (SELECT bitstream.uuid FROM bitstream WHERE metadatavalue.resource_id = bitstream.bitstream_id AND metadatavalue.resource_type_id = 0) WHERE metadatavalue.resource_type_id= 0;
 DROP INDEX metadatavalue_item_idx;
 DROP INDEX metadatavalue_item_idx2;
-ALTER TABLE metadatavalue DROP COLUMN resource_id;
+ALTER TABLE metadatavalue DROP COLUMN IF EXISTS resource_id;
 ALTER TABLE metadatavalue DROP COLUMN resource_type_id;
 UPDATE MetadataValue SET confidence = -1 WHERE confidence IS NULL;
 
 -- Alter harvested item
 ALTER TABLE harvested_item RENAME COLUMN item_id to item_legacy_id;
-ALTER TABLE harvested_item ADD item_id RAW(16) REFERENCES item(uuid);
+ALTER TABLE harvested_item ADD COLUMN item_id UUID REFERENCES item(uuid);
 UPDATE harvested_item SET item_id = (SELECT item.uuid FROM item WHERE harvested_item.item_legacy_id = item.item_id);
 ALTER TABLE harvested_item DROP COLUMN item_legacy_id;
 
 -- Alter harvested collection
 ALTER TABLE harvested_collection RENAME COLUMN collection_id to collection_legacy_id;
-ALTER TABLE harvested_collection ADD collection_id RAW(16) REFERENCES Collection(uuid);
+ALTER TABLE harvested_collection ADD COLUMN collection_id UUID REFERENCES Collection(uuid);
 UPDATE harvested_collection SET collection_id = (SELECT collection.uuid FROM collection WHERE harvested_collection.collection_legacy_id = collection.collection_id);
 ALTER TABLE harvested_collection DROP COLUMN collection_legacy_id;
 
 
 --Alter workspaceitem
 ALTER TABLE workspaceitem RENAME COLUMN item_id to item_legacy_id;
-ALTER TABLE workspaceitem ADD item_id RAW(16) REFERENCES Item(uuid);
+ALTER TABLE workspaceitem ADD COLUMN item_id UUID REFERENCES Item(uuid);
 UPDATE workspaceitem SET item_id = (SELECT item.uuid FROM item WHERE workspaceitem.item_legacy_id = item.item_id);
 ALTER TABLE workspaceitem DROP COLUMN item_legacy_id;
 
 ALTER TABLE workspaceitem RENAME COLUMN collection_id to collection_legacy_id;
-ALTER TABLE workspaceitem ADD collection_id RAW(16) REFERENCES Collection(uuid);
+ALTER TABLE workspaceitem ADD COLUMN collection_id UUID REFERENCES Collection(uuid);
+ALTER TABLE workspaceitem ADD CONSTRAINT workspaceitem_collection_id_fk FOREIGN KEY (collection_id) REFERENCES collection;
 UPDATE workspaceitem SET collection_id = (SELECT collection.uuid FROM collection WHERE workspaceitem.collection_legacy_id = collection.collection_id);
 ALTER TABLE workspaceitem DROP COLUMN collection_legacy_id;
 
 ALTER TABLE epersongroup2workspaceitem RENAME COLUMN eperson_group_id to eperson_group_legacy_id;
-ALTER TABLE epersongroup2workspaceitem ADD eperson_group_id RAW(16) REFERENCES epersongroup(uuid);
+ALTER TABLE epersongroup2workspaceitem ADD COLUMN eperson_group_id UUID REFERENCES epersongroup(uuid);
 UPDATE epersongroup2workspaceitem SET eperson_group_id = (SELECT epersongroup.uuid FROM epersongroup WHERE epersongroup2workspaceitem.eperson_group_legacy_id = epersongroup.eperson_group_id);
 ALTER TABLE epersongroup2workspaceitem DROP COLUMN eperson_group_legacy_id;
 ALTER TABLE epersongroup2workspaceitem DROP COLUMN id;
-ALTER TABLE epersongroup2workspaceitem MODIFY workspace_item_id NOT NULL;
-ALTER TABLE epersongroup2workspaceitem MODIFY eperson_group_id NOT NULL;
-ALTER TABLE epersongroup2workspaceitem add CONSTRAINT  epersongroup2wsitem_unqiue primary key (workspace_item_id,eperson_group_id);
+ALTER TABLE epersongroup2workspaceitem ALTER COLUMN workspace_item_id SET NOT NULL;
+ALTER TABLE epersongroup2workspaceitem ALTER COLUMN eperson_group_id SET NOT NULL;
+ALTER TABLE epersongroup2workspaceitem add primary key (workspace_item_id,eperson_group_id);
 
 
 --Alter most_recent_checksum
 ALTER TABLE most_recent_checksum RENAME COLUMN bitstream_id to bitstream_legacy_id;
-ALTER TABLE most_recent_checksum ADD bitstream_id RAW(16) REFERENCES Bitstream(uuid);
+ALTER TABLE most_recent_checksum ADD COLUMN bitstream_id UUID REFERENCES Bitstream(uuid);
 UPDATE most_recent_checksum SET bitstream_id = (SELECT Bitstream.uuid FROM Bitstream WHERE most_recent_checksum.bitstream_legacy_id = Bitstream.bitstream_id);
 ALTER TABLE most_recent_checksum DROP COLUMN bitstream_legacy_id;
 
 ALTER TABLE checksum_history RENAME COLUMN bitstream_id to bitstream_legacy_id;
-ALTER TABLE checksum_history ADD bitstream_id RAW(16) REFERENCES Bitstream(uuid);
+ALTER TABLE checksum_history ADD COLUMN bitstream_id UUID REFERENCES Bitstream(uuid);
 UPDATE checksum_history SET bitstream_id = (SELECT Bitstream.uuid FROM Bitstream WHERE checksum_history.bitstream_legacy_id = Bitstream.bitstream_id);
 ALTER TABLE checksum_history DROP COLUMN bitstream_legacy_id;
-RENAME checksum_history_seq TO checksum_history_check_id_seq;
 
 --Alter table doi
-ALTER TABLE doi ADD dspace_object RAW(16) REFERENCES dspaceobject(uuid);
+ALTER TABLE doi ADD COLUMN dspace_object UUID REFERENCES dspaceobject(uuid);
 UPDATE doi SET dspace_object = (SELECT community.uuid FROM community WHERE doi.resource_id = community.community_id AND doi.resource_type_id = 4)  WHERE doi.resource_type_id = 4;
 UPDATE doi SET dspace_object = (SELECT collection.uuid FROM collection WHERE doi.resource_id = collection.collection_id AND doi.resource_type_id = 3)  WHERE doi.resource_type_id = 3;
 UPDATE doi SET dspace_object = (SELECT item.uuid FROM item WHERE doi.resource_id = item.item_id AND doi.resource_type_id = 2)  WHERE doi.resource_type_id = 2;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/workflow/h2/basicWorkflow/V6.0_2015.08.11__DS-2701_Basic_Workflow_Migration.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/workflow/h2/basicWorkflow/V6.0_2015.08.11__DS-2701_Basic_Workflow_Migration.sql
@@ -6,6 +6,9 @@
 -- http://www.dspace.org/license/
 --
 
+------------------------------------------------------
+-- DS-2701 Service based API / Hibernate integration
+------------------------------------------------------
 ALTER TABLE workflowitem ALTER COLUMN item_id rename to item_legacy_id;
 ALTER TABLE workflowitem ADD COLUMN item_id UUID;
 ALTER TABLE workflowitem ADD CONSTRAINT workflowitem_item_id_fk FOREIGN KEY (item_id) REFERENCES Item;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/workflow/oracle/basicWorkflow/V6.0_2015.08.11__DS-2701_Basic_Workflow_Migration.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/workflow/oracle/basicWorkflow/V6.0_2015.08.11__DS-2701_Basic_Workflow_Migration.sql
@@ -6,25 +6,28 @@
 -- http://www.dspace.org/license/
 --
 
+------------------------------------------------------
+-- DS-2701 Service based API / Hibernate integration
+------------------------------------------------------
 -- Alter workflow item
 ALTER TABLE workflowitem RENAME COLUMN item_id to item_legacy_id;
-ALTER TABLE workflowitem ADD COLUMN item_id UUID REFERENCES Item(uuid);
+ALTER TABLE workflowitem ADD item_id RAW(16) REFERENCES Item(uuid);
 UPDATE workflowitem SET item_id = (SELECT item.uuid FROM item WHERE workflowitem.item_legacy_id = item.item_id);
 ALTER TABLE workflowitem DROP COLUMN item_legacy_id;
 
 -- Migrate task list item
 ALTER TABLE TasklistItem RENAME COLUMN eperson_id to eperson_legacy_id;
-ALTER TABLE TasklistItem ADD COLUMN eperson_id UUID REFERENCES EPerson(uuid);
+ALTER TABLE TasklistItem ADD eperson_id RAW(16) REFERENCES EPerson(uuid);
 UPDATE TasklistItem SET eperson_id = (SELECT eperson.uuid FROM eperson WHERE TasklistItem.eperson_legacy_id = eperson.eperson_id);
 ALTER TABLE TasklistItem DROP COLUMN eperson_legacy_id;
 
 -- Migrate task workflow item
 ALTER TABLE workflowitem RENAME COLUMN collection_id to collection_legacy_id;
-ALTER TABLE workflowitem ADD COLUMN collection_id UUID REFERENCES Collection(uuid);
+ALTER TABLE workflowitem ADD collection_id RAW(16) REFERENCES Collection(uuid);
 UPDATE workflowitem SET collection_id = (SELECT collection.uuid FROM collection WHERE workflowitem.collection_legacy_id = collection.collection_id);
 ALTER TABLE workflowitem DROP COLUMN collection_legacy_id;
 ALTER TABLE workflowitem RENAME COLUMN owner to owner_legacy_id;
-ALTER TABLE workflowitem ADD COLUMN owner UUID REFERENCES EPerson (uuid);
+ALTER TABLE workflowitem ADD owner RAW(16) REFERENCES EPerson (uuid);
 UPDATE workflowitem SET owner = (SELECT eperson.uuid FROM eperson WHERE workflowitem.owner_legacy_id = eperson.eperson_id);
 ALTER TABLE workflowitem DROP COLUMN owner_legacy_id;
 

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/workflow/oracle/xmlworkflow/V6.0_2015.08.11__DS-2701_Xml_Workflow_Migration.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/workflow/oracle/xmlworkflow/V6.0_2015.08.11__DS-2701_Xml_Workflow_Migration.sql
@@ -6,15 +6,9 @@
 -- http://www.dspace.org/license/
 --
 
---
--- The contents of this file are subject to the license and copyright
--- detailed in the LICENSE and NOTICE files at the root of the source
--- tree and available online at
---
--- http://www.dspace.org/license/
---
-
-
+------------------------------------------------------
+-- DS-2701 Service based API / Hibernate integration
+------------------------------------------------------
 UPDATE collection SET workflow_step_1 = null;
 UPDATE collection SET workflow_step_2 = null;
 UPDATE collection SET workflow_step_3 = null;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/workflow/postgres/basicWorkflow/V6.0_2015.08.11__DS-2701_Basic_Workflow_Migration.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/workflow/postgres/basicWorkflow/V6.0_2015.08.11__DS-2701_Basic_Workflow_Migration.sql
@@ -6,25 +6,28 @@
 -- http://www.dspace.org/license/
 --
 
+------------------------------------------------------
+-- DS-2701 Service based API / Hibernate integration
+------------------------------------------------------
 -- Alter workflow item
 ALTER TABLE workflowitem RENAME COLUMN item_id to item_legacy_id;
-ALTER TABLE workflowitem ADD item_id RAW(16) REFERENCES Item(uuid);
+ALTER TABLE workflowitem ADD COLUMN item_id UUID REFERENCES Item(uuid);
 UPDATE workflowitem SET item_id = (SELECT item.uuid FROM item WHERE workflowitem.item_legacy_id = item.item_id);
 ALTER TABLE workflowitem DROP COLUMN item_legacy_id;
 
 -- Migrate task list item
 ALTER TABLE TasklistItem RENAME COLUMN eperson_id to eperson_legacy_id;
-ALTER TABLE TasklistItem ADD eperson_id RAW(16) REFERENCES EPerson(uuid);
+ALTER TABLE TasklistItem ADD COLUMN eperson_id UUID REFERENCES EPerson(uuid);
 UPDATE TasklistItem SET eperson_id = (SELECT eperson.uuid FROM eperson WHERE TasklistItem.eperson_legacy_id = eperson.eperson_id);
 ALTER TABLE TasklistItem DROP COLUMN eperson_legacy_id;
 
 -- Migrate task workflow item
 ALTER TABLE workflowitem RENAME COLUMN collection_id to collection_legacy_id;
-ALTER TABLE workflowitem ADD collection_id RAW(16) REFERENCES Collection(uuid);
+ALTER TABLE workflowitem ADD COLUMN collection_id UUID REFERENCES Collection(uuid);
 UPDATE workflowitem SET collection_id = (SELECT collection.uuid FROM collection WHERE workflowitem.collection_legacy_id = collection.collection_id);
 ALTER TABLE workflowitem DROP COLUMN collection_legacy_id;
 ALTER TABLE workflowitem RENAME COLUMN owner to owner_legacy_id;
-ALTER TABLE workflowitem ADD owner RAW(16) REFERENCES EPerson (uuid);
+ALTER TABLE workflowitem ADD COLUMN owner UUID REFERENCES EPerson (uuid);
 UPDATE workflowitem SET owner = (SELECT eperson.uuid FROM eperson WHERE workflowitem.owner_legacy_id = eperson.eperson_id);
 ALTER TABLE workflowitem DROP COLUMN owner_legacy_id;
 

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/workflow/postgres/xmlworkflow/V6.0_2015.08.11__DS-2701_Xml_Workflow_Migration.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/workflow/postgres/xmlworkflow/V6.0_2015.08.11__DS-2701_Xml_Workflow_Migration.sql
@@ -6,7 +6,9 @@
 -- http://www.dspace.org/license/
 --
 
-
+------------------------------------------------------
+-- DS-2701 Service based API / Hibernate integration
+------------------------------------------------------
 UPDATE collection SET workflow_step_1 = null;
 UPDATE collection SET workflow_step_2 = null;
 UPDATE collection SET workflow_step_3 = null;

--- a/dspace-sword/src/main/java/org/dspace/sword/ATOMCollectionGenerator.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/ATOMCollectionGenerator.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;

--- a/dspace-sword/src/main/java/org/dspace/sword/BitstreamEntryGenerator.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/BitstreamEntryGenerator.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;

--- a/dspace-sword/src/main/java/org/dspace/sword/CollectionCollectionGenerator.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/CollectionCollectionGenerator.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;

--- a/dspace-sword/src/main/java/org/dspace/sword/CollectionDepositor.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/CollectionDepositor.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;

--- a/dspace-sword/src/main/java/org/dspace/sword/CollectionLocation.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/CollectionLocation.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;
@@ -17,7 +17,6 @@ import org.dspace.content.Collection;
 import org.dspace.content.DSpaceObject;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
-import org.dspace.handle.HandleServiceImpl;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
 

--- a/dspace-sword/src/main/java/org/dspace/sword/CommunityCollectionGenerator.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/CommunityCollectionGenerator.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;

--- a/dspace-sword/src/main/java/org/dspace/sword/DSpaceATOMEntry.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/DSpaceATOMEntry.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;

--- a/dspace-sword/src/main/java/org/dspace/sword/DSpaceSWORDErrorCodes.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/DSpaceSWORDErrorCodes.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;

--- a/dspace-sword/src/main/java/org/dspace/sword/DSpaceSWORDException.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/DSpaceSWORDException.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;

--- a/dspace-sword/src/main/java/org/dspace/sword/DSpaceSWORDServer.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/DSpaceSWORDServer.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;

--- a/dspace-sword/src/main/java/org/dspace/sword/DepositManager.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/DepositManager.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;
@@ -18,7 +18,6 @@ import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.CollectionService;
-import org.dspace.content.service.CommunityService;
 import org.dspace.core.Context;
 import org.dspace.core.LogManager;
 import org.dspace.core.Utils;

--- a/dspace-sword/src/main/java/org/dspace/sword/DepositResult.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/DepositResult.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;

--- a/dspace-sword/src/main/java/org/dspace/sword/Depositor.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/Depositor.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;

--- a/dspace-sword/src/main/java/org/dspace/sword/ItemCollectionGenerator.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/ItemCollectionGenerator.java
@@ -2,13 +2,12 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;
 
 import org.apache.commons.lang.StringUtils;
-import org.dspace.content.authority.Choice;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.ItemService;
 import org.purl.sword.base.Collection;

--- a/dspace-sword/src/main/java/org/dspace/sword/ItemDepositor.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/ItemDepositor.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;

--- a/dspace-sword/src/main/java/org/dspace/sword/ItemEntryGenerator.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/ItemEntryGenerator.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;

--- a/dspace-sword/src/main/java/org/dspace/sword/LoadDSpaceConfig.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/LoadDSpaceConfig.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;

--- a/dspace-sword/src/main/java/org/dspace/sword/MediaEntryManager.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/MediaEntryManager.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;

--- a/dspace-sword/src/main/java/org/dspace/sword/SWORDAuthentication.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/SWORDAuthentication.java
@@ -2,12 +2,11 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;
 
-import org.dspace.authenticate.AuthenticationServiceImpl;
 import org.dspace.authenticate.factory.AuthenticateServiceFactory;
 import org.dspace.authenticate.service.AuthenticationService;
 import org.dspace.core.Context;

--- a/dspace-sword/src/main/java/org/dspace/sword/SWORDAuthenticator.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/SWORDAuthenticator.java
@@ -2,15 +2,13 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;
 
-import org.dspace.authenticate.AuthenticationServiceImpl;
 import org.dspace.authenticate.factory.AuthenticateServiceFactory;
 import org.dspace.authenticate.service.AuthenticationService;
-import org.dspace.authorize.AuthorizeServiceImpl;
 import org.dspace.authorize.factory.AuthorizeServiceFactory;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Collection;
@@ -25,12 +23,10 @@ import org.dspace.core.Constants;
 import org.dspace.authenticate.AuthenticationMethod;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
-import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.*;
 import org.apache.log4j.Logger;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
-import org.dspace.eperson.service.GroupService;
 import org.purl.sword.base.*;
 
 import java.sql.SQLException;

--- a/dspace-sword/src/main/java/org/dspace/sword/SWORDConfiguration.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/SWORDConfiguration.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;

--- a/dspace-sword/src/main/java/org/dspace/sword/SWORDContext.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/SWORDContext.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;

--- a/dspace-sword/src/main/java/org/dspace/sword/SWORDIngester.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/SWORDIngester.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;

--- a/dspace-sword/src/main/java/org/dspace/sword/SWORDIngesterFactory.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/SWORDIngesterFactory.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;

--- a/dspace-sword/src/main/java/org/dspace/sword/SWORDMETSIngester.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/SWORDMETSIngester.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;
@@ -19,11 +19,9 @@ import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.packager.PackageIngester;
 import org.dspace.content.packager.PackageParameters;
 import org.dspace.content.service.ItemService;
-import org.dspace.content.service.MetadataValueService;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 import org.dspace.core.PluginManager;
-import org.dspace.handle.HandleServiceImpl;
 
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;

--- a/dspace-sword/src/main/java/org/dspace/sword/SWORDProperties.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/SWORDProperties.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;

--- a/dspace-sword/src/main/java/org/dspace/sword/SWORDService.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/SWORDService.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;

--- a/dspace-sword/src/main/java/org/dspace/sword/SWORDUrlManager.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/SWORDUrlManager.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;
@@ -11,7 +11,6 @@ import org.apache.commons.lang.StringUtils;
 import org.dspace.content.*;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.BitstreamService;
-import org.dspace.handle.HandleServiceImpl;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 import org.dspace.handle.factory.HandleServiceFactory;

--- a/dspace-sword/src/main/java/org/dspace/sword/ServiceDocumentManager.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/ServiceDocumentManager.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;

--- a/dspace-sword/src/main/java/org/dspace/sword/SimpleFileIngester.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/SimpleFileIngester.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/AbstractSimpleDC.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/AbstractSimpleDC.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/AbstractSwordContentIngester.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/AbstractSwordContentIngester.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/AtomCollectionGenerator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/AtomCollectionGenerator.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/AtomStatementDisseminator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/AtomStatementDisseminator.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/BinaryContentIngester.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/BinaryContentIngester.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/CollectionCollectionGenerator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/CollectionCollectionGenerator.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/CollectionDepositManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/CollectionDepositManagerDSpace.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/CollectionListManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/CollectionListManagerDSpace.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/CommunityCollectionGenerator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/CommunityCollectionGenerator.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/ContainerManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/ContainerManagerDSpace.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/DSpaceSwordAPI.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/DSpaceSwordAPI.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/DSpaceSwordException.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/DSpaceSwordException.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/DSpaceUriRegistry.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/DSpaceUriRegistry.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/DepositResult.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/DepositResult.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/FeedContentDisseminator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/FeedContentDisseminator.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/GenericStatementDisseminator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/GenericStatementDisseminator.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/MediaResourceManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/MediaResourceManagerDSpace.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/OreStatementDisseminator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/OreStatementDisseminator.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/ReceiptGenerator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/ReceiptGenerator.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/ServiceDocumentManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/ServiceDocumentManagerDSpace.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleDCEntryDisseminator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleDCEntryDisseminator.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleDCEntryIngester.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleDCEntryIngester.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleDCMetadata.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleDCMetadata.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleZipContentDisseminator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleZipContentDisseminator.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleZipContentIngester.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleZipContentIngester.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/StatementManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/StatementManagerDSpace.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordAuthenticator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordAuthenticator.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordConfigurationDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordConfigurationDSpace.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordContentDisseminator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordContentDisseminator.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordContentIngester.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordContentIngester.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordContext.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordContext.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordDisseminatorFactory.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordDisseminatorFactory.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordEntryDisseminator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordEntryDisseminator.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordEntryIngester.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordEntryIngester.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordIngesterFactory.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordIngesterFactory.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordMETSContentIngester.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordMETSContentIngester.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordMETSPackageIngester.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordMETSPackageIngester.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordStatementDisseminator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordStatementDisseminator.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordUrlManager.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordUrlManager.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/TempFileInputStream.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/TempFileInputStream.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/VerboseDescription.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/VerboseDescription.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/VersionManager.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/VersionManager.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/WorkflowManager.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/WorkflowManager.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/WorkflowManagerDefault.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/WorkflowManagerDefault.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/WorkflowManagerFactory.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/WorkflowManagerFactory.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/WorkflowManagerUnrestricted.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/WorkflowManagerUnrestricted.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/WorkflowTools.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/WorkflowTools.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.sword2;


### PR DESCRIPTION
This PR touches a lot of files, but makes minor changes:
- Corrects the license headers of all classes in SWORDv1 and SWORDv2.  During refactoring, a random `<p>` was added to all license headers, causing `mvn install` to fail for these modules.  (As part of this, a few unused imports were auto-removed by my IDE as well)
- Renames all new DB migration scripts to follow our established naming conventions (based on the 5.x migration script names).  The scripts should all reference DS-2701, so that we can more easily track the reason behind those migrations.
- Also adds a missing license header to one DB migration script, which caused `mvn install` to fail for dspace-api

After these changes, a `mvn install -P -dspace-rest` completes successfully.  (I haven't looked at REST, cause it's still being worked on in #1026).

None of these are major changes, but I'll let someone else do a quick sanity check.
