### PR TITLE
DS-2832: Limit requiresIndexing() query to only returning the LAST_INDEXED_FIELD

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -591,6 +591,8 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
         SolrQuery query = new SolrQuery();
         query.setQuery("handle:" + handle);
+        // Specify that we ONLY want the LAST_INDEXED_FIELD returned in the field list (fl)
+        query.setParam(CommonParams.FL, LAST_INDEXED_FIELD);
         QueryResponse rsp;
 
         try {


### PR DESCRIPTION
This is a tiny, but VERY important, fix to the `SolrServiceImpl.requiresIndexing()` method.

https://jira.duraspace.org/browse/DS-2832

When running `index-discovery` (no args) this method is executed for every Item in DSpace (to check if it needs reindexing). Unfortunately, currently the Solr query requests that ALL FIELDS be returned in that query (including the "fulltext" field that includes the full text of the document).  This causes a massive memory spike when running `index-discovery` as the fulltext of all opened documents is loaded into memory (via the Solr "documentCache").

So, this tiny one liner just fixes our Solr query to only request the _single field_ that we need.

I've tested this, and the memory spike now disappears completely as only the `LAST_INDEXED_FIELD` is loaded into memory for each document.  Updating an item and re-running `index-discovery` also still works properly.
