### PR TITLE
DS-2831 connections cleanup and context reuse

### DIFF
--- a/dspace-api/src/main/java/org/dspace/event/EventManager.java
+++ b/dspace-api/src/main/java/org/dspace/event/EventManager.java
@@ -284,14 +284,23 @@ public class EventManager
         {
             Context ctx = new Context();
 
-            for (Iterator ci = ((Dispatcher) dispatcher).getConsumers()
-                    .iterator(); ci.hasNext();)
-            {
-                ConsumerProfile cp = (ConsumerProfile) ci.next();
-                if (cp != null)
+            try {
+
+                for (Iterator ci = ((Dispatcher) dispatcher).getConsumers()
+                        .iterator(); ci.hasNext();)
                 {
-                    cp.getConsumer().finish(ctx);
+                    ConsumerProfile cp = (ConsumerProfile) ci.next();
+                    if (cp != null)
+                    {
+                        cp.getConsumer().finish(ctx);
+                    }
                 }
+
+                ctx.complete();
+
+            } catch (Exception e) {
+                ctx.abort();
+                throw e;
             }
             return;
 

--- a/dspace-rest/src/main/java/org/dspace/rest/CollectionsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/CollectionsResource.java
@@ -355,7 +355,7 @@ public class CollectionsResource extends Resource
             workspaceItem.update();
 
             // Index item to browse.
-            org.dspace.browse.IndexBrowse browse = new org.dspace.browse.IndexBrowse();
+            org.dspace.browse.IndexBrowse browse = new org.dspace.browse.IndexBrowse(context);
             browse.indexItem(dspaceItem);
 
             log.trace("Installing item to collection(id=" + collectionId + ").");


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2831

Hi, 
- sometimes the system is waiting for the garbage collector to collect database connections 
- sometimes a new database connection is created whereas there is one available in the Context object 

See the details of this fix in the Jira ticket.
