### PR TITLE
[DS-2767] Sites can no longer inject preconfigured connection pool using config/dspace.cfg:db.jndi

### DIFF
--- a/dspace/config/spring/api/core-hibernate.xml
+++ b/dspace/config/spring/api/core-hibernate.xml
@@ -8,7 +8,17 @@
         <property name="dataSource" ref="dataSource" />
     </bean>
 
-    <bean id="dataSource" class="org.apache.commons.dbcp2.BasicDataSource" lazy-init="true" destroy-method="close">
+    <bean id='dataSource'
+          class='org.springframework.jndi.JndiObjectFactoryBean'>
+        <description>
+            Try to look up the DataSource in JNDI.  If not found, return a
+            DataSource built from connection details in the DSpace configuration.
+        </description>
+        <property name='jndiName' value='java:comp/env/jdbc/dspace'/>
+        <property name='defaultObject' ref='dspaceDataSource'/>
+    </bean>
+
+    <bean id="dspaceDataSource" class="org.apache.commons.dbcp2.BasicDataSource" lazy-init="true" destroy-method="close">
         <property name="driverClassName" value="${db.driver}"/>
         <property name="url" value="${db.url}"/>
         <property name="username" value="${db.username}"/>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2767

Note that this does not resurrect db.jndi.  It uses a fixed name 'java:comp/env/jdbc/dspace'.  This name is only used in the Context, where it is linked either to the DataSource itself or to a global resource which may have any name.
