### PR TITLE
DS-3133 Add case-insensitive flag in SpiderDetector

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetector.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetector.java
@@ -175,7 +175,7 @@ public class SpiderDetector {
                 }
                 for (String pattern : patterns)
                 {
-                    patternList.add(Pattern.compile(pattern));
+                    patternList.add(Pattern.compile(pattern,Pattern.CASE_INSENSITIVE));
                 }
                 log.info("Loaded pattern file:  {}", file.getPath());
             }


### PR DESCRIPTION
When matching for spiders, add a case insensitive flag
(so for example, spider, would match "Spider", "SPIDER", "spideR", etc)
