### PR TITLE
Ds 2629 excel media filter

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ExcelFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ExcelFilter.java
@@ -7,15 +7,17 @@
  */
 package org.dspace.app.mediafilter;
 
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.poi.POITextExtractor;
 import org.apache.poi.extractor.ExtractorFactory;
 import org.apache.poi.hssf.extractor.ExcelExtractor;
 import org.apache.poi.xssf.extractor.XSSFExcelExtractor;
 
 import org.apache.log4j.Logger;
+import org.dspace.content.Item;
 
 /*
  * ExcelFilter
@@ -55,7 +57,7 @@ public class ExcelFilter extends MediaFilter
     /**
      * @return String bitstream format
      * 
-     *         TODO: Check that this is correct
+     *
      */
     public String getFormatString()
     {
@@ -76,19 +78,24 @@ public class ExcelFilter extends MediaFilter
      * 
      * @return InputStream the resulting input stream
      */
-    public InputStream getDestinationStream(InputStream source)
+    public InputStream getDestinationStream(Item item, InputStream source, boolean verbose)
             throws Exception
     {
         String extractedText = null;
 
         try
         {
-            new ExtractorFactory();
             POITextExtractor theExtractor = ExtractorFactory.createExtractor(source);
-            if (theExtractor instanceof ExcelExtractor) // for xls file
-                extractedText = ((ExcelExtractor ) theExtractor).getText();
-            else if (theExtractor instanceof XSSFExcelExtractor) // for xlsx file
-                extractedText = ((XSSFExcelExtractor ) theExtractor).getText();
+            if (theExtractor instanceof ExcelExtractor)
+            {
+                // for xls file
+                extractedText = (theExtractor).getText();
+            }
+            else if (theExtractor instanceof XSSFExcelExtractor)
+            {
+                // for xlsx file
+                extractedText = (theExtractor).getText();
+            }
         }
         catch (Exception e)
         {
@@ -98,18 +105,8 @@ public class ExcelFilter extends MediaFilter
 
         if (extractedText != null)
         {
-            // if verbose flag is set, print out extracted text
-            // to STDOUT
-            if (MediaFilterManager.isVerbose)
-            {
-                System.out.println(extractedText);
-            }
-
             // generate an input stream with the extracted text
-            byte[] textBytes = extractedText.getBytes();
-            ByteArrayInputStream bais = new ByteArrayInputStream(textBytes);
-
-            return bais;
+            return IOUtils.toInputStream(extractedText, StandardCharsets.UTF_8);
         }
 
         return null;

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ExcelFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ExcelFilter.java
@@ -1,0 +1,117 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.mediafilter;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import org.apache.poi.POITextExtractor;
+import org.apache.poi.extractor.ExtractorFactory;
+import org.apache.poi.hssf.extractor.ExcelExtractor;
+import org.apache.poi.xssf.extractor.XSSFExcelExtractor;
+
+import org.apache.log4j.Logger;
+
+/*
+ * ExcelFilter
+ *
+ * Entries you must add to dspace.cfg:
+ *
+ * filter.plugins = blah, \
+ *     Excel Text Extractor
+ *
+ * plugin.named.org.dspace.app.mediafilter.FormatFilter = \
+ *     blah = blah, \
+ *     org.dspace.app.mediafilter.ExcelFilter = Excel Text Extractor
+ *
+ * #Configure each filter's input Formats
+ * filter.org.dspace.app.mediafilter.ExcelFilter.inputFormats = Microsoft Excel, Microsoft Excel XML
+ *
+ */
+public class ExcelFilter extends MediaFilter
+{
+
+    private static Logger log = Logger.getLogger(ExcelFilter.class);
+
+    public String getFilteredName(String oldFilename)
+    {
+        return oldFilename + ".txt";
+    }
+
+    /**
+     * @return String bundle name
+     * 
+     */
+    public String getBundleName()
+    {
+        return "TEXT";
+    }
+
+    /**
+     * @return String bitstream format
+     * 
+     *         TODO: Check that this is correct
+     */
+    public String getFormatString()
+    {
+        return "Text";
+    }
+
+    /**
+     * @return String description
+     */
+    public String getDescription()
+    {
+        return "Extracted text";
+    }
+
+    /**
+     * @param source
+     *            source input stream
+     * 
+     * @return InputStream the resulting input stream
+     */
+    public InputStream getDestinationStream(InputStream source)
+            throws Exception
+    {
+        String extractedText = null;
+
+        try
+        {
+            new ExtractorFactory();
+            POITextExtractor theExtractor = ExtractorFactory.createExtractor(source);
+            if (theExtractor instanceof ExcelExtractor) // for xls file
+                extractedText = ((ExcelExtractor ) theExtractor).getText();
+            else if (theExtractor instanceof XSSFExcelExtractor) // for xlsx file
+                extractedText = ((XSSFExcelExtractor ) theExtractor).getText();
+        }
+        catch (Exception e)
+        {
+            log.error("Error filtering bitstream: " + e.getMessage(), e);
+            throw e;
+        }
+
+        if (extractedText != null)
+        {
+            // if verbose flag is set, print out extracted text
+            // to STDOUT
+            if (MediaFilterManager.isVerbose)
+            {
+                System.out.println(extractedText);
+            }
+
+            // generate an input stream with the extracted text
+            byte[] textBytes = extractedText.getBytes();
+            ByteArrayInputStream bais = new ByteArrayInputStream(textBytes);
+
+            return bais;
+        }
+
+        return null;
+    }
+}

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -402,7 +402,8 @@ http.proxy.port = ${http.proxy.port}
 #Names of the enabled MediaFilter or FormatFilter plugins
 filter.plugins = PDF Text Extractor, HTML Text Extractor, \
                  PowerPoint Text Extractor, \
-                 Word Text Extractor, JPEG Thumbnail
+                 Word Text Extractor, JPEG Thumbnail, \
+                 Excel Text Extractor
 
 # [To enable Branded Preview]: uncomment and insert the following into the plugin list
 #                Branded Preview JPEG, \
@@ -421,7 +422,8 @@ plugin.named.org.dspace.app.mediafilter.FormatFilter = \
   org.dspace.app.mediafilter.JPEGFilter = JPEG Thumbnail, \
   org.dspace.app.mediafilter.BrandedPreviewJPEGFilter = Branded Preview JPEG, \
   org.dspace.app.mediafilter.ImageMagickImageThumbnailFilter = ImageMagick Image Thumbnail, \
-  org.dspace.app.mediafilter.ImageMagickPdfThumbnailFilter = ImageMagick PDF Thumbnail
+  org.dspace.app.mediafilter.ImageMagickPdfThumbnailFilter = ImageMagick PDF Thumbnail, \
+  org.dspace.app.mediafilter.ExcelFilter = Excel Text Extractor
 
 #Configure each filter's input format(s)
 filter.org.dspace.app.mediafilter.PDFFilter.inputFormats = Adobe PDF
@@ -432,6 +434,7 @@ filter.org.dspace.app.mediafilter.JPEGFilter.inputFormats = BMP, GIF, JPEG, imag
 filter.org.dspace.app.mediafilter.BrandedPreviewJPEGFilter.inputFormats = BMP, GIF, JPEG, image/png
 filter.org.dspace.app.mediafilter.ImageMagickImageThumbnailFilter.inputFormats = BMP, GIF, image/png, JPG, TIFF, JPEG, JPEG 2000
 filter.org.dspace.app.mediafilter.ImageMagickPdfThumbnailFilter.inputFormats = Adobe PDF
+filter.org.dspace.app.mediafilter.ExcelFilter.inputFormats = Microsoft Excel, Microsoft Excel XML
 
 #Publicly accessible thumbnails of restricted content.
 #List the MediaFilter name's that would get publicly accessible permissions


### PR DESCRIPTION
DS-2629 Add ability to filter Excel (xls and xlsx) files for full text searching

https://jira.duraspace.org/browse/DS-2629

Replaces pull request: https://github.com/DSpace/DSpace/pull/98, differences: 
- Ensured compilation against latest master
- Removed the verbose print extracted text as it would really clutter the output
- Compressed the string to inputStream from 3 lines into a single one.
- Removed obsolete constructor call to the "ExtractorFactory"
- Removed a TODO that I verified is correct
