### PR TITLE
DS-2791 : Restore accidentally refactored out logic to Packager

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/packager/Packager.java
+++ b/dspace-api/src/main/java/org/dspace/app/packager/Packager.java
@@ -506,70 +506,48 @@ public class Packager
         //NOTE: at this point, Parent may be null -- in which case it is up to the PackageIngester
         // to either determine the Parent (from package contents) or throw an error.
 
-        try{
+        try
+        {
             //If we are doing a recursive ingest, call ingestAll()
-            if(pkgParams.recursiveModeEnabled()) {
+            if(pkgParams.recursiveModeEnabled())
+            {
                 System.out.println("\nAlso ingesting all referenced packages (recursive mode)..");
                 System.out.println("This may take a while, please check your logs for ongoing status while we process each package.");
 
                 //ingest first package & recursively ingest anything else that package references (child packages, etc)
                 List<String> hdlResults = sip.ingestAll(context, parent, pkgFile, pkgParams, null);
 
-                if (hdlResults != null) {
+                if (hdlResults != null)
+                {
                     //Report total objects created
                     System.out.println("\nCREATED a total of " + hdlResults.size() + " DSpace Objects.");
 
-                    //ingest first package & recursively ingest anything else that package references (child packages, etc)
-                    List<String> dsoResults = sip.ingestAll(context, parent, pkgFile, pkgParams, null);
-
-                    if (dsoResults != null) {
-                        //Report total objects created
-                        System.out.println("\nCREATED a total of " + dsoResults.size() + " DSpace Objects.");
-
-                        String choiceString = null;
-                        //Ask if user wants full list printed to command line, as this may be rather long.
-                        if (this.userInteractionEnabled) {
-                            BufferedReader input = new BufferedReader(new InputStreamReader(System.in));
-                            System.out.print("\nWould you like to view a list of all objects that were created? [y/n]: ");
-                            choiceString = input.readLine();
-                        } else {
-                            // user interaction disabled -- default answer to 'yes', as
-                            // we want to provide user with as detailed a report as possible.
-                            choiceString = "y";
-                        }
-
-                        // Provide detailed report if user answered 'yes'
-                        if (choiceString.equalsIgnoreCase("y"))
-                        {
-                            System.out.println("\n\n");
-                            for (String result : hdlResults)
-                            {
-                                DSpaceObject dso = HandleServiceFactory.getInstance().getHandleService().resolveToObject(context, result);
-
-                                if(dso!=null)
-                                {
-
-                                    if (pkgParams.restoreModeEnabled()) {
-                                        System.out.println("RESTORED DSpace " + Constants.typeText[dso.getType()] +
-                                                " [ hdl=" + dso.getHandle() + ", dbID=" + dso.getID() + " ] ");
-                                    } else {
-                                        System.out.println("CREATED new DSpace " + Constants.typeText[dso.getType()] +
-                                                " [ hdl=" + dso.getHandle() + ", dbID=" + dso.getID() + " ] ");
-                                    }
-                                }
-                            }
-                        }
-
+                    String choiceString = null;
+                    //Ask if user wants full list printed to command line, as this may be rather long.
+                    if (this.userInteractionEnabled)
+                    {
+                        BufferedReader input = new BufferedReader(new InputStreamReader(System.in));
+                        System.out.print("\nWould you like to view a list of all objects that were created? [y/n]: ");
+                        choiceString = input.readLine();
                     }
-                } else {
+                    else
+                    {
+                        // user interaction disabled -- default answer to 'yes', as
+                        // we want to provide user with as detailed a report as possible.
+                        choiceString = "y";
+                    }
 
-                    //otherwise, just one package to ingest
-                    try {
+                    // Provide detailed report if user answered 'yes'
+                    if (choiceString.equalsIgnoreCase("y"))
+                    {
                         System.out.println("\n\n");
-                        for (String result : hdlResults) {
+                        for (String result : hdlResults)
+                        {
                             DSpaceObject dso = HandleServiceFactory.getInstance().getHandleService().resolveToObject(context, result);
 
-                            if (dso != null) {
+                            if(dso!=null)
+                            {
+
                                 if (pkgParams.restoreModeEnabled()) {
                                     System.out.println("RESTORED DSpace " + Constants.typeText[dso.getType()] +
                                             " [ hdl=" + dso.getHandle() + ", dbID=" + dso.getID() + " ] ");
@@ -579,25 +557,52 @@ public class Packager
                                 }
                             }
                         }
-                    } catch (IllegalStateException ie) {
-                        // NOTE: if we encounter an IllegalStateException, this means the
-                        // handle is already in use and this object already exists.
+                    }
+                }
 
-                        //if we are skipping over (i.e. keeping) existing objects
-                        if (pkgParams.keepExistingModeEnabled()) {
-                            System.out.println("\nSKIPPED processing package '" + pkgFile + "', as an Object already exists with this handle.");
-                        } else // Pass this exception on -- which essentially causes a full rollback of all changes (this is the default)
+            }
+            else
+            {
+                //otherwise, just one package to ingest
+                try
+                {
+                    DSpaceObject dso = sip.ingest(context, parent, pkgFile, pkgParams, null);
+
+                    if (dso != null)
+                    {
+                        if (pkgParams.restoreModeEnabled())
                         {
-                            throw ie;
+                            System.out.println("RESTORED DSpace " + Constants.typeText[dso.getType()] +
+                                    " [ hdl=" + dso.getHandle() + ", dbID=" + dso.getID() + " ] ");
+                        }
+                        else
+                        {
+                            System.out.println("CREATED new DSpace " + Constants.typeText[dso.getType()] +
+                                    " [ hdl=" + dso.getHandle() + ", dbID=" + dso.getID() + " ] ");
                         }
                     }
+                }
+                catch (IllegalStateException ie)
+                {
+                    // NOTE: if we encounter an IllegalStateException, this means the
+                    // handle is already in use and this object already exists.
 
+                    //if we are skipping over (i.e. keeping) existing objects
+                    if (pkgParams.keepExistingModeEnabled())
+                    {
+                        System.out.println("\nSKIPPED processing package '" + pkgFile + "', as an Object already exists with this handle.");
+                    }
+                    else // Pass this exception on -- which essentially causes a full rollback of all changes (this is the default)
+                    {
+                        throw ie;
+                    }
                 }
             }
-        } catch (WorkflowException e) {
+        }
+        catch (WorkflowException e)
+        {
             throw new PackageException(e);
         }
-
     }
 
 
@@ -721,10 +726,11 @@ public class Packager
         // NOTE: At this point, objToReplace may be null.  If it is null, it is up to the PackageIngester
         // to determine which Object needs to be replaced (based on the handle specified in the pkg, etc.)
 
-
-        //If we are doing a recursive replace, call replaceAll()
-        try {
-            if (pkgParams.recursiveModeEnabled()) {
+        try
+        {
+            //If we are doing a recursive replace, call replaceAll()
+            if (pkgParams.recursiveModeEnabled())
+            {
                 //ingest first object using package & recursively replace anything else that package references (child objects, etc)
                 List<String> hdlResults = sip.replaceAll(context, objToReplace, pkgFile, pkgParams);
 
@@ -734,23 +740,29 @@ public class Packager
 
                     String choiceString = null;
                     //Ask if user wants full list printed to command line, as this may be rather long.
-                    if (this.userInteractionEnabled) {
+                    if (this.userInteractionEnabled)
+                    {
                         BufferedReader input = new BufferedReader(new InputStreamReader(System.in));
                         System.out.print("\nWould you like to view a list of all objects that were replaced? [y/n]: ");
                         choiceString = input.readLine();
-                    } else {
+                    }
+                    else
+                    {
                         // user interaction disabled -- default answer to 'yes', as
                         // we want to provide user with as detailed a report as possible.
                         choiceString = "y";
                     }
 
                     // Provide detailed report if user answered 'yes'
-                    if (choiceString.equalsIgnoreCase("y")) {
+                    if (choiceString.equalsIgnoreCase("y"))
+                    {
                         System.out.println("\n\n");
-                        for (String result : hdlResults) {
+                        for (String result : hdlResults)
+                        {
                             DSpaceObject dso = HandleServiceFactory.getInstance().getHandleService().resolveToObject(context, result);
 
-                            if (dso != null) {
+                            if (dso != null)
+                            {
                                 System.out.println("REPLACED DSpace " + Constants.typeText[dso.getType()] +
                                         " [ hdl=" + dso.getHandle() + " ] ");
                             }
@@ -759,18 +771,22 @@ public class Packager
 
 
                 }
-            } else {
+            }
+            else
+            {
                 //otherwise, just one object to replace
                 DSpaceObject dso = sip.replace(context, objToReplace, pkgFile, pkgParams);
 
-                if (dso != null) {
+                if (dso != null)
+                {
                     System.out.println("REPLACED DSpace " + Constants.typeText[dso.getType()] +
                             " [ hdl=" + dso.getHandle() + " ] ");
                 }
             }
-        } catch (WorkflowException e) {
+        }
+        catch (WorkflowException e)
+        {
             throw new PackageException(e);
         }
     }
-
 }


### PR DESCRIPTION
During the Service API refactor, some of the logic in the Packager (commandline) script was accidentally removed (specifically from the `ingest()` method).  This caused single package ingestion/restore to fail silently as noted in this ticket: https://jira.duraspace.org/browse/DS-2791

This PR simply restores the missing logic from the 5.x version of the Packager script.

Untested as of yet, but it's basically an exact copy from the 5.x version of the `ingest()` method (with minor updates to work with 6.x API).
