### PR TITLE
DS-2809 Set default search operator to AND

### DIFF
--- a/dspace/solr/search/conf/schema.xml
+++ b/dspace/solr/search/conf/schema.xml
@@ -632,7 +632,7 @@
  <defaultSearchField>search_text</defaultSearchField>
 
  <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
- <solrQueryParser defaultOperator="OR"/>
+ <solrQueryParser defaultOperator="AND"/>
 
   <!-- copyField commands copy one field to another at the time a document
         is added to the index.  It's used either to index the same field differently,


### PR DESCRIPTION
Setting Solr's default search operator to AND for the Discovery index leads to
search behaviour that's closer to what our users expect -- "do what Google
does". There is a configuration option for the search operator in dspace.cfg.
However, that setting is used only by the legacy DSQuery class for the now
deprecated Lucene-based search.
