### PR TITLE
[DS-2820] fixes XOAI Not filter

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/NotFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/NotFilter.java
@@ -19,7 +19,7 @@ public class NotFilter extends DSpaceFilter {
 
     @Override
     public SolrFilterResult buildSolrQuery() {
-        return new SolrFilterResult("NOT("+inFilter.buildSolrQuery().getQuery()+")");
+        return new SolrFilterResult("*:* AND NOT(" + inFilter.buildSolrQuery().getQuery() + ")");
     }
 
     @Override


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2820

This fixes the Not filter that doesn't work if there are multiple conditions in addition to the not filter. 
Like: A **And** **Not** B. 

To test the error and the solution apply the attached patch [xoai-test.zip](https://github.com/DSpace/DSpace/files/124493/xoai-test.zip) of the xoai.xml configuration.
This adds a context named **test** containing two Sets (**withdrawn** and **notWithdrawn**).

The error is replicable if you have at least one withdrawn item in the test system. Just go to:
**http://your-dspace-test/oai/test?verb=ListSets** and check the content of the sets before and after the fix.
