### PR TITLE
DS-2783: edit discovery messages

### DIFF
--- a/dspace-xmlui/src/main/resources/aspects/Discovery/i18n/messages.xml
+++ b/dspace-xmlui/src/main/resources/aspects/Discovery/i18n/messages.xml
@@ -21,6 +21,13 @@
 		2) Some general keys which are specific to a particular aspect
 		   may be found at xmlui.<Aspect> without specifiying a
 		   particular java class.
+
+		Advanced Search related keys
+		Filter name:               xmlui.ArtifactBrowser.SimpleSearch.filter.author
+		Facet heading:             xmlui.ArtifactBrowser.AdvancedSearch.type_author
+		"Filter by" page heading:  xmlui.Discovery.AbstractSearch.type_author
+		
+		To overlay this file, copy it to [dspace-source]/dspace/modules/xmlui/src/main/resources/aspects/Discovery/i18n/messages.xml.
 		-->
 
 

--- a/dspace-xmlui/src/main/resources/aspects/Discovery/i18n/messages.xml
+++ b/dspace-xmlui/src/main/resources/aspects/Discovery/i18n/messages.xml
@@ -38,7 +38,7 @@
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dateIssued">Date Issued</message>
 
 
-    <!-- Site Leve Recently Added Content -->
+    <!-- Site Level Recently Added Content -->
     <message key="xmlui.ArtifactBrowser.SiteViewer.head_recent_submissions">Recently Added</message>
 
     <message key="xmlui.ArtifactBrowser.AbstractRecentSubmissionTransformer.recent_submissions_more">View more</message>
@@ -86,11 +86,8 @@
     <message key="xmlui.ArtifactBrowser.AbstractSearch.type_department_browse">Browsing by: Department</message>
     <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dateissued_dt_browse">Browsing by: Issue date</message>
 
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author">Author</message>
     <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.title">Title</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject">Subject</message>
     <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued">Date issued</message>
-
 
 
     <message key="xmlui.dri2xhtml.structural.pagination-info.nototal">Now showing items {0}-{1}</message>


### PR DESCRIPTION
The first commit in this branch removes two duplicate key definitions and fixes a typo.

The second commit add brief instructions to make it easier for users to customize the Advanced Search.
