### PR TITLE
[DS-2905] Fix format bugs with the EPerson CLI scripts & UUIDs

### DIFF
--- a/dspace-api/src/main/java/org/dspace/eperson/EPersonCLITool.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPersonCLITool.java
@@ -191,7 +191,7 @@ public class EPersonCLITool {
         try {
             ePersonService.update(context, eperson);
             context.complete();
-            System.out.printf("Created EPerson %d\n", eperson.getID());
+            System.out.printf("Created EPerson %s\n", eperson.getID().toString());
         } catch (SQLException ex) {
             context.abort();
             System.err.println(ex.getMessage());
@@ -261,7 +261,7 @@ public class EPersonCLITool {
         try {
             ePersonService.delete(context, eperson);
             context.complete();
-            System.out.printf("Deleted EPerson %d\n", eperson.getID());
+            System.out.printf("Deleted EPerson %s\n", eperson.getID().toString());
         } catch (SQLException ex) {
             System.err.println(ex.getMessage());
             return 1;
@@ -390,7 +390,7 @@ public class EPersonCLITool {
                 try {
                     ePersonService.update(context, eperson);
                     context.complete();
-                    System.out.printf("Modified EPerson %d\n", eperson.getID());
+                    System.out.printf("Modified EPerson %s\n", eperson.getID().toString());
                 } catch (SQLException ex) {
                     context.abort();
                     System.err.println(ex.getMessage());
@@ -416,7 +416,7 @@ public class EPersonCLITool {
         try {
             for (EPerson person : ePersonService.findAll(context, EPerson.EMAIL))
             {
-                System.out.printf("%d\t%s/%s\t%s, %s\n",
+                System.out.printf("%s\t%s/%s\t%s, %s\n",
                         person.getID(),
                         person.getEmail(),
                         person.getNetid(),

--- a/dspace-api/src/main/java/org/dspace/eperson/EPersonCLITool.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPersonCLITool.java
@@ -417,7 +417,7 @@ public class EPersonCLITool {
             for (EPerson person : ePersonService.findAll(context, EPerson.EMAIL))
             {
                 System.out.printf("%s\t%s/%s\t%s, %s\n",
-                        person.getID(),
+                        person.getID().toString(),
                         person.getEmail(),
                         person.getNetid(),
                         person.getLastName(), person.getFirstName()); // TODO more user details

--- a/dspace-api/src/main/java/org/dspace/eperson/LoadLastLogin.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/LoadLastLogin.java
@@ -168,8 +168,8 @@ public class LoadLastLogin
             {
                 if (PRETEND)
                 {
-                    System.out.printf("%d\t%s\t%s\t%s\t%s\n",
-                            ePerson.getID(),
+                    System.out.printf("%s\t%s\t%s\t%s\t%s\n",
+                            ePerson.getID().toString(),
                             date,
                             ePerson.getEmail(),
                             ePerson.getNetid(),


### PR DESCRIPTION
Replacing %d by %s & adding a toString to the UUID retrieval should fix these issues.
