### PR TITLE
DS-2452: Upgrade to Commons Pool v2

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -611,7 +611,7 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-            <version>3.0</version>
+            <version>3.2.1</version>
         </dependency>
 
         <!-- Google Analytics -->

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -368,8 +368,8 @@
             <artifactId>commons-lang</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-pool</groupId>
-            <artifactId>commons-pool</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseLegacyReindexer.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseLegacyReindexer.java
@@ -158,6 +158,16 @@ public class DatabaseLegacyReindexer implements FlywayCallback
     }
 
     @Override
+    public void beforeBaseline(Connection connection) {
+
+    }
+
+    @Override
+    public void afterBaseline(Connection connection) {
+
+    }
+
+    @Override
     public void beforeRepair(Connection connection) {
 
     }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseRegistryUpdater.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseRegistryUpdater.java
@@ -141,6 +141,16 @@ public class DatabaseRegistryUpdater implements FlywayCallback
     }
 
     @Override
+    public void beforeBaseline(Connection connection) {
+
+    }
+
+    @Override
+    public void afterBaseline(Connection connection) {
+
+    }
+
+    @Override
     public void beforeRepair(Connection connection) {
 
     }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -393,7 +393,7 @@ public class DatabaseUtils
             // (i.e. all later migrations are left as "pending"). By default we always migrate to latest version.
             if(!StringUtils.isBlank(targetVersion))
             {
-                flyway.setTarget(targetVersion);
+                flyway.setTargetAsString(targetVersion);
             }
 
             // Does the necessary Flyway table ("schema_version") exist in this database?
@@ -409,14 +409,14 @@ public class DatabaseUtils
                 if (dbVersion==null)
                 {
                     // Initialize the Flyway database table with defaults (version=1)
-                    flyway.init();
+                    flyway.baseline();
                 }
                 else
                 {
                     // Otherwise, pass our determined DB version to Flyway to initialize database table
-                    flyway.setInitVersion(dbVersion);
-                    flyway.setInitDescription("Initializing from DSpace " + dbVersion + " database schema");
-                    flyway.init();
+                    flyway.setBaselineVersionAsString(dbVersion);
+                    flyway.setBaselineDescription("Initializing from DSpace " + dbVersion + " database schema");
+                    flyway.baseline();
                 }
             }
 
@@ -1114,6 +1114,12 @@ public class DatabaseUtils
         }
     }
 
+    /**
+     * Determine the type of Database, based on the DB connection's metadata info
+     * @param meta DatabaseMetaData from DB Connection
+     * @return a DB keyword/type (see DatabaseUtils.DBMS_* constants)
+     * @throws SQLException
+     */
     protected static String findDbKeyword(DatabaseMetaData meta)
             throws SQLException
     {

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -115,7 +115,7 @@ public class DatabaseUtils
                     System.out.println(" - Driver: " + meta.getDriverName() + " version " + meta.getDriverVersion());
                     System.out.println(" - Username: " + meta.getUserName());
                     System.out.println(" - Password: [hidden]");
-                    System.out.println(" - Schema: " + getSchemaName(connection));
+                    System.out.println(" - Schema: " + connection.getSchema());
                     connection.close();
                 }
                 catch (SQLException sqle)
@@ -132,7 +132,7 @@ public class DatabaseUtils
                 Connection connection = dataSource.getConnection();
                 DatabaseMetaData meta = connection.getMetaData();
                 System.out.println("\nDatabase URL: " + meta.getURL());
-                System.out.println("Database Schema: " + getSchemaName(connection));
+                System.out.println("Database Schema: " + connection.getSchema());
                 System.out.println("Database Software: " + meta.getDatabaseProductName() + " version " + meta.getDatabaseProductVersion());
                 System.out.println("Database Driver: " + meta.getDriverName() + " version " + meta.getDriverVersion());
 
