### PR TITLE
[DS-2942] Fix (template) item metadata edit

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/EditItemMetadataForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/EditItemMetadataForm.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 
 import org.apache.cocoon.environment.ObjectModelHelper;
 import org.apache.cocoon.environment.Request;
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.xmlui.cocoon.AbstractDSpaceTransformer;
 import org.dspace.app.xmlui.wing.Message;
 import org.dspace.app.xmlui.wing.WingException;
@@ -132,11 +133,11 @@ public class EditItemMetadataForm extends AbstractDSpaceTransformer {
         // Metadata editing is the only type of editing available for a template item.
         boolean editingTemplateItem = false;
         String templateCollectionID = parameters.getParameter("templateCollectionID", null);
-        Collection templateCollection = templateCollectionID == null ? null : collectionService.find(context, UUID.fromString(templateCollectionID));
+        Collection templateCollection = StringUtils.isBlank(templateCollectionID) ? null : collectionService.find(context, UUID.fromString(templateCollectionID));
         if (templateCollection != null)
         {
             Item templateItem = templateCollection.getTemplateItem();
-            if (templateItem != null && templateItem.getID() == itemID)
+            if (templateItem != null && templateItem.getID().equals(itemID))
             {
                 editingTemplateItem = true;
             }

--- a/dspace-xmlui/src/main/resources/aspects/Administrative/administrative.js
+++ b/dspace-xmlui/src/main/resources/aspects/Administrative/administrative.js
@@ -1446,7 +1446,7 @@ function doEditItem(itemID)
 		}
 		else if (cocoon.request.get("submit_metadata"))
 		{
-			doEditItemMetadata(itemID, -1);
+			doEditItemMetadata(itemID, null);
 		}
 		else if (cocoon.request.get("view_item"))
 		{


### PR DESCRIPTION
http://jira.duraspace.org/browse/DS-2942

This pull request not only fixes the -1 casting problem but also ensures that the edit collection template item page works properly. This page was broken by using a "==" to compare UUID's instead of equals.
