### PR TITLE
DS-79: Remove creation of assetstore.dir from Ant.

### DIFF
--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -746,8 +746,6 @@ Common usage:
 
         <mkdir dir="${org.dspace.app.itemexport.download.dir}" />
 
-        <mkdir dir="${assetstore.dir}" />
-
         <mkdir dir="${handle.dir}" />
 
         <mkdir dir="${log.dir}" />


### PR DESCRIPTION
Noted by @mwoodiupui in IRC.  Ant is still creating an "assetstore.dir", even though that config was moved to Spring by #1159 

Ant no longer needs to create the `assetstore.dir` as it is now created in `DSBitStoreService` the first time a bitstream is created:
https://github.com/DSpace/DSpace/blob/master/dspace-api/src/main/java/org/dspace/storage/bitstore/DSBitStoreService.java#L119

This is a tiny, obvious fix. I'm just linking it as associated with DS-79 (already closed) as it is a minor followup to #1159 
