### PR TITLE
DS-2888: JSPUI: Add language tags to submission edit metadata step

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
@@ -28,6 +28,15 @@ public class DCInput
 
     /** the DC namespace schema */
     private String dcSchema = null;
+    
+    /** the input language */
+    private boolean language = false;
+    
+    /** the language code use for the input */
+    private static final String LanguageName = "common_iso_languages";
+
+    /** the language list and their value */
+    private List<String> valueLanguageList = null;
 
     /** a label describing input */
     private String label = null;
@@ -100,6 +109,14 @@ public class DCInput
             dcSchema = MetadataSchema.DC_SCHEMA;
         }
 
+        //check if the input have a language tag
+        language = Boolean.valueOf(fieldMap.get("language"));
+        valueLanguageList = new ArrayList();
+        if (language)
+        {
+            valueLanguageList = listMap.get(LanguageName);
+        }
+        
         String repStr = fieldMap.get("repeatable");
         repeatable = "true".equalsIgnoreCase(repStr)
                 || "yes".equalsIgnoreCase(repStr);
@@ -255,6 +272,16 @@ public class DCInput
     {
         return dcQualifier;
     }
+    
+    /**
+     * Get the language for this form row.
+     * 
+     * @return the language state
+     */
+    public boolean getLanguage()
+    {
+        return language;
+    }
 
     /**
      * Get the hint for this form row, formatted for an HTML table
@@ -296,6 +323,17 @@ public class DCInput
         return valueList;
     }
 
+    /**
+     * Get the list of language tags 
+     * 
+     * @return the list of language
+     */
+
+    public List<String> getValueLanguageList() 
+    {
+        return valueLanguageList;
+    }
+    
     /**
      * Get the name of the controlled vocabulary that is associated with this
      * field

--- a/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
@@ -375,28 +375,46 @@ public class DCInputsReader
                         field.put(tagName, value);
                         if (tagName.equals("input-type"))
                         {
-                    if (value.equals("dropdown")
-                            || value.equals("qualdrop_value")
-                            || value.equals("list"))
+                            if (value.equals("dropdown")
+                                    || value.equals("qualdrop_value")
+                                    || value.equals("list"))
+                            {
+                                    String pairTypeName = getAttribute(nd, PAIR_TYPE_NAME);
+                                    if (pairTypeName == null)
+                                    {
+                                            throw new SAXException("Form " + formName + ", field " +
+                                                                           field.get("dc-element") +
+                                                                           "." + field.get("dc-qualifier") +
+                                                                           " has no name attribute");
+                                    }
+                                    else
+                                    {
+                                            field.put(PAIR_TYPE_NAME, pairTypeName);
+                                    }
+                            }
+                        }
+                        else if (tagName.equals("vocabulary"))
+                        {
+                                String closedVocabularyString = getAttribute(nd, "closed");
+                                field.put("closedVocabulary", closedVocabularyString);
+                        }
+                        else if (tagName.equals("language"))
+                        {
+                                if (Boolean.valueOf(value))
                                 {
                                         String pairTypeName = getAttribute(nd, PAIR_TYPE_NAME);
                                         if (pairTypeName == null)
                                         {
                                                 throw new SAXException("Form " + formName + ", field " +
-                                                                                                field.get("dc-element") +
-                                                                                                        "." + field.get("dc-qualifier") +
-                                                                                                " has no name attribute");
+                                                                               field.get("dc-element") +
+                                                                               "." + field.get("dc-qualifier") +
+                                                                               " has no language attribute");
                                         }
                                         else
                                         {
                                                 field.put(PAIR_TYPE_NAME, pairTypeName);
                                         }
                                 }
-                        }
-                        else if (tagName.equals("vocabulary"))
-                        {
-                                String closedVocabularyString = getAttribute(nd, "closed");
-                            field.put("closedVocabulary", closedVocabularyString);
                         }
                 }
         }

--- a/dspace-jspui/src/main/webapp/submit/edit-metadata.jsp
+++ b/dspace-jspui/src/main/webapp/submit/edit-metadata.jsp
@@ -624,7 +624,9 @@
              {
                  lang = ConfigurationManager.getProperty("default.language");
              }
-                 sb = doLanguageTag(sb, fieldNameIdx, valueLanguageList, lang);
+             sb.append("<div class=\"col-md-2\">");
+             sb = doLanguageTag(sb, fieldNameIdx, valueLanguageList, lang);
+             sb.append("</div>");
          }
             
          if (authorityType != null)
@@ -735,7 +737,9 @@
                {
                     lang = ConfigurationManager.getProperty("default.language");
                }
+               sb.append("<div class=\"col-md-2\">");
                sb = doLanguageTag(sb, fieldNameIdx, valueLanguageList, lang);
+               sb.append("</div>");
            }
             
            if (authorityType != null)
@@ -778,140 +782,236 @@
 
     void doTwoBox(javax.servlet.jsp.JspWriter out, Item item,
       String fieldName, String schema, String element, String qualifier, boolean repeatable, boolean required, boolean readonly,
-      int fieldCountIncr, String label, PageContext pageContext, String vocabulary, boolean closedVocabulary)
+      int fieldCountIncr, String label, PageContext pageContext, String vocabulary, boolean closedVocabulary,
+      boolean language, List<String> valueLanguageList)
       throws java.io.IOException
     {
-      List<MetadataValue> defaults = ContentServiceFactory.getInstance().getItemService().getMetadata(item, schema, element, qualifier, Item.ANY);
-      int fieldCount = defaults.size() + fieldCountIncr;
-      StringBuffer sb = new StringBuffer();
-      StringBuffer headers = new StringBuffer();
+        /*
+    <div class="row"><label class="col-md-2">Subject Keywords</label>
+        <div class="col-md-10">
+            <div class="row">
+                <div class="col-md-5">
+                    <span class="col-md-6"><input type="text" class="form-control" name="dc_subject_1" size="15" value="test"></span>
+                    <span class="col-md-4"><select class="form-control" name="dc_subject_other_1[lang]"><option value="">N/A</option><option selected="selected" value="en">English</option><option value="de">German</option></select></span>
+                    <button value="Remove" name="submit_dc_subject_remove_0" class="btn btn-danger col-md-2"><span class="glyphicon glyphicon-trash"></span></button>
+                </div>
+                <div class="col-md-5">
+                    <span class="col-md-6"><input type="text" class="form-control" name="dc_subject_2" size="15" value="tes2"></span>
+                    <span class="col-md-4"><select class="form-control" name="dc_subject_other_1[lang]"><option value="">N/A</option><option selected="selected" value="en">English</option><option value="de">German</option></select></span>
+                    <button class="col-md-2 btn btn-danger" name="submit_dc_subject_remove_1" value="Remove"><span class="glyphicon glyphicon-trash"></span></button>
+                </div>
+                <span class="col-md-2"></span>
+            </div>
+            <div class="row">
+              <div class="col-md-5">
+                <span class="col-md-6"><input type="text" class="form-control" name="dc_subject_3" size="15"></span>
+                <span class="col-md-4"><select class="form-control" name="dc_subject_other_1[lang]"><option value="">N/A</option><option selected="selected" value="en">English</option><option value="de">German</option></select></span>
+                <span class="col-md-2"></span>
+              </div>
+              <div class="col-md-5">
+                <span class="col-md-6"><input type="text" class="form-control" name="dc_subject_3" size="15"></span>
+                <span class="col-md-4"><select class="form-control" name="dc_subject_other_1[lang]"><option value="">N/A</option><option selected="selected" value="en">English</option><option value="de">German</option></select></span>
+                <span class="col-md-2"></span>
+              </div>
+              <button class="btn btn-default col-md-2" name="submit_dc_subject_add" value="Add More"><span class="glyphicon glyphicon-plus"></span>&nbsp;&nbsp;Add More</button>
+            </div>
+        </div>
+    </div>
+        */
 
