### PR TITLE
DS-2635 discovery facets with configurable ordering

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoverySearchFilterFacet.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoverySearchFilterFacet.java
@@ -54,7 +54,7 @@ public class DiscoverySearchFilterFacet extends DiscoverySearchFilter {
 
     public void setSortOrderSidebar(DiscoveryConfigurationParameters.SORT sortOrderSidebar)
     {
-        this.sortOrderFilterPage = sortOrderSidebar;
+        this.sortOrderSidebar = sortOrderSidebar;
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoverySearchFilterFacet.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoverySearchFilterFacet.java
@@ -18,7 +18,8 @@ public class DiscoverySearchFilterFacet extends DiscoverySearchFilter {
 
     private static final int DEFAULT_FACET_LIMIT = 10;
     private int facetLimit = -1;
-    private DiscoveryConfigurationParameters.SORT sortOrder = DiscoveryConfigurationParameters.SORT.COUNT;
+    private DiscoveryConfigurationParameters.SORT sortOrderSidebar = DiscoveryConfigurationParameters.SORT.COUNT;
+    private DiscoveryConfigurationParameters.SORT sortOrderFilterPage = DiscoveryConfigurationParameters.SORT.COUNT;
     public static final String FILTER_TYPE_FACET = "facet";
 
 
@@ -36,14 +37,24 @@ public class DiscoverySearchFilterFacet extends DiscoverySearchFilter {
         this.facetLimit = facetLimit;
     }
 
-    public DiscoveryConfigurationParameters.SORT getSortOrder()
+    public DiscoveryConfigurationParameters.SORT getSortOrderFilterPage()
     {
-        return sortOrder;
+        return sortOrderFilterPage;
     }
 
-    public void setSortOrder(DiscoveryConfigurationParameters.SORT sortOrder)
+    public void setSortOrderFilterPage(DiscoveryConfigurationParameters.SORT sortOrderFilterPage)
     {
-        this.sortOrder = sortOrder;
+        this.sortOrderFilterPage = sortOrderFilterPage;
+    }
+
+    public DiscoveryConfigurationParameters.SORT getSortOrderSidebar()
+    {
+        return sortOrderSidebar;
+    }
+
+    public void setSortOrderSidebar(DiscoveryConfigurationParameters.SORT sortOrderSidebar)
+    {
+        this.sortOrderFilterPage = sortOrderSidebar;
     }
 
     @Override

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/discovery/DiscoverUtility.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/discovery/DiscoverUtility.java
@@ -583,7 +583,7 @@ public class DiscoverUtility
                             // filterquery
                             queryArgs.addFacetField(new DiscoverFacetField(
                                     facet.getIndexFieldName(), facet.getType(),
-                                    10, facet.getSortOrder()));
+                                    10, facet.getSortOrderSidebar()));
                         }
                         else
                         {
@@ -671,7 +671,7 @@ public class DiscoverUtility
                             .getIndexFieldName(),
                             DiscoveryConfigurationParameters.TYPE_TEXT,
                            limit, facet
-                                    .getSortOrder(), facetPage * facetLimit));
+                                    .getSortOrderSidebar(), facetPage * facetLimit));
                 }
             }
         }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SearchFacetFilter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SearchFacetFilter.java
@@ -482,6 +482,7 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
         parameters.putAll(browseParams.getCommonBrowseParams());
         parameters.putAll(browseParams.getControlParameters());
         parameters.put(SearchFilterParam.OFFSET, String.valueOf(offSet + getPageSize()));
+        parameters.put(SearchFilterParam.ORDER, getSortOrder(request).name());
 
         // Add the filter queries
         String url = generateURL("search-filter", parameters);
@@ -507,6 +508,7 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
         Map<String, String> parameters = new HashMap<String, String>();
         parameters.putAll(browseParams.getCommonBrowseParams());
         parameters.putAll(browseParams.getControlParameters());
+        parameters.put(SearchFilterParam.ORDER, getSortOrder(request).name());
         String offSet = String.valueOf((currentOffset - getPageSize()<0)? 0:currentOffset - getPageSize());
         parameters.put(SearchFilterParam.OFFSET, offSet);
 
@@ -556,6 +558,7 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
         /** The browse control params **/
         public static final String OFFSET = "offset";
         public static final String STARTS_WITH = "starts_with";
