### PR TITLE
DS-2885: Making sort option for metadata browse indexes configurable

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1059,7 +1059,8 @@ webui.strengths.show = false
 #
 # webui.browse.index.<n> = <index name> : metadata : \
 #                                                       <schema prefix>.<element>[.<qualifier>|.*] : \
-#                                                       (date | title | text) : (asc | desc)
+#                                                       (date | title | text) : (asc | desc) : \
+#                                                       <sort option name>
 #
 # This form represent a unique index of metadata values from the item.
 #
@@ -1072,9 +1073,10 @@ webui.strengths.show = false
 #           <other>: any other datatype will be treated the same as 'text', although
 #                   it will apply any custom ordering normalisation configured below
 #
-#   The final part of the configuration is optional, and specifies the default ordering
+#   The two last parts of the configuration are optional, and specifies the default ordering
 #   for the index - whether it is ASCending (the default, and best for text indexes), or
-#   DESCending (useful for dates - ie. most recent submissions)
+#   DESCending (useful for dates - ie. most recent submissions) - and the sort option to use.
+#   If you want to define the sort option you must define order as well.
 #
 #   NOTE: the text to render the index will use the <index name> parameter to select
 #   the message key from Messages.properties using a key of the form:


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2885

If you create a new browse index it can be an item browse index or a metadata browse index. For an item browse index it is possible to configure a sort option. This PR adds the possibility to add a sort option to an metadata browse index.

To test this PR create a metadata browse index (or change an existing one) to use another sort option then the default sort option. Ensure that the metadata index contains some entries, open the metadata index, click on one key and see that the item list uses the configured sort option instead of the default one.
