### PR TITLE
DS-2777 : Fix OAI-PMH to work with Service API refactor

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
@@ -138,6 +138,12 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
     }
 
     @Override
+    public List<Community> findAll(Context context, Integer limit, Integer offset) throws SQLException {
+        MetadataField nameField = metadataFieldService.findByElement(context, MetadataSchema.DC_SCHEMA, "title", null);
+        return communityDAO.findAll(context, nameField, limit, offset);
+    }
+
+    @Override
     public List<Community> findAllTop(Context context) throws SQLException
     {
         // get all communities that are not children

--- a/dspace-api/src/main/java/org/dspace/content/dao/CommunityDAO.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/CommunityDAO.java
@@ -27,6 +27,8 @@ public interface CommunityDAO extends DSpaceObjectLegacySupportDAO<Community> {
 
     public List<Community> findAll(Context context, MetadataField sortField) throws SQLException;
 
+    public List<Community> findAll(Context context, MetadataField sortField, Integer limit, Integer offset) throws SQLException;
+
     public Community findByAdminGroup(Context context, Group group) throws SQLException;
 
     public List<Community> findAllNoParent(Context context, MetadataField sortField) throws SQLException;

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/CommunityDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/CommunityDAOImpl.java
@@ -46,13 +46,24 @@ public class CommunityDAOImpl extends AbstractHibernateDSODAO<Community> impleme
     @Override
     public List<Community> findAll(Context context, MetadataField sortField) throws SQLException
     {
+        return findAll(context, sortField, null, null);
+    }
+
+    @Override
+    public List<Community> findAll(Context context, MetadataField sortField, Integer limit, Integer offset) throws SQLException {
         StringBuilder queryBuilder = new StringBuilder();
-        queryBuilder.append("SELECT community FROM Community as community ");
-        addMetadataLeftJoin(queryBuilder, Community.class.getSimpleName().toLowerCase(), Arrays.asList(sortField));
+        queryBuilder.append("SELECT ").append(Community.class.getSimpleName()).append(" FROM Community as ").append(Community.class.getSimpleName()).append(" ");
+        addMetadataLeftJoin(queryBuilder, Community.class.getSimpleName(), Arrays.asList(sortField));
         addMetadataSortQuery(queryBuilder, Arrays.asList(sortField), ListUtils.EMPTY_LIST);
 
-
         Query query = createQuery(context, queryBuilder.toString());
+        if(offset != null)
+        {
+            query.setFirstResult(offset);
+        }
+        if(limit != null){
+            query.setMaxResults(limit);
+        }
         query.setParameter(sortField.toString(), sortField.getFieldID());
         return list(query);
     }

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
@@ -49,14 +49,24 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
             boolean withdrawn, boolean discoverable, Date lastModified)
             throws SQLException
     {
-        Query query = createQuery(context, "SELECT i FROM Item i"
-                + " WHERE (inArchive = :in_archive OR withdrawn = :withdrawn)"
-                + "  AND discoverable = :discoverable"
-                + "  AND last_modified > :last_modified");
+        StringBuilder queryStr = new StringBuilder();
+        queryStr.append("SELECT i FROM Item i");
+        queryStr.append(" WHERE (inArchive = :in_archive OR withdrawn = :withdrawn)");
+        queryStr.append(" AND discoverable = :discoverable");
+
+        if(lastModified != null)
+        {
+            queryStr.append(" AND last_modified > :last_modified");
+        }
+
+        Query query = createQuery(context, queryStr.toString());
         query.setParameter("in_archive", archived);
         query.setParameter("withdrawn", withdrawn);
         query.setParameter("discoverable", discoverable);
-        query.setDate("last_modified", lastModified);
+        if(lastModified != null)
+        {
+            query.setTimestamp("last_modified", lastModified);
+	}
         return iterate(query);
     }
 
@@ -151,7 +161,7 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
             throws SQLException
     {
         Query query = createQuery(context, "SELECT i FROM item i WHERE last_modified > :last_modified");
-        query.setDate("last_modified", since);
+        query.setTimestamp("last_modified", since);
         return iterate(query);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
@@ -56,7 +56,7 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
         query.setParameter("in_archive", archived);
         query.setParameter("withdrawn", withdrawn);
         query.setParameter("discoverable", discoverable);
-        query.setParameter("last_modified", lastModified);
+        query.setDate("last_modified", lastModified);
         return iterate(query);
     }
 
@@ -151,7 +151,7 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
             throws SQLException
     {
         Query query = createQuery(context, "SELECT i FROM item i WHERE last_modified > :last_modified");
-        query.setParameter("last_modified", since);
+        query.setDate("last_modified", since);
         return iterate(query);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/MetadataValueDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/MetadataValueDAOImpl.java
@@ -60,7 +60,7 @@ public class MetadataValueDAOImpl extends AbstractHibernateDAO<MetadataValue> im
     public MetadataValue getMinimum(Context context, int metadataFieldId)
             throws SQLException
     {
-        String queryString = "SELECT m FROM metadatavalue m WHERE metadata_field_id = :metadata_field_id ORDER BY value";
+        String queryString = "SELECT m FROM MetadataValue m WHERE metadata_field_id = :metadata_field_id ORDER BY text_value";
         Query query = createQuery(context, queryString);
         query.setParameter("metadata_field_id", metadataFieldId);
         query.setMaxResults(1);

--- a/dspace-api/src/main/java/org/dspace/content/service/CommunityService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/CommunityService.java
@@ -66,6 +66,16 @@ public interface CommunityService extends DSpaceObjectService<Community>, DSpace
     public List<Community> findAll(Context context) throws SQLException;
 
     /**
+     * Get all communities in the system. Adds support for limit and offset.
+     * @param context
+     * @param limit
+     * @param offset
+     * @return
+     * @throws SQLException
+     */
+    public List<Community> findAll(Context context, Integer limit, Integer offset) throws SQLException;
+
+    /**
      * Get a list of all top-level communities in the system. These are
      * alphabetically sorted by community name. A top-level community is one
      * without a parent community.

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/BasicConfiguration.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/BasicConfiguration.java
@@ -29,6 +29,7 @@ import org.dspace.xoai.services.api.solr.SolrServerResolver;
 import org.dspace.xoai.services.api.xoai.DSpaceFilterResolver;
 import org.dspace.xoai.services.api.xoai.IdentifyResolver;
 import org.dspace.xoai.services.api.xoai.ItemRepositoryResolver;
+import org.dspace.xoai.services.api.xoai.SetRepositoryResolver;
 import org.dspace.xoai.services.impl.cache.DSpaceEmptyCacheService;
 import org.dspace.xoai.services.impl.cache.DSpaceXOAICacheService;
 import org.dspace.xoai.services.impl.cache.DSpaceXOAIItemCacheService;
@@ -42,6 +43,7 @@ import org.dspace.xoai.services.impl.solr.DSpaceSolrServerResolver;
 import org.dspace.xoai.services.impl.xoai.BaseDSpaceFilterResolver;
 import org.dspace.xoai.services.impl.xoai.DSpaceIdentifyResolver;
 import org.dspace.xoai.services.impl.xoai.DSpaceItemRepositoryResolver;
+import org.dspace.xoai.services.impl.xoai.DSpaceSetRepositoryResolver;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -114,6 +116,12 @@ public class BasicConfiguration {
     public ItemRepositoryResolver itemRepositoryResolver () {
         return new DSpaceItemRepositoryResolver();
     }
+
+    @Bean
+    public SetRepositoryResolver setRepositoryResolver () {
+        return new DSpaceSetRepositoryResolver();
+    }
+
     @Bean
     public IdentifyResolver identifyResolver () {
         return new DSpaceIdentifyResolver();

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/DSpaceHandleResolver.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/DSpaceHandleResolver.java
@@ -10,6 +10,7 @@ package org.dspace.xoai.services.impl;
 import java.sql.SQLException;
 import javax.inject.Inject;
 import org.dspace.content.DSpaceObject;
+import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
 import org.dspace.xoai.services.api.context.ContextService;
 import org.dspace.xoai.services.api.context.ContextServiceException;
@@ -20,8 +21,12 @@ public class DSpaceHandleResolver implements HandleResolver {
     @Inject
     private ContextService contextService;
 
-    @Inject
-    private HandleService handleService;
+    private final HandleService handleService;
+
+    public DSpaceHandleResolver()
+    {
+        handleService = HandleServiceFactory.getInstance().getHandleService();
+    }
 
     @Override
     public DSpaceObject resolve(String handle) throws HandleResolverException {

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceSetRepository.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceSetRepository.java
@@ -1,0 +1,220 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xoai.services.impl.xoai;
+
+import com.lyncode.xoai.dataprovider.core.ListSetsResult;
+import com.lyncode.xoai.dataprovider.core.Set;
+import com.lyncode.xoai.dataprovider.services.api.SetRepository;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.DSpaceObject;
+import org.dspace.core.Context;
+import org.dspace.xoai.data.DSpaceSet;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.CollectionService;
+import org.dspace.content.service.CommunityService;
+import org.dspace.handle.factory.HandleServiceFactory;
+import org.dspace.handle.service.HandleService;
+
+/**
+ *
+ * @author Lyncode Development Team <dspace@lyncode.com>
+ */
+public class DSpaceSetRepository implements SetRepository
+{
+    private static final Logger log = LogManager.getLogger(DSpaceSetRepository.class);
+
+    private final Context _context;
+
+    private final HandleService handleService;
+    private final CommunityService communityService;
+    private final CollectionService collectionService;
+
+    public DSpaceSetRepository(Context context)
+    {
+        _context = context;
+        handleService = HandleServiceFactory.getInstance().getHandleService();
+        communityService = ContentServiceFactory.getInstance().getCommunityService();
+        collectionService = ContentServiceFactory.getInstance().getCollectionService();
+    }
+
+    private int getCommunityCount()
+    {
+        try
+        {
+            List<Community> communityList = communityService.findAll(_context);
+
+            return communityList.size();
+        }
+        catch (SQLException e)
+        {
+            log.error(e.getMessage(), e);
+        }
+        return 0;
+    }
+
+    private int getCollectionCount()
+    {
+        try
+        {
+            List<Collection> collectionList = collectionService.findAll(_context);
+
+            return collectionList.size();
+        }
+        catch (SQLException e)
+        {
+            log.error(e.getMessage(), e);
+        }
+        return 0;
+    }
+
+    /**
+     * Produce a list of DSpaceCommunitySet.  The list is a segment of the full
+     * list of Community ordered alphabetically by name.
+     *
+     * @param offset start this far down the list of Community.
+     * @param length return up to this many Sets.
+     * @return some Sets representing the Community list segment.
+     */
+    private List<Set> community(int offset, int length)
+    {
+        List<Set> array = new ArrayList<Set>();
+
+        try
+        {
+            List<Community> communityList = communityService.findAll(_context, length, offset);
+
+            for(Community community : communityList)
+            {
+                array.add(DSpaceSet.newDSpaceCommunitySet(
+                        community.getHandle(),
+                        community.getName()));
+            }
+        }
+        catch (SQLException e)
+        {
+            log.error(e.getMessage(), e);
+        }
+        return array;
+    }
+
+    /**
+     * Produce a list of DSpaceCollectionSet.  The list is a segment of the full
+     * list of Collection ordered alphabetically by name.
+     *
+     * @param offset start this far down the list of Collection.
+     * @param length return up to this many Sets.
+     * @return some Sets representing the Collection list segment.
+     */
+    private List<Set> collection(int offset, int length)
+    {
+        List<Set> array = new ArrayList<Set>();
+
+        try
+        {
+            List<Collection> collectionList = collectionService.findAll(_context, length, offset);
+
+            for(Collection collection : collectionList)
+            {
+                array.add(DSpaceSet.newDSpaceCollectionSet(
+                        collection.getHandle(),
+                        collection.getName()));
+            }
+        }
+        catch (SQLException e)
+        {
+            log.error(e.getMessage(), e);
+        }
+        return array;
+    }
+
+    @Override
+    public ListSetsResult retrieveSets(int offset, int length)
+    {
+        // Only database sets (virtual sets are added by lyncode common library)
+        log.debug("Querying sets. Offset: " + offset + " - Length: " + length);
+        List<Set> array = new ArrayList<Set>();
+        int communityCount = this.getCommunityCount();
+        log.debug("Communities: " + communityCount);
+        int collectionCount = this.getCollectionCount();
+        log.debug("Collections: " + collectionCount);
+
+        if (offset < communityCount)
+        {
+            if (offset + length > communityCount)
+            {
+                // Add some collections
+                List<Set> tmp = community(offset, length);
+                array.addAll(tmp);
+                array.addAll(collection(0, length - tmp.size()));
+            }
+            else
+                array.addAll(community(offset, length));
+        }
+        else if (offset < communityCount + collectionCount)
+        {
+            array.addAll(collection(offset - communityCount, length));
+        }
+        log.debug("Has More Results: "
+                + ((offset + length < communityCount + collectionCount) ? "Yes"
+                        : "No"));
+        return new ListSetsResult(offset + length < communityCount
+                + collectionCount, array, communityCount + collectionCount);
+    }
+
+    @Override
+    public boolean supportSets()
+    {
+        return true;
+    }
+
+    @Override
+    public boolean exists(String setSpec)
+    {
+        if (setSpec.startsWith("col_"))
+        {
+            try
+            {
+
+                DSpaceObject dso = handleService.resolveToObject(_context,
+                        setSpec.replace("col_", "").replace("_", "/"));
+                if (dso == null || !(dso instanceof Collection))
+                    return false;
+                return true;
+            }
+            catch (SQLException ex)
+            {
+                log.error(ex.getMessage(), ex);
+            }
+        }
+        else if (setSpec.startsWith("com_"))
+        {
+            try
+            {
+                DSpaceObject dso = handleService.resolveToObject(_context,
+                        setSpec.replace("com_", "").replace("_", "/"));
+                if (dso == null || !(dso instanceof Community))
+                    return false;
+                return true;
+            }
+            catch (SQLException ex)
+            {
+                log.error(ex.getMessage(), ex);
+            }
+        }
+        return false;
+    }
+
+}
+

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceSetRepositoryResolver.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceSetRepositoryResolver.java
@@ -1,0 +1,24 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xoai.services.impl.xoai;
+
+import com.lyncode.xoai.dataprovider.services.api.SetRepository;
+import org.dspace.xoai.services.api.context.ContextService;
+import org.dspace.xoai.services.api.context.ContextServiceException;
+import org.dspace.xoai.services.api.xoai.SetRepositoryResolver;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class DSpaceSetRepositoryResolver implements SetRepositoryResolver {
+    @Autowired
+    private ContextService contextService;
+
+    @Override
+    public SetRepository getSetRepository() throws ContextServiceException {
+        return new DSpaceSetRepository(contextService.getContext());
+    }
+}

--- a/dspace-oai/src/main/webapp/WEB-INF/spring/applicationContext.xml
+++ b/dspace-oai/src/main/webapp/WEB-INF/spring/applicationContext.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+-->
+<beans 
+    xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xmlns:util="http://www.springframework.org/schema/util"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+                           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.0.xsd">
+
+    <!-- Acquires the DSpace Utility Class with initialized Service Manager -->
+    <bean id="dspace" class="org.dspace.utils.DSpace"/>
+    
+    <!-- Acquires reference to EventService --> 
+    <bean id="dspace.eventService" factory-bean="dspace" factory-method="getEventService"/>
+
+    <!-- Inject the Default LoggerUsageEventListener into the EventService  -->
+    <bean class="org.dspace.usage.LoggerUsageEventListener">
+    	<property name="eventService" >
+    		<ref bean="dspace.eventService"/>
+    	</property>
+    </bean>
+       
+    <!-- Inject the SolrLoggerUsageEventListener into the EventService  -->
+    <bean class="org.dspace.statistics.SolrLoggerUsageEventListener">
+        <property name="eventService" >
+            <ref bean="dspace.eventService"/>
+        </property>
+    </bean>
+
+    <!-- Google Analytics recording  -->
+    <bean class="org.dspace.google.GoogleRecorderEventListener">
+        <property name="eventService" >
+            <ref bean="dspace.eventService"/>
+        </property>
+    </bean>
+
+    <!-- 
+    Uncomment to enable TabFileUsageEventListener 
+    <bean class="org.dspace.app.statistics.TabFileUsageEventListener">
+    	<property name="eventService" >
+    		<ref bean="dspace.eventService"/>
+    	</property>
+    </bean>
+    -->
+    
+    <!-- 
+    Uncomment to enable PassiveUsageEventListener
+    <bean class="org.dspace.app.statistics.PassiveUsageEventListener">
+    	<property name="eventService" >
+    		<ref bean="dspace.eventService"/>
+    	</property>
+    </bean>
+     -->
+</beans>

--- a/dspace-oai/src/main/webapp/WEB-INF/web.xml
+++ b/dspace-oai/src/main/webapp/WEB-INF/web.xml
@@ -12,54 +12,75 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
 	
-	<display-name>XOAI Data Provider</display-name>
+    <display-name>XOAI Data Provider</display-name>
 	
-	<context-param>
-		<description>
-			The location of the main DSpace configuration file
-		</description>
-		<param-name>dspace-config</param-name>
-		<param-value>${dspace.dir}/config/dspace.cfg</param-value>
-	</context-param>
+    <context-param>
+        <description>
+            The location of the main DSpace configuration file
+        </description>
+        <param-name>dspace-config</param-name>
+        <param-value>${dspace.dir}/config/dspace.cfg</param-value>
+    </context-param>
 
-	<context-param>
-		<description>The location of the main DSpace configuration file</description>
-		<param-name>dspace.dir</param-name>
-		<param-value>${dspace.dir}</param-value>
-	</context-param>
+    <context-param>
+        <description>The location of the main DSpace configuration file</description>
+        <param-name>dspace.dir</param-name>
+        <param-value>${dspace.dir}</param-value>
+    </context-param>
 
 
-	<listener>
-		<listener-class>org.dspace.app.util.DSpaceContextListener</listener-class>
-	</listener>
-	<listener>
-	   <listener-class>
+    <!-- Location of root application context configs (to be loaded by ContextLoaderListener below) -->
+    <!-- This contains the beans that initialize DSpace Services -->
+    <context-param>
+        <param-name>contextConfigLocation</param-name>
+        <param-value>/WEB-INF/spring/*.xml</param-value>
+    </context-param>
+
+    <!-- Initializes the DSpace Context object -->
+    <listener>
+        <listener-class>org.dspace.app.util.DSpaceContextListener</listener-class>
+    </listener>
+
+    <!-- Initializes the DSpace Kernel -->
+    <listener>
+        <listener-class>
 		  org.dspace.servicemanager.servlet.DSpaceKernelServletContextListener
-	   </listener-class>
-	</listener>
+        </listener-class>
+    </listener>
 
-	<listener>
-		<listener-class>org.dspace.app.util.DSpaceWebappListener</listener-class>
-	</listener>
+    <!-- Registers this DSpace webapp as "running" -->
+    <listener>
+        <listener-class>org.dspace.app.util.DSpaceWebappListener</listener-class>
+    </listener>
+
+    <!-- Load the root application context / beans (defined in contextConfigLocation above) -->
+    <listener>
+        <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
+    </listener>
 
 	<servlet>
         <servlet-name>oai</servlet-name>
         <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
+        <!-- Configure DispatcherServlet to use AnnotationConfigWebApplicationContext
+             instead of the default XmlWebApplicationContext -->
         <init-param>
             <param-name>contextClass</param-name>
             <param-value>
                 org.springframework.web.context.support.AnnotationConfigWebApplicationContext
             </param-value>
         </init-param>
+        <!-- @Configuration class which defines our servlet context config -->
+        <!-- This defines beans that are specific to OAI webapp -->
         <init-param>
             <param-name>contextConfigLocation</param-name>
             <param-value>org.dspace.xoai.app.DSpaceWebappConfiguration</param-value>
         </init-param>
     </servlet>
 
-	<servlet-mapping>
-		<servlet-name>oai</servlet-name>
-		<url-pattern>/*</url-pattern>
-	</servlet-mapping>
+    <!-- Load the oai servlet for all paths -->
+    <servlet-mapping>
+        <servlet-name>oai</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
 
 </web-app>

--- a/dspace/solr/oai/conf/schema.xml
+++ b/dspace/solr/oai/conf/schema.xml
@@ -149,13 +149,16 @@
       </analyzer>
     </fieldType>
     <fieldtype name="ignored" stored="false" indexed="false" multiValued="true" class="solr.StrField" /> 
+
+    <!-- UUID support -->
+    <fieldType name="uuid" class="solr.UUIDField" indexed="true" />
  </types>
 
 
  <fields>
    <field name="_version_" type="long" indexed="true" stored="true" multiValued="false"/>
    <!-- Item always present information -->
-   <field name="item.id" type="int" indexed="true" stored="true" multiValued="false" />
+   <field name="item.id" type="uuid" indexed="true" stored="true" multiValued="false" />
    <field name="item.public" type="boolean" indexed="true" stored="true" multiValued="false" />
    <field name="item.handle" type="string" indexed="true" stored="true" multiValued="false" />
    <field name="item.collections" type="string" indexed="true" stored="true" multiValued="true" />


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2777

This PR officially fixes OAI-PMH to work properly (at least at a minimal level) after the Service API refactor.  Note: I have not tested EVERY feature in OAI-PMH, but OAI-PMH now loads properly and functions at a basic level.

Involved the following:
- Updates OAI-PMH to use the same 'applicationContext.xml' as all other webapps (to initialize DSpace Services)
- Stops attempting to inject `HandleService` and just loads it via its provided Factory
- Restores `DSpaceSetRepository` classes (accidentally removed during the initial refactor). They are required for OAI-PMH sets to work.
- Adds a new `CommunityService.findAll()` method that supports limit/offset. I based this off the method of the same name/type in the `CollectionService`. This was required to support the `DSpaceSetRepository`.

@KevinVdV , if you have a moment, can you give this a sanity check?  It all seems to work, but I'd like your opinion as the Service-based API creator/expert.
