### PR TITLE
DS-2699 Only escape colon-space, not other characters

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/discovery/DiscoverUtility.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/discovery/DiscoverUtility.java
@@ -228,7 +228,7 @@ public class DiscoverUtility
         if (StringUtils.isNotBlank(query))
         {
             // Escape any special characters in this user-entered query
-            query = SearchUtils.getSearchService().escapeQueryChars(query);
+            query = escapeQueryChars(query);
             queryArgs.setQuery(query);
         }
 
@@ -269,6 +269,19 @@ public class DiscoverUtility
 
         return userFilters;
 
+    }
+
+    /**
+     * Escape colon-space sequence in a user-entered query, based on the
+     * underlying search service. This is intended to let end users paste in a
+     * title containing colon-space without requiring them to escape the colon.
+     *
+     * @param query user-entered query string
+     * @return query with colon in colon-space sequence escaped
+     */
+    private static String escapeQueryChars(String query)
+    {
+        return StringUtils.replace(query, ": ", "\\: ");
     }
 
     private static void setPagination(HttpServletRequest request,

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/DiscoveryUIUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/DiscoveryUIUtils.java
@@ -98,18 +98,15 @@ public class DiscoveryUIUtils {
     }
 
     /**
-     * Escape special characters in a user-entered query, based on the
-     * underlying search service.
-     * <P>
-     * WARNING: This likely shouldn't be used in field-based queries
-     * (e.g. search/browse by title) as it may unintentionally escape the
-     * special characters used to denote fields (e.g. ":").
+     * Escape colon-space sequence in a user-entered query, based on the
+     * underlying search service. This is intended to let end users paste in a
+     * title containing colon-space without requiring them to escape the colon.
      *
-     * @param query
-     * @return query with special characters escaped
+     * @param query user-entered query string
+     * @return query with colon in colon-space sequence escaped
      */
     public static String escapeQueryChars(String query)
     {
-        return searchService.escapeQueryChars(query);
+        return StringUtils.replace(query, ": ", "\\: ");
     }
 }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SidebarFacetsTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SidebarFacetsTransformer.java
@@ -161,7 +161,7 @@ public class SidebarFacetsTransformer extends AbstractDSpaceTransformer implemen
         //If we are on a search page performing a search a query may be used
         String query = request.getParameter("query");
         if(query != null && !"".equals(query)){
-            // Escape any special characters in this user-entered query
+            // Do standard escaping of some characters in this user-entered query
             query = DiscoveryUIUtils.escapeQueryChars(query);
             queryArgs.setQuery(query);
         }


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2699
Escaping all characters with special meaning in Solr query syntax prevents
users from doing advanced searches, including those with explicit operators
(AND/OR), range queries and NOT-type queries. The colon character quite
commonly occurs in titles of research publications, where it is typically
followed by a space. Unfortunately, it's regarded as a special character by
Solr and would normally need to be escaped when it's just part of a phrase
search (not part of a fielded search). Escaping the colon character _only_ when
it's followed by a space character still allows the user to manually enter
fielded queries (eg -fulltext:[\* TO *] to find all items without fulltext). At
the same time, queries where someone pastes in a publication title containing
colon-space still "just work".
