### PR TITLE
[DS-2846] Optimize memory usage when using iterators

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/AbstractHibernateDAO.java
+++ b/dspace-api/src/main/java/org/dspace/core/AbstractHibernateDAO.java
@@ -164,7 +164,7 @@ public abstract class AbstractHibernateDAO<T> implements GenericDAO<T> {
     public Iterator<T> iterate(Query query)
     {
         @SuppressWarnings("unchecked")
-        Iterator<T> result = (Iterator<T>) query.iterate();
+        Iterator<T> result = new HibernateScrollableResultsIterator<>(query.setCacheMode(CacheMode.IGNORE));
         return result;
     }
 

--- a/dspace-api/src/main/java/org/dspace/core/HibernateScrollableResultsIterator.java
+++ b/dspace-api/src/main/java/org/dspace/core/HibernateScrollableResultsIterator.java
@@ -1,0 +1,47 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.core;
+
+import org.hibernate.Query;
+import org.hibernate.ScrollMode;
+import org.hibernate.ScrollableResults;
+
+import java.util.Iterator;
+
+/**
+ * Iterator implementation that allows for forward scrolling through a query. An iterator is still returned to the UI,
+ * while in the backend the hibernate scrolling can be used without tying the DSpace to the hibernate implementation.
+ *
+ * @author kevinvandevelde at atmire.com
+ */
+public class HibernateScrollableResultsIterator<T> implements Iterator<T> {
+
+    private ScrollableResults scrollableResults;
+
+    public HibernateScrollableResultsIterator(Query query) {
+        this.scrollableResults = query.scroll(ScrollMode.FORWARD_ONLY);
+    }
+
+    @Override
+    public boolean hasNext() {
+        return !scrollableResults.isLast();
+    }
+
+    @Override
+    public T next() {
+        scrollableResults.next();
+        @SuppressWarnings("unchecked")
+        T nextObject = (T) scrollableResults.get(0);
+        return nextObject;
+    }
+
+    @Override
+    public void remove() {
+        //Don't need this method, we are using hibernate scrolling with a forward only, so a remove has no effect.
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/core/HibernateScrollableResultsIterator.java
+++ b/dspace-api/src/main/java/org/dspace/core/HibernateScrollableResultsIterator.java
@@ -23,21 +23,51 @@ public class HibernateScrollableResultsIterator<T> implements Iterator<T> {
 
     private ScrollableResults scrollableResults;
 
+    private T nextObject;
+    private boolean retrievedObject = false;
+
+
     public HibernateScrollableResultsIterator(Query query) {
         this.scrollableResults = query.scroll(ScrollMode.FORWARD_ONLY);
     }
 
     @Override
     public boolean hasNext() {
-        return !scrollableResults.isLast();
+        // if we have a next element that was not pulled, just simply return true.
+      		if(!retrievedObject && nextObject != null){
+      			return true;
+      		}
+
+      		if(scrollableResults.next()){
+      			//we remember the element
+                nextObject = (T)scrollableResults.get(0);
+      			retrievedObject = false;
+      			return true;
+      		}else{
+                scrollableResults.close();
+            }
+      		return false;
     }
 
     @Override
     public T next() {
-        scrollableResults.next();
-        @SuppressWarnings("unchecked")
-        T nextObject = (T) scrollableResults.get(0);
-        return nextObject;
+        T toReturn = null;
+      		//next variable could be null because the last element was sent or because we iterate on the next()
+      		//instead of hasNext()
+      		if(nextObject == null){
+      			//if we can retrieve an element, do it
+      			if(scrollableResults.next()){
+      				toReturn = (T)scrollableResults.get(0);
+      			}
+      		}
+      		else{
+                //the element was retrieved by hasNext, return it
+      			toReturn = nextObject;
+                nextObject = null;
+      		}
+
+      		retrievedObject = true;
+      		return toReturn;
     }
 
     @Override


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2846
Use a scrollable result when returning an iterator, this will decrease changes of getting a heap error.
