### PR TITLE
DS-3021 upgrade xerces

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -404,7 +404,7 @@
         </dependency>
         <dependency>
             <groupId>xml-apis</groupId>
-            <artifactId>xmlParserAPIs</artifactId>
+            <artifactId>xml-apis</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.activation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1058,13 +1058,13 @@
          <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
-            <version>2.8.1</version>
+            <version>2.11.0</version>
             <!--  <version>2.8.0</version> in xmlui -->
          </dependency>
          <dependency>
             <groupId>xml-apis</groupId>
-            <artifactId>xmlParserAPIs</artifactId>
-            <version>2.0.2</version>
+            <artifactId>xml-apis</artifactId>
+            <version>1.4.01</version>
          </dependency>
          <dependency>
             <groupId>javax.activation</groupId>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3021

The xerces mess is due to xerecs not being released to Maven Central by its upstream development team. Therefore there are multiple third-party groups releasing these artifacts, splitting them in parts differently, which causes versioning mess.

xml-apis:xml-apis:1.4.01 is actually newer than xml-apis:xml-apis:2.0.2 (or xml-apis:xmlParserAPIs:2.0.2), see:
http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22xml-apis%22%20AND%20a%3A%22xml-apis%22
http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22xml-apis%22%20AND%20a%3A%22xmlParserAPIs%22
