### PR TITLE
DS-2701: Bug fix, cleanup and pgcrypto checking

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -1251,7 +1251,7 @@ public class DatabaseUtils
         }
         else
         {
-            return null;
+            return dbms_lc;
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -73,11 +73,6 @@ public class DatabaseUtils
     public static final String DBMS_ORACLE="oracle";
     public static final String DBMS_H2="h2";
 
-    // PostgreSQL pgcrypto extention name, and required versions of Postgres & pgcrypto
-    public static final String PGCRYPTO="pgcrypto";
-    public static final Double PGCRYPTO_VERSION=1.1;
-    public static final Double POSTGRES_VERSION=9.4;
-
     /**
      * Commandline tools for managing database changes, etc.
      * @param argv
@@ -144,9 +139,9 @@ public class DatabaseUtils
                     // (If it isn't, we'll also write out warnings...see below)
                     if(dbType.equals(DBMS_POSTGRES))
                     {
-                        boolean pgcryptoUpToDate = DatabaseUtils.isPgcryptoUpToDate();
-                        Double pgcryptoVersion = getPgcryptoInstalledVersion(connection);
-                        System.out.println("PostgreSQL '" + PGCRYPTO + "' extension installed/up-to-date? " + pgcryptoUpToDate  + " " + ((pgcryptoVersion!=null) ? "(version=" + pgcryptoVersion + ")" : "(not installed)"));
+                        boolean pgcryptoUpToDate = PostgresUtils.isPgcryptoUpToDate();
+                        Double pgcryptoVersion = PostgresUtils.getPgcryptoInstalledVersion(connection);
+                        System.out.println("PostgreSQL '" + PostgresUtils.PGCRYPTO + "' extension installed/up-to-date? " + pgcryptoUpToDate  + " " + ((pgcryptoVersion!=null) ? "(version=" + pgcryptoVersion + ")" : "(not installed)"));
                     }
 
                     // Get info table from Flyway
@@ -173,48 +168,48 @@ public class DatabaseUtils
                     if(dbType.equals(DBMS_POSTGRES))
                     {
                         // Get version of pgcrypto available in this postgres instance
-                        Double pgcryptoAvailable = getPgcryptoAvailableVersion(connection);
+                        Double pgcryptoAvailable = PostgresUtils.getPgcryptoAvailableVersion(connection);
 
                         // Generic requirements message
-                        String requirementsMsg = "\n** DSpace REQUIRES PostgreSQL >= " + POSTGRES_VERSION + " AND " + PGCRYPTO + " extension >= " + PGCRYPTO_VERSION + " **\n";
+                        String requirementsMsg = "\n** DSpace REQUIRES PostgreSQL >= " + PostgresUtils.POSTGRES_VERSION + " AND " + PostgresUtils.PGCRYPTO + " extension >= " + PostgresUtils.PGCRYPTO_VERSION + " **\n";
 
                         // Check if installed in PostgreSQL & a supported version
-                        if(pgcryptoAvailable!=null && pgcryptoAvailable.compareTo(PGCRYPTO_VERSION)>=0)
+                        if(pgcryptoAvailable!=null && pgcryptoAvailable.compareTo(PostgresUtils.PGCRYPTO_VERSION)>=0)
                         {
                             // We now know it's available in this Postgres. Let's see if it is installed in this database.
-                            Double pgcryptoInstalled = getPgcryptoInstalledVersion(connection);
+                            Double pgcryptoInstalled = PostgresUtils.getPgcryptoInstalledVersion(connection);
 
                             // Check if installed in database, but outdated version
-                            if(pgcryptoInstalled!=null && pgcryptoInstalled.compareTo(PGCRYPTO_VERSION)<0)
+                            if(pgcryptoInstalled!=null && pgcryptoInstalled.compareTo(PostgresUtils.PGCRYPTO_VERSION)<0)
                             {
-                                System.out.println("\nWARNING: PostgreSQL '" + PGCRYPTO + "' extension is OUTDATED (installed version=" + pgcryptoInstalled + ", available version = " + pgcryptoAvailable + ").");
+                                System.out.println("\nWARNING: PostgreSQL '" + PostgresUtils.PGCRYPTO + "' extension is OUTDATED (installed version=" + pgcryptoInstalled + ", available version = " + pgcryptoAvailable + ").");
                                 System.out.println(requirementsMsg);
                                 System.out.println("To update it, please connect to your DSpace database as a 'superuser' and manually run the following command: ");
-                                System.out.println("\n  ALTER EXTENSION " + PGCRYPTO + " UPDATE TO '" + pgcryptoAvailable + "';\n");
+                                System.out.println("\n  ALTER EXTENSION " + PostgresUtils.PGCRYPTO + " UPDATE TO '" + pgcryptoAvailable + "';\n");
                             }
                             else if(pgcryptoInstalled==null) // If it's not installed in database
                             {
-                                System.out.println("\nWARNING: PostgreSQL '" + PGCRYPTO + "' extension is NOT INSTALLED on this database.");
+                                System.out.println("\nWARNING: PostgreSQL '" + PostgresUtils.PGCRYPTO + "' extension is NOT INSTALLED on this database.");
                                 System.out.println(requirementsMsg);
                                 System.out.println("To install it, please connect to your DSpace database as a 'superuser' and manually run the following command: ");
-                                System.out.println("\n  CREATE EXTENSION " + PGCRYPTO + ";\n");
+                                System.out.println("\n  CREATE EXTENSION " + PostgresUtils.PGCRYPTO + ";\n");
                             }
                         }
                         // Check if installed in Postgres, but an unsupported version
-                        else if(pgcryptoAvailable!=null && pgcryptoAvailable.compareTo(PGCRYPTO_VERSION)<0)
+                        else if(pgcryptoAvailable!=null && pgcryptoAvailable.compareTo(PostgresUtils.PGCRYPTO_VERSION)<0)
                         {
-                            System.out.println("\nWARNING: UNSUPPORTED version of PostgreSQL '" + PGCRYPTO + "' extension found (version=" + pgcryptoAvailable + ").");
+                            System.out.println("\nWARNING: UNSUPPORTED version of PostgreSQL '" + PostgresUtils.PGCRYPTO + "' extension found (version=" + pgcryptoAvailable + ").");
                             System.out.println(requirementsMsg);
-                            System.out.println("Make sure you are running a supported version of PostgreSQL, and then install " + PGCRYPTO + " version >= " + PGCRYPTO_VERSION);
-                            System.out.println("The '" + PGCRYPTO + "' extension is often provided in the 'postgresql-contrib' package for your operating system.");
+                            System.out.println("Make sure you are running a supported version of PostgreSQL, and then install " + PostgresUtils.PGCRYPTO + " version >= " + PostgresUtils.PGCRYPTO_VERSION);
+                            System.out.println("The '" + PostgresUtils.PGCRYPTO + "' extension is often provided in the 'postgresql-contrib' package for your operating system.");
                         }
                         else if(pgcryptoAvailable==null) // If it's not installed in Postgres
                         {
-                            System.out.println("\nWARNING: PostgreSQL '" + PGCRYPTO + "' extension is NOT AVAILABLE. Please install it into this PostgreSQL instance.");
+                            System.out.println("\nWARNING: PostgreSQL '" + PostgresUtils.PGCRYPTO + "' extension is NOT AVAILABLE. Please install it into this PostgreSQL instance.");
                             System.out.println(requirementsMsg);
-                            System.out.println("The '" + PGCRYPTO + "' extension is often provided in the 'postgresql-contrib' package for your operating system.");
+                            System.out.println("The '" + PostgresUtils.PGCRYPTO + "' extension is often provided in the 'postgresql-contrib' package for your operating system.");
                             System.out.println("Once the extension is installed globally, please connect to your DSpace database as a 'superuser' and manually run the following command: ");
-                            System.out.println("\n  CREATE EXTENSION " + PGCRYPTO + ";\n");
+                            System.out.println("\n  CREATE EXTENSION " + PostgresUtils.PGCRYPTO + ";\n");
                         }
                     }
                 }
@@ -299,14 +294,14 @@ public class DatabaseUtils
                     if(dbType.equals(DBMS_POSTGRES))
                     {
                         // Check if database user has permissions suitable to run a clean
-                        if(!checkCleanPermissions(connection))
+                        if(!PostgresUtils.checkCleanPermissions(connection))
                         {
                             String username = connection.getMetaData().getUserName();
                             // Exit immediately, providing a descriptive error message
                             System.out.println("\nERROR: The database user '" + username + "' does not have sufficient privileges to run a 'database clean' (via Flyway).");
                             System.out.println("\nIn order to run a 'clean', the database user MUST have 'superuser' privileges");
-                            System.out.println("OR the '" + PGCRYPTO + "' extension must be installed in a separate schema (see documentation).");
-                            System.out.println("\nOptionally, you could also manually remove the '" + PGCRYPTO + "' extension first (DROP EXTENSION '" + PGCRYPTO + "' CASCADE), then rerun the 'clean'");
+                            System.out.println("OR the '" + PostgresUtils.PGCRYPTO + "' extension must be installed in a separate schema (see documentation).");
+                            System.out.println("\nOptionally, you could also manually remove the '" + PostgresUtils.PGCRYPTO + "' extension first (DROP EXTENSION '" + PostgresUtils.PGCRYPTO + "' CASCADE), then rerun the 'clean'");
                             System.exit(1);
                         }
                     }
@@ -322,7 +317,7 @@ public class DatabaseUtils
                     }
                     else if(dbType.equals(DBMS_POSTGRES))
                     {
-                        System.out.println("\nPOSTGRES WARNING: the '" + PGCRYPTO + "' extension will be dropped if it is in the same schema as the DSpace database.\n");
+                        System.out.println("\nPOSTGRES WARNING: the '" + PostgresUtils.PGCRYPTO + "' extension will be dropped if it is in the same schema as the DSpace database.\n");
                     }
                     System.out.print("Do you want to PERMANENTLY DELETE everything from your database? [y/n]: ");
                     String choiceString = input.readLine();
@@ -1287,7 +1282,7 @@ public class DatabaseUtils
      * which bypass Hibernate. Only Flyway should be allowed a direct connection.
      * @return DataSource
      */
-    private static DataSource getDataSource()
+    protected static DataSource getDataSource()
     {
         // DataSource is configured via our ServiceManager (i.e. via Spring).
         return new DSpace().getServiceManager().getServiceByName("dataSource", BasicDataSource.class);
@@ -1318,221 +1313,4 @@ public class DatabaseUtils
         }
         return null;
     }
