### PR TITLE
DS-2887 AuthorizeException stacktrace shown instead of restricted access page

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/BitstreamReader.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/BitstreamReader.java
@@ -313,7 +313,7 @@ public class BitstreamReader extends AbstractReader implements Recyclable
                         return;
                 }
                 else{
-                	if(DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("request.item.type")==null||
+                	if(StringUtils.isBlank(DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("request.item.type")) ||
                 			                			DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("request.item.type").equalsIgnoreCase("logged")){
                         // The user does not have read access to this bitstream. Interrupt this current request
                         // and then forward them to the login page so that they can be authenticated. Once that is

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/BitstreamReader.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/BitstreamReader.java
@@ -314,7 +314,7 @@ public class BitstreamReader extends AbstractReader implements Recyclable
                         return;
                 }
                 else{
-                	if(ConfigurationManager.getProperty("request.item.type")==null||
+                	if(StringUtils.isBlank(ConfigurationManager.getProperty("request.item.type")) ||
                 			                			ConfigurationManager.getProperty("request.item.type").equalsIgnoreCase("logged")){
                         // The user does not have read access to this bitstream. Interrupt this current request
                         // and then forward them to the login page so that they can be authenticated. Once that is


### PR DESCRIPTION
replaced the "==null" check with StringUtils.isBlank() to prevent the error described in jira ticket https://jira.duraspace.org/browse/DS-2887
