### PR TITLE
Resolve dependency conflict complaints from maven-enforcer-plugin

### DIFF
--- a/dspace-rest/pom.xml
+++ b/dspace-rest/pom.xml
@@ -129,11 +129,25 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
             <version>${spring-security.version}</version>
+            <exclusions>
+                <!-- Latest version will be provided by spring-context-->
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-expression</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-web</artifactId>
             <version>${spring-security.version}</version>
+            <exclusions>
+                <!-- Latest version will be provided by spring-context-->
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-expression</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>


### PR DESCRIPTION
This PR is a followup to #1226 

After merging #1226, our `maven-enforcer-plugin` complained of dependency conflicts surrounding the `spring-expression` dependency.  This PR resolves those conflicts, by excluding that dependency from the newly added `spring-security-core` and `spring-security-web` dependencies (added by #1226).

Assuming Travis approves of this, I'll merge it immediately, as "master" is currently broken.