-
-    /**
-     * Get version of pgcrypto extension available. The extension is "available"
-     * if it's been installed via operating system tools/packages. It also
-     * MUST be installed in the DSpace database (see getPgcryptoInstalled()).
-     * <P>
-     * The pgcrypto extension is required for Postgres databases
-     * * @param current database connection
-     * @return version number or null if not available
-     */
-    private static Double getPgcryptoAvailableVersion(Connection connection)
-    {
-        Double version = null;
-
-        String checkPgCryptoAvailable = "SELECT default_version AS version FROM pg_available_extensions WHERE name=?";
-
-        // Run the query to obtain the version of 'pgcrypto' available
-        try (PreparedStatement statement = connection.prepareStatement(checkPgCryptoAvailable))
-        {
-            statement.setString(1,PGCRYPTO);
-            try(ResultSet results = statement.executeQuery())
-            {
-                if(results.next())
-                {
-                    version = results.getDouble("version");
-                }
-            }
-        }
-        catch(SQLException e)
-        {
-            throw new FlywayException("Unable to determine whether 'pgcrypto' extension is available.", e);
-        }
-
-        return version;
-    }
-
-    /**
-     * Get version of pgcrypto extension installed in the DSpace database.
-     * <P>
-     * The pgcrypto extension is required for Postgres databases to support
-     * UUIDs.
-     * @param current database connection
-     * @return version number or null if not installed
-     */
-    private static Double getPgcryptoInstalledVersion(Connection connection)
-    {
-        Double version = null;
-
-        String checkPgCryptoInstalled = "SELECT extversion AS version FROM pg_extension WHERE extname=?";
-
-        // Run the query to obtain the version of 'pgcrypto' installed on this database
-        try (PreparedStatement statement = connection.prepareStatement(checkPgCryptoInstalled))
-        {
-            statement.setString(1,PGCRYPTO);
-            try(ResultSet results = statement.executeQuery())
-            {
-                if(results.next())
-                {
-                    version = results.getDouble("version");
-                }
-            }
-        }
-        catch(SQLException e)
-        {
-            throw new FlywayException("Unable to determine whether 'pgcrypto' extension is available.", e);
-        }
-
-        return version;
-    }
-
-    /**
-     * Check if the pgcrypto extension is BOTH installed AND up-to-date.
-     * <P>
-     * This requirement is only needed for PostgreSQL databases.
-     * It doesn't matter what schema pgcrypto is installed in, as long as it exists.
-     * @return true if everything is installed & up-to-date. False otherwise.
-     */
-    public static boolean isPgcryptoUpToDate()
-    {
-        // Get our configured dataSource
-        DataSource dataSource = getDataSource();
-
-        try(Connection connection = dataSource.getConnection())
-        {
-            Double pgcryptoInstalled = getPgcryptoInstalledVersion(connection);
-
-            // Check if installed & up-to-date in this DSpace database
-            if(pgcryptoInstalled!=null && pgcryptoInstalled.compareTo(PGCRYPTO_VERSION)>=0)
-            {
-                return true;
-            }
-
-            return false;
-        }
-        catch(SQLException e)
-        {
-            throw new FlywayException("Unable to determine whether 'pgcrypto' extension is up-to-date.", e);
-        }
-    }
-
-    /**
-     * Check if the pgcrypto extension is installed into a particular schema
-     * <P>
-     * This allows us to check if pgcrypto needs to be REMOVED prior to running
-     * a 'clean' on this database. If pgcrypto is in the same schema as the
-     * dspace database, a 'clean' will require removing pgcrypto FIRST.
-     *
-     * @param schema name of schema
-     * @return true if pgcrypto is in this schema. False otherwise.
-     */
-    public static boolean isPgcryptoInSchema(String schema)
-    {
-        // Get our configured dataSource
-        DataSource dataSource = getDataSource();
-
-        try(Connection connection = dataSource.getConnection())
-        {
-            // Check if pgcrypto is installed in the current database schema.
-            String pgcryptoInstalledInSchema = "SELECT extversion FROM pg_extension,pg_namespace " +
-                                                 "WHERE pg_extension.extnamespace=pg_namespace.oid " +
-                                                 "AND extname=? " +
-                                                 "AND nspname=?;";
-            Double pgcryptoVersion = null;
-            try (PreparedStatement statement = connection.prepareStatement(pgcryptoInstalledInSchema))
-            {
-                statement.setString(1,PGCRYPTO);
-                statement.setString(2, schema);
-                try(ResultSet results = statement.executeQuery())
-                {
-                    if(results.next())
-                    {
-                        pgcryptoVersion = results.getDouble("extversion");
-                    }
-                }
-            }
-
-            // If a pgcrypto version returns, it's installed in this schema
-            if(pgcryptoVersion!=null)
-                return true;
-            else
-                return false;
-        }
-        catch(SQLException e)
-        {
-            throw new FlywayException("Unable to determine whether 'pgcrypto' extension is installed in schema '" + schema + "'.", e);
-        }
-    }
-
-
-    /**
-     * Check if the current user has permissions to run a clean on existing
-     * database.
-     * <P>
-     * Mostly this just checks if you need to remove pgcrypto, and if so,
-     * whether you have permissions to do so.
-     *
-     * @param current database connection
-     * @return true if permissions valid, false otherwise
-     */
-    private static boolean checkCleanPermissions(Connection connection)
-    {
-        try
-        {
-            String dbType = getDbType(connection);
-           
-            // If we are using Postgres, special permissions or setup are
-            // necessary to be able to remove the 'pgcrypto' extension.
-            if(dbType.equals(DBMS_POSTGRES))
-            {
-                // get username of our db user
-                String username = connection.getMetaData().getUserName();
-
-                // Check their permissions. Are they a 'superuser'?
-                String checkSuperuser = "SELECT rolsuper FROM pg_roles WHERE rolname=?;";
-                boolean superuser = false;
-                try (PreparedStatement statement = connection.prepareStatement(checkSuperuser))
-                {
-                    statement.setString(1,username);
-                    try(ResultSet results = statement.executeQuery())
-                    {
-                        if(results.next())
-                        {
-                            superuser = results.getBoolean("rolsuper");
-                        }
-                    }
-                }
-                catch(SQLException e)
-                {
-                    throw new FlywayException("Unable to determine if user '" + username + "' is a superuser.", e);
-                }
-
-                // If user is a superuser, then "clean" can be run successfully
-                if(superuser)
-                {
-                    return true;
-                }
-                else // Otherwise, we'll need to see which schema 'pgcrypto' is installed in
-                {
-                    // Get current schema name
-                    String schema = getSchemaName(connection);
-
-                    // If pgcrypto is installed in this schema, then superuser privileges are needed to remove it
-                    if(isPgcryptoInSchema(schema))
-                        return false;
-                    else // otherwise, a 'clean' can be run by anyone
-                        return true;
-                }
-            }
-            else // for all other dbTypes, a clean is possible
-                return true;
-        }
-        catch(SQLException e)
-        {
-            throw new FlywayException("Unable to determine if DB user has 'clean' privileges.", e);
-        }
-    }
-
 }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/PostgreSQLCryptoChecker.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/PostgreSQLCryptoChecker.java
