### PR TITLE
DS-3104: Fix log4j's issues with finding log directory via commandline

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/LoggerServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/core/LoggerServiceImpl.java
@@ -109,17 +109,8 @@ public class LoggerServiceImpl implements KernelStartupCallbackService
                             fatal("Can't load dspace provided log4j configuration from " + logConfigFile.getAbsolutePath(), e);
                         }
 
-                        // Merge the loaded log4j props with those in ConfigurationService
-                        // This ensures variable substitution can be used in log4j.properties (e.g. ${log.dir})
-                        // NOTE: if the same setting exists in both places, the setting in ConfigurationService
-                        // overwrites the one in log4j.properties. This lets you easily override default log4j
-                        // settings in your DSpace configs
-                        Properties mergedProps = new Properties();
-                        mergedProps.putAll(log4jProps);
-                        mergedProps.putAll(config.getProperties());
-
-                        // Configure log4j based on all the loaded properties
-                        PropertyConfigurator.configure(mergedProps);
+                        // Configure log4j based on all its properties
+                        PropertyConfigurator.configure(log4jProps);
                     }
                 }
                 else

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -7,11 +7,6 @@
 #  * JSPUI Specific Configurations
 #  * XMLUI Specific Configurations
 #
-# Revision: $Revision$
-#
-# Date:     $Date$
-#
-
 
 #------------------------------------------------------------------#
 #------------------GENERAL CONFIGURATIONS--------------------------#
@@ -166,27 +161,12 @@ mail.allowed.referrers = ${dspace.hostname}
 # Moved to config/spring/bitstore.xml
 
 ##### Logging configuration #####
-
-# Override default log4j configuration
+# Override default log4j configuration file
 # You may provide your own configuration here, existing alternatives are:
-# log.init.config = ${dspace.dir}/config/log4j.xml
 # log.init.config = ${dspace.dir}/config/log4j-console.properties
 log.init.config = ${dspace.dir}/config/log4j.properties
 
-# Where to put the logs (used in configuration only)
-log.dir = ${dspace.dir}/log
-
-# loglevel.dspace: Log level for all DSpace-specific code (org.dspace.*)
-# Possible values (from most to least info): DEBUG, INFO, WARN, ERROR, FATAL
-loglevel.dspace = INFO
-
-# loglevel.other: Log level for other third-party tools/APIs used by DSpace
-# Possible values (from most to least info): DEBUG, INFO, WARN, ERROR, FATAL
-loglevel.other = INFO
-
-# If enabled, the logging and the Solr statistics system will look for
-# an X-Forwarded-For header. If it finds it, it will use this for the user IP address
-#useProxies = true
+# All other log4j settings moved to config/log4j.properties
 
 ##### DOI registration agency credentials ######
 # To mint DOIs you have to use a DOI registration agency like DataCite. Several
@@ -344,6 +324,9 @@ http.proxy.host =
 # port number of proxy server
 http.proxy.port =
 
+# If enabled, the logging and the Solr statistics system will look for
+# an X-Forwarded-For header. If it finds it, it will use this for the user IP address
+#useProxies = true
 
 #### Media Filter / Format Filter plugins (through PluginService) ####
 # Media/Format Filters help to full-text index content or

--- a/dspace/config/log4j-console.properties
+++ b/dspace/config/log4j-console.properties
@@ -1,6 +1,10 @@
-##########################################################
-# Simple log4j configuration file used during build tasks
-##########################################################
+#############################################################
+# log4j-console.properties
+#
+# Simple log4j configuration file used during Ant build tasks
+#
+# Its goal is to simply output logs to the commandline / console.
+#############################################################
 
 # Set root category priority to INFO and its only appender to A1.
 log4j.rootCategory=INFO, A1

--- a/dspace/config/log4j-handle-plugin.properties
+++ b/dspace/config/log4j-handle-plugin.properties
@@ -1,63 +1,20 @@
 ###########################################################################
-# REMEMBER: ONLY UPDATE THE VERSION IN dspace/config/templates
-# AND THEN RUN dspace/bin/install-configs!
-# DO NOT EDIT THE 'LIVE' VERSION!
-###########################################################################
-
-###########################################################################
-#
 # log4j-handle-plugin.properties
 #
