### PR TITLE
DS-2637 configurable pagination for discovery

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/scripts/browse.js
+++ b/dspace-xmlui-mirage2/src/main/webapp/scripts/browse.js
@@ -17,7 +17,8 @@
             $this = $(this);
             browse_controls = $('#aspect_artifactbrowser_ConfigurableBrowse_div_browse-controls, ' +
                     '#aspect_administrative_WithdrawnItems_div_browse-controls, ' +
-                    '#aspect_administrative_PrivateItems_div_browse-controls');
+                    '#aspect_administrative_PrivateItems_div_browse-controls, '+
+                    '#aspect_discovery_SearchFacetFilter_div_browse-controls');
             $('*[name="' +$this.data('name') + '"]', browse_controls).val($this.data('returnvalue'));
             $('.btn', browse_controls).click();
             $this.closest('.open').removeClass('open');

--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/core/attribute-handlers.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/core/attribute-handlers.xsl
@@ -209,6 +209,7 @@
                     </xsl:if>
 
                 </div>
+                <ul class="ds-artifact-list list-unstyled"></ul>
             </xsl:when>
             <xsl:when test=". = 'masked'">
                 <div class="pagination-masked clearfix {$position}">

--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/core/attribute-handlers.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/core/attribute-handlers.xsl
@@ -112,7 +112,8 @@
                     <xsl:variable name="gear"
                                   select="//dri:div[@id='aspect.artifactbrowser.ConfigurableBrowse.div.browse-controls'
                                   or @id='aspect.administrative.WithdrawnItems.div.browse-controls'
-                                  or @id='aspect.administrative.PrivateItems.div.browse-controls']"/>
+                                  or @id='aspect.administrative.PrivateItems.div.browse-controls'
+                                  or @id='aspect.discovery.SearchFacetFilter.div.browse-controls']"/>
                     <xsl:choose>
                         <xsl:when test="$position = 'top' and $gear">
                             <div class="row">
@@ -412,7 +413,8 @@
                 <xsl:for-each
                         select="//dri:div[@id='aspect.artifactbrowser.ConfigurableBrowse.div.browse-controls'
                         or @id='aspect.administrative.WithdrawnItems.div.browse-controls'
-                        or @id='aspect.administrative.PrivateItems.div.browse-controls']//dri:field[@type='select']">
+                        or @id='aspect.administrative.PrivateItems.div.browse-controls'
+                        or @id='aspect.discovery.SearchFacetFilter.div.browse-controls']//dri:field[@type='select']">
                     <xsl:if test="position() > 1">
                         <li class="divider"/>
                     </xsl:if>

--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/preprocess/browse.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/preprocess/browse.xsl
@@ -104,7 +104,8 @@
 
     <xsl:template match="dri:div[@id = 'aspect.artifactbrowser.ConfigurableBrowse.div.browse-controls'
     or @id='aspect.administrative.WithdrawnItems.div.browse-controls'
-    or @id='aspect.administrative.PrivateItems.div.browse-controls']">
+    or @id='aspect.administrative.PrivateItems.div.browse-controls'
+    or @id='aspect.discovery.SearchFacetFilter.div.browse-controls']">
         <div>
             <xsl:call-template name="copy-attributes"/>
                 <xsl:attribute name="rend">

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ConfigurableBrowse.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ConfigurableBrowse.java
@@ -121,7 +121,8 @@ public class ConfigurableBrowse extends AbstractDSpaceTransformer implements
 
     /** The options for results per page */
     private static final int[] RESULTS_PER_PAGE_PROGRESSION = {5,10,20,40,60,80,100};
-    
+    private int currentOffset = 0;
+
     /** Cached validity object */
     private SourceValidity validity;
 
@@ -293,7 +294,9 @@ public class ConfigurableBrowse extends AbstractDSpaceTransformer implements
 
         // If there are items to browse, add the pagination
         int itemsTotal = info.getTotal();
