### PR TITLE
DS-2408: Fix ordering of listeners in web.xml to ensure Kernel always starts before DB migrations happen

### DIFF
--- a/dspace-jspui/src/main/webapp/WEB-INF/web.xml
+++ b/dspace-jspui/src/main/webapp/WEB-INF/web.xml
@@ -127,7 +127,11 @@
   </filter-mapping>
  
 
-  <!-- kernel start listener (from impl), starts up the kernel for standalong webapps -->
+  <!--
+       DSpace Kernel startup listener. This listener is in charge of initializing/starting the
+       DSpace Kernel. It MUST be listed BEFORE any other DSpace listeners, as DSpace services
+       will not function until the Kernel is initialized.
+  -->
   <listener>
      <listener-class>org.dspace.servicemanager.servlet.DSpaceKernelServletContextListener</listener-class>
   </listener>

--- a/dspace-lni/src/main/webapp/WEB-INF/web.xml
+++ b/dspace-lni/src/main/webapp/WEB-INF/web.xml
@@ -32,7 +32,11 @@
 
 
 
-    <!-- kernel start listener (from impl), starts up the kernel for standalong webapps -->
+    <!--
+       DSpace Kernel startup listener. This listener is in charge of initializing/starting the
+       DSpace Kernel. It MUST be listed BEFORE any other DSpace listeners, as DSpace services
+       will not function until the Kernel is initialized.
+    -->
     <listener>
         <listener-class>org.dspace.servicemanager.servlet.DSpaceKernelServletContextListener</listener-class>
     </listener>

--- a/dspace-oai/src/main/webapp/WEB-INF/web.xml
+++ b/dspace-oai/src/main/webapp/WEB-INF/web.xml
@@ -28,6 +28,15 @@
 		<param-value>${dspace.dir}</param-value>
 	</context-param>
 
+        <!--
+          DSpace Kernel startup listener. This listener is in charge of initializing/starting the
+          DSpace Kernel. It MUST be listed BEFORE any other DSpace listeners, as DSpace services
+          will not function until the Kernel is initialized.
+         -->
+        <listener>
+                <listener-class>org.dspace.servicemanager.servlet.DSpaceKernelServletContextListener</listener-class>
+        </listener>
+
 	<listener>
 		<listener-class>org.dspace.app.util.DSpaceContextListener</listener-class>
 	</listener>

