### PR TITLE
[DS-2794] Increase logging if a bean retrieval fails or if the database connection is null

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -133,8 +133,8 @@ public class Context
             dbConnection = new DSpace().getSingletonService(DBConnection.class);
             if(dbConnection == null)
             {
-                log.fatal("Cannot obtain the bean the provides a database connection, " +
-                        "check previous entries in the dspace.log to find why the db failed to initialize.");
+                log.fatal("Cannot obtain the bean which provides a database connection. " +
+                        "Check previous entries in the dspace.log to find why the db failed to initialize.");
             }
         }
 

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -131,6 +131,11 @@ public class Context
         {
             // Obtain a non-auto-committing connection
             dbConnection = new DSpace().getSingletonService(DBConnection.class);
+            if(dbConnection == null)
+            {
+                log.fatal("Cannot obtain the bean the provides a database connection, " +
+                        "check previous entries in the dspace.log to find why the db failed to initialize.");
+            }
         }
 
         currentUser = null;

--- a/dspace-services/src/main/java/org/dspace/servicemanager/spring/SpringServiceManager.java
+++ b/dspace-services/src/main/java/org/dspace/servicemanager/spring/SpringServiceManager.java
@@ -99,6 +99,7 @@ public final class SpringServiceManager implements ServiceManagerSystem {
                     bean = (T) applicationContext.getBean(name, type);
                 } catch (BeansException e) {
                     // no luck, try the fall back option
+                    log.error(e.getMessage(), e);
                     bean = null;
                 }
             } else {
@@ -107,6 +108,7 @@ public final class SpringServiceManager implements ServiceManagerSystem {
                     bean = (T) applicationContext.getBean(type.getName(), type);
                 } catch (BeansException e) {
                     // no luck, try the fall back option
+                    log.error(e.getMessage(), e);
                     bean = null;
                 }
             }
@@ -121,6 +123,7 @@ public final class SpringServiceManager implements ServiceManagerSystem {
                     }
                 } catch (BeansException e) {
                     // I guess there are no beans of this type
+                    log.error(e.getMessage(), e);
                     bean = null;
                 }
             }


### PR DESCRIPTION
This pull requests adds additional logging if beans cannot be retrieved, this will be particularly useful of the hibernate SessionFactory bean. If this bean fails to init the database connection in a context could be null. An example stacktrace is shown below:

Caused by: org.springframework.beans.factory.BeanCreationException: Could not autowire field: private org.hibernate.SessionFactory org.dspace.core.HibernateDBConnection.sessionFactory; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'sessionFactory' defined in file [/Users/kevin/Development/DSpace/dspace-kevin/config/spring/api/core-hibernate.xml]: Invocation of init method failed; nested exception is org.hibernate.HibernateException: Missing column: dspace_object in public.doi
        at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredFieldElement.inject(AutowiredAnnotationBeanPostProcessor.java:531)

In case the database connection is null an additional log is added to provide guidance.