-        if (itemsTotal > 0) 
+        currentOffset=info.getOffset();
+
+        if (itemsTotal > 0)
         {
             //results.setSimplePagination(itemsTotal, firstItemIndex, lastItemIndex, previousPage, nextPage)
             results.setSimplePagination(itemsTotal, browseInfo.getOverallPosition() + 1,
@@ -728,8 +731,7 @@ public class ConfigurableBrowse extends AbstractDSpaceTransformer implements
             
             params.scope.setJumpToItem(RequestUtils.getIntParameter(request, BrowseParams.JUMPTO_ITEM));
             params.scope.setOrder(request.getParameter(BrowseParams.ORDER));
-            int offset = RequestUtils.getIntParameter(request, BrowseParams.OFFSET);
-            params.scope.setOffset(offset > 0 ? offset : 0);
+            updateOffset(request, params);
             params.scope.setResultsPerPage(RequestUtils.getIntParameter(request, BrowseParams.RESULTS_PER_PAGE));
             params.scope.setStartsWith(decodeFromURL(request.getParameter(BrowseParams.STARTS_WITH)));
             String filterValue = request.getParameter(BrowseParams.FILTER_VALUE[0]);
@@ -790,6 +792,20 @@ public class ConfigurableBrowse extends AbstractDSpaceTransformer implements
 
         this.userParams = params;
         return params;
+    }
+
+    private void updateOffset(Request request, BrowseParams params) {
+        int configuredOffset=-1;
+        boolean retainOffset = false;
+        if (request.getParameters().containsKey("update")) {
+            configuredOffset = currentOffset;
+            retainOffset=true;
+        }
+        int offset = RequestUtils.getIntParameter(request, BrowseParams.OFFSET);
+        params.scope.setOffset(offset > 0 ? offset : 0);
+        if (retainOffset) {
+            params.scope.setOffset(configuredOffset);
+        }
     }
 
     /**

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SearchFacetFilter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SearchFacetFilter.java
@@ -77,6 +77,8 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
 
     private SearchService searchService = null;
     private static final Message T_go = message("xmlui.general.go");
+    private static final Message T_rpp = message("xmlui.Discovery.AbstractSearch.rpp");
+    private static final int[] RESULTS_PER_PAGE_PROGRESSION = {5, 10, 20, 40, 60, 80, 100};
 
     public SearchFacetFilter() {
 
@@ -220,9 +222,9 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
         DiscoverFacetField discoverFacetField;
         if(request.getParameter(SearchFilterParam.STARTS_WITH) != null)
         {
-            discoverFacetField = new DiscoverFacetField(facetField, DiscoveryConfigurationParameters.TYPE_TEXT, DEFAULT_PAGE_SIZE + 1, DiscoveryConfigurationParameters.SORT.VALUE, request.getParameter(SearchFilterParam.STARTS_WITH).toLowerCase());
+            discoverFacetField = new DiscoverFacetField(facetField, DiscoveryConfigurationParameters.TYPE_TEXT, getPageSize() + 1, DiscoveryConfigurationParameters.SORT.VALUE, request.getParameter(SearchFilterParam.STARTS_WITH).toLowerCase());
         }else{
-            discoverFacetField = new DiscoverFacetField(facetField, DiscoveryConfigurationParameters.TYPE_TEXT, DEFAULT_PAGE_SIZE + 1, DiscoveryConfigurationParameters.SORT.VALUE);
+            discoverFacetField = new DiscoverFacetField(facetField, DiscoveryConfigurationParameters.TYPE_TEXT, getPageSize() + 1, DiscoveryConfigurationParameters.SORT.VALUE);
         }
 
 
@@ -269,6 +271,7 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
         Division div = body.addDivision("browse-by-" + request.getParameter(SearchFilterParam.FACET_FIELD), "primary");
 
         addBrowseJumpNavigation(div, browseParams, request);
+        addBrowseControls(div, browseParams);
 
         // Set up the major variables
         //Collection collection = (Collection) dso;
@@ -307,20 +310,20 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
 
                     //Only show the nextpageurl if we have at least one result following our current results
                     String nextPageUrl = null;
-                    if (values.size() == (DEFAULT_PAGE_SIZE + 1))
+                    if (values.size() == (getPageSize() + 1))
                     {
                         nextPageUrl = getNextPageURL(browseParams, request);
                     }
 
 
 
-                    int shownItemsMax = offSet + (DEFAULT_PAGE_SIZE < values.size() ? values.size() - 1 : values.size());
+                    int shownItemsMax = offSet + (getPageSize() < values.size() ? values.size() - 1 : values.size());
 
 
 
                     // We put our total results to -1 so this doesn't get shown in the results (will be hidden by the xsl)
                     // The reason why we do this is because solr 1.4 can't retrieve the total number of facets found
-                    results.setSimplePagination(-1, offSet + 1,
+                    results.setSimplePagination((int) queryResults.getTotalSearchResults(), offSet + 1,
                                                     shownItemsMax, getPreviousPageURL(browseParams, request), nextPageUrl);
 
                     Table singleTable = results.addTable("browse-by-" + facetField + "-results", (int) (queryResults.getDspaceObjects().size() + 1), 1);
@@ -329,9 +332,9 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
 
 
                     int end = values.size();
-                    if(DEFAULT_PAGE_SIZE < end)
+                    if(getPageSize() < end)
                     {
-                        end = DEFAULT_PAGE_SIZE;
+                        end = getPageSize();
                     }
                     for (int i = 0; i < end; i++) {
                         DiscoverResult.FacetResult value = values.get(i);
@@ -441,7 +444,7 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
         Map<String, String> parameters = new HashMap<String, String>();
         parameters.putAll(browseParams.getCommonBrowseParams());
         parameters.putAll(browseParams.getControlParameters());
-        parameters.put(SearchFilterParam.OFFSET, String.valueOf(offSet + DEFAULT_PAGE_SIZE));
+        parameters.put(SearchFilterParam.OFFSET, String.valueOf(offSet + getPageSize()));
 
         // Add the filter queries
         String url = generateURL("search-filter", parameters);
@@ -466,7 +469,7 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
         Map<String, String> parameters = new HashMap<String, String>();
         parameters.putAll(browseParams.getCommonBrowseParams());
         parameters.putAll(browseParams.getControlParameters());
-        parameters.put(SearchFilterParam.OFFSET, String.valueOf(offset - DEFAULT_PAGE_SIZE));
+        parameters.put(SearchFilterParam.OFFSET, String.valueOf(offset - getPageSize()));
 
         // Add the filter queries
         String url = generateURL("search-filter", parameters);
@@ -573,6 +576,55 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
         }
 
         return dso;
+    }
+    protected int getPageSize() {
+        try {
+            int rpp =Integer.parseInt(ObjectModelHelper.getRequest(objectModel).getParameter("rpp"));
+            DEFAULT_PAGE_SIZE=rpp;
+            return rpp;
+        }
+        catch (Exception e) {
+            return DEFAULT_PAGE_SIZE;
+        }
+    }
+
+    /**
+     * Add the controls to changing sorting and display options.
+     *
+     * @param div
+     * @param params
+     * @throws WingException
+     */
+    private void addBrowseControls(Division div, SearchFilterParam params)
+            throws WingException
+    {
+        // Prepare a Map of query parameters required for all links
+        Map<String, String> queryParams = new HashMap<String, String>();
+
+        queryParams.putAll(params.getCommonBrowseParams());
+        Request request = ObjectModelHelper.getRequest(objectModel);
+        queryParams.put("order",request.getParameter("order"));
+        String facetField = request.getParameter(SearchFilterParam.FACET_FIELD);
+        Division controls = div.addInteractiveDivision("browse-controls", "search-filter?field="+facetField,
+                Division.METHOD_POST, "browse controls");
+
+        // Add all the query parameters as hidden fields on the form
+        for (Map.Entry<String, String> param : queryParams.entrySet())
+        {
+            controls.addHidden(param.getKey()).setValue(param.getValue());
+        }
+
+        Para controlsForm = controls.addPara();
+        // Create a control for the number of records to display
+        controlsForm.addContent(T_rpp);
+
+        Select rppSelect = controlsForm.addSelect("rpp");
+
+        for (int i : RESULTS_PER_PAGE_PROGRESSION)
+        {
+            rppSelect.addOption((i == getPageSize()), i, Integer.toString(i));
+        }
+        controlsForm.addButton("update").setValue("update");
     }
 
 }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SearchFacetFilter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SearchFacetFilter.java
