### PR TITLE
[DS-2778] Properly configure BasicDataSource pool

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -75,8 +75,11 @@ db.schema = public
 # Maximum number of DB connections in pool
 db.maxconnections = 30
 
-# Determine the number of statements that can be cached (set to 0 to disable caching)
-db.statementpool.cache = 50
+# Maximum time to wait before giving up if all connections in pool are busy (milliseconds)
+db.maxwait = 5000
+
+# Maximum number of idle connections in pool (-1 = unlimited)
+db.maxidle = -1
 
 
 #######################

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -307,10 +307,6 @@
         	<artifactId>hibernate-ehcache</artifactId>
         </dependency>
         <dependency>
-      			<groupId>org.hibernate</groupId>
-      			<artifactId>hibernate-c3p0</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-orm</artifactId>
         </dependency>

--- a/dspace-api/src/test/data/dspaceFolder/config/hibernate.cfg.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/hibernate.cfg.xml
@@ -31,15 +31,6 @@
 
 
 
-        <!--Connection pool parameters -->
-        <!-- Maximum number of DB connections in pool -->
-        <property name="hibernate.c3p0.max_size">${db.maxconnections}</property>
-        <!-- Determine the number of statements to be cached. -->
-        <property name="hibernate.c3p0.max_statements">${db.statementpool.cache}</property>
-
-
-
-
 
         <!--Debug property that can be used to display the sql-->
         <property name="show_sql">false</property>

--- a/dspace/config/hibernate.cfg.xml
+++ b/dspace/config/hibernate.cfg.xml
@@ -26,15 +26,6 @@
 
 
 
-        <!--Connection pool parameters -->
-        <!-- Maximum number of DB connections in pool -->
-        <property name="hibernate.c3p0.max_size">${db.maxconnections}</property>
-        <!-- Determine the number of statements to be cached. -->
-        <property name="hibernate.c3p0.max_statements">${db.statementpool.cache}</property>
-
-
-
-
 
         <!--Debug property that can be used to display the sql-->
         <property name="show_sql">false</property>

--- a/dspace/config/spring/api/core-hibernate.xml
+++ b/dspace/config/spring/api/core-hibernate.xml
@@ -13,6 +13,8 @@
         <property name="url" value="${db.url}"/>
         <property name="username" value="${db.username}"/>
         <property name="password" value="${db.password}"/>
+        <property name="maxWaitMillis" value="${db.maxwait}"/>
+        <property name="maxIdle" value="${db.maxidle}"/>
     </bean>
 
 </beans>

--- a/pom.xml
+++ b/pom.xml
@@ -843,12 +843,6 @@
           	<artifactId>hibernate-ehcache</artifactId>
           	<version>${hibernate.version}</version>
           </dependency>
-          <dependency>
-             <groupId>org.hibernate</groupId>
-             <artifactId>hibernate-c3p0</artifactId>
-             <version>${hibernate.version}</version>
-          </dependency>
-
 
           <dependency>
               <groupId>org.springframework</groupId>

--- a/src/main/filters/testEnvironment.properties
+++ b/src/main/filters/testEnvironment.properties
@@ -53,11 +53,11 @@ db.password =
 # H2 doesn't use schemas
 db.schema =
 
-# Maximum number of DB connections in pool
-db.maxconnections = 30
+# Maximum time to wait before giving up if all connections in pool are busy (milliseconds)
+db.maxwait = 5000
 
-# Determine the number of statements that can be cached (set to 0 to disable caching)
-db.statementpool.cache = 50
+# Maximum number of idle connections in pool (-1 = unlimited)
+db.maxidle = -1
 
 #######################
 # EMAIL CONFIGURATION #


### PR DESCRIPTION
Removes the c3p0 config & dependency & configures the data source as before the hibernate change.
