### PR TITLE
[DS-2779] Fix versioning due to service api

### DIFF
--- a/dspace-api/src/main/java/org/dspace/eperson/SupervisorServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/SupervisorServiceImpl.java
@@ -57,6 +57,7 @@ public class SupervisorServiceImpl implements SupervisorService{
         // make a table row in the database table, and update with the relevant
         // details
         workspaceItem.getSupervisorGroups().add(group);
+        group.getSupervisedItems().add(workspaceItem);
 
         // If a default policy type has been requested, apply the policies using
         // the DSpace API for doing so

--- a/dspace-api/src/main/java/org/dspace/handle/Handle.java
+++ b/dspace-api/src/main/java/org/dspace/handle/Handle.java
@@ -29,7 +29,7 @@ public class Handle {
     @Column(name = "handle", unique = true)
     private String handle;
 
-    @OneToOne(fetch =  FetchType.EAGER)
+    @ManyToOne(fetch =  FetchType.EAGER)
     @JoinColumn(name = "resource_id")
     private DSpaceObject dso;
 

--- a/dspace-api/src/main/java/org/dspace/handle/HandleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/handle/HandleServiceImpl.java
@@ -137,7 +137,7 @@ public class HandleServiceImpl implements HandleService
 
         handle.setHandle(handleId);
         handle.setDSpaceObject(dso);
-        dso.setHandle(handle);
+        dso.addHandle(handle);
         handle.setResourceTypeId(dso.getType());
         handleDAO.save(context, handle);
 
@@ -201,7 +201,7 @@ public class HandleServiceImpl implements HandleService
 
         handle.setResourceTypeId(dso.getType());
         handle.setDSpaceObject(dso);
-        dso.setHandle(handle);
+        dso.addHandle(handle);
         handleDAO.save(context, handle);
 
         if (log.isDebugEnabled())

--- a/dspace-api/src/main/java/org/dspace/handle/HandleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/handle/HandleServiceImpl.java
@@ -326,8 +326,12 @@ public class HandleServiceImpl implements HandleService
         Handle dbHandle = findHandleInternal(context, handle);
         if(dbHandle != null)
         {
+            //Remove the old handle from the current handle list
+            dbHandle.getDSpaceObject().getHandles().remove(dbHandle);
+            //Transfer the current handle to the new object
             dbHandle.setDSpaceObject(newOwner);
             dbHandle.setResourceTypeId(newOwner.getType());
+            newOwner.getHandles().add(0, dbHandle);
             handleDAO.save(context, dbHandle);
         }
 

--- a/dspace-api/src/main/java/org/dspace/handle/HandleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/handle/HandleServiceImpl.java
@@ -326,9 +326,14 @@ public class HandleServiceImpl implements HandleService
         Handle dbHandle = findHandleInternal(context, handle);
         if(dbHandle != null)
         {
-            //Remove the old handle from the current handle list
-            dbHandle.getDSpaceObject().getHandles().remove(dbHandle);
-            //Transfer the current handle to the new object
+            // Check if we have to remove the handle from the current handle list
+            // or if object is alreday deleted.
+            if (dbHandle.getDSpaceObject() != null)
+            {
+                // Remove the old handle from the current handle list
+                dbHandle.getDSpaceObject().getHandles().remove(dbHandle);
+            }
+            // Transfer the current handle to the new object
             dbHandle.setDSpaceObject(newOwner);
             dbHandle.setResourceTypeId(newOwner.getType());
             newOwner.getHandles().add(0, dbHandle);

--- a/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
@@ -134,7 +134,7 @@ public class HandleIdentifierProvider extends IdentifierProvider {
         }
 
         try{
-            return handleService.createHandle(context, dso, null);
+            return handleService.createHandle(context, dso);
         }catch (Exception e){
             log.error(LogManager.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
             throw new RuntimeException("Error while attempting to create identifier for Item id: " + dso.getID());

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
@@ -111,7 +111,14 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
                     Version previous = versionHistoryService.getPrevious(history, version);
                     if (versionHistoryService.isFirstVersion(history, previous))
                     {
-                        modifyHandleMetadata(context, previous.getItem(), (canonical + DOT + 1));
+                        try{
+                            //If we have a reviewer he/she might not have the rights to edit the metadata of this item, so temporarly grant them.
+                            context.turnOffAuthorisationSystem();
+                            modifyHandleMetadata(context, previous.getItem(), (canonical + DOT + 1));
+                        }finally {
+                            context.restoreAuthSystemState();
+                        }
+
                     }
                     // Check if our previous item hasn't got a handle anymore.
                     // This only occurs when a switch has been made from the standard handle identifier provider

--- a/dspace-api/src/main/java/org/dspace/versioning/AbstractVersionProvider.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/AbstractVersionProvider.java
@@ -101,7 +101,7 @@ public abstract class AbstractVersionProvider {
     }
 
 
-    protected Bitstream createBitstream(Context context, Bitstream nativeBitstream) throws AuthorizeException, SQLException, IOException {
+    protected Bitstream  createBitstream(Context context, Bitstream nativeBitstream) throws AuthorizeException, SQLException, IOException {
         Bitstream newBitstream = bitstreamStorageService.clone(context, nativeBitstream);
 	    List<MetadataValue> bitstreamMeta = bitstreamService.getMetadata(nativeBitstream, Item.ANY, Item.ANY, Item.ANY, Item.ANY);
 	    for (MetadataValue value : bitstreamMeta) {

--- a/dspace-api/src/main/java/org/dspace/versioning/VersioningServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/VersioningServiceImpl.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Required;
 import java.sql.SQLException;
 import java.util.Date;
 import java.util.List;
+import org.apache.log4j.Logger;
 
 /**
  *
@@ -95,7 +96,9 @@ public class VersioningServiceImpl implements VersioningService {
             //Delete the item linked to the version
             Item item = version.getItem();
             // Completely delete the item
-            itemService.delete(c, item);
+            if (item != null) {
+                itemService.delete(c, item);
+            }
         }catch (Exception e) {
             c.abort();
             throw new RuntimeException(e.getMessage(), e);
@@ -171,10 +174,10 @@ public class VersioningServiceImpl implements VersioningService {
 
     protected int getNextVersionNumer(Version latest){
         if(latest==null) return 1;
-
+        
         return latest.getVersionNumber()+1;
-    }
-
+        }
+        
     @Required
     public void setProvider(DefaultItemVersionProvider provider) {
         this.provider = provider;

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/components/VersioningItemHome.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/components/VersioningItemHome.java
@@ -93,7 +93,7 @@ public class VersioningItemHome implements ItemHomeProcessor {
 
 			if (latestVersion != null) {
 				if (latestVersion != null && latestVersion.getItem() != null
-						&& latestVersion.getItem().getID().equals(item.getID())) {
+						&& !latestVersion.getItem().getID().equals(item.getID())) {
 					// We have a newer version
 					Item latestVersionItem = latestVersion.getItem();
 					if (latestVersionItem.isArchived()) {

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EditItemServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EditItemServlet.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -255,11 +256,13 @@ public class EditItemServlet extends DSpaceServlet
             // Delete the item - if "cancel" was pressed this would be
             // picked up above
             // FIXME: Don't know if this does all it should - remove Handle?
-            List<Collection> collections = item.getCollections();
-
+            Iterator<Collection> collIter = item.getCollections().iterator();
+            
             // Remove item from all the collections it's in
-            for (Collection c : collections)
+            while(collIter.hasNext())
             {
+                Collection c = collIter.next();
+                collIter.remove();
                 collectionService.removeItem(context, c, item);
             }
 

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/versioning/VersionHistoryForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/versioning/VersionHistoryForm.java
@@ -64,7 +64,7 @@ public class VersionHistoryForm extends AbstractDSpaceTransformer {
 
     public void addBody(Body body) throws WingException, SQLException, AuthorizeException
     {
-        boolean isItemView=parameters.getParameterAsInteger("itemID",-1) == -1;
+        boolean isItemView=parameters.getParameter("itemID",null) == null;
         Item item = getItem();
 
         if(item==null || !authorizeService.isAdmin(this.context, item.getOwningCollection()))
@@ -106,7 +106,7 @@ public class VersionHistoryForm extends AbstractDSpaceTransformer {
     {
         try
         {
-            if(parameters.getParameterAsInteger("itemID",-1) == -1)
+            if(parameters.getParameter("itemID",null) == null)
             {
                 DSpaceObject dso;
                 dso = HandleUtil.obtainHandle(objectModel);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/versioning/VersionNoticeTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/versioning/VersionNoticeTransformer.java
@@ -88,7 +88,7 @@ public class VersionNoticeTransformer extends AbstractDSpaceTransformer {
 
         if(history != null){
             Version latestVersion = retrieveLatestVersion(history, item);
-            if(latestVersion != null && latestVersion.getItem().equals(item))
+            if(latestVersion != null && !latestVersion.getItem().equals(item))
             {
                 //We have a newer version
                 Item latestVersionItem = latestVersion.getItem();

--- a/dspace-xmlui/src/main/resources/aspects/Versioning/versioning.js
+++ b/dspace-xmlui/src/main/resources/aspects/Versioning/versioning.js
@@ -8,6 +8,7 @@
 
 importClass(Packages.java.lang.Class);
 importClass(Packages.java.lang.ClassLoader);
+importClass(Packages.java.util.UUID)
 
 importClass(Packages.org.dspace.app.xmlui.utils.FlowscriptUtils);
 
@@ -16,11 +17,9 @@ importClass(Packages.org.dspace.app.xmlui.aspect.administrative.FlowResult);
 importClass(Packages.org.apache.cocoon.environment.http.HttpEnvironment);
 importClass(Packages.org.apache.cocoon.servlet.multipart.Part);
 importClass(Packages.org.dspace.content.Item);
+importClass(Packages.org.dspace.content.factory.ContentServiceFactory)
 
-importClass(Packages.org.dspace.handle.HandleManager);
 importClass(Packages.org.dspace.core.Constants);
-importClass(Packages.org.dspace.authorize.AuthorizeManager);
-importClass(Packages.org.dspace.license.CreativeCommons);
 
 importClass(Packages.org.dspace.app.xmlui.utils.ContextUtil);
 importClass(Packages.org.dspace.app.xmlui.cocoon.HttpServletRequestCocoonWrapper);
@@ -42,6 +41,12 @@ function getObjectModel()
 {
   return FlowscriptUtils.getObjectModel(cocoon);
 }
+
+function getItemService()
+{
+    return ContentServiceFactory.getInstance().getItemService();
+}
+
 
 /**
  * Return the DSpace context for this request since each HTTP request generates
@@ -87,7 +92,7 @@ function getHttpResponse()
  * Start editing an individual item.
  */
 function startCreateNewVersionItem(){
-	var itemID = cocoon.request.get("itemID");
+	var itemID = UUID.fromString((cocoon.request.get("itemID")));
 
 	assertEditItem(itemID);
 
@@ -96,7 +101,7 @@ function startCreateNewVersionItem(){
         result = doCreateNewVersion(itemID, result);
     }while(result!=null);
 
-	var item = Item.find(getDSContext(),itemID);
+	var item = getItemService().find(getDSContext(),itemID);
 
     //Send us back to the item page if we cancel !
     cocoon.redirectTo(cocoon.request.getContextPath() + "/handle/" + item.getHandle(), true);
@@ -139,7 +144,7 @@ function doCreateNewVersion(itemID, result){
  * Start editing an individual item.
  */
 function startVersionHistoryItem(){
-	var itemID = cocoon.request.get("itemID");
+	var itemID = UUID.fromString((cocoon.request.get("itemID")));
 
 	assertEditItem(itemID);
 
@@ -158,7 +163,7 @@ function doVersionHistoryItem(itemID, result){
 
         if (cocoon.request.get("submit_cancel")){
             //Pressed the cancel button, redirect us to the item page
-            var item = Item.find(getDSContext(),itemID);
+            var item = getItemService().find(getDSContext(),itemID);
 
            	cocoon.redirectTo(cocoon.request.getContextPath()+"/handle/"+item.getHandle(),true);
            	getDSContext().complete();
@@ -183,13 +188,13 @@ function doVersionHistoryItem(itemID, result){
 		}
         else if (cocoon.request.get("submit_restore") && cocoon.request.get("versionID")){
 		    var versionID = cocoon.request.get("versionID");
-            itemID = cocoon.request.get("itemID");
+            itemID = UUID.fromString(cocoon.request.get("itemID"));
 
 		    result = doRestoreVersion(itemID, versionID);
 		}
         else if (cocoon.request.get("submit_update") && cocoon.request.get("versionID")){
 		    var versionID = cocoon.request.get("versionID");
-            itemID = cocoon.request.get("itemID");
+            itemID = UUID.fromString((cocoon.request.get("itemID")));
 		    result = doUpdateVersion(itemID, versionID);
 		}
 	} while (true)

--- a/dspace/config/spring/api/versioning-service.xml
+++ b/dspace/config/spring/api/versioning-service.xml
@@ -19,7 +19,7 @@
          Default Item Versioning Provider, defines behavior for replicating
          Item, Metadata, Bundles and Bitstreams. Autowired at this time.
      -->
-    <bean id="org.dspace.versioning.VersioningService"
+    <bean id="org.dspace.versioning.service.VersioningService"
           class="org.dspace.versioning.VersioningServiceImpl"
           autowire="byType"
           scope="singleton">
@@ -36,7 +36,7 @@
                
            </bean>
        </property>
- 
+
     </bean>
-    
+
 </beans>


### PR DESCRIPTION
This pull request has one controversial change in it, it makes the DSpaceObject, Handle relation a OneToMany.

If versioning is enabled a single item can have multiple handles. I have kept the getHandle() method on DSpaceObject for now since it has over 600 usages.
The getHandle() will always attempt to return the non versioned handle, if ever required a getHandles() method is also available. 
