### PR TITLE
DS-2437:  Ensure all webapps unpack "additions" into their WEB-INF/classes

### DIFF
--- a/dspace/modules/jspui/pom.xml
+++ b/dspace/modules/jspui/pom.xml
@@ -41,6 +41,31 @@
     
     <build>
         <plugins>
+            <!-- Unpack the "additions" module into our target directory,
+                 so that any custom classes in that module can be included
+                 into this WAR's WEB-INF/classes (see maven-war-plugin below). -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeGroupIds>org.dspace.modules</includeGroupIds>
+                            <includeArtifactIds>additions</includeArtifactIds>
+                            <!--NOTE: by default this will also unpack transitive dependencies. To disable, uncomment this next line:
+                            <excludeTransitive>true</excludeTransitive>
+                            -->
+                            <outputDirectory>${project.build.directory}/additions</outputDirectory>
+                            <excludes>META-INF/**</excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
@@ -48,6 +73,16 @@
                     <archiveClasses>false</archiveClasses>
                     <!-- Filter the web.xml (needed for IDE compatibility/debugging) -->
                     <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
+                    <!-- Copy any 'additions' (see m-dependency-p above) into WEB-INF/classes.
+                         This ensures they are loaded prior to dependencies in WEB-INF/lib
+                         (per Servlet 3.0 spec, section 10.5), and allows them to override
+                         default classes in this WAR -->
+                    <webResources>
+                        <resource>
+                            <directory>${project.build.directory}/additions</directory>
+                            <targetPath>WEB-INF/classes</targetPath>
+                        </resource>
+                    </webResources>
                     <overlays>
                         <overlay />
                         <overlay>

--- a/dspace/modules/oai/pom.xml
+++ b/dspace/modules/oai/pom.xml
@@ -23,6 +23,31 @@
 
     <build>
         <plugins>
+            <!-- Unpack the "additions" module into our target directory,
+                 so that any custom classes in that module can be included
+                 into this WAR's WEB-INF/classes (see maven-war-plugin below). -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeGroupIds>org.dspace.modules</includeGroupIds>
+                            <includeArtifactIds>additions</includeArtifactIds>
+                            <!--NOTE: by default this will also unpack transitive dependencies. To disable, uncomment this next line:
+                            <excludeTransitive>true</excludeTransitive>
+                            -->
+                            <outputDirectory>${project.build.directory}/additions</outputDirectory>
+                            <excludes>META-INF/**</excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
@@ -30,6 +55,16 @@
                     <archiveClasses>false</archiveClasses>
                     <!-- Filter the web.xml (needed for IDE compatibility/debugging) -->
                     <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
+                    <!-- Copy any 'additions' (see m-dependency-p above) into WEB-INF/classes.
+                         This ensures they are loaded prior to dependencies in WEB-INF/lib
+                         (per Servlet 3.0 spec, section 10.5), and allows them to override
+                         default classes in this WAR -->
+                    <webResources>
+                        <resource>
+                            <directory>${project.build.directory}/additions</directory>
+                            <targetPath>WEB-INF/classes</targetPath>
+                        </resource>
+                    </webResources>
                 </configuration>
                 <executions>
                     <execution>

--- a/dspace/modules/rdf/pom.xml
+++ b/dspace/modules/rdf/pom.xml
@@ -22,6 +22,31 @@
 
     <build>
         <plugins>
+            <!-- Unpack the "additions" module into our target directory,
+                 so that any custom classes in that module can be included
+                 into this WAR's WEB-INF/classes (see maven-war-plugin below). -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeGroupIds>org.dspace.modules</includeGroupIds>
+                            <includeArtifactIds>additions</includeArtifactIds>
+                            <!--NOTE: by default this will also unpack transitive dependencies. To disable, uncomment this next line:
+                            <excludeTransitive>true</excludeTransitive>
+                            -->
+                            <outputDirectory>${project.build.directory}/additions</outputDirectory>
+                            <excludes>META-INF/**</excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
@@ -29,6 +54,16 @@
                     <archiveClasses>false</archiveClasses>
                     <!-- Filter the web.xml (needed for IDE compatibility/debugging) -->
                     <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
+                    <!-- Copy any 'additions' (see m-dependency-p above) into WEB-INF/classes.
+                         This ensures they are loaded prior to dependencies in WEB-INF/lib
+                         (per Servlet 3.0 spec, section 10.5), and allows them to override
+                         default classes in this WAR -->
+                    <webResources>
+                        <resource>
+                            <directory>${project.build.directory}/additions</directory>
+                            <targetPath>WEB-INF/classes</targetPath>
+                        </resource>
+                    </webResources>
                 </configuration>
                 <executions>
                     <execution>

--- a/dspace/modules/rest/pom.xml
+++ b/dspace/modules/rest/pom.xml
@@ -23,6 +23,31 @@
 
     <build>
         <plugins>
+            <!-- Unpack the "additions" module into our target directory,
+                 so that any custom classes in that module can be included
+                 into this WAR's WEB-INF/classes (see maven-war-plugin below). -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeGroupIds>org.dspace.modules</includeGroupIds>
+                            <includeArtifactIds>additions</includeArtifactIds>
+                            <!--NOTE: by default this will also unpack transitive dependencies. To disable, uncomment this next line:
+                            <excludeTransitive>true</excludeTransitive>
+                            -->
+                            <outputDirectory>${project.build.directory}/additions</outputDirectory>
+                            <excludes>META-INF/**</excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
@@ -30,6 +55,16 @@
                     <archiveClasses>false</archiveClasses>
                     <!-- Filter the web.xml (needed for IDE compatibility/debugging) -->
                     <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
+                    <!-- Copy any 'additions' (see m-dependency-p above) into WEB-INF/classes.
+                         This ensures they are loaded prior to dependencies in WEB-INF/lib
+                         (per Servlet 3.0 spec, section 10.5), and allows them to override
+                         default classes in this WAR -->
+                    <webResources>
+                        <resource>
+                            <directory>${project.build.directory}/additions</directory>
+                            <targetPath>WEB-INF/classes</targetPath>
+                        </resource>
+                    </webResources>
                     <overlays>
                         <!--
                            the priority of overlays is determined here

--- a/dspace/modules/sword/pom.xml
+++ b/dspace/modules/sword/pom.xml
@@ -25,25 +25,59 @@
        <root.basedir>${basedir}/../../..</root.basedir>
    </properties>
 
-   <build>
-      <plugins>
-         <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-war-plugin</artifactId>
-            <configuration>
-               <archiveClasses>false</archiveClasses>
-               <!-- Filter the web.xml (needed for IDE compatibility/debugging) -->
-               <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
-            </configuration>
-            <executions>
-               <execution>
-                  <phase>prepare-package</phase>
-               </execution>
-            </executions>
-         </plugin>
-
-      </plugins>
-   </build>
+    <build>
+        <plugins>
+            <!-- Unpack the "additions" module into our target directory,
+                 so that any custom classes in that module can be included
+                 into this WAR's WEB-INF/classes (see maven-war-plugin below). -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeGroupIds>org.dspace.modules</includeGroupIds>
+                            <includeArtifactIds>additions</includeArtifactIds>
+                            <!--NOTE: by default this will also unpack transitive dependencies. To disable, uncomment this next line:
+                            <excludeTransitive>true</excludeTransitive>
+                            -->
+                            <outputDirectory>${project.build.directory}/additions</outputDirectory>
+                            <excludes>META-INF/**</excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <configuration>
+                    <archiveClasses>false</archiveClasses>
+                    <!-- Filter the web.xml (needed for IDE compatibility/debugging) -->
+                    <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
+                    <!-- Copy any 'additions' (see m-dependency-p above) into WEB-INF/classes.
+                         This ensures they are loaded prior to dependencies in WEB-INF/lib
+                         (per Servlet 3.0 spec, section 10.5), and allows them to override
+                         default classes in this WAR -->
+                    <webResources>
+                        <resource>
+                            <directory>${project.build.directory}/additions</directory>
+                            <targetPath>WEB-INF/classes</targetPath>
+                        </resource>
+                    </webResources>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>prepare-package</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
    <profiles>
       <profile>

--- a/dspace/modules/swordv2/pom.xml
+++ b/dspace/modules/swordv2/pom.xml
@@ -27,23 +27,57 @@
 
    <build>
       <plugins>
-         <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-war-plugin</artifactId>
-            <configuration>
-               <archiveClasses>false</archiveClasses>
-               <!-- Filter the web.xml (needed for IDE compatibility/debugging) -->
-               <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
-            </configuration>
-            <executions>
-               <execution>
-                  <phase>prepare-package</phase>
-               </execution>
-            </executions>
-         </plugin>
-
-      </plugins>
-   </build>
+         <!-- Unpack the "additions" module into our target directory,
+                 so that any custom classes in that module can be included
+                 into this WAR's WEB-INF/classes (see maven-war-plugin below). -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeGroupIds>org.dspace.modules</includeGroupIds>
+                            <includeArtifactIds>additions</includeArtifactIds>
+                            <!--NOTE: by default this will also unpack transitive dependencies. To disable, uncomment this next line:
+                            <excludeTransitive>true</excludeTransitive>
+                            -->
+                            <outputDirectory>${project.build.directory}/additions</outputDirectory>
+                            <excludes>META-INF/**</excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <configuration>
+                    <archiveClasses>false</archiveClasses>
+                    <!-- Filter the web.xml (needed for IDE compatibility/debugging) -->
+                    <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
+                    <!-- Copy any 'additions' (see m-dependency-p above) into WEB-INF/classes.
+                         This ensures they are loaded prior to dependencies in WEB-INF/lib
+                         (per Servlet 3.0 spec, section 10.5), and allows them to override
+                         default classes in this WAR -->
+                    <webResources>
+                        <resource>
+                            <directory>${project.build.directory}/additions</directory>
+                            <targetPath>WEB-INF/classes</targetPath>
+                        </resource>
+                    </webResources>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>prepare-package</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
    <profiles>
       <profile>

--- a/dspace/modules/xmlui/pom.xml
+++ b/dspace/modules/xmlui/pom.xml
@@ -21,6 +21,37 @@
         <root.basedir>${basedir}/../../..</root.basedir>
     </properties>
 
+    <build>
+        <plugins>
+            <!-- Unpack the "additions" module into our target directory,
+                 so that any custom classes in that module can be included
+                 into this WAR's WEB-INF/classes (see maven-war-plugin below). -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeGroupIds>org.dspace.modules</includeGroupIds>
+                            <includeArtifactIds>additions</includeArtifactIds>
+                            <!--NOTE: by default this will also unpack transitive dependencies. To disable, uncomment this next line:
+                            <excludeTransitive>true</excludeTransitive>
+                            -->
+                            <outputDirectory>${project.build.directory}/additions</outputDirectory>
+                            <excludes>META-INF/**</excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
     <profiles>
         <profile>
             <id>oracle-support</id>
@@ -53,6 +84,16 @@
                             <archiveClasses>false</archiveClasses>
                             <!-- Filter the web.xml (needed for IDE compatibility/debugging) -->
                             <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
+                            <!-- Copy any 'additions' (see m-dependency-p above) into WEB-INF/classes.
+                                 This ensures they are loaded prior to dependencies in WEB-INF/lib
+                                (per Servlet 3.0 spec, section 10.5), and allows them to override
+                                 default classes in this WAR -->
+                            <webResources>
+                                <resource>
+                                    <directory>${project.build.directory}/additions</directory>
+                                    <targetPath>WEB-INF/classes</targetPath>
+                                </resource>
+                            </webResources>
                             <overlays>
                                 <!--
                                    the priority of overlays is determined here
@@ -107,6 +148,18 @@
                         <artifactId>maven-war-plugin</artifactId>
                         <configuration>
                             <archiveClasses>false</archiveClasses>
+                            <!-- Filter the web.xml (needed for IDE compatibility/debugging) -->
+                            <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
+                            <!-- Copy any 'additions' (see m-dependency-p above) into WEB-INF/classes.
+                                 This ensures they are loaded prior to dependencies in WEB-INF/lib
+                                (per Servlet 3.0 spec, section 10.5), and allows them to override
+                                 default classes in this WAR -->
+                            <webResources>
+                                <resource>
+                                    <directory>${project.build.directory}/additions</directory>
+                                    <targetPath>WEB-INF/classes</targetPath>
+                                </resource>
+                            </webResources>
                             <overlays>
                                 <!--
                                    the priority of overlays is determined here


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2437

This PR fixes our issues with loading the "additions.jar" in WebApps in Tomcat 8 or Glassfish. It does the following:

Ensure all webapps unpack `org.dspace.modules.additions` (and any transitive dependencies) into their `WEB-INF/classes/`. This ensures classes in "additions" are loaded prior to any other JARs, per Servlet 3.0 spec, section 10.5:

> "The Web application class loader must load classes from the WEB-INF/ classes directory first, and then from library JARs in the WEB-INF/lib directory."

This work was a collaboration between myself and @rradillen (see notes below)
