### PR TITLE
DS-2965 - Allow cache clear during re-index (V2)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -595,4 +595,8 @@ public class Context
     public void shutDownDatabase() throws SQLException {
         dbConnection.shutdown();
     }
+
+	public void clearCache() throws SQLException {
+		this.getDBConnection().clearCache();
+	}
 }

--- a/dspace-api/src/main/java/org/dspace/core/DBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/DBConnection.java
@@ -38,4 +38,6 @@ public interface DBConnection<T> {
     public DataSource getDataSource();
 
     public DatabaseConfigVO getDatabaseConfig() throws SQLException;
+    
+    public void clearCache() throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
@@ -107,4 +107,9 @@ public class HibernateDBConnection implements DBConnection<Session> {
         }
         return databaseConfigVO;
     }
+
+	@Override
+	public void clearCache() throws SQLException {
+		this.getSession().clear();
+	}
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -389,10 +389,15 @@ public class SolrServiceImpl implements SearchService, IndexingService {
     {
         try {
             Iterator<Item> items = null;
+            int itemCount = 0;
             for (items = itemService.findAllUnfiltered(context); items.hasNext();)
             {
                 Item item = items.next();
                 indexContent(context, item, force);
+                if (itemCount++ >= 1000) {
+                	context.clearCache();
+                	itemCount = 0;
+                }
             }
 
             List<Collection> collections = collectionService.findAll(context);


### PR DESCRIPTION
This replaces https://github.com/DSpace/DSpace/pull/1231.  The branch that was used for the prior PR is corrupted.

I am testing in a repository with 250,000+ items.

Without this fix, I am unable to re-index a repository.  With this fix, index-discovery succeeds.

@KevinVdV , I applied the suggestion that you made in the prior version of this PR.
