### PR TITLE
DS-3016 upgrade dependencies before 6.0 release (2)

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -493,7 +493,7 @@
         <dependency>
             <groupId>com.maxmind.geoip</groupId>
             <artifactId>geoip-api</artifactId>
-            <version>1.2.11</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.ant</groupId>
@@ -502,7 +502,7 @@
         <dependency>
             <groupId>dnsjava</groupId>
             <artifactId>dnsjava</artifactId>
-            <version>2.1.1</version>
+            <version>2.1.7</version>
         </dependency>
 
         <dependency>
@@ -527,7 +527,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>19.0</version>
         </dependency>
 
 
@@ -594,7 +594,7 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.3</version>
+            <version>2.9.2</version>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>
@@ -606,40 +606,40 @@
         <dependency>
             <groupId>org.apache.ws.commons.axiom</groupId>
             <artifactId>axiom-impl</artifactId>
-            <version>1.2.14</version>
+            <version>1.2.17</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.ws.commons.axiom</groupId>
             <artifactId>axiom-api</artifactId>
-            <version>1.2.14</version>
+            <version>1.2.17</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>2.9.1</version>
+            <version>2.22.1</version>
         </dependency>
         <!-- S3 -->
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.10.26</version>
+            <version>1.10.50</version>
         </dependency>
         <!-- S3 also wanted jackson... -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.5.3</version>
+            <version>2.7.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.5.3</version>
+            <version>2.7.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.5.3</version>
+            <version>2.7.0</version>
         </dependency>
     </dependencies>
 

--- a/dspace-jspui/pom.xml
+++ b/dspace-jspui/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>jstl</artifactId>
-            <version>1.1.2</version>
+            <version>1.2</version>
         </dependency>
         <dependency>
             <groupId>taglibs</groupId>

--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -158,7 +158,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>13.0</version>
+            <version>19.0</version>
         </dependency>
         <dependency>
             <groupId>com.lyncode</groupId>
@@ -171,7 +171,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>1.9.5</version>
+            <version>1.10.19</version>
         </dependency>
         <dependency>
             <groupId>com.lyncode</groupId>
@@ -193,17 +193,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.3.0</version>
+            <version>2.7.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.3.3</version>
+            <version>2.7.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.3.3</version>
+            <version>2.7.0</version>
         </dependency>
         <dependency>
             <groupId>org.xmlmatchers</groupId>

--- a/dspace-rest/pom.xml
+++ b/dspace-rest/pom.xml
@@ -136,7 +136,7 @@
         <dependency>
             <groupId>org.atteo</groupId>
             <artifactId>evo-inflector</artifactId>
-            <version>1.0.1</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>

--- a/dspace-services/pom.xml
+++ b/dspace-services/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>net.sf.ehcache</groupId>
             <artifactId>ehcache-core</artifactId>
-            <version>2.4.3</version>
+            <version>2.6.11</version>
             <scope>compile</scope>
         </dependency>
         <!-- for filters -->
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.mortbay.jetty</groupId>
             <artifactId>jetty</artifactId>
-            <version>6.1.14</version>
+            <version>6.1.26</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mortbay.jetty</groupId>
             <artifactId>jetty-servlet-tester</artifactId>
-            <version>6.1.14</version>
+            <version>6.1.26</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dspace-services/pom.xml
+++ b/dspace-services/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>net.sf.ehcache</groupId>
             <artifactId>ehcache-core</artifactId>
-            <version>2.6.11</version>
+            <version>2.4.3</version>
             <scope>compile</scope>
         </dependency>
         <!-- for filters -->

--- a/dspace-solr/pom.xml
+++ b/dspace-solr/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
 
-        <solr.version>4.10.2</solr.version>
+        <solr.version>4.10.4</solr.version>
         <!-- 'root.basedir' is the path to the root [dspace-src] dir. It must be redefined by each child POM,
              as it is used to reference the LICENSE_HEADER and *.properties file(s) in that directory. -->
         <root.basedir>${basedir}/..</root.basedir>
