### PR TITLE
exlude entire comm, coll, and single  items from sitemap

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
+++ b/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
@@ -281,6 +281,7 @@ public class GenerateSitemaps
                                             ArrayList<AbstractMap.SimpleEntry<String, Date>> handleList) throws SQLException {
         if (excludes.contains(obj)) {
             log.info("Skipping " + obj.getHandle()  + "  '" + obj.getName() + "'");
+
             return;
         }
         handleList.add(new java.util.AbstractMap.SimpleEntry<String, Date>(obj.getHandle(),null));
@@ -292,7 +293,7 @@ public class GenerateSitemaps
                 log.info("Skipping " + i.getHandle() + "  '" + i.getName() + "'");
             } else {
                 Date lastMod = i.getLastModified();
-                handleList.add(new java.util.AbstractMap.SimpleEntry<String, Date>(obj.getHandle(),lastMod));
+                handleList.add(new java.util.AbstractMap.SimpleEntry<String, Date>(i.getHandle(),lastMod));
             }
         }
     }


### PR DESCRIPTION
relates to https://jira.duraspace.org/browse/DS-2381

this simply excludes items - it does not look at authorizations - in my case it does what I need - since all restricted items are bundled in a few communities/collections 

authorization can be added  easily  - but there are two levels that can be implemented - exclude when  dspace obj is access restricted  or additionally exclude items if they have no accessible ORIGINAL bitstreams

i don't need  this functionality - but if there is interest to use this - I can add the authorization bit 
