### PR TITLE
[DS-2397] Sort out Unit vs. Integration tests, and run them separately

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,11 @@ script:
   # 1. [Install & Unit Test] Check source code licenses and run source code Unit Tests
   #        license:check => Validate all source code license headers
   #        -Dmaven.test.skip=false => Enable DSpace Unit Tests
+  #        -DskipITs=false         => Enable DSpace Integration Tests
   #        -P !assembly            => Skip normal assembly (as it can be memory intensive)
   #        -B => Maven batch/non-interactive mode (recommended for CI)
   #        -V => Display Maven version info before build
-  - "mvn clean install license:check -Dmaven.test.skip=false -P !assembly -B -V"
+  - "mvn clean install license:check -Dmaven.test.skip=false -DskipITs=false -P !assembly -B -V"
   # 2. [Assemble DSpace] Ensure assembly process works (from [src]/dspace/), including Mirage 2
   #        -Dmirage2.on=true => Build Mirage2
   #        -Dmirage2.deps.included=false => Don't include Mirage2 build dependencies (We installed them in before_install)

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -114,10 +114,6 @@
                 </executions>
             </plugin>
 
-            <plugin>
-               <artifactId>maven-failsafe-plugin</artifactId>
-            </plugin>
-
         </plugins>
     </build>
 
@@ -162,6 +158,18 @@
                     <plugin>
                         <artifactId>maven-dependency-plugin</artifactId>
                         <version>2.8</version>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/testing</outputDirectory>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.dspace</groupId>
+                                    <artifactId>dspace-parent</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>zip</type>
+                                    <classifier>testEnvironment</classifier>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>setupTestEnvironment</id>
@@ -169,18 +177,13 @@
                                 <goals>
                                     <goal>unpack</goal>
                                 </goals>
-                                <configuration>
-                                    <outputDirectory>${project.build.directory}/testing</outputDirectory>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>org.dspace</groupId>
-                                            <artifactId>dspace-parent</artifactId>
-                                            <version>${project.version}</version>
-                                            <type>zip</type>
-                                            <classifier>testEnvironment</classifier>
-                                        </artifactItem>
-                                    </artifactItems>
-                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>setupIntegrationTestEnvironment</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
                             </execution>
                         </executions>
                     </plugin>
@@ -202,7 +205,7 @@
                         <executions>
                             <execution>
                                 <id>setproperty</id>
-                                <phase>generate-test-resources</phase>
+                                <phase>generate-test-resources</phase> <!-- XXX I think this should be 'initialize' - MHW -->
                                 <goals>
                                     <goal>execute</goal>
                                 </goals>
@@ -284,9 +287,22 @@
                         </executions>
                     </plugin>
 
-                    <!-- Run Unit/Integration Testing! This plugin just kicks off the tests (when enabled). -->
+                    <!-- Run Unit Testing! This plugin just kicks off the tests (when enabled). -->
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <!-- Specify the dspace.cfg file to use for test environment -->
+                                <dspace.configuration>${agnostic.build.dir}/testing/dspace/config/dspace.cfg</dspace.configuration>
+                                <!-- Turn off any DSpace logging -->
+                                <dspace.log.init.disable>true</dspace.log.init.disable>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+
+                    <!-- Run Integration Testing! This plugin just kicks off the tests (when enabled). -->
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables>
                                 <!-- Specify the dspace.cfg file to use for test environment -->

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -113,6 +113,11 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+               <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+
         </plugins>
     </build>
 
@@ -136,6 +141,7 @@
                 </plugins>
             </build>
         </profile>
+
         <!-- If Unit Testing is enabled, then setup the Unit Test Environment.
              See also the 'skiptests' profile in Parent POM. -->
         <profile>

--- a/dspace-api/src/test/java/org/dspace/content/ITCommunityCollection.java
+++ b/dspace-api/src/test/java/org/dspace/content/ITCommunityCollection.java
@@ -34,10 +34,10 @@ import static org.hamcrest.CoreMatchers.*;
  *
  * @author pvillega
  */
-public class CommunityCollectionIntegrationTest extends AbstractIntegrationTest
+public class ITCommunityCollection extends AbstractIntegrationTest
 {
     /** log4j category */
-    private static final Logger log = Logger.getLogger(CommunityCollectionIntegrationTest.class);
+    private static final Logger log = Logger.getLogger(ITCommunityCollection.class);
 
     protected CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
     protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();

--- a/dspace-api/src/test/java/org/dspace/content/ITMetadata.java
+++ b/dspace-api/src/test/java/org/dspace/content/ITMetadata.java
@@ -28,10 +28,10 @@ import static org.hamcrest.CoreMatchers.*;
  * This is an integration test to validate the metadata classes
  * @author pvillega
  */
-public class MetadataIntegrationTest  extends AbstractIntegrationTest
+public class ITMetadata  extends AbstractIntegrationTest
 {
     /** log4j category */
-    private static final Logger log = Logger.getLogger(MetadataIntegrationTest.class);
+    private static final Logger log = Logger.getLogger(ITMetadata.class);
 
 
     protected CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();

--- a/dspace-api/src/test/java/org/dspace/content/packager/ITDSpaceAIP.java
+++ b/dspace-api/src/test/java/org/dspace/content/packager/ITDSpaceAIP.java
@@ -49,10 +49,10 @@ import org.junit.rules.TemporaryFolder;
  * 
  * @author Tim Donohue
  */
-public class DSpaceAIPIntegrationTest extends AbstractUnitTest
+public class ITDSpaceAIP extends AbstractUnitTest
 {
     /** log4j category */
-    private static final Logger log = Logger.getLogger(DSpaceAIPIntegrationTest.class);
+    private static final Logger log = Logger.getLogger(ITDSpaceAIP.class);
     
     protected CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
     protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,25 @@
                 </configuration>
              </plugin>
              <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.18.1</version>
+                <configuration>
+                   <excludes>
+                      <exclude>**/Abstract*</exclude>
+                   </excludes>
+                   <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                </configuration>
+                <executions>
+                   <execution>
+                      <id>integration-test</id>
+                      <goals>
+                         <goal>integration-test</goal>
+                         <goal>verify</goal>
+                      </goals>
+                   </execution>
+                </executions>
+             </plugin>
+             <plugin>
                   <groupId>org.codehaus.mojo</groupId>
                   <artifactId>findbugs-maven-plugin</artifactId>
                   <version>3.0.0</version>
@@ -303,6 +322,22 @@
            </activation>
            <properties>
                <maven.test.skip>true</maven.test.skip>
+           </properties>
+       </profile>
+
+       <!-- Skip Integration Tests by default, but allow override on
+           command line by setting property "-DskipITs=false" -->
+       <profile>
+           <id>skipits</id>
+           <activation>
+               <!-- This profile should be active at all times, unless the user
+                    specifies a different value for "skipITs" -->
+               <property>
+                   <name>!skipITs</name>
+               </property>
+           </activation>
+           <properties>
+               <skipITs>true</skipITs>
            </properties>
        </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>
         <java.version>1.7</java.version>
         <lucene.version>4.10.2</lucene.version>
         <solr.version>4.10.2</solr.version>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2397

This is just a start, but it provides the infrastructure for integration tests in dspace-api and moves two tests so that they are run in the IT phase rather than the UT phase.  Other projects should be able to reuse the changes here.
