### PR TITLE
DS-2852 Discovery search labels show authority key instead of author name

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/templates/discovery_simple_filters.hbs
+++ b/dspace-xmlui-mirage2/src/main/webapp/templates/discovery_simple_filters.hbs
@@ -8,5 +8,5 @@
 
 -->
 {{#each orig_filters}}
-    <label href="#" class="label label-primary" data-index="{{index}}">{{query}}&nbsp;&times;</label>
+    <label href="#" class="label label-primary" data-index="{{index}}">{{display_query}}&nbsp;&times;</label>
 {{/each}}

--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/discovery/discovery.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/discovery/discovery.xsl
@@ -401,6 +401,7 @@
                     type: '</xsl:text><xsl:value-of select="stringescapeutils:escapeEcmaScript(dri:cell/dri:field[starts-with(@n, 'filtertype')]/dri:value/@option)"/><xsl:text>',
                     relational_operator: '</xsl:text><xsl:value-of select="stringescapeutils:escapeEcmaScript(dri:cell/dri:field[starts-with(@n, 'filter_relational_operator')]/dri:value/@option)"/><xsl:text>',
                     query: '</xsl:text><xsl:value-of select="stringescapeutils:escapeEcmaScript(dri:cell/dri:field[@rend = 'discovery-filter-input']/dri:value)"/><xsl:text>',
+	                display_query: '</xsl:text><xsl:value-of select="stringescapeutils:escapeEcmaScript(util:getDiscoveryFilterDisplay(dri:cell/dri:field[@rend = 'discovery-filter-input']/dri:value))"/><xsl:text>',
                 });
             </xsl:text>
         </script>

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SimpleSearch.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SimpleSearch.java
@@ -243,10 +243,10 @@ public class SimpleSearch extends AbstractSearch implements CacheableProcessingC
         Select typeSelect = row.addCell("", Cell.ROLE_DATA, "selection").addSelect("filter_relational_operator_" + index);
         typeSelect.addOption(StringUtils.equals(relationalOperator, "contains"), "contains", T_filter_contain);
         typeSelect.addOption(StringUtils.equals(relationalOperator, "equals"), "equals", T_filter_equals);
-        typeSelect.addOption(StringUtils.equals(relationalOperator, "authority"), "authority", T_filter_authority);
+//        typeSelect.addOption(StringUtils.equals(relationalOperator, "authority"), "authority", T_filter_authority);
         typeSelect.addOption(StringUtils.equals(relationalOperator, "notcontains"), "notcontains", T_filter_notcontain);
         typeSelect.addOption(StringUtils.equals(relationalOperator, "notequals"), "notequals", T_filter_notequals);
-        typeSelect.addOption(StringUtils.equals(relationalOperator, "notauthority"), "notauthority", T_filter_notauthority);
+//        typeSelect.addOption(StringUtils.equals(relationalOperator, "notauthority"), "notauthority", T_filter_notauthority);
          
 
 

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/XSLUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/XSLUtils.java
@@ -7,6 +7,12 @@
  */
 package org.dspace.app.xmlui.utils;
 
+import org.dspace.authority.AuthorityValue;
+import org.dspace.authority.AuthorityValueFinder;
+import org.dspace.core.Context;
+
+import java.sql.SQLException;
+
 /**
  * Utilities that are needed in XSL transformations.
  *
@@ -53,4 +59,21 @@ public class XSLUtils {
         return string.substring(0, targetLength) + " ...";
 
     }
+
+	public static String getDiscoveryFilterDisplay(String display) throws SQLException {
+		Context ctx = new Context();
+
+		if (display != null) {
+			if (display.length() == 36 && display.contains("-")) {
+				AuthorityValue authorityValue = new AuthorityValueFinder().findByUID(ctx, display);
+				if (authorityValue != null) {
+					display = authorityValue.getValue();
+				}
+			}
+		}
+
+		ctx.complete();
+
+		return display;
+	}
 }


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2852

Adjusted the discovery theming of Mirage 2 to show author names instead
of authority values.
