### PR TITLE
DS-2872 Speed up builds; drop unnecessary repos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1652,18 +1652,4 @@
         <!-- further distribution management is found upstream in the sonatype parent -->
     </distributionManagement>
 
-    <repositories>
-        <repository>
-            <id>sonatype-releases</id>
-            <name>Sonatype Releases Repository</name>
-            <url>https://oss.sonatype.org/content/repositories/releases/</url>
-        </repository>
-        <!--Nor sonatype nor maven central appear to still contain org.restlet.jee:org.restlet.ext.servlet:jar:2.1.1 any more. No problem if it is in your local repo. Build fail if it isn't-->
-        <repository>
-            <id>restlet</id>
-            <name>restlet</name>
-            <url>http://maven.restlet.org</url>
-        </repository>
-    </repositories>
-
 </project>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2872

To test this, move your current ~/.m2 aside temporarily, then initiate a full DSpace build. Notice how all necessary dependencies are loaded correctly.

I tested with and without this change, and a fresh build with a clean local .m2 dir took 7min 16sec without, and 5min 18sec with. Mainly because it didn't have to hammer on sonatype oss and the restlet repo before checking central for most dependencies.
