### PR TITLE
[DS-3125] Submitters cannot delete bistreams of workspaceitems

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -238,7 +238,7 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
     @Override
     public void delete(Context context, Bitstream bitstream) throws SQLException, AuthorizeException {
 
-        // changed to a check on remove
+        // changed to a check on delete
         // Check authorisation
         authorizeService.authorizeAction(context, bitstream, Constants.DELETE);
         log.info(LogManager.getHeader(context, "delete_bitstream",
@@ -249,15 +249,13 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
 
         bitstream.getBundles().clear();
 
-
-        // Remove policies
-        authorizeService.removeAllPolicies(context, bitstream);
-
         deleteMetadata(context, bitstream);
 
         // Remove bitstream itself
         bitstream.setDeleted(true);
         update(context, bitstream);
+        // Remove policies from the file, we do this at the end since the methods above still require write rights.
+        authorizeService.removeAllPolicies(context, bitstream);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
@@ -386,6 +386,8 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
         log.info(LogManager.getHeader(context, "delete_bundle", "bundle_id="
                 + bundle.getID()));
 
+        authorizeService.authorizeAction(context, bundle, Constants.DELETE);
+
         context.addEvent(new Event(Event.DELETE, Constants.BUNDLE, bundle.getID(),
                 bundle.getName(), getIdentifiers(context, bundle)));
 

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -577,7 +577,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
 
     @Override
     public void delete(Context context, Item item) throws SQLException, AuthorizeException, IOException {
-        authorizeService.authorizeAction(context, item, Constants.REMOVE);
+        authorizeService.authorizeAction(context, item, Constants.DELETE);
         item.getCollections().clear();
         item.setOwningCollection(null);
         rawDelete(context,  item);

--- a/dspace-api/src/main/java/org/dspace/content/WorkspaceItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/WorkspaceItemServiceImpl.java
@@ -106,6 +106,8 @@ public class WorkspaceItemServiceImpl implements WorkspaceItemService {
         authorizeService.addPolicy(context, item, Constants.ADD, item.getSubmitter(), ResourcePolicy.TYPE_SUBMISSION);
         // remove contents permission
         authorizeService.addPolicy(context, item, Constants.REMOVE, item.getSubmitter(), ResourcePolicy.TYPE_SUBMISSION);
+        // delete permission
+        authorizeService.addPolicy(context, item, Constants.DELETE, item.getSubmitter(), ResourcePolicy.TYPE_SUBMISSION);
 
 
         // Copy template if appropriate

--- a/dspace-api/src/main/java/org/dspace/workflowbasic/BasicWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/workflowbasic/BasicWorkflowServiceImpl.java
@@ -170,6 +170,20 @@ public class BasicWorkflowServiceImpl implements BasicWorkflowService
         {
             authorizeService.addPolicy(context, item, Constants.REMOVE, step3group, ResourcePolicy.TYPE_WORKFLOW);
         }
+        if (step1group != null)
+        {
+            authorizeService.addPolicy(context, item, Constants.DELETE, step1group, ResourcePolicy.TYPE_WORKFLOW);
+        }
+
+        if (step2group != null)
+        {
+            authorizeService.addPolicy(context, item, Constants.DELETE, step2group, ResourcePolicy.TYPE_WORKFLOW);
+        }
+
+        if (step3group != null)
+        {
+            authorizeService.addPolicy(context, item, Constants.DELETE, step3group, ResourcePolicy.TYPE_WORKFLOW);
+        }
     }
 
     @Override

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V6.0_2016.04.14__DS-3125-fix-bundle-bitstream-delete-rights.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V6.0_2016.04.14__DS-3125-fix-bundle-bitstream-delete-rights.sql
@@ -1,0 +1,33 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+---------------------------------------------------------------
+-- DS-3125 Submitters cannot delete bistreams of workspaceitems
+---------------------------------------------------------------
+-- This script will add delete rights on all bundles/bitstreams
+-- for people who already have REMOVE rights.
+-- In previous versions REMOVE rights was enough to ensure that
+-- you could delete an object.
+---------------------------------------------------------------
+INSERT INTO resourcepolicy (policy_id, resource_type_id, resource_id, action_id, start_date, end_date, rpname,
+rptype, rpdescription, eperson_id, epersongroup_id, dspace_object)
+SELECT
+resourcepolicy_seq.nextval AS policy_id,
+resource_type_id,
+resource_id,
+-- Insert the Constants.DELETE action
+2 AS action_id,
+start_date,
+end_date,
+rpname,
+rptype,
+rpdescription,
+eperson_id,
+epersongroup_id,
+dspace_object
+FROM resourcepolicy WHERE action_id=4 AND (resource_type_id=0 OR resource_type_id=1 OR resource_type_id=2);

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V6.0_2016.04.14__DS-3125-fix-bundle-bitstream-delete-rights.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V6.0_2016.04.14__DS-3125-fix-bundle-bitstream-delete-rights.sql
@@ -1,0 +1,33 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+---------------------------------------------------------------
+-- DS-3125 Submitters cannot delete bistreams of workspaceitems
+---------------------------------------------------------------
+-- This script will add delete rights on all bundles/bitstreams
+-- for people who already have REMOVE rights.
+-- In previous versions REMOVE rights was enough to ensure that
+-- you could delete an object.
+---------------------------------------------------------------
+INSERT INTO resourcepolicy (policy_id, resource_type_id, resource_id, action_id, start_date, end_date, rpname,
+rptype, rpdescription, eperson_id, epersongroup_id, dspace_object)
+SELECT
+resourcepolicy_seq.nextval AS policy_id,
+resource_type_id,
+resource_id,
+-- Insert the Constants.DELETE action
+2 AS action_id,
+start_date,
+end_date,
+rpname,
+rptype,
+rpdescription,
+eperson_id,
+epersongroup_id,
+dspace_object
+FROM resourcepolicy WHERE action_id=4 AND (resource_type_id=0 OR resource_type_id=1 OR resource_type_id=2);

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V6.0_2016.04.14__DS-3125-fix-bundle-bitstream-delete-rights.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V6.0_2016.04.14__DS-3125-fix-bundle-bitstream-delete-rights.sql
@@ -1,0 +1,33 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+---------------------------------------------------------------
+-- DS-3125 Submitters cannot delete bistreams of workspaceitems
+---------------------------------------------------------------
+-- This script will add delete rights on all bundles/bitstreams
+-- for people who already have REMOVE rights.
+-- In previous versions REMOVE rights was enough to ensure that
+-- you could delete an object.
+---------------------------------------------------------------
+INSERT INTO resourcepolicy (policy_id, resource_type_id, resource_id, action_id, start_date, end_date, rpname,
+rptype, rpdescription, eperson_id, epersongroup_id, dspace_object)
+SELECT
+getnextid('resourcepolicy') AS policy_id,
+resource_type_id,
+resource_id,
+-- Insert the Constants.DELETE action
+2 AS action_id,
+start_date,
+end_date,
+rpname,
+rptype,
+rpdescription,
+eperson_id,
+epersongroup_id,
+dspace_object
+FROM resourcepolicy WHERE action_id=4 AND (resource_type_id=0 OR resource_type_id=1 OR resource_type_id=2);

--- a/dspace-api/src/test/java/org/dspace/content/BundleTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/BundleTest.java
@@ -567,6 +567,8 @@ public class BundleTest extends AbstractDSpaceObjectTest
             // Allow Bundle REMOVE perms (to test remove)
             authorizeService.authorizeAction((Context) any, (Bundle) any,
                     Constants.REMOVE); result = null;
+            authorizeService.authorizeAction((Context) any, (Bundle) any,
+                    Constants.DELETE); result = null;
         }};
 
         UUID id = b.getID();

--- a/dspace-api/src/test/java/org/dspace/content/CollectionTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/CollectionTest.java
@@ -883,6 +883,8 @@ public class CollectionTest extends AbstractDSpaceObjectTest
                     Constants.REMOVE); result = null;
             authorizeService.authorizeAction((Context) any, (Item) any,
                     Constants.WRITE); result = null;
+            authorizeService.authorizeAction((Context) any, (Item) any,
+                    Constants.DELETE); result = null;
         }};
 
         WorkspaceItem workspaceItem = workspaceItemService.create(context, collection, false);

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -785,6 +785,8 @@ public class ItemTest  extends AbstractDSpaceObjectTest
                     Constants.ADD); result = null;
             authorizeService.authorizeAction((Context) any, (Item) any,
                     Constants.REMOVE); result = null;
