### PR TITLE
DS-2857 : Update all Codehaus plugins to latest version in Maven central

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -89,7 +89,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.9</version>
+                <version>1.9.1</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>
@@ -103,7 +103,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>buildnumber-maven-plugin</artifactId>
-                <version>1.3</version>
+                <version>1.4</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>

--- a/dspace/modules/xmlui-mirage2/pom.xml
+++ b/dspace/modules/xmlui-mirage2/pom.xml
@@ -204,7 +204,7 @@
                         <plugin>
                             <groupId>org.codehaus.mojo</groupId>
                             <artifactId>exec-maven-plugin</artifactId>
-                            <version>1.3.1</version>
+                            <version>1.4.0</version>
                         </plugin>
                     </plugins>
                 </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
              <plugin>
                   <groupId>org.codehaus.mojo</groupId>
                   <artifactId>findbugs-maven-plugin</artifactId>
-                  <version>3.0.0</version>
+                  <version>3.0.2</version>
                   <configuration>
                       <effort>Max</effort>
                       <threshold>Low</threshold>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2857

I've tested this locally against latest "master". DSpace still builds properly after upgrading these Maven plugins.  I also tested Mirage 2 and it still builds/works (as it also uses a codehaus plugin).

Scanning the Maven output, after upgrading these plugins to the latest version, it looks like Maven no longer attempts to download anything from https://nexus.codehaus.org (which no longer exists)
