### PR TITLE
[DS-3008] Fix metadata order storage

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -215,7 +215,7 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
 
         log.info(LogManager.getHeader(context, "update_bitstream",
                 "bitstream_id=" + bitstream.getID()));
-
+        super.update(context, bitstream);
         if (bitstream.isModified())
         {
             context.addEvent(new Event(Event.MODIFY, Constants.BITSTREAM, bitstream.getID(), null, getIdentifiers(context, bitstream)));

--- a/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
@@ -361,6 +361,7 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
         log.info(LogManager.getHeader(context, "update_bundle", "bundle_id="
                 + bundle.getID()));
 
+        super.update(context, bundle);
         bundleDAO.save(context, bundle);
 
         if (bundle.isModified() || bundle.isMetadataModified())

--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -566,6 +566,7 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
         log.info(LogManager.getHeader(context, "update_collection",
                 "collection_id=" + collection.getID()));
 
+        super.update(context, collection);
         collectionDAO.save(context, collection);
 
         if (collection.isModified())

--- a/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
@@ -235,6 +235,8 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
         log.info(LogManager.getHeader(context, "update_community",
                 "community_id=" + community.getID()));
 
+        super.update(context, community);
+
         communityDAO.save(context, community);
         if (community.isModified())
         {

--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
@@ -11,6 +11,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
+import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.authority.Choices;
 import org.dspace.content.authority.service.ChoiceAuthorityService;
 import org.dspace.content.authority.service.MetadataAuthorityService;
@@ -530,6 +531,44 @@ public abstract class DSpaceObjectServiceImpl<T extends DSpaceObject> implements
         }else{
             return getMDValueByLegacyField(field);
         }
+    }
+
+    @Override
+    public void update(Context context, T dso) throws SQLException, AuthorizeException
+    {
+        if(dso.isMetadataModified())
+        {
+            /*
+            Update the order of the metadata values
+             */
+                // A map created to store the latest place for each metadata field
+                Map<MetadataField, Integer> fieldToLastPlace = new HashMap<>();
+                List<MetadataValue> metadataValues = dso.getMetadata();
+                for (MetadataValue metadataValue : metadataValues)
+                {
+                    //Retrieve & store the place for each metadata value
+                    int mvPlace = getMetadataValuePlace(fieldToLastPlace, metadataValue);
+                    metadataValue.setPlace(mvPlace);
+                }
+        }
+    }
+
+    /**
+     * Retrieve the place of the metadata value
+     * @param fieldToLastPlace the map containing the latest place of each metadata field
+     * @param metadataValue the metadata value that needs to get a place
+     * @return The new place for the metadata valu
+     */
+    protected int getMetadataValuePlace(Map<MetadataField, Integer> fieldToLastPlace, MetadataValue metadataValue) {
+        MetadataField metadataField = metadataValue.getMetadataField();
+        if(fieldToLastPlace.containsKey(metadataField))
+        {
+            fieldToLastPlace.put(metadataField, fieldToLastPlace.get(metadataField) + 1);
+        }else{
+            // The metadata value place starts at 0
+            fieldToLastPlace.put(metadataField, 0);
+        }
+        return fieldToLastPlace.get(metadataField);
     }
 
     protected String[] getMDValueByLegacyField(String field){

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -414,6 +414,8 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         log.info(LogManager.getHeader(context, "update_item", "item_id="
                 + item.getID()));
 
+        super.update(context, item);
+
         // Set sequence IDs for bitstreams in item
         int sequence = 0;
         List<Bundle> bunds = item.getBundles();

--- a/dspace-api/src/main/java/org/dspace/content/SiteServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/SiteServiceImpl.java
@@ -72,6 +72,9 @@ public class SiteServiceImpl extends DSpaceObjectServiceImpl<Site> implements Si
         if(!authorizeService.isAdmin(context)){
             throw new AuthorizeException();
         }
+
+        super.update(context, site);
+
         if(site.isMetadataModified())
         {
             context.addEvent(new Event(Event.MODIFY_METADATA, site.getType(), site.getID(), site.getDetails(), getIdentifiers(context, site)));

--- a/dspace-api/src/main/java/org/dspace/eperson/EPersonServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPersonServiceImpl.java
@@ -318,6 +318,8 @@ public class EPersonServiceImpl extends DSpaceObjectServiceImpl<EPerson> impleme
             authorizeService.authorizeAction(context, ePerson, Constants.WRITE);
         }
 
+        super.update(context, ePerson);
+
         ePersonDAO.save(context, ePerson);
 
         log.info(LogManager.getHeader(context, "update_eperson",

--- a/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
@@ -383,6 +383,8 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
     @Override
     public void update(Context context, Group group) throws SQLException, AuthorizeException
     {
+
+        super.update(context, group);
         // FIXME: Check authorisation
         groupDAO.save(context, group);
 


### PR DESCRIPTION
Added update() method to the DSpaceObjectService, this will (if the metadata has changed) update the "place" column.
All DSpaceObjectServices call this method using super(), this solves the issue.

https://jira.duraspace.org/browse/DS-3008