@@ -91,7 +91,7 @@ public class PostgreSQLCryptoChecker implements FlywayCallback
                     try(Statement statement = connection.createStatement())
                     {
                         // WARNING: ONLY superusers can remove pgcrypto. However, at this point,
-                        // we have already verified user acct permissions via DatabaseUtils.checkCleanPermissions()
+                        // we have already verified user acct permissions via PostgresUtils.checkCleanPermissions()
                         // (which is called prior to a 'clean' being triggered).
                         statement.execute("DROP EXTENSION " + PostgresUtils.PGCRYPTO + " CASCADE");
                     }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/PostgreSQLCryptoChecker.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/PostgreSQLCryptoChecker.java
@@ -1,0 +1,147 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.storage.rdbms;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import org.apache.log4j.Logger;
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.api.MigrationInfo;
+import org.flywaydb.core.api.callback.FlywayCallback;
+
+/**
+ * This is a FlywayCallback class which automatically verifies that "pgcrypto"
+ * is at the proper version before running any database migrations.
+ * <P>
+ * When running PostgreSQL, pgcrypto is REQUIRED by DSpace as it allows UUIDs
+ * to be generated.
+ * <P>
+ * During a database "clean", this also de-registers "pgcrypto" proir to the
+ * full database clean.
+ *
+ * @author Tim Donohue
+ */
+public class PostgreSQLCryptoChecker implements FlywayCallback
+{
+    private Logger log = Logger.getLogger(PostgreSQLCryptoChecker.class);
+
+    /**
+     * Check for pgcrypto (if needed). Throws an exception if pgcrypto is
+     * not installed or needs an upgrade.
+     * @param connection database connection
+     */
+    public void checkPgCrypto(Connection connection)
+    {
+        String dbType;
+        try
+        {
+            dbType = DatabaseUtils.getDbType(connection);
+        }
+        catch(SQLException se)
+        {
+            throw new FlywayException("Unable to determine database type.", se);
+        }
+
+        // ONLY Check if this is a PostgreSQL database
+        if(dbType!=null && dbType.equals(DatabaseUtils.DBMS_POSTGRES))
+        {
+            // If this is a PostgreSQL database, then a supported version
+            // of the 'pgcrypto' extension MUST be installed to continue.
+            
+            // Check if pgcrypto is both installed & a supported version
+            if(!DatabaseUtils.isPgcryptoUpToDate())
+            {
+                throw new FlywayException("This PostgreSQL Database is INCOMPATIBLE with DSpace. The upgrade will NOT proceed. " +
+                        "A supported version (>=" + DatabaseUtils.PGCRYPTO_VERSION + ") of the '" + DatabaseUtils.PGCRYPTO + "' extension must be installed! " +
+                        "Please run 'dspace database info' for additional info/tips.");
+            }
+        }
+    }
+
+    @Override
+    public void beforeClean(Connection connection) {
+   
+    }
+
+    @Override
+    public void afterClean(Connection connection) {
+
+    }
+
+    @Override
+    public void beforeMigrate(Connection connection) {
+        // Before migrating database, check for pgcrypto
+        checkPgCrypto(connection);
+    }
+
+    @Override
+    public void afterMigrate(Connection connection) {
+
+    }
+
+    @Override
+    public void beforeEachMigrate(Connection connection, MigrationInfo migrationInfo) {
+
+    }
+
+    @Override
+    public void afterEachMigrate(Connection connection, MigrationInfo migrationInfo) {
+
+    }
+
+    @Override
+    public void beforeValidate(Connection connection) {
+
+    }
+
+    @Override
+    public void afterValidate(Connection connection) {
+
+    }
+
+    @Override
+    public void beforeInit(Connection connection) {
+
+    }
+
+    @Override
+    public void afterInit(Connection connection) {
+
+    }
+
+    @Override
+    public void beforeBaseline(Connection connection) {
+        // Before initializing database, check for pgcrypto
+        checkPgCrypto(connection);
+    }
+
+    @Override
+    public void afterBaseline(Connection connection) {
+
+    }
+
+    @Override
+    public void beforeRepair(Connection connection) {
+
+    }
+
+    @Override
+    public void afterRepair(Connection connection) {
+
+    }
+
+    @Override
+    public void beforeInfo(Connection connection) {
+
+    }
+
+    @Override
+    public void afterInfo(Connection connection) {
+
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/PostgreSQLCryptoChecker.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/PostgreSQLCryptoChecker.java
@@ -55,10 +55,10 @@ public class PostgreSQLCryptoChecker implements FlywayCallback
             // of the 'pgcrypto' extension MUST be installed to continue.
             
             // Check if pgcrypto is both installed & a supported version
-            if(!DatabaseUtils.isPgcryptoUpToDate())
+            if(!PostgresUtils.isPgcryptoUpToDate())
             {
                 throw new FlywayException("This PostgreSQL Database is INCOMPATIBLE with DSpace. The upgrade will NOT proceed. " +
-                        "A supported version (>=" + DatabaseUtils.PGCRYPTO_VERSION + ") of the '" + DatabaseUtils.PGCRYPTO + "' extension must be installed! " +
+                        "A supported version (>=" + PostgresUtils.PGCRYPTO_VERSION + ") of the '" + PostgresUtils.PGCRYPTO + "' extension must be installed! " +
                         "Please run 'dspace database info' for additional info/tips.");
             }
         }
@@ -85,7 +85,7 @@ public class PostgreSQLCryptoChecker implements FlywayCallback
 
                 // Check if pgcrypto is in this schema
                 // If so, it MUST be removed before a 'clean'
-                if(DatabaseUtils.isPgcryptoInSchema(schema))
+                if(PostgresUtils.isPgcryptoInSchema(schema))
                 {
                     // remove the extension
                     try(Statement statement = connection.createStatement())
@@ -93,14 +93,14 @@ public class PostgreSQLCryptoChecker implements FlywayCallback
                         // WARNING: ONLY superusers can remove pgcrypto. However, at this point,
                         // we have already verified user acct permissions via DatabaseUtils.checkCleanPermissions()
                         // (which is called prior to a 'clean' being triggered).
-                        statement.execute("DROP EXTENSION " + DatabaseUtils.PGCRYPTO + " CASCADE");
+                        statement.execute("DROP EXTENSION " + PostgresUtils.PGCRYPTO + " CASCADE");
                     }
                 }
             }
         }
         catch(SQLException e)
         {
-            throw new FlywayException("Failed to check for and/or remove '" + DatabaseUtils.PGCRYPTO + "' extension", e);
+            throw new FlywayException("Failed to check for and/or remove '" + PostgresUtils.PGCRYPTO + "' extension", e);
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/PostgresUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/PostgresUtils.java
@@ -1,0 +1,239 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.storage.rdbms;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import static org.dspace.storage.rdbms.DatabaseUtils.getSchemaName;
+import org.flywaydb.core.api.FlywayException;
+
+/**
+ * Database utility class specific to Postgres.
+ * This class contains tools and methods which are useful in determining
+ * the status of a PostgreSQL database backend.  It's a companion class
+ * to DatabaseUtils, but PostgreSQL specific.
+ *
+ * @author Tim Donohue
+ */
+public class PostgresUtils
+{
+    // PostgreSQL pgcrypto extention name, and required versions of Postgres & pgcrypto
+    public static final String PGCRYPTO="pgcrypto";
+    public static final Double PGCRYPTO_VERSION=1.1;
+    public static final Double POSTGRES_VERSION=9.4;
+
+    /**
+     * Get version of pgcrypto extension available. The extension is "available"
+     * if it's been installed via operating system tools/packages. It also
+     * MUST be installed in the DSpace database (see getPgcryptoInstalled()).
+     * <P>
+     * The pgcrypto extension is required for Postgres databases
+     * @param connection database connection
+     * @return version number or null if not available
+     */
+    protected static Double getPgcryptoAvailableVersion(Connection connection)
+    {
+        Double version = null;
+
+        String checkPgCryptoAvailable = "SELECT default_version AS version FROM pg_available_extensions WHERE name=?";
+
+        // Run the query to obtain the version of 'pgcrypto' available
+        try (PreparedStatement statement = connection.prepareStatement(checkPgCryptoAvailable))
+        {
+            statement.setString(1,PGCRYPTO);
+            try(ResultSet results = statement.executeQuery())
+            {
+                if(results.next())
+                {
+                    version = results.getDouble("version");
+                }
+            }
+        }
+        catch(SQLException e)
+        {
+            throw new FlywayException("Unable to determine whether 'pgcrypto' extension is available.", e);
+        }
+
+        return version;
+    }
+
+    /**
+     * Get version of pgcrypto extension installed in the DSpace database.
+     * <P>
+     * The pgcrypto extension is required for Postgres databases to support
+     * UUIDs.
+     * @param connection database connection
+     * @return version number or null if not installed
+     */
+    protected static Double getPgcryptoInstalledVersion(Connection connection)
+    {
+        Double version = null;
+
+        String checkPgCryptoInstalled = "SELECT extversion AS version FROM pg_extension WHERE extname=?";
+
+        // Run the query to obtain the version of 'pgcrypto' installed on this database
+        try (PreparedStatement statement = connection.prepareStatement(checkPgCryptoInstalled))
+        {
+            statement.setString(1,PGCRYPTO);
+            try(ResultSet results = statement.executeQuery())
+            {
+                if(results.next())
+                {
+                    version = results.getDouble("version");
+                }
+            }
+        }
+        catch(SQLException e)
+        {
+            throw new FlywayException("Unable to determine whether 'pgcrypto' extension is available.", e);
+        }
+
+        return version;
+    }
+
+    /**
+     * Check if the pgcrypto extension is BOTH installed AND up-to-date.
+     * <P>
+     * This requirement is only needed for PostgreSQL databases.
+     * It doesn't matter what schema pgcrypto is installed in, as long as it exists.
+     * @return true if everything is installed & up-to-date. False otherwise.
+     */
+    public static boolean isPgcryptoUpToDate()
+    {
+        // Get our configured dataSource
+        DataSource dataSource = DatabaseUtils.getDataSource();
+
+        try(Connection connection = dataSource.getConnection())
+        {
+            Double pgcryptoInstalled = getPgcryptoInstalledVersion(connection);
+
+            // Check if installed & up-to-date in this DSpace database
+            if(pgcryptoInstalled!=null && pgcryptoInstalled.compareTo(PGCRYPTO_VERSION)>=0)
+            {
+                return true;
+            }
+
+            return false;
+        }
+        catch(SQLException e)
+        {
+            throw new FlywayException("Unable to determine whether 'pgcrypto' extension is up-to-date.", e);
+        }
+    }
+
+    /**
+     * Check if the pgcrypto extension is installed into a particular schema
+     * <P>
+     * This allows us to check if pgcrypto needs to be REMOVED prior to running
+     * a 'clean' on this database. If pgcrypto is in the same schema as the
+     * dspace database, a 'clean' will require removing pgcrypto FIRST.
+     *
+     * @param schema name of schema
+     * @return true if pgcrypto is in this schema. False otherwise.
+     */
+    public static boolean isPgcryptoInSchema(String schema)
+    {
+        // Get our configured dataSource
+        DataSource dataSource = DatabaseUtils.getDataSource();
+
+        try(Connection connection = dataSource.getConnection())
+        {
+            // Check if pgcrypto is installed in the current database schema.
+            String pgcryptoInstalledInSchema = "SELECT extversion FROM pg_extension,pg_namespace " +
+                                                 "WHERE pg_extension.extnamespace=pg_namespace.oid " +
+                                                 "AND extname=? " +
+                                                 "AND nspname=?;";
+            Double pgcryptoVersion = null;
+            try (PreparedStatement statement = connection.prepareStatement(pgcryptoInstalledInSchema))
+            {
+                statement.setString(1,PGCRYPTO);
+                statement.setString(2, schema);
+                try(ResultSet results = statement.executeQuery())
+                {
+                    if(results.next())
+                    {
+                        pgcryptoVersion = results.getDouble("extversion");
+                    }
+                }
+            }
+
+            // If a pgcrypto version returns, it's installed in this schema
+            if(pgcryptoVersion!=null)
+                return true;
+            else
+                return false;
+        }
+        catch(SQLException e)
+        {
+            throw new FlywayException("Unable to determine whether 'pgcrypto' extension is installed in schema '" + schema + "'.", e);
+        }
+    }
+
+
+    /**
+     * Check if the current user has permissions to run a clean on existing
+     * database.
+     * <P>
+     * Mostly this just checks if you need to remove pgcrypto, and if so,
+     * whether you have permissions to do so.
+     *
+     * @param connection database connection
+     * @return true if permissions valid, false otherwise
+     */
+    protected static boolean checkCleanPermissions(Connection connection)
+    {
+        try
+        {
+            // get username of our db user
+            String username = connection.getMetaData().getUserName();
+
+            // Check their permissions. Are they a 'superuser'?
+            String checkSuperuser = "SELECT rolsuper FROM pg_roles WHERE rolname=?;";
+            boolean superuser = false;
+            try (PreparedStatement statement = connection.prepareStatement(checkSuperuser))
+            {
+                statement.setString(1,username);
+                try(ResultSet results = statement.executeQuery())
+                {
+                    if(results.next())
+                    {
+                        superuser = results.getBoolean("rolsuper");
+                    }
+                }
+            }
+            catch(SQLException e)
+            {
+                throw new FlywayException("Unable to determine if user '" + username + "' is a superuser.", e);
+            }
+
+            // If user is a superuser, then "clean" can be run successfully
+            if(superuser)
+            {
+                return true;
+            }
+            else // Otherwise, we'll need to see which schema 'pgcrypto' is installed in
+            {
+                // Get current schema name
+                String schema = getSchemaName(connection);
+
+                // If pgcrypto is installed in this schema, then superuser privileges are needed to remove it
+                if(isPgcryptoInSchema(schema))
+                    return false;
+                else // otherwise, a 'clean' can be run by anyone
+                    return true;
+            }
+        }
+        catch(SQLException e)
+        {
+            throw new FlywayException("Unable to determine if DB user has 'clean' privileges.", e);
+        }
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/PostgresUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/PostgresUtils.java
@@ -93,7 +93,7 @@ public class PostgresUtils
         }
         catch(SQLException e)
         {
-            throw new FlywayException("Unable to determine whether 'pgcrypto' extension is available.", e);
+            throw new FlywayException("Unable to determine whether 'pgcrypto' extension is installed.", e);
         }
 
         return version;

--- a/dspace-api/src/main/resources/spring/spring-dspace-core-services.xml
+++ b/dspace-api/src/main/resources/spring/spring-dspace-core-services.xml
@@ -35,8 +35,10 @@
 
     <bean name="org.dspace.core.DBConnection" class="org.dspace.core.HibernateDBConnection" lazy-init="true"/>
 
+    <!-- Register all our Flyway callback classes (which run before/after database migrations) -->
     <bean class="org.dspace.storage.rdbms.DatabaseLegacyReindexer"/>
     <bean class="org.dspace.storage.rdbms.DatabaseRegistryUpdater"/>
     <bean class="org.dspace.storage.rdbms.GroupServiceInitializer"/>
+    <bean class="org.dspace.storage.rdbms.PostgreSQLCryptoChecker"/>
     <bean class="org.dspace.storage.rdbms.SiteServiceInitializer"/>
 </beans>

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -48,6 +48,13 @@ dspace.name = ${dspace.name}
 # Default language for metadata values
 default.language = ${default.language}
 
+##### Database settings #####
+# The DSpace database is now configured via Hibernate (http://hibernate.org)
+# All configurations related to the database have been moved to:
+#
+# * config/spring/api/core-hibernate.xml => Database connection settings
+# * config/hibernate.cfg.xml => Additional hibernate-specific settings
+
 ##### Email settings ######
 
 # SMTP mail server

--- a/dspace/pom.xml
+++ b/dspace/pom.xml
@@ -24,13 +24,6 @@
         <root.basedir>${basedir}/..</root.basedir>
     </properties>
 
-    <build>
-        <filters>
-            <!-- Filter using the properties file defined by dspace-parent POM -->
-            <filter>${filters.file}</filter>
-        </filters>
-    </build>
-
     <profiles>
 
         <!-- Build Profile. This builds all Overlay modules for DSpace -->   
@@ -78,6 +71,10 @@
                             <descriptors>
                                 <descriptor>src/main/assembly/assembly.xml</descriptor>
                             </descriptors>
+                            <filters>
+                                <!-- Filter using the properties file defined by dspace-parent POM -->
+                                <filter>${filters.file}</filter>
+                            </filters>
                         </configuration>
                         <executions>
                             <execution>

--- a/dspace/src/main/assembly/assembly.xml
+++ b/dspace/src/main/assembly/assembly.xml
@@ -43,55 +43,27 @@
          </excludes>
       </fileSet>
       <!-- Copy necessary subdirectories to resulting directory -->
+      <!-- First, copy over our configurations -->
       <fileSet>
-         <outputDirectory>.</outputDirectory>
-         <includes>
-            <include>bin/**</include>
-            <include>config/**</include>
-            <include>docs/**</include>
-            <include>etc/**</include>
-            <include>solr/**</include>
-         </includes>
-         <!-- Exclude source code & configs (we'll copy configs below) -->
-         <excludes>
-            <exclude>src</exclude>
-            <exclude>config/dspace.cfg</exclude>
-            <exclude>config/hibernate.cfg.xml</exclude>
-            <exclude>config/log4j.properties</exclude>
-            <exclude>config/modules/**</exclude>
-            <exclude>config/spring/**</exclude>
-         </excludes>
-      </fileSet>
-      <!-- Copy over all module configs & filter them -->
-      <fileSet>
-         <outputDirectory>.</outputDirectory>
-         <includes>
-            <include>config/modules/**</include>
-            <include>config/spring/**</include>
-            <include>config/hibernate.cfg.xml</include>
-         </includes>
+         <directory>config</directory>
+         <outputDirectory>config</outputDirectory>
+         <!-- Filter all config files -->
          <filtered>true</filtered>
+      </fileSet>
+      <!-- Then, copy over all other necessary directories -->
+      <fileSet>
+         <directory>bin</directory>
+         <outputDirectory>bin</outputDirectory>
+      </fileSet>
+      <fileSet>
+         <directory>etc</directory>
+         <outputDirectory>etc</outputDirectory>
+      </fileSet>
+      <fileSet>
+         <directory>solr</directory>
+         <outputDirectory>solr</outputDirectory>
       </fileSet>
    </fileSets>
-
-   <!-- Copy over the dspace.cfg and log4j.properties files & filter them -->
-   <files>
-      <file>
-         <source>config/dspace.cfg</source>
-         <outputDirectory>config</outputDirectory>
-         <filtered>true</filtered>
-      </file>
-      <file>
-         <source>config/log4j.properties</source>
-         <outputDirectory>config</outputDirectory>
-         <filtered>true</filtered>
-      </file>
-      <file>
-         <source>config/crosswalks/oai/description.xml</source>
-         <outputDirectory>config</outputDirectory>
-         <filtered>true</filtered>
-      </file>
-   </files>
 
    <!--
    Copy ALL JAR dependencies specified in [src]/dspace/pom.xml

--- a/src/main/filters/testEnvironment.properties
+++ b/src/main/filters/testEnvironment.properties
@@ -46,10 +46,8 @@ default.language = en_US
 # For Unit Testing we use the H2 (in memory) database
 db.driver = org.h2.Driver
 db.dialect=org.hibernate.dialect.H2Dialect
-# Use H2 running in "Oracle mode"
 # Use a 10 second database lock timeout to avoid occasional JDBC lock timeout errors
-db.url = jdbc:h2:mem:test;LOCK_TIMEOUT=10000;MVCC=true
-#db.url = jdbc:h2:mem:test;MODE=Oracle;LOCK_TIMEOUT=10000
+db.url = jdbc:h2:mem:test;LOCK_TIMEOUT=10000;
 db.username = sa
 db.password =
 # H2 doesn't use schemas


### PR DESCRIPTION
This PR provides some enhancements and a minor bug fix to the Services API branch. It also provides tools/fixes for DS-2716, because it automatically checks to see if 'pgcrypto' is installed and up-to-date, and provides reporting tools that let you know how to properly install 'pgcrypto'.

https://jira.duraspace.org/browse/DS-2716
- General code cleanup in DatabaseUtils and AbstractUnitTest (see https://github.com/DSpace/DSpace/commit/84f67cd771ef9df6dcd5b9ca036acfd8e4cdb19e)
- Remove unnecessary MVCC setting for H2 (see also #582) (see https://github.com/DSpace/DSpace/commit/1de42c9b21d60b74d233c4b0e081d607177d8891)
- Fix a bug where 'dspace-installer' wasn't being built properly. Occurred after upgrading maven-assembly-plugin to latest version (see https://github.com/DSpace/DSpace/commit/3c45c0d5542aaa5b0c46d93f2f0c3e0b3b8484ac)
- Leave a comment in dspace.cfg about where DB settings are found now (see https://github.com/DSpace/DSpace/commit/e73c7b47fed58d34ae98decd0f897d1b8804316d)
- For PostgreSQL databases, automatically check that 'pgcrypto' extension is installed AND version >= 1.1. If pgcrypto is NOT up-to-date, the 'migrate' will refuse to run and will report that the database is incompatible (see `PostgreSQLCryptoChecker` and new methods in `DatabaseUtils`).  Also provide new checks/reports in the `dspace database info` command to tell you whether `pgcrypto` needs installed, updated, etc.  (see https://github.com/DSpace/DSpace/commit/0a9aead126a5d4cbf6d1d2acf8f1002ee02a6037)
- For PostgreSQL databases, check to see if a "clean" will succeed (requires special permissions based on how pgcrypto was installed). If "clean" will fail, throw a useful error message. If "clean" will likely work, run it (after auto-removing pgcrypto if needed).  (see https://github.com/DSpace/DSpace/commit/0b873f5e62d5ae7682e67165b12def4f0457e3f8)

I've tested all these locally. I've also done some thorough testing of the 'pgcrypto' checks in all the following scenarios:
- New, empty database, pgcrypto not installed
- New, empty database, pgcrypto installed but wrong version
- New, empty database, pgcrypto installed but not enabled on this DB
- Old 5.x database, pgcrypto not installed
- Old 5.x database, pgcrypto installed but wrong version
- Old 5.x database, pgcrypto installed but not enabled on this DB

The majority of these changes are about providing more useful error messages from the "./dspace database" scripts (and fixing one assembly bug). I've done some thorough testing, but I'd appreciate a review from others.
