### PR TITLE
[DS-2813] fixed NullPointer in submission lookup if pubmed is down.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/submit/lookup/PubmedService.java
+++ b/dspace-api/src/main/java/org/dspace/submit/lookup/PubmedService.java
@@ -98,7 +98,7 @@ public class PubmedService
 
     public List<Record> search(String query) throws IOException, HttpException
     {
-        List<Record> results = null;
+        List<Record> results = new ArrayList<>();
         if (!ConfigurationManager.getBooleanProperty(SubmissionLookupService.CFG_MODULE, "remoteservice.demo"))
         {
             HttpGet method = null;


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2813

If PubMed is down there will be a NullPointerException in PubmedOnlineDataLoader. To fix this return an empty list instead of null
