### PR TITLE
[DS-3056] added and configured xml-maven-plugin to validate all XML 

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -255,6 +255,7 @@
                                  <includes>
                                      <include>**/*.xml</include>
                                      <include>**/*.xsl</include>
+                                     <include>**/*.xconf</include>
                                  </includes>
                              </validationSet>
                              <!-- validate ALL XML and XSL files throughout the project -->
@@ -263,6 +264,7 @@
                                  <includes>
                                      <include>**/*.xml</include>
                                      <include>**/*.xsl</include>
+                                     <include>**/*.xmap</include>
                                  </includes>
                               </validationSet>
                           </validationSets>

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -233,6 +233,44 @@
                         </configuration>
                     </plugin>
 
+
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>xml-maven-plugin</artifactId>
+                        <version>1.0.1</version>
+                        <executions>
+                          <execution>
+                            <id>validate-ALL-xml-and-xsl</id>
+                            <phase>process-test-resources</phase>
+                            <goals>
+                              <goal>validate</goal>
+                            </goals>
+                          </execution>
+                        </executions>
+                        <configuration>
+                          <validationSets>
+                            <!-- validate ALL XML and XSL config files in the testing folder -->
+                             <validationSet>
+                                 <dir>${agnostic.build.dir}/testing</dir>
+                                 <includes>
+                                     <include>**/*.xml</include>
+                                     <include>**/*.xsl</include>
+                                 </includes>
+                             </validationSet>
+                             <!-- validate ALL XML and XSL files throughout the project -->
+                             <validationSet>
+                                <dir>${root.basedir}</dir>
+                                 <includes>
+                                     <include>**/*.xml</include>
+                                     <include>**/*.xsl</include>
+                                 </includes>
+                              </validationSet>
+                          </validationSets>
+                        </configuration>
+                    </plugin>
+
+
+
                     <!-- Run Integration Testing! This plugin just kicks off the tests (when enabled). -->
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>


### PR DESCRIPTION
[DS-3056](https://jira.duraspace.org/projects/DS/issues/DS-3056): Validate all XML and XSL files during the testing phase, using the [xml-maven-plugin](http://www.mojohaus.org/xml-maven-plugin/) to check for well-formed-ness.
