### PR TITLE
DS-2873

### DIFF
--- a/dspace-jspui/src/main/webapp/tools/group-edit.jsp
+++ b/dspace-jspui/src/main/webapp/tools/group-edit.jsp
@@ -68,12 +68,12 @@
     <div class="row">
     <div class="col-md-6"> 
 	    <label for="eperson_id"><fmt:message key="jsp.tools.group-edit.eperson"/></label>
-	    <dspace:selecteperson multiple="true" selected="<%= epeople %>"/> 
+	    <dspace:selecteperson multiple="true" selected="<%= epeople.toArray(new EPerson[epeople.size()]) %>"/>
     </div>
     
     <div class="col-md-6">
 	    <label for="eperson_id"><fmt:message key="jsp.tools.group-edit.group"/></label>
-	    <dspace:selectgroup   multiple="true" selected="<%= groups  %>"/>
+	    <dspace:selectgroup   multiple="true" selected="<%= groups.toArray(new Group[groups.size()])  %>"/>
 	</div>
 	</div>
 	<br/>


### PR DESCRIPTION
The Group Edit Form didn't show groups or epersons because SelectEPersonTag.setSelected() expects an EPerson object or array, and it was receiving a List.  

https://jira.duraspace.org/browse/DS-2873
