### PR TITLE
DS-2366 : Correctly filter web.xml using filteringDeploymentDescriptors

### DIFF
--- a/dspace-jspui/pom.xml
+++ b/dspace-jspui/pom.xml
@@ -36,15 +36,8 @@
                     <!-- In version 2.1-alpha-1, this was incorrectly named warSourceExcludes -->
                     <packagingExcludes>WEB-INF/lib/*.jar</packagingExcludes>
                     <warSourceExcludes>WEB-INF/lib/*.jar</warSourceExcludes>
-                    <webResources>
-                        <resource>
-                            <filtering>true</filtering>
-                            <directory>${basedir}/src/main/webapp</directory>
-                            <includes>
-                                <include>WEB-INF/web.xml</include>
-                            </includes>
-                        </resource>
-                    </webResources>
+                    <!-- Filter the web.xml -->
+                    <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
                 </configuration>
                 <executions>
                     <execution>
@@ -137,7 +130,6 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.2.1</version>
             <type>jar</type>
         </dependency>
 		<dependency>

--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -34,15 +34,8 @@
                     <!-- In version 2.1-alpha-1, this was incorrectly named warSourceExcludes -->
                     <packagingExcludes>WEB-INF/lib/*.jar</packagingExcludes>
                     <warSourceExcludes>WEB-INF/lib/*.jar</warSourceExcludes>
-                    <webResources>
-                        <resource>
-                            <filtering>true</filtering>
-                            <directory>${basedir}/src/main/webapp</directory>
-                            <includes>
-                                <include>WEB-INF/web.xml</include>
-                            </includes>
-                        </resource>
-                    </webResources>
+                    <!-- Filter the web.xml -->
+                    <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
                 </configuration>
                 <executions>
                     <execution>

--- a/dspace-rest/pom.xml
+++ b/dspace-rest/pom.xml
@@ -26,6 +26,8 @@
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
                     <attachClasses>true</attachClasses>
+                    <!-- Filter the web.xml -->
+                    <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
                 </configuration>
             </plugin>
         </plugins>

--- a/dspace-solr/pom.xml
+++ b/dspace-solr/pom.xml
@@ -63,15 +63,8 @@
                             </excludes>
                         </overlay>
                     </overlays>
-                    <webResources>
-                        <resource>
-                            <filtering>true</filtering>
-                            <directory>${basedir}/src/main/webapp</directory>
-                            <includes>
-                                <include>WEB-INF/web.xml</include>
-                            </includes>
-                        </resource>
-                    </webResources>
+                    <!-- Filter the web.xml -->
+                    <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
                 </configuration>
                 <executions>
                     <execution>
@@ -251,25 +244,21 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.6.1</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <artifactId>log4j</artifactId>
             <groupId>log4j</groupId>
             <type>jar</type>
-            <version>1.2.16</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
-            <version>2.5</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.1.1</version>
          </dependency>
     </dependencies>
 

--- a/dspace-sword/pom.xml
+++ b/dspace-sword/pom.xml
@@ -38,15 +38,8 @@
                     <!-- In version 2.1-alpha-1, this was incorrectly named warSourceExcludes -->
                     <packagingExcludes>WEB-INF/lib/*.jar</packagingExcludes>
                     <warSourceExcludes>WEB-INF/lib/*.jar</warSourceExcludes>
-                    <webResources>
-                        <resource>
-                            <filtering>true</filtering>
-                            <directory>${basedir}/src/main/webapp</directory>
-                            <includes>
-                                <include>WEB-INF/web.xml</include>
-                            </includes>
-                        </resource>
-                    </webResources>
+                    <!-- Filter the web.xml -->
+                    <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
                 </configuration>
                 <executions>
                     <execution>

--- a/dspace-swordv2/pom.xml
+++ b/dspace-swordv2/pom.xml
@@ -36,15 +36,8 @@
                     <!-- In version 2.1-alpha-1, this was incorrectly named warSourceExcludes -->
                     <packagingExcludes>WEB-INF/lib/*.jar</packagingExcludes>
                     <warSourceExcludes>WEB-INF/lib/*.jar</warSourceExcludes>
-                    <webResources>
-                        <resource>
-                            <filtering>true</filtering>
-                            <directory>${basedir}/src/main/webapp</directory>
-                            <includes>
-                                <include>WEB-INF/web.xml</include>
-                            </includes>
-                        </resource>
-                    </webResources>
+                    <!-- Filter the web.xml -->
+                    <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
                 </configuration>
                 <executions>
                     <execution>

--- a/dspace-xmlui/pom.xml
+++ b/dspace-xmlui/pom.xml
@@ -34,15 +34,8 @@
                     <!-- In version 2.1-alpha-1, this was incorrectly named warSourceExcludes -->
                     <packagingExcludes>WEB-INF/lib/*.jar</packagingExcludes>
                     <warSourceExcludes>WEB-INF/lib/*.jar</warSourceExcludes>
-                    <webResources>
-                        <resource>
-                            <filtering>true</filtering>
-                            <directory>${basedir}/src/main/webapp</directory>
-                            <includes>
-                                <include>WEB-INF/web.xml</include>
-                            </includes>
-                        </resource>
-                    </webResources>
+                    <!-- Filter the web.xml -->
+                    <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
                 </configuration>
                 <executions>
                     <execution>

--- a/dspace/modules/jspui/pom.xml
+++ b/dspace/modules/jspui/pom.xml
@@ -50,17 +50,8 @@
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
                     <archiveClasses>false</archiveClasses>
-                    <webResources>
-                        <resource>
-                            <filtering>true</filtering>
-                            <directory>
-                                ${basedir}/src/main/webapp
-                            </directory>
-                            <includes>
-                                <include>WEB-INF/web.xml</include>
-                            </includes>
-                        </resource>
-                    </webResources>
+                     <!-- Filter the web.xml -->
+                    <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
                     <overlays>
                         <overlay />
                         <overlay>

--- a/dspace/modules/oai/pom.xml
+++ b/dspace/modules/oai/pom.xml
@@ -32,15 +32,8 @@
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
                     <archiveClasses>false</archiveClasses>
-                    <webResources>
-                        <resource>
-                            <filtering>true</filtering>
-                            <directory>${basedir}/src/main/webapp</directory>
-                            <includes>
-                                    <include>WEB-INF/web.xml</include>
-                            </includes>
-                        </resource>
-                    </webResources>
+                     <!-- Filter the web.xml -->
+                    <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
                 </configuration>
                 <executions>
                     <execution>

--- a/dspace/modules/rdf/pom.xml
+++ b/dspace/modules/rdf/pom.xml
@@ -31,15 +31,8 @@
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
                     <archiveClasses>false</archiveClasses>
-                    <webResources>
-                        <resource>
-                            <filtering>true</filtering>
-                            <directory>${basedir}/src/main/webapp</directory>
-                            <includes>
-                                    <include>WEB-INF/web.xml</include>
-                            </includes>
-                        </resource>
-                    </webResources>
+                     <!-- Filter the web.xml -->
+                    <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
                 </configuration>
                 <executions>
                     <execution>

--- a/dspace/modules/rest/pom.xml
+++ b/dspace/modules/rest/pom.xml
@@ -32,15 +32,8 @@
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
                     <archiveClasses>false</archiveClasses>
-                    <webResources>
-                        <resource>
-                            <filtering>true</filtering>
-                            <directory>${basedir}/src/main/webapp</directory>
-                            <includes>
-                                <include>WEB-INF/web.xml</include>
-                            </includes>
-                        </resource>
-                    </webResources>
+                     <!-- Filter the web.xml -->
+                    <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
                     <overlays>
                         <!--
                            the priority of overlays is determined here

--- a/dspace/modules/sword/pom.xml
+++ b/dspace/modules/sword/pom.xml
@@ -37,15 +37,8 @@
             <artifactId>maven-war-plugin</artifactId>
             <configuration>
                <archiveClasses>false</archiveClasses>
-               <webResources>
-                  <resource>
-                     <filtering>true</filtering>
-                     <directory>${basedir}/src/main/webapp</directory>
-                     <includes>
-                        <include>WEB-INF/web.xml</include>
-                     </includes>
-                  </resource>
-               </webResources>
+               <!-- Filter the web.xml -->
+               <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
             </configuration>
             <executions>
                <execution>

--- a/dspace/modules/swordv2/pom.xml
+++ b/dspace/modules/swordv2/pom.xml
@@ -37,15 +37,8 @@
             <artifactId>maven-war-plugin</artifactId>
             <configuration>
                <archiveClasses>false</archiveClasses>
-               <webResources>
-                  <resource>
-                     <filtering>true</filtering>
-                     <directory>${basedir}/src/main/webapp</directory>
-                     <includes>
-                        <include>WEB-INF/web.xml</include>
-                     </includes>
-                  </resource>
-               </webResources>
+               <!-- Filter the web.xml -->
+               <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
             </configuration>
             <executions>
                <execution>

--- a/dspace/modules/xmlui-mirage2/pom.xml
+++ b/dspace/modules/xmlui-mirage2/pom.xml
@@ -146,14 +146,9 @@
                 <configuration>
                     <archiveClasses>false</archiveClasses>
                     <warSourceExcludes>themes/**</warSourceExcludes>
+                    <!-- Filter the web.xml -->
+                    <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
                     <webResources>
-                        <resource>
-                            <filtering>true</filtering>
-                            <directory>${basedir}/src/main/webapp</directory>
-                            <includes>
-                                <include>WEB-INF/web.xml</include>
-                            </includes>
-                        </resource>
                         <resource>
                             <directory>${project.build.directory}/themes</directory>
                             <targetPath>themes</targetPath>

--- a/dspace/modules/xmlui/pom.xml
+++ b/dspace/modules/xmlui/pom.xml
@@ -59,15 +59,8 @@
                         <artifactId>maven-war-plugin</artifactId>
                         <configuration>
                             <archiveClasses>false</archiveClasses>
-                            <webResources>
-                                <resource>
-                                    <filtering>true</filtering>
-                                    <directory>${basedir}/src/main/webapp</directory>
-                                    <includes>
-                                        <include>WEB-INF/web.xml</include>
-                                    </includes>
-                                </resource>
-                            </webResources>
+                            <!-- Filter the web.xml -->
+                            <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
                             <overlays>
                                 <!--
                                    the priority of overlays is determined here
@@ -122,15 +115,8 @@
                         <artifactId>maven-war-plugin</artifactId>
                         <configuration>
                             <archiveClasses>false</archiveClasses>
-                            <webResources>
-                                <resource>
-                                    <filtering>true</filtering>
-                                    <directory>${basedir}/src/main/webapp</directory>
-                                    <includes>
-                                        <include>WEB-INF/web.xml</include>
-                                    </includes>
-                                </resource>
-                            </webResources>
+                            <!-- Filter the web.xml -->
+                            <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
                             <overlays>
                                 <!--
                                    the priority of overlays is determined here

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,8 @@
                 <version>2.4</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
+                    <!-- Filter the web.xml -->
+                    <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
                     <archive>
                         <manifest>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>


### PR DESCRIPTION
We've been incorrectly filtering our web.xml files, trying to work around the recommendations of maven-war-plugin.  We should be using `filteringDeploymentDescriptors`

See this FAQ answer on how to correctly filter web.xml files: https://maven.apache.org/plugins/maven-war-plugin/faq.html#filtering

Also, see this StackOverflow answer which points out that the way we were doing it only filters the web.xml to `target/classes`: http://stackoverflow.com/a/27574270/3750035  This in turn causes IDE integration to not exactly work as expected.

I'm pretty sure this is exactly what @mdiggory complains about in DS-2366. But, I'm not sure if it fixes the entire issue (as that ticket is a bit vague on the extent of the problem).

https://jira.duraspace.org/browse/DS-2366

I've tested these changes, and the `web.xml` is filtered as expected, and webapps can be run from within my IDE (Netbeans).
