### PR TITLE
[DS-1494] Facilitate use of jndi.properties instead of DSpace configuration for LDAP credentials

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
@@ -584,8 +584,9 @@ public class LDAPAuthentication
                 env.put(javax.naming.Context.SECURITY_PRINCIPAL, netid);
                 env.put(javax.naming.Context.SECURITY_CREDENTIALS, password);
             }
-            /* Else the LDAP provider may be externally configured in an
-             * application resource file
+            /* Else the LDAP provider may be externally configured in the "jndi.properties"
+             * application resource file.  See "Application Resource Files" in
+             * https://docs.oracle.com/javase/7/docs/api/javax/naming/Context.html
              */
 
             env.put(javax.naming.Context.AUTHORITATIVE, "true");

--- a/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
@@ -36,7 +36,7 @@ import org.dspace.eperson.service.GroupService;
 /**
  * This combined LDAP authentication method supersedes both the 'LDAPAuthentication'
  * and the 'LDAPHierarchicalAuthentication' methods. It's capable of both:
- * - authenticaton  against a flat LDAP tree where all users are in the same unit
+ * - authentication  against a flat LDAP tree where all users are in the same unit
  *   (if search.user or search.password is not set)
  * - authentication against structured hierarchical LDAP trees of users. 
  *   An initial bind is required using a user name and password in order to
@@ -50,7 +50,7 @@ public class LDAPAuthentication
     implements AuthenticationMethod {
 
     /** log4j category */
-    private static Logger log = Logger.getLogger(LDAPAuthentication.class);
+    private static final Logger log = Logger.getLogger(LDAPAuthentication.class);
 
     protected AuthenticationService authenticationService = AuthenticateServiceFactory.getInstance().getAuthenticationService();
     protected EPersonService ePersonService = EPersonServiceFactory.getInstance().getEPersonService();
@@ -571,7 +571,7 @@ public class LDAPAuthentication
          */
         protected boolean ldapAuthenticate(String netid, String password,
                         Context context) {
-            Hashtable<String, String> env = new Hashtable<String, String>();
+            Hashtable<String, String> env = new Hashtable<>();
             if (null != password && !password.isEmpty()) {
                 // Set up environment for creating initial context
                 env.put(javax.naming.Context.INITIAL_CONTEXT_FACTORY,

--- a/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
@@ -567,44 +567,47 @@ public class LDAPAuthentication
         }
 
         /**
-         * contact the ldap server and attempt to authenticate
+         * Contact the LDAP server and attempt to authenticate.
          */
         protected boolean ldapAuthenticate(String netid, String password,
                         Context context) {
-            if (!password.equals("")) {
+            Hashtable<String, String> env = new Hashtable<String, String>();
+            if (null != password && !password.isEmpty()) {
                 // Set up environment for creating initial context
-                Hashtable<String, String> env = new Hashtable<String, String>();
                 env.put(javax.naming.Context.INITIAL_CONTEXT_FACTORY,
-                        "com.sun.jndi.ldap.LdapCtxFactory");
-                env.put(javax.naming.Context.PROVIDER_URL, ldap_provider_url);
+                        "com.sun.jndi.ldap.LdapCtxFactory"); // XXX is this needed?
+                if (null != ldap_provider_url)
+                    env.put(javax.naming.Context.PROVIDER_URL, ldap_provider_url);
 
                 // Authenticate
                 env.put(javax.naming.Context.SECURITY_AUTHENTICATION, "Simple");
                 env.put(javax.naming.Context.SECURITY_PRINCIPAL, netid);
                 env.put(javax.naming.Context.SECURITY_CREDENTIALS, password);
-                env.put(javax.naming.Context.AUTHORITATIVE, "true");
-                env.put(javax.naming.Context.REFERRAL, "follow");
+            }
+            /* Else the LDAP provider may be externally configured in an
+             * application resource file
+             */
 
-                DirContext ctx = null;
-                try {
-                    // Try to bind
-                    ctx = new InitialDirContext(env);
-                } catch (NamingException e) {
-                    log.warn(LogManager.getHeader(context,
-                            "ldap_authentication", "type=failed_auth " + e));
-                    return false;
-                } finally {
-                    // Close the context when we're done
-                    try {
-                        if (ctx != null)
-                        {
-                            ctx.close();
-                        }
-                    } catch (NamingException e) {
-                    }
-                }
-            } else {
+            env.put(javax.naming.Context.AUTHORITATIVE, "true");
+            env.put(javax.naming.Context.REFERRAL, "follow");
+
+            DirContext ctx = null;
+            try {
+                // Try to bind
+                ctx = new InitialDirContext(env);
+            } catch (NamingException e) {
+                log.warn(LogManager.getHeader(context,
+                        "ldap_authentication", "type=failed_auth " + e));
                 return false;
+            } finally {
+                // Close the context when we're done
+                try {
+                    if (ctx != null)
+                    {
+                        ctx.close();
+                    }
+                } catch (NamingException e) {
+                }
             }
 
             return true;

--- a/dspace/config/jndi.properties
+++ b/dspace/config/jndi.properties
@@ -1,0 +1,25 @@
+# Properties of the LDAP service connection.  Please consult the 
+# JNDI documentation and that of your LDAP service provider for full 
+# details.
+#
+# These properties are defined by the JNDI specification and your 
+# provider, not DSpace.  Extend this file as needed.
+
+# LDAP: or LDAPS: URL to the LDAP service.
+# See also java.naming.security.protocol.
+java.naming.provider.url =
+
+# Authentication method:  none, simple, or a space-separated list of
+# SASL mechanisms.
+java.naming.security.authentication =
+
+# Security principal (a user name, a DN, etc.) as required by the 
+# authentication method.
+java.naming.security.principal =
+
+# Password or other credential, as required by the authentication 
+# method.
+java.naming.security.credentials =
+
+# Uncomment if you will be using SSL for the initial connection
+#java.naming.security.protocol = ssl


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-1494 "Add authentication-ldap username/password configs to build.properties"

Instead of further extending build.properties, use native JNDI facilities for this.
