### PR TITLE
[DS-1518] Support of StartTLS in LDAPAuthentication.

### DIFF
--- a/dspace/config/modules/authentication-ldap.cfg
+++ b/dspace/config/modules/authentication-ldap.cfg
@@ -167,3 +167,6 @@ autoregister = true
 #login.groupmap.2 = ldap-dept2:dspace-groupA
 #login.groupmap.3 = ldap-dept3:dspace-groupA
 
+# Enables support for StartTLS (default is false). If this flag is true be sure provider_url looks like:
+# ldap://ldap.myu.edu:389
+#starttls=true


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-1518

Added support for StartTLS. To test this pull request try:
1. Change the provider_url to use port 389 and remove the s from ldap**s** eg.: provider_url=ldap://ldap.myu.edu:389
2. Uncomment the last line of dspace/config/modules/authentication-ldap.cfg (#starttls=true) to enable startttls
3. Try to login
