### PR TITLE
DS-3058: Fix creating new resource policies. -1 MUST be passed as the policy ID

### DIFF
--- a/dspace-xmlui/src/main/resources/aspects/Administrative/administrative.js
+++ b/dspace-xmlui/src/main/resources/aspects/Administrative/administrative.js
@@ -2184,8 +2184,8 @@ function doAuthorizeContainer(containerType, containerID)
             return null;
         }
         else if (cocoon.request.get("submit_add")) {
-            // Create a new policy
-            result = doEditPolicy(containerType,containerID,null);
+            // Create a new policy (pass policyID=-1 to create a new one)
+            result = doEditPolicy(containerType,containerID,-1);
             if (result != null && result.getParameter("policyID"))
             	highlightID = result.getParameter("policyID");
         }


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3058

During the code refactor, the dummy policyID (to create a new policy) was switched to "null" instead of -1.  As the `processEditPolicy()` method clearly documents, to create a new policy, the ID should be set to -1:
https://github.com/DSpace/DSpace/blob/master/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowAuthorizationUtils.java#L130

So, this PR sets it back to -1, which fixes the problem. This has been lightly tested and it works for me.
