### PR TITLE
[DS-3024] "Administrator" and "Anonymous" groups can be renamed, which would cause them to no longer function in 6.x

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -313,7 +313,8 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
             Group g = groupService.create(context);
             context.restoreAuthSystemState();
 
-            g.setName(context, "COLLECTION_" + collection.getID() + "_WORKFLOW_STEP_" + step);
+            groupService.setName(context, g,
+                    "COLLECTION_" + collection.getID() + "_WORKFLOW_STEP_" + step);
             groupService.update(context, g);
             setWorkflowGroup(collection, step, g);
 
@@ -390,7 +391,8 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
             submitters = groupService.create(context);
             context.restoreAuthSystemState();
 
-            submitters.setName(context, "COLLECTION_" + collection.getID() + "_SUBMIT");
+            groupService.setName(context, submitters,
+                    "COLLECTION_" + collection.getID() + "_SUBMIT");
             groupService.update(context, submitters);
         }
 
@@ -430,7 +432,7 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
             admins = groupService.create(context);
             context.restoreAuthSystemState();
 
-            admins.setName(context, "COLLECTION_" + collection.getID() + "_ADMIN");
+            groupService.setName(context, admins, "COLLECTION_" + collection.getID() + "_ADMIN");
             groupService.update(context, admins);
         }
 

--- a/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
@@ -264,7 +264,7 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
             admins = groupService.create(context);
             context.restoreAuthSystemState();
 
-            admins.setName(context, "COMMUNITY_" + community.getID() + "_ADMIN");
+            groupService.setName(context, admins, "COMMUNITY_" + community.getID() + "_ADMIN");
             groupService.update(context, admins);
         }
 

--- a/dspace-api/src/main/java/org/dspace/content/packager/RoleIngester.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/RoleIngester.java
@@ -356,7 +356,7 @@ public class RoleIngester implements PackageIngester
                 }
 
                 // Always set the name:  parent.createBlop() is guessing
-                groupObj.setName(context, name);
+                groupService.setName(context, groupObj, name);
 
                 log.info("Created Group {}.", groupObj.getName());
             }

--- a/dspace-api/src/main/java/org/dspace/eperson/Group.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/Group.java
@@ -201,7 +201,7 @@ public class Group extends DSpaceObject implements DSpaceObjectLegacySupport
     }
 
     /** Change the name of this Group. */
-    public void setName(Context context, String name) throws SQLException
+    void setName(Context context, String name) throws SQLException
     {
         getGroupService().setMetadataSingleValue(context, this,
                 MetadataSchema.DC_SCHEMA, "title", null, null, name);

--- a/dspace-api/src/main/java/org/dspace/eperson/Group.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/Group.java
@@ -26,7 +26,6 @@ import java.util.List;
  * Class representing a group of e-people.
  * 
  * @author David Stuve
- * @version $Revision$
  */
 @Entity
 @Table(name = "epersongroup" )
@@ -44,6 +43,10 @@ public class Group extends DSpaceObject implements DSpaceObjectLegacySupport
      */
     @Column(name="eperson_group_id", insertable = false, updatable = false)
     private Integer legacyId;
+
+    /** This Group may not be deleted or renamed. */
+    @Column
+    private Boolean permanent = false;
 
     /** lists of epeople and groups in the group */
     @ManyToMany(fetch = FetchType.LAZY)
@@ -171,11 +174,7 @@ public class Group extends DSpaceObject implements DSpaceObjectLegacySupport
              return false;
          }
          final Group other = (Group) obj;
-         if (!this.getID().equals(other.getID()))
-         {
-             return false;
-         }
-         return true;
+         return this.getID().equals(other.getID());
      }
 
      @Override
@@ -203,7 +202,9 @@ public class Group extends DSpaceObject implements DSpaceObjectLegacySupport
 
     public void setName(Context context, String name) throws SQLException
     {
-        getGroupService().setMetadataSingleValue(context, this, MetadataSchema.DC_SCHEMA, "title", null, null, name);
+        if (!permanent)
+            getGroupService().setMetadataSingleValue(context, this,
+                    MetadataSchema.DC_SCHEMA, "title", null, null, name);
     }
 
     public boolean isGroupsChanged() {
@@ -229,5 +230,28 @@ public class Group extends DSpaceObject implements DSpaceObjectLegacySupport
             groupService = EPersonServiceFactory.getInstance().getGroupService();
         }
         return groupService;
