### PR TITLE
Fix for DS-2990 Unable to create subcommunites

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EditCommunitiesServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EditCommunitiesServlet.java
@@ -152,8 +152,9 @@ public class EditCommunitiesServlet extends DSpaceServlet
          */
         Community community = communityService.find(context, UIUtil.getUUIDParameter(
                 request, "community_id"));
-        Community parentCommunity = communityService.find(context, UIUtil
-                .getUUIDParameter(request, "parent_community_id"));
+        UUID parentCommunityID = (request.getAttribute("parent_community_id") != null ? UIUtil.getUUIDParameter(request,
+                "parent_community_id") : null);
+        Community parentCommunity = communityService.find(context, parentCommunityID);
         Collection collection = collectionService.find(context, UIUtil
                 .getUUIDParameter(request, "collection_id"));
 
@@ -517,8 +518,8 @@ public class EditCommunitiesServlet extends DSpaceServlet
         {
             // if there is a parent community id specified, create community
             // as its child; otherwise, create it as a top-level community
-            UUID parentCommunityID = UIUtil.getUUIDParameter(request,
-                    "parent_community_id");
+        	UUID parentCommunityID = (request.getAttribute("parent_community_id") != null ? UIUtil.getUUIDParameter(request,
+                    "parent_community_id") : null);
 
             if (parentCommunityID != null)
             {

--- a/dspace-jspui/src/main/webapp/tools/edit-community.jsp
+++ b/dspace-jspui/src/main/webapp/tools/edit-community.jsp
@@ -19,6 +19,7 @@
 <%@page import="org.dspace.content.service.CommunityService"%>
 <%@ page contentType="text/html;charset=UTF-8" %>
 
+<%@ page import="java.util.UUID" %> 
 <%@ page import="javax.servlet.jsp.jstl.fmt.LocaleSupport" %>
 
 <%@ page import="org.dspace.app.webui.servlet.admin.EditCommunitiesServlet" %>
@@ -34,7 +35,8 @@
 <%
 	CommunityService comServ = ContentServiceFactory.getInstance().getCommunityService();
     Community community = (Community) request.getAttribute("community");
-    int parentID = UIUtil.getIntParameter(request, "parent_community_id");
+	Community parentCommunity = (Community) request.getAttribute("parent");
+    UUID parentID = (parentCommunity != null ? parentCommunity.getID() : null);
     // Is the logged in user a sys admin
     Boolean admin = (Boolean)request.getAttribute("is.admin");
     boolean isAdmin = (admin == null ? false : admin.booleanValue());


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2990

Adds parent community id, so that subcommunities are created as subcommunities and not top level communities
