### PR TITLE
DS-3080 Counting withdrawn items (bugfix)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -1172,7 +1172,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
 
     @Override
     public int countWithdrawnItems(Context context) throws SQLException {
-       // return count of items that are in archive and withdrawn
+       // return count of items that are not in archive and withdrawn
        return itemDAO.countItems(context, false, true);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -1173,6 +1173,6 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
     @Override
     public int countWithdrawnItems(Context context) throws SQLException {
        // return count of items that are in archive and withdrawn
-       return itemDAO.countItems(context, true, true);
+       return itemDAO.countItems(context, false, true);
     }
 }


### PR DESCRIPTION
I realised there were not records both "in_archive" and "withdrawn". Any withdrawn item is "not in_archive" and "withdrawn"
