### PR TITLE
[DS-2778] Fix max connections configuration

### DIFF
--- a/dspace/config/spring/api/core-hibernate.xml
+++ b/dspace/config/spring/api/core-hibernate.xml
@@ -15,6 +15,7 @@
         <property name="password" value="${db.password}"/>
         <property name="maxWaitMillis" value="${db.maxwait}"/>
         <property name="maxIdle" value="${db.maxidle}"/>
+        <property name="maxTotal" value="${db.maxconnections}"/>
     </bean>
 
 </beans>

--- a/src/main/filters/testEnvironment.properties
+++ b/src/main/filters/testEnvironment.properties
@@ -53,6 +53,9 @@ db.password =
 # H2 doesn't use schemas
 db.schema =
 
+# Maximum number of DB connections in pool
+db.maxconnections = 30
+
 # Maximum time to wait before giving up if all connections in pool are busy (milliseconds)
 db.maxwait = 5000
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2778

Ensure that the "db.maxconnections" is configured to the maxTotal of the BasicDataSource, from the docs: "Sets the maximum total number of idle and borrows connections that can be active at the same time"
