### PR TITLE
[DS-2976] Ensure all database entities have a protected constructor

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItem.java
+++ b/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItem.java
@@ -9,6 +9,7 @@ package org.dspace.app.requestitem;
 
 import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
+import org.dspace.core.Context;
 
 import javax.persistence.*;
 import java.util.Date;
@@ -67,7 +68,12 @@ public class RequestItem {
     @Column(name = "accept_request")
     private Boolean accept_request = null;
 
-    public RequestItem() {
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.app.requestitem.service.RequestItemService#createRequest(Context, Bitstream, Item, boolean, String, String, String)}
+     */
+    protected RequestItem()
+    {
     }
 
     public int getID() {

--- a/dspace-api/src/main/java/org/dspace/app/util/WebApp.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/WebApp.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.app.util;
 
+import org.dspace.core.Context;
+
 import javax.persistence.*;
 import java.util.Date;
 
@@ -38,6 +40,15 @@ public class WebApp {
 
     @Column(name = "isui")
     private Integer isui;
+
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.app.util.service.WebAppService#create(Context, String, String, Date, int)}
+     */
+    protected WebApp()
+    {
+
+    }
 
     public Integer getId() {
         return id;

--- a/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicy.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicy.java
@@ -9,6 +9,7 @@ package org.dspace.authorize;
 
 import org.apache.commons.lang.ObjectUtils;
 import org.dspace.content.DSpaceObject;
+import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.hibernate.proxy.HibernateProxyHelper;
@@ -71,6 +72,15 @@ public class ResourcePolicy{
 
     @Column(name="rpdescription", length = 100)
     private String rpdescription;
+
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.authorize.service.ResourcePolicyService#create(Context)}
+     */
+    protected ResourcePolicy()
+    {
+
+    }
 
     /**
      * Return true if this object equals obj, false otherwise.

--- a/dspace-api/src/main/java/org/dspace/checker/ChecksumHistory.java
+++ b/dspace-api/src/main/java/org/dspace/checker/ChecksumHistory.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.checker;
 
+import org.dspace.core.Context;
+
 import javax.persistence.*;
 import java.util.Date;
 import java.util.UUID;
@@ -55,7 +57,11 @@ public class ChecksumHistory
     private ChecksumResult checksumResult;
 
 
-    public ChecksumHistory()
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.checker.service.ChecksumHistoryService#addHistory(Context, MostRecentChecksum)}
+     */
+    protected ChecksumHistory()
     {
     }
 

--- a/dspace-api/src/main/java/org/dspace/checker/ChecksumResult.java
+++ b/dspace-api/src/main/java/org/dspace/checker/ChecksumResult.java
@@ -28,6 +28,13 @@ public class ChecksumResult
     @Column(name = "result_description")
     private String resultDescription;
 
+    /**
+     * Protected constructor, new object creation impossible
+     */
+    protected ChecksumResult()
+    {
+
+    }
     public ChecksumResultCode getResultCode() {
         return resultCode;
     }

--- a/dspace-api/src/main/java/org/dspace/checker/MostRecentChecksum.java
+++ b/dspace-api/src/main/java/org/dspace/checker/MostRecentChecksum.java
@@ -61,6 +61,16 @@ public class MostRecentChecksum implements Serializable
     @JoinColumn(name= "result")
     private ChecksumResult checksumResult;
 
+
+    /**
+     * Protected constructor, create handled by the
+     * {@link org.dspace.checker.service.MostRecentChecksumService}
+     */
+    protected MostRecentChecksum()
+    {
+
+    }
+
     public Bitstream getBitstream() {
         return bitstream;
     }

--- a/dspace-api/src/main/java/org/dspace/content/Bitstream.java
+++ b/dspace-api/src/main/java/org/dspace/content/Bitstream.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.content;
 
+import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -74,7 +75,13 @@ public class Bitstream extends DSpaceObject implements DSpaceObjectLegacySupport
     private transient BitstreamService bitstreamService;
 
 
-    public Bitstream()
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.content.service.BitstreamService#create(Context, Bundle, InputStream)}
+     * or
+     * {@link org.dspace.content.service.BitstreamService#create(Context, InputStream)}
+     */
+    protected Bitstream()
     {
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/BitstreamFormat.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamFormat.java
@@ -96,6 +96,16 @@ public class BitstreamFormat implements Serializable
     public static final int SUPPORTED = 2;
 
     /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.content.service.BitstreamFormatService#create(Context)}
+     *
+     */
+    protected BitstreamFormat()
+    {
+
+    }
+
+    /**
      * Get the internal identifier of this bitstream format
      * 
      * @return the internal identifier

--- a/dspace-api/src/main/java/org/dspace/content/Bundle.java
+++ b/dspace-api/src/main/java/org/dspace/content/Bundle.java
@@ -60,6 +60,11 @@ public class Bundle extends DSpaceObject implements DSpaceObjectLegacySupport
     @Transient
     protected transient BundleService bundleService;
 
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.content.service.BundleService#create(Context, Item, String)}
+     *
+     */
     protected Bundle()
     {
     }

--- a/dspace-api/src/main/java/org/dspace/content/Collection.java
+++ b/dspace-api/src/main/java/org/dspace/content/Collection.java
@@ -100,6 +100,13 @@ public class Collection extends DSpaceObject implements DSpaceObjectLegacySuppor
     @Transient
     public static final String PROVENANCE_TEXT = "provenance_description";
 
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.content.service.CollectionService#create(Context, Community)}
+     * or
+     * {@link org.dspace.content.service.CollectionService#create(Context, Community, String)}
+     *
+     */
     protected Collection()
     {
 

--- a/dspace-api/src/main/java/org/dspace/content/Community.java
+++ b/dspace-api/src/main/java/org/dspace/content/Community.java
@@ -71,7 +71,16 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
     @Transient
     protected transient CommunityService communityService;
 
-    protected Community() {
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.content.service.CommunityService#create(Community, Context)}
+     * or
+     * {@link org.dspace.content.service.CommunityService#create(Community, Context, String)}
+     *
+     */
+    protected Community()
+    {
+
     }
 
     void addSubCommunity(Community subCommunity)

--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
@@ -61,6 +61,10 @@ public abstract class DSpaceObject implements Serializable
     @Transient
     private boolean modified = false;
 
+    protected DSpaceObject()
+    {
+
+    }
 
     /**
      * Reset the cache of event details.

--- a/dspace-api/src/main/java/org/dspace/content/Item.java
+++ b/dspace-api/src/main/java/org/dspace/content/Item.java
@@ -10,6 +10,7 @@ package org.dspace.content;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Constants;
+import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.hibernate.proxy.HibernateProxyHelper;
 
@@ -86,7 +87,14 @@ public class Item extends DSpaceObject implements DSpaceObjectLegacySupport
     @Transient
     private transient ItemService itemService;
 
-    protected Item() {
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.content.service.ItemService#create(Context, WorkspaceItem)}
+     *
+     */
+    protected Item()
+    {
+
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/MetadataField.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataField.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.content;
 
+import org.dspace.core.Context;
 import org.hibernate.proxy.HibernateProxyHelper;
 
 import javax.persistence.*;
@@ -46,6 +47,11 @@ public class MetadataField {
     @Column(name="scope_note", columnDefinition = "text")
     private String scopeNote;
 
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.content.service.MetadataFieldService#create(Context, MetadataSchema, String, String, String)}
+     *
+     */
     protected MetadataField()
     {
 

--- a/dspace-api/src/main/java/org/dspace/content/MetadataSchema.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataSchema.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.content;
 
+import org.dspace.core.Context;
 import org.hibernate.proxy.HibernateProxyHelper;
 
 import javax.persistence.*;
@@ -43,7 +44,14 @@ public class MetadataSchema
     @Column(name = "short_id", unique = true, length = 32)
     private String name;
 
-    protected MetadataSchema() {
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.content.service.MetadataSchemaService#create(Context, String, String)}
+     *
+     */
+    protected MetadataSchema()
+    {
+
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/MetadataValue.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataValue.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.content;
 
+import org.dspace.core.Context;
 import org.hibernate.annotations.Type;
 import org.hibernate.proxy.HibernateProxyHelper;
 
@@ -65,7 +66,14 @@ public class MetadataValue
     @JoinColumn(name="dspace_object_id")
     protected DSpaceObject dSpaceObject;
 
-    protected MetadataValue() {
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.content.service.MetadataValueService#create(Context, DSpaceObject, MetadataField)}
+     *
+     */
+    protected MetadataValue()
+    {
+
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/Site.java
+++ b/dspace-api/src/main/java/org/dspace/content/Site.java
@@ -11,6 +11,7 @@ import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.SiteService;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Constants;
+import org.dspace.core.Context;
 
 import javax.persistence.Entity;
 import javax.persistence.Table;
@@ -27,6 +28,16 @@ public class Site extends DSpaceObject
 
     @Transient
     private transient SiteService siteService;
+
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.content.service.SiteService#createSite(Context)}
+     *
+     */
+    protected Site()
+    {
+
+    }
 
     /**
      * Get the type of this object, found in Constants

--- a/dspace-api/src/main/java/org/dspace/content/WorkspaceItem.java
+++ b/dspace-api/src/main/java/org/dspace/content/WorkspaceItem.java
@@ -13,8 +13,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
+import org.dspace.workflow.WorkflowItem;
 import org.hibernate.proxy.HibernateProxyHelper;
 
 import javax.persistence.*;
@@ -70,6 +72,17 @@ public class WorkspaceItem implements InProgressSubmission, Serializable
     )
     private final List<Group> supervisorGroups = new ArrayList<>();
 
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.content.service.WorkspaceItemService#create(Context, Collection, boolean)}
+     * or
+     * {@link org.dspace.content.service.WorkspaceItemService#create(Context, WorkflowItem)}
+     *
+     */
+    protected WorkspaceItem()
+    {
+
+    }
 
     /**
      * Get the internal ID of this workspace item

--- a/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
@@ -84,7 +84,14 @@ public class EPerson extends DSpaceObject implements DSpaceObjectLegacySupport
     @Transient
     protected transient EPersonService ePersonService;
 
-    protected EPerson() {
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.eperson.service.EPersonService#create(Context)}
+     *
+     */
+    protected EPerson()
+    {
+
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/eperson/Group.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/Group.java
@@ -74,7 +74,14 @@ public class Group extends DSpaceObject implements DSpaceObjectLegacySupport
     @Transient
     private transient GroupService groupService;
 
-    public Group() {
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.eperson.service.GroupService#create(Context)}
+     *
+     */
+    protected Group()
+    {
+
     }
 
     void addMember(EPerson e)

--- a/dspace-api/src/main/java/org/dspace/eperson/Group2GroupCache.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/Group2GroupCache.java
@@ -47,6 +47,16 @@ public class Group2GroupCache implements Serializable {
         this.child = child;
     }
 
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.eperson.service.GroupService}
+     *
+     */
+    protected Group2GroupCache()
+    {
+
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == null)

--- a/dspace-api/src/main/java/org/dspace/eperson/RegistrationData.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/RegistrationData.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.eperson;
 
+import org.dspace.core.Context;
+
 import javax.persistence.*;
 import java.util.Date;
 
@@ -34,6 +36,16 @@ public class RegistrationData {
     @Column(name = "expires")
     @Temporal(TemporalType.TIMESTAMP)
     private Date expires;
+
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.eperson.service.RegistrationDataService#create(Context)}
+     *
+     */
+    protected RegistrationData()
+    {
+
+    }
 
     public int getId() {
         return id;

--- a/dspace-api/src/main/java/org/dspace/eperson/Subscription.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/Subscription.java
@@ -8,6 +8,7 @@
 package org.dspace.eperson;
 
 import org.dspace.content.Collection;
+import org.dspace.core.Context;
 
 import javax.persistence.*;
 
@@ -34,7 +35,14 @@ public class Subscription {
     @JoinColumn(name = "eperson_id")
     private EPerson ePerson;
 
-    protected Subscription() {
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.eperson.service.SubscribeService#subscribe(Context, EPerson, Collection)}
+     *
+     */
+    protected Subscription()
+    {
+
     }
 
     public int getId() {

--- a/dspace-api/src/main/java/org/dspace/handle/Handle.java
+++ b/dspace-api/src/main/java/org/dspace/handle/Handle.java
@@ -8,6 +8,7 @@
 package org.dspace.handle;
 
 import org.dspace.content.DSpaceObject;
+import org.dspace.core.Context;
 
 import javax.persistence.*;
 
@@ -35,6 +36,20 @@ public class Handle {
 
     @Column(name = "resource_type_id")
     private Integer resourceTypeId;
+
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.handle.service.HandleService#createHandle(Context, DSpaceObject)}
+     * or
+     * {@link org.dspace.handle.service.HandleService#createHandle(Context, DSpaceObject, String)}
+     * or
+     * {@link org.dspace.handle.service.HandleService#createHandle(Context, DSpaceObject, String, boolean)}
+     *
+     */
+    protected Handle()
+    {
+
+    }
 
     public Integer getId() {
         return id;

--- a/dspace-api/src/main/java/org/dspace/harvest/HarvestedCollection.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/HarvestedCollection.java
@@ -8,6 +8,7 @@
 package org.dspace.harvest;
 
 import org.dspace.content.Collection;
+import org.dspace.core.Context;
 
 import javax.persistence.*;
 import java.util.Date;
@@ -75,8 +76,13 @@ public class HarvestedCollection
 	public static final int STATUS_OAI_ERROR = 3;
     @Transient
 	public static final int STATUS_UNKNOWN_ERROR = -1;
-	
-	public HarvestedCollection()
+
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.harvest.service.HarvestedCollectionService#create(Context, Collection)}
+     *
+     */
+	protected HarvestedCollection()
     {
     }
 

--- a/dspace-api/src/main/java/org/dspace/harvest/HarvestedItem.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/HarvestedItem.java
@@ -10,6 +10,7 @@ package org.dspace.harvest;
 import java.util.Date;
 
 import org.dspace.content.Item;
+import org.dspace.core.Context;
 
 import javax.persistence.*;
 
@@ -38,8 +39,12 @@ public class HarvestedItem
     private String oaiId;
 
 
-
-    public HarvestedItem()
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.harvest.service.HarvestedItemService#create(Context, Item, String)}
+     *
+     */
+    protected HarvestedItem()
     {
     }
 

--- a/dspace-api/src/main/java/org/dspace/identifier/DOI.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/DOI.java
@@ -9,6 +9,7 @@
 package org.dspace.identifier;
 
 import org.dspace.content.DSpaceObject;
+import org.dspace.core.Context;
 
 import javax.persistence.*;
 
@@ -41,6 +42,15 @@ public class DOI
 
     @Column(name = "status")
     private Integer status;
+
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.identifier.service.DOIService#create(Context)}
+     *
+     */
+    protected DOI()
+    {
+    }
 
     public Integer getId() {
         return id;

--- a/dspace-api/src/main/java/org/dspace/versioning/Version.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/Version.java
@@ -8,6 +8,7 @@
 package org.dspace.versioning;
 
 import org.dspace.content.Item;
+import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.hibernate.proxy.HibernateProxyHelper;
 
@@ -52,6 +53,20 @@ public class Version {
     @ManyToOne
     @JoinColumn(name = "versionhistory_id")
     private VersionHistory versionHistory;
+
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.versioning.service.VersioningService#createNewVersion(Context, Item)}
+     * or
+     * {@link org.dspace.versioning.service.VersioningService#createNewVersion(Context, Item, String)}
+     * or
+     * {@link org.dspace.versioning.service.VersioningService#createNewVersion(Context, VersionHistory, Item, String, Date, int)}
+     *
+     */
+    protected Version()
+    {
+
+    }
 
     public int getId() {
         return id;

--- a/dspace-api/src/main/java/org/dspace/versioning/VersionHistory.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/VersionHistory.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.versioning;
 
+import org.dspace.core.Context;
 import org.hibernate.proxy.HibernateProxyHelper;
 
 import javax.persistence.*;
@@ -34,6 +35,16 @@ public class VersionHistory {
     @OneToMany(fetch = FetchType.EAGER, mappedBy = "versionHistory")
     @OrderBy(value = "versionNumber desc")
     private List<Version> versions = new ArrayList<Version>();
+
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.versioning.service.VersionHistoryService#create(Context)}
+     *
+     */
+    protected VersionHistory()
+    {
+
+    }
 
     public int getId() {
         return id;

--- a/dspace-api/src/main/java/org/dspace/workflowbasic/BasicWorkflowItem.java
+++ b/dspace-api/src/main/java/org/dspace/workflowbasic/BasicWorkflowItem.java
@@ -11,6 +11,7 @@ import java.sql.SQLException;
 
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
+import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.dspace.workflow.WorkflowItem;
 
@@ -61,6 +62,15 @@ public class BasicWorkflowItem implements WorkflowItem
     @Column(name = "multiple_files")
     private boolean multipleFiles = false;
 
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.workflowbasic.service.BasicWorkflowItemService#create(Context, Item, Collection)}
+     *
+     */
+    protected BasicWorkflowItem()
+    {
+
+    }
 
     /**
      * Get the internal ID of this workflow item

--- a/dspace-api/src/main/java/org/dspace/workflowbasic/TaskListItem.java
+++ b/dspace-api/src/main/java/org/dspace/workflowbasic/TaskListItem.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.workflowbasic;
 
+import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 
 import javax.persistence.*;
@@ -33,6 +34,16 @@ public class TaskListItem {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "workflow_id")
     private BasicWorkflowItem workflowItem;
+
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.workflowbasic.service.TaskListItemService#create(Context, BasicWorkflowItem, EPerson)}
+     *
+     */
+    protected TaskListItem()
+    {
+
+    }
 
     public int getTaskListItemId() {
         return taskListItemId;

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/ClaimedTask.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/ClaimedTask.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.xmlworkflow.storedcomponents;
 
+import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 
 import javax.persistence.*;
@@ -53,8 +54,14 @@ public class ClaimedTask {
     @JoinColumn(name = "owner_id")
     private EPerson owner;
 
-    public ClaimedTask()
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.xmlworkflow.storedcomponents.service.ClaimedTaskService#create(Context)}
+     *
+     */
+    protected ClaimedTask()
     {
+
     }
 
     public int getId() {

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/CollectionRole.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/CollectionRole.java
@@ -8,6 +8,7 @@
 package org.dspace.xmlworkflow.storedcomponents;
 
 import org.dspace.content.Collection;
+import org.dspace.core.Context;
 import org.dspace.eperson.Group;
 
 import javax.persistence.*;
@@ -48,8 +49,14 @@ public class CollectionRole {
     @JoinColumn(name = "group_id")
     private Group group;
 
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.xmlworkflow.storedcomponents.service.CollectionRoleService#create(Context, Collection, String, Group)}
+     *
+     */
+    protected CollectionRole()
+    {
 
-    public CollectionRole() {
     }
 
     public void setRoleId(String id){

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/InProgressUser.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/InProgressUser.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.xmlworkflow.storedcomponents;
 
+import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 
 import javax.persistence.*;
@@ -40,7 +41,14 @@ public class InProgressUser {
     @Column(name ="finished")
     private boolean finished = false;
 
-    public InProgressUser() {
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.xmlworkflow.storedcomponents.service.InProgressUserService#create(Context)}
+     *
+     */
+    protected InProgressUser()
+    {
+
     }
 
     public int getId() {

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/PoolTask.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/PoolTask.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.xmlworkflow.storedcomponents;
 
+import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 
@@ -59,6 +60,15 @@ public class PoolTask {
     private Group group;
 
 
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.xmlworkflow.storedcomponents.service.PoolTaskService#create(Context)}
+     *
+     */
+    protected PoolTask()
+    {
+
+    }
 
     public void setEperson(EPerson eperson){
         this.ePerson = eperson;

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/WorkflowItemRole.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/WorkflowItemRole.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.xmlworkflow.storedcomponents;
 
+import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 
@@ -50,6 +51,15 @@ public class WorkflowItemRole {
     @JoinColumn(name = "group_id")
     private Group group;
 
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.xmlworkflow.storedcomponents.service.WorkflowItemRoleService#create(Context)}
+     *
+     */
+    protected WorkflowItemRole()
+    {
+
+    }
 
 
     public void setRoleId(String id){

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/XmlWorkflowItem.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/XmlWorkflowItem.java
@@ -9,6 +9,7 @@ package org.dspace.xmlworkflow.storedcomponents;
 
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
+import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.dspace.workflow.WorkflowItem;
 
@@ -49,6 +50,16 @@ public class XmlWorkflowItem implements WorkflowItem {
 
     @Column(name = "multiple_files")
     private boolean multipleFiles = false;
+
+    /**
+     * Protected constructor, create object using:
+     * {@link org.dspace.xmlworkflow.storedcomponents.service.XmlWorkflowItemService#create(Context, Item, Collection)}
+     *
+     */
+    protected XmlWorkflowItem()
+    {
+
+    }
 
     /**
      * Get the internal ID of this workflow item


### PR DESCRIPTION
Since the service api all database objects must be created within a service. Since the service implementation should always reside in the same package as the database entity object the constructor should be protected. 

This will ensure that no database objects can be created outside of the services (& thus bypassing our service logic).

https://jira.duraspace.org/browse/DS-2976