-      String fieldParam = "";
+        List<MetadataValue> defaults = ContentServiceFactory.getInstance().getItemService().getMetadata(item, schema, element, qualifier, Item.ANY);
+        int fieldCount = defaults.size() + fieldCountIncr;
+        StringBuffer sb = new StringBuffer();
+        StringBuffer headers = new StringBuffer();
 
-      if (fieldCount == 0)
-         fieldCount = 1;
+        String fieldParam = "";
 
-      sb.append("<div class=\"row\"><label class=\"col-md-2"+ (required?" label-required":"") +"\">")
-        .append(label)
-        .append("</label>");
-      sb.append("<div class=\"col-md-10\">");
-      for (int i = 0; i < fieldCount; i++)
-      {
-     	 sb.append("<div class=\"row col-md-12\">");
+        if (fieldCount == 0)
+           fieldCount = 1;
+
+        sb.append("<div class=\"row\"><label class=\"col-md-2"+ (required?" label-required":"") +"\">")
+          .append(label)
+          .append("</label>");
+        sb.append("<div class=\"col-md-10\">");
+        for (int i = 0; i < fieldCount; i++)
+        {
+            sb.append("<div class=\"row\">\n");
+            sb.append("<div class=\"col-md-5\">");
          
-         if(repeatable)
-         {
-             //param is field name and index, starting from 1 (e.g. myfield_2)
-             fieldParam = fieldName + "_" + (i+1);
-         }
-         else
-         {
-             //param is just the field name
-             fieldParam = fieldName;
-         }
-         
-         if (i < defaults.size()) 
-         {
-                 sb.append("<span class=\"col-md-4\"><input class=\"form-control\" type=\"text\" name=\"")
-                         .append(fieldParam)
-                         .append("\" size=\"15\" value=\"")
-                         .append(defaults.get(i).getValue().replaceAll("\"", "&quot;"))
-                         .append("\"")
-                         .append((hasVocabulary(vocabulary) && closedVocabulary) || readonly ? " disabled=\"disabled\" " : "")
-                         .append("\" />");
+            if(repeatable)
+            {
+                //param is field name and index, starting from 1 (e.g. myfield_2)
+                fieldParam = fieldName + "_" + (i+1);
+            }
+            else
+            {
+                //param is just the field name
+                fieldParam = fieldName;
+            }
 
-                 sb.append(doControlledVocabulary(fieldParam, pageContext, vocabulary, readonly));
-                 sb.append("</span>");
-                 if (repeatable && !readonly && i < fieldCount - 1) 
-                 {
-                     // put a remove button next to filled in values
-                     sb.append("<button class=\"btn btn-danger col-md-2\" name=\"submit_")
-                             .append(fieldName)
-                             .append("_remove_")
-                             .append(i)
-                             .append("\" value=\"")
-                             .append(LocaleSupport.getLocalizedMessage(pageContext, "jsp.submit.edit-metadata.button.remove2"))
-                             .append("\"><span class=\"glyphicon glyphicon-trash\"></span>&nbsp;&nbsp;" + LocaleSupport.getLocalizedMessage(pageContext, "jsp.submit.edit-metadata.button.remove") + "</button>");
-                 } 
-                 else 
-                 {
-                     sb.append("<span class=\"col-md-2\">&nbsp;</span>");
-                 }
-             }
-         else
-         {
-           sb.append("<span class=\"col-md-4\"><input class=\"form-control\" type=\"text\" name=\"")
-             .append(fieldParam)
-             .append("\" size=\"15\"")
-             .append((hasVocabulary(vocabulary)&&closedVocabulary) || readonly?" disabled=\"disabled\" ":"")
-             .append("/>")
-             .append(doControlledVocabulary(fieldParam, pageContext, vocabulary, readonly))
-             .append("</span>\n")
-             .append("<span class=\"col-md-2\">&nbsp;</span>");
-         } 
-         
-         i++;
+            if (i < defaults.size()) 
+            {
+                sb.append("<span class=\"col-md-")
+                    .append(language ? "6" : "10")
+                    .append("\"><input class=\"form-control\" type=\"text\" name=\"")
+                    .append(fieldParam)
+                    .append("\" size=\"15\" value=\"")
+                    .append(defaults.get(i).getValue().replaceAll("\"", "&quot;"))
+                    .append("\"")
+                    .append((hasVocabulary(vocabulary) && closedVocabulary) || readonly ? " disabled=\"disabled\" " : "")
+                    .append("/>");
 
-         if(repeatable)
-                 {
-                         //param is field name and index, starting from 1 (e.g. myfield_2)
-                     fieldParam = fieldName + "_" + (i+1);
-                 }
-                 else
-                 {
-                         //param is just the field name
-                         fieldParam = fieldName;
-                 }
-        
-                 if (i < defaults.size()) 
-                 {
-                         sb.append("<span class=\"col-md-4\"><input class=\"form-control\" type=\"text\" name=\"")
-                                 .append(fieldParam)
-                                 .append("\" size=\"15\" value=\"")
-                                 .append(defaults.get(i).getValue().replaceAll("\"", "&quot;"))
-                                 .append("\"")
-                                 .append((hasVocabulary(vocabulary) && closedVocabulary) || readonly ? " disabled=\"disabled\" " : "")
-                                 .append("/>");
-                         sb.append(doControlledVocabulary(fieldParam, pageContext, vocabulary, readonly));
-                         sb.append("</span>");
-                         if (repeatable && !readonly && i < fieldCount - 1) 
-                         {
-                             // put a remove button next to filled in values
-                             sb.append(" <button class=\"btn btn-danger col-md-2\" name=\"submit_")
-                                     .append(fieldName)
-                                     .append("_remove_")
-                                     .append(i)
-                                     .append("\" value=\"")
-                                     .append(LocaleSupport.getLocalizedMessage(pageContext, "jsp.submit.edit-metadata.button.remove2"))
-                                     .append("\"><span class=\"glyphicon glyphicon-trash\"></span>&nbsp;&nbsp;" + LocaleSupport.getLocalizedMessage(pageContext, "jsp.submit.edit-metadata.button.remove") + "</button>");
-                         } 
-                         else 
-                         {
-                             sb.append("<span class=\"col-md-2\">&nbsp;</span>");
-                         }
-                     }
-                 else
-           {
-                   sb.append("<span class=\"col-md-4\"><input class=\"form-control\" type=\"text\" name=\"")
-                     .append(fieldParam)
-                     .append("\" size=\"15\"")
+                sb.append(doControlledVocabulary(fieldParam, pageContext, vocabulary, readonly));
+                sb.append("</span>");
+                
+                if (language)
+                {
+                    String lang = defaults.get(i).getLanguage();
+                    if(null == lang)
+                    {
+                        lang = ConfigurationManager.getProperty("default.language");
+                    }
+                    sb.append("<span class=\"col-md-4\">");
+                    sb = doLanguageTag(sb, fieldParam, valueLanguageList, lang);
+                    sb.append("</span>");
+                }
+                
+                if (repeatable && !readonly)
+                {
+                    // put a remove button next to filled in values
+                    sb.append("<button class=\"btn btn-danger col-md-2\" name=\"submit_")
+                            .append(fieldName)
+                            .append("_remove_")
+                            .append(i)
+                            .append("\" value=\"")
+                            .append(LocaleSupport.getLocalizedMessage(pageContext, "jsp.submit.edit-metadata.button.remove2"))
+                            .append("\"><span class=\"glyphicon glyphicon-trash\"></span></button>");
+                }
+                else 
+                {
+                    sb.append("<span class=\"col-md-2\">&nbsp;</span>");
+                }
+            }
+            else
+            {
+                sb.append("<span class=\"col-md-")
+                    .append(language ? "6" : "10")
+                    .append("\"><input class=\"form-control\" type=\"text\" name=\"")
+                    .append(fieldParam)
+                    .append("\" size=\"15\"")
+                    .append((hasVocabulary(vocabulary)&&closedVocabulary) || readonly?" disabled=\"disabled\" ":"")
+                    .append("/>")
+                    .append(doControlledVocabulary(fieldParam, pageContext, vocabulary, readonly))
+                    .append("</span>\n");
+                
+                if (language)
+                {
+                    String lang = ConfigurationManager.getProperty("default.language");
+                    sb.append("<span class=\"col-md-4\">");
+                    sb = doLanguageTag(sb, fieldParam, valueLanguageList, lang);
+                    sb.append("</span>");
+                }
+                
+                sb.append("<span class=\"col-md-2\">&nbsp;</span>"); // no remove button
+            }
+            sb.append("</div>\n"); //<div class="col-md-5>
+         
+            i++;
+         
+            sb.append("<div class=\"col-md-5\">");
+            if(repeatable)
+            {
+                    //param is field name and index, starting from 1 (e.g. myfield_2)
+                fieldParam = fieldName + "_" + (i+1);
+            }
+            else
+            {
+                    //param is just the field name
+                    fieldParam = fieldName;
+            }
+
+            if (i < defaults.size()) 
+            {
+                sb.append("<span class=\"col-md-")
+                 .append(language ? 6 : 10)
+                 .append("\"><input class=\"form-control\" type=\"text\" name=\"")
+                 .append(fieldParam)
+                 .append("\" size=\"15\" value=\"")
+                 .append(defaults.get(i).getValue().replaceAll("\"", "&quot;"))
+                 .append("\"")
+                 .append((hasVocabulary(vocabulary) && closedVocabulary) || readonly ? " disabled=\"disabled\" " : "")
+                 .append("/>");
+                sb.append(doControlledVocabulary(fieldParam, pageContext, vocabulary, readonly));
+                sb.append("</span>");
+
+                if (language)
+                {
+                    String lang = defaults.get(i).getLanguage();
+                    if(null == lang)
+                    {
+                        lang = ConfigurationManager.getProperty("default.language");
+                    }
+                    sb.append("<span class=\"col-md-4\">");
+                    sb = doLanguageTag(sb, fieldParam, valueLanguageList, lang);
+                    sb.append("</span>");
+                }
+
+                if (repeatable && !readonly) 
+                {
+                    // put a remove button next to filled in values
+                    sb.append(" <button class=\"btn btn-danger col-md-2\" name=\"submit_")
+                        .append(fieldName)
+                        .append("_remove_")
+                        .append(i)
+                        .append("\" value=\"")
+                        .append(LocaleSupport.getLocalizedMessage(pageContext, "jsp.submit.edit-metadata.button.remove2"))
+                        .append("\"><span class=\"glyphicon glyphicon-trash\" /></button>");
+                }
+                  else
+                {
+                    sb.append("<span class=\"col-md-2\">&nbsp;</span>");
+                }
+            }
+            else
+            {
+                sb.append("<span class=\"col-md-")
+                    .append(language ? "6" : "10")
+                    .append("\"><input class=\"form-control\" type=\"text\" name=\"")
+                    .append(fieldParam)
+                    .append("\" size=\"15\"")
                      .append((hasVocabulary(vocabulary)&&closedVocabulary)||readonly?" disabled=\"disabled\" ":"")
-                     .append("/>")
-                     .append(doControlledVocabulary(fieldParam, pageContext, vocabulary, readonly))
-        			 .append("</span>\n");
-                   if (i+1 >= fieldCount && !readonly)
-                   {
-                     sb.append(" <button class=\"btn btn-default col-md-2\" name=\"submit_")
-                       .append(fieldName)
-                       .append("_add\" value=\"")
-                       .append(LocaleSupport.getLocalizedMessage(pageContext, "jsp.submit.edit-metadata.button.add"))
-                       .append("\"><span class=\"glyphicon glyphicon-plus\"></span>&nbsp;&nbsp;"+LocaleSupport.getLocalizedMessage(pageContext, "jsp.submit.edit-metadata.button.add")+"</button>\n");
-                   }
-                 }
-       sb.append("</div>");          
-      }
-      sb.append("</div></div><br/>");
-      out.write(sb.toString());
+                    .append("/>")
+                    .append(doControlledVocabulary(fieldParam, pageContext, vocabulary, readonly))
+                    .append("</span>\n");
+                
+                if (language)
+                {
+                    String lang = ConfigurationManager.getProperty("default.language");
+                    sb.append("<span class=\"col-md-4\">");
+                    sb = doLanguageTag(sb, fieldParam, valueLanguageList, lang);
+                    sb.append("</span>");
+                }
+                
+                sb.append("<span class=\"col-md-2\">&nbsp;</span>"); // no remove button
+            }
+            sb.append("</div>\n"); //<div class="col-md-5>
+
+            
+            if (repeatable && !readonly && i >= fieldCount - 1)
+            {
+                sb.append(" <button class=\"btn btn-default col-md-2\" name=\"submit_")
+                .append(fieldName)
+                .append("_add\" value=\"")
+                .append(LocaleSupport.getLocalizedMessage(pageContext, "jsp.submit.edit-metadata.button.add"))
+                .append("\"><span class=\"glyphicon glyphicon-plus\"></span>&nbsp;&nbsp;"+LocaleSupport.getLocalizedMessage(pageContext, "jsp.submit.edit-metadata.button.add")+"</button>\n");
+            } else {
+                sb.append("<!-- repeatable: " + (repeatable ? "true" : "false") + " readonly " + (readonly ? "true" : "false") + " i " + i + " fieldCount " + fieldCount + " -->");
+            }
+
+            sb.append("</div>"); //<div class="row">
+        }
+        sb.append("</div></div><br/>"); //<div class="row">...<div class="col-md-10">
+        out.write(sb.toString());
     }
     
     
