### PR TITLE
[DS-2996] Fix retrieval of hierarchical of communities from a collection

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/CollectionDropDown.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/CollectionDropDown.java
@@ -12,13 +12,19 @@ import java.util.*;
 
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.CommunityService;
 import org.dspace.core.ConfigurationManager;
+import org.dspace.core.Context;
 
 /**
  * Utility class for lists of collections.
  */
 
 public class CollectionDropDown {
+
+
+	private static final CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
 
     /**
      * Get full path starting from a top-level community via subcommunities down to a collection.
@@ -28,9 +34,9 @@ public class CollectionDropDown {
      *            Get full path for this collection
      * @return Full path to the collection
      */
-    public static String collectionPath(Collection col) throws SQLException
+    public static String collectionPath(Context context, Collection col) throws SQLException
     {
-        return CollectionDropDown.collectionPath(col, 0);
+        return CollectionDropDown.collectionPath(context, col, 0);
     }
     
     /**
@@ -43,7 +49,7 @@ public class CollectionDropDown {
      *            Truncate the full path to maxchar characters. 0 means do not truncate.
      * @return Full path to the collection (truncated)
      */
-    public static String collectionPath(Collection col, int maxchars) throws SQLException
+    public static String collectionPath(Context context, Collection col, int maxchars) throws SQLException
     {
         String separator = ConfigurationManager.getProperty("subcommunity.separator");
         if (separator == null)
@@ -53,7 +59,7 @@ public class CollectionDropDown {
         
         List<Community> getCom = null;
         StringBuffer name = new StringBuffer("");
-        getCom = col.getCommunities(); // all communities containing given collection
+        getCom = communityService.getAllParents(context, col); // all communities containing given collection
         for (Community com : getCom)
         {
             name.insert(0, com.getName() + separator);
@@ -81,13 +87,13 @@ public class CollectionDropDown {
 	 * @return A sorted array of collection path entries (essentially collection/path pairs).
 	 * @throws SQLException In case there are problems annotating a collection with its path.
 	 */
-	public static CollectionPathEntry[] annotateWithPaths(List<Collection> collections) throws SQLException
+	public static CollectionPathEntry[] annotateWithPaths(Context context, List<Collection> collections) throws SQLException
 	{
 		CollectionPathEntry[] result = new CollectionPathEntry[collections.size()];
 		for (int i = 0; i < collections.size(); i++)
 		{
 			Collection collection = collections.get(i);
-			CollectionPathEntry entry = new CollectionPathEntry(collection, collectionPath(collection));
+			CollectionPathEntry entry = new CollectionPathEntry(collection, collectionPath(context, collection));
 			result[i] = entry;
 		}
 		Arrays.sort(result);

--- a/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
@@ -299,7 +299,7 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
             collection = item.getOwningCollection();
             if (collection != null)
             {
-                community = collection.getCommunities().iterator().next();
+                community = collection.getCommunities().get(0);
             }
         }
         switch (action)

--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -614,7 +614,7 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
 
     @Override
     public void canEdit(Context context, Collection collection, boolean useInheritance) throws SQLException, AuthorizeException {
-        List<Community> parents = collection.getCommunities();
+        List<Community> parents = communityService.getAllParents(context, collection);
         for (Community parent : parents) {
             if (authorizeService.authorizeActionBoolean(context, parent,
                     Constants.WRITE, useInheritance)) {
@@ -787,7 +787,7 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
         List<Community> communities = collection.getCommunities();
         if (CollectionUtils.isNotEmpty(communities))
         {
-            community = communities.iterator().next();
+            community = communities.get(0);
         }
 
         switch (action)
@@ -820,7 +820,7 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
     public DSpaceObject getParentObject(Context context, Collection collection) throws SQLException {
         List<Community> communities = collection.getCommunities();
         if(CollectionUtils.isNotEmpty(communities)){
-            return communities.iterator().next();
+            return communities.get(0);
         }else{
             return null;
         }

--- a/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
@@ -309,6 +309,17 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
     }
 
     @Override
+    public List<Community> getAllParents(Context context, Collection collection) throws SQLException {
+        List<Community> result = new ArrayList<>();
+        List<Community> communities = collection.getCommunities();
+        result.addAll(communities);
+        for (Community community : communities) {
+            result.addAll(getAllParents(context, community));
+        }
+        return result;
+    }
+
+    @Override
     public List<Collection> getAllCollections(Context context, Community community) throws SQLException {
         List<Collection> collectionList = new ArrayList<Collection>();
         List<Community> subCommunities = community.getSubcommunities();

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -232,11 +232,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         List<Community> result = new ArrayList<>();
         List<Collection> collections = item.getCollections();
         for (Collection collection : collections) {
-            List<Community> owningCommunities = collection.getCommunities();
-            for (Community community : owningCommunities) {
-                result.add(community);
-                result.addAll(communityService.getAllParents(context, community));
-            }
+            result.addAll(communityService.getAllParents(context, collection));
         }
 
         return result;

--- a/dspace-api/src/main/java/org/dspace/content/service/CommunityService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/CommunityService.java
@@ -162,6 +162,13 @@ public interface CommunityService extends DSpaceObjectService<Community>, DSpace
     public List<Community> getAllParents(Context context, Community community) throws SQLException;
 
     /**
+     * Return an array of parent communities of this collection.
+     *
+     * @return an array of parent communities
+     */
+    public List<Community> getAllParents(Context context, Collection collection) throws SQLException;
+
+    /**
      * Return an array of collections of this community and its subcommunities
      *
      * @return an array of collections

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -678,10 +678,10 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         return locations;
     }
 
-    protected List<String> getCollectionLocations(Collection target) throws SQLException {
+    protected List<String> getCollectionLocations(Context context, Collection target) throws SQLException {
         List<String> locations = new Vector<String>();
         // build list of community ids
-        List<Community> communities = target.getCommunities();
+        List<Community> communities = communityService.getAllParents(context, target);
 
         // now put those into strings
         for (Community community : communities)
@@ -799,7 +799,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
      */
     protected void buildDocument(Context context, Collection collection)
     throws SQLException, IOException {
-        List<String> locations = getCollectionLocations(collection);
+        List<String> locations = getCollectionLocations(context, collection);
 
         // Create Lucene Document
         SolrInputDocument doc = buildDocument(Constants.COLLECTION, collection.getID(),

--- a/dspace-api/src/main/java/org/dspace/health/ItemCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/ItemCheck.java
@@ -128,7 +128,7 @@ public class ItemCheck extends Check {
         return sb.toString();
     }
 
-    public  String getCollectionSizesInfo(Context context) throws SQLException {
+    public  String getCollectionSizesInfo(final Context context) throws SQLException {
         final StringBuffer ret = new StringBuffer();
         List<Map.Entry<Collection, Long>> colBitSizes = collectionService.getCollectionsWithBitstreamSizesTotal(context);
         long total_size = 0;
@@ -137,8 +137,8 @@ public class ItemCheck extends Check {
             @Override
             public int compare(Map.Entry<Collection, Long> o1, Map.Entry<Collection, Long> o2) {
                 try {
-                    return CollectionDropDown.collectionPath(o1.getKey()).compareTo(
-                            CollectionDropDown.collectionPath(o2.getKey())
+                    return CollectionDropDown.collectionPath(context, o1.getKey()).compareTo(
+                            CollectionDropDown.collectionPath(context, o2.getKey())
                     );
                 } catch (Exception e) {
                     ret.append(e.getMessage());
@@ -151,7 +151,7 @@ public class ItemCheck extends Check {
             total_size += size;
             Collection col = row.getKey();
             ret.append(String.format(
-                    "\t%s:  %s\n", CollectionDropDown.collectionPath(col), FileUtils.byteCountToDisplaySize((long) size)));
+                    "\t%s:  %s\n", CollectionDropDown.collectionPath(context, col), FileUtils.byteCountToDisplaySize((long) size)));
         }
         ret.append(String.format(
                 "Total size:              %s\n", FileUtils.byteCountToDisplaySize(total_size)));

--- a/dspace-api/src/main/java/org/dspace/rdf/conversion/SimpleDSORelationsConverterPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/rdf/conversion/SimpleDSORelationsConverterPlugin.java
@@ -422,7 +422,7 @@ implements ConverterPlugin
         }
         
         // add all parents
-        for (DSpaceObject parent : collection.getCommunities())
+        for (DSpaceObject parent : communityService.getAllParents(context, collection))
         {
             if (!RDFUtil.isPublicBoolean(context, parent))
             {

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/SelectCollectionTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/SelectCollectionTag.java
@@ -88,7 +88,7 @@ public class SelectCollectionTag extends TagSupport
                 {
                     sb.append(" selected=\"selected\"");
                 }
-                sb.append(">").append(CollectionDropDown.collectionPath(coll)).append("</option>\n");
+                sb.append(">").append(CollectionDropDown.collectionPath(context, coll)).append("</option>\n");
             }
 
             sb.append("</select>\n");

--- a/dspace-jspui/src/main/webapp/mydspace/subscriptions.jsp
+++ b/dspace-jspui/src/main/webapp/mydspace/subscriptions.jsp
@@ -30,6 +30,8 @@
 <%@ page import="org.dspace.app.util.CollectionDropDown" %>
 <%@ page import="org.dspace.eperson.Subscription" %>
 <%@ page import="java.util.List" %>
+<%@ page import="org.dspace.app.webui.util.UIUtil" %>
+<%@ page import="org.dspace.core.Context" %>
 
 <%
     List<Collection> availableSubscriptions =
@@ -38,6 +40,7 @@
         (List<Subscription>) request.getAttribute("subscriptions");
     boolean updated =
         ((Boolean) request.getAttribute("updated")).booleanValue();
+    Context context = UIUtil.obtainContext(request);
 %>
 
 <dspace:layout style="submission" locbar="link"
@@ -72,7 +75,7 @@ for (int i = 0; i < availableSubscriptions.size(); i++)
 {
 %>
                 <option value="<%= availableSubscriptions.get(i).getID() %>">
-                    <%= CollectionDropDown.collectionPath(availableSubscriptions.get(i), 0) %>
+                    <%= CollectionDropDown.collectionPath(context, availableSubscriptions.get(i), 0) %>
                 </option>
 <%
 }
@@ -110,7 +113,7 @@ for (int i = 0; i < availableSubscriptions.size(); i++)
 
                  <td class="<%= row %>RowOddCol">
                       <a href="<%= request.getContextPath() %>/handle/<%= subscriptions.get(i).getCollection().getHandle() %>">
-                          <%= CollectionDropDown.collectionPath(subscriptions.get(i).getCollection(),0) %>
+                          <%= CollectionDropDown.collectionPath(context, subscriptions.get(i).getCollection(),0) %>
                       </a>
                  </td>
                  <td class="<%= row %>RowEvenCol">

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -237,7 +237,7 @@ public class XOAI {
         for (Collection col : item.getCollections())
             doc.addField("item.collections",
                     "col_" + col.getHandle().replace("/", "_"));
-        for (Community com : collectionsService.flatParentCommunities(item))
+        for (Community com : collectionsService.flatParentCommunities(context, item))
             doc.addField("item.communities",
                     "com_" + com.getHandle().replace("/", "_"));
 

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/api/CollectionsService.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/api/CollectionsService.java
@@ -10,6 +10,7 @@ package org.dspace.xoai.services.api;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.Item;
+import org.dspace.core.Context;
 import org.dspace.xoai.services.api.context.ContextService;
 
 import java.sql.SQLException;
@@ -20,5 +21,5 @@ public interface CollectionsService {
     List<UUID> getAllSubCollections(ContextService contextService, UUID communityId) throws SQLException;
     List<Community> flatParentCommunities(Collection collection) throws SQLException;
     List<Community> flatParentCommunities(Community community) throws SQLException;
-    List<Community> flatParentCommunities(Item item) throws SQLException;
+    List<Community> flatParentCommunities(Context context, Item item) throws SQLException;
 }

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/DSpaceCollectionsService.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/DSpaceCollectionsService.java
@@ -10,6 +10,7 @@ package org.dspace.xoai.services.impl;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.Item;
+import org.dspace.core.Context;
 import org.dspace.xoai.services.api.context.ContextService;
 import org.dspace.xoai.services.api.context.ContextServiceException;
 import org.dspace.xoai.services.api.CollectionsService;
@@ -96,14 +97,14 @@ public class DSpaceCollectionsService implements CollectionsService {
     }
 
     @Override
-    public List<Community> flatParentCommunities(Item c)
+    public List<Community> flatParentCommunities(Context context, Item c)
             throws SQLException
     {
         Queue<Community> queue = new LinkedList<>();
         List<Community> result = new ArrayList<>();
 
-        for (Collection com : c.getCollections())
-            queue.addAll(com.getCommunities());
+        for (Collection collection : c.getCollections())
+            queue.addAll(communityService.getAllParents(context, collection));
 
         while (!queue.isEmpty())
         {

--- a/dspace-rest/src/main/java/org/dspace/rest/common/Collection.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/common/Collection.java
@@ -10,6 +10,7 @@ package org.dspace.rest.common;
 import org.apache.log4j.Logger;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.CollectionService;
+import org.dspace.content.service.CommunityService;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
 
@@ -31,6 +32,7 @@ import java.util.List;
  */
 @XmlRootElement(name = "collection")
 public class Collection extends DSpaceObject {
+    protected CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
     protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
     protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();
 
@@ -69,7 +71,7 @@ public class Collection extends DSpaceObject {
         this.setSidebarText(collectionService.getMetadata(collection, org.dspace.content.Collection.SIDEBAR_TEXT));
         
         if(expandFields.contains("parentCommunityList") || expandFields.contains("all")) {
-            List<org.dspace.content.Community> parentCommunities = collection.getCommunities();
+            List<org.dspace.content.Community> parentCommunities = communityService.getAllParents(context, collection);
             for(org.dspace.content.Community parentCommunity : parentCommunities) {
                 this.addParentCommunityList(new Community(parentCommunity, servletContext, null, context));
             }

--- a/dspace-rest/src/main/java/org/dspace/rest/common/FilteredCollection.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/common/FilteredCollection.java
@@ -77,7 +77,7 @@ public class FilteredCollection extends DSpaceObject {
         }
 
         if(expandFields.contains("parentCommunityList") || expandFields.contains("all")) {
-            List<org.dspace.content.Community> parentCommunities = collection.getCommunities();
+            List<org.dspace.content.Community> parentCommunities = communityService.getAllParents(context, collection);
             List<Community> parentCommunityList = new ArrayList<Community>();
             for(org.dspace.content.Community parentCommunity : parentCommunities) {
                 parentCommunityList.add(new Community(parentCommunity, servletContext, null, context));
@@ -95,7 +95,7 @@ public class FilteredCollection extends DSpaceObject {
         }
 
         if(expandFields.contains("topCommunity") | expandFields.contains("all")) {
-            List<org.dspace.content.Community> parentCommunities = collection.getCommunities();
+            List<org.dspace.content.Community> parentCommunities = communityService.getAllParents(context, collection);
             if (parentCommunities.size() > 0) {
                 org.dspace.content.Community topCommunity = parentCommunities.get(parentCommunities.size()-1);
                 this.setTopCommunity(new Community(topCommunity, servletContext, null, context));

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/batchimport/BatchImportMain.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/batchimport/BatchImportMain.java
@@ -72,7 +72,7 @@ public class BatchImportMain extends AbstractDSpaceTransformer {
         select.addOption("",T_collection_default);
         for (Collection collection : collections)
         {
-            select.addOption(collection.getHandle(), CollectionDropDown.collectionPath(collection));
+            select.addOption(collection.getHandle(), CollectionDropDown.collectionPath(context, collection));
         }
 
         //Zip File Upload

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/MoveItemForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/MoveItemForm.java
@@ -97,7 +97,7 @@ public class MoveItemForm extends AbstractDSpaceTransformer {
             // Only add the item if it isn't already the owner
             if (!itemService.isOwningCollection(item, collection))
             {
-                select.addOption(collection.equals(owningCollection), collection.getID().toString(), CollectionDropDown.collectionPath(collection));
+                select.addOption(collection.equals(owningCollection), collection.getID().toString(), CollectionDropDown.collectionPath(context, collection));
             }
         }
         

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/EditProfile.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/EditProfile.java
@@ -385,7 +385,7 @@ public class EditProfile extends AbstractDSpaceTransformer
            subscriptions.enableDeleteOperation();
            
            subscriptions.addOption(-1,T_select_collection);
-	       CollectionDropDown.CollectionPathEntry[] possibleEntries = CollectionDropDown.annotateWithPaths(possibleList);
+	       CollectionDropDown.CollectionPathEntry[] possibleEntries = CollectionDropDown.annotateWithPaths(context, possibleList);
            for (CollectionDropDown.CollectionPathEntry possible : possibleEntries)
            {
                subscriptions.addOption(possible.collection.getID().toString(), possible.path);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/SelectCollectionStep.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/SelectCollectionStep.java
@@ -105,7 +105,7 @@ public class SelectCollectionStep extends AbstractSubmissionStep
         select.setHelp(T_collection_help);
         
         select.addOption("",T_collection_default);
-	    CollectionDropDown.CollectionPathEntry[] collectionPaths = CollectionDropDown.annotateWithPaths(collections);
+	    CollectionDropDown.CollectionPathEntry[] collectionPaths = CollectionDropDown.annotateWithPaths(context, collections);
         for (CollectionDropDown.CollectionPathEntry entry : collectionPaths)
         {
             select.addOption(entry.collection.getHandle(), entry.path);


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2996

The collection.getCommunities() method only retrieves direct parents, the old method used to retrieve them all. I create a new service method on community to retrieve all parent communities from a collection. All places which use this method & didn't just retrieve the first one have been altered.
