### PR TITLE
[DS-2792] Add dc.creator to the output of qdc.xsl

### DIFF
--- a/dspace/config/crosswalks/oai/metadataFormats/qdc.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/qdc.xsl
@@ -26,6 +26,11 @@
 			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='title']/doc:element/doc:field[@name='value']">
 				<dc:title><xsl:value-of select="." /></dc:title>
 			</xsl:for-each>
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='creator']/doc:element/doc:field[@name='value']">
+				<dc:creator>
+					<xsl:value-of select="." />
+				</dc:creator>
+			</xsl:for-each>
 			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='contributor']/doc:element[@name='author']/doc:element/doc:field[@name='value']">
 				<dc:creator>
 					<xsl:value-of select="." />

--- a/dspace/config/crosswalks/oai/metadataFormats/qdc.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/qdc.xsl
@@ -26,6 +26,11 @@
 			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='title']/doc:element/doc:field[@name='value']">
 				<dc:title><xsl:value-of select="." /></dc:title>
 			</xsl:for-each>
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='contributor']/doc:element[@name='author']/doc:element/doc:field[@name='value']">
+				<dc:creator>
+					<xsl:value-of select="." />
+				</dc:creator>
+			</xsl:for-each>
 			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='contributor']/doc:element[@name!='author']/doc:element/doc:field[@name='value']">
 				<dc:contributor>
 					<xsl:value-of select="." />


### PR DESCRIPTION
This will improve the metadata that is harvested via OAI when the selected metadataFormat is qdc.  Previously, there was no attempt to include a dc:creator element.
