### PR TITLE
re DS-2898, fix up some dependency version mismatches from DSPR#1226,…

### DIFF
--- a/dspace-rest/pom.xml
+++ b/dspace-rest/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <!-- This is the path to the root [dspace-src] directory. -->
         <root.basedir>${basedir}/..</root.basedir>
-        <spring-security.version>3.2.9.RELEASE</spring-security.version>
+        <spring-security.version>4.0.4.RELEASE</spring-security.version>
     </properties>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
             Upgrading the spring version will make the XMLUI crash
         -->
         <hibernate.version>4.2.21.Final</hibernate.version>
-        <spring.version>3.2.16.RELEASE</spring.version>
+        <spring.version>4.2.5.RELEASE</spring.version>
         <!-- 'root.basedir' is the path to the root [dspace-src] dir. It must be redefined by each child POM,
              as it is used to reference the LICENSE_HEADER and *.properties file(s) in that directory. -->
         <root.basedir>${basedir}</root.basedir>


### PR DESCRIPTION
… caught by Maven Enforcer, this change bumps up our Spring version from 3.2.16 to 4.2.5, which will very likely require testing, do not just simply merge this change.
