### PR TITLE
Minor bug fix to fresh_install. 

### DIFF
--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -865,7 +865,7 @@ Common usage:
     <!-- ============================================================= -->
 
     <target name="fresh_install"
-            depends="init_installation,init_configs,test_database,migrate_database,install_code"
+            depends="init_installation,init_configs,test_database,install_code,migrate_database"
             description="Do a fresh install of the system, overwriting any data">
 
         <delete failonerror="no">


### PR DESCRIPTION
Ant target ordering is wrong, so fresh_install fails.

The "install_code" target MUST be before "migrate_database", as Flyway attempts to check [dspace]/etc/postgres/ for any additional (custom) SQL migrations. That directory doesn't exist until "install_code" runs.

This was encountered by @hardyoyo, and has been tested/verified by both Hardy & I.