+    }
+
+    /**
+     * May this Group be renamed or deleted?  (The content of any group may be
+     * changed.)
+     *
+     * @return true if this Group may not be renamed or deleted.
+     */
+    public Boolean isPermanent()
+    {
+        return permanent;
+    }
+
+    /**
+     * May this Group be renamed or deleted?  (The content of any group may be
+     * changed.)
+     *
+     * @param permanence true if this group may not be renamed or deleted.
+     */
+    void setPermanent(boolean permanence)
+    {
+        permanent = permanence;
+        setModified();
     }
 }

--- a/dspace-api/src/main/java/org/dspace/eperson/Group.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/Group.java
@@ -203,11 +203,8 @@ public class Group extends DSpaceObject implements DSpaceObjectLegacySupport
     /** Change the name of this Group. */
     public void setName(Context context, String name) throws SQLException
     {
-        if (!permanent)
-            getGroupService().setMetadataSingleValue(context, this,
-                    MetadataSchema.DC_SCHEMA, "title", null, null, name);
-        else
-            throw new SQLException("Attempt to rename a permanent Group");
+        getGroupService().setMetadataSingleValue(context, this,
+                MetadataSchema.DC_SCHEMA, "title", null, null, name);
     }
 
     public boolean isGroupsChanged() {

--- a/dspace-api/src/main/java/org/dspace/eperson/Group.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/Group.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 /**
  * Class representing a group of e-people.
- * 
+ *
  * @author David Stuve
  */
 @Entity
@@ -150,14 +150,14 @@ public class Group extends DSpaceObject implements DSpaceObjectLegacySupport
     {
         return groups;
     }
-    
+
     /**
      * Return <code>true</code> if <code>other</code> is the same Group as
      * this object, <code>false</code> otherwise
-     * 
+     *
      * @param obj
      *            object to compare to
-     * 
+     *
      * @return <code>true</code> if object passed in represents the same group
      *         as this object
      */
@@ -200,11 +200,14 @@ public class Group extends DSpaceObject implements DSpaceObjectLegacySupport
         return getGroupService().getName(this);
     }
 
