### PR TITLE
DS-2830 add proper synchronization in TokenHolder

### DIFF
--- a/dspace-rest/src/main/java/org/dspace/rest/TokenHolder.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/TokenHolder.java
@@ -61,19 +61,21 @@ public class TokenHolder
             context = new org.dspace.core.Context();
             EPerson dspaceUser = EPerson.findByEmail(context, user.getEmail());
 
-            if ((dspaceUser == null) || (!dspaceUser.checkPassword(user.getPassword())))
-            {
-                token = null;
-            }
-            else if (tokens.containsKey(user.getEmail()))
-            {
-                token = tokens.get(user.getEmail());
-            }
-            else
-            {
-                token = generateToken();
-                persons.put(token, dspaceUser);
-                tokens.put(user.getEmail(), token);
+            synchronized (TokenHolder.class) {
+                if ((dspaceUser == null) || (!dspaceUser.checkPassword(user.getPassword())))
+                {
+                    token = null;
+                }
+                else if (tokens.containsKey(user.getEmail()))
+                {
+                    token = tokens.get(user.getEmail());
+                }
+                else
+                {
+                    token = generateToken();
+                    persons.put(token, dspaceUser);
+                    tokens.put(user.getEmail(), token);
+                }
             }
 
             log.trace("User(" + user.getEmail() + ") has been logged.");
@@ -113,7 +115,7 @@ public class TokenHolder
      * @return Return instance of EPerson if is token right, otherwise it
      *         returns NULL.
      */
-    public static EPerson getEPerson(String token)
+    public static synchronized EPerson getEPerson(String token)
     {
         return persons.get(token);
     }
@@ -125,7 +127,7 @@ public class TokenHolder
      *            Token under which is stored eperson.
      * @return Return true if was all okay, otherwise return false.
      */
-    public static boolean logout(String token)
+    public static synchronized boolean logout(String token)
     {
         if ((token == null) || (persons.get(token) == null))
         {


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2830

Hi, I have just figured out that the token management in the REST API is not thread-safe. So if the API is consumed concurrently by multiple scripts then one may encounter some erroneous 401/403 statuses even if the token is present and valid. 

In TokenHolder.java everything is static and the access to the tokens and persons hashes should be synchronized.
