### PR TITLE
DS-2833: UploadWithEmbargoStep didn't parse Bitstream UUID correctly

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/Util.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/Util.java
@@ -256,6 +256,10 @@ public class Util {
         }
         catch (Exception e)
         {
+            // at least log this error to make debugging easier
+            // do not silently return null only.
+            log.warn("Unable to recoginze UUID from String \"" 
+                    + val.trim() + "\". Will return null.", e);
             // Problem with parameter
             return null;
         }

--- a/dspace-api/src/main/java/org/dspace/submit/step/UploadWithEmbargoStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/UploadWithEmbargoStep.java
@@ -513,8 +513,8 @@ public class UploadWithEmbargoStep extends UploadStep
         }
         // FORM: UploadStep SELECTED OPERATION: go to EditBitstreamPolicies
         else if (buttonPressed.startsWith("submit_editPolicy_")){
-            String bitstreamID = buttonPressed.substring("submit_editPolicy_".length());
-            Bitstream b = bitstreamService.find(context, Util.getUUIDParameter(request, bitstreamID));
+            UUID bitstreamID = UUID.fromString(buttonPressed.substring("submit_editPolicy_".length()));
+            Bitstream b = bitstreamService.find(context, bitstreamID);
             subInfo.setBitstream(b);
             return STATUS_EDIT_POLICIES;
         }


### PR DESCRIPTION
To test this PR enable UploadWithEmbargoStep, create a document, upload some files and click the button to change the embargo for one of them. Without the patch (at least in JSPUI) clicking this buttom let DSpace return a notice about a malformed request, but no error in the log files. With this patch you'll see the formular to set an embargo. While testing this part you should also test parts of the UploadWithEmbargoStep that are not changed by this PR: just set a date, continue and ensure that the embargo was stored correctly (e.g. by finishing the submission and looking on the bitstream's Policies or by looking into the resourcepolicy DB table).

I did not confirm this bug in XMLUI, but I tested my PR against both UIs. From looking on the code I would expect both UIs of beeing affected. Please test this PR against both UIs.
