### PR TITLE
DS-2879: Adds configuration to suppress notifications on returned tasks.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/workflowbasic/BasicWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/workflowbasic/BasicWorkflowServiceImpl.java
@@ -419,6 +419,11 @@ public class BasicWorkflowServiceImpl implements BasicWorkflowService
 
         //Gather our old data for launching the workflow event
         int oldState = workflowItem.getState();
+        
+        // in case we don't want to inform reviewers about tasks returned to
+        // the pool by other reviewers, we'll ne to know whether they were owned
+        // before. => keep this information before setting the new owner.
+        EPerson oldOwner = workflowItem.getOwner();
 
         workflowItem.setState(newstate);
 
@@ -443,8 +448,13 @@ public class BasicWorkflowServiceImpl implements BasicWorkflowService
                 createTasks(context, workflowItem, epa);
                 workflowItemService.update(context, workflowItem);
 
-                // email notification
-                notifyGroupOfTask(context, workflowItem, mygroup, epa);
+                if (ConfigurationManager.getBooleanProperty("workflow", "notify.returned.tasks", true)
+                        || oldState != WFSTATE_STEP1
+                        || oldOwner == null)
+                {
+                    // email notification
+                    notifyGroupOfTask(context, workflowItem, mygroup, epa);
+                }                
             }
             else
             {
@@ -484,8 +494,13 @@ public class BasicWorkflowServiceImpl implements BasicWorkflowService
                 //  timestamp, and add them to the list
                 createTasks(context, workflowItem, epa);
 
-                // email notification
-                notifyGroupOfTask(context, workflowItem, mygroup, epa);
+                if (ConfigurationManager.getBooleanProperty("workflow", "notify.returned.tasks", true) 
+                        || oldState != WFSTATE_STEP2
+                        || oldOwner == null)
+                {
+                    // email notification
+                    notifyGroupOfTask(context, workflowItem, mygroup, epa);
+                }
             }
             else
             {
@@ -521,8 +536,13 @@ public class BasicWorkflowServiceImpl implements BasicWorkflowService
                 //  timestamp, and add them to the list
                 createTasks(context, workflowItem, epa);
 
-                // email notification
-                notifyGroupOfTask(context, workflowItem, mygroup, epa);
+                if (ConfigurationManager.getBooleanProperty("workflow", "notify.returned.tasks", true)
+                        || oldState != WFSTATE_STEP3
+                        || oldOwner == null)
+                {
+                    // email notification
+                    notifyGroupOfTask(context, workflowItem, mygroup, epa);
+                }
             }
             else
             {

--- a/dspace/config/modules/workflow.cfg
+++ b/dspace/config/modules/workflow.cfg
@@ -14,3 +14,6 @@ workflow.framework=originalworkflow
 #Allow the reviewers to add/edit/remove files from the submission
 #When changing this property you might want to alert submitters in the license that reviewers can alter their files
 reviewer.file-edit=false
+
+# Notify reviewers about tasks returned to the pool
+#notify.returned.tasks = true


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2879
To test this PR first ensure no behavior is changed on default:
Install DSpace, create a community and a collection, create a WorkflowStep and add at least one EPerson to the WorkflowStep Group. Create an item in this collection and see if the EPerson that is part of the WorkflowStepGroup got a mail (by the way the EPerson in the WorkflowStepGroup can also be the submitter of the item). Take the task out of the pool as if you would want to perform this task and return it to the pool. Verify you got a second mail.

Now change the file [dspace]/config/modules/workflow.cfg and set notifiy.return.tasks=false. Restart tomcat and do exact the same steps as before. You should get a mail after creating the submission, but you shouldn't get the second mail about a new task after you returned the task to the pool.
