### PR TITLE
DS-3050 XOAI wrong URL encoding

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/util/URLUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/URLUtils.java
@@ -9,9 +9,9 @@ package org.dspace.xoai.util;
 
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
-
+import org.dspace.app.util.Util;
+import org.dspace.core.Constants;
 import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 
 /**
  * 
@@ -24,7 +24,8 @@ public class URLUtils
     public static String encode (String value) {
         try
         {
-            return URLEncoder.encode(value, "UTF-8");
+        	return Util.encodeBitstreamName(value, Constants.DEFAULT_ENCODING);
+
         }
         catch (UnsupportedEncodingException e)
         {


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3050

use `org.dspace.app.util.Util` instead of `java.net.URLEncoder` for URL encoding in XOAI