@@ -1200,8 +1300,7 @@
     /** Display language tags **/
      StringBuffer doLanguageTag(StringBuffer sb, String fieldNameIdx, List<String> valueLanguageList, String lang)
      {
-         sb.append("<div class=\"col-md-2\">")
-                 .append("<select class=\"form-control\" name=\"")
+         sb.append("<select class=\"form-control\" name=\"")
                  .append(fieldNameIdx + "[lang]")
                  .append("\"")
                  .append(">");
@@ -1221,7 +1320,6 @@
          }
 
          sb.append("</select>");
-         sb.append("</div>");
          return sb;
     }
 %>
@@ -1444,7 +1542,7 @@
        {
                         doTwoBox(out, item, fieldName, dcSchema, dcElement, dcQualifier,
                                  repeatable, required, readonly, fieldCountIncr, label, pageContext, 
-                                 vocabulary, closedVocabulary);
+                                 vocabulary, closedVocabulary, language, inputs[z].getValueLanguageList());
        }
        else if (inputType.equals("list"))
        {

--- a/dspace-jspui/src/main/webapp/submit/edit-metadata.jsp
+++ b/dspace-jspui/src/main/webapp/submit/edit-metadata.jsp
@@ -277,12 +277,12 @@
     	 }
          first.setLength(0);
          first.append(fieldName).append("_first");
