### PR TITLE
[DS-2958] Automated documentation generation for REST API: Swagger + swagger UI

### DIFF
--- a/dspace-rest/pom.xml
+++ b/dspace-rest/pom.xml
@@ -18,6 +18,8 @@
     <properties>
         <!-- This is the path to the root [dspace-src] directory. -->
         <root.basedir>${basedir}/..</root.basedir>
+        <jersey.version>2.22.1</jersey.version>
+        <jersey.swagger.version>1.5.6</jersey.swagger.version>
     </properties>
     <build>
         <plugins>
@@ -39,6 +41,7 @@
                         <exclude>**/static/reports/spin.js</exclude>
                         <exclude>**/static/reports/README.md</exclude>
                         <exclude>**/*.xsd</exclude>
+                        <exclude>**/index.html</exclude>
                     </excludes>
                 </configuration>
             </plugin>
@@ -50,17 +53,88 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
-            <version>2.22.1</version>
+            <version>${jersey.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet</artifactId>
-            <version>2.22.1</version>
+            <version>${jersey.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
-            <version>2.22.1</version>
+            <version>${jersey.version}</version>
+            <exclusions>
+                <!-- Pinned to 2.5.4 below, this is because the current version number includes both 2.5.4 AND 2.5.0 jackson-annotations-->
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.5.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-jersey2-jaxrs</artifactId>
+            <version>${jersey.swagger.version}</version>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.containers</groupId>
+                    <artifactId>jersey-container-servlet-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                    <artifactId>jackson-jaxrs-json-provider</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>joda-time</groupId>
+                    <artifactId>joda-time</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.media</groupId>
+                    <artifactId>jersey-media-multipart</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-xml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.javassist</groupId>
+                    <artifactId>javassist</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Spring 3 dependencies -->
@@ -78,24 +152,23 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
         </dependency>
-		
-        <!-- Jersey + Spring -->
+
         <dependency>
-            <groupId>org.glassfish.jersey.ext</groupId>
-            <artifactId>jersey-spring3</artifactId>
-            <version>2.22.1</version>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>2.5.4</version>
             <exclusions>
                 <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring</artifactId>
+                    <groupId>org.codehaus.woodstox</groupId>
+                    <artifactId>stax2-api</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-core</artifactId>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-web</artifactId>
+                    <groupId>javax.inject</groupId>
+                    <artifactId>javax.inject</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.springframework</groupId>
@@ -105,17 +178,45 @@
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-context</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-aop</artifactId>
-                </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>2.5.4</version>
+        </dependency>
+
+        <!-- Use DSpace, for now, an older version to minimize spring generated dependency on Discovery -->
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet-core</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-multipart</artifactId>
+            <version>${jersey.version}</version>
         </dependency>
 
         <!-- Use DSpace, for now, an older version to minimize spring generated dependency on Discovery -->
         <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>dspace-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Connecting to DSpace datasource sets a dependency on Postgres DB-->

--- a/dspace-rest/pom.xml
+++ b/dspace-rest/pom.xml
@@ -41,7 +41,7 @@
                         <exclude>**/static/reports/spin.js</exclude>
                         <exclude>**/static/reports/README.md</exclude>
                         <exclude>**/*.xsd</exclude>
-                        <exclude>**/index.html</exclude>
+                        <exclude>**/index.jsp</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/dspace-rest/src/main/java/org/dspace/rest/BitstreamResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/BitstreamResource.java
@@ -33,6 +33,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import io.swagger.annotations.Api;
 import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.factory.AuthorizeServiceFactory;
@@ -58,6 +59,7 @@ import org.dspace.usage.UsageEvent;
 // Every DSpace class used without namespace is from package
 // org.dspace.rest.common.*. Otherwise namespace is defined.
 @Path("/bitstreams")
+@Api(value = "Bitstreams endpoint", tags = "bitstreams")
 public class BitstreamResource extends Resource
 {
     protected BitstreamService bitstreamService = ContentServiceFactory.getInstance().getBitstreamService();

--- a/dspace-rest/src/main/java/org/dspace/rest/CollectionsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/CollectionsResource.java
@@ -30,6 +30,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.swagger.annotations.Api;
 import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.factory.AuthorizeServiceFactory;
@@ -52,6 +53,7 @@ import org.dspace.usage.UsageEvent;
  * @author Rostislav Novak (Computing and Information Centre, CTU in Prague)
  */
 @Path("/collections")
+@Api(value = "Collection endpoint", tags = "collections")
 public class CollectionsResource extends Resource
 {
     protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();

--- a/dspace-rest/src/main/java/org/dspace/rest/CommunitiesResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/CommunitiesResource.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.rest;
 
+import io.swagger.annotations.Api;
 import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.factory.AuthorizeServiceFactory;
@@ -38,6 +39,7 @@ import java.util.List;
  * 
  */
 @Path("/communities")
+@Api(value = "Communities endpoint", tags = "communities")
 public class CommunitiesResource extends Resource
 {
     protected CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();

--- a/dspace-rest/src/main/java/org/dspace/rest/DSpaceRestApplication.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/DSpaceRestApplication.java
@@ -15,6 +15,7 @@ public class DSpaceRestApplication extends ResourceConfig {
 
     public DSpaceRestApplication() {
         register(JacksonFeature.class);
+        packages("io.swagger.jaxrs.listing");
         packages("org.dspace.rest");
     }
 }

--- a/dspace-rest/src/main/java/org/dspace/rest/FilteredCollectionsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/FilteredCollectionsResource.java
@@ -8,6 +8,7 @@
 package org.dspace.rest;
 
 
+import io.swagger.annotations.Api;
 import org.apache.log4j.Logger;
 import org.dspace.authorize.factory.AuthorizeServiceFactory;
 import org.dspace.authorize.service.AuthorizeService;
@@ -36,6 +37,7 @@ import java.util.List;
  * @author Terry Brady, Georgetown University
  */
 @Path("/filtered-collections")
+@Api(value = "Filtered collection endpoint", tags = {"collections", "filters"})
 public class FilteredCollectionsResource extends Resource {
     protected AuthorizeService authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();
     protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();

--- a/dspace-rest/src/main/java/org/dspace/rest/FilteredItemsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/FilteredItemsResource.java
@@ -8,6 +8,7 @@
 package org.dspace.rest;
 
 
+import io.swagger.annotations.Api;
 import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Item;
@@ -46,6 +47,7 @@ import java.util.UUID;
  * @author Terry Brady, Georgetown University
  */
 @Path("/filtered-items")
+@Api(value = "Filtered items endpoint", tags = {"items", "filters"})
 public class FilteredItemsResource extends Resource {
     protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();
     protected MetadataFieldService metadataFieldService = ContentServiceFactory.getInstance().getMetadataFieldService();

--- a/dspace-rest/src/main/java/org/dspace/rest/FiltersResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/FiltersResource.java
@@ -18,6 +18,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 
+import io.swagger.annotations.Api;
 import org.apache.log4j.Logger;
 import org.dspace.rest.common.ItemFilter;
 
@@ -28,7 +29,8 @@ import org.dspace.rest.common.ItemFilter;
   * 
  */
 @Path("/filters")
-public class FiltersResource 
+@Api(value = "Filters endpoint", tags = "filters")
+public class FiltersResource
 {
     private static Logger log = Logger.getLogger(FiltersResource.class);
 

--- a/dspace-rest/src/main/java/org/dspace/rest/HandleResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/HandleResource.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.rest;
 
+import io.swagger.annotations.Api;
 import org.apache.log4j.Logger;
 import org.dspace.authorize.factory.AuthorizeServiceFactory;
 import org.dspace.authorize.service.AuthorizeService;
@@ -35,6 +36,7 @@ import java.sql.SQLException;
  * To change this template use File | Settings | File Templates.
  */
 @Path("/handle")
+@Api(value = "Handle endpoint", tags = "handle")
 public class HandleResource extends Resource {
     protected HandleService handleService = HandleServiceFactory.getInstance().getHandleService();
     protected AuthorizeService authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();

--- a/dspace-rest/src/main/java/org/dspace/rest/HierarchyResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/HierarchyResource.java
@@ -8,6 +8,7 @@
 package org.dspace.rest;
 
 
+import io.swagger.annotations.Api;
 import org.apache.log4j.Logger;
 import org.dspace.authorize.factory.AuthorizeServiceFactory;
 import org.dspace.authorize.service.AuthorizeService;
@@ -42,6 +43,7 @@ import java.util.List;
  */
 @Path("/hierarchy")
 @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+@Api(value = "Hierarchy endpoint", tags = "hierarchy")
 public class HierarchyResource extends Resource {
     private static Logger log = Logger.getLogger(HierarchyResource.class);
     protected SiteService siteService = ContentServiceFactory.getInstance().getSiteService();

--- a/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.rest;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiParam;
 import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.factory.AuthorizeServiceFactory;
@@ -47,6 +49,7 @@ import java.util.List;
 // Every DSpace class used without namespace is from package org.dspace.rest.common.*. Otherwise namespace is defined.
 @SuppressWarnings("deprecation")
 @Path("/items")
+@Api(value = "Item endpoint", tags = "items")
 public class ItemsResource extends Resource
 {
     protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
@@ -87,7 +90,9 @@ public class ItemsResource extends Resource
     @GET
     @Path("/{item_id}")
     @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
-    public Item getItem(@PathParam("item_id") String itemId, @QueryParam("expand") String expand,
+    public Item getItem(
+            @ApiParam(value = "Internal DSpace identifier of the item", required = true)
+            @PathParam("item_id") String itemId, @QueryParam("expand") String expand,
             @QueryParam("userIP") String user_ip, @QueryParam("userAgent") String user_agent,
             @QueryParam("xforwardedfor") String xforwardedfor, @Context HttpHeaders headers, @Context HttpServletRequest request)
             throws WebApplicationException

--- a/dspace-rest/src/main/java/org/dspace/rest/MetadataRegistryResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/MetadataRegistryResource.java
@@ -29,6 +29,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.swagger.annotations.Api;
 import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.factory.AuthorizeServiceFactory;
@@ -63,7 +64,8 @@ import org.dspace.rest.common.MetadataField;
  * PUT    /registries/schema/{schema_id}
  */
 @Path("/registries")
-public class MetadataRegistryResource extends Resource 
+@Api(value = "Metadata Registry endpoint", tags = "metadata registry")
+public class MetadataRegistryResource extends Resource
 {
     protected AuthorizeService authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();
     protected MetadataFieldService metadataFieldService = ContentServiceFactory.getInstance().getMetadataFieldService();

--- a/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
@@ -22,6 +22,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.swagger.annotations.Api;
 import org.apache.log4j.Logger;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.factory.EPersonServiceFactory;
@@ -38,6 +39,7 @@ import org.dspace.rest.exceptions.ContextException;
  * 
  */
 @Path("/")
+@Api(value = "General", tags = "general")
 public class RestIndex {
     protected EPersonService epersonService = EPersonServiceFactory.getInstance().getEPersonService();
     private static Logger log = Logger.getLogger(RestIndex.class);

--- a/dspace-rest/src/main/java/org/dspace/rest/RestReports.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/RestReports.java
@@ -21,6 +21,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.annotations.Api;
 import org.apache.log4j.Logger;
 import org.dspace.rest.common.Report;
 import org.dspace.services.ConfigurationService;
@@ -35,6 +36,7 @@ import org.dspace.services.factory.DSpaceServicesFactory;
  * 
  */
 @Path("/reports")
+@Api(value = "Reports endpoint", tags = "reports")
 public class RestReports {
     private static Logger log = Logger.getLogger(RestReports.class);
 

--- a/dspace-rest/src/main/java/org/dspace/rest/swagger/DSpaceSwaggerBootstrapServlet.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/swagger/DSpaceSwaggerBootstrapServlet.java
@@ -1,0 +1,41 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.rest.swagger;
+
+import io.swagger.jaxrs.config.BeanConfig;
+import org.dspace.app.util.Util;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+
+/**
+ * Bootstrap class to setup the configuration for swagger
+ *
+ * @author kevinvandevelde at atmire.com
+ */
+public class DSpaceSwaggerBootstrapServlet extends HttpServlet
+{
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        super.init(config);
+
+        ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+        BeanConfig beanConfig = new BeanConfig();
+        //We set the version to the DSpace version
+        beanConfig.setVersion(Util.getSourceVersion());
+        beanConfig.setSchemes(configurationService.getArrayProperty("rest.schemes"));
+        beanConfig.setHost(configurationService.getProperty("rest.host"));
+        beanConfig.setBasePath(configurationService.getProperty("rest.setBasePath"));
+
+        beanConfig.setResourcePackage(configurationService.getProperty("rest.swagger.scan-packages"));
+        beanConfig.setScan(true);
+    }
+}

--- a/dspace-rest/src/main/webapp/WEB-INF/web.xml
+++ b/dspace-rest/src/main/webapp/WEB-INF/web.xml
@@ -26,9 +26,16 @@
         <load-on-startup>1</load-on-startup>
     </servlet>
 
+    <servlet>
+        <servlet-name>SwaggerBootstrap</servlet-name>
+        <servlet-class>org.dspace.rest.swagger.DSpaceSwaggerBootstrapServlet</servlet-class>
+        <load-on-startup>2</load-on-startup>
+    </servlet>
+
+
     <servlet-mapping>
         <servlet-name>DSpace REST API</servlet-name>
-        <url-pattern>/*</url-pattern>
+        <url-pattern>/api/*</url-pattern>
     </servlet-mapping>
     
     <servlet-mapping>
@@ -37,15 +44,15 @@
     </servlet-mapping>
     
     <!-- Security settings and mapping -->
-    <security-constraint>
-        <web-resource-collection>
-            <web-resource-name>DSpace REST API</web-resource-name>
-            <url-pattern>/*</url-pattern>
-        </web-resource-collection>
-        <user-data-constraint>
-            <transport-guarantee>CONFIDENTIAL</transport-guarantee>
-        </user-data-constraint>
-    </security-constraint>
+    <!--<security-constraint>-->
+        <!--<web-resource-collection>-->
+            <!--<web-resource-name>DSpace REST API</web-resource-name>-->
+            <!--<url-pattern>/*</url-pattern>-->
+        <!--</web-resource-collection>-->
+        <!--<user-data-constraint>-->
+            <!--<transport-guarantee>CONFIDENTIAL</transport-guarantee>-->
+        <!--</user-data-constraint>-->
+    <!--</security-constraint>-->
     
     <!-- ConfigurationService initialization for dspace.dir -->
     <context-param>

--- a/dspace-rest/src/main/webapp/WEB-INF/web.xml
+++ b/dspace-rest/src/main/webapp/WEB-INF/web.xml
@@ -44,15 +44,15 @@
     </servlet-mapping>
     
     <!-- Security settings and mapping -->
-    <!--<security-constraint>-->
-        <!--<web-resource-collection>-->
-            <!--<web-resource-name>DSpace REST API</web-resource-name>-->
-            <!--<url-pattern>/*</url-pattern>-->
-        <!--</web-resource-collection>-->
-        <!--<user-data-constraint>-->
-            <!--<transport-guarantee>CONFIDENTIAL</transport-guarantee>-->
-        <!--</user-data-constraint>-->
-    <!--</security-constraint>-->
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>DSpace REST API</web-resource-name>
+            <url-pattern>/*</url-pattern>
+        </web-resource-collection>
+        <user-data-constraint>
+            <transport-guarantee>CONFIDENTIAL</transport-guarantee>
+        </user-data-constraint>
+    </security-constraint>
     
     <!-- ConfigurationService initialization for dspace.dir -->
     <context-param>

--- a/dspace-rest/src/main/webapp/WEB-INF/web.xml
+++ b/dspace-rest/src/main/webapp/WEB-INF/web.xml
@@ -50,7 +50,7 @@
             <url-pattern>/*</url-pattern>
         </web-resource-collection>
         <user-data-constraint>
-            <transport-guarantee>CONFIDENTIAL</transport-guarantee>
+            <transport-guarantee>NONE</transport-guarantee>
         </user-data-constraint>
     </security-constraint>
     

--- a/dspace-rest/src/main/webapp/index.jsp
+++ b/dspace-rest/src/main/webapp/index.jsp
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Swagger UI</title>
+  <link rel="icon" type="image/png" href="images/favicon-32x32.png" sizes="32x32" />
+  <link rel="icon" type="image/png" href="images/favicon-16x16.png" sizes="16x16" />
+  <link href='<%=request.getContextPath()%>/swagger-ui-master/dist/css/typography.css' media='screen' rel='stylesheet' type='text/css'/>
+  <link href='<%=request.getContextPath()%>/swagger-ui-master/dist/css/reset.css' media='screen' rel='stylesheet' type='text/css'/>
+  <link href='<%=request.getContextPath()%>/swagger-ui-master/dist/css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
+  <link href='<%=request.getContextPath()%>/swagger-ui-master/dist/css/reset.css' media='print' rel='stylesheet' type='text/css'/>
+  <link href='<%=request.getContextPath()%>/swagger-ui-master/dist/css/print.css' media='print' rel='stylesheet' type='text/css'/>
+  <script src='<%=request.getContextPath()%>/swagger-ui-master/dist/lib/jquery-1.8.0.min.js' type='text/javascript'></script>
+  <script src='<%=request.getContextPath()%>/swagger-ui-master/dist/lib/jquery.slideto.min.js' type='text/javascript'></script>
+  <script src='<%=request.getContextPath()%>/swagger-ui-master/dist/lib/jquery.wiggle.min.js' type='text/javascript'></script>
+  <script src='<%=request.getContextPath()%>/swagger-ui-master/dist/lib/jquery.ba-bbq.min.js' type='text/javascript'></script>
+  <script src='<%=request.getContextPath()%>/swagger-ui-master/dist/lib/handlebars-2.0.0.js' type='text/javascript'></script>
+  <script src='<%=request.getContextPath()%>/swagger-ui-master/dist/lib/js-yaml.min.js' type='text/javascript'></script>
+  <script src='<%=request.getContextPath()%>/swagger-ui-master/dist/lib/lodash.min.js' type='text/javascript'></script>
+  <script src='<%=request.getContextPath()%>/swagger-ui-master/dist/lib/backbone-min.js' type='text/javascript'></script>
+  <script src='<%=request.getContextPath()%>/swagger-ui-master/dist/swagger-ui.js' type='text/javascript'></script>
+  <script src='<%=request.getContextPath()%>/swagger-ui-master/dist/lib/highlight.7.3.pack.js' type='text/javascript'></script>
+  <script src='<%=request.getContextPath()%>/swagger-ui-master/dist/lib/jsoneditor.min.js' type='text/javascript'></script>
+  <script src='<%=request.getContextPath()%>/swagger-ui-master/dist/lib/marked.js' type='text/javascript'></script>
+  <script src='<%=request.getContextPath()%>/swagger-ui-master/dist/lib/swagger-oauth.js' type='text/javascript'></script>
+
+  <!-- Some basic translations -->
+  <!-- <script src='<%=request.getContextPath()%>/swagger-ui-master/dist/lang/translator.js' type='text/javascript'></script> -->
+  <!-- <script src='<%=request.getContextPath()%>/swagger-ui-master/dist/lang/ru.js' type='text/javascript'></script> -->
+  <!-- <script src='<%=request.getContextPath()%>/swagger-ui-master/dist/lang/en.js' type='text/javascript'></script> -->
+
+  <script type="text/javascript">
+    $(function () {
+      var url = window.location.search.match(/url=([^&]+)/);
+      if (url && url.length > 1) {
+        url = decodeURIComponent(url[1]);
+      } else {
+        url = "<%=request.getContextPath()%>/api/swagger.json";
+      }
+
+      // Pre load translate...
+      if(window.SwaggerTranslator) {
+        window.SwaggerTranslator.translate();
+      }
+      window.swaggerUi = new SwaggerUi({
+        url: url,
+        dom_id: "swagger-ui-container",
+        supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
+        onComplete: function(swaggerApi, swaggerUi){
+          if(typeof initOAuth == "function") {
+            initOAuth({
+              clientId: "your-client-id",
+              clientSecret: "your-client-secret-if-required",
+              realm: "your-realms",
+              appName: "your-app-name",
+              scopeSeparator: ",",
+              additionalQueryStringParams: {}
+            });
+          }
+
+          if(window.SwaggerTranslator) {
+            window.SwaggerTranslator.translate();
+          }
+
+          $('pre code').each(function(i, e) {
+            hljs.highlightBlock(e)
+          });
+
+          addApiKeyAuthorization();
+        },
+        onFailure: function(data) {
+          log("Unable to Load SwaggerUI");
+        },
+        docExpansion: "none",
+        jsonEditor: false,
+        apisSorter: "alpha",
+        defaultModelRendering: 'schema',
+        showRequestHeaders: false
+      });
+
+      function addApiKeyAuthorization(){
+        var key = encodeURIComponent($('#input_apiKey')[0].value);
+        if(key && key.trim() != "") {
+            var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("api_key", key, "query");
+            window.swaggerUi.api.clientAuthorizations.add("api_key", apiKeyAuth);
+            log("added key " + key);
+        }
+      }
+
+      $('#input_apiKey').change(addApiKeyAuthorization);
+
+      // if you have an apiKey you would like to pre-populate on the page for demonstration purposes...
+      /*
+        var apiKey = "myApiKeyXXXX123456789";
+        $('#input_apiKey').val(apiKey);
+      */
+
+      window.swaggerUi.load();
+
+      function log() {
+        if ('console' in window) {
+          console.log.apply(console, arguments);
+        }
+      }
+  });
+  </script>
+</head>
+
+<body class="swagger-section">
+<div id='header'>
+  <div class="swagger-ui-wrap">
+    <a id="logo" href="http://swagger.io">swagger</a>
+    <form id='api_selector'>
+      <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/></div>
+      <div class='input'><input placeholder="api_key" id="input_apiKey" name="apiKey" type="text"/></div>
+      <div class='input'><a id="explore" href="#" data-sw-translate>Explore</a></div>
+    </form>
+  </div>
+</div>
+
+<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>
+<div id="swagger-ui-container" class="swagger-ui-wrap"></div>
+</body>
+</html>

--- a/dspace/config/modules/rest.cfg
+++ b/dspace/config/modules/rest.cfg
@@ -4,6 +4,18 @@
 # These configs are used by the REST module                     #
 #---------------------------------------------------------------#
 
+# Sets the schemes for the API URLs (http, https).
+rest.schemes=${rest.schemes}
+
+# Sets the host (including a port) for the API URLs. Does not include the schemes nor context root.
+rest.host=${rest.host}
+
+# Sets the context root for the API calls.
+rest.setBasePath=${rest.setBasePath}
+
+#Sets which package(s) Swagger should scan to pick up resources. If there's more than one package, it can be a list of comma-separated packages.
+rest.swagger.scan-packages=org.dspace.rest
+
 # record stats in DSpace statistics module
 rest.stats = true
 

--- a/dspace/config/modules/rest.cfg
+++ b/dspace/config/modules/rest.cfg
@@ -5,13 +5,13 @@
 #---------------------------------------------------------------#
 
 # Sets the schemes for the API URLs (http, https).
-rest.schemes=${rest.schemes}
+rest.schemes=https
 
 # Sets the host (including a port) for the API URLs. Does not include the schemes nor context root.
-rest.host=${rest.host}
+rest.host=localhost
 
 # Sets the context root for the API calls.
-rest.setBasePath=${rest.setBasePath}
+rest.setBasePath=/rest/api
 
 #Sets which package(s) Swagger should scan to pick up resources. If there's more than one package, it can be a list of comma-separated packages.
 rest.swagger.scan-packages=org.dspace.rest

--- a/dspace/modules/rest/pom.xml
+++ b/dspace/modules/rest/pom.xml
@@ -24,12 +24,44 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+                <version>1.2.1</version>
+                <executions>
+                    <execution>
+                        <id>swagger-ui</id>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>https://github.com/swagger-api/swagger-ui/archive/master.tar.gz</url>
+                            <unpack>true</unpack>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
                     <archiveClasses>false</archiveClasses>
                     <!-- Filter the web.xml (needed for IDE compatibility/debugging) -->
                     <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
+                    <!-- Copy swagger generated json file & swagger UI files-->
+                    <webResources>
+                        <resource>
+                            <filtering>true</filtering>
+                            <directory>${build.directory}</directory>
+                            <includes>
+                                <include>swagger-ui-master/dist/**</include>
+                            </includes>
+                            <excludes>
+                                <exclude>swagger-ui-master/dist/index.html</exclude>
+                            </excludes>
+                            <targetPath>/</targetPath>
+                        </resource>
+                    </webResources>
                     <overlays>
                         <!--
                            the priority of overlays is determined here

--- a/local.cfg.EXAMPLE
+++ b/local.cfg.EXAMPLE
@@ -63,16 +63,6 @@ dspace.name = DSpace at My University
 # But, you may need to modify this if you are running DSpace on a custom port, etc.
 solr.server = http://localhost:8080/solr
 
-# Sets the schemes for the API URLs (http, https).
-rest.schemes=https
-
-# Sets the host (including a port) for the API URLs. Does not include the schemes nor context root.
-rest.host=localhost:8080
-
-# Sets the context root for the API calls.
-rest.setBasePath=/rest/api
-
-
 ##########################
 # DATABASE CONFIGURATION #
 ##########################

--- a/local.cfg.EXAMPLE
+++ b/local.cfg.EXAMPLE
@@ -63,6 +63,16 @@ dspace.name = DSpace at My University
 # But, you may need to modify this if you are running DSpace on a custom port, etc.
 solr.server = http://localhost:8080/solr
 
+# Sets the schemes for the API URLs (http, https).
+rest.schemes=https
+
+# Sets the host (including a port) for the API URLs. Does not include the schemes nor context root.
+rest.host=localhost:8080
+
+# Sets the context root for the API calls.
+rest.setBasePath=/rest/api
+
+
 ##########################
 # DATABASE CONFIGURATION #
 ##########################


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2958

Incomplete adding of swagger and swagger UI to the rest api of DSpace. The ItemResource & CollectionResource have been partially documented as proof of concept.
In order to run this locally some configuration will need to be added to the local.cfg file (it has already been added to the local.cfg.EXAMPLE):

# Sets the schemes for the API URLs (http, https).
rest.schemes=https
# Sets the host (including a port) for the API URLs. Does not include the schemes nor context root.
rest.host=localhost:8080
# Sets the context root for the API calls.
rest.setBasePath=/rest/api

Still todo:
- [ ] Pin the swagger UI version, do not depend on "master"
- [ ] Add DSpace color scheme & logo to the swagger UI
- [ ] Document the BitstreamResource endpoint
- [ ] Document the CollectionsResource endpoint
- [ ] Document the CollectionsResource endpoint
- [ ] Document the CommunitiesResource endpoint
- [ ] Document the FilteredCollectionsResource endpoint
- [ ] Document the FilteredItemsResource endpoint
- [ ] Document the FiltersResource endpoint
- [ ] Document the HandleResource endpoint
- [ ] Document the HierarchyResource endpoint
- [ ] Document the ItemsResource endpoint
- [ ] Document the MetadataRegistryResource endpoint
- [ ] Document the RestIndex endpoint
- [ ] Document the RestReports endpoint
