### PR TITLE
DS-2971 Make bitstream description deletable again (5.x)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/Bitstream.java
+++ b/dspace-api/src/main/java/org/dspace/content/Bitstream.java
@@ -351,7 +351,16 @@ public class Bitstream extends DSpaceObject
      *            the new description of the bitstream
      */
     public void setDescription(String n) {
-        setMetadataSingleValue(MetadataSchema.DC_SCHEMA, "description", null, null, n);
+    	if (n == null)
+    	{
+            clearMetadata(MetadataSchema.DC_SCHEMA, "description", null, null);
+            modifiedMetadata = true;
+        }
+    	else
+    	{
+            setMetadataSingleValue(MetadataSchema.DC_SCHEMA, "description", null, null, n);
+    	}
+
     }
 
     /**


### PR DESCRIPTION
Via edit item it is now possible to delete the bitstream description for an item.
