### PR TITLE
DS-2738: Ensure admin-only filter is also triggered when we internally redirect to a dspace-admin JSP

### DIFF
--- a/dspace-jspui/src/main/webapp/WEB-INF/web.xml
+++ b/dspace-jspui/src/main/webapp/WEB-INF/web.xml
@@ -84,6 +84,9 @@
   <filter-mapping>
     <filter-name>admin-only</filter-name>
     <url-pattern>/dspace-admin/*</url-pattern>
+    <!-- Ensure this filter is triggered both for client requests and for internal forwards/redirects -->
+    <dispatcher>REQUEST</dispatcher>
+    <dispatcher>FORWARD</dispatcher>
   </filter-mapping>
 
   <filter-mapping>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2738

This fixes the path issues in DS-2738 by ensuring that redirects to any JSP under `/dspace-admin/*.jsp` properly trigger the admin-only filter.

For more info on the `<dispatcher>` setting (first added in Servlet 2.4), see the section on "RequestDispatcher changes" here:
http://www.javaworld.com/article/2073323/java-web-development/servlet-2-4--what-s-in-store.html

I've done some minimal testing here and it all seems to work, but this could use a second pair of eyes / additional testing.

This also will need to be cherry-picked over to "master"
