### PR TITLE
DS-2965 - Allow cache clear during re-index

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -20,6 +20,7 @@ import org.dspace.event.factory.EventServiceFactory;
 import org.dspace.event.service.EventService;
 import org.dspace.storage.rdbms.DatabaseConfigVO;
 import org.dspace.utils.DSpace;
+import org.hibernate.Session;
 import org.springframework.util.CollectionUtils;
 
 /**
@@ -594,5 +595,9 @@ public class Context
 
     public void shutDownDatabase() throws SQLException {
         dbConnection.shutdown();
+    }
+    
+    public void clearCache() throws SQLException {
+    	((Session)this.getDBConnection().getSession()).clear();
     }
 }

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -598,6 +598,6 @@ public class Context
     }
     
     public void clearCache() throws SQLException {
-    	((Session)this.getDBConnection().getSession()).clear();
+    	this.getDBConnection().clearCache();
     }
 }

--- a/dspace-api/src/main/java/org/dspace/core/DBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/DBConnection.java
@@ -38,4 +38,6 @@ public interface DBConnection<T> {
     public DataSource getDataSource();
 
     public DatabaseConfigVO getDatabaseConfig() throws SQLException;
+
+    public void clearCache() throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
@@ -107,4 +107,9 @@ public class HibernateDBConnection implements DBConnection<Session> {
         }
         return databaseConfigVO;
     }
+
+    @Override
+    public void clearCache() throws SQLException {
+        this.getSession().clear();
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -50,6 +50,7 @@ import org.dspace.handle.service.HandleService;
 import org.dspace.storage.rdbms.DatabaseUtils;
 import org.dspace.util.MultiFormatDateParser;
 import org.dspace.utils.DSpace;
+import org.hibernate.Session;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -389,10 +390,16 @@ public class SolrServiceImpl implements SearchService, IndexingService {
     {
         try {
             Iterator<Item> items = null;
+            int itemCount = 0;
             for (items = itemService.findAllUnfiltered(context); items.hasNext();)
             {
                 Item item = items.next();
                 indexContent(context, item, force);
+                if (itemCount++ >= 1000) {
+                	context.clearCache();
+                	itemCount = 0;
+                }
+                
             }
 
             List<Collection> collections = collectionService.findAll(context);


### PR DESCRIPTION
The PR has enabled me to successfully index tens of thousands of items in my DSpace 6 instance.

For method visibility purposes, I added the clearCache method to the Context object.

I wonder if a more generic implementation could be placed on AbstractHibernateDAO.iterate() to manage the cache size when pulling a large number of objects in different contexts.

https://jira.duraspace.org/browse/DS-2965
