### PR TITLE
DS-3027 ItemImport fix to use the collections file

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -347,7 +347,7 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
                 {
                     clist = mycollections;
                 }
-                addItem(c, mycollections, sourceDir, dircontents[i], mapOut, template);
+                addItem(c, clist, sourceDir, dircontents[i], mapOut, template);
                 System.out.println(i + " " + dircontents[i]);
             }
         }


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3027

Tiny bug was introduced a while ago for ItemImport processing collections file. IDE even had a small info/warning that it was an unused variable. The commandline specifies the "mycollections" variable, and cols is from the collection file. clist is supposed to be the correct one of either of those two.

The most typical use of ItemImport and collections is:

```
bin/dspace import -a -c 123456789/123 -s /path/to/batch/SAF -m /path/to/import1.map
```

However, you can specify an item to go to a specific collection. So, perhaps use SAFBuilder to do this. But it looks like:
SimpleArchiveFormat/item1/collections
123456789/456

Thus, you can run the import without specifying the collection, it will be detected from the collections file for each item.

```
bin/dspace import -a -s /path/to/batch/SAF
```

The problem this bug caused was that it would never actually use the collections from the collections file for the item.
