### PR TITLE
DS-3030 operations with bitstream policies fail in JSPUI

### DIFF
--- a/dspace-api/src/main/java/org/dspace/eperson/dao/impl/EPersonDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/dao/impl/EPersonDAOImpl.java
@@ -81,7 +81,14 @@ public class EPersonDAOImpl extends AbstractHibernateDSODAO<EPerson> implements 
     @Override
     public List<EPerson> findAll(Context context, MetadataField metadataSortField, String sortField) throws SQLException {
         String queryString = "SELECT " + EPerson.class.getSimpleName().toLowerCase() + " FROM EPerson as " + EPerson.class.getSimpleName().toLowerCase();
-        Query query = getSearchQuery(context, queryString, null, ListUtils.EMPTY_LIST, Collections.singletonList(metadataSortField), sortField);
+
+        List<MetadataField> sortFields = ListUtils.EMPTY_LIST;
+
+        if(metadataSortField!=null){
+            sortFields =  Collections.singletonList(metadataSortField);
+        }
+
+        Query query = getSearchQuery(context, queryString, null, ListUtils.EMPTY_LIST, sortFields, sortField);
         return list(query);
 
     }

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/AuthorizeAdminServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/AuthorizeAdminServlet.java
@@ -291,7 +291,9 @@ public class AuthorizeAdminServlet extends DSpaceServlet
             ResourcePolicy policy = resourcePolicyService.find(c, UIUtil
                     .getIntParameter(request, "policy_id"));
 
-            Item item = (Item) policy.getdSpaceObject();
+            Item item = itemService
+                    .find(c, UIUtil.getUUIDParameter(request, "item_id"));
+
 			AuthorizeUtil.authorizeManageItemPolicy(c, item);
             
             // do the remove


### PR DESCRIPTION
Updated class EPersonDAOImpl to prevent a list containing a 'null' object from being created. 

Updated class AuthorizeAdminServlet to get the item ID from the request, because policy.getdSpaceObject() returns a bitstream when deleting a bitstream policy.

jira ticket:
https://jira.duraspace.org/browse/DS-3030
