### PR TITLE
Correct dcterm "dcterms.conformsTo" in registry configuration

### DIFF
--- a/dspace/config/registries/dcterms-types.xml
+++ b/dspace/config/registries/dcterms-types.xml
@@ -93,7 +93,7 @@
 
   <dc-type>
 	<schema>dcterms</schema>
-    <element>comformsTo</element>
+    <element>conformsTo</element>
     <scope_note>An established standard to which the described resource conforms.</scope_note>
   </dc-type>
 


### PR DESCRIPTION
https://jira.duraspace.org/projects/DS/issues/DS-2998
Resolved: DSpace DS-2998 (Ticket in the Space Issue Tracker), Incorrect metadata element
"dcterms.comformsTo" in dspace registry configuration.