+        public static final String ORDER = "order";
 
 
         private SearchFilterParam(Request request){

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SidebarFacetsTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SidebarFacetsTransformer.java
@@ -222,7 +222,7 @@ public class SidebarFacetsTransformer extends AbstractDSpaceTransformer implemen
                             {
                                 //When we have an hierarchical facet always show the "view more" they may want to filter the children of the top nodes
                                 if(field.getType().equals(DiscoveryConfigurationParameters.TYPE_HIERARCHICAL)){
-                                    addViewMoreUrl(filterValsList, dso, request, field.getIndexFieldName());
+                                    addViewMoreUrl(filterValsList, dso, request, field);
                                 }
                                 break;
                             }
@@ -252,7 +252,7 @@ public class SidebarFacetsTransformer extends AbstractDSpaceTransformer implemen
                             }
                             //Show a "view more" url should there be more values, unless we have a date
                             if (i == shownFacets - 1 && !field.getType().equals(DiscoveryConfigurationParameters.TYPE_DATE)/*&& facetField.getGap() == null*/) {
-                                addViewMoreUrl(filterValsList, dso, request, field.getIndexFieldName());
+                                addViewMoreUrl(filterValsList, dso, request, field);
                             }
                         }
                     }
@@ -301,12 +301,12 @@ public class SidebarFacetsTransformer extends AbstractDSpaceTransformer implemen
         return parametersString;
     }
 
-    private void addViewMoreUrl(List facet, DSpaceObject dso, Request request, String fieldName) throws WingException, UnsupportedEncodingException {
+    private void addViewMoreUrl(List facet, DSpaceObject dso, Request request, DiscoverySearchFilterFacet field) throws WingException, UnsupportedEncodingException {
         String parameters = retrieveParameters(request);
         facet.addItem().addXref(
                 contextPath +
                         (dso == null ? "" : "/handle/" + dso.getHandle()) +
-                        "/search-filter?" + parameters + BrowseFacet.FACET_FIELD + "=" + fieldName,
+                        "/search-filter?" + parameters + BrowseFacet.FACET_FIELD + "=" + field.getIndexFieldName()+"&order="+field.getSortOrder(),
                 T_VIEW_MORE
 
         );

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SidebarFacetsTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SidebarFacetsTransformer.java
@@ -306,7 +306,7 @@ public class SidebarFacetsTransformer extends AbstractDSpaceTransformer implemen
         facet.addItem().addXref(
                 contextPath +
                         (dso == null ? "" : "/handle/" + dso.getHandle()) +
-                        "/search-filter?" + parameters + BrowseFacet.FACET_FIELD + "=" + field.getIndexFieldName()+"&order="+field.getSortOrder(),
+                        "/search-filter?" + parameters + BrowseFacet.FACET_FIELD + "=" + field.getIndexFieldName()+"&order="+field.getSortOrderFilterPage(),
                 T_VIEW_MORE
 
         );
@@ -426,7 +426,7 @@ public class SidebarFacetsTransformer extends AbstractDSpaceTransformer implemen
                             //We need a list of our years
                             //We have a date range add faceting for our field
                             //The faceting will automatically be limited to the 10 years in our span due to our filterquery
-                            queryArgs.addFacetField(new DiscoverFacetField(facet.getIndexFieldName(), facet.getType(), 10, facet.getSortOrder()));
+                            queryArgs.addFacetField(new DiscoverFacetField(facet.getIndexFieldName(), facet.getType(), 10, facet.getSortOrderSidebar()));
                         }else{
                             java.util.List<String> facetQueries = new ArrayList<String>();
                             //Create facet queries but limit them to 11 (11 == when we need to show a "show more" url)
@@ -463,7 +463,7 @@ public class SidebarFacetsTransformer extends AbstractDSpaceTransformer implemen
                     int facetLimit = facet.getFacetLimit();
                     //Add one to our facet limit to make sure that if we have more then the shown facets that we show our "show more" url
                     facetLimit++;
-                    queryArgs.addFacetField(new DiscoverFacetField(facet.getIndexFieldName(), facet.getType(), facetLimit, facet.getSortOrder()));
+                    queryArgs.addFacetField(new DiscoverFacetField(facet.getIndexFieldName(), facet.getType(), facetLimit, facet.getSortOrderSidebar()));
                 }
             }
         }

--- a/dspace/config/modules/workflow.cfg
+++ b/dspace/config/modules/workflow.cfg
@@ -8,7 +8,7 @@
 # Possible values:
 #   originalworkflow = Traditional DSpace Workflow
 #   xmlworkflow = New (as of 1.8.0) Configurable Reviewer Workflow
