### PR TITLE
DS-3076 All REST API endpoints fail with Accept: application/json

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -669,17 +669,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.7.0</version>
+            <version>2.5.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.7.0</version>
+            <version>2.5.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.7.0</version>
+            <version>2.5.3</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3076

revert jackson upgrade 2.7.0 -> 2.5.3

http://stackoverflow.com/questions/34721851/spring-4-2-3-and-fasterxml-jackson-2-7-0-are-incompatible