+    /** Change the name of this Group. */
     public void setName(Context context, String name) throws SQLException
     {
         if (!permanent)
             getGroupService().setMetadataSingleValue(context, this,
                     MetadataSchema.DC_SCHEMA, "title", null, null, name);
+        else
+            throw new SQLException("Attempt to rename a permanent Group");
     }
 
     public boolean isGroupsChanged() {

--- a/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
@@ -8,7 +8,6 @@
 package org.dspace.eperson;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeConfiguration;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.service.AuthorizeService;
@@ -29,9 +28,11 @@ import org.dspace.eperson.service.GroupService;
 import org.dspace.event.Event;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.nio.ByteBuffer;
 import java.sql.SQLException;
 import java.util.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Service implementation for the Group object.
@@ -42,7 +43,7 @@ import java.util.*;
  */
 public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements GroupService
 {
-    private static final Logger log = Logger.getLogger(GroupServiceImpl.class);
+    private static final Logger log = LoggerFactory.getLogger(GroupServiceImpl.class);
 
     @Autowired(required = true)
     protected GroupDAO groupDAO;
@@ -89,7 +90,7 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
 
     @Override
     public void setName(Context context, Group group, String name) throws SQLException {
-        setMetadataSingleValue(context, group, MetadataSchema.DC_SCHEMA, "title", null, null, name);
+        group.setName(context, name);
     }
 
     @Override
@@ -161,7 +162,7 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
 
     @Override
     public List<Group> allMemberGroups(Context context, EPerson ePerson) throws SQLException {
-        Set<Group> groups = new HashSet<Group>();
+        Set<Group> groups = new HashSet<>();
 
         if (ePerson != null)
         {
@@ -206,7 +207,7 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
 
         // Get all groups which are a member of this group
         List<Group2GroupCache> group2GroupCaches = group2GroupCacheDAO.findByParent(c, g);
-        Set<Group> groups = new HashSet<Group>();
+        Set<Group> groups = new HashSet<>();
         for (Group2GroupCache group2GroupCache : group2GroupCaches) {
             groups.add(group2GroupCache.getChild());
         }
@@ -292,7 +293,14 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
 
     @Override
     public void delete(Context context, Group group) throws SQLException {
-        context.addEvent(new Event(Event.DELETE, Constants.GROUP, group.getID(), group.getName(), getIdentifiers(context, group)));
+        if (group.isPermanent())
+        {
+            log.error("Attempt to delete permanent Group $", group.getName());
+            throw new SQLException("Attempt to delete a permanent Group");
+        }
+
+        context.addEvent(new Event(Event.DELETE, Constants.GROUP, group.getID(),
+                group.getName(), getIdentifiers(context, group)));
 
         //Remove the supervised group from any workspace items linked to us.
         group.getSupervisedItems().clear();
@@ -335,7 +343,7 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
     public boolean isEmpty(Group group)
     {
         // the only fast check available is on epeople...
-        boolean hasMembers = (group.getMembers().size() != 0);
+        boolean hasMembers = (!group.getMembers().isEmpty());
 
         if (hasMembers)
         {
@@ -363,6 +371,7 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
         {
             anonymousGroup = groupService.create(context);
             anonymousGroup.setName(context, Group.ANONYMOUS);
+            anonymousGroup.setPermanent(true);
             groupService.update(context, anonymousGroup);
         }
 
@@ -373,6 +382,7 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
         {
             adminGroup = groupService.create(context);
             adminGroup.setName(context, Group.ADMIN);
+            adminGroup.setPermanent(true);
             groupService.update(context, adminGroup);
         }
     }

--- a/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
@@ -90,7 +90,10 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
 
     @Override
     public void setName(Context context, Group group, String name) throws SQLException {
-        group.setName(context, name);
+        if (!group.isPermanent())
+            group.setName(context, name);
+        else
+            throw new SQLException("Attempt to rename a permanent Group");
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
@@ -90,10 +90,14 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
 
     @Override
     public void setName(Context context, Group group, String name) throws SQLException {
-        if (!group.isPermanent())
-            group.setName(context, name);
-        else
+        if (group.isPermanent())
+        {
+            log.error("Attempt to rename permanent Group {} to {}.",
+                    group.getName(), name);
             throw new SQLException("Attempt to rename a permanent Group");
+        }
+        else
+            group.setName(context, name);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/eperson/service/GroupService.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/service/GroupService.java
@@ -198,8 +198,10 @@ public interface GroupService extends DSpaceObjectService<Group>, DSpaceObjectLe
     public boolean isEmpty(Group group);
 
     /**
-     * Initializes the group names for anymous & administrator
-     * @param context the dspace context
+     * Initializes the group names for anonymous & administrator, and marks them
+     * "permanent".
+     *
+     * @param context the DSpace context
      * @throws SQLException database exception
      * @throws AuthorizeException
      */

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
@@ -127,9 +127,11 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
                     authorizeService.authorizeAction(context, collection, Constants.WRITE);
                     roleGroup = groupService.create(context);
                     if(role.getScope() == Role.Scope.COLLECTION){
-                        roleGroup.setName(context, "COLLECTION_" + collection.getID().toString() + "_WORKFLOW_ROLE_" + roleName);
+                        groupService.setName(context, roleGroup,
+                                "COLLECTION_" + collection.getID().toString()
+                                        + "_WORKFLOW_ROLE_" + roleName);
                     }else{
-                        roleGroup.setName(context,  role.getName());
+                        groupService.setName(context, roleGroup,  role.getName());
                     }
                     groupService.update(context, roleGroup);
                     authorizeService.addPolicy(context, collection, Constants.ADD, roleGroup);

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V6.0_2015.03.07__DS-2701_Hibernate_migration.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V6.0_2015.03.07__DS-2701_Hibernate_migration.sql
@@ -32,6 +32,11 @@ ALTER TABLE eperson ALTER COLUMN eperson_id SET NULL;
 
 
 
+UPDATE metadatavalue SET text_value='Administrator'
+  WHERE resource_type_id=6 AND resource_id=1;
+UPDATE metadatavalue SET text_value='Anonymous'
+  WHERE resource_type_id=6 AND resource_id=0;
+
 ALTER TABLE epersongroup ADD COLUMN uuid UUID DEFAULT random_uuid();
 INSERT INTO dspaceobject  (uuid) SELECT uuid FROM epersongroup;
 ALTER TABLE epersongroup ADD FOREIGN KEY (uuid) REFERENCES dspaceobject;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V6.0_2016.01.03__DS-3024.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V6.0_2016.01.03__DS-3024.sql
@@ -1,0 +1,27 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+------------------------------------------------------
+-- DS-3024 Invent "permanent" groups
+------------------------------------------------------
+
+ALTER TABLE epersongroup
+      ADD (permanent BOOLEAN DEFAULT false);
+UPDATE epersongroup SET permanent = true
+       WHERE uuid IN (
+         SELECT dspace_object_id
+	   FROM metadataschemaregistry AS s
+	     JOIN metadatafieldregistry AS f
+	       ON (s.metadata_schema_id = f.metadata_schema_id)
+	     JOIN metadatavalue AS v
+	       ON (f.metadata_field_id = v.metadata_field_id)
+	   WHERE s.short_id = 'dc'
+	     AND f.element = 'title'
+	     AND f.qualifier IS NULL
+	     AND v.text_value IN ('Administrator', 'Anonymous')
+       );

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V6.0_2015.03.07__DS-2701_Hibernate_migration.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V6.0_2015.03.07__DS-2701_Hibernate_migration.sql
@@ -32,6 +32,11 @@ UPDATE eperson SET self_registered = '0' WHERE self_registered IS NULL;
 
 
 
+UPDATE metadatavalue SET text_value='Administrator'
+  WHERE resource_type_id=6 AND resource_id=1;
+UPDATE metadatavalue SET text_value='Anonymous'
+  WHERE resource_type_id=6 AND resource_id=0;
+
 ALTER TABLE epersongroup ADD uuid RAW(16) DEFAULT SYS_GUID();
 INSERT INTO dspaceobject  (uuid) SELECT uuid FROM epersongroup;
 ALTER TABLE epersongroup ADD FOREIGN KEY (uuid) REFERENCES dspaceobject;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V6.0_2016.01.03__DS-3024.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V6.0_2016.01.03__DS-3024.sql
@@ -1,0 +1,25 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+------------------------------------------------------
+-- DS-3024 Invent "permanent" groups
+------------------------------------------------------
+
+ALTER TABLE epersongroup
+      ADD (permanent NUMBER(1) DEFAULT 0);
+UPDATE epersongroup SET permanent = 1
+       WHERE uuid IN (
+         SELECT dspace_object_id
+	   FROM metadataschemaregistry s
+	     JOIN metadatafieldregistry f USING (metadata_schema_id)
+	     JOIN metadatavalue v USING (metadata_field_id)
+	   WHERE s.short_id = 'dc'
+	     AND f.element = 'title'
+	     AND f.qualifier IS NULL
+	     AND v.text_value IN ('Administrator', 'Anonymous')
+       );

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V6.0_2015.03.07__DS-2701_Hibernate_migration.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V6.0_2015.03.07__DS-2701_Hibernate_migration.sql
@@ -35,6 +35,11 @@ UPDATE eperson SET self_registered = false WHERE self_registered IS NULL;
 
 
 
+UPDATE metadatavalue SET text_value='Administrator'
+  WHERE resource_type_id=6 AND resource_id=1;
+UPDATE metadatavalue SET text_value='Anonymous'
+  WHERE resource_type_id=6 AND resource_id=0;
+
 ALTER TABLE epersongroup ADD COLUMN uuid UUID DEFAULT gen_random_uuid() UNIQUE;
 INSERT INTO dspaceobject  (uuid) SELECT uuid FROM epersongroup;
 ALTER TABLE epersongroup ADD FOREIGN KEY (uuid) REFERENCES dspaceobject;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V6.0_2016.01.03__DS-3024.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V6.0_2016.01.03__DS-3024.sql
@@ -1,0 +1,25 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+------------------------------------------------------
+-- DS-3024 Invent "permanent" groups
+------------------------------------------------------
+
+ALTER TABLE epersongroup
+      ADD COLUMN permanent BOOLEAN DEFAULT false;
+UPDATE epersongroup SET permanent = true
+       WHERE uuid IN (
+         SELECT dspace_object_id
+	   FROM metadataschemaregistry s
+	     JOIN metadatafieldregistry f USING (metadata_schema_id)
+	     JOIN metadatavalue v USING (metadata_field_id)
+	   WHERE s.short_id = 'dc'
+	     AND f.element = 'title'
+	     AND f.qualifier IS NULL
+	     AND v.text_value IN ('Administrator', 'Anonymous')
+       );

--- a/dspace-api/src/test/java/org/dspace/eperson/GroupServiceImplIT.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/GroupServiceImplIT.java
@@ -1,0 +1,660 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.eperson;
+
+import java.sql.SQLException;
+import org.dspace.AbstractUnitTest;
+import org.dspace.eperson.factory.EPersonServiceFactory;
+import org.dspace.eperson.service.GroupService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test integration of GroupServiceImpl.
+ *
+ * @author mwood
+ */
+public class GroupServiceImplIT
+        extends AbstractUnitTest
+{
+    public GroupServiceImplIT()
+    {
+        super();
+    }
+
+/*
+    @BeforeClass
+    public static void setUpClass()
+    {
+    }
+*/
+
+/*
+    @AfterClass
+    public static void tearDownClass()
+    {
+    }
+*/
+
+    @Before
+    @Override
+    public void init()
+    {
+        super.init();
+    }
+
+    @After
+    @Override
+    public void destroy()
+    {
+        super.destroy();
+    }
+
+    /**
+     * Test of create method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testCreate()
+            throws Exception
+    {
+        System.out.println("create");
+        Context context = null;
+        GroupServiceImpl instance = new GroupServiceImpl();
+        Group expResult = null;
+        Group result = instance.create(context);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of setName method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testSetName()
+            throws Exception
+    {
+        System.out.println("setName");
+        Context context = null;
+        Group group = null;
+        String name = "";
+        GroupServiceImpl instance = new GroupServiceImpl();
+        instance.setName(context, group, name);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of setName method applied to a 'permanent' Group.
+     */
+    @Test(expected = SQLException.class)
+    public void testSetName_permanent()
+            throws Exception
+    {
+        System.out.println("setName on a 'permanent' Group");
+        String name = "NOTANONYMOUS";
+        GroupService groupService = EPersonServiceFactory.getInstance().getGroupService();
+        Group group = groupService.findByName(context, Group.ANONYMOUS);
+        groupService.setName(context, group, name);
+    }
+
+    /**
+     * Test of addMember method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testAddMember_3args_1()
+    {
+        System.out.println("addMember");
+        Context context = null;
+        Group group = null;
+        EPerson e = null;
+        GroupServiceImpl instance = new GroupServiceImpl();
+        instance.addMember(context, group, e);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of addMember method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testAddMember_3args_2()
+            throws Exception
+    {
+        System.out.println("addMember");
+        Context context = null;
+        Group groupParent = null;
+        Group groupChild = null;
+        GroupServiceImpl instance = new GroupServiceImpl();
+        instance.addMember(context, groupParent, groupChild);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of removeMember method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testRemoveMember_3args_1()
+    {
+        System.out.println("removeMember");
+        Context context = null;
+        Group group = null;
+        EPerson ePerson = null;
+        GroupServiceImpl instance = new GroupServiceImpl();
+        instance.removeMember(context, group, ePerson);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of removeMember method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testRemoveMember_3args_2()
+            throws Exception
+    {
+        System.out.println("removeMember");
+        Context context = null;
+        Group groupParent = null;
+        Group childGroup = null;
+        GroupServiceImpl instance = new GroupServiceImpl();
+        instance.removeMember(context, groupParent, childGroup);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of isDirectMember method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testIsDirectMember()
+    {
+        System.out.println("isDirectMember");
+        Group group = null;
+        EPerson ePerson = null;
+        GroupServiceImpl instance = new GroupServiceImpl();
+        boolean expResult = false;
+        boolean result = instance.isDirectMember(group, ePerson);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of isMember method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testIsMember_Group_Group()
+    {
+        System.out.println("isMember");
+        Group owningGroup = null;
+        Group childGroup = null;
+        GroupServiceImpl instance = new GroupServiceImpl();
+        boolean expResult = false;
+        boolean result = instance.isMember(owningGroup, childGroup);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of isMember method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testIsMember_Context_Group()
+            throws Exception
+    {
+        System.out.println("isMember");
+        Context context = null;
+        Group group = null;
+        GroupServiceImpl instance = new GroupServiceImpl();
+        boolean expResult = false;
+        boolean result = instance.isMember(context, group);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of allMemberGroups method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testAllMemberGroups()
+            throws Exception
+    {
+        System.out.println("allMemberGroups");
+        Context context = null;
+        EPerson ePerson = null;
+        GroupServiceImpl instance = new GroupServiceImpl();
+        List<Group> expResult = null;
+        List<Group> result = instance.allMemberGroups(context, ePerson);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of allMembers method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testAllMembers()
+            throws Exception
+    {
+        System.out.println("allMembers");
+        Context c = null;
+        Group g = null;
+        GroupServiceImpl instance = new GroupServiceImpl();
+        List<EPerson> expResult = null;
+        List<EPerson> result = instance.allMembers(c, g);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of find method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testFind()
+            throws Exception
+    {
+        System.out.println("find");
+        Context context = null;
+        UUID id = null;
+        GroupServiceImpl instance = new GroupServiceImpl();
+        Group expResult = null;
+        Group result = instance.find(context, id);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of findByName method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testFindByName()
+            throws Exception
+    {
+        System.out.println("findByName");
+        Context context = null;
+        String name = "";
+        GroupServiceImpl instance = new GroupServiceImpl();
+        Group expResult = null;
+        Group result = instance.findByName(context, name);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of findAll method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testFindAll()
+            throws Exception
+    {
+        System.out.println("findAll");
+        Context context = null;
+        int sortField = 0;
+        GroupServiceImpl instance = new GroupServiceImpl();
+        List<Group> expResult = null;
+        List<Group> result = instance.findAll(context, sortField);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of search method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testSearch_Context_String()
+            throws Exception
+    {
+        System.out.println("search");
+        Context context = null;
+        String query = "";
+        GroupServiceImpl instance = new GroupServiceImpl();
+        List<Group> expResult = null;
+        List<Group> result = instance.search(context, query);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of search method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testSearch_4args()
+            throws Exception
+    {
+        System.out.println("search");
+        Context context = null;
+        String query = "";
+        int offset = 0;
+        int limit = 0;
+        GroupServiceImpl instance = new GroupServiceImpl();
+        List<Group> expResult = null;
+        List<Group> result = instance.search(context, query, offset, limit);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of searchResultCount method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testSearchResultCount()
+            throws Exception
+    {
+        System.out.println("searchResultCount");
+        Context context = null;
+        String query = "";
+        GroupServiceImpl instance = new GroupServiceImpl();
+        int expResult = 0;
+        int result = instance.searchResultCount(context, query);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of delete method applied to a 'permanent' Group.
+     */
+    @Test(expected = SQLException.class)
+    public void testDelete_permanent()
+            throws Exception
+    {
+        System.out.println("delete on a 'permanent' Group");
+        GroupService groupService = EPersonServiceFactory.getInstance().getGroupService();
+        Group group = groupService.findByName(context, Group.ANONYMOUS);
+        groupService.delete(context, group);
+    }
+
+    /**
+     * Test of getSupportsTypeConstant method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testGetSupportsTypeConstant()
+    {
+        System.out.println("getSupportsTypeConstant");
+        GroupServiceImpl instance = new GroupServiceImpl();
+        int expResult = 0;
+        int result = instance.getSupportsTypeConstant();
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of isEmpty method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testIsEmpty()
+    {
+        System.out.println("isEmpty");
+        Group group = null;
+        GroupServiceImpl instance = new GroupServiceImpl();
+        boolean expResult = false;
+        boolean result = instance.isEmpty(group);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of initDefaultGroupNames method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testInitDefaultGroupNames()
+            throws Exception
+    {
+        System.out.println("initDefaultGroupNames");
+        Context context = null;
+        GroupServiceImpl instance = new GroupServiceImpl();
+        instance.initDefaultGroupNames(context);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of getEmptyGroups method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testGetEmptyGroups()
+            throws Exception
+    {
+        System.out.println("getEmptyGroups");
+        Context context = null;
+        GroupServiceImpl instance = new GroupServiceImpl();
+        List<Group> expResult = null;
+        List<Group> result = instance.getEmptyGroups(context);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of update method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testUpdate()
+            throws Exception
+    {
+        System.out.println("update");
+        Context context = null;
+        Group group = null;
+        GroupServiceImpl instance = new GroupServiceImpl();
+        instance.update(context, group);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of epersonInGroup method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testEpersonInGroup()
+            throws Exception
+    {
+        System.out.println("epersonInGroup");
+        Context c = null;
+        Group group = null;
+        EPerson e = null;
+        GroupServiceImpl instance = new GroupServiceImpl();
+        boolean expResult = false;
+        boolean result = instance.epersonInGroup(c, group, e);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of rethinkGroupCache method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testRethinkGroupCache()
+            throws Exception
+    {
+        System.out.println("rethinkGroupCache");
+        Context context = null;
+        boolean flushQueries = false;
+        GroupServiceImpl instance = new GroupServiceImpl();
+        instance.rethinkGroupCache(context, flushQueries);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of getParentObject method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testGetParentObject()
+            throws Exception
+    {
+        System.out.println("getParentObject");
+        Context context = null;
+        Group group = null;
+        GroupServiceImpl instance = new GroupServiceImpl();
+        DSpaceObject expResult = null;
+        DSpaceObject result = instance.getParentObject(context, group);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of updateLastModified method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testUpdateLastModified()
+    {
+        System.out.println("updateLastModified");
+        Context context = null;
+        Group dso = null;
+        GroupServiceImpl instance = new GroupServiceImpl();
+        instance.updateLastModified(context, dso);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of getChildren method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testGetChildren()
+    {
+        System.out.println("getChildren");
+        Map<UUID, Set<UUID>> parents = null;
+        UUID parent = null;
+        GroupServiceImpl instance = new GroupServiceImpl();
+        Set<UUID> expResult = null;
+        Set<UUID> result = instance.getChildren(parents, parent);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of findByIdOrLegacyId method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testFindByIdOrLegacyId()
+            throws Exception
+    {
+        System.out.println("findByIdOrLegacyId");
+        Context context = null;
+        String id = "";
+        GroupServiceImpl instance = new GroupServiceImpl();
+        Group expResult = null;
+        Group result = instance.findByIdOrLegacyId(context, id);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of findByLegacyId method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testFindByLegacyId()
+            throws Exception
+    {
+        System.out.println("findByLegacyId");
+        Context context = null;
+        int id = 0;
+        GroupServiceImpl instance = new GroupServiceImpl();
+        Group expResult = null;
+        Group result = instance.findByLegacyId(context, id);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of countTotal method, of class GroupServiceImpl.
+     */
+/*
+    @Test
+    public void testCountTotal()
+            throws Exception
+    {
+        System.out.println("countTotal");
+        Context context = null;
+        GroupServiceImpl instance = new GroupServiceImpl();
+        int expResult = 0;
+        int result = instance.countTotal(context);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+}

--- a/dspace-api/src/test/java/org/dspace/eperson/GroupTest.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/GroupTest.java
@@ -190,8 +190,8 @@ public class GroupTest extends AbstractUnitTest {
 
         // Add all group names to two arraylists (arraylists are unsorted)
         // NOTE: we use lists here because we don't want duplicate names removed
-        List<String> names = new ArrayList<String>();
-        List<String> sortedNames = new ArrayList<String>();
+        List<String> names = new ArrayList<>();
+        List<String> sortedNames = new ArrayList<>();
         for (Group group : groups) {
             names.add(group.getName());
             sortedNames.add(group.getName());
@@ -374,6 +374,28 @@ public class GroupTest extends AbstractUnitTest {
     }
 
     @Test
+    public void isPermanent()
+            throws SQLException
+    {
+        Group anonymousGroup = groupService.findByName(context, Group.ANONYMOUS);
+        assertTrue("Anonymous group should be 'permanent'", anonymousGroup.isPermanent());
+        assertFalse("topGroup should *not* be 'permanent'", topGroup.isPermanent());
+    }
+
+    @Test
+    public void setPermanent()
+            throws SQLException, AuthorizeException, IOException
+    {
+        Group permaGroup = new Group();
+        permaGroup.setPermanent(true);
+        assertTrue("setPermanent(true) should be reflected in the group's state",
+                permaGroup.isPermanent());
+        permaGroup.setPermanent(false);
+        assertFalse("setPermanent(false) should be reflected in the group's state",
+                permaGroup.isPermanent());
+    }
+
+    @Test
     public void removeMemberEPerson() throws SQLException, AuthorizeException, EPersonDeletionException, IOException {
         EPerson ePerson = null;
         try {
@@ -429,7 +451,7 @@ public class GroupTest extends AbstractUnitTest {
 
     @Test
     public void allMembers() throws SQLException, AuthorizeException, EPersonDeletionException, IOException {
-        List<EPerson> allEPeopleAdded = new ArrayList<EPerson>();
+        List<EPerson> allEPeopleAdded = new ArrayList<>();
         try {
             context.turnOffAuthorisationSystem();
             allEPeopleAdded.add(createEPersonAndAddToGroup("allMemberGroups1@dspace.org", topGroup));

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/CollectionWizardServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/CollectionWizardServlet.java
@@ -400,9 +400,8 @@ public class CollectionWizardServlet extends DSpaceServlet
             g = groupService.create(context);
 
             // Name it according to our conventions
-            g
-                    .setName(context, "COLLECTION_" + collection.getID()
-                            + "_DEFAULT_ITEM_READ");
+            groupService.setName(context, g,
+                    "COLLECTION_" + collection.getID() + "_DEFAULT_ITEM_READ");
 
             // Give it the needed permission
             authorizeService.addPolicy(context, collection,

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/GroupEditServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/GroupEditServlet.java
@@ -97,7 +97,7 @@ public class GroupEditServlet extends DSpaceServlet
 
                 if (!newName.equals(group.getName()))
                 {
-                    group.setName(c, newName);
+                    groupService.setName(c, group, newName);
                     groupService.update(c, group);
                 }
 
@@ -257,7 +257,7 @@ public class GroupEditServlet extends DSpaceServlet
             {
                 group = groupService.create(c);
 
-                group.setName(c, "new group" + group.getID());
+                groupService.setName(c, group, "new group" + group.getID());
                 groupService.update(c, group);
 
                 request.setAttribute("group", group);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowContainerUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowContainerUtils.java
@@ -603,7 +603,7 @@ public class FlowContainerUtils
         }
 		
 		Group role = groupService.create(context);
-		role.setName(context, "COLLECTION_"+collection.getID().toString() +"_DEFAULT_READ");
+        groupService.setName(context, role, "COLLECTION_"+collection.getID().toString() +"_DEFAULT_READ");
 		
 		// Remove existing privileges from the anonymous group.
 		authorizeService.removePoliciesActionFilter(context, collection, Constants.DEFAULT_ITEM_READ);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowGroupUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowGroupUtils.java
@@ -217,7 +217,7 @@ public class FlowGroupUtils {
 	    	{
 				// All good, create the new group.
 				group = groupService.create(context);
-				group.setName(context, newName);
+				groupService.setName(context, group, newName);
 	    	}
 			else
 			{
@@ -245,7 +245,7 @@ public class FlowGroupUtils {
 				if (potentialDuplicate == null)
 		    	{
 					// All good, update the name
-					group.setName(context, newName);
+					groupService.setName(context, group, newName);
 		    	}
 				else
 				{


### PR DESCRIPTION
We need the ability to make some groups incapable of deletion or renaming.
https://jira.duraspace.org/browse/DS-3024
