### PR TITLE
DS-2869 : Refactor SolrServiceImpl to always specify a list of fields for Solr to return

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/DiscoverQuery.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/DiscoverQuery.java
@@ -218,10 +218,20 @@ public class DiscoverQuery {
         this.facetOffset = facetOffset;
     }
 
+    /**
+     * Sets the fields which you want Discovery to return in the search results.
+     * It is HIGHLY recommended to limit the fields returned, as by default
+     * some backends (like Solr) will return everything.
+     * @param field field to add to the list of fields returned
+     */
     public void addSearchField(String field){
         this.searchFields.add(field);
     }
 
+    /**
+     * Get list of fields which Discovery will return in the search results
+     * @return List of field names
+     */
     public List<String> getSearchFields() {
         return searchFields;
     }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -119,6 +119,9 @@ public class SolrServiceImpl implements SearchService, IndexingService {
     private static final Logger log = Logger.getLogger(SolrServiceImpl.class);
 
     protected static final String LAST_INDEXED_FIELD = "SolrIndexer.lastIndexed";
+    protected static final String HANDLE_FIELD = "handle";
+    protected static final String RESOURCE_TYPE_FIELD = "search.resourcetype";
+    protected static final String RESOURCE_ID_FIELD = "search.resourceid";
 
     public static final String FILTER_SEPARATOR = "\n|||\n";
 
@@ -149,9 +152,11 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
                     solr.setBaseURL(solrService);
                     solr.setUseMultiPartPost(true);
+                    // Dummy/test query to search for Item (type=2) of ID=1
                     SolrQuery solrQuery = new SolrQuery()
-                            .setQuery("search.resourcetype:2 AND search.resourceid:1");
-
+                            .setQuery(RESOURCE_TYPE_FIELD + ":2 AND " + RESOURCE_ID_FIELD + ":1");
+                    // Only return obj identifier fields in result doc
+                    solrQuery.setFields(RESOURCE_TYPE_FIELD, RESOURCE_ID_FIELD);
                     solr.query(solrQuery);
 
                     // As long as Solr initialized, check with DatabaseUtils to see
@@ -323,7 +328,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
         try {
             if(getSolr() != null){
-                getSolr().deleteByQuery("handle:\"" + handle + "\"");
+                getSolr().deleteByQuery(HANDLE_FIELD + ":\"" + handle + "\"");
                 if(commit)
                 {
                     getSolr().commit();
@@ -462,10 +467,13 @@ public class SolrServiceImpl implements SearchService, IndexingService {
             }
             if (force)
             {
-                getSolr().deleteByQuery("search.resourcetype:[2 TO 4]");
+                getSolr().deleteByQuery(RESOURCE_TYPE_FIELD + ":[2 TO 4]");
             } else {
                 SolrQuery query = new SolrQuery();
-                query.setQuery("search.resourcetype:[2 TO 4]");
+                // Query for all indexed Items, Collections and Communities,
+                // returning just their handle
+                query.setFields(HANDLE_FIELD);
+                query.setQuery(RESOURCE_TYPE_FIELD + ":[2 TO 4]");
                 QueryResponse rsp = getSolr().query(query);
                 SolrDocumentList docs = rsp.getResults();
 
@@ -475,7 +483,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
                  SolrDocument doc = (SolrDocument) iter.next();
 
-                String handle = (String) doc.getFieldValue("handle");
+                String handle = (String) doc.getFieldValue(HANDLE_FIELD);
 
                 DSpaceObject o = HandleManager.resolveToObject(context, handle);
 
@@ -616,9 +624,9 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         boolean inIndex = false;
 
         SolrQuery query = new SolrQuery();
-        query.setQuery("handle:" + handle);
+        query.setQuery(HANDLE_FIELD + ":" + handle);
         // Specify that we ONLY want the LAST_INDEXED_FIELD returned in the field list (fl)
-        query.setParam(CommonParams.FL, LAST_INDEXED_FIELD);
+        query.setFields(LAST_INDEXED_FIELD);
         QueryResponse rsp;
 
         try {
@@ -1446,9 +1454,9 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         // New fields to weaken the dependence on handles, and allow for faster
         // list display
 		doc.addField("search.uniqueid", type+"-"+id);
-        doc.addField("search.resourcetype", Integer.toString(type));
+        doc.addField(RESOURCE_TYPE_FIELD, Integer.toString(type));
 
-        doc.addField("search.resourceid", Integer.toString(id));
+        doc.addField(RESOURCE_ID_FIELD, Integer.toString(id));
 
         // want to be able to search for handle, so use keyword
         // (not tokenized, but it is indexed)
@@ -1456,7 +1464,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         {
             // want to be able to search for handle, so use keyword
             // (not tokenized, but it is indexed)
-            doc.addField("handle", handle);
+            doc.addField(HANDLE_FIELD, handle);
         }
 
         if (locations != null)
@@ -1586,7 +1594,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                 discoveryQuery.addFilterQueries("location:l" + dso.getID());
             } else if (dso instanceof Item)
             {
-                discoveryQuery.addFilterQueries("handle:" + dso.getHandle());
+                discoveryQuery.addFilterQueries(HANDLE_FIELD + ":" + dso.getHandle());
             }
         }
         return search(context, discoveryQuery, includeUnDiscoverable);
@@ -1622,6 +1630,18 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 		}
 
         solrQuery.setQuery(query);
+
+        // Add any search fields to our query. This is the limited list
+        // of fields that will be returned in the solr result
+        for(String fieldName : discoveryQuery.getSearchFields())
+        {
+            solrQuery.addField(fieldName);
+        }
+        // Also ensure a few key obj identifier fields are returned with every query
+        solrQuery.addField(HANDLE_FIELD);
+        solrQuery.addField(RESOURCE_TYPE_FIELD);
+        solrQuery.addField(RESOURCE_ID_FIELD);
+
         if(discoveryQuery.isSpellCheck())
         {
             solrQuery.setParam(SpellingParams.SPELLCHECK_Q, query);
@@ -1642,7 +1662,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         }
         if(discoveryQuery.getDSpaceObjectFilter() != -1)
         {
-            solrQuery.addFilterQuery("search.resourcetype:" + discoveryQuery.getDSpaceObjectFilter());
+            solrQuery.addFilterQuery(RESOURCE_TYPE_FIELD + ":" + discoveryQuery.getDSpaceObjectFilter());
         }
 
         for (int i = 0; i < discoveryQuery.getFieldPresentQueries().size(); i++)
@@ -1755,7 +1775,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                 query.addFilterQueries("location:l" + dso.getID());
             } else if (dso instanceof Item)
             {
-                query.addFilterQueries("handle:" + dso.getHandle());
+                query.addFilterQueries(HANDLE_FIELD + ":" + dso.getHandle());
             }
         }
         return searchJSON(context, query, jsonIdentifier);
@@ -1809,7 +1829,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                 {
                     result.addDSpaceObject(dso);
                 } else {
-                    log.error(LogManager.getHeader(context, "Error while retrieving DSpace object from discovery index", "Handle: " + doc.getFirstValue("handle")));
+                    log.error(LogManager.getHeader(context, "Error while retrieving DSpace object from discovery index", "Handle: " + doc.getFirstValue(HANDLE_FIELD)));
                     continue;
                 }
 
@@ -1928,9 +1948,9 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
     protected static DSpaceObject findDSpaceObject(Context context, SolrDocument doc) throws SQLException {
 
-        Integer type = (Integer) doc.getFirstValue("search.resourcetype");
-        Integer id = (Integer) doc.getFirstValue("search.resourceid");
-        String handle = (String) doc.getFirstValue("handle");
+        Integer type = (Integer) doc.getFirstValue(RESOURCE_TYPE_FIELD);
+        Integer id = (Integer) doc.getFirstValue(RESOURCE_ID_FIELD);
+        String handle = (String) doc.getFirstValue(HANDLE_FIELD);
 
         if (type != null && id != null)
         {
@@ -1983,7 +2003,8 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
             SolrQuery solrQuery = new SolrQuery();
             solrQuery.setQuery(query);
-            solrQuery.setFields("search.resourceid", "search.resourcetype");
+            //Only return obj identifier fields in result doc
+            solrQuery.setFields(RESOURCE_ID_FIELD, RESOURCE_TYPE_FIELD);
             solrQuery.setStart(offset);
             solrQuery.setRows(max);
             if (orderfield != null)
@@ -2003,7 +2024,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
             {
                 SolrDocument doc = (SolrDocument) iter.next();
 
-                DSpaceObject o = DSpaceObject.find(context, (Integer) doc.getFirstValue("search.resourcetype"), (Integer) doc.getFirstValue("search.resourceid"));
+                DSpaceObject o = DSpaceObject.find(context, (Integer) doc.getFirstValue(RESOURCE_TYPE_FIELD), (Integer) doc.getFirstValue(RESOURCE_ID_FIELD));
 
                 if (o != null)
                 {
@@ -2091,7 +2112,9 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         try{
             SolrQuery solrQuery = new SolrQuery();
             //Set the query to handle since this is unique
-            solrQuery.setQuery("handle: " + item.getHandle());
+            solrQuery.setQuery(HANDLE_FIELD + ": " + item.getHandle());
+            //Only return obj identifier fields in result doc
+            solrQuery.setFields(HANDLE_FIELD, RESOURCE_TYPE_FIELD, RESOURCE_ID_FIELD);
             //Add the more like this parameters !
             solrQuery.setParam(MoreLikeThisParams.MLT, true);
             //Add a comma separated list of the similar fields

--- a/dspace/solr/search/conf/schema.xml
+++ b/dspace/solr/search/conf/schema.xml
@@ -478,7 +478,7 @@
               <filter class="solr.StopFilterFactory" ignoreCase="true"
                       words="stopwords.txt"/>
               <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
-              ￼￼￼￼￼  </analyzer>
+          </analyzer>
       </fieldType>
  </types>
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2869

This PR tweaks a few things:
1. Removes a very strange set of characters from our Solr search schema. It's not directly related to DS-2869, but I stumbled on it during my investigations into this bug (see https://github.com/DSpace/DSpace/commit/50c4a54bd6295fee55dd2d64b6afb021295ad97d). **NOTE:** It seems these characters may not appear on OSX, but they do appear on Windows & Linux.
2. Refactors/updates the `SolrServiceImpl` class to ALWAYS send a specific list of fields to Solr (using either `SolrQuery.addField()` or `SolrQuery.setFields()`). This ensures that Solr will only ever respond with specifically requested fields, instead of defaulting to returning all fields (including the "full_text" field).
3. As part of # 2, I also defined some new constants in `SolrServiceImpl` for very commonly used Solr fields (ones relating to object identification). I've refactored the code to use these constants throughout, and also ensure they are ALWAYS returned by Solr for any query run.
4. Minor enhancements to comments of `DiscoverQuery` to recommend using `addSearchField()`.

I've tested these fixes with an exact copy of a 5.3 production site which was previously exhibiting the behaviors described in DS-2869.
- Prior to these fixes, the production site's memory usage would gradually increase while browsing/searching. Eventually, after about 5 minutes of browsing it would hit an OOM heap size error (as it only has 1GB allocated heap).
- AFTER this PR was applied, that same site never goes over 500MB of memory (measured via YourKit) while browsing/searching, and the gradual increase in memory never occurs.

I've also verified that all searching/browsing capabilities still seem to function as expected. This includes hit highlighting and "did you mean" (spellcheck) functionality.  I also re-verified that the fixes in #1124 still function properly.

I'd appreciate further testers/eyes on this code. While I think it works, it does refactor the core code that runs all search/browse functionality in DSpace. Therefore, it would be worth additional testers taking a close look.

Once this is merged, it will also need to be ported to "master".  Currently, this PR has a minor merge conflict with "master" (but it's very easily fixed).
