### PR TITLE
DS-2823: Limit Solr text field size to 10,000 tokens

### DIFF
--- a/dspace/solr/search/conf/schema.xml
+++ b/dspace/solr/search/conf/schema.xml
@@ -222,9 +222,11 @@
         Duplicate tokens at the same position (which may result from Stemmed Synonyms or
         WordDelim parts) are removed.
         -->
-   	<fieldType name="text" class="solr.TextField" positionIncrementGap="100">
+    <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <!-- Limit field size to 10,000 tokens (can be commented out if you want full text in indexes)-->
+        <filter class="solr.LimitTokenCountFilterFactory" maxTokenCount="10000"/>
         <!-- in this example, we will only use synonyms at query time
         <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
         -->


### PR DESCRIPTION
Simple PR to limit the "text" fieldType in our Solr Search index to just 10,000 tokens (words).  This limit used to exist in Discovery/Solr, but was accidentally dropped in DSpace 4.0

This will mean that only the first 10K tokens (words) of full text documents are indexed by default. But it decreases the size of search indexes significantly if you are using DSpace to store larger textual documents.

https://jira.duraspace.org/browse/DS-2823

It's a tiny change, but I'd appreciate verification from others.  To test this PR, you'd need to do the following:
1. First, just check to see what the current size of your `[dspace]/solr/search/data/index/` folder
2. Apply the PR
3. Reindex all documents (`./dspace index-discovery -b`)
4. Optimize your index (`./dspace index-discovery -o`). NOTE: The size of the folder will not change until you re-optimize.
5. Check the new size of your `[dspace]/solr/search/data/index/` folder.

The PR is against "master", but it should be backported/cherry-picked to 5.x as well.
