### PR TITLE
[DS-2883] Resurrect TabFileUsageEventListener

### DIFF
--- a/dspace-api/src/main/java/org/dspace/usage/package-info.java
+++ b/dspace-api/src/main/java/org/dspace/usage/package-info.java
@@ -1,0 +1,27 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+/**
+ * Capture of "usage events".  A {@link org.dspace.usage.UsageEvent} represents
+ * something like a download or viewing of a Bitstream -- that is, the
+ * <em>use</em> of content as opposed to its ingestion or alteration.  Usage
+ * events are meant to be useful for statistical analysis of content usage.
+ *
+ * <p>
+ * Multiple {@link org.dspace.usage.AbstractUsageEventListener} implementations
+ * may be configured for processing these events.  When an event is "fired",
+ * it is passed to each configured listener.  Several stock listeners are provided,
+ * in this package and others, for doing common tasks.
+ * </p>
+ *
+ * @see org.dspace.statistics.ElasticSearchLoggerEventListener
+ * @see org.dspace.google.GoogleRecorderEventListener
+ * @see org.dspace.statistics.SolrLoggerUsageEventListener
+ */
+
+package org.dspace.usage;

--- a/dspace-api/src/main/java/org/dspace/usage/package-info.java
+++ b/dspace-api/src/main/java/org/dspace/usage/package-info.java
@@ -19,6 +19,12 @@
  * in this package and others, for doing common tasks.
  * </p>
  *
+ * <p>
+ * To add a usage event listener to the bus, configure it as a new {@code <bean>}
+ * in a web application's {@code applicationContext.xml} and inject the
+ * {@code EventService}, as with the stock listeners.
+ * </p>
+ *
  * @see org.dspace.statistics.ElasticSearchLoggerEventListener
  * @see org.dspace.google.GoogleRecorderEventListener
  * @see org.dspace.statistics.SolrLoggerUsageEventListener

--- a/dspace-jspui/src/main/webapp/WEB-INF/spring/applicationContext.xml
+++ b/dspace-jspui/src/main/webapp/WEB-INF/spring/applicationContext.xml
@@ -42,15 +42,15 @@
         </property>
     </bean>
 
-    <!-- 
-    Uncomment to enable TabFileUsageEventListener 
-    <bean class="org.dspace.app.statistics.TabFileUsageEventListener">
+    <!-- TabFileUsageEventListener -->
+    <!-- Uncomment to enable
+    <bean class="org.dspace.usage.TabFileUsageEventListener">
     	<property name="eventService" >
     		<ref bean="dspace.eventService"/>
     	</property>
     </bean>
     -->
-    
+
     <!-- 
     Uncomment to enable PassiveUsageEventListener
     <bean class="org.dspace.app.statistics.PassiveUsageEventListener">

--- a/dspace-oai/src/main/webapp/WEB-INF/spring/applicationContext.xml
+++ b/dspace-oai/src/main/webapp/WEB-INF/spring/applicationContext.xml
@@ -42,15 +42,15 @@
         </property>
     </bean>
 
-    <!-- 
-    Uncomment to enable TabFileUsageEventListener 
-    <bean class="org.dspace.app.statistics.TabFileUsageEventListener">
+    <!-- TabFileUsageEventListener -->
+    <!-- Uncomment to enable
+    <bean class="org.dspace.usage.TabFileUsageEventListener">
     	<property name="eventService" >
     		<ref bean="dspace.eventService"/>
     	</property>
     </bean>
     -->
-    
+
     <!-- 
     Uncomment to enable PassiveUsageEventListener
     <bean class="org.dspace.app.statistics.PassiveUsageEventListener">

--- a/dspace-rest/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/dspace-rest/src/main/webapp/WEB-INF/applicationContext.xml
@@ -28,8 +28,8 @@
             <ref bean="dspace.eventService"/>
         </property>
     </bean>
-     
-    <!-- Inject the Default LoggerUsageEventListener into the EventService  -->
+
+    <!-- Inject the SolrLoggerUsageEventListener into the EventService  -->
     <bean class="org.dspace.statistics.SolrLoggerUsageEventListener">
         <property name="eventService" >
             <ref bean="dspace.eventService"/>
@@ -42,16 +42,16 @@
             <ref bean="dspace.eventService" />
         </property>
     </bean>-->
-          
-    <!-- 
-    Uncomment to enable TabFileUsageEventListener 
-    <bean class="org.dspace.app.statistics.TabFileUsageEventListener">
+
+    <!-- TabFileUsageEventListener -->
+    <!-- Uncomment to enable
+    <bean class="org.dspace.usage.TabFileUsageEventListener">
         <property name="eventService" >
             <ref bean="dspace.eventService"/>
         </property>
     </bean>
     -->
-    
+
     <!-- 
     Uncomment to enable PassiveUsageEventListener
     <bean class="org.dspace.app.statistics.PassiveUsageEventListener">

--- a/dspace-xmlui/src/main/webapp/WEB-INF/spring/applicationContext.xml
+++ b/dspace-xmlui/src/main/webapp/WEB-INF/spring/applicationContext.xml
@@ -43,8 +43,8 @@
             <ref bean="dspace.eventService"/>
         </property>
     </bean>
-     
-    <!-- Inject the Default LoggerUsageEventListener into the EventService  -->
+
+    <!-- Inject the SolrLoggerUsageEventListener into the EventService  -->
     <bean class="org.dspace.statistics.SolrLoggerUsageEventListener">
         <property name="eventService" >
             <ref bean="dspace.eventService"/>
@@ -64,16 +64,16 @@
             <ref bean="dspace.eventService" />
         </property>
     </bean>-->
-          
-    <!-- 
-    Uncomment to enable TabFileUsageEventListener 
-    <bean class="org.dspace.app.statistics.TabFileUsageEventListener">
+
+    <!-- TabFileUsageEventListener -->
+    <!-- Uncomment to enable TabFileUsageEventListener
+    <bean class="org.dspace.usage.TabFileUsageEventListener">
         <property name="eventService" >
             <ref bean="dspace.eventService"/>
         </property>
     </bean>
     -->
-    
+
     <!-- 
     Uncomment to enable PassiveUsageEventListener
     <bean class="org.dspace.app.statistics.PassiveUsageEventListener">


### PR DESCRIPTION
Someone found a use for this, so I recovered it from history (and tightened up the code a wee bit).  This would give DSpace a simple, compact primary source for usage cases, letting Solr be what it wants to be: a cache representing a primary source. It's also a handy format for feeding to dedicated statistical tools like SAS or R, for doing exploratory statistics. These cases would not be lost in the clutter of the general dspace.log file, allowing us to separate data with long-term value from data with only short-term (i.e. diagnostic) value. 

Lightly tested with XMLUI.

https://jira.duraspace.org/browse/DS-2883
