### PR TITLE
DS-2889: Fix AuthorizeException by getting a reference to logo prior to nullifying

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
@@ -202,13 +202,14 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
             canEdit(context, community);
         }
 
-                // First, delete any existing logo
-        if (community.getLogo() != null)
+        // First, delete any existing logo
+        Bitstream oldLogo = community.getLogo();
+        if (oldLogo != null)
         {
             log.info(LogManager.getHeader(context, "remove_logo",
                     "community_id=" + community.getID()));
             community.setLogo(null);
-            bitstreamService.delete(context, community.getLogo());
+            bitstreamService.delete(context, oldLogo);
         }
 
         if (is != null)


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2889

This should be a rather obvious fix to an obscure error message. The existing code accidentally nullified the logo _before_ removing its bitstream.

I've tested this, and along with #1167, it now allows AIP replacements to succeed on master.

I'll merge this as soon as Travis returns success, as the fix is very obvious.
