### PR TITLE
DS-3088 REST API put collections / item: Added 'putCollectionsItem' i…

### DIFF
--- a/dspace-rest/README.md
+++ b/dspace-rest/README.md
@@ -97,6 +97,9 @@ Find collection by name
 Update collection
 - PUT http://localhost:8080/rest/collections/:ID
 
+Add item in collection
+- PUT http://localhost:8080/rest/collections/:ID/items
+
 Delete collection
 - DELETE http://localhost:8080/rest/collections/:ID
 
@@ -108,7 +111,7 @@ Delete item in collection
 View the list of items
 - GET http://localhost:8080/rest/items[?expand={metadata,parentCollection,parentcollectionList,parentCommunityList,bitstreams,all}]
 
-View speciific item
+View specific item
 - GET http://localhost:8080/rest/items/:ID[?expand={metadata,parentCollection,parentcollectionList,parentCommunityList,bitstreams,all}]
 
 View an Item and view its bitstreams

--- a/dspace-rest/src/main/java/org/dspace/rest/CollectionsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/CollectionsResource.java
@@ -401,6 +401,106 @@ public class CollectionsResource extends Resource
         return returnItem;
     }
 
+	/**
+	 * Request the enclosed entity to be stored under the supplied Request-URI. An existing item
+	 * will be added to a collection. An Item can be added without metadata as only the id of
+	 * the enclosed item will be matched against existing items.
+	 *
+	 * @param collectionId
+	 *            Id of collection in which the item will be added.
+	 * @param item
+	 *            Item filled only with id any metadata will taken from the existing item.
+	 * @param headers
+	 *            If you want to access to collection and item under logged user into
+	 *            context. In headers must be set header "rest-dspace-token"
+	 *            with passed token from login method.
+	 * @return Return status code with item. Return status (OK)200 if item was
+	 *         add successfully. NOT_FOUND(404) if id of collection does not exists.
+	 *         UNAUTHORIZED(401) if user have not permission to write items in
+	 *         collection.
+	 * @throws WebApplicationException
+	 *             It is thrown when was problem with database reading or
+	 *             writing (SQLException) or problem with creating
+	 *             context(ContextException) or problem with authorization to
+	 *             collection or IOException or problem with index item into
+	 *             browse index. It is thrown by NOT_FOUND and UNATHORIZED
+	 *             status codes, too.
+	 *
+	 */
+	@PUT
+	@Path("/{collection_id}/items")
+	@Consumes({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+	public Item putCollectionItem(@PathParam("collection_id") Integer collectionId, Item item,
+	                              @QueryParam("userIP") String user_ip, @QueryParam("userAgent") String user_agent,
+	                              @QueryParam("xforwardedfor") String xforwardedfor, @Context HttpHeaders headers, @Context HttpServletRequest request)
+			throws WebApplicationException
+	{
+
+		log.info("Adding item to collection(id=" + collectionId + ").");
+		org.dspace.core.Context context = null;
+		Item returnItem = null;
+
+		try
+		{
+			context = createContext(getUser(headers));
+
+			//expect findCollection() to fail with a 404 or 500 if the item is not returned or unauthorized access
+			org.dspace.content.Collection dspaceCollection = findCollection(context, collectionId,
+					org.dspace.core.Constants.WRITE);
+
+			//expect findItem() to fail with a 404 or 500 if the item is not returned or unauthorized access
+			org.dspace.content.Item dspaceItem = findItem(context, item.getId(),
+					org.dspace.core.Constants.WRITE);
+
+			if(!dspaceItem.isIn(dspaceCollection)){
+
+				writeStats(dspaceCollection, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor, headers, request, context);
+
+				//TODO is a re-index needed after the update to find in the new collection?
+				// Index or re-item to browse.
+				org.dspace.browse.IndexBrowse browse = new org.dspace.browse.IndexBrowse(context);
+				browse.indexItem(dspaceItem);
+
+				log.trace("Adding existing item to collection(id=" + collectionId + ").");
+				dspaceCollection.addItem(dspaceItem);
+
+			}else {
+				//No reason to fail - item is already in the collection
+				log.trace("Item already exists in collection(id=" + collectionId + ").");
+			}
+
+			returnItem = new Item(dspaceItem, "", context);
+			//return 200 (OK)
+			context.complete();
+
+		}
+		catch (SQLException e)
+		{
+			processException("Could not add item to collection(id=" + collectionId + "), SQLException. Message: " + e, context);
+		}
+		catch (AuthorizeException e)
+		{
+			processException("Could not add item to collection(id=" + collectionId + "), AuthorizeException. Message: " + e,
+					context);
+		}
+		catch (BrowseException e)
+		{
+			processException("Could not update browse index, BrowseException. Message: " + e, context);
+		}
+		catch (ContextException e)
+		{
+			processException("Could not add item to collection(id=" + collectionId + "), ContextException. Message: " + e.getMessage(),
+					context);
+		}
+		finally
+		{
+			processFinally(context);
+		}
+
+		log.info("Item successfully created in collection(id=" + collectionId + "). Item handle=" + ((returnItem != null)? returnItem.getHandle() : "<null>"));
+		return returnItem;
+	}
+
     /**
      * Update collection. It replace all properties.
      * 
@@ -772,4 +872,59 @@ public class CollectionsResource extends Resource
         }
         return collection;
     }
+
+	/**
+	 * Find item from DSpace database. It is encapsulation of method
+	 * org.dspace.content.Item.find with checking if item exist and if
+	 * user logged into context has permission to do passed action.
+	 *
+	 * @param context
+	 *            Context of actual logged user.
+	 * @param id
+	 *            Id of item in DSpace.
+	 * @param action
+	 *            Constant from org.dspace.core.Constants.
+	 *
+	 * @return DSpace Item found.
+	 *
+	 * @throws WebApplicationException
+	 *             Is thrown when item with passed id is not exists and if user
+	 *             has no permission to do passed action.
+	 */
+	private org.dspace.content.Item findItem(org.dspace.core.Context context, int id, int action)
+			throws WebApplicationException
+	{
+		org.dspace.content.Item item = null;
+		try
+		{
+			item = org.dspace.content.Item.find(context, id);
+
+			if (item == null)
+			{
+				context.abort();
+				log.warn("Item(id=" + id + ") was not found!");
+				throw new WebApplicationException(Response.Status.NOT_FOUND);
+			}
+			else if (!AuthorizeManager.authorizeActionBoolean(context, item, action))
+			{
+				context.abort();
+				if (context.getCurrentUser() != null)
+				{
+					log.error("User(" + context.getCurrentUser().getEmail() + ") has not permission to "
+							+ getActionString(action) + " item!");
+				}
+				else
+				{
+					log.error("User(anonymous) does not have permission to " + getActionString(action) + " item!");
+				}
+				throw new WebApplicationException(Response.Status.UNAUTHORIZED);
+			}
+
+		}
+		catch (SQLException e)
+		{
+			processException("Something went wrong while finding item(id=" + id + "). SQLException, Message: " + e, context);
+		}
+		return item;
+	}
 }

--- a/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
@@ -86,6 +86,7 @@ public class RestIndex {
                   		"<li>POST /collections/{collectionId}/items - Create an item in the specified collection. You must post an item.</li>" +
                   		"<li>POST /collections/find-collection - Find a collection by name.</li>" +
                   		"<li>PUT /collections/{collectionId} </li> - Update the specified collection. You must post a collection." +
+                  		"<li>PUT /collections/{collectionId}/items </li> - Update collection by adding the specified item. You must post an item." +
                   		"<li>DELETE /collections/{collectionId} - Delete the specified collection from DSpace.</li>" +
                   		"<li>DELETE /collections/{collectionId}/items/{itemId} - Delete the specified item (itemId) in the specified collection (collectionId). </li>" +
                   	"</ul>" +


### PR DESCRIPTION
As suggested in [DS-3088](https://jira.duraspace.org/browse/DS-3088). There are already operations for CREATE and DELETE items in collections: 
POST /collections/{collectionId}/items
DELETE /collections/{collectionId}/items/{itemId} 

This adds an additional put method to the collections API
1. PUT /collections/{collectionId}/items/
2. Updates the README.md with the new method
3. Updates the RestIndex with the new method
