### PR TITLE
DS-3122: Make DataCite XML namespace configurable.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/identifier/doi/DataCiteConnector.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/DataCiteConnector.java
@@ -65,14 +65,16 @@ implements DOIConnector
     // Configuration property names
     static final String CFG_USER = "identifier.doi.user";
     static final String CFG_PASSWORD = "identifier.doi.password";
-    private static final String CFG_PREFIX
+    static final String CFG_PREFIX
             = "identifier.doi.prefix";
-    private static final String CFG_PUBLISHER
+    static final String CFG_PUBLISHER
             = "crosswalk.dissemination.DataCite.publisher";
-    private static final String CFG_DATAMANAGER
+    static final String CFG_DATAMANAGER
             = "crosswalk.dissemination.DataCite.dataManager";
-    private static final String CFG_HOSTINGINSTITUTION
+    static final String CFG_HOSTINGINSTITUTION
             = "crosswalk.dissemination.DataCite.hostingInstitution";
+    static final String CFG_NAMESPACE
+            = "crosswalk.dissemination.DataCite.namespace";
 
     /**
      * Stores the scheme used to connect to the DataCite server. It will be set
@@ -931,7 +933,9 @@ implements DOIConnector
         {
             return root;
         }
-        Element identifier = new Element("identifier", "http://datacite.org/schema/kernel-3");
+        Element identifier = new Element("identifier",
+                    configurationService.getProperty(CFG_NAMESPACE,
+                        "http://datacite.org/schema/kernel-3"));
         identifier.setAttribute("identifierType", "DOI");
         identifier.addContent(doi.substring(DOI.SCHEME.length()));
         return root.addContent(0, identifier);

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -466,6 +466,7 @@ crosswalk.dissemination.DataCite.preferList = false
 crosswalk.dissemination.DataCite.publisher = My University
 #crosswalk.dissemination.DataCite.dataManager = # defaults to publisher
 #crosswalk.dissemination.DataCite.hostingInstitution = # defaults to publisher
+crosswalk.dissemination.DataCite.namespace = http://datacite.org/schema/kernel-3
 
 # Crosswalk Plugin Configuration:
 #   The purpose of Crosswalks is to translate an external metadata format to/from


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3122

This must be merged after #1197 as it already uses the schema version 3.

I don't think this really needs to be tested as the code change are so small an obvious. Just in case a short description on how to test this: take the XSLT from #1197, configure DSpace to mint DOIs with DataCite (see DSpace documentation), publish an Item and run [dspace-install]/bin/dspace doi-organiser -u. If it tells you that it successfully updated a DOI everything is fine.
