### PR TITLE
[DS-2879] Make it configurable if reviewers should be notified about return to pool: XmlWorkflow implementation

### DIFF
--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/userassignment/ClaimAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/userassignment/ClaimAction.java
@@ -84,10 +84,15 @@ public class ClaimAction extends UserSelectionAction {
     }
 
     @Override
-    public void regenerateTasks(Context c, XmlWorkflowItem wfi, RoleMembers roleMembers) throws SQLException, AuthorizeException {
+    public void regenerateTasks(Context c, XmlWorkflowItem wfi, RoleMembers roleMembers) throws SQLException, AuthorizeException, IOException {
         if(roleMembers != null && (roleMembers.getEPersons().size() > 0 || roleMembers.getGroups().size() >0)){
             //Create task for the users left
             XmlWorkflowServiceFactory.getInstance().getXmlWorkflowService().createPoolTasks(c, wfi, roleMembers, getParent().getStep(), getParent());
+            if(ConfigurationManager.getBooleanProperty("workflow", "notify.returned.tasks", false))
+            {
+                alertUsersOnActivation(c, wfi, roleMembers);
+            }
+
         }
         else
             log.info(LogManager.getHeader(c, "warning while activating claim action", "No group or person was found for the following roleid: " + getParent().getStep().getId()));

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/userassignment/UserSelectionAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/userassignment/UserSelectionAction.java
@@ -67,7 +67,7 @@ public abstract class UserSelectionAction extends Action {
      * @throws SQLException ...
      * @throws AuthorizeException thrown if the current user isn't authorized
      */
-    public abstract void regenerateTasks(Context c, XmlWorkflowItem wfi, RoleMembers roleMembers) throws SQLException, AuthorizeException;
+    public abstract void regenerateTasks(Context c, XmlWorkflowItem wfi, RoleMembers roleMembers) throws SQLException, AuthorizeException, IOException;
 
     /**
      * Verifies if the user selection action is valid


### PR DESCRIPTION
Support for the "notify.returned.tasks" config in the configurable (xml) workflow with the difference that the default for the configurable workflow is false.
