### PR TITLE
DS-3131 Context gets committed even when exception is thrown

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/sitemap.xmap
+++ b/dspace-xmlui-mirage2/src/main/webapp/sitemap.xmap
@@ -54,6 +54,11 @@
             <transformer name="strip-namespaces" src="org.apache.cocoon.transformation.StripNameSpacesTransformer"/>
         </map:transformers>
 
+        <map:actions>
+            <map:action name="ContextAbortAction" src="org.dspace.app.xmlui.cocoon.ContextAbortAction" />
+        </map:actions>
+
+
         <map:serializers>
             <map:serializer name="html-no-doctype" logger="sitemap.serializer.xhtml"
                             src="org.apache.cocoon.serialization.HTMLSerializer"
@@ -215,6 +220,7 @@
                 </map:when>
                 <!-- All other errors (HTTP 500 Internal Server Error) -->
                 <map:otherwise>
+                    <map:act type="ContextAbortAction"/>
                     <map:serialize type="html-no-doctype" status-code="500"/>
                 </map:otherwise>
             </map:select>

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/ContextAbortAction.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/ContextAbortAction.java
@@ -1,0 +1,30 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.xmlui.cocoon;
+
+import java.util.*;
+import org.apache.avalon.framework.parameters.*;
+import org.apache.cocoon.acting.*;
+import org.apache.cocoon.environment.*;
+import org.dspace.app.xmlui.utils.*;
+
+/**
+ * This action is used to abort the context when an exception occurs.
+ * The action is called by the handle-errors section in either the theme's sitemap or the
+ * main webapp/sitemap if the theme does not have a handle-errors section.
+ *
+ * @author philip at atmire.com
+ */
+public class ContextAbortAction extends ServiceableAction {
+    @Override
+    public Map act(Redirector redirector, SourceResolver resolver, Map objectModel, String source, Parameters parameters) throws Exception {
+        org.dspace.core.Context context = ContextUtil.obtainContext(objectModel);
+        context.abort();
+        return EMPTY_MAP;
+    }
+}

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/ContextAbortAction.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/ContextAbortAction.java
@@ -23,8 +23,7 @@ import org.dspace.app.xmlui.utils.*;
 public class ContextAbortAction extends ServiceableAction {
     @Override
     public Map act(Redirector redirector, SourceResolver resolver, Map objectModel, String source, Parameters parameters) throws Exception {
-        org.dspace.core.Context context = ContextUtil.obtainContext(objectModel);
-        context.abort();
+        ContextUtil.abortContext(ObjectModelHelper.getRequest(objectModel));
         return EMPTY_MAP;
     }
 }

--- a/dspace-xmlui/src/main/webapp/sitemap.xmap
+++ b/dspace-xmlui/src/main/webapp/sitemap.xmap
@@ -208,6 +208,7 @@
                         <map:action name="StartAuthentication" src="org.dspace.app.xmlui.aspect.eperson.StartAuthenticationAction"/>
                         <map:action name="DSpacePropertyFileReader" src="org.dspace.app.xmlui.cocoon.DSpacePropertyFileReader" />
                         <map:action name="PropertyFileReader" src="org.dspace.app.xmlui.cocoon.PropertyFileReader" />
+                        <map:action name="ContextAbortAction" src="org.dspace.app.xmlui.cocoon.ContextAbortAction" />
                 </map:actions>
                 <map:pipes default="caching">
                         <map:pipe name="noncaching" src="org.apache.cocoon.components.pipeline.impl.NonCachingProcessingPipeline">
@@ -747,7 +748,9 @@
                                 </map:when>
 
                                 <map:otherwise>
-                                        <map:generate type="exception"/>
+                                    <map:act type="ContextAbortAction"/>
+
+                                    <map:generate type="exception"/>
                                         <map:transform src="exception2html.xslt">
                                                 <map:parameter name="contextPath" value="{request:contextPath}"/>
                                         </map:transform>

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/sitemap.xmap
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/sitemap.xmap
@@ -49,6 +49,10 @@
         <map:readers>
             <map:reader name="ConcatenationReader" src="org.dspace.app.xmlui.cocoon.ConcatenationReader"/>
         </map:readers>
+        <map:actions>
+            <map:action name="ContextAbortAction" src="org.dspace.app.xmlui.cocoon.ContextAbortAction" />
+        </map:actions>
+
     </map:components>
 
     <!-- Define global resources that are used in multiple areas of the pipeline. -->
@@ -197,7 +201,7 @@
             <!-- Step 3: Transform that DRI formatted exception into XHTML (using our Theme) -->
             <map:call resource="transform-to-xhtml"/>
 
-            <!-- Step 4: Serialize XHTML page to user's brower. Based on the type of error, 
+            <!-- Step 4: Serialize XHTML page to user's brower. Based on the type of error,
                          provide a different HTTP response code. -->
             <map:select type="exception">
                 <!-- HTTP 400 Bad Request -->
@@ -210,6 +214,7 @@
                 </map:when>
                 <!-- All other errors (HTTP 500 Internal Server Error) -->
                 <map:otherwise>
+                    <map:act type="ContextAbortAction"/>
                     <map:serialize type="xhtml" status-code="500"/>
                 </map:otherwise>
             </map:select>


### PR DESCRIPTION
When an uncaught exception occurs the context is committed while it should be aborted.

This pull request adds a ContextAbortAction that aborts the context whenever an error is handled by the theme's sitemap or main webapp/sitemap.

jira ticket:

https://jira.duraspace.org/browse/DS-3131