@@ -73,6 +73,7 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
     protected DiscoverQuery queryArgs;
 
     private int DEFAULT_PAGE_SIZE = 10;
+    private int currentOffset = 0;
 
 
     private SearchService searchService = null;
@@ -265,7 +266,7 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
     public void addBody(Body body) throws SAXException, WingException, UIException, SQLException, IOException, AuthorizeException {
         Request request = ObjectModelHelper.getRequest(objectModel);
         DSpaceObject dso = HandleUtil.obtainHandle(objectModel);
-
+        updateQueryResultsAndOffset(request, dso);
         SearchFilterParam browseParams = new SearchFilterParam(request);
         // Build the DRI Body
         Division div = body.addDivision("browse-by-" + request.getParameter(SearchFilterParam.FACET_FIELD), "primary");
@@ -279,7 +280,6 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
         // Build the collection viewer division.
 
         //Make sure we get our results
-        queryResults = getQueryResponse(dso);
         if (this.queryResults != null) {
 
             Map<String, List<DiscoverResult.FacetResult>> facetFields = this.queryResults.getFacetResults();
@@ -307,6 +307,7 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
                     if(offSet == -1){
                         offSet = 0;
                     }
+                    currentOffset=offSet;
 
                     //Only show the nextpageurl if we have at least one result following our current results
                     String nextPageUrl = null;
@@ -344,6 +345,19 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
                     results.addPara(message("xmlui.discovery.SearchFacetFilter.no-results"));
                 }
             }