@@ -235,7 +235,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
-            <version>1.6.1</version>
+            <version>1.7.14</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/dspace-sword/pom.xml
+++ b/dspace-sword/pom.xml
@@ -136,7 +136,7 @@
         <dependency>
             <groupId>xom</groupId>
             <artifactId>xom</artifactId>
-            <version>1.1</version>
+            <version>1.2.5</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/dspace-swordv2/pom.xml
+++ b/dspace-swordv2/pom.xml
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>org.apache.abdera</groupId>
             <artifactId>abdera-client</artifactId>
-            <version>1.1.1</version>
+            <version>1.1.3</version>
         </dependency>
     </dependencies>
 

--- a/dspace-xmlui/pom.xml
+++ b/dspace-xmlui/pom.xml
@@ -209,14 +209,14 @@
         <dependency>
             <groupId>com.yahoo.platform.yui</groupId>
             <artifactId>yuicompressor</artifactId>
-            <version>2.3.6</version>
+            <version>2.4.8</version>
         </dependency>
 
         <!--Latest spring version requires an up to date jackson core -->
         <dependency>
         	<groupId>com.fasterxml.jackson.core</groupId>
         	<artifactId>jackson-core</artifactId>
-        	<version>2.5.0</version>
+        	<version>2.7.0</version>
         </dependency>
 
         <!-- Needed for Form Validation -->
@@ -227,13 +227,13 @@
         <dependency>
             <groupId>net.sf.opencsv</groupId>
             <artifactId>opencsv</artifactId>
-            <version>2.0</version>
+            <version>2.3</version>
         </dependency>
         <!--  Gson: Java to Json conversion -->
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.2.1</version>
+            <version>2.5</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/dspace/modules/solr/pom.xml
+++ b/dspace/modules/solr/pom.xml
@@ -41,7 +41,7 @@
                      need to take precedence over the solr-core, the solr-core will still be loaded in the solr-core.jar
                      -->
                      <excludes>
-                         <exclude>WEB-INF/lib/apache-solr-core-4.10.2.jar</exclude>
+                         <exclude>WEB-INF/lib/apache-solr-core-4.10.4.jar</exclude>
                          <!--Also ensure we use the DSpace solr web.xml file else our localhost filter will not work !-->
                          <exclude>WEB-INF/web.xml</exclude>
                      </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -1055,7 +1055,7 @@
          <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
-            <version>2.11.0</version>
+            <version>2.8.1</version>
             <!--  <version>2.8.0</version> in xmlui -->
          </dependency>
          <dependency>
@@ -1133,7 +1133,7 @@
          <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.1</version>
+            <version>4.3.5</version>
          </dependency>
          <dependency>
              <groupId>org.slf4j</groupId>
@@ -1165,7 +1165,7 @@
          <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.11</version>
             <scope>test</scope>
          </dependency>
          <dependency>
@@ -1178,7 +1178,7 @@
          <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.191</version>
+            <version>1.4.187</version>
             <scope>test</scope>
          </dependency>
          <!-- Contiperf is used for performance tests within our Unit/Integration tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -32,15 +32,15 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>
         <java.version>1.7</java.version>
-        <solr.version>4.10.2</solr.version>
-        <jena.version>2.12.0</jena.version>
-        <slf4j.version>1.6.1</slf4j.version>
+        <solr.version>4.10.4</solr.version>
+        <jena.version>2.13.0</jena.version>
+        <slf4j.version>1.7.14</slf4j.version>
         <!--
             Hibernate version pinned to 4.2, 4.3 does not work with the spring version we are currently using
             Upgrading the spring version will make the XMLUI crash
         -->
-        <hibernate.version>4.2.19.Final</hibernate.version>
-        <spring.version>3.2.14.RELEASE</spring.version>
+        <hibernate.version>4.2.21.Final</hibernate.version>
+        <spring.version>3.2.16.RELEASE</spring.version>
         <!-- 'root.basedir' is the path to the root [dspace-src] dir. It must be redefined by each child POM,
              as it is used to reference the LICENSE_HEADER and *.properties file(s) in that directory. -->
         <root.basedir>${basedir}</root.basedir>
@@ -901,17 +901,17 @@
          <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.2</version>
+            <version>1.3.1</version>
          </dependency>
          <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.9</version>
+            <version>1.10</version>
          </dependency>
          <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2</version>
