### PR TITLE
[DS-2909] Fix EPerson netId setter

### DIFF
--- a/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
@@ -198,10 +198,10 @@ public class EPerson extends DSpaceObject implements DSpaceObjectLegacySupport
     /**
      * Set the EPerson's netid
      * 
-     * @param s
+     * @param netid
      *            the new netid
      */
-    public void setNetid(String s) {
+    public void setNetid(String netid) {
         this.netid = netid;
         setModified();
     }


### PR DESCRIPTION
Was a self assigned variable so the netid could never be set.
