### PR TITLE
DS-2701 : Flyway Upgrade

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -611,7 +611,7 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-            <version>3.0</version>
+            <version>3.2.1</version>
         </dependency>
 
         <!-- Google Analytics -->

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseLegacyReindexer.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseLegacyReindexer.java
@@ -158,6 +158,16 @@ public class DatabaseLegacyReindexer implements FlywayCallback
     }
 
     @Override
+    public void beforeBaseline(Connection connection) {
+
+    }
+
+    @Override
+    public void afterBaseline(Connection connection) {
+
+    }
+
+    @Override
     public void beforeRepair(Connection connection) {
 
     }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseRegistryUpdater.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseRegistryUpdater.java
@@ -141,6 +141,16 @@ public class DatabaseRegistryUpdater implements FlywayCallback
     }
 
     @Override
+    public void beforeBaseline(Connection connection) {
+
+    }
+
+    @Override
+    public void afterBaseline(Connection connection) {
+
+    }
+
+    @Override
     public void beforeRepair(Connection connection) {
 
     }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -393,7 +393,7 @@ public class DatabaseUtils
             // (i.e. all later migrations are left as "pending"). By default we always migrate to latest version.
             if(!StringUtils.isBlank(targetVersion))
             {
-                flyway.setTarget(targetVersion);
+                flyway.setTargetAsString(targetVersion);
             }
 
             // Does the necessary Flyway table ("schema_version") exist in this database?
@@ -409,14 +409,14 @@ public class DatabaseUtils
                 if (dbVersion==null)
                 {
                     // Initialize the Flyway database table with defaults (version=1)
-                    flyway.init();
+                    flyway.baseline();
                 }
                 else
                 {
                     // Otherwise, pass our determined DB version to Flyway to initialize database table
-                    flyway.setInitVersion(dbVersion);
-                    flyway.setInitDescription("Initializing from DSpace " + dbVersion + " database schema");
-                    flyway.init();
+                    flyway.setBaselineVersionAsString(dbVersion);
+                    flyway.setBaselineDescription("Initializing from DSpace " + dbVersion + " database schema");
+                    flyway.baseline();
                 }
             }
 
@@ -1114,6 +1114,12 @@ public class DatabaseUtils
         }
     }
 
+    /**
+     * Determine the type of Database, based on the DB connection's metadata info
+     * @param meta DatabaseMetaData from DB Connection
+     * @return a DB keyword/type (see DatabaseUtils.DBMS_* constants)
+     * @throws SQLException
+     */
     protected static String findDbKeyword(DatabaseMetaData meta)
             throws SQLException
     {

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/GroupServiceInitializer.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/GroupServiceInitializer.java
@@ -17,7 +17,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.sql.Connection;
 
 /**
- * Callback method to ensure that the default groups are created each time a kernel is created.
+ * Callback method to ensure that the default groups are created in the database
+ * AFTER the database migration completes.
  *
  * @author kevinvandevelde at atmire.com
  */

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/GroupServiceInitializer.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/GroupServiceInitializer.java
@@ -9,7 +9,6 @@ package org.dspace.storage.rdbms;
 
 import org.apache.log4j.Logger;
 import org.dspace.core.Context;
-import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.GroupService;
 import org.flywaydb.core.api.MigrationInfo;
 import org.flywaydb.core.api.callback.FlywayCallback;
@@ -104,6 +103,16 @@ public class GroupServiceInitializer implements FlywayCallback {
 
     @Override
     public void afterInit(Connection connection) {
+
+    }
+
+    @Override
+    public void beforeBaseline(Connection connection) {
+
+    }
+
+    @Override
+    public void afterBaseline(Connection connection) {
 
     }
 

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/SiteServiceInitializer.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/SiteServiceInitializer.java
@@ -8,10 +8,8 @@
 package org.dspace.storage.rdbms;
 
 import org.apache.log4j.Logger;
-import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.SiteService;
 import org.dspace.core.Context;
-import org.dspace.services.KernelStartupCallbackService;
 import org.flywaydb.core.api.MigrationInfo;
 import org.flywaydb.core.api.callback.FlywayCallback;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -108,6 +106,16 @@ public class SiteServiceInitializer implements FlywayCallback {
 
     @Override
     public void afterInit(Connection connection) {
+
+    }
+
+    @Override
+    public void beforeBaseline(Connection connection) {
+
+    }
+
+    @Override
+    public void afterBaseline(Connection connection) {
 
     }
 

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/SiteServiceInitializer.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/SiteServiceInitializer.java
@@ -17,7 +17,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.sql.Connection;
 
 /**
- * Callback method to ensure that the Site is created (if no site exists) each time a kernel is created.
+ * Callback method to ensure that the Site object is created (if no site exists)
+ * after the database migration completes.
  *
  * @author kevinvandevelde at atmire.com
  */

--- a/dspace/config/hibernate.cfg.xml
+++ b/dspace/config/hibernate.cfg.xml
@@ -3,6 +3,11 @@
         "http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
 <hibernate-configuration>
     <session-factory>
+        <!--
+         NOTE: If you are looking for the Hibernate database connection info
+         (driver, url, username, pwd), it is initialized in the 'dataSource'
+         bean in [dspace.dir]/config/spring/api/core-hibernate.xml
+        -->
 
         <property name="hibernate.dialect">${db.dialect}</property>
         <!--


### PR DESCRIPTION
PR to upgrade Flyway to the latest version (version 3.2.1) and update all Flyway classes to use non-deprecated methods.

These changes are minor overall. It's mostly about replacing "init" methods with "baseline", as "init" was renamed and deprecated in Flyway 3.2.