--- a/dspace-rdf/src/main/webapp/WEB-INF/web.xml
+++ b/dspace-rdf/src/main/webapp/WEB-INF/web.xml
@@ -40,12 +40,17 @@
         <url-pattern>/*</url-pattern>
     </filter-mapping>
 
+    <!--
+       DSpace Kernel startup listener. This listener is in charge of initializing/starting the
+       DSpace Kernel. It MUST be listed BEFORE any other DSpace listeners, as DSpace services
+       will not function until the Kernel is initialized.
+    -->
     <listener>
-        <listener-class>org.dspace.app.util.DSpaceContextListener</listener-class>
+        <listener-class>org.dspace.servicemanager.servlet.DSpaceKernelServletContextListener</listener-class>
     </listener>
 
     <listener>
-        <listener-class>org.dspace.servicemanager.servlet.DSpaceKernelServletContextListener</listener-class>
+        <listener-class>org.dspace.app.util.DSpaceContextListener</listener-class>
     </listener>
 
     <servlet>

--- a/dspace-rest/src/main/webapp/WEB-INF/web.xml
+++ b/dspace-rest/src/main/webapp/WEB-INF/web.xml
@@ -79,17 +79,17 @@
         -->
     </context-param>
 
-    <listener>
-        <listener-class>org.dspace.app.util.DSpaceContextListener</listener-class>
-    </listener>
-
-    <!-- kernel start listener (from impl)
-        The following listener can be used instead of the filter below, it is simpler, cleaner
-        and eliminates the need for a DSpaceKernelServletFilter filter to be involved with the
-        request cycle.
+    <!-- 
+       DSpace Kernel startup listener. This listener is in charge of initializing/starting the
+       DSpace Kernel. It MUST be listed BEFORE any other DSpace listeners, as DSpace services
+       will not function until the Kernel is initialized.
     -->
     <listener>
         <listener-class>org.dspace.servicemanager.servlet.DSpaceKernelServletContextListener</listener-class>
+    </listener>
+
+    <listener>
+        <listener-class>org.dspace.app.util.DSpaceContextListener</listener-class>
     </listener>
     
     <listener>

--- a/dspace-sword/src/main/webapp/WEB-INF/web.xml
+++ b/dspace-sword/src/main/webapp/WEB-INF/web.xml
@@ -49,10 +49,12 @@
     </description>
   </context-param>
   
-   <!-- 
-   Listener to initialise DSpace configuration and clean up the application 
-   -->
-    <listener>
+   <!--
+       DSpace Kernel startup listener. This listener is in charge of initializing/starting the
+       DSpace Kernel. It MUST be listed BEFORE any other DSpace listeners, as DSpace services
+       will not function until the Kernel is initialized.
+   --> 
+   <listener>
       <listener-class>
          org.dspace.servicemanager.servlet.DSpaceKernelServletContextListener
       </listener-class>

--- a/dspace-swordv2/src/main/webapp/WEB-INF/web.xml
+++ b/dspace-swordv2/src/main/webapp/WEB-INF/web.xml
@@ -100,9 +100,11 @@
 		</description>
 	</context-param>
 
-	<!--
-	   Listener to initialise DSpace configuration and clean up the application
-	   -->
+        <!--
+          DSpace Kernel startup listener. This listener is in charge of initializing/starting the
+          DSpace Kernel. It MUST be listed BEFORE any other DSpace listeners, as DSpace services
+          will not function until the Kernel is initialized.
+        -->
 	<listener>
 		<listener-class>
 			org.dspace.servicemanager.servlet.DSpaceKernelServletContextListener

--- a/dspace-xmlui/src/main/webapp/WEB-INF/web.xml
+++ b/dspace-xmlui/src/main/webapp/WEB-INF/web.xml
@@ -161,10 +161,14 @@
 
   <!-- Servlet Context Listener ======================================= -->
   
-    <!-- kernel start listener (from impl), starts up the kernel for standalong webapps -->
-  <listener>
-     <listener-class>org.dspace.servicemanager.servlet.DSpaceKernelServletContextListener</listener-class>
-  </listener>
+    <!--
+       DSpace Kernel startup listener. This listener is in charge of initializing/starting the
+       DSpace Kernel. It MUST be listed BEFORE any other DSpace listeners, as DSpace services
+       will not function until the Kernel is initialized.
+    -->
+    <listener>
+       <listener-class>org.dspace.servicemanager.servlet.DSpaceKernelServletContextListener</listener-class>
+    </listener>
   
     <!-- Listener to clean up Commons-FileUpload -->
     <listener>


### PR DESCRIPTION
(_This PR replaces #1008 as this fix is only applicable for the 5.x branch and NOT for master. In the master branch, the way in which DB migrations are kicked off has changed significantly in the API refactor._)

Several of our webapps load our custom `<listener>` classes in the wrong order, which can cause "DSpace Kernel cannot be null" errors to occur that end up blocking the creation of the default Groups...see

https://jira.duraspace.org/browse/DS-2408

Simply put, the "org.dspace.servicemanager.servlet.DSpaceKernelServletContextListener" MUST always be listed FIRST. That Listener is what initializes the DSpace Kernel, and the Kernel must be initialized for DSpace Spring Services to function (otherwise you get those "DSpace Kernel cannot be null" errors)

OAI, REST and RDF all have slightly incorrect `web.xml` files.  This PR fixes each of them, and adds a warning comment to all `web.xml` files to hopefully avoid this problem in the future.

Regarding DS-2408, if one of these three webapps (OAI, REST, RDF) loads first, then we end up with this Kernel error (and no admin group). If another webapp loads first, then the Kernel is initialized properly and all groups are created successfully.
