### PR TITLE
DS-2879/XmlWorkflow: keep the old behavior as default

### DIFF
--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/userassignment/ClaimAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/userassignment/ClaimAction.java
@@ -88,7 +88,7 @@ public class ClaimAction extends UserSelectionAction {
         if(roleMembers != null && (roleMembers.getEPersons().size() > 0 || roleMembers.getGroups().size() >0)){
             //Create task for the users left
             XmlWorkflowServiceFactory.getInstance().getXmlWorkflowService().createPoolTasks(c, wfi, roleMembers, getParent().getStep(), getParent());
-            if(ConfigurationManager.getBooleanProperty("workflow", "notify.returned.tasks", false))
+            if(ConfigurationManager.getBooleanProperty("workflow", "notify.returned.tasks", true))
             {
                 alertUsersOnActivation(c, wfi, roleMembers);
             }


### PR DESCRIPTION
This PR harmonizes the default behavior of the old workflow system and
XMLWorkflow system regarding whether notifications for tasks returned
to the task pool should be send or not.