+        }
+    }
+
+    private void updateQueryResultsAndOffset(Request request, DSpaceObject dso) {
+        int configuredOffset=-1;
+        boolean retainOffset = false;
+        if (request.getParameters().containsKey("update")) {
+            configuredOffset = currentOffset;
+            retainOffset=true;
+        }
+        queryResults = getQueryResponse(dso);
+        if (retainOffset) {
+            queryArgs.setFacetOffset(configuredOffset);
         }
     }
 
@@ -438,7 +452,7 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
         int offSet = Util.getIntParameter(request, SearchFilterParam.OFFSET);
         if (offSet == -1)
         {
-            offSet = 0;
+            offSet = currentOffset;
         }
 
         Map<String, String> parameters = new HashMap<String, String>();
@@ -455,13 +469,14 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
 
     private String getPreviousPageURL(SearchFilterParam browseParams, Request request) throws UnsupportedEncodingException, UIException {
         //If our offset should be 0 then we shouldn't be able to view a previous page url
-        if (0 == queryArgs.getFacetOffset() && Util.getIntParameter(request, "offset") == -1)
+        boolean currentOffsetSmallerOrEqualTO0 = currentOffset <= 0;
+        if (0 == queryArgs.getFacetOffset() && Util.getIntParameter(request, "offset") == -1 && currentOffsetSmallerOrEqualTO0)
         {
             return null;
         }
 
         int offset = Util.getIntParameter(request, SearchFilterParam.OFFSET);
-        if(offset == -1 || offset == 0)
+        if(currentOffsetSmallerOrEqualTO0 && (offset == -1 || offset == 0))
         {
             return null;
         }
@@ -469,7 +484,8 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
         Map<String, String> parameters = new HashMap<String, String>();
         parameters.putAll(browseParams.getCommonBrowseParams());
         parameters.putAll(browseParams.getControlParameters());
-        parameters.put(SearchFilterParam.OFFSET, String.valueOf(offset - getPageSize()));
+        String offSet = String.valueOf((currentOffset - getPageSize()<0)? 0:currentOffset - getPageSize());
+        parameters.put(SearchFilterParam.OFFSET, offSet);
 
         // Add the filter queries
         String url = generateURL("search-filter", parameters);


### PR DESCRIPTION
This contribution adds the possibility to configure the pagination for discovery on the fly.
Initially, the pagination for discovery was hard-set to 10 results per page.
This fix adds the same configurability to the discovery pagination that was already in place in the standard browse by pages, making it possible to change the number of results per page through a similar gear icon.
This contribution is based on the following JIRA ticket - https://jira.duraspace.org/browse/DS-2637
Atmire (http://www.atmire.com) has been commissioned by CGIAR (http://www.cgiar.org/) to fix this particular JIRA ticket as wel as helping improve the usability of DSpace by contributing it to the community.
