### PR TITLE
DS-2856 : Stop autowiring statistics services. Instead only load them on demand (by name).

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/factory/StatisticsServiceFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/factory/StatisticsServiceFactoryImpl.java
@@ -9,7 +9,7 @@ package org.dspace.statistics.factory;
 
 import org.dspace.statistics.service.ElasticSearchLoggerService;
 import org.dspace.statistics.service.SolrLoggerService;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.dspace.utils.DSpace;
 
 /**
  * Factory implementation to get services for the statistics package, use StatisticsServiceFactory.getInstance() to retrieve an implementation
@@ -18,20 +18,15 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public class StatisticsServiceFactoryImpl extends StatisticsServiceFactory {
 
-    @Autowired(required = true)
-//    @Lazy
-    private ElasticSearchLoggerService elasticSearchLogger;
-
-    @Autowired(required = true)
-    private SolrLoggerService solrLoggerService;
-
     @Override
     public SolrLoggerService getSolrLoggerService() {
-        return solrLoggerService;
+        // In order to lazy load, we cannot autowire it and instead load it by name
+        return new DSpace().getServiceManager().getServiceByName("solrLoggerService", SolrLoggerService.class);
     }
 
     @Override
     public ElasticSearchLoggerService getElasticSearchLoggerService() {
-        return elasticSearchLogger;
+        // In order to lazy load, we cannot autowire it and instead load it by name
+        return new DSpace().getServiceManager().getServiceByName("elasticSearchLoggerService", ElasticSearchLoggerService.class);
     }
 }

--- a/dspace/config/spring/api/core-services.xml
+++ b/dspace/config/spring/api/core-services.xml
@@ -81,8 +81,9 @@
 
     <bean class="org.dspace.license.CreativeCommonsServiceImpl"/>
 
-    <bean class="org.dspace.statistics.ElasticSearchLoggerServiceImpl" lazy-init="true"/>
-    <bean class="org.dspace.statistics.SolrLoggerServiceImpl"/>
+    <!-- Statistics services are both lazy loaded (by name), as you are likely just using ONE of them and not both -->
+    <bean id="elasticSearchLoggerService" class="org.dspace.statistics.ElasticSearchLoggerServiceImpl" lazy-init="true"/>
+    <bean id="solrLoggerService" class="org.dspace.statistics.SolrLoggerServiceImpl" lazy-init="true"/>
 
     <bean class="org.dspace.versioning.VersionHistoryServiceImpl"/>
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2856

This fixes the issue of ElasticSearch always initializing on startup (even if you don't have it configured/enabled).  Solr statistics are also no longer autowired (in case they are disabled), but they will still initialize by default on startup (as they are loaded by default in DSpace).

This PR also fixes my issues with XMLUI still not loading properly (it spins indefinitely) even after @pnbecker 's #1135 fix. (But, to be clear, #1135 was also necessary, as my webapps now get _further_ along, but now spin on Elastic Search loading up.)