@@ -648,7 +648,7 @@ public class DatabaseUtils
         {
             // Get the name of the Schema that the DSpace Database is using
             // (That way we can search the right schema)
-            String schema = getSchemaName(connection);
+            String schema = connection.getSchema();
 
             // Get information about our database.
             DatabaseMetaData meta = connection.getMetaData();
@@ -709,7 +709,7 @@ public class DatabaseUtils
         {
             // Get the name of the Schema that the DSpace Database is using
             // (That way we can search the right schema)
-            String schema = getSchemaName(connection);
+            String schema = connection.getSchema();
 
             // Canonicalize everything to the proper case based on DB type
             schema = canonicalize(connection, schema);
@@ -768,7 +768,7 @@ public class DatabaseUtils
         {
             // Get the name of the Schema that the DSpace Database is using
             // (That way we can search the right schema)
-            String schema = getSchemaName(connection);
+            String schema = connection.getSchema();
 
             // Canonicalize everything to the proper case based on DB type
             schema = canonicalize(connection, schema);
@@ -884,46 +884,6 @@ public class DatabaseUtils
         }
     }
 
-    /**
-     * Get the Database Schema Name in use by this Connection, so that it can
-     * be used to limit queries in other methods (e.g. tableExists()).
-     * <P>
-     * NOTE: Once we upgrade to using Apache Commons DBCP / Pool version 2.0,
-     * this method WILL BE REMOVED in favor of java.sql.Connection's new
-     * "getSchema()" method.
-     * http://docs.oracle.com/javase/7/docs/api/java/sql/Connection.html#getSchema()
-     * 
-     * @param connection 
-     *            Current Database Connection
-     * @return Schema name as a string, or "null" if cannot be determined or unspecified
-     */
-    public static String getSchemaName(Connection connection)
-            throws SQLException
-    {
-        String schema = null;
-        DatabaseMetaData meta = connection.getMetaData();
-
-        // Determine our DB type
-
-        // If unspecified, determine "sane" defaults based on DB type
-        String dbType = findDbKeyword(meta);
-        if (StringUtils.equals(dbType, DBMS_POSTGRES))
-        {
-            // For PostgreSQL, the default schema is named "public"
-            // See: http://www.postgresql.org/docs/9.0/static/ddl-schemas.html
-            schema = "public";
-        }
-        else if (StringUtils.equals(dbType, DBMS_ORACLE))
-        {
-            // Schema is actually the user account
-            // See: http://stackoverflow.com/a/13341390
-            schema = meta.getUserName();
-        }
-        else
-            schema = null;
-        return schema;
-    }
-    
     /**
      * Return the canonical name for a database identifier based on whether this
      * database defaults to storing identifiers in uppercase or lowercase.

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/GroupServiceInitializer.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/GroupServiceInitializer.java
@@ -17,7 +17,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.sql.Connection;
 
 /**
- * Callback method to ensure that the default groups are created each time a kernel is created.
+ * Callback method to ensure that the default groups are created in the database
+ * AFTER the database migration completes.
  *
  * @author kevinvandevelde at atmire.com
  */

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/GroupServiceInitializer.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/GroupServiceInitializer.java
@@ -9,7 +9,6 @@ package org.dspace.storage.rdbms;
 
 import org.apache.log4j.Logger;
 import org.dspace.core.Context;
-import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.GroupService;
 import org.flywaydb.core.api.MigrationInfo;
 import org.flywaydb.core.api.callback.FlywayCallback;
@@ -104,6 +103,16 @@ public class GroupServiceInitializer implements FlywayCallback {
 
     @Override
     public void afterInit(Connection connection) {
+
+    }
+
+    @Override
+    public void beforeBaseline(Connection connection) {
+
+    }
+
+    @Override
+    public void afterBaseline(Connection connection) {
 
     }
 

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/SiteServiceInitializer.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/SiteServiceInitializer.java
@@ -8,10 +8,8 @@
 package org.dspace.storage.rdbms;
 
 import org.apache.log4j.Logger;
-import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.SiteService;
 import org.dspace.core.Context;
-import org.dspace.services.KernelStartupCallbackService;
 import org.flywaydb.core.api.MigrationInfo;
 import org.flywaydb.core.api.callback.FlywayCallback;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -108,6 +106,16 @@ public class SiteServiceInitializer implements FlywayCallback {
 
     @Override
     public void afterInit(Connection connection) {
+
+    }
+
+    @Override
+    public void beforeBaseline(Connection connection) {
+
+    }
+
+    @Override
+    public void afterBaseline(Connection connection) {
 
     }
 

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/SiteServiceInitializer.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/SiteServiceInitializer.java
@@ -17,7 +17,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.sql.Connection;
 
 /**
- * Callback method to ensure that the Site is created (if no site exists) each time a kernel is created.
+ * Callback method to ensure that the Site object is created (if no site exists)
+ * after the database migration completes.
  *
  * @author kevinvandevelde at atmire.com
  */

--- a/dspace/config/hibernate.cfg.xml
+++ b/dspace/config/hibernate.cfg.xml
@@ -3,6 +3,11 @@
         "http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
 <hibernate-configuration>
     <session-factory>
+        <!--
+         NOTE: If you are looking for the Hibernate database connection info
+         (driver, url, username, pwd), it is initialized in the 'dataSource'
+         bean in [dspace.dir]/config/spring/api/core-hibernate.xml
+        -->
 
         <property name="hibernate.dialect">${db.dialect}</property>
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -1003,9 +1003,9 @@
             <version>1.1.1</version>
          </dependency>
          <dependency>
-            <groupId>commons-pool</groupId>
-            <artifactId>commons-pool</artifactId>
-            <version>1.4</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
+            <version>2.4.2</version>
          </dependency>
           <dependency>
               <groupId>commons-validator</groupId>


### PR DESCRIPTION
Related to the following tickets:
- https://jira.duraspace.org/browse/DS-2452
- https://jira.duraspace.org/browse/DS-2758

Also a followup to #1067 

This PR ensures we are upgraded to the latest version of Apache Commons Pool 2 (since #1067 previously upgraded us to Apache Commons DBCP 2, which uses Pool 2).  It performs a refactor of `EventServiceImpl` to use Pool v2 instead of Pool v1.  The refactor was performed based on the migration notes at: https://commons.apache.org/proper/commons-pool/

I've only performed some basic tests, and it looks like our event handler is still working after the refactor to Pool v2.

(Note: This was built off a branch that also includes #1070, as it involves tweaks to a few of the same maven POMs. Please consider merging #1070 first.)