+            authorizeService.authorizeAction((Context) any, (Item) any,
+                    Constants.DELETE); result = null;
         }};
 
         String name = "bundle";
@@ -926,6 +928,8 @@ public class ItemTest  extends AbstractDSpaceObjectTest
                     Constants.ADD); result = null;
             authorizeService.authorizeAction((Context) any, (Item) any,
                     Constants.REMOVE); result = null;
+            authorizeService.authorizeAction((Context) any, (Item) any,
+                    Constants.DELETE); result = null;
         }};
 
         String name = "LICENSE";
@@ -1216,6 +1220,8 @@ public class ItemTest  extends AbstractDSpaceObjectTest
             authorizeService.authorizeAction((Context) any, (Item) any,
                     Constants.REMOVE, true); result = null;
             authorizeService.authorizeAction((Context) any, (Item) any,
+                    Constants.DELETE, true); result = null;
+            authorizeService.authorizeAction((Context) any, (Item) any,
                 Constants.WRITE); result = null;
         }};
 
@@ -1257,6 +1263,8 @@ public class ItemTest  extends AbstractDSpaceObjectTest
                 Constants.WRITE); result = null;
             authorizeService.authorizeAction((Context) any, (Item) any,
                 Constants.REMOVE); result = null;
+            authorizeService.authorizeAction((Context) any, (Item) any,
+                Constants.DELETE); result = null;
 
         }};
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3125

This pull requests make some changes to the authorization system of workspace items. When you delete an Item/Bundle/Bitstream a check is made on the DELETE rights.

In previous DSpace versions this didn't exists because you couldn't call the "delete()" method directly, you had to call the collection.removeItem(), item.removeBundle(), ....

When a new workspace item is created DELETE rights are granted to delete the item, when created the bundle, bitstreams will inherit this from Item.

An SQL script is included (for postgres & H2, oracle to follow later) that will grant DELETE rights to anybody who already has remove rights on these records (since anybody who had remove rights in the past could delete the objects).

Below you can find a small test plan to make sure we test everything related to these changes.

**Test plan**
- [x] Delete bundle/bitstream as submitter
- [x] Delete workspace item as a submitter
- [x] Delete bundle/bitstream as a reviewer in the basic workflow
- [x] Delete bundle/bitstream as a reviewer in the configurable workflow