-         if (repeatable && i != fieldCount-1)
+         if (repeatable)
             first.append('_').append(i+1);
 
          last.setLength(0);
          last.append(fieldName).append("_last");
-         if (repeatable && i != fieldCount-1)
+         if (repeatable)
             last.append('_').append(i+1);
 
          if (i < defaults.size())
@@ -329,7 +329,7 @@
     	 }
          
 
-         if (repeatable && !readonly && i < defaults.size())
+         if (repeatable && !readonly && i < fieldCount - 1)
          {
             name.setLength(0);
             name.append(Utils.addEntities(dpn.getLastName()))
@@ -390,9 +390,9 @@
             .append("</span><select class=\"form-control\" name=\"")
             .append(fieldName)
             .append("_month");
-         if (repeatable && i>0)
+         if (repeatable)
          {
-            sb.append('_').append(i);
+            sb.append('_').append(i+1);
          }
          if (readonly)
          {
@@ -421,8 +421,8 @@
                 .append("</span><input class=\"form-control\" type=\"text\" name=\"")
             .append(fieldName)
             .append("_day");
-         if (repeatable && i>0)
-            sb.append("_").append(i);
+         if (repeatable)
+            sb.append("_").append(i+1);
          if (readonly)
          {
              sb.append("\" disabled=\"disabled");
@@ -435,8 +435,8 @@
                 .append("</span><input class=\"form-control\" type=\"text\" name=\"")
             .append(fieldName)
             .append("_year");
-         if (repeatable && i>0)
-            sb.append("_").append(i);
+         if (repeatable)
+            sb.append("_").append(i+1);
          if (readonly)
          {
              sb.append("\" disabled=\"disabled");
@@ -445,8 +445,8 @@
             .append((dateIssued.getYear() > 0 ?
                  String.valueOf(dateIssued.getYear()) : "" ))
             .append("\"/></span></div></div>\n");
-
-          if (repeatable && !readonly && i < defaults.size())
+    
+         if (repeatable && !readonly && i < fieldCount - 1)
          {
             // put a remove button next to filled in values
             sb.append("<button class=\"btn btn-danger col-md-2\" name=\"submit_")
@@ -502,7 +502,7 @@
          sb.append("<div class=\"row col-md-12\"><span class=\"col-md-5\"><input class=\"form-control\" type=\"text\" name=\"")
            .append(fieldName)
            .append("_series");
-         if (repeatable && i!= fieldCount)
+         if (repeatable)
            sb.append("_").append(i+1);
          if (readonly)
          {
@@ -515,7 +515,7 @@
            .append("\"/></span><span class=\"col-md-5\"><input class=\"form-control\" type=\"text\" name=\"")
            .append(fieldName)
            .append("_number");
-         if (repeatable && i!= fieldCount)
+         if (repeatable)
            sb.append("_").append(i+1);
          if (readonly)
          {
@@ -527,7 +527,7 @@
            .append(sn.getNumber().replaceAll("\"", "&quot;"))
            .append("\"/></span>\n");
 
-         if (repeatable && !readonly && i < defaults.size())
+         if (repeatable && !readonly && i < fieldCount - 1)
          {
             // put a remove button next to filled in values
             sb.append("<button class=\"btn btn-danger col-md-2\" name=\"submit_")
@@ -558,7 +558,8 @@
 
     void doTextArea(javax.servlet.jsp.JspWriter out, Item item,
       String fieldName, String schema, String element, String qualifier, boolean repeatable, boolean required, boolean readonly,
-      int fieldCountIncr, String label, PageContext pageContext, String vocabulary, boolean closedVocabulary, Collection collection)
+      int fieldCountIncr, String label, PageContext pageContext, String vocabulary, boolean closedVocabulary, Collection collection,
+      boolean language, List<String> valueLanguageList)
       throws java.io.IOException
     {
       String authorityType = getAuthorityType(pageContext, fieldName, collection);
@@ -576,12 +577,15 @@
       	.append("</label><div class=\"col-md-10\">");
       
       for (int i = 0; i < fieldCount; i++)
-      {
+      { 
+         String lang = null;
+         
          if (i < defaults.size())
          {
-           val = defaults.get(i).getValue();
-              auth = defaults.get(i).getAuthority();
-              conf = defaults.get(i).getConfidence();
+             val = defaults.get(i).getValue();
+             lang = defaults.get(i).getLanguage();
+             auth = defaults.get(i).getAuthority();
+             conf = defaults.get(i).getConfidence();
          }
          else
          {
@@ -589,8 +593,17 @@
             auth = "";
          }
          sb.append("<div class=\"row col-md-12\">\n");
-         String fieldNameIdx = fieldName + ((repeatable && i != fieldCount-1)?"_" + (i+1):"");
-         sb.append("<div class=\"col-md-10\">");
+         String fieldNameIdx = fieldName + ((repeatable)?"_" + (i+1):"");
+
+         if (language) 
+         {
+             sb.append("<div class=\"col-md-8\">");
+         }
+         else 
+         {
+             sb.append("<div class=\"col-md-10\">");
+         }
+
          if (authorityType != null)
          {
         	 sb.append("<div class=\"col-md-10\">");
@@ -602,7 +615,18 @@
            .append(">")
            .append(val)
            .append("</textarea>")
-           .append(doControlledVocabulary(fieldNameIdx, pageContext, vocabulary, readonly));
+           .append(doControlledVocabulary(fieldNameIdx, pageContext, vocabulary, readonly))
+           .append("</div>");
+           
+         if (language) 
+         {
+             if (null == lang)
+             {
+                 lang = ConfigurationManager.getProperty("default.language");
+             }
+                 sb = doLanguageTag(sb, fieldNameIdx, valueLanguageList, lang);
+         }
+            
          if (authorityType != null)
          {
         	 sb.append("</div><div class=\"col-md-2\">");
@@ -611,11 +635,8 @@
                             defaults, null, collection));
 	         sb.append("</div>");
          }
-
-         sb.append("</div>");
-           
          
-         if (repeatable && !readonly && i < defaults.size())
+         if (repeatable && !readonly && i < fieldCount - 1)
          {
             // put a remove button next to filled in values
             sb.append("<button class=\"btn btn-danger col-md-2\" name=\"submit_")
@@ -646,7 +667,8 @@
 
     void doOneBox(javax.servlet.jsp.JspWriter out, Item item,
       String fieldName, String schema, String element, String qualifier, boolean repeatable, boolean required, boolean readonly,
-      int fieldCountIncr, String label, PageContext pageContext, String vocabulary, boolean closedVocabulary, Collection collection)
+      int fieldCountIncr, String label, PageContext pageContext, String vocabulary, boolean closedVocabulary, Collection collection,
+      boolean language, List<String> valueLanguageList)
       throws java.io.IOException
     {
       String authorityType = getAuthorityType(pageContext, fieldName, collection);
@@ -664,11 +686,14 @@
         .append("</label>");
       sb.append("<div class=\"col-md-10\">");  
       for (int i = 0; i < fieldCount; i++)
-      {
+      { 
+          String lang = null;
+         
            if (i < defaults.size())
            {
              val = defaults.get(i).getValue().replaceAll("\"", "&quot;");
-               auth = defaults.get(i).getAuthority();
+             lang = defaults.get(i).getLanguage();
+             auth = defaults.get(i).getAuthority();
              conf = defaults.get(i).getConfidence();
            }
            else
@@ -679,9 +704,17 @@
            }
 
            sb.append("<div class=\"row col-md-12\">");
-           String fieldNameIdx = fieldName + ((repeatable && i != fieldCount-1)?"_" + (i+1):"");
-           
-           sb.append("<div class=\"col-md-10\">");
+           String fieldNameIdx = fieldName + ((repeatable)?"_" + (i+1):""); 
+            
+           if (language)
+           {
+               sb.append("<div class=\"col-md-8\">");
+           }
+           else 
+           {
+               sb.append("<div class=\"col-md-10\">");
+           }
+         
            if (authorityType != null)
            {
         	   sb.append("<div class=\"row col-md-10\">");
@@ -696,6 +729,15 @@
 			 .append(doControlledVocabulary(fieldNameIdx, pageContext, vocabulary, readonly))             
              .append("</div>");
            
+           if (language) 
+           {
+               if(null == lang)
+               {
+                    lang = ConfigurationManager.getProperty("default.language");
+               }
+               sb = doLanguageTag(sb, fieldNameIdx, valueLanguageList, lang);
+           }
+            
            if (authorityType != null)
            {
         	   sb.append("<div class=\"col-md-2\">");
@@ -705,7 +747,7 @@
            	   sb.append("</div></div>");
            }             
 
-          if (repeatable && !readonly && i < defaults.size())
+          if (repeatable && !readonly && i < fieldCount - 1)
           {
              // put a remove button next to filled in values
              sb.append("<button class=\"btn btn-danger col-md-2\" name=\"submit_")
@@ -756,8 +798,8 @@
       for (int i = 0; i < fieldCount; i++)
       {
      	 sb.append("<div class=\"row col-md-12\">");
-    	  
-         if(i != fieldCount)
+         
+         if(repeatable)
          {
              //param is field name and index, starting from 1 (e.g. myfield_2)
              fieldParam = fieldName + "_" + (i+1);
@@ -767,33 +809,35 @@
              //param is just the field name
              fieldParam = fieldName;
          }
-                 
-         if (i < defaults.size())
+         
+         if (i < defaults.size()) 
          {
-           sb.append("<span class=\"col-md-4\"><input class=\"form-control\" type=\"text\" name=\"")
-             .append(fieldParam)
-             .append("\" size=\"15\" value=\"")
-             .append(defaults.get(i).getValue().replaceAll("\"", "&quot;"))
-                   .append("\"")
-             .append((hasVocabulary(vocabulary)&&closedVocabulary) || readonly?" disabled=\"disabled\" ":"")
-             .append("\" />");
-          
-           sb.append(doControlledVocabulary(fieldParam, pageContext, vocabulary, readonly));
-           sb.append("</span>");
-          if (!readonly)
-          {
-                       sb.append("<button class=\"btn btn-danger col-md-2\" name=\"submit_")
+                 sb.append("<span class=\"col-md-4\"><input class=\"form-control\" type=\"text\" name=\"")
+                         .append(fieldParam)
+                         .append("\" size=\"15\" value=\"")
+                         .append(defaults.get(i).getValue().replaceAll("\"", "&quot;"))
+                         .append("\"")
+                         .append((hasVocabulary(vocabulary) && closedVocabulary) || readonly ? " disabled=\"disabled\" " : "")
+                         .append("\" />");
+
+                 sb.append(doControlledVocabulary(fieldParam, pageContext, vocabulary, readonly));
+                 sb.append("</span>");
+                 if (repeatable && !readonly && i < fieldCount - 1) 
+                 {
+                     // put a remove button next to filled in values
+                     sb.append("<button class=\"btn btn-danger col-md-2\" name=\"submit_")
                              .append(fieldName)
                              .append("_remove_")
                              .append(i)
                              .append("\" value=\"")
                              .append(LocaleSupport.getLocalizedMessage(pageContext, "jsp.submit.edit-metadata.button.remove2"))
-                             .append("\"><span class=\"glyphicon glyphicon-trash\"></span>&nbsp;&nbsp;"+LocaleSupport.getLocalizedMessage(pageContext, "jsp.submit.edit-metadata.button.remove")+"</button>");
-          }
-          else {
-        	  sb.append("<span class=\"col-md-2\">&nbsp;</span>");
-          }
-         }
+                             .append("\"><span class=\"glyphicon glyphicon-trash\"></span>&nbsp;&nbsp;" + LocaleSupport.getLocalizedMessage(pageContext, "jsp.submit.edit-metadata.button.remove") + "</button>");
+                 } 
+                 else 
+                 {
+                     sb.append("<span class=\"col-md-2\">&nbsp;</span>");
+                 }
+             }
          else
          {
            sb.append("<span class=\"col-md-4\"><input class=\"form-control\" type=\"text\" name=\"")
@@ -804,11 +848,11 @@
              .append(doControlledVocabulary(fieldParam, pageContext, vocabulary, readonly))
              .append("</span>\n")
              .append("<span class=\"col-md-2\">&nbsp;</span>");
-         }
+         } 
          
          i++;
 
-         if(i != fieldCount)
+         if(repeatable)
                  {
                          //param is field name and index, starting from 1 (e.g. myfield_2)
                      fieldParam = fieldName + "_" + (i+1);
@@ -819,33 +863,35 @@
                          fieldParam = fieldName;
                  }
         
-                 if (i < defaults.size())
+                 if (i < defaults.size()) 
                  {
-                   sb.append("<span class=\"col-md-4\"><input class=\"form-control\" type=\"text\" name=\"")
-                     .append(fieldParam)
-                     .append("\" size=\"15\" value=\"")
-                     .append(defaults.get(i).getValue().replaceAll("\"", "&quot;"))
-                           .append("\"")
-                         .append((hasVocabulary(vocabulary)&&closedVocabulary) || readonly?" disabled=\"disabled\" ":"")
-                         .append("/>");
-                   sb.append(doControlledVocabulary(fieldParam, pageContext, vocabulary, readonly));      
-                   sb.append("</span>");
-                   if (!readonly)
-                   {
-                               sb.append(" <button class=\"btn btn-danger col-md-2\" name=\"submit_")
+                         sb.append("<span class=\"col-md-4\"><input class=\"form-control\" type=\"text\" name=\"")
+                                 .append(fieldParam)
+                                 .append("\" size=\"15\" value=\"")
+                                 .append(defaults.get(i).getValue().replaceAll("\"", "&quot;"))
+                                 .append("\"")
+                                 .append((hasVocabulary(vocabulary) && closedVocabulary) || readonly ? " disabled=\"disabled\" " : "")
+                                 .append("/>");
+                         sb.append(doControlledVocabulary(fieldParam, pageContext, vocabulary, readonly));
+                         sb.append("</span>");
+                         if (repeatable && !readonly && i < fieldCount - 1) 
+                         {
+                             // put a remove button next to filled in values
+                             sb.append(" <button class=\"btn btn-danger col-md-2\" name=\"submit_")
                                      .append(fieldName)
                                      .append("_remove_")
                                      .append(i)
                                      .append("\" value=\"")
                                      .append(LocaleSupport.getLocalizedMessage(pageContext, "jsp.submit.edit-metadata.button.remove2"))
-                                     .append("\"><span class=\"glyphicon glyphicon-trash\"></span>&nbsp;&nbsp;"+LocaleSupport.getLocalizedMessage(pageContext, "jsp.submit.edit-metadata.button.remove")+"</button>");
-                   }
-                   else {
-                 	  sb.append("<span class=\"col-md-2\">&nbsp;</span>");
-                   }              
-                 }
+                                     .append("\"><span class=\"glyphicon glyphicon-trash\"></span>&nbsp;&nbsp;" + LocaleSupport.getLocalizedMessage(pageContext, "jsp.submit.edit-metadata.button.remove") + "</button>");
+                         } 
+                         else 
+                         {
+                             sb.append("<span class=\"col-md-2\">&nbsp;</span>");
+                         }
+                     }
                  else
-                 {
+           {
                    sb.append("<span class=\"col-md-4\"><input class=\"form-control\" type=\"text\" name=\"")
                      .append(fieldParam)
                      .append("\" size=\"15\"")
@@ -921,7 +967,7 @@
          sb.append("<div class=\"row col-md-12\"><span class=\"input-group col-md-10\"><span class=\"input-group-addon\"><select name=\"")
            .append(fieldName)
            .append("_qualifier");
-         if (repeatable && j!= fieldCount-1)
+         if (repeatable)
            sb.append("_").append(j+1);
          if (readonly)
          {
@@ -945,7 +991,7 @@
          sb.append("</select></span><input class=\"form-control\" type=\"text\" name=\"")
            .append(fieldName)
            .append("_value");
-         if (repeatable && j!= fieldCount-1)
+         if (repeatable)
            sb.append("_").append(j+1);
          if (readonly)
          {
@@ -955,9 +1001,9 @@
            .append(currentVal.replaceAll("\"", "&quot;"))
            .append("\"/></span>\n");
 
-         if (repeatable && !readonly && j < defaults.size())
-         {
-            // put a remove button next to filled in values
+         if (repeatable && !readonly && j < fieldCount - 1)
+          {
+             // put a remove button next to filled in values
             sb.append("<button class=\"btn btn-danger col-md-2\" name=\"submit_")
               .append(fieldName)
               .append("_remove_")
@@ -1150,6 +1196,34 @@
             
             out.write(sb.toString());
           }//end doList
+    
+    /** Display language tags **/
+     StringBuffer doLanguageTag(StringBuffer sb, String fieldNameIdx, List<String> valueLanguageList, String lang)
+     {
+         sb.append("<div class=\"col-md-2\">")
+                 .append("<select class=\"form-control\" name=\"")
+                 .append(fieldNameIdx + "[lang]")
+                 .append("\"")
+                 .append(">");
+
+         for (int j = 0; j < valueLanguageList.size(); j += 2) 
+         {
+             String display = (String) valueLanguageList.get(j);
+             String value = (String) valueLanguageList.get(j + 1);
+
+             sb.append("<option ")
+                     .append(value.equals(lang) ? " selected=\"selected\" " : "")
+                     .append("value=\"")
+                     .append(value.replaceAll("\"", "&quot;"))
+                     .append("\">")
+                     .append(display)
+                     .append("</option>");
+         }
+
+         sb.append("</select>");
+         sb.append("</div>");
+         return sb;
+    }
 %>
 
 <%
@@ -1265,6 +1339,7 @@
        String dcElement = inputs[z].getElement();
        String dcQualifier = inputs[z].getQualifier();
        String dcSchema = inputs[z].getSchema();
+       boolean language = inputs[z].getLanguage();
        
        String fieldName;
        int fieldCountIncr;
@@ -1316,16 +1391,13 @@
 				<%
            }
        }
-
+       
        repeatable = inputs[z].getRepeatable();
        fieldCountIncr = 0;
-       if (repeatable && !readonly)
+      
+       if (si.getMoreBoxesFor() != null && si.getMoreBoxesFor().equals(fieldName)) 
        {
-         fieldCountIncr = 1;
-         if (si.getMoreBoxesFor() != null && si.getMoreBoxesFor().equals(fieldName))
-             {
-           fieldCountIncr = 2;
-         }
+           fieldCountIncr = 1;
        }
 
        String inputType = inputs[z].getInputType();
@@ -1361,7 +1433,7 @@
        {
                    doTextArea(out, item, fieldName, dcSchema, dcElement, dcQualifier,
                                   repeatable, required, readonly, fieldCountIncr, label, pageContext, vocabulary,
-                                  closedVocabulary, collection);
+                                  closedVocabulary, collection, language, inputs[z].getValueLanguageList());
        }
        else if (inputType.equals("dropdown"))
        {
@@ -1383,7 +1455,7 @@
        {
                         doOneBox(out, item, fieldName, dcSchema, dcElement, dcQualifier,
                                  repeatable, required, readonly, fieldCountIncr, label, pageContext, vocabulary,
-                                 closedVocabulary, collection);
+                                 closedVocabulary, collection, language, inputs[z].getValueLanguageList());
        }
        
      } // end of 'for rows'

--- a/dspace/config/input-forms.dtd
+++ b/dspace/config/input-forms.dtd
@@ -14,10 +14,11 @@
  <!ATTLIST form name NMTOKEN #REQUIRED>
  <!ELEMENT page (field)+ >
  <!ATTLIST page number NMTOKEN #REQUIRED>
- <!ELEMENT field (dc-schema, dc-element, dc-qualifier?, repeatable?, label, type-bind?, input-type, hint, required?, vocabulary?, visibility?) >
+ <!ELEMENT field (dc-schema, dc-element, dc-qualifier?, language?, repeatable?, label, type-bind?, input-type, hint, required?, vocabulary?, visibility?) >
  <!ELEMENT dc-schema (#PCDATA) >
  <!ELEMENT dc-element (#PCDATA) >
  <!ELEMENT dc-qualifier (#PCDATA) >
+ <!ELEMENT language (#PCDATA)>
  <!ELEMENT type-bind (#PCDATA) >
  
  <!ELEMENT repeatable (#PCDATA) >
@@ -54,3 +55,5 @@
  <!ATTLIST vocabulary closed (true|false) "false"> 
 
  <!ELEMENT visibility (#PCDATA) >
+
+ <!ATTLIST language value-pairs-name CDATA  #IMPLIED>  


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2888

This PR adds the posibility to define in input-forms.xml that language
tags should be added to selected metadata fields. This possibility is
limited to fields of the following input types: onebox, twobox and
textarea.

To test this PR add <language value-pairs-name="common_languages_iso">true</language> into input-forms.xml after a dc-qualifier of any field with an appropriate input type. Start a new Submission in JSPUI and take a look on the dropdown field in the edit metadata step beside the field. Finish the submission, open the published item as administrator, click on edit and take a look on the language tag of the field.
