### PR TITLE
DS-2941 PasswordAuthentication getSpecialGroups empty exception catchblock

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/PasswordAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/PasswordAuthentication.java
@@ -137,9 +137,8 @@ public class PasswordAuthentication
 		// ensures they are password users
 		try
 		{
-            if (context.getCurrentUser() != null &&
-                    (EPersonServiceFactory.getInstance().getEPersonService().getPasswordHash(context.getCurrentUser()) != null &&
-                            StringUtils.isNotBlank(EPersonServiceFactory.getInstance().getEPersonService().getPasswordHash(context.getCurrentUser()).toString())))
+            if (context.getCurrentUser() != null
+                && StringUtils.isNotBlank(EPersonServiceFactory.getInstance().getEPersonService().getPasswordHash(context.getCurrentUser()).toString()))
 			{
 				String groupName = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("authentication-password.login.specialgroup");
 				if ((groupName != null) && (!groupName.trim().equals("")))

--- a/dspace-api/src/main/java/org/dspace/authenticate/PasswordAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/PasswordAuthentication.java
@@ -15,6 +15,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.collections.ListUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.dspace.core.Context;
 import org.dspace.core.LogManager;
@@ -136,7 +137,9 @@ public class PasswordAuthentication
 		// ensures they are password users
 		try
 		{
-			if (EPersonServiceFactory.getInstance().getEPersonService().getPasswordHash(context.getCurrentUser()) != null && !EPersonServiceFactory.getInstance().getEPersonService().getPasswordHash(context.getCurrentUser()).toString().equals(""))
+            if (context.getCurrentUser() != null &&
+                    (EPersonServiceFactory.getInstance().getEPersonService().getPasswordHash(context.getCurrentUser()) != null &&
+                            StringUtils.isNotBlank(EPersonServiceFactory.getInstance().getEPersonService().getPasswordHash(context.getCurrentUser()).toString())))
 			{
 				String groupName = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("authentication-password.login.specialgroup");
 				if ((groupName != null) && (!groupName.trim().equals("")))
@@ -157,7 +160,7 @@ public class PasswordAuthentication
 			}
 		}
 		catch (Exception e) {
-			// The user is not a password user, so we don't need to worry about them
+            log.error(LogManager.getHeader(context,"getSpecialGroups",""),e);
 		}
 		return ListUtils.EMPTY_LIST;
     }


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2941
- No longer hitting the 'catch' part as part of the logic to determine what happens when a user is not logged in. 
- Logging an error rather than an empty catch block, in case something else goes wrong. 
