### PR TITLE
[DS-3031] Remove maven warning "Cannot include project artifact ..." in the assembly step

### DIFF
--- a/dspace/src/main/assembly/assembly.xml
+++ b/dspace/src/main/assembly/assembly.xml
@@ -82,6 +82,7 @@
             <include>*:jar:*</include>
          </includes>
          <outputDirectory>lib</outputDirectory>
+         <useProjectArtifact>false</useProjectArtifact>
       </dependencySet>
    </dependencySets>
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3031
