### PR TITLE
DS-3054: PDF Citation Page feature is not reading its configurations correctly

### DIFF
--- a/dspace-api/src/main/java/org/dspace/disseminate/CitationDocumentServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/disseminate/CitationDocumentServiceImpl.java
@@ -158,24 +158,21 @@ public class CitationDocumentServiceImpl implements CitationDocumentService, Ini
         }
 
         // Configurable text/fields, we'll set sane defaults
-        String header1Config = configurationService.getProperty("citation-page.header1");
-        if(StringUtils.isNotBlank(header1Config)) {
-            header1 = header1Config.split(",");
-        } else {
+        header1 = configurationService.getArrayProperty("citation-page.header1");
+        if (header1==null || header1.length==0)
+        {
             header1 = new String[]{"DSpace Institution", ""};
         }
 
-        String header2Config = configurationService.getProperty("citation-page.header2");
-        if(StringUtils.isNotBlank(header2Config)) {
-            header2 = header2Config.split(",");
-        } else {
+        header2 = configurationService.getArrayProperty("citation-page.header2");
+        if (header2==null || header2.length==0)
+        {
             header2 = new String[]{"DSpace Repository", "http://dspace.org"};
         }
 
-        String fieldsConfig = configurationService.getProperty("citation-page.fields");
-        if(StringUtils.isNotBlank(fieldsConfig)) {
-            fields = fieldsConfig.split(",");
-        } else {
+        fields = configurationService.getArrayProperty("citation-page.fields");
+        if (fields==null || fields.length==0)
+        {
             fields = new String[]{"dc.date.issued", "dc.title", "dc.creator", "dc.contributor.author", "dc.publisher", "_line_", "dc.identifier.citation", "dc.identifier.uri"};
         }
 

--- a/dspace/config/modules/citation-page.cfg
+++ b/dspace/config/modules/citation-page.cfg
@@ -6,7 +6,7 @@
 #---------------------------------------------------------------#
 #Boolean to determine is citation-functionality is enabled globally for entire site.
 #default => false
-#citation-page.citation.enable_globally=true
+#citation-page.enable_globally=true
 
 #List of collection handles to enable, to apply to nested bitstreams within
 #default =>  empty. This is to be collection handles, separated by commas. ex: 1811/123, 1811/234
@@ -22,9 +22,11 @@
 
 # Customize the text/appearance of the citation PDF
 # First row of header, perhaps put your institution/university name
+# A comma separator with create a header with multiple sections on one line.
 #citation-page.header1=DSpace Institution
 
 # Second row of header, perhaps put your DSpace branded name, and url to your DSpace
+# A comma separator with create a header with multiple sections on one line.
 #citation-page.header2=DSpace Repository,http://dspace.org
 
 # Metadata fields to display on the citation PDF.
@@ -32,4 +34,5 @@
 #citation-page.fields=dc.date.issued,dc.title,dc.creator,dc.contributor.author,dc.publisher,_line_,dc.identifier.citation,dc.identifier.uri
 
 # Footer text, either some type of license/copyright info, or just letting them know where they got the document from.
-#citation-page.footer=Downloaded from DSpace Repository, DSpace Institution's institutional repository
+# Any commas in this footer should be escaped (\,)
+#citation-page.footer=Downloaded from DSpace Repository\, DSpace Institution's institutional repository

--- a/dspace/config/modules/citation-page.cfg
+++ b/dspace/config/modules/citation-page.cfg
@@ -22,11 +22,11 @@
 
 # Customize the text/appearance of the citation PDF
 # First row of header, perhaps put your institution/university name
-# A comma separator with create a header with multiple sections on one line.
+# A comma separator will create a header with multiple sections on one line.
 #citation-page.header1=DSpace Institution
 
 # Second row of header, perhaps put your DSpace branded name, and url to your DSpace
-# A comma separator with create a header with multiple sections on one line.
+# A comma separator will create a header with multiple sections on one line.
 #citation-page.header2=DSpace Repository,http://dspace.org
 
 # Metadata fields to display on the citation PDF.


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3054

Use `getArrayProperty()` for all multivalued configs. Enhance/correct comments in `citation-page.cfg`

This is untested, but corrects some extremely obvious bugs in how the configurations are being loaded/read via the new ConfigurationService, especially having to do with commas in values (as commas are a special character in Apache Commons Configuration).