-workflow.framework=originalworkflow
+workflow.workflow.framework=originalworkflow
 #workflow.framework=xmlworkflow
 
 #Allow the reviewers to add/edit/remove files from the submission

--- a/dspace/config/modules/workflow.cfg
+++ b/dspace/config/modules/workflow.cfg
@@ -8,7 +8,7 @@
 # Possible values:
 #   originalworkflow = Traditional DSpace Workflow
 #   xmlworkflow = New (as of 1.8.0) Configurable Reviewer Workflow
-workflow.workflow.framework=originalworkflow
+workflow.framework=originalworkflow
 #workflow.framework=xmlworkflow
 
 #Allow the reviewers to add/edit/remove files from the submission

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -382,7 +382,8 @@
             </list>
         </property>
         <property name="facetLimit" value="10"/>
-        <property name="sortOrder" value="COUNT"/>
+        <property name="sortOrderSidebar" value="COUNT"/>
+        <property name="sortOrderFilterPage" value="VALUE"/>
     </bean>
 
     <bean id="searchFilterSubject" class="org.dspace.discovery.configuration.HierarchicalSidebarFacetConfiguration">
@@ -393,7 +394,8 @@
             </list>
         </property>
         <property name="facetLimit" value="10"/>
-        <property name="sortOrder" value="COUNT"/>
+        <property name="sortOrderSidebar" value="COUNT"/>
+        <property name="sortOrderFilterPage" value="VALUE"/>
         <property name="splitter" value="::"/>
     </bean>
 
@@ -405,7 +407,8 @@
             </list>
         </property>
         <property name="type" value="date"/>
-        <property name="sortOrder" value="VALUE"/>
+        <property name="sortOrderSidebar" value="COUNT"/>
+        <property name="sortOrderFilterPage" value="VALUE"/>
     </bean>
     
     <bean id="searchFilterContentInOriginalBundle" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -418,7 +418,8 @@
         </property>
         <property name="facetLimit" value="2"/>
         <property name="type" value="standard"/>
-        <property name="sortOrder" value="VALUE"/>
+        <property name="sortOrderSidebar" value="COUNT"/>
+        <property name="sortOrderFilterPage" value="VALUE"/>
     </bean>
 
     <!--Sort properties-->

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -383,7 +383,7 @@
         </property>
         <property name="facetLimit" value="10"/>
         <property name="sortOrderSidebar" value="COUNT"/>
-        <property name="sortOrderFilterPage" value="VALUE"/>
+        <property name="sortOrderFilterPage" value="COUNT"/>
     </bean>
 
     <bean id="searchFilterSubject" class="org.dspace.discovery.configuration.HierarchicalSidebarFacetConfiguration">
@@ -395,7 +395,7 @@
         </property>
         <property name="facetLimit" value="10"/>
         <property name="sortOrderSidebar" value="COUNT"/>
-        <property name="sortOrderFilterPage" value="VALUE"/>
+        <property name="sortOrderFilterPage" value="COUNT"/>
         <property name="splitter" value="::"/>
     </bean>
 
@@ -408,7 +408,7 @@
         </property>
         <property name="type" value="date"/>
         <property name="sortOrderSidebar" value="COUNT"/>
-        <property name="sortOrderFilterPage" value="VALUE"/>
+        <property name="sortOrderFilterPage" value="COUNT"/>
     </bean>
     
     <bean id="searchFilterContentInOriginalBundle" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
@@ -419,7 +419,7 @@
         <property name="facetLimit" value="2"/>
         <property name="type" value="standard"/>
         <property name="sortOrderSidebar" value="COUNT"/>
-        <property name="sortOrderFilterPage" value="VALUE"/>
+        <property name="sortOrderFilterPage" value="COUNT"/>
     </bean>
 
     <!--Sort properties-->


### PR DESCRIPTION
This contribution adds the possibility to differentiate the standard sort orders for discovery.
Initially, upon clicking the "view more" link in a discovery facet, the user is simply sent to an alphabetically sorted page.
It would be more logical that, when the facet is sorted based on the count, the view more page isn't hard-set to sort on this as well, but rather be able to have its own configurable sorting. 
A differentiation between the discovery facets and actual view-more pages has been added to be able to configure them through the discovery.xml file. This allows for a more custom configuration for different facets. 
This fix is based on the following JIRA ticket - https://jira.duraspace.org/browse/DS-2635
Atmire (http://www.atmire.com) has been commissioned by CGIAR (http://www.cgiar.org/) to fix this particular JIRA ticket as wel as helping improve the usability of DSpace by contributing it to the community.