+            <version>3.2.2</version>
             <!-- <version>3.1</version> xmlui - wing -->
          </dependency>
          <dependency>
@@ -927,17 +927,17 @@
          <dependency>
             <groupId>commons-discovery</groupId>
             <artifactId>commons-discovery</artifactId>
-            <version>0.2</version>
+            <version>0.5</version>
          </dependency>
          <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.2.1</version>
+            <version>1.3.1</version>
          </dependency>
          <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.3</version>
+            <version>2.4</version>
          </dependency>
          <dependency>
             <groupId>commons-lang</groupId>
@@ -948,7 +948,7 @@
          <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.1.1</version>
+            <version>1.2</version>
          </dependency>
          <dependency>
             <groupId>org.apache.commons</groupId>
@@ -958,12 +958,12 @@
           <dependency>
               <groupId>commons-validator</groupId>
               <artifactId>commons-validator</artifactId>
-              <version>1.4.0</version>
+              <version>1.5.0</version>
           </dependency>
          <dependency>
             <groupId>javax.mail</groupId>
             <artifactId>mail</artifactId>
-            <version>1.4</version>
+            <version>1.4.7</version>
          </dependency>
          <dependency>
             <groupId>javax.servlet</groupId>
@@ -974,7 +974,7 @@
          <dependency>
             <groupId>jaxen</groupId>
             <artifactId>jaxen</artifactId>
-            <version>1.1</version>
+            <version>1.1.6</version>
             <exclusions>
                <exclusion>
                   <artifactId>xom</artifactId>
@@ -985,7 +985,7 @@
          <dependency>
             <groupId>jdom</groupId>
             <artifactId>jdom</artifactId>
-            <version>1.0</version>
+            <version>1.1</version>
          </dependency>
          <dependency>
             <groupId>log4j</groupId>
@@ -1000,7 +1000,7 @@
          <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
-            <version>1.8.7</version>
+            <version>1.8.11</version>
          </dependency>
          <dependency>
             <groupId>org.apache.pdfbox</groupId>
@@ -1015,27 +1015,27 @@
          <dependency>
 	        <groupId>org.bouncycastle</groupId>
 	        <artifactId>bcprov-jdk15</artifactId>
-	        <version>1.44</version>
+	        <version>1.46</version>
 	    </dependency>
 	    <dependency>
 	        <groupId>org.bouncycastle</groupId>
 	        <artifactId>bcmail-jdk15</artifactId>
-	        <version>1.44</version>
+	        <version>1.46</version>
 	    </dependency>
          <dependency>
            <groupId>org.apache.poi</groupId>
            <artifactId>poi</artifactId>
-           <version>3.6</version>
+           <version>3.13</version>
          </dependency>
          <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-scratchpad</artifactId>
-            <version>3.6</version>
+            <version>3.13</version>
          </dependency>
          <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>3.6</version>
+            <version>3.13</version>
          </dependency>
          <dependency>
             <groupId>rome</groupId>
@@ -1050,12 +1050,12 @@
          <dependency>
             <groupId>xalan</groupId>
             <artifactId>xalan</artifactId>
-            <version>2.7.0</version>
+            <version>2.7.2</version>
          </dependency>
          <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
-            <version>2.8.1</version>
+            <version>2.11.0</version>
             <!--  <version>2.8.0</version> in xmlui -->
          </dependency>
          <dependency>
@@ -1066,44 +1066,44 @@
          <dependency>
             <groupId>javax.activation</groupId>
             <artifactId>activation</artifactId>
-            <version>1.1</version>
+            <version>1.1.1</version>
          </dependency>
 
          <dependency>
             <groupId>wsdl4j</groupId>
             <artifactId>wsdl4j</artifactId>
-            <version>1.5.1</version>
+            <version>1.6.3</version>
          </dependency>
          <dependency>
             <groupId>javax.xml</groupId>
             <artifactId>jaxrpc-api</artifactId>
-            <version>1.1</version>
+            <version>1.3</version>
          </dependency>
          <dependency>
             <groupId>axis</groupId>
             <artifactId>axis</artifactId>
