### PR TITLE
DS-3075: Comma-separated configurations now need to be loaded via getArrayProperty()

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterCLITool.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterCLITool.java
@@ -14,11 +14,15 @@ import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
-import org.dspace.core.*;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.core.SelfNamedPlugin;
+import org.dspace.core.factory.CoreServiceFactory;
 import org.dspace.handle.factory.HandleServiceFactory;
 
 import java.util.*;
-import org.dspace.core.factory.CoreServiceFactory;
+import org.apache.commons.lang.ArrayUtils;
+import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
  * MediaFilterManager is the class that invokes the media/format filters over the
@@ -39,7 +43,6 @@ public class MediaFilterCLITool {
 
     //suffix (in dspace.cfg) for input formats supported by each filter
     private static final String INPUT_FORMATS_SUFFIX = "inputFormats";
-
 
     public static void main(String[] argv) throws Exception
     {
@@ -162,8 +165,7 @@ public class MediaFilterCLITool {
         else
         {
             //retrieve list of all enabled media filter plugins!
-            String enabledPlugins = ConfigurationManager.getProperty(MEDIA_FILTER_PLUGINS_KEY);
-            filterNames = enabledPlugins.split(",\\s*");
+            filterNames = DSpaceServicesFactory.getInstance().getConfigurationService().getArrayProperty(MEDIA_FILTER_PLUGINS_KEY);
         }
 
         MediaFilterService mediaFilterService = MediaFilterServiceFactory.getInstance().getMediaFilterService();
@@ -210,13 +212,14 @@ public class MediaFilterCLITool {
                 //  filter.<class-name>.<plugin-name>.inputFormats
                 //For other MediaFilters, format of key is:
                 //  filter.<class-name>.inputFormats
-                String formats = ConfigurationManager.getProperty(
+                String[] formats = 
+                        DSpaceServicesFactory.getInstance().getConfigurationService().getArrayProperty(
                         FILTER_PREFIX + "." + filterClassName +
                                 (pluginName!=null ? "." + pluginName : "") +
                                 "." + INPUT_FORMATS_SUFFIX);
 
                 //add to internal map of filters to supported formats
-                if (formats != null)
+                if (ArrayUtils.isNotEmpty(formats))
                 {
                     //For SelfNamedPlugins, map key is:
                     //  <class-name><separator><plugin-name>
@@ -224,7 +227,7 @@ public class MediaFilterCLITool {
                     //  <class-name>
                     filterFormats.put(filterClassName +
                                     (pluginName!=null ? MediaFilterService.FILTER_PLUGIN_SEPARATOR + pluginName : ""),
-                            Arrays.asList(formats.split(",[\\s]*")));
+                            Arrays.asList(formats));
                 }
             }//end if filter!=null
         }//end for

--- a/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
+++ b/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
@@ -28,6 +28,7 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PosixParser;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.log4j.Logger;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
@@ -36,9 +37,10 @@ import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.CommunityService;
 import org.dspace.content.service.ItemService;
-import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 import org.dspace.core.LogManager;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
  * Command-line utility for generating HTML and Sitemaps.org protocol Sitemaps.
@@ -54,6 +56,7 @@ public class GenerateSitemaps
     private static final CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
     private static final CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
     private static final ItemService itemService = ContentServiceFactory.getInstance().getItemService();
+    private static final ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
 
     public static void main(String[] args) throws Exception
     {
@@ -157,14 +160,14 @@ public class GenerateSitemaps
     public static void generateSitemaps(boolean makeHTMLMap,
             boolean makeSitemapOrg) throws SQLException, IOException
     {
-        String sitemapStem = ConfigurationManager.getProperty("dspace.url")
+        String sitemapStem = configurationService.getProperty("dspace.url")
                 + "/sitemap";
-        String htmlMapStem = ConfigurationManager.getProperty("dspace.url")
+        String htmlMapStem = configurationService.getProperty("dspace.url")
                 + "/htmlmap";
-        String handleURLStem = ConfigurationManager.getProperty("dspace.url")
+        String handleURLStem = configurationService.getProperty("dspace.url")
                 + "/handle/";
 
-        File outputDir = new File(ConfigurationManager.getProperty("sitemap.dir"));
+        File outputDir = new File(configurationService.getProperty("sitemap.dir"));
         if (!outputDir.exists() && !outputDir.mkdir())
         {
             log.error("Unable to create output directory");
@@ -264,17 +267,10 @@ public class GenerateSitemaps
     public static void pingConfiguredSearchEngines()
             throws UnsupportedEncodingException
     {
-        String engineURLProp = ConfigurationManager
-                .getProperty("sitemap.engineurls");
-        String engineURLs[] = null;
-
-        if (engineURLProp != null)
-        {
-            engineURLs = engineURLProp.trim().split("\\s*,\\s*");
-        }
-
-        if (engineURLProp == null || engineURLs == null
-                || engineURLs.length == 0 || engineURLs[0].trim().equals(""))
+        String[] engineURLs = configurationService
+                .getArrayProperty("sitemap.engineurls");
+        
+        if (ArrayUtils.isEmpty(engineURLs))
         {
             log.warn("No search engine URLs configured to ping");
             return;
@@ -309,17 +305,17 @@ public class GenerateSitemaps
             throws MalformedURLException, UnsupportedEncodingException
     {
         // Set up HTTP proxy
-        if ((StringUtils.isNotBlank(ConfigurationManager.getProperty("http.proxy.host")))
-                && (StringUtils.isNotBlank(ConfigurationManager.getProperty("http.proxy.port"))))
+        if ((StringUtils.isNotBlank(configurationService.getProperty("http.proxy.host")))
+                && (StringUtils.isNotBlank(configurationService.getProperty("http.proxy.port"))))
         {
             System.setProperty("proxySet", "true");
-            System.setProperty("proxyHost", ConfigurationManager
+            System.setProperty("proxyHost", configurationService
                     .getProperty("http.proxy.host"));
-            System.getProperty("proxyPort", ConfigurationManager
+            System.getProperty("proxyPort", configurationService
                     .getProperty("http.proxy.port"));
         }
 
-        String sitemapURL = ConfigurationManager.getProperty("dspace.url")
+        String sitemapURL = configurationService.getProperty("dspace.url")
                 + "/sitemap";
 
         URL url = new URL(engineURL + URLEncoder.encode(sitemapURL, "UTF-8"));

--- a/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
@@ -50,6 +50,8 @@ import com.sun.syndication.io.SyndFeedOutput;
 import com.sun.syndication.io.FeedException;
 
 import org.apache.log4j.Logger;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
  * Invoke ROME library to assemble a generic model of a syndication
@@ -83,38 +85,43 @@ public class SyndicationFeed
     protected  String defaultTitleField = "dc.title";
     protected  String defaultAuthorField = "dc.contributor.author";
     protected  String defaultDateField = "dc.date.issued";
-    private static  String defaultDescriptionFields = "dc.description.abstract, dc.description, dc.title.alternative, dc.title";
+    private static final String[] defaultDescriptionFields = new String[]{"dc.description.abstract", "dc.description", "dc.title.alternative", "dc.title"};
     protected  String defaultExternalMedia = "dc.source.uri";
 
+    private final ConfigurationService configurationService = 
+            DSpaceServicesFactory.getInstance().getConfigurationService();
+
     // metadata field for Item title in entry:
-    protected  String titleField =
-        getDefaultedConfiguration("webui.feed.item.title", defaultTitleField);
+    protected String titleField = 
+            configurationService.getProperty("webui.feed.item.title", defaultTitleField);
 
     // metadata field for Item publication date in entry:
-    protected  String dateField =
-        getDefaultedConfiguration("webui.feed.item.date", defaultDateField);
+    protected String dateField =
+            configurationService.getProperty("webui.feed.item.date", defaultDateField);
 
     // metadata field for Item description in entry:
-    private static String descriptionFields[] =
-        getDefaultedConfiguration("webui.feed.item.description", defaultDescriptionFields).split("\\s*,\\s*");
-
-    protected  String authorField =
-        getDefaultedConfiguration("webui.feed.item.author", defaultAuthorField);
+    private static final String descriptionFields[] =
+            DSpaceServicesFactory.getInstance().getConfigurationService().getArrayProperty("webui.feed.item.description", defaultDescriptionFields);
+    
+    protected String authorField =
+            configurationService.getProperty("webui.feed.item.author", defaultAuthorField);
 
     // metadata field for Podcast external media source url
-    protected  String externalSourceField = getDefaultedConfiguration("webui.feed.podcast.sourceuri", defaultExternalMedia);
+    protected String externalSourceField = 
+            configurationService.getProperty("webui.feed.podcast.sourceuri", defaultExternalMedia);
 
     // metadata field for Item dc:creator field in entry's DCModule (no default)
-    protected  String dcCreatorField = ConfigurationManager.getProperty("webui.feed.item.dc.creator");
+    protected String dcCreatorField = configurationService.getProperty("webui.feed.item.dc.creator");
 
     // metadata field for Item dc:date field in entry's DCModule (no default)
-    protected  String dcDateField = ConfigurationManager.getProperty("webui.feed.item.dc.date");
+    protected String dcDateField = configurationService.getProperty("webui.feed.item.dc.date");
 
     // metadata field for Item dc:author field in entry's DCModule (no default)
-    protected  String dcDescriptionField = ConfigurationManager.getProperty("webui.feed.item.dc.description");
+    protected String dcDescriptionField = configurationService.getProperty("webui.feed.item.dc.description");
 
     // List of available mimetypes that we'll add to podcast feed. Multiple values separated by commas
-    protected  String podcastableMIMETypes = getDefaultedConfiguration("webui.feed.podcast.mimetypes", "audio/x-mpeg");
+    protected String[] podcastableMIMETypes =
+            configurationService.getArrayProperty("webui.feed.podcast.mimetypes", new String[]{"audio/x-mpeg"});
 
     // -------- Instance variables:
 
@@ -374,7 +381,7 @@ public class SyndicationFeed
                             List<Bitstream> bits = bunds.get(0).getBitstreams();
                             for (Bitstream bit : bits) {
                                 String mime = bit.getFormat(context).getMIMEType();
-                                if (podcastableMIMETypes.contains(mime)) {
+                                if (ArrayUtils.contains(podcastableMIMETypes,mime)) {
                                     SyndEnclosure enc = new SyndEnclosureImpl();
                                     enc.setType(bit.getFormat(context).getMIMEType());
                                     enc.setLength(bit.getSize());

--- a/dspace-api/src/main/java/org/dspace/authenticate/IPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/IPAuthentication.java
@@ -93,7 +93,7 @@ public class IPAuthentication implements AuthenticationMethod
 
             if (nameParts.length == 2)
             {
-                addMatchers(nameParts[1], DSpaceServicesFactory.getInstance().getConfigurationService().getProperty(propName));
+                addMatchers(nameParts[1], DSpaceServicesFactory.getInstance().getConfigurationService().getArrayProperty(propName));
             }
             else
             {
@@ -111,11 +111,9 @@ public class IPAuthentication implements AuthenticationMethod
      * @param ipRanges
      *            IP ranges
      */
-    protected void addMatchers(String groupName, String ipRanges)
+    protected void addMatchers(String groupName, String[] ipRanges)
     {
-        String[] ranges = ipRanges.split("\\s*,\\s*");
-
-        for (String entry : ranges)
+        for (String entry : ipRanges)
         {
             try
             {

--- a/dspace-api/src/main/java/org/dspace/authenticate/X509Authentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/X509Authentication.java
@@ -30,11 +30,11 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 import org.apache.commons.collections.ListUtils;
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.log4j.Logger;
 import org.dspace.authenticate.factory.AuthenticateServiceFactory;
 import org.dspace.authenticate.service.AuthenticationService;
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 import org.dspace.core.LogManager;
 import org.dspace.eperson.EPerson;
@@ -42,6 +42,8 @@ import org.dspace.eperson.Group;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
 import org.dspace.eperson.service.GroupService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
  * Implicit authentication method that gets credentials from the X.509 client
@@ -118,6 +120,8 @@ public class X509Authentication implements AuthenticationMethod
     protected AuthenticationService authenticationService = AuthenticateServiceFactory.getInstance().getAuthenticationService();
     protected EPersonService ePersonService = EPersonServiceFactory.getInstance().getEPersonService();
     protected GroupService groupService = EPersonServiceFactory.getInstance().getGroupService();
+    protected ConfigurationService configurationService = 
+            DSpaceServicesFactory.getInstance().getConfigurationService();
 
 
     /**
@@ -127,21 +131,23 @@ public class X509Authentication implements AuthenticationMethod
      */
     static
     {
+        ConfigurationService configurationService = 
+            DSpaceServicesFactory.getInstance().getConfigurationService();
         /*
          * allow identification of alternative entry points for certificate
          * authentication when selected by the user rather than implicitly.
          */
-        loginPageTitle = ConfigurationManager
-                .getProperty("authentication-x509", "chooser.title.key");
-        loginPageURL = ConfigurationManager
-                .getProperty("authentication-x509", "chooser.uri");
+        loginPageTitle = configurationService
+                .getProperty("authentication-x509.chooser.title.key");
+        loginPageURL = configurationService
+                .getProperty("authentication-x509.hooser.uri");
 
-        String keystorePath = ConfigurationManager
-                .getProperty("authentication-x509", "keystore.path");
-        String keystorePassword = ConfigurationManager
-                .getProperty("authentication-x509", "keystore.password");
-        String caCertPath = ConfigurationManager
-                .getProperty("authentication-x509", "ca.cert");
+        String keystorePath = configurationService
+                .getProperty("authentication-x509.keystore.path");
+        String keystorePassword = configurationService
+                .getProperty("authentication-x509.keystore.password");
+        String caCertPath = configurationService
+                .getProperty("authentication-x509.ca.cert");
 
         // First look for keystore full of trusted certs.
         if (keystorePath != null)
@@ -386,8 +392,8 @@ public class X509Authentication implements AuthenticationMethod
     public boolean canSelfRegister(Context context, HttpServletRequest request,
             String username) throws SQLException
     {
-        return ConfigurationManager
-                .getBooleanProperty("authentication-x509", "autoregister");
+        return configurationService
+                .getBooleanProperty("authentication-x509.autoregister");
     }
 
     /**
@@ -428,17 +434,14 @@ public class X509Authentication implements AuthenticationMethod
     {
         List<String> groupNames = new ArrayList<String>();
 
-        String x509GroupConfig = null;
-        x509GroupConfig = ConfigurationManager
-                .getProperty("authentication-x509", "groups");
+        String[] groups = configurationService
+                .getArrayProperty("authentication-x509.groups");
 
-        if (null != x509GroupConfig && !"".equals(x509GroupConfig))
+        if(ArrayUtils.isNotEmpty(groups))
         {
-            String[] groups = x509GroupConfig.split("\\s*,\\s*");
-
-            for (int i = 0; i < groups.length; i++)
+            for (String group : groups)
             {
-                groupNames.add(groups[i].trim());
+                groupNames.add(group.trim());
             }
         }
 

--- a/dspace-api/src/main/java/org/dspace/authenticate/X509Authentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/X509Authentication.java
@@ -140,7 +140,7 @@ public class X509Authentication implements AuthenticationMethod
         loginPageTitle = configurationService
                 .getProperty("authentication-x509.chooser.title.key");
         loginPageURL = configurationService
-                .getProperty("authentication-x509.hooser.uri");
+                .getProperty("authentication-x509.chooser.uri");
 
         String keystorePath = configurationService
                 .getProperty("authentication-x509.keystore.path");

--- a/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSDisseminator.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSDisseminator.java
@@ -69,7 +69,6 @@ import org.dspace.content.crosswalk.StreamDisseminationCrosswalk;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.SiteService;
-import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.LogManager;
@@ -78,6 +77,8 @@ import org.dspace.core.factory.CoreServiceFactory;
 import org.dspace.core.service.PluginService;
 import org.dspace.license.factory.LicenseServiceFactory;
 import org.dspace.license.service.CreativeCommonsService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 import org.jdom.Element;
 import org.jdom.Namespace;
 import org.jdom.output.Format;
@@ -128,6 +129,7 @@ public abstract class AbstractMETSDisseminator
     protected final BitstreamService bitstreamService = ContentServiceFactory.getInstance().getBitstreamService();
     protected final SiteService siteService = ContentServiceFactory.getInstance().getSiteService();
     protected final CreativeCommonsService creativeCommonsService = LicenseServiceFactory.getInstance().getCreativeCommonsService();
+    protected final ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
 
     // for gensym()
     protected int idCounter = 1;
@@ -1498,7 +1500,7 @@ public abstract class AbstractMETSDisseminator
                 }
                 if (handle != null)
                 {
-                    return ConfigurationManager
+                    return configurationService
                                     .getProperty("dspace.url")
                             + "/bitstream/"
                             + handle
@@ -1510,7 +1512,7 @@ public abstract class AbstractMETSDisseminator
                 else
                 {   //no Handle assigned, so persistent(-ish) URI for bitstream is
                     // Format: {site-base-url}/retrieve/{bitstream-internal-id}
-                    return ConfigurationManager
+                    return configurationService
                                     .getProperty("dspace.url")
                             + "/retrieve/"
                             + String.valueOf(bitstream.getID());

--- a/dspace-api/src/main/java/org/dspace/content/packager/DSpaceAIPDisseminator.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/DSpaceAIPDisseminator.java
@@ -25,7 +25,6 @@ import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.crosswalk.CrosswalkException;
 import org.dspace.core.Constants;
-import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 
 import edu.harvard.hul.ois.mets.Agent;
@@ -41,7 +40,10 @@ import edu.harvard.hul.ois.mets.Type;
 import edu.harvard.hul.ois.mets.helper.MetsException;
 import edu.harvard.hul.ois.mets.helper.PCData;
 import java.util.Date;
+import org.apache.commons.lang.ArrayUtils;
 import org.dspace.core.Utils;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
  * Subclass of the METS packager framework to disseminate a DSpace
@@ -117,6 +119,10 @@ public class DSpaceAIPDisseminator extends AbstractMETSDisseminator
     protected List<String> filterBundles = new ArrayList<String>();
     // Whether 'filterBundles' specifies an exclusion list (default) or inclusion list.
     protected boolean excludeBundles = true;
+    
+    protected ConfigurationService configurationService = 
+            DSpaceServicesFactory.getInstance().getConfigurationService();
+
 
     @Override
     public void disseminate(Context context, DSpaceObject dso,
@@ -257,17 +263,14 @@ public class DSpaceAIPDisseminator extends AbstractMETSDisseminator
     public String [] getDmdTypes(Context context, DSpaceObject dso, PackageParameters params)
         throws SQLException, IOException, AuthorizeException
     {
-        String dmdTypes = ConfigurationManager.getProperty("aip.disseminate.dmd");
-        if (dmdTypes == null)
+        String[] dmdTypes = configurationService.getArrayProperty("aip.disseminate.dmd");
+        if (ArrayUtils.isEmpty(dmdTypes))
         {
-            String result[] = new String[2];
-            result[0] = "MODS";
-            result[1] = "DIM";
-            return result;
+            return new String[] { "MODS","DIM"};
         }
         else
         {
-            return dmdTypes.split("\\s*,\\s*");
+            return dmdTypes;
         }
     }
 
@@ -289,14 +292,12 @@ public class DSpaceAIPDisseminator extends AbstractMETSDisseminator
     public String[] getTechMdTypes(Context context, DSpaceObject dso, PackageParameters params)
         throws SQLException, IOException, AuthorizeException
     {
-        String techTypes = ConfigurationManager.getProperty("aip.disseminate.techMD");
-        if (techTypes == null)
+        String[] techTypes = configurationService.getArrayProperty("aip.disseminate.techMD");
+        if (ArrayUtils.isEmpty(techTypes))
         {
             if (dso.getType() == Constants.BITSTREAM)
             {
-                String result[] = new String[1];
-                result[0] = "PREMIS";
-                return result;
+                return new String[]{"PREMIS"};
             }
             else
             {
@@ -305,7 +306,7 @@ public class DSpaceAIPDisseminator extends AbstractMETSDisseminator
         }
         else
         {
-            return techTypes.split("\\s*,\\s*");
+            return techTypes;
         }
     }
 
@@ -331,16 +332,14 @@ public class DSpaceAIPDisseminator extends AbstractMETSDisseminator
     public String[] getSourceMdTypes(Context context, DSpaceObject dso, PackageParameters params)
         throws SQLException, IOException, AuthorizeException
     {
-        String sourceTypes = ConfigurationManager.getProperty("aip.disseminate.sourceMD");
-        if (sourceTypes == null)
+        String[] sourceTypes = configurationService.getArrayProperty("aip.disseminate.sourceMD");
+        if (ArrayUtils.isEmpty(sourceTypes))
         {
-            String result[] = new String[1];
-            result[0] = "AIP-TECHMD";
-            return result;
+            return new String[] {"AIP-TECHMD"};
         }
         else
         {
-            return sourceTypes.split("\\s*,\\s*");
+            return sourceTypes;
         }
     }
 
@@ -362,14 +361,14 @@ public class DSpaceAIPDisseminator extends AbstractMETSDisseminator
     public String[] getDigiprovMdTypes(Context context, DSpaceObject dso, PackageParameters params)
         throws SQLException, IOException, AuthorizeException
     {
-        String dpTypes = ConfigurationManager.getProperty("aip.disseminate.digiprovMD");
-        if (dpTypes == null)
+        String[] dpTypes = configurationService.getArrayProperty("aip.disseminate.digiprovMD");
+        if (ArrayUtils.isEmpty(dpTypes))
         {
             return new String[0];
         }
         else
         {
-            return dpTypes.split("\\s*,\\s*");
+            return dpTypes;
         }
     }
 
@@ -394,10 +393,10 @@ public class DSpaceAIPDisseminator extends AbstractMETSDisseminator
     {
 
         List<String> result = new ArrayList<String>();
-        String rTypes = ConfigurationManager.getProperty("aip.disseminate.rightsMD");
+        String[] rTypes = configurationService.getArrayProperty("aip.disseminate.rightsMD");
 
         //If unspecified in configuration file, add default settings
-        if (rTypes == null)
+        if (ArrayUtils.isEmpty(rTypes))
         {
             // Licenses only apply to an Item
             if (dso.getType() == Constants.ITEM)
@@ -424,7 +423,7 @@ public class DSpaceAIPDisseminator extends AbstractMETSDisseminator
         }
         else
         {
-            return rTypes.split("\\s*,\\s*");
+            return rTypes;
         }
 
         return result.toArray(new String[result.size()]);

--- a/dspace-api/src/main/java/org/dspace/ctask/general/AbstractTranslator.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/AbstractTranslator.java
@@ -11,14 +11,16 @@ import org.apache.log4j.Logger;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
-import org.dspace.core.ConfigurationManager;
 import org.dspace.curate.AbstractCurationTask;
 import org.dspace.curate.Curator;
 import org.dspace.curate.Distributive;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
 
 /**
  * MicrosoftTranslator translates stuff
@@ -42,6 +44,9 @@ public abstract class AbstractTranslator extends AbstractCurationTask
     private static Logger log = Logger.getLogger(AbstractTranslator.class);
 
     protected List<String> results = new ArrayList<String>();
+    
+    private final transient ConfigurationService configurationService
+             = DSpaceServicesFactory.getInstance().getConfigurationService();
 
 
     @Override
@@ -50,12 +55,10 @@ public abstract class AbstractTranslator extends AbstractCurationTask
         super.init(curator, taskId);
 
         // Load configuration
-        authLang = ConfigurationManager.getProperty("default.locale");
-        authLangField = ConfigurationManager.getProperty(PLUGIN_PREFIX, "field.language");
-        String toTranslateStr = ConfigurationManager.getProperty(PLUGIN_PREFIX, "field.targets");
-        String langsStr = ConfigurationManager.getProperty(PLUGIN_PREFIX, "language.targets");
-        toTranslate = toTranslateStr.split(",");
-        langs = langsStr.split(",");
+        authLang = configurationService.getProperty("default.locale");
+        authLangField = configurationService.getProperty(PLUGIN_PREFIX + ".field.language");
+        String[] toTranslate = configurationService.getArrayProperty(PLUGIN_PREFIX + ".field.targets");
+        String[] langs = configurationService.getArrayProperty(PLUGIN_PREFIX + ".language.targets");
 
         if(!(toTranslate.length > 0 && langs.length > 0))
         {

--- a/dspace-api/src/main/java/org/dspace/ctask/general/ClamScan.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/ClamScan.java
@@ -25,7 +25,6 @@ import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.*;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.BitstreamService;
-import org.dspace.core.ConfigurationManager;
 import org.dspace.curate.AbstractCurationTask;
 import org.dspace.curate.Curator;
 import org.dspace.curate.Suspendable;
@@ -74,10 +73,10 @@ public class ClamScan extends AbstractCurationTask
     public void init(Curator curator, String taskId) throws IOException
     {
         super.init(curator, taskId);
-        host = ConfigurationManager.getProperty(PLUGIN_PREFIX, "service.host");
-        port = ConfigurationManager.getIntProperty(PLUGIN_PREFIX, "service.port");
-        timeout = ConfigurationManager.getIntProperty(PLUGIN_PREFIX, "socket.timeout");
-        failfast = ConfigurationManager.getBooleanProperty(PLUGIN_PREFIX, "scan.failfast");
+        host = configurationService.getProperty(PLUGIN_PREFIX + ".service.host");
+        port = configurationService.getIntProperty(PLUGIN_PREFIX + ".service.port");
+        timeout = configurationService.getIntProperty(PLUGIN_PREFIX + ".socket.timeout");
+        failfast = configurationService.getBooleanProperty(PLUGIN_PREFIX + ".scan.failfast");
         bitstreamService = ContentServiceFactory.getInstance().getBitstreamService();
     }
 

--- a/dspace-api/src/main/java/org/dspace/ctask/general/MetadataWebService.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/MetadataWebService.java
@@ -48,7 +48,6 @@ import org.xml.sax.SAXException;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
-import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Constants;
 import org.dspace.curate.AbstractCurationTask;
 import org.dspace.curate.Curator;
@@ -167,7 +166,7 @@ public class MetadataWebService extends AbstractCurationTask implements Namespac
     @Override
     public void init(Curator curator, String taskId) throws IOException {
     	super.init(curator, taskId);
-    	lang = ConfigurationManager.getProperty("default.language");
+    	lang = configurationService.getProperty("default.language");
         String fldSep = taskProperty("separator");
         fieldSeparator = (fldSep != null) ? fldSep : " ";
     	urlTemplate = taskProperty("template");
@@ -177,7 +176,7 @@ public class MetadataWebService extends AbstractCurationTask implements Namespac
     	lookupField = parsed[0];
     	lookupTransform = parsed[1];
     	dataList = new ArrayList<DataInfo>();
-    	for (String entry : taskProperty("datamap").split(",")) {
+    	for (String entry : taskArrayProperty("datamap")) {
     		entry = entry.trim();
     		String src = entry;
     		String mapping = null;

--- a/dspace-api/src/main/java/org/dspace/curate/FileTaskQueue.java
+++ b/dspace-api/src/main/java/org/dspace/curate/FileTaskQueue.java
@@ -20,8 +20,8 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.log4j.Logger;
+import org.dspace.services.factory.DSpaceServicesFactory;
 
-import org.dspace.core.ConfigurationManager;
 
 /**
  * FileTaskQueue provides a TaskQueue implementation based on flat files
@@ -33,7 +33,7 @@ public class FileTaskQueue implements TaskQueue
 {
     private static Logger log = Logger.getLogger(TaskQueue.class);   
     // base directory for curation task queues
-    protected String tqDir = ConfigurationManager.getProperty("curate", "taskqueue.dir");
+    protected String tqDir;
 
     // ticket for queue readers
     protected long readTicket = -1L;
@@ -42,6 +42,7 @@ public class FileTaskQueue implements TaskQueue
 
     public FileTaskQueue()
     {
+        tqDir = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("curate.taskqueue.dir");
     }
     
     @Override

--- a/dspace-api/src/main/java/org/dspace/curate/TaskResolver.java
+++ b/dspace-api/src/main/java/org/dspace/curate/TaskResolver.java
@@ -23,8 +23,8 @@ import javax.script.ScriptException;
 
 import org.apache.log4j.Logger;
 
-import org.dspace.core.ConfigurationManager;
 import org.dspace.core.factory.CoreServiceFactory;
+import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
  * TaskResolver takes a logical name of a curation task and attempts to deliver 
@@ -71,13 +71,14 @@ public class TaskResolver
 	
 	// base directory of task scripts & catalog name
 	protected static final String CATALOG = "task.catalog";
-	protected static final String scriptDir = ConfigurationManager.getProperty("curate", "script.dir");
+	protected final String scriptDir;
 	
 	// catalog of script tasks
 	protected Properties catalog;
 	
 	public TaskResolver()
 	{
+            scriptDir = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("curate.script.dir");
 	}
 		
 	/**

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -968,14 +968,10 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
 
             List<String> toProjectionFields = new ArrayList<String>();
-            String projectionFieldsString = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("discovery.index.projection");
-            if(projectionFieldsString != null){
-                if(projectionFieldsString.indexOf(",") != -1){
-                    for (int i = 0; i < projectionFieldsString.split(",").length; i++) {
-                        toProjectionFields.add(projectionFieldsString.split(",")[i].trim());
-                    }
-                } else {
-                    toProjectionFields.add(projectionFieldsString);
+            String[] projectionFields = DSpaceServicesFactory.getInstance().getConfigurationService().getArrayProperty("discovery.index.projection");
+            if(projectionFields != null){
+                for (String field : projectionFields) {
+                    toProjectionFields.add(field.trim());
                 }
             }
 

--- a/dspace-api/src/main/java/org/dspace/event/EventServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/event/EventServiceImpl.java
@@ -9,10 +9,11 @@ package org.dspace.event;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang.ArrayUtils;
 
 import org.apache.commons.pool2.KeyedObjectPool;
 import org.apache.commons.pool2.KeyedPooledObjectFactory;
@@ -22,9 +23,10 @@ import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
 import org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig;
 import org.apache.log4j.Logger;
-import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 import org.dspace.event.service.EventService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
  * Class for managing the content event environment. The EventManager mainly
@@ -48,7 +50,10 @@ public class EventServiceImpl implements EventService
 
     protected Map<String, Integer> consumerIndicies = null;
 
-    protected String CONSUMER_PFX = "event.consumer.";
+    protected String CONSUMER_PFX = "event.consumer";
+    
+    private static final ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+
 
     protected EventServiceImpl()
     {
@@ -140,7 +145,8 @@ public class EventServiceImpl implements EventService
 
     protected void enumerateConsumers()
     {
-        Enumeration propertyNames = ConfigurationManager.propertyNames();
+        // Get all configs starting with CONSUMER_PFX
+        List<String> propertyNames = configurationService.getPropertyKeys(CONSUMER_PFX);
         int bitSetIndex = 0;
 
         if (consumerIndicies == null)
@@ -148,13 +154,11 @@ public class EventServiceImpl implements EventService
             consumerIndicies = new HashMap<String, Integer>();
         }
 
-        while (propertyNames.hasMoreElements())
+        for(String ckey : propertyNames)
         {
-            String ckey = ((String) propertyNames.nextElement()).trim();
-
-            if (ckey.startsWith(CONSUMER_PFX) && ckey.endsWith(".class"))
+            if (ckey.endsWith(".class"))
             {
-                String consumerName = ckey.substring(CONSUMER_PFX.length(),
+                String consumerName = ckey.substring(CONSUMER_PFX.length()+1,
                         ckey.length() - 6);
 
                 consumerIndicies.put(consumerName, (Integer) bitSetIndex);
@@ -167,7 +171,7 @@ public class EventServiceImpl implements EventService
     {
 
         // Prefix of keys in DSpace Configuration
-        private static final String PROP_PFX = "event.dispatcher.";
+        private static final String PROP_PFX = "event.dispatcher";
 
         // Cache of event dispatchers, keyed by name, for re-use.
         protected Map<String, String> dispatchers = new HashMap<String, String>();
@@ -201,37 +205,23 @@ public class EventServiceImpl implements EventService
                     dispatcher = (Dispatcher) dc.newInstance(args);
 
                     // OK, now get its list of consumers/filters
-                    String consumerKey = PROP_PFX + dispatcherName
+                    String consumerKey = PROP_PFX + "." + dispatcherName
                             + ".consumers";
-                    String consumerList = ConfigurationManager
-                            .getProperty(consumerKey);
-                    if (consumerList == null)
+                    String[] consumers = configurationService
+                            .getArrayProperty(consumerKey);
+                    if (ArrayUtils.isEmpty(consumers))
                     {
                         throw new IllegalStateException(
                                 "No Configuration entry found for consumer list of event Dispatcher: \""
                                         + consumerKey + "\"");
                     }
 
-                    // Consumer list format:
-                    // <consumer-name>:<mode>, ...
-                    String[] consumerStanza = consumerList.trim().split(
-                            "\\s*,\\s*");
-
-                    // I think this should be a fatal error.. --lcs
-                    if (consumerStanza.length < 1)
-                    {
-                        throw new IllegalStateException(
-                                "Cannot initialize Dispatcher, malformed Configuration value for "
-                                        + consumerKey);
-                    }
-
                     ConsumerProfile consumerProfile = null;
 
-                    // parts: 0 is name, part 1 is mode.
-                    for (int i = 0; i < consumerStanza.length; i++)
+                    for (String consumer : consumers)
                     {
                         consumerProfile = ConsumerProfile
-                                .makeConsumerProfile(consumerStanza[i]);
+                                .makeConsumerProfile(consumer);
                         consumerProfile.getConsumer().initialize();
 
                         dispatcher.addConsumerProfile(consumerProfile);
@@ -346,16 +336,16 @@ public class EventServiceImpl implements EventService
          */
         private void parseEventConfig()
         {
-            Enumeration propertyNames = ConfigurationManager.propertyNames();
-            while (propertyNames.hasMoreElements())
+            // Get all configs starting with PROP_PFX
+            List<String> propertyNames = configurationService.getPropertyKeys(PROP_PFX);
+            
+            for(String ckey : propertyNames)
             {
-                String ckey = ((String) propertyNames.nextElement()).trim();
-
-                if (ckey.startsWith(PROP_PFX) && ckey.endsWith(".class"))
+                if (ckey.endsWith(".class"))
                 {
-                    String name = ckey.substring(PROP_PFX.length(), ckey
+                    String name = ckey.substring(PROP_PFX.length()+1, ckey
                             .length() - 6);
-                    String dispatcherClass = ConfigurationManager
+                    String dispatcherClass = configurationService
                             .getProperty(ckey);
 
                     // Can we grab all of the consumers configured for this

--- a/dspace-api/src/main/java/org/dspace/health/Report.java
+++ b/dspace-api/src/main/java/org/dspace/health/Report.java
@@ -18,6 +18,7 @@ import java.util.*;
 import java.util.Map.Entry;
 import org.dspace.core.factory.CoreServiceFactory;
 import org.dspace.core.service.PluginService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
  * @author LINDAT/CLARIN dev team
@@ -70,7 +71,7 @@ public class Report {
     // create check list
     public static LinkedHashMap<String, Check> checks() {
         LinkedHashMap<String, Check> checks = new LinkedHashMap<>();
-        String check_names[] = ConfigurationManager.getProperty("healthcheck", "checks").split(",");
+        String check_names[] = DSpaceServicesFactory.getInstance().getConfigurationService().getArrayProperty("healthcheck.checks");
         PluginService pluginService = CoreServiceFactory.getInstance().getPluginService();
         for ( String check_name : check_names ) {
             Check check = (Check) pluginService.getNamedPlugin(

--- a/dspace-api/src/main/java/org/dspace/license/CCLookup.java
+++ b/dspace-api/src/main/java/org/dspace/license/CCLookup.java
@@ -32,7 +32,8 @@ import org.jdom.JDOMException;
 import org.jdom.input.SAXBuilder;
 import org.jdom.output.XMLOutputter;
 
-import org.dspace.core.ConfigurationManager;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 
 
 /**
@@ -45,9 +46,9 @@ public class CCLookup {
         /** log4j logger */
         private static Logger log = Logger.getLogger(CCLookup.class);
 
-	private static String cc_root = ConfigurationManager.getProperty("cc.api.rooturl");
-	private static String jurisdiction; 
-	private static List<String> lcFilter = new ArrayList<String>();
+	private String cc_root;
+	private String jurisdiction; 
+	private List<String> lcFilter = new ArrayList<String>();
 	
 	private Document license_doc        = null;
 	private String rdfString            = null;
@@ -57,18 +58,6 @@ public class CCLookup {
 	private SAXBuilder parser           = new SAXBuilder();
 	private List<CCLicense> licenses    = new ArrayList<CCLicense>();
 	private List<CCLicenseField> licenseFields = new ArrayList<CCLicenseField>();
-	
-	static {
-		String jurisProp = ConfigurationManager.getProperty("cc.license.jurisdiction");
-		jurisdiction = (jurisProp != null) ? jurisProp : "";
-		
-		String filterList = ConfigurationManager.getProperty("cc.license.classfilter");
-		if (filterList != null) {
-			for (String name: filterList.split(",")) {
-				lcFilter.add(name.trim());
-			}
-		}
-	}
 
 	/**
 	 * Constructs a new instance with the default web services root.
@@ -76,6 +65,20 @@ public class CCLookup {
 	 */
 	public CCLookup() {
 		super();
+                
+                ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+                
+                cc_root = configurationService.getProperty("cc.api.rooturl");
+                
+                String jurisProp = configurationService.getProperty("cc.license.jurisdiction");
+		jurisdiction = (jurisProp != null) ? jurisProp : "";
+		
+		String[] filters = configurationService.getArrayProperty("cc.license.classfilter");
+		if (filters != null) {
+			for (String name: filters) {
+				lcFilter.add(name.trim());
+			}
+		}
 	}
 
 	/**

--- a/dspace-api/src/main/java/org/dspace/rdf/conversion/MetadataConverterPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/rdf/conversion/MetadataConverterPlugin.java
@@ -203,29 +203,23 @@ public class MetadataConverterPlugin implements ConverterPlugin
     
     protected Model loadConfiguration()
     {
-        String mappingPathes = configurationService.getProperty(METADATA_MAPPING_PATH_KEY);
-        if (StringUtils.isEmpty(mappingPathes))
-        {
-            return null;
-        }
-        String[] mappings = mappingPathes.split(",\\s*");        
-        if (mappings == null || mappings.length == 0)
+        InputStream is = null;
+        Model config = ModelFactory.createDefaultModel();
+        String mapping = configurationService.getProperty(METADATA_MAPPING_PATH_KEY);
+        if (StringUtils.isEmpty(mapping))
         {
             log.error("Cannot find metadata mappings (looking for "
                     + "property " + METADATA_MAPPING_PATH_KEY + ")!");
             return null;
         }
-        
-        InputStream is = null;
-        Model config = ModelFactory.createDefaultModel();
-        for (String mappingPath : mappings)
+        else
         {
-            is = FileManager.get().open(mappingPath);
+            is = FileManager.get().open(mapping);
             if (is == null)
             {
-                log.warn("Cannot find file '" + mappingPath + "', ignoring...");
+                log.warn("Cannot find file '" + mapping + "', ignoring...");
             }
-            config.read(is, "file://" + mappingPath, FileUtils.guessLang(mappingPath));
+            config.read(is, "file://" + mapping, FileUtils.guessLang(mapping));
             try {
                 // Make sure that we have an input stream to avoid NullPointer
                 if(is != null)

--- a/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetector.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetector.java
@@ -18,7 +18,7 @@ import java.util.Set;
 import java.util.Collections;
 import java.util.regex.Pattern;
 import javax.servlet.http.HttpServletRequest;
-import org.dspace.core.ConfigurationManager;
+import org.dspace.services.factory.DSpaceServicesFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -107,7 +107,7 @@ public class SpiderDetector {
         if (table == null) {
             table = new IPTable();
 
-            String filePath = ConfigurationManager.getProperty("dspace.dir");
+            String filePath = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("dspace.dir");
 
             try {
                 File spidersDir = new File(filePath, "config/spiders");
@@ -156,7 +156,7 @@ public class SpiderDetector {
      */
     private static void loadPatterns(String directory, List<Pattern> patternList)
     {
-        String dspaceHome = ConfigurationManager.getProperty("dspace.dir");
+        String dspaceHome = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("dspace.dir");
         File spidersDir = new File(dspaceHome, "config/spiders");
         File patternsDir = new File(spidersDir, directory);
         if (patternsDir.exists() && patternsDir.isDirectory())
@@ -296,7 +296,7 @@ public class SpiderDetector {
 
     private static boolean isUseProxies() {
         if(useProxies == null) {
-            useProxies = "true".equals(ConfigurationManager.getProperty("useProxies"));
+            useProxies = DSpaceServicesFactory.getInstance().getConfigurationService().getBooleanProperty("useProxies");
         }
 
         return useProxies;

--- a/dspace-api/src/main/java/org/dspace/statistics/util/StatisticsClient.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/StatisticsClient.java
@@ -10,12 +10,12 @@ package org.dspace.statistics.util;
 import org.apache.commons.cli.*;
 import org.apache.log4j.Logger;
 import org.apache.tools.ant.taskdefs.Get;
-import org.dspace.core.ConfigurationManager;
 import org.dspace.statistics.factory.StatisticsServiceFactory;
 import org.dspace.statistics.service.SolrLoggerService;
 
 import java.io.*;
 import java.net.URL;
+import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
  * Class to load intermediate statistics files into solr
@@ -54,7 +54,7 @@ public class StatisticsClient
 
         options.addOption("u", "update-spider-files", false,
                 "Update Spider IP Files from internet into " +
-                        ConfigurationManager.getProperty("dspace.dir") + "/config/spiders");
+                        DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("dspace.dir") + "/config/spiders");
 
         options.addOption("m", "mark-spiders", false, "Update isBot Flag in Solr");
         options.addOption("f", "delete-spiders-by-flag", false, "Delete Spiders in Solr By isBot Flag");
@@ -123,23 +123,22 @@ public class StatisticsClient
             System.out.println("Downloading latest spider IP addresses:");
 
             // Get the list URLs to download from
-            String urls = ConfigurationManager.getProperty("solr-statistics", "spiderips.urls");
-            if ((urls == null) || ("".equals(urls)))
+            String[] urls = DSpaceServicesFactory.getInstance().getConfigurationService().getArrayProperty("solr-statistics.spiderips.urls");
+            if((urls == null) || (urls.length==0))
             {
                 System.err.println(" - Missing setting from dspace.cfg: solr.spiderips.urls");
                 System.exit(0);
             }
 
             // Get the location of spiders directory
-            File spiders = new File(ConfigurationManager.getProperty("dspace.dir"),"config/spiders");
+            File spiders = new File(DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("dspace.dir"),"config/spiders");
 
             if (!spiders.exists() && !spiders.mkdirs())
             {
                 log.error("Unable to create spiders directory");
             }
 
-            String[] values = urls.split(",");
-            for (String value : values)
+            for (String value : urls)
             {
                 value = value.trim();
                 System.out.println(" Downloading: " + value);

--- a/dspace-api/src/main/java/org/dspace/text/filter/MARC21InitialArticleWord.java
+++ b/dspace-api/src/main/java/org/dspace/text/filter/MARC21InitialArticleWord.java
@@ -12,7 +12,7 @@ import java.util.*;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
-import org.dspace.core.ConfigurationManager;
+import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
  * Implements MARC 21 standards to disregard initial
@@ -278,18 +278,15 @@ public class MARC21InitialArticleWord extends InitialArticleWord
         }
 
         // Setup default stop words for null languages
-        String defaultLangs = ConfigurationManager.getProperty("marc21wordfilter.defaultlang");
-        if (!StringUtils.isEmpty(defaultLangs))
+        String[] defaultLangs = DSpaceServicesFactory.getInstance().getConfigurationService().getArrayProperty("marc21wordfilter.defaultlang");
+        if (ArrayUtils.isNotEmpty(defaultLangs))
         {
-            String[] langArr = defaultLangs.split("[, ]+");
-            if (langArr != null && langArr.length > 0)
-            {
                 int wordCount = 0;
-                ArticlesForLang[] afl = new ArticlesForLang[langArr.length];
+                ArticlesForLang[] afl = new ArticlesForLang[defaultLangs.length];
 
                 for (int idx = 0; idx < afl.length; idx++)
                 {
-                    Language l = Language.getLanguage(langArr[idx]);
+                    Language l = Language.getLanguage(defaultLangs[idx]);
                     if (l != null && ianaArticleMap.containsKey(l.IANA))
                     {
                         afl[idx] = ianaArticleMap.get(l.IANA);
@@ -313,7 +310,6 @@ public class MARC21InitialArticleWord extends InitialArticleWord
                         }
                     }
                 }
-            }
         }
     }
 

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/handle/HandleJSONResolver.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/handle/HandleJSONResolver.java
@@ -19,10 +19,11 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.dspace.app.webui.json.JSONRequest;
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 
 import com.google.gson.Gson;
 
@@ -32,9 +33,11 @@ public class HandleJSONResolver extends JSONRequest
             .getLogger(HandleJSONResolver.class);
 
 	private HandleService handleService;
+        private ConfigurationService configurationService;
 
 	public HandleJSONResolver() {
 		handleService = HandleServiceFactory.getInstance().getHandleService();
+                configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
 	}
 
     public void doJSONRequest(Context context, HttpServletRequest request,
@@ -77,11 +80,11 @@ public class HandleJSONResolver extends JSONRequest
             {
                 List<String> prefixes = new ArrayList<String>();
                 prefixes.add(handleService.getPrefix());
-                String additionalPrefixes = ConfigurationManager
-                        .getProperty("handle.additional.prefixes");
-                if (StringUtils.isNotBlank(additionalPrefixes))
+                String[] additionalPrefixes = configurationService
+                        .getArrayProperty("handle.additional.prefixes");
+                if (additionalPrefixes!=null)
                 {
-                    for (String apref : additionalPrefixes.split(","))
+                    for (String apref : additionalPrefixes)
                     {
                         prefixes.add(apref.trim());
                     }
@@ -90,7 +93,7 @@ public class HandleJSONResolver extends JSONRequest
             }
             else if (reqPath.startsWith("listhandles/"))
             {
-                if (ConfigurationManager.getBooleanProperty(
+                if (configurationService.getBooleanProperty(
                         "handle.hide.listhandles", true))
                 {
                     resp.sendError(HttpServletResponse.SC_NOT_FOUND);

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemListTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemListTag.java
@@ -23,6 +23,7 @@ import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.JspWriter;
 import javax.servlet.jsp.jstl.fmt.LocaleSupport;
 import javax.servlet.jsp.tagext.TagSupport;
+import org.apache.commons.lang.ArrayUtils;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
@@ -41,10 +42,11 @@ import org.dspace.content.authority.service.MetadataAuthorityService;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.ItemService;
-import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.Utils;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.sort.SortOption;
 
 /**
@@ -84,10 +86,10 @@ public class ItemListTag extends TagSupport
     private boolean disableCrossLinks = false;
 
     /** The default fields to be displayed when listing items */
-    private static final String DEFAULT_LIST_FIELDS;
+    private static final String[] DEFAULT_LIST_FIELDS;
 
     /** The default widths for the columns */
-    private static final String DEFAULT_LIST_WIDTHS;
+    private static final String[] DEFAULT_LIST_WIDTHS;
 
     /** The default field which is bound to the browse by date */
     private static String dateField = "dc.date.issued";
@@ -111,6 +113,9 @@ public class ItemListTag extends TagSupport
 
     private final transient BitstreamService bitstreamService
             = ContentServiceFactory.getInstance().getBitstreamService();
+    
+    private final transient ConfigurationService configurationService
+             = DSpaceServicesFactory.getInstance().getConfigurationService();
 
     static
     {
@@ -118,29 +123,29 @@ public class ItemListTag extends TagSupport
 
         if (showThumbs)
         {
-            DEFAULT_LIST_FIELDS = "thumbnail, dc.date.issued(date), dc.title, dc.contributor.*";
-            DEFAULT_LIST_WIDTHS = "*, 130, 60%, 40%";
+            DEFAULT_LIST_FIELDS = new String[] {"thumbnail", "dc.date.issued(date)", "dc.title", "dc.contributor.*"};
+            DEFAULT_LIST_WIDTHS = new String[] {"*", "130", "60%", "40%"};
         }
         else
         {
-            DEFAULT_LIST_FIELDS = "dc.date.issued(date), dc.title, dc.contributor.*";
-            DEFAULT_LIST_WIDTHS = "130, 60%, 40%";
+            DEFAULT_LIST_FIELDS = new String[] {"dc.date.issued(date)", "dc.title", "dc.contributor.*"};
+            DEFAULT_LIST_WIDTHS = new String[] {"130", "60%", "40%"};
         }
 
         // get the date and title fields
-        String dateLine = ConfigurationManager.getProperty("webui.browse.index.date");
+        String dateLine = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("webui.browse.index.date");
         if (dateLine != null)
         {
             dateField = dateLine;
         }
 
-        String titleLine = ConfigurationManager.getProperty("webui.browse.index.title");
+        String titleLine = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("webui.browse.index.title");
         if (titleLine != null)
         {
             titleField = titleLine;
         }
 
-        String authorLine = ConfigurationManager.getProperty("webui.browse.author-field");
+        String authorLine = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("webui.browse.author-field");
         if (authorLine != null)
         {
             authorField = authorLine;
@@ -168,96 +173,62 @@ public class ItemListTag extends TagSupport
         }
 
         // get the elements to display
-        String configLine = null;
-        String widthLine  = null;
+        String[] browseFields  = null;
+        String[] browseWidths = null;;
 
         if (sortOption != null)
         {
-            if (configLine == null)
+            if (ArrayUtils.isEmpty(browseFields))
             {
-                configLine = ConfigurationManager.getProperty("webui.itemlist.sort." + sortOption.getName() + ".columns");
-                widthLine  = ConfigurationManager.getProperty("webui.itemlist.sort." + sortOption.getName() + ".widths");
+                browseFields = configurationService.getArrayProperty("webui.itemlist.sort." + sortOption.getName() + ".columns");
+                browseWidths  = configurationService.getArrayProperty("webui.itemlist.sort." + sortOption.getName() + ".widths");
             }
 
-            if (configLine == null)
+            if (ArrayUtils.isEmpty(browseFields))
             {
-                configLine = ConfigurationManager.getProperty("webui.itemlist." + sortOption.getName() + ".columns");
-                widthLine  = ConfigurationManager.getProperty("webui.itemlist." + sortOption.getName() + ".widths");
+                browseFields = configurationService.getArrayProperty("webui.itemlist." + sortOption.getName() + ".columns");
+                browseWidths  = configurationService.getArrayProperty("webui.itemlist." + sortOption.getName() + ".widths");
             }
         }
 
-        if (configLine == null)
+        if (ArrayUtils.isEmpty(browseFields))
         {
-            configLine = ConfigurationManager.getProperty("webui.itemlist.columns");
-            widthLine  = ConfigurationManager.getProperty("webui.itemlist.widths");
+            browseFields = configurationService.getArrayProperty("webui.itemlist.columns");
+            browseWidths  = configurationService.getArrayProperty("webui.itemlist.widths");
         }
 
         // Have we read a field configration from dspace.cfg?
-        if (configLine != null)
+        if (ArrayUtils.isNotEmpty(browseFields))
         {
             // If thumbnails are disabled, strip out any thumbnail column from the configuration
-            if (!showThumbs && configLine.contains("thumbnail"))
+            if (!showThumbs)
             {
-                // Ensure we haven't got any nulls
-                configLine = configLine  == null ? "" : configLine;
-                widthLine  = widthLine   == null ? "" : widthLine;
-
-                // Tokenize the field and width lines
-                StringTokenizer llt = new StringTokenizer(configLine,  ",");
-                StringTokenizer wlt = new StringTokenizer(widthLine, ",");
-
-                StringBuilder newLLine = new StringBuilder();
-                StringBuilder newWLine = new StringBuilder();
-                while (llt.hasMoreTokens() || wlt.hasMoreTokens())
+                // check if it contains a thumbnail entry
+                // If so, remove it, and the width associated with it
+                int thumbnailIndex = ArrayUtils.indexOf(browseFields, "thumbnail");
+                if(thumbnailIndex>=0)
                 {
-                    String listTok  = llt.hasMoreTokens() ? llt.nextToken() : null;
-                    String widthTok = wlt.hasMoreTokens() ? wlt.nextToken() : null;
-
-                    // Only use the Field and Width tokens, if the field isn't 'thumbnail'
-                    if (listTok == null || !listTok.trim().equals("thumbnail"))
+                    browseFields = (String[]) ArrayUtils.remove(browseFields, thumbnailIndex);
+                    if(ArrayUtils.isNotEmpty(browseWidths))
                     {
-                        if (listTok != null)
-                        {
-                            if (newLLine.length() > 0)
-                            {
-                                newLLine.append(",");
-                            }
-
-                            newLLine.append(listTok);
-                        }
-
-                        if (widthTok != null)
-                        {
-                            if (newWLine.length() > 0)
-                            {
-                                newWLine.append(",");
-                            }
-
-                            newWLine.append(widthTok);
-                        }
+                       browseWidths = (String[]) ArrayUtils.remove(browseWidths, thumbnailIndex);
                     }
                 }
-
-                // Use the newly built configuration file
-                configLine  = newLLine.toString();
-                widthLine = newWLine.toString();
             }
         }
         else
         {
-            configLine = DEFAULT_LIST_FIELDS;
-            widthLine = DEFAULT_LIST_WIDTHS;
+            browseFields = DEFAULT_LIST_FIELDS;
+            browseWidths = DEFAULT_LIST_WIDTHS;
         }
 
         // Arrays used to hold the information we will require when outputting each row
-        String[] fieldArr  = configLine == null ? new String[0] : configLine.split("\\s*,\\s*");
-        String[] widthArr  = widthLine  == null ? new String[0] : widthLine.split("\\s*,\\s*");
-        boolean isDate[]   = new boolean[fieldArr.length];
-        boolean emph[]     = new boolean[fieldArr.length];
-        boolean isAuthor[] = new boolean[fieldArr.length];
-        boolean viewFull[] = new boolean[fieldArr.length];
-        String[] browseType = new String[fieldArr.length];
-        String[] cOddOrEven = new String[fieldArr.length];
+        boolean isDate[]   = new boolean[browseFields.length];
+        boolean emph[]     = new boolean[browseFields.length];
+        boolean isAuthor[] = new boolean[browseFields.length];
+        boolean viewFull[] = new boolean[browseFields.length];
+        String[] browseType = new String[browseFields.length];
+        String[] cOddOrEven = new String[browseFields.length];
 
         try
         {
@@ -265,11 +236,11 @@ public class ItemListTag extends TagSupport
             CrossLinks cl = new CrossLinks();
 
             // Get a width for the table
-            String tablewidth = ConfigurationManager.getProperty("webui.itemlist.tablewidth");
+            String tablewidth = configurationService.getProperty("webui.itemlist.tablewidth");
 
             // If we have column widths, output a fixed layout table - faster for browsers to render
             // but not if we have to add an 'edit item' button - we can't know how big it will be
-            if (widthArr.length > 0 && widthArr.length == fieldArr.length && !linkToEdit)
+            if (ArrayUtils.isNotEmpty(browseWidths) && browseWidths.length == browseFields.length && !linkToEdit)
             {
                 // If the table width has been specified, we can make this a fixed layout
                 if (!StringUtils.isEmpty(tablewidth))
@@ -285,18 +256,18 @@ public class ItemListTag extends TagSupport
                 // Output the known column widths
                 out.print("<colgroup>");
 
-                for (int w = 0; w < widthArr.length; w++)
+                for (int w = 0; w < browseWidths.length; w++)
                 {
                     out.print("<col width=\"");
 
                     // For a thumbnail column of width '*', use the configured max width for thumbnails
-                    if (fieldArr[w].equals("thumbnail") && widthArr[w].equals("*"))
+                    if (browseFields[w].equals("thumbnail") && browseWidths[w].equals("*"))
                     {
                         out.print(thumbItemListMaxWidth);
                     }
                     else
                     {
-                        out.print(StringUtils.isEmpty(widthArr[w]) ? "*" : widthArr[w]);
+                        out.print(StringUtils.isEmpty(browseWidths[w]) ? "*" : browseWidths[w]);
                     }
 
                     out.print("\" />");
@@ -316,9 +287,9 @@ public class ItemListTag extends TagSupport
             // Output the table headers
             out.println("<tr>");
 
-            for (int colIdx = 0; colIdx < fieldArr.length; colIdx++)
+            for (int colIdx = 0; colIdx < browseFields.length; colIdx++)
             {
-                String field = fieldArr[colIdx].toLowerCase().trim();
+                String field = browseFields[colIdx].toLowerCase().trim();
                 cOddOrEven[colIdx] = (((colIdx + 1) % 2) == 0 ? "Odd" : "Even");
 
                 // find out if the field is a date
@@ -329,7 +300,7 @@ public class ItemListTag extends TagSupport
                 }
 
                 // Cache any modifications to field
-                fieldArr[colIdx] = field;
+                browseFields[colIdx] = field;
 
                 // find out if this is the author column
                 if (field.equals(authorField))
@@ -393,9 +364,9 @@ public class ItemListTag extends TagSupport
                 // now prepare the XHTML frag for this division
             	out.print("<tr>"); 
 
-                for (int colIdx = 0; colIdx < fieldArr.length; colIdx++)
+                for (int colIdx = 0; colIdx < browseFields.length; colIdx++)
                 {
-                    String field = fieldArr[colIdx];
+                    String field = browseFields[colIdx];
 
                     // get the schema and the element qualifier pair
                     // (Note, the schema is not used for anything yet)
@@ -741,31 +712,34 @@ public class ItemListTag extends TagSupport
     /* get the required thumbnail config items */
     private static void getThumbSettings()
     {
-        showThumbs = ConfigurationManager
+        ConfigurationService configurationService =
+                DSpaceServicesFactory.getInstance().getConfigurationService();
+        
+        showThumbs = configurationService
                 .getBooleanProperty("webui.browse.thumbnail.show");
 
         if (showThumbs)
         {
-            thumbItemListMaxHeight = ConfigurationManager
+            thumbItemListMaxHeight = configurationService
                     .getIntProperty("webui.browse.thumbnail.maxheight");
 
             if (thumbItemListMaxHeight == 0)
             {
-                thumbItemListMaxHeight = ConfigurationManager
+                thumbItemListMaxHeight = configurationService
                         .getIntProperty("thumbnail.maxheight");
             }
 
-            thumbItemListMaxWidth = ConfigurationManager
+            thumbItemListMaxWidth = configurationService
                     .getIntProperty("webui.browse.thumbnail.maxwidth");
 
             if (thumbItemListMaxWidth == 0)
             {
-                thumbItemListMaxWidth = ConfigurationManager
+                thumbItemListMaxWidth = configurationService
                         .getIntProperty("thumbnail.maxwidth");
             }
         }
 
-        String linkBehaviour = ConfigurationManager
+        String linkBehaviour = configurationService
                 .getProperty("webui.browse.thumbnail.linkbehaviour");
 
         if ("bitstream".equals(linkBehaviour))

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemListTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemListTag.java
@@ -174,7 +174,7 @@ public class ItemListTag extends TagSupport
 
         // get the elements to display
         String[] browseFields  = null;
-        String[] browseWidths = null;;
+        String[] browseWidths = null;
 
         if (sortOption != null)
         {

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/util/CollectionStyleSelection.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/util/CollectionStyleSelection.java
@@ -8,13 +8,14 @@
 package org.dspace.app.webui.util;
 
 import java.sql.SQLException;
-import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.List;
 
 import org.apache.log4j.Logger;
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
-import org.dspace.core.ConfigurationManager;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
  * This is the standard (until 1.4.x) configuration mode based on owning collection handle
@@ -27,14 +28,18 @@ import org.dspace.core.ConfigurationManager;
 public class CollectionStyleSelection extends AKeyBasedStyleSelection
 {
     /** Hashmap of collection Handles to styles to use, from dspace.cfg */
-    private static java.util.Map<String, String> styles;
+    private java.util.Map<String, String> styles;
 
     /** log4j logger */
     private static Logger log = Logger.getLogger(CollectionStyleSelection.class);
     
+    private final transient ConfigurationService configurationService
+             = DSpaceServicesFactory.getInstance().getConfigurationService();
+    
     /**
      * Get the style using the owning collection handle
      */
+    @Override
     public String getStyleForItem(Item item) throws SQLException
     {
         Collection c = item.getOwningCollection();
@@ -57,20 +62,17 @@ public class CollectionStyleSelection extends AKeyBasedStyleSelection
     {
         styles = new HashMap<String, String>();
 
-        Enumeration<String> e = (Enumeration<String>)ConfigurationManager.propertyNames();
-
-        while (e.hasMoreElements())
+        // Get all properties starting with "webui.itemdisplay"
+        List<String> keys = configurationService.getPropertyKeys("webui.itemdisplay");
+       
+        for(String key: keys)
         {
-            String key = e.nextElement();
-
-            if (key.startsWith("webui.itemdisplay.")
-                    && key.endsWith(".collections"))
+            if (key.endsWith(".collections"))
             {
                 String styleName = key.substring("webui.itemdisplay.".length(),
                         key.length() - ".collections".length());
 
-                String[] collections = ConfigurationManager.getProperty(key)
-                        .split(",");
+                String[] collections = configurationService.getArrayProperty(key);
 
                 for (int i = 0; i < collections.length; i++)
                 {

--- a/dspace-jspui/src/main/webapp/collection-home.jsp
+++ b/dspace-jspui/src/main/webapp/collection-home.jsp
@@ -28,6 +28,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="http://www.dspace.org/dspace-tags.tld" prefix="dspace" %>
 
+<%@ page import="org.apache.commons.lang.StringUtils" %>
 <%@ page import="org.dspace.app.webui.components.RecentSubmissions" %>
 
 <%@ page import="org.dspace.app.webui.servlet.admin.EditCommunitiesServlet" %>
@@ -36,9 +37,10 @@
 <%@ page import="org.dspace.browse.BrowseInfo" %>
 <%@ page import="org.dspace.browse.ItemCounter"%>
 <%@ page import="org.dspace.content.*"%>
-<%@ page import="org.dspace.core.ConfigurationManager"%>
 <%@ page import="org.dspace.core.Utils" %>
 <%@ page import="org.dspace.eperson.Group"     %>
+<%@ page import="org.dspace.services.ConfigurationService" %>
+<%@ page import="org.dspace.services.factory.DSpaceServicesFactory" %>
 <%@ page import="javax.servlet.jsp.jstl.fmt.LocaleSupport" %>
 
 <%
@@ -89,11 +91,16 @@
 
     Bitstream logo = collection.getLogo();
     
-    boolean feedEnabled = ConfigurationManager.getBooleanProperty("webui.feed.enable");
+    ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+    
+    boolean feedEnabled = configurationService.getBooleanProperty("webui.feed.enable");
     String feedData = "NONE";
     if (feedEnabled)
     {
-        feedData = "coll:" + ConfigurationManager.getProperty("webui.feed.formats");
+        // FeedData is expected to be a comma separated list
+        String[] formats = configurationService.getArrayProperty("webui.feed.formats");
+        String allFormats = StringUtils.join(formats, ",");
+        feedData = "coll:" + allFormats;
     }
     
     ItemCounter ic = new ItemCounter(UIUtil.obtainContext(request));
@@ -110,7 +117,7 @@
     <div class="well">
     <div class="row"><div class="col-md-8"><h2><%= name %>
 <%
-            if(ConfigurationManager.getBooleanProperty("webui.strengths.show"))
+            if(configurationService.getBooleanProperty("webui.strengths.show"))
             {
 %>
                 : [<%= ic.getCount(collection) %>]

--- a/dspace-jspui/src/main/webapp/community-home.jsp
+++ b/dspace-jspui/src/main/webapp/community-home.jsp
@@ -27,6 +27,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="http://www.dspace.org/dspace-tags.tld" prefix="dspace" %>
 
+<%@ page import="org.apache.commons.lang.StringUtils" %>
 <%@ page import="org.dspace.app.webui.components.RecentSubmissions" %>
 
 <%@ page import="org.dspace.app.webui.servlet.admin.EditCommunitiesServlet" %>
@@ -34,8 +35,9 @@
 <%@ page import="org.dspace.browse.BrowseIndex" %>
 <%@ page import="org.dspace.browse.ItemCounter" %>
 <%@ page import="org.dspace.content.*" %>
-<%@ page import="org.dspace.core.ConfigurationManager" %>
 <%@ page import="org.dspace.core.Utils" %>
+<%@ page import="org.dspace.services.ConfigurationService" %>
+<%@ page import="org.dspace.services.factory.DSpaceServicesFactory" %>
 <%@ page import="javax.servlet.jsp.jstl.fmt.LocaleSupport" %>
 
 <%
@@ -66,11 +68,16 @@
     String sidebar = comServ.getMetadata(community, "side_bar_text");
     Bitstream logo = community.getLogo();
     
-    boolean feedEnabled = ConfigurationManager.getBooleanProperty("webui.feed.enable");
+    ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+    
+    boolean feedEnabled = configurationService.getBooleanProperty("webui.feed.enable");
     String feedData = "NONE";
     if (feedEnabled)
     {
-        feedData = "comm:" + ConfigurationManager.getProperty("webui.feed.formats");
+        // FeedData is expected to be a comma separated list
+        String[] formats = configurationService.getArrayProperty("webui.feed.formats");
+        String allFormats = StringUtils.join(formats, ",");
+        feedData = "comm:" + allFormats;
     }
     
     ItemCounter ic = new ItemCounter(UIUtil.obtainContext(request));
@@ -83,7 +90,7 @@
 	<div class="col-md-8">
         <h2><%= name %>
         <%
-            if(ConfigurationManager.getBooleanProperty("webui.strengths.show"))
+            if(configurationService.getBooleanProperty("webui.strengths.show"))
             {
 %>
                 : [<%= ic.getCount(community) %>]
@@ -239,7 +246,7 @@
 	
 <div class="row">
 <%
-	boolean showLogos = ConfigurationManager.getBooleanProperty("jspui.community-home.logos", true);
+	boolean showLogos = configurationService.getBooleanProperty("jspui.community-home.logos", true);
 	if (subcommunities.size() != 0)
     {
 %>
@@ -267,7 +274,7 @@
 	      <h4 class="list-group-item-heading"><a href="<%= request.getContextPath() %>/handle/<%= subcommunities.get(j).getHandle() %>">
 	                <%= subcommunities.get(j).getName() %></a>
 <%
-                if (ConfigurationManager.getBooleanProperty("webui.strengths.show"))
+                if (configurationService.getBooleanProperty("webui.strengths.show"))
                 {
 %>
                     [<%= ic.getCount(subcommunities.get(j)) %>]
@@ -323,7 +330,7 @@
 	      <h4 class="list-group-item-heading"><a href="<%= request.getContextPath() %>/handle/<%= collections.get(i).getHandle() %>">
 	      <%= collections.get(i).getName() %></a>
 <%
-            if(ConfigurationManager.getBooleanProperty("webui.strengths.show"))
+            if(configurationService.getBooleanProperty("webui.strengths.show"))
             {
 %>
                 [<%= ic.getCount(collections.get(i)) %>]

--- a/dspace-jspui/src/main/webapp/home.jsp
+++ b/dspace-jspui/src/main/webapp/home.jsp
@@ -32,13 +32,15 @@
 <%@ page import="java.util.Locale"%>
 <%@ page import="javax.servlet.jsp.jstl.core.*" %>
 <%@ page import="javax.servlet.jsp.jstl.fmt.LocaleSupport" %>
+<%@ page import="org.apache.commons.lang.StringUtils" %>
 <%@ page import="org.dspace.core.I18nUtil" %>
 <%@ page import="org.dspace.app.webui.util.UIUtil" %>
 <%@ page import="org.dspace.app.webui.components.RecentSubmissions" %>
 <%@ page import="org.dspace.content.Community" %>
-<%@ page import="org.dspace.core.ConfigurationManager" %>
 <%@ page import="org.dspace.browse.ItemCounter" %>
 <%@ page import="org.dspace.content.Item" %>
+<%@ page import="org.dspace.services.ConfigurationService" %>
+<%@ page import="org.dspace.services.factory.DSpaceServicesFactory" %>
 
 <%
     List<Community> communities = (List<Community>) request.getAttribute("communities");
@@ -49,11 +51,16 @@
     String topNews = newsService.readNewsFile(LocaleSupport.getLocalizedMessage(pageContext, "news-top.html"));
     String sideNews = newsService.readNewsFile(LocaleSupport.getLocalizedMessage(pageContext, "news-side.html"));
 
-    boolean feedEnabled = ConfigurationManager.getBooleanProperty("webui.feed.enable");
+    ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+    
+    boolean feedEnabled = configurationService.getBooleanProperty("webui.feed.enable");
     String feedData = "NONE";
     if (feedEnabled)
     {
-        feedData = "ALL:" + ConfigurationManager.getProperty("webui.feed.formats");
+        // FeedData is expected to be a comma separated list
+        String[] formats = configurationService.getArrayProperty("webui.feed.formats");
+        String allFormats = StringUtils.join(formats, ",");
+        feedData = "ALL:" + allFormats;
     }
     
     ItemCounter ic = new ItemCounter(UIUtil.obtainContext(request));
@@ -170,7 +177,7 @@ if (communities != null && communities.size() != 0)
                 <p><fmt:message key="jsp.home.com2"/></p>
 				<div class="list-group">
 <%
-	boolean showLogos = ConfigurationManager.getBooleanProperty("jspui.home-page.logos", true);
+	boolean showLogos = configurationService.getBooleanProperty("jspui.home-page.logos", true);
     for (Community com : communities)
     {
 %><div class="list-group-item row">
@@ -186,7 +193,7 @@ if (communities != null && communities.size() != 0)
 <% }  %>		
 		<h4 class="list-group-item-heading"><a href="<%= request.getContextPath() %>/handle/<%= com.getHandle() %>"><%= com.getName() %></a>
 <%
-        if (ConfigurationManager.getBooleanProperty("webui.strengths.show"))
+        if (configurationService.getBooleanProperty("webui.strengths.show"))
         {
 %>
 		<span class="badge pull-right"><%= ic.getCount(com) %></span>

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/GenericStatementDisseminator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/GenericStatementDisseminator.java
@@ -10,7 +10,6 @@ package org.dspace.sword2;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.Item;
-import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 import org.swordapp.server.OriginalDeposit;
 import org.swordapp.server.ResourcePart;
@@ -22,6 +21,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.dspace.services.factory.DSpaceServicesFactory;
 
 public abstract class GenericStatementDisseminator
         implements SwordStatementDisseminator
@@ -177,15 +177,14 @@ public abstract class GenericStatementDisseminator
 
     private List<String> getIncludeBundles()
     {
-        String cfg = ConfigurationManager
-                .getProperty("swordv2-server", "statement.bundles");
-        if (cfg == null || "".equals(cfg))
+        String[] bundles = DSpaceServicesFactory.getInstance().getConfigurationService()
+                .getArrayProperty("swordv2-server.statement.bundles");
+        if (bundles == null || bundles.length==0)
         {
-            cfg = "ORIGINAL, SWORD";
+            bundles = new String[] {"ORIGINAL", "SWORD"};
         }
-        String[] bits = cfg.split(",");
         List<String> include = new ArrayList<String>();
-        for (String bit : bits)
+        for (String bit : bundles)
         {
             String bundleName = bit.trim().toUpperCase();
             if (!include.contains(bundleName))
@@ -198,8 +197,8 @@ public abstract class GenericStatementDisseminator
 
     private String getOriginalDepositsBundle()
     {
-        String swordBundle = ConfigurationManager
-                .getProperty("swordv2-server", "bundle.name");
+        String swordBundle = DSpaceServicesFactory.getInstance().getConfigurationService()
+                .getProperty("swordv2-server.bundle.name");
         if (swordBundle == null)
         {
             swordBundle = "SWORD";

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/GenericStatementDisseminator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/GenericStatementDisseminator.java
@@ -21,6 +21,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang.ArrayUtils;
 import org.dspace.services.factory.DSpaceServicesFactory;
 
 public abstract class GenericStatementDisseminator
@@ -179,7 +180,7 @@ public abstract class GenericStatementDisseminator
     {
         String[] bundles = DSpaceServicesFactory.getInstance().getConfigurationService()
                 .getArrayProperty("swordv2-server.statement.bundles");
-        if (bundles == null || bundles.length==0)
+        if (ArrayUtils.isEmpty(bundles))
         {
             bundles = new String[] {"ORIGINAL", "SWORD"};
         }

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleDCEntryIngester.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleDCEntryIngester.java
@@ -12,15 +12,17 @@ import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.*;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.WorkspaceItemService;
-import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 import org.swordapp.server.*;
 
-import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+
 
 public class SimpleDCEntryIngester extends AbstractSimpleDC
         implements SwordEntryIngester
@@ -30,6 +32,9 @@ public class SimpleDCEntryIngester extends AbstractSimpleDC
 
     protected WorkspaceItemService workspaceItemService = ContentServiceFactory
             .getInstance().getWorkspaceItemService();
+    
+    protected ConfigurationService configurationService = DSpaceServicesFactory
+            .getInstance().getConfigurationService();
 
     public SimpleDCEntryIngester()
     {
@@ -115,10 +120,9 @@ public class SimpleDCEntryIngester extends AbstractSimpleDC
     private void removeMetadata(Context context, Item item)
             throws DSpaceSwordException
     {
-        String raw = ConfigurationManager
-                .getProperty("swordv2-server", "metadata.replaceable");
-        String[] parts = raw.split(",");
-        for (String part : parts)
+        String[] replaceableMetadata = configurationService
+                .getArrayProperty("swordv2-server.metadata.replaceable");
+        for (String part : replaceableMetadata)
         {
             MetadataValueInfo info = this
                     .makeMetadataValueInfo(part.trim(), null);
@@ -340,12 +344,12 @@ public class SimpleDCEntryIngester extends AbstractSimpleDC
             VerboseDescription verboseDescription)
             throws DSpaceSwordException
     {
-        String field = ConfigurationManager
-                .getProperty("swordv2-server", "updated.field");
-        if (field == null || "".equals(field))
+        String field = configurationService
+                .getProperty("swordv2-server.updated.field");
+        if (StringUtils.isBlank(field))
         {
             throw new DSpaceSwordException(
-                    "No configuration, or configuration is invalid for: sword.updated.field");
+                    "No configuration, or configuration is invalid for: swordv2-server.updated.field");
         }
 
         MetadataValueInfo info = this.makeMetadataValueInfo(field, null);
@@ -389,12 +393,12 @@ public class SimpleDCEntryIngester extends AbstractSimpleDC
             return;
         }
 
-        String field = ConfigurationManager
-                .getProperty("swordv2-server", "slug.field");
-        if (field == null || "".equals(field))
+        String field = configurationService
+                .getProperty("swordv2-server.slug.field");
+        if (StringUtils.isBlank(field))
         {
             throw new DSpaceSwordException(
-                    "No configuration, or configuration is invalid for: sword.slug.field");
+                    "No configuration, or configuration is invalid for: swordv2-server.slug.field");
         }
 
         MetadataValueInfo info = this.makeMetadataValueInfo(field, null);

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleDCEntryIngester.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleDCEntryIngester.java
@@ -21,7 +21,7 @@ import java.sql.SQLException;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 
 
 public class SimpleDCEntryIngester extends AbstractSimpleDC

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordConfigurationDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordConfigurationDSpace.java
@@ -14,18 +14,16 @@ import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.BitstreamFormatService;
-import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
-import org.dspace.core.LegacyPluginServiceImpl;
-import org.jaxen.function.FalseFunction;
 import org.swordapp.server.SwordConfiguration;
 import org.swordapp.server.SwordError;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
-import java.util.Set;
+import org.apache.commons.lang.StringUtils;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 
 public class SwordConfigurationDSpace implements SwordConfiguration
 {
@@ -35,6 +33,9 @@ public class SwordConfigurationDSpace implements SwordConfiguration
 
     protected BitstreamFormatService bitstreamFormatService = ContentServiceFactory
             .getInstance().getBitstreamFormatService();
+    
+    protected ConfigurationService configurationService = DSpaceServicesFactory
+            .getInstance().getConfigurationService();
 
     /** whether we can be verbose */
     private boolean verbose = true;
@@ -71,59 +72,58 @@ public class SwordConfigurationDSpace implements SwordConfiguration
     public SwordConfigurationDSpace()
     {
         // set the max upload size
-        int mus = ConfigurationManager
-                .getIntProperty("swordv2-server", "max-upload-size");
+        int mus = configurationService
+                .getIntProperty("swordv2-server.max-upload-size");
         if (mus > 0)
         {
             this.maxUploadSize = mus;
         }
 
         // set the mediation value
-        this.mediated = ConfigurationManager
-                .getBooleanProperty("swordv2-server", "on-behalf-of.enable");
+        this.mediated = configurationService
+                .getBooleanProperty("swordv2-server.on-behalf-of.enable", false);
 
         // find out if we keep the original as bitstream
-        this.keepOriginal = ConfigurationManager
-                .getBooleanProperty("swordv2-server", "keep-original-package");
+        this.keepOriginal = configurationService
+                .getBooleanProperty("swordv2-server.keep-original-package");
 
         // get the sword bundle
-        String bundle = ConfigurationManager
-                .getProperty("swordv2-server", "bundle.name");
-        if (bundle != null && "".equals(bundle))
+        String bundle = configurationService
+                .getProperty("swordv2-server.bundle.name");
+        if (StringUtils.isBlank(bundle))
         {
             this.swordBundle = bundle;
         }
 
         // find out if we keep the package as a file in specified directory
-        this.keepPackageOnFailedIngest = ConfigurationManager
-                .getBooleanProperty("swordv2-server", "keep-package-on-fail",
+        this.keepPackageOnFailedIngest = configurationService
+                .getBooleanProperty("swordv2-server.keep-package-on-fail",
                         false);
 
         // get directory path and name
-        this.failedPackageDir = ConfigurationManager
-                .getProperty("swordv2-server", "failed-package.dir");
+        this.failedPackageDir = configurationService
+                .getProperty("swordv2-server.failed-package.dir");
 
         // Get the accepted formats
-        String acceptsProperty = ConfigurationManager
-                .getProperty("swordv2-server", "accepts");
+        String[] acceptsFormats = configurationService
+                .getArrayProperty("swordv2-server.accepts");
         swordaccepts = new ArrayList<String>();
-        if (acceptsProperty == null)
+        if (acceptsFormats == null)
         {
-            acceptsProperty = "application/zip";
+            acceptsFormats = new String[]{"application/zip"};
         }
-        for (String element : acceptsProperty.split(","))
+        for (String element : acceptsFormats)
         {
             swordaccepts.add(element.trim());
         }
 
         // find out if community deposit is allowed
-        this.allowCommunityDeposit = ConfigurationManager
-                .getBooleanProperty("swordv2-server",
-                        "allow-community-deposit");
+        this.allowCommunityDeposit = configurationService
+                .getBooleanProperty("swordv2-server.allow-community-deposit");
 
         // find out if we keep the package as a file in specified directory
-        this.entryFirst = ConfigurationManager
-                .getBooleanProperty("swordv2-server", "multipart.entry-first",
+        this.entryFirst = configurationService
+                .getBooleanProperty("swordv2-server.multipart.entry-first",
                         false);
 
     }
@@ -132,19 +132,11 @@ public class SwordConfigurationDSpace implements SwordConfiguration
     // Utilities
     ///////////////////////////////////////////////////////////////////////////////////
 
-    public String getStringProperty(String module, String propName,
+    public String getStringProperty(String propName,
             String defaultValue, String[] allowedValues)
     {
-        String cfg;
-        if (module == null)
-        {
-            cfg = ConfigurationManager.getProperty(propName);
-        }
-        else
-        {
-            cfg = ConfigurationManager.getProperty(module, propName);
-        }
-        if (cfg == null || "".equals(cfg))
+        String cfg = configurationService.getProperty(propName);   
+        if (StringUtils.isBlank(cfg))
         {
             return defaultValue;
         }
@@ -170,10 +162,10 @@ public class SwordConfigurationDSpace implements SwordConfiguration
         return defaultValue;
     }
 
-    public String getStringProperty(String module, String propName,
+    public String getStringProperty(String propName,
             String defaultValue)
     {
-        return this.getStringProperty(module, propName, defaultValue, null);
+        return this.getStringProperty(propName, defaultValue, null);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////
@@ -187,8 +179,7 @@ public class SwordConfigurationDSpace implements SwordConfiguration
 
     public boolean returnStackTraceInError()
     {
-        return ConfigurationManager.getBooleanProperty("swordv2-server",
-                "verbose-description.error.enable");
+        return configurationService.getBooleanProperty("swordv2-server.verbose-description.error.enable");
     }
 
     public boolean returnErrorBody()
@@ -198,24 +189,24 @@ public class SwordConfigurationDSpace implements SwordConfiguration
 
     public String generator()
     {
-        return this.getStringProperty("swordv2-server", "generator.url",
+        return this.getStringProperty("swordv2-server.generator.url",
                 DSpaceUriRegistry.DSPACE_SWORD_NS);
     }
 
     public String generatorVersion()
     {
-        return this.getStringProperty("swordv2-server", "generator.version",
+        return this.getStringProperty("swordv2-server.generator.version",
                 "2.0");
     }
 
     public String administratorEmail()
     {
-        return this.getStringProperty(null, "mail.admin", null);
+        return this.getStringProperty("mail.admin", null);
     }
 
     public String getAuthType()
     {
-        return this.getStringProperty("swordv2-server", "auth-type", "Basic",
+        return this.getStringProperty("swordv2-server.auth-type", "Basic",
                 new String[] { "Basic", "None" });
     }
 
@@ -226,19 +217,19 @@ public class SwordConfigurationDSpace implements SwordConfiguration
 
     public String getTempDirectory()
     {
-        return this.getStringProperty("swordv2-server", "upload.tempdir", null);
+        return this.getStringProperty("swordv2-server.upload.tempdir", null);
     }
 
     public String getAlternateUrl()
     {
-        return ConfigurationManager
-                .getProperty("swordv2-server", "error.alternate.url");
+        return configurationService
+                .getProperty("swordv2-server.error.alternate.url");
     }
 
     public String getAlternateUrlContentType()
     {
-        return ConfigurationManager
-                .getProperty("swordv2-server", "error.alternate.content-type");
+        return configurationService
+                .getProperty("swordv2-server.error.alternate.content-type");
     }
 
     ///////////////////////////////////////////////////////////////////////////////////
@@ -255,25 +246,10 @@ public class SwordConfigurationDSpace implements SwordConfiguration
             throws DSpaceSwordException, SwordError
     {
         List<String> dps = new ArrayList<String>();
-        Properties props = ConfigurationManager.getProperties("swordv2-server");
-        Set keyset = props.keySet();
-        for (Object keyObj : keyset)
+        List<String> packagingFormats = configurationService.getPropertyKeys("swordv2-server.disseminate-packaging");
+        for (String key : packagingFormats)
         {
-            // start by getting anything that starts with sword.disseminate-packging.
-            String sw = "disseminate-packaging.";
-
-            if (!(keyObj instanceof String))
-            {
-                continue;
-            }
-            String key = (String) keyObj;
-
-            if (!key.startsWith(sw))
-            {
-                continue;
-            }
-
-            String value = props.getProperty((key));
+            String value = configurationService.getProperty(key);
 
             // now we want to ensure that the packaging format we offer has a disseminator
             // associated with it
@@ -517,28 +493,14 @@ public class SwordConfigurationDSpace implements SwordConfiguration
         List<String> aps = new ArrayList<String>();
 
         // build the holding maps of identifiers
-        Properties props = ConfigurationManager.getProperties("swordv2-server");
-        Set keyset = props.keySet();
-        for (Object keyObj : keyset)
+        String acceptPackagingPrefix = "swordv2-server.accept-packaging.collection";
+        List<String> acceptFormats = configurationService.getPropertyKeys(acceptPackagingPrefix);
+        for (String key : acceptFormats)
         {
-            // start by getting anything that starts with sword.accept-packaging.collection.
-            String sw = "accept-packaging.collection.";
-
-            if (!(keyObj instanceof String))
-            {
-                continue;
-            }
-            String key = (String) keyObj;
-
-            if (!key.startsWith(sw))
-            {
-                continue;
-            }
-
             // extract the configuration into the holding Maps
 
             // the suffix will be [typeid] or [handle].[typeid]
-            String suffix = key.substring(sw.length());
+            String suffix = key.substring(acceptPackagingPrefix.length()+1);
 
             // is there a handle which represents this collection?
             boolean withHandle = false;
@@ -557,7 +519,7 @@ public class SwordConfigurationDSpace implements SwordConfiguration
 
             if (withHandle || general)
             {
-                String value = props.getProperty((key));
+                String value = configurationService.getProperty(key);
                 aps.add(value);
             }
         }
@@ -570,26 +532,12 @@ public class SwordConfigurationDSpace implements SwordConfiguration
         List<String> aps = new ArrayList<String>();
 
         // build the holding maps of identifiers
-        Properties props = ConfigurationManager.getProperties("swordv2-server");
-        Set keyset = props.keySet();
-        for (Object keyObj : keyset)
+        String acceptPackagingPrefix = "swordv2-server.accept-packaging.item";
+        List<String> acceptFormats = configurationService.getPropertyKeys(acceptPackagingPrefix);
+        for (String key : acceptFormats)
         {
-            // start by getting anything that starts with sword.accept-packging.collection.
-            String sw = "accept-packaging.item.";
-
-            if (!(keyObj instanceof String))
-            {
-                continue;
-            }
-            String key = (String) keyObj;
-
-            if (!key.startsWith(sw))
-            {
-                continue;
-            }
-
             // extract the configuration into the holding Maps
-            String value = props.getProperty((key));
+            String value = configurationService.getProperty(key);
             aps.add(value);
         }
 
@@ -696,14 +644,14 @@ public class SwordConfigurationDSpace implements SwordConfiguration
 
     public String getStateUri(String state)
     {
-        return ConfigurationManager
-                .getProperty("swordv2-server", "state." + state + ".uri");
+        return configurationService
+                .getProperty("swordv2-server.state." + state + ".uri");
     }
 
     public String getStateDescription(String state)
     {
-        return ConfigurationManager.getProperty("swordv2-server",
-                "state." + state + ".description");
+        return configurationService
+                .getProperty("swordv2-server.state." + state + ".description");
     }
 
     public boolean allowUnauthenticatedMediaAccess()

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordConfigurationDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordConfigurationDSpace.java
@@ -22,6 +22,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.ArrayUtils;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 
@@ -108,7 +109,7 @@ public class SwordConfigurationDSpace implements SwordConfiguration
         String[] acceptsFormats = configurationService
                 .getArrayProperty("swordv2-server.accepts");
         swordaccepts = new ArrayList<String>();
-        if (acceptsFormats == null)
+        if (ArrayUtils.isEmpty(acceptsFormats))
         {
             acceptsFormats = new String[]{"application/zip"};
         }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowCurationUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowCurationUtils.java
@@ -68,8 +68,8 @@ public class FlowCurationUtils
     {
         if (map.isEmpty())
         {
-            String statusCodes = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("curate.ui.statusmessages");
-            for (String pair : statusCodes.split(","))
+            String[] statusCodes = DSpaceServicesFactory.getInstance().getConfigurationService().getArrayProperty("curate.ui.statusmessages");
+            for (String pair : statusCodes)
             {
                 String[] parts = pair.split("=");
                 map.put(parts[0].trim(), parts[1].trim());
@@ -270,8 +270,7 @@ public class FlowCurationUtils
     
     public static void setAllTasks() throws WingException, UnsupportedEncodingException
     {
-    	String csvList = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("curate." + CURATE_TASK_NAMES);
-    	String[] properties = csvList.split(",");
+    	String[] properties = DSpaceServicesFactory.getInstance().getConfigurationService().getArrayProperty("curate." + CURATE_TASK_NAMES);
     	for (String property : properties)
     	{
              //System.out.println("set all tasks and property = " + property + "\n");
@@ -283,12 +282,11 @@ public class FlowCurationUtils
     
     public static void setGroups() throws WingException, UnsupportedEncodingException
     {
-    	String csvList = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("curate." + CURATE_GROUP_NAMES);
-        if (csvList != null)
+    	String[] properties = DSpaceServicesFactory.getInstance().getConfigurationService().getArrayProperty("curate." + CURATE_GROUP_NAMES);
+        if (properties != null)
         {
-        	String[] properties = csvList.split(",");
         	for (String property : properties)
-            {
+                {
         		String[] keyValuePair = property.split("=");
         		groups.put(URLDecoder.decode(keyValuePair[0].trim(), "UTF-8"),
                           URLDecoder.decode(keyValuePair[1].trim(), "UTF-8"));
@@ -308,8 +306,7 @@ public class FlowCurationUtils
     		while (iterator.hasNext())
     		{
                 String key = iterator.next();
-                String csvList = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("curate." + CURATE_GROUP_PREFIX + "." + key);
-                String[] properties  = csvList.split(",");
+                String[] properties = DSpaceServicesFactory.getInstance().getConfigurationService().getArrayProperty("curate." + CURATE_GROUP_PREFIX + "." + key);
                 groupedTasks.put(URLDecoder.decode(key, "UTF-8"), properties);
             }
         }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/AddBitstreamForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/AddBitstreamForm.java
@@ -10,6 +10,7 @@ package org.dspace.app.xmlui.aspect.administrative.item;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.UUID;
+import org.apache.commons.lang.ArrayUtils;
 
 import org.dspace.app.xmlui.aspect.submission.submit.AccessStepUtil;
 import org.dspace.app.xmlui.cocoon.AbstractDSpaceTransformer;
@@ -64,7 +65,7 @@ public class AddBitstreamForm extends AbstractDSpaceTransformer
 	private static final Message T_no_bundles = message("xmlui.administrative.item.AddBitstreamForm.no_bundles");
 
 	
-	private static final String DEFAULT_BUNDLE_LIST = "ORIGINAL, METADATA, THUMBNAIL, LICENSE, CC-LICENSE";
+	private static final String[] DEFAULT_BUNDLE_LIST = new String[]{"ORIGINAL", "METADATA", "THUMBNAIL", "LICENSE", "CC-LICENSE"};
 
     private boolean isAdvancedFormEnabled=true;
 
@@ -103,9 +104,9 @@ public class AddBitstreamForm extends AbstractDSpaceTransformer
             // Get the list of bundles to allow the user to upload too. Either use the default
             // or one supplied from the dspace.cfg.
             String[] bundles = DSpaceServicesFactory.getInstance().getConfigurationService().getArrayProperty("xmlui.bundle.upload");
-            if (bundles == null || bundles.length == 0)
+            if (ArrayUtils.isEmpty(bundles))
             {
-                bundles = DEFAULT_BUNDLE_LIST.split(",");
+                bundles = DEFAULT_BUNDLE_LIST;
             }
             for (String part : bundles)
             {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/AddBitstreamForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/AddBitstreamForm.java
@@ -102,13 +102,12 @@ public class AddBitstreamForm extends AbstractDSpaceTransformer
 
             // Get the list of bundles to allow the user to upload too. Either use the default
             // or one supplied from the dspace.cfg.
-            String bundleString = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("xmlui.bundle.upload");
-            if (bundleString == null || bundleString.length() == 0)
+            String[] bundles = DSpaceServicesFactory.getInstance().getConfigurationService().getArrayProperty("xmlui.bundle.upload");
+            if (bundles == null || bundles.length == 0)
             {
-                bundleString = DEFAULT_BUNDLE_LIST;
+                bundles = DEFAULT_BUNDLE_LIST.split(",");
             }
-            String[] parts = bundleString.split(",");
-            for (String part : parts)
+            for (String part : bundles)
             {
                 if (addBundleOption(item, select, part.trim()))
                 {

--- a/dspace/config/modules/swordv2-server.cfg
+++ b/dspace/config/modules/swordv2-server.cfg
@@ -135,7 +135,7 @@ swordv2-server.keep-original-package = true
 # See the SWORD specification for a detailed explanation of deposit
 # On-Behalf-Of another user
 #
-swordv2-server.on-behalf-of.enable = true
+swordv2-server.on-behalf-of.enable = false
 #
 # Which user accounts are allowed to do updates on items which already
 # exist in DSpace, on-behalf-of other users?
@@ -190,7 +190,8 @@ swordv2-server.error.alternate.content-type = text/html
 swordv2-server.generator.version = 2.0
 
 # The form of authentication to use
-# This is normally set to 'basic' for HTTP Basic
+# This is normally set to 'Basic' for HTTP Basic
+# Other valid values: 'None'
 swordv2-server.auth-type = Basic
 
 # The location where uploaded files and packages are


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3075

This commit fixes comma-separated configuration loading where it still occurs in our codebase. I've created a separate commit per module, to hopefully help ease the review process.

Please note: I also made a minor configuration change to SWORDv2 in this PR by changing the default value of this setting to "false" (it's "true" on master):
`swordv2-server.on-behalf-of.enable = false`

I changed that value because of the stern warnings about enabling "on-behalf-of" in that same file:
https://github.com/DSpace/DSpace/blob/master/dspace/config/modules/swordv2-server.cfg#L125
(Somehow these warnings have slipped past us until now, but I stumbled on them as I was fixing up the SWORDv2 codebase)

This all compiles but needs some further testing to ensure nothing major breaks.
