### PR TITLE
DS-2796 Solr core auto-discovery (static cores)

### DIFF
--- a/dspace/solr/authority/core.properties
+++ b/dspace/solr/authority/core.properties
@@ -1,0 +1,1 @@
+name=authority

--- a/dspace/solr/oai/core.properties
+++ b/dspace/solr/oai/core.properties
@@ -1,0 +1,1 @@
+name=oai

--- a/dspace/solr/search/core.properties
+++ b/dspace/solr/search/core.properties
@@ -1,0 +1,1 @@
+name=search

--- a/dspace/solr/solr.xml
+++ b/dspace/solr/solr.xml
@@ -1,38 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
-
-<!--
- All (relative) paths are relative to the installation path
-  
-  persistent: Save changes made via the API to this file
-  sharedLib: path to a lib directory that will be shared across all cores
--->
-<solr persistent="false">
-
+<solr>
   <!--
-  adminPath: RequestHandler path to manage cores.  
-    If 'null' (or absent), cores will not be manageable via REST
+  Definitions of Solr cores have been removed from this file. For details, see
+  https://cwiki.apache.org/confluence/display/solr/Moving+to+the+New+solr.xml+Format
   -->
-  <cores adminPath="/admin/cores">
-    <core name="search" instanceDir="search" />
-    <core name="statistics" instanceDir="statistics" />
-    <core name="oai" instanceDir="oai" />
-    <core name="authority" instanceDir="authority" />
-  </cores>
-  
 </solr>

--- a/dspace/solr/statistics/core.properties
+++ b/dspace/solr/statistics/core.properties
@@ -1,0 +1,1 @@
+name=statistics


### PR DESCRIPTION
http://jira.duraspace.org/browse/DS-2796

I tested this change for the 4 static cores.

I haven't tested it with sharded statistics ([dspace]/bin/dspace stats-util --shard-solr-index). The sharded cores are created here:

https://github.com/DSpace/DSpace/blob/master/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java#L1195