-            <version>1.3</version>
+            <version>1.4</version>
          </dependency>
          <dependency>
             <groupId>axis</groupId>
             <artifactId>axis-ant</artifactId>
-            <version>1.3</version>
+            <version>1.4</version>
             <scope>compile</scope>
          </dependency>
          <dependency>
             <groupId>axis</groupId>
             <artifactId>axis-saaj</artifactId>
-            <version>1.2</version>
+            <version>1.4</version>
          </dependency>
          <dependency>
             <groupId>com.ibm.icu</groupId>
             <artifactId>icu4j</artifactId>
-            <version>51.1</version>
+            <version>56.1</version>
          </dependency>
          <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>9.4-1203-jdbc41</version>
+            <version>9.4-1206-jdbc41</version>
          </dependency>
          <dependency>
             <groupId>com.oracle</groupId>
@@ -1113,12 +1113,12 @@
          <dependency>
             <groupId>com.sun.media</groupId>
             <artifactId>jai_imageio</artifactId>
-            <version>1.0_01</version>
+            <version>1.1</version>
          </dependency>
          <dependency>
             <groupId>javax.media</groupId>
             <artifactId>jai_core</artifactId>
-            <version>1.1.2_01</version>
+            <version>1.1.3</version>
          </dependency>
          <dependency>
             <groupId>org.dspace</groupId>
@@ -1128,12 +1128,12 @@
          <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.3.2</version>
+            <version>4.4.4</version>
          </dependency>
          <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.5</version>
+            <version>4.5.1</version>
          </dependency>
          <dependency>
              <groupId>org.slf4j</groupId>
@@ -1159,13 +1159,13 @@
          <dependency> <!-- Keep jmockit before junit -->
             <groupId>org.jmockit</groupId>
             <artifactId>jmockit</artifactId>
-            <version>1.10</version>
+            <version>1.21</version>
             <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
             <scope>test</scope>
          </dependency>
          <dependency>
@@ -1178,42 +1178,42 @@
          <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.187</version>
+            <version>1.4.191</version>
             <scope>test</scope>
          </dependency>
          <!-- Contiperf is used for performance tests within our Unit/Integration tests -->
          <dependency>
             <groupId>org.databene</groupId>
             <artifactId>contiperf</artifactId>
-            <version>2.2.0</version>
+            <version>2.3.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.2.1</version>
+            <version>2.5</version>
             <scope>compile</scope>
         </dependency>
           <!-- Google Analytics -->
           <dependency>
               <groupId>com.google.apis</groupId>
               <artifactId>google-api-services-analytics</artifactId>
-              <version>v3-rev103-1.19.0</version>
+              <version>v3-rev123-1.21.0</version>
           </dependency>
           <dependency>
             <groupId>com.google.api-client</groupId>
             <artifactId>google-api-client</artifactId>
-            <version>1.19.1</version>
+            <version>1.21.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.http-client</groupId>
             <artifactId>google-http-client</artifactId>
-            <version>1.19.0</version>
+            <version>1.21.0</version>
         </dependency>
         <dependency>
               <groupId>com.google.http-client</groupId>
               <artifactId>google-http-client-jackson2</artifactId>
-              <version>1.19.0</version>
+              <version>1.21.0</version>
               <exclusions>
                   <exclusion>
                       <artifactId>jackson-core</artifactId>
@@ -1228,19 +1228,19 @@
           <dependency>
               <groupId>com.google.oauth-client</groupId>
               <artifactId>google-oauth-client</artifactId>
-              <version>1.19.0</version>
+              <version>1.21.0</version>
           </dependency>
           <!-- Findbugs annotations -->
           <dependency>
               <groupId>com.google.code.findbugs</groupId>
               <artifactId>jsr305</artifactId>
-              <version>3.0.0</version>
+              <version>3.0.1</version>
               <scope>provided</scope>
           </dependency>
           <dependency>
               <groupId>com.google.code.findbugs</groupId>
               <artifactId>annotations</artifactId>
-              <version>3.0.0</version>
+              <version>3.0.1u2</version>
               <scope>provided</scope>
           </dependency>
       </dependencies>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3025

Supersedes #1260. Only upgrades dependencies which don't cause build failures.
