### PR TITLE
Process headers to allow shibb and ip authentication

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/ShibAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/ShibAuthentication.java
@@ -226,7 +226,12 @@ public class ShibAuthentication implements AuthenticationMethod
 			// Step 4: Log the user in.
 			context.setCurrentUser(eperson);
 			request.getSession().setAttribute("shib.authenticated", true);
-            authenticationService.initEPerson(context, request, eperson);
+
+			//When testing, this object did not seem to be properly initialized on the first test
+			if (authenticationService == null) {
+				authenticationService = AuthenticateServiceFactory.getInstance().getAuthenticationService();
+			}
+             authenticationService.initEPerson(context, request, eperson);
 
 			log.info(eperson.getEmail()+" has been authenticated via shibboleth.");
 			return AuthenticationMethod.SUCCESS;

--- a/dspace-rest/src/main/java/org/dspace/rest/BitstreamResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/BitstreamResource.java
@@ -110,7 +110,7 @@ public class BitstreamResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
             org.dspace.content.Bitstream dspaceBitstream = findBitstream(context, bitstreamId, org.dspace.core.Constants.READ);
 
             writeStats(dspaceBitstream, UsageEvent.Action.VIEW, user_ip, user_agent, xforwardedfor, headers,
@@ -154,7 +154,8 @@ public class BitstreamResource extends Resource
     @GET
     @Path("/{bitstream_id}/policy")
     @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
-    public ResourcePolicy[] getBitstreamPolicies(@PathParam("bitstream_id") String bitstreamId, @Context HttpHeaders headers)
+    public ResourcePolicy[] getBitstreamPolicies(@PathParam("bitstream_id") String bitstreamId, @Context HttpHeaders headers, 
+    		@Context HttpServletRequest request)
     {
 
         log.info("Reading bitstream(id=" + bitstreamId + ") policies.");
@@ -163,7 +164,7 @@ public class BitstreamResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
             org.dspace.content.Bitstream dspaceBitstream = findBitstream(context, bitstreamId, org.dspace.core.Constants.READ);
             policies = new Bitstream(dspaceBitstream,"policies", context).getPolicies();
 
@@ -223,7 +224,7 @@ public class BitstreamResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
             List<org.dspace.content.Bitstream> dspaceBitstreams = bitstreamService.findAll(context);
 
             if (!((limit != null) && (limit >= 0) && (offset != null) && (offset >= 0)))
@@ -305,7 +306,7 @@ public class BitstreamResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
             org.dspace.content.Bitstream dspaceBitstream = findBitstream(context, bitstreamId, org.dspace.core.Constants.READ);
 
             writeStats(dspaceBitstream, UsageEvent.Action.VIEW, user_ip, user_agent, xforwardedfor, headers,
@@ -374,7 +375,7 @@ public class BitstreamResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
             org.dspace.content.Bitstream dspaceBitstream = findBitstream(context, bitstreamId, org.dspace.core.Constants.WRITE);
 
             writeStats(dspaceBitstream, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor, headers,
@@ -444,7 +445,7 @@ public class BitstreamResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
             org.dspace.content.Bitstream dspaceBitstream = findBitstream(context, bitstreamId, org.dspace.core.Constants.WRITE);
 
             writeStats(dspaceBitstream, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor,
@@ -549,7 +550,7 @@ public class BitstreamResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
             org.dspace.content.Bitstream dspaceBitstream = findBitstream(context, bitstreamId, org.dspace.core.Constants.WRITE);
 
             writeStats(dspaceBitstream, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor,
@@ -618,7 +619,7 @@ public class BitstreamResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
             org.dspace.content.Bitstream dspaceBitstream = findBitstream(context, bitstreamId, org.dspace.core.Constants.DELETE);
 
             writeStats(dspaceBitstream, UsageEvent.Action.DELETE, user_ip, user_agent, xforwardedfor,
@@ -680,7 +681,7 @@ public class BitstreamResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
             org.dspace.content.Bitstream dspaceBitstream = findBitstream(context, bitstreamId, org.dspace.core.Constants.WRITE);
 
             writeStats(dspaceBitstream, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor, headers,

--- a/dspace-rest/src/main/java/org/dspace/rest/CollectionsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/CollectionsResource.java
@@ -109,7 +109,7 @@ public class CollectionsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
 
             org.dspace.content.Collection dspaceCollection = findCollection(context, collectionId, org.dspace.core.Constants.READ);
             writeStats(dspaceCollection, UsageEvent.Action.VIEW, user_ip, user_agent, xforwardedfor,
@@ -178,7 +178,7 @@ public class CollectionsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
 
             if (!((limit != null) && (limit >= 0) && (offset != null) && (offset >= 0)))
             {
@@ -264,7 +264,7 @@ public class CollectionsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
 
             org.dspace.content.Collection dspaceCollection = findCollection(context, collectionId, org.dspace.core.Constants.READ);
             writeStats(dspaceCollection, UsageEvent.Action.VIEW, user_ip, user_agent, xforwardedfor,
@@ -345,7 +345,7 @@ public class CollectionsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
             org.dspace.content.Collection dspaceCollection = findCollection(context, collectionId,
                     org.dspace.core.Constants.WRITE);
 
@@ -440,7 +440,7 @@ public class CollectionsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
             org.dspace.content.Collection dspaceCollection = findCollection(context, collectionId,
                     org.dspace.core.Constants.WRITE);
 
@@ -510,7 +510,7 @@ public class CollectionsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
             org.dspace.content.Collection dspaceCollection = findCollection(context, collectionId,
                     org.dspace.core.Constants.DELETE);
 
@@ -580,7 +580,7 @@ public class CollectionsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
 
             org.dspace.content.Collection dspaceCollection = collectionService.findByIdOrLegacyId(context, collectionId);
             org.dspace.content.Item item = itemService.findByIdOrLegacyId(context, itemId);
@@ -668,7 +668,7 @@ public class CollectionsResource extends Resource
     @Path("/find-collection")
     @Consumes({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
     @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
-    public Collection findCollectionByName(String name, @Context HttpHeaders headers) throws WebApplicationException
+    public Collection findCollectionByName(String name, @Context HttpHeaders headers, @Context HttpServletRequest request) throws WebApplicationException
     {
         log.info("Searching for first collection with name=" + name + ".");
         org.dspace.core.Context context = null;
@@ -676,7 +676,7 @@ public class CollectionsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
 
             List<org.dspace.content.Collection> dspaceCollections = collectionService.findAll(context);
             //TODO, this would be more efficient with a findByName query

--- a/dspace-rest/src/main/java/org/dspace/rest/CommunitiesResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/CommunitiesResource.java
@@ -82,7 +82,7 @@ public class CommunitiesResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
 
             org.dspace.content.Community dspaceCommunity = findCommunity(context, communityId, org.dspace.core.Constants.READ);
             writeStats(dspaceCommunity, UsageEvent.Action.VIEW, user_ip, user_agent, xforwardedfor, headers,
@@ -148,7 +148,7 @@ public class CommunitiesResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
 
             List<org.dspace.content.Community> dspaceCommunities = communityService.findAll(context);
             communities = new ArrayList<Community>();
@@ -230,7 +230,7 @@ public class CommunitiesResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
 
             List<org.dspace.content.Community> dspaceCommunities = communityService.findAllTop(context);
             communities = new ArrayList<Community>();
@@ -312,7 +312,7 @@ public class CommunitiesResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
 
             org.dspace.content.Community dspaceCommunity = findCommunity(context, communityId, org.dspace.core.Constants.READ);
             writeStats(dspaceCommunity, UsageEvent.Action.VIEW, user_ip, user_agent, xforwardedfor, headers,
@@ -398,7 +398,7 @@ public class CommunitiesResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
 
             org.dspace.content.Community dspaceCommunity = findCommunity(context, communityId, org.dspace.core.Constants.READ);
             writeStats(dspaceCommunity, UsageEvent.Action.VIEW, user_ip, user_agent, xforwardedfor, headers,
@@ -474,7 +474,7 @@ public class CommunitiesResource extends Resource
         try
         {
             EPerson eperson = getUser(headers);
-            context = createContext(eperson);
+            context = createContext(eperson, request);
             if (!authorizeService.isAdmin(context))
             {
                 context.abort();
@@ -557,7 +557,7 @@ public class CommunitiesResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
 
             org.dspace.content.Community dspaceCommunity = findCommunity(context, communityId, org.dspace.core.Constants.WRITE);
             writeStats(dspaceCommunity, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor,
@@ -638,7 +638,7 @@ public class CommunitiesResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
             org.dspace.content.Community dspaceParentCommunity = findCommunity(context, communityId,
                     org.dspace.core.Constants.WRITE);
 
@@ -717,7 +717,7 @@ public class CommunitiesResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
 
             org.dspace.content.Community dspaceCommunity = findCommunity(context, communityId, org.dspace.core.Constants.WRITE);
             writeStats(dspaceCommunity, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor,
@@ -780,7 +780,7 @@ public class CommunitiesResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
 
             org.dspace.content.Community community = findCommunity(context, communityId, org.dspace.core.Constants.DELETE);
             writeStats(community, UsageEvent.Action.DELETE, user_ip, user_agent, xforwardedfor, headers,
@@ -851,7 +851,7 @@ public class CommunitiesResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
 
             org.dspace.content.Community community = findCommunity(context, communityId, org.dspace.core.Constants.WRITE);
             org.dspace.content.Collection collection = collectionService.findByIdOrLegacyId(context, collectionId);
@@ -951,7 +951,7 @@ public class CommunitiesResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
 
             org.dspace.content.Community parentCommunity = findCommunity(context, parentCommunityId,
                     org.dspace.core.Constants.WRITE);

--- a/dspace-rest/src/main/java/org/dspace/rest/HandleResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/HandleResource.java
@@ -21,7 +21,9 @@ import org.dspace.rest.common.DSpaceObject;
 import org.dspace.rest.common.Item;
 import org.dspace.rest.exceptions.ContextException;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -45,10 +47,11 @@ public class HandleResource extends Resource {
     @GET
     @Path("/{prefix}/{suffix}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-    public org.dspace.rest.common.DSpaceObject getObject(@PathParam("prefix") String prefix, @PathParam("suffix") String suffix, @QueryParam("expand") String expand, @javax.ws.rs.core.Context HttpHeaders headers) {
+    public org.dspace.rest.common.DSpaceObject getObject(@PathParam("prefix") String prefix, @PathParam("suffix") String suffix, @QueryParam("expand") String expand, 
+    		@javax.ws.rs.core.Context HttpHeaders headers, @Context HttpServletRequest request) {
         DSpaceObject dSpaceObject = new DSpaceObject();
         try {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
 
             org.dspace.content.DSpaceObject dso = handleService.resolveToObject(context, prefix + "/" + suffix);
 

--- a/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
@@ -99,7 +99,7 @@ public class ItemsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
             org.dspace.content.Item dspaceItem = findItem(context, itemId, org.dspace.core.Constants.READ);
 
             writeStats(dspaceItem, UsageEvent.Action.VIEW, user_ip, user_agent, xforwardedfor, headers, request, context);
@@ -159,7 +159,7 @@ public class ItemsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
 
             Iterator<org.dspace.content.Item> dspaceItems = itemService.findAllUnfiltered(context);
             items = new ArrayList<Item>();
@@ -235,7 +235,7 @@ public class ItemsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
             org.dspace.content.Item dspaceItem = findItem(context, itemId, org.dspace.core.Constants.READ);
 
             writeStats(dspaceItem, UsageEvent.Action.VIEW, user_ip, user_agent, xforwardedfor, headers, request, context);
@@ -294,7 +294,7 @@ public class ItemsResource extends Resource
         List<Bitstream> bitstreams = null;
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
             org.dspace.content.Item dspaceItem = findItem(context, itemId, org.dspace.core.Constants.READ);
 
             writeStats(dspaceItem, UsageEvent.Action.VIEW, user_ip, user_agent, xforwardedfor, headers, request, context);
@@ -365,7 +365,7 @@ public class ItemsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
             org.dspace.content.Item dspaceItem = findItem(context, itemId, org.dspace.core.Constants.WRITE);
 
             writeStats(dspaceItem, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor, headers, request, context);
@@ -440,7 +440,7 @@ public class ItemsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
             org.dspace.content.Item dspaceItem = findItem(context, itemId, org.dspace.core.Constants.WRITE);
 
             writeStats(dspaceItem, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor, headers, request, context);
@@ -606,7 +606,7 @@ public class ItemsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
             org.dspace.content.Item dspaceItem = findItem(context, itemId, org.dspace.core.Constants.WRITE);
 
             writeStats(dspaceItem, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor, headers, request, context);
@@ -687,7 +687,7 @@ public class ItemsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
             org.dspace.content.Item dspaceItem = findItem(context, itemId, org.dspace.core.Constants.DELETE);
 
             writeStats(dspaceItem, UsageEvent.Action.REMOVE, user_ip, user_agent, xforwardedfor, headers, request, context);
@@ -755,7 +755,7 @@ public class ItemsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
             org.dspace.content.Item dspaceItem = findItem(context, itemId, org.dspace.core.Constants.WRITE);
 
             writeStats(dspaceItem, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor, headers, request, context);
@@ -830,7 +830,7 @@ public class ItemsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
             org.dspace.content.Item item = findItem(context, itemId, org.dspace.core.Constants.WRITE);
 
             org.dspace.content.Bitstream bitstream = bitstreamService.findByIdOrLegacyId(context, bitstreamId);
@@ -925,7 +925,7 @@ public class ItemsResource extends Resource
 
         try
         {
-            context = createContext(getUser(headers));
+            context = createContext(getUser(headers), request);
 
             Iterator<org.dspace.content.Item> itemIterator = itemService.findByMetadataField(context, metadataEntry.getSchema(), metadataEntry.getElement(), metadataEntry.getQualifier(), metadataEntry.getValue());
 

--- a/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
@@ -7,11 +7,15 @@
  */
 package org.dspace.rest;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.sql.SQLException;
+import java.util.Iterator;
 import java.util.List;
 
 import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -23,7 +27,12 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.apache.log4j.Logger;
+import org.dspace.authenticate.AuthenticationMethod;
+import org.dspace.authenticate.ShibAuthentication;
+import org.dspace.authenticate.factory.AuthenticateServiceFactory;
+import org.dspace.authenticate.service.AuthenticationService;
 import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
 import org.dspace.rest.common.Status;
@@ -157,6 +166,46 @@ public class RestIndex {
     }
 
     /**
+     * Method to login a user into REST API.
+     * 
+     * @param user
+     *            User which will be logged in to REST API.
+     * @return Returns response code OK and a token. Otherwise returns response
+     *         code FORBIDDEN(403).
+     */
+    @GET
+    @Path("/login-shibboleth")
+    @Produces(MediaType.TEXT_HTML)
+    public String loginShibboleth(@Context HttpHeaders headers, @Context HttpServletRequest request, @Context HttpServletResponse response)
+    {
+    	String path ="...";
+        org.dspace.core.Context context = null;
+    	try {
+        	context = Resource.createContext(Resource.getUser(headers), request);
+        	AuthenticationService authenticationService = AuthenticateServiceFactory.getInstance().getAuthenticationService();
+        	Iterator<AuthenticationMethod> methodIt = authenticationService.authenticationMethodIterator();
+        	while(methodIt.hasNext()) {
+        		AuthenticationMethod method = methodIt.next();
+        		if (method instanceof ShibAuthentication) {
+        			path = method.loginPageURL(context, request, response);
+        			if (path != null) {
+        				response.sendRedirect(path);
+        			}
+        		}
+        	}    		
+        } catch (ContextException e) {
+            Resource.processException("Error creating context: " + e.getMessage(), context);
+        } catch (SQLException e) {
+            Resource.processException("Error creating context: " + e.getMessage(), context);
+        } catch (IOException e) {
+            Resource.processException("Error creating context: " + e.getMessage(), context);
+		} finally {
+            context.abort();
+        }
+        return "<html><body>" + path + "</body></html>";
+    }
+
+    /**
      * Method to logout a user from DSpace REST API. Removes the token and user from
      * TokenHolder.
      * 
@@ -205,20 +254,29 @@ public class RestIndex {
     @GET
     @Path("/status")
     @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-    public Status status(@Context HttpHeaders headers) throws UnsupportedEncodingException {
+    public Status status(@Context HttpHeaders headers, @Context HttpServletRequest request) throws UnsupportedEncodingException {
         org.dspace.core.Context context = null;
 
+        Status status = new Status();
         try {
-            context = Resource.createContext(Resource.getUser(headers));
+            context = Resource.createContext(Resource.getUser(headers), request);
             EPerson ePerson = context.getCurrentUser();
 
             if(ePerson != null) {
                 //DB EPerson needed since token won't have full info, need context
                 EPerson dbEPerson = epersonService.findByEmail(context, ePerson.getEmail());
                 String token = Resource.getToken(headers);
-                Status status = new Status(dbEPerson.getEmail(), dbEPerson.getFullName(), token);
-                return status;
-            }
+                status = new Status(dbEPerson.getEmail(), dbEPerson.getFullName(), token);
+            } 
+
+        	StringBuilder groupslist = new StringBuilder();
+        	for(Group group: context.getSpecialGroups()) {
+        		if (groupslist.length() > 0) {
+        			groupslist.append(",");
+        		}
+        		groupslist.append(group.getName());
+        	}
+        	status.setSpecialGroups(groupslist.toString());
 
         } catch (ContextException e)
         {
@@ -230,8 +288,13 @@ public class RestIndex {
         }
 
         //fallback status, unauth
-        return new Status();
+        return status;
     }
 
-
+    @GET
+    @Path("/shibboleth-login")
+    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    public Status confirmShibbolethLogin(@Context HttpHeaders headers, @Context HttpServletRequest request) throws UnsupportedEncodingException {
+        return status(headers, request);
+    }
 }

--- a/dspace-rest/src/main/java/org/dspace/rest/common/Status.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/common/Status.java
@@ -8,7 +8,6 @@
 package org.dspace.rest.common;
 
 import org.codehaus.jackson.annotate.JsonProperty;
-import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -25,6 +24,7 @@ public class Status
     private boolean authenticated;
     private String email;
     private String fullname;
+    private String specialGroups;
 
     public String getToken() {
         return token;
@@ -101,5 +101,15 @@ public class Status
     @JsonProperty("fullname")
     public void setFullname(String fullname) {
         this.fullname = fullname;
+    }
+
+    @JsonProperty("specialGroups")
+    public String getSpecialGroups() {
+        return specialGroups;
+    }
+
+    @JsonProperty("specialGroups")
+    public void setSpecialGroups(String specialGroups) {
+        this.specialGroups = specialGroups;
     }
 }

--- a/dspace-rest/src/test/resources/org/dspace/rest/common/expected_xsd0.xsd
+++ b/dspace-rest/src/test/resources/org/dspace/rest/common/expected_xsd0.xsd
@@ -141,6 +141,7 @@
       <xs:element name="email" type="xs:string" minOccurs="0"/>
       <xs:element name="fullname" type="xs:string" minOccurs="0"/>
       <xs:element name="okay" type="xs:boolean"/>
+      <xs:element name="specialGroups" type="xs:string" minOccurs="0"/>
       <xs:element name="token" type="xs:string" minOccurs="0"/>
     </xs:sequence>
   </xs:complexType>


### PR DESCRIPTION
See https://jira.duraspace.org/browse/DS-2898

I have tested this code with Shibb authentication and with IP authentication.  The headers are processed to pull Shibb credentials or IP credentials.

A call was also added to process SpecialGroup permissions.

Call /login-shibboleth to retrieve a Shibboleth login page from the authentication manager.  That code redirects to /shibboleth-login after login.  I created a method to present the user's authentication credentials after login.  I presume that this needs to be cleaned up a bit, and I am seeking suggestions on this code.