-# Version: $Revision$
-#
-# Date: $Date$
-#
-# Copyright (c) 2002-2009, The DSpace Foundation.  All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are
-# met:
-#
-# - Redistributions of source code must retain the above copyright
-# notice, this list of conditions and the following disclaimer.
-#
-# - Redistributions in binary form must reproduce the above copyright
-# notice, this list of conditions and the following disclaimer in the
-# documentation and/or other materials provided with the distribution.
-#
-# - Neither the name of the DSpace Foundation nor the names of its
-# contributors may be used to endorse or promote products derived from
-# this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-# HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
-# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-# DAMAGE.
-#
+# This is the log4j configuration file for the embedded DSpace Handle server,
+# writing daily rolling logs. We cannot simply write to the same logs, since
+# log4j does not support more than one JVM writing to the same rolling log.
 ###########################################################################
 
-# This is the log4j configuration file for the DSpace Handle server, writing
-# daily rolling logs.  We cannot simply write to the same logs, since log4j
-# does not support more than one JVM writing to the same rolling log.
+# VARIABLES:
+# The following variables can be used to easily tweak the default log4j settings.
+# These variables are used by the log4j config / appenders later in this file.
 
-# Text surrounded by two '@' symbols is replaced with the corresponding
-# property from dspace.cfg.  For example:
-#
-# @@dspace.url@@
-#
-# would be replaced with the dspace.url property in dspace.cfg.
-# When /dspace/bin/install-configs is run, this file will be installed in the
-# location specified by the property:
-# config.template.log4j-handle-plugin.properties
-
+# log.dir
+#   Default log file directory for DSpace. Defaults to the 'log' subdirectory
+#   under [dspace.dir]. NOTE: The value of 'dspace.dir' will be replaced by
+#   its value in your configuration when DSpace is deployed (via Ant).
+log.dir=${dspace.dir}/log
 
 # Set root category priority to INFO and its only appender to A1.
 log4j.rootCategory=INFO, A1

--- a/dspace/config/log4j-solr.properties
+++ b/dspace/config/log4j-solr.properties
@@ -1,13 +1,23 @@
 ###########################################################################
 # log4j-solr.properties
-###########################################################################
-
+#
 # This is the log4j configuration file for the Solr webapp that comes bundled
-# with DSpace. Because Solr is a dependency, its log4j settings are kept separate
-# from the default DSpace log4j settings (in log4j.properties).
+# with DSpace. Because Solr is a dependency, its log4j settings are kept
+# separate from the default DSpace log4j settings (in log4j.properties).
 #
 # Therefore, this log4j file is standalone. If you wish to tweak the location of
-# your Solr logs, you must do so within this file (or in your DSpace source code).
+# your Solr logs, you must do so within this file.
+###########################################################################
+
+# VARIABLES:
+# The following variables can be used to easily tweak the default log4j settings.
+# These variables are used by the log4j config / appenders later in this file.
+
+# log.dir
+#   Default log file directory for DSpace. Defaults to the 'log' subdirectory
+#   under [dspace.dir]. NOTE: The value of 'dspace.dir' will be replaced by
+#   its value in your configuration when DSpace is deployed (via Ant).
+log.dir=${dspace.dir}/log
 
 #  Logging level for Solr
 log4j.rootLogger=INFO, file

--- a/dspace/config/log4j.properties
+++ b/dspace/config/log4j.properties
@@ -1,46 +1,33 @@
 ###########################################################################
-#
 # log4j.properties
 #
-# Version: $Revision$
-#
-# Date: $Date$
-#
+# This is the primary log4j (logging) configuration file for DSpace. By default,
+# Log4j is configured to write log files that rotate daily. However, you may
+# tweak these settings based on your local needs / best practices.
+# For more information on log4j configuration, see:
+# https://logging.apache.org/log4j/1.2/manual.html
 ###########################################################################
 
-# This is the log4j configuration file for DSpace. Log4j can be configured to
-# write files that rotate every day or every month.
-#
-# Some specific variables/properties are specified in the log4j settings below.
-# These properties are given default values in this log4j configuration file,
-# HOWEVER they will be overridden by a property of the same name within your
-# DSpace Configuration. For example, the default value of ${log.dir} will be
-# overridden by the "log.dir" setting within dspace.cfg or local.cfg.
-#
-# The default settings below MUST be retained here as they will be used by the
-# DSpaceKernel during startup until the point where log4j is fully configured
-# by LoggerServiceImpl. Once LoggerServiceImpl is initialized (after Kernel
-# startup & configuration init), these values will be overridden by ones in
-# the DSpaceConfigurationService.
-# For more information, see LoggerServiceImpl class.
-#
-# PARAMETERS:
-#   [WARNING:] Please be sure to retain the uncommented, default values here.
-#   If you wish to update a value, do so within your local.cfg file, and it will
-#   automatically override the default setting below.
-#
+# VARIABLES:
+# The following variables can be used to easily tweak the default log4j settings.
+# These variables are used by the log4j config / appenders later in this file.
+
 # log.dir
