### PR TITLE
[DS-2790] removed duplicate log4j config lines for Solr

### DIFF
--- a/dspace/config/log4j.properties
+++ b/dspace/config/log4j.properties
@@ -101,19 +101,6 @@ log4j.appender.A3.layout.ConversionPattern=%d %-5p %c %x - %m%n
 
 
 ###########################################################################
-# A4 is the name of the appender for Solr
-###########################################################################
-log4j.logger.org.apache.solr=ERROR, A4
-log4j.additivity.org.apache.solr=false
-log4j.appender.A4=org.dspace.app.util.DailyFileAppender
-log4j.appender.A4.File=${log.dir}/solr.log
-log4j.appender.A4.DatePattern=yyyy-MM-dd
-log4j.appender.A4.MaxLogs=14
-log4j.appender.A4.layout=org.apache.log4j.PatternLayout
-log4j.appender.A4.layout.ConversionPattern=%d %-5p %c %x - %m%n
-
-
-###########################################################################
 # Other settings
 ###########################################################################
 


### PR DESCRIPTION
As per the issue description, the log4j-solr.properties file seems to be required by DSpace-Solr (see https://github.com/DSpace/DSpace/blob/59f07bd4dab763eaff050a04ce65dd87a4ac84c6/dspace-solr/src/main/webapp/WEB-INF/web.xml#L39 ) so I will remove the duplicate configuration lines in log4j.properties, tested with DSpace 5.x.