-#   Default log file directory for DSpace. Often set to ${dspace.dir}/log in dspace.cfg
-log.dir=../log
-#
+#   Default log file directory for DSpace. Defaults to the 'log' subdirectory
+#   under [dspace.dir]. NOTE: The value of 'dspace.dir' will be replaced by
+#   its value in your configuration when DSpace is deployed (via Ant).
+log.dir=${dspace.dir}/log
+
 # loglevel.dspace
 #   Log level for all DSpace-specific code (org.dspace.*)
 #   Possible values (from most to least info): DEBUG, INFO, WARN, ERROR, FATAL
+#   Defaults to INFO
 loglevel.dspace=INFO
-#
+
 # loglevel.other
 #   Log level for other third-party tools/APIs used by DSpace
 #   Possible values (from most to least info): DEBUG, INFO, WARN, ERROR, FATAL
+#   Defaults to INFO
 loglevel.other=INFO
 
 ###########################################################################
@@ -69,7 +56,7 @@ log4j.appender.A1.layout.ConversionPattern=%d %-5p %c @ %m%n
 
 
 ###########################################################################
-# A2 is the name of the appender for the Checker
+# A2 is the name of the appender for the Checksum Checker
 ###########################################################################
 # This line sets the logging level for the checksum checker log file.
 # Set this to DEBUG to see extra detailed logging.

--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -350,13 +350,13 @@ Common usage:
         <!-- Finally, filter some very specific configuration files, which cannot
              be managed by DSpace's configuration service. NOTE: please refrain
              from appending files to this list unless ABSOLUTELY NECESSARY.
-             Most config files are now auto-interpolated and don't need filtering! -->
+             MOST config files are now auto-interpolated at runtime and don't need filtering! -->
         <copy todir="config-temp" preservelastmodified="true" overwrite="true" failonerror="false">
             <fileset dir="config">
-                <!-- Filter extra (third-party) log4j files, as log4j requires absolute paths
-                     to its log files. This does NOT include the default log4j.properties file
-                     as its absolute paths are interpolated by DSpace's ConfigurationService. -->
-                <include name="log4j-*.properties"/>
+                <!-- Filter all log4j files, as log4j requires absolute paths
+                     to its log files. In addition, log4j strongly prefers
+                     autoconfiguring itself (e.g. see DS-3104). -->
+                <include name="log4j*.properties"/>
                 <!-- Filter OAI-PMH description so it can include hostname and handle prefix -->
                 <include name="crosswalks/oai/description.xml"/>
                 <!-- Filter sample Tomcat context.xml -->
@@ -767,10 +767,7 @@ Common usage:
     <!-- Fresh install of config files                                 -->
     <!-- ============================================================= -->
 
-    <!-- Writes the configuration files to ${dspace.dir}/config.  It does *not*
-       run the install-configs script.  The "log4j.build.properties" file is
-       copied to ${dspace.dir}/config so there's a simple log4j.properties
-       file present for the initial run of "install-configs". -->
+    <!-- Copies the configuration files to ${dspace.dir}/config. -->
     <target name="init_configs" depends="init_installation">
 
         <copy todir="${dspace.dir}/config" preservelastmodified="true" failonerror="false">
@@ -780,7 +777,6 @@ Common usage:
         <copy file="${config}" tofile="${dspace.dir}/config/dspace.cfg" preservelastmodified="true" />
 
         <echo file='${dspace.dir}/config/ant.properties' message='ant.version = ${ant.version}'/>
-
 
     </target>
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3104

This PR does the following:
- Moves all `log.*` configurations from `dspace.cfg` to `log4j.properties` (and other `log4j*.properties` files, where necessary). This allows these log4j config files to be "standalone" and no longer depend on configs from `dspace.cfg` or `local.cfg`
  - Only exception is `log.init.config` which is needed to actually reference the location of our log4j.properties
- Update Ant build process to filter all log4j files. This ensures that `dspace.dir` gets filled out in the `log4j*.properties` files
- Update our `LoggerServiceImpl` class (which tells log4j where its config file is) to no longer pass all our configs to log4j. Instead, log4j will only use what is in `log4j.properties`.

Essentially the goal of this PR is to ensure our log4j configuration no longer depends on any other configs, that way log4j can initialize itself without any external (configuration) dependencies.

I've tested and the errors described in DS-3104 no longer exist. In addition, logging seems to be working fine.
