### PR TITLE
DS-3141 Allow metadata field internationalization in XMLUI

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/DescribeStep.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/DescribeStep.java
@@ -31,6 +31,7 @@ import org.dspace.app.xmlui.wing.element.Division;
 import org.dspace.app.xmlui.wing.element.Field;
 import org.dspace.app.xmlui.wing.element.Instance;
 import org.dspace.app.xmlui.wing.element.List;
+import org.dspace.app.xmlui.wing.element.Option;
 import org.dspace.app.xmlui.wing.element.PageMeta;
 import org.dspace.app.xmlui.wing.element.Params;
 import org.dspace.app.xmlui.wing.element.Radio;
@@ -817,13 +818,18 @@ public class DescribeStep extends AbstractSubmissionStep
          *                      The field's pre-existing values.
          */
         private void renderTextArea(List form, String fieldName, DCInput dcInput, java.util.List<MetadataValue> dcValues, boolean readonly) throws WingException
-        {
-                // Plain old Textarea
+        {                
+        		// Plain old Textarea
                 TextArea textArea = form.addItem().addTextArea(fieldName,"submit-textarea");
-
+                org.dspace.app.xmlui.wing.element.Item item = form.addItem();
+                
                 // Setup the text area
                 textArea.setLabel(dcInput.getLabel());
                 textArea.setHelp(cleanHints(dcInput.getHints()));
+                
+                //add the language select field
+                addLanguageOptions(textArea, dcInput);
+                
                 String fieldKey = metadataAuthorityService.makeFieldKey(dcInput.getSchema(), dcInput.getElement(), dcInput.getQualifier());
                 boolean isAuth = metadataAuthorityService.isAuthorityControlled(fieldKey);
                 if (isAuth)
@@ -865,7 +871,7 @@ public class DescribeStep extends AbstractSubmissionStep
                 {
                     textArea.setDisabled();
                 }
-                
+
                 // Setup the field's values
                 if (dcInput.isRepeatable() || dcValues.size() > 1)
                 {
@@ -873,6 +879,11 @@ public class DescribeStep extends AbstractSubmissionStep
                         {
                                 Instance ti = textArea.addInstance();
                                 ti.setValue(dcValue.getValue());
+                                if(dcValue.getLanguage() != null)
+                                {
+                                	ti.setLanguageValue(dcValue.getLanguage());
+                                }
+                                
                                 if (isAuth)
                                 {
                                     if (dcValue.getAuthority() == null || dcValue.getAuthority().equals(""))
@@ -889,6 +900,10 @@ public class DescribeStep extends AbstractSubmissionStep
                 else if (dcValues.size() == 1)
                 {
                         textArea.setValue(dcValues.get(0).getValue());
+                        if(dcValues.get(0).getLanguage() != null)
+                        {
+                        	textArea.setLanguageValue(dcValues.get(0).getLanguage());                        	
+                        }
                         if (isAuth)
                         {
                             if (dcValues.get(0).getAuthority() == null || dcValues.get(0).getAuthority().equals(""))
@@ -1157,6 +1172,8 @@ public class DescribeStep extends AbstractSubmissionStep
             org.dspace.app.xmlui.wing.element.Item item = form.addItem();
             Text text = item.addText(fieldName, "submit-text");
 
+            addLanguageOptions(text, dcInput);
+          
             if(dcInput.getVocabulary() != null){
                 String vocabularyUrl = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("dspace.url");
                 vocabularyUrl += "/JSON/controlled-vocabulary?vocabularyIdentifier=" + dcInput.getVocabulary();
@@ -1218,6 +1235,10 @@ public class DescribeStep extends AbstractSubmissionStep
                         {
                                 Instance ti = text.addInstance();
                                 ti.setValue(dcValue.getValue());
+                                if(dcValue.getLanguage() != null)
+                                {
+                                	ti.setLanguageValue(dcValue.getLanguage());
+                                }
                                 if (isAuth)
                                 {
                                     if (dcValue.getAuthority() == null || dcValue.getAuthority().equals(""))
@@ -1234,6 +1255,10 @@ public class DescribeStep extends AbstractSubmissionStep
                 else if (dcValues.size() == 1)
                 {
                         text.setValue(dcValues.get(0).getValue());
+                        if(dcValues.get(0).getLanguage() != null)
+                        {
+                        	text.setLanguageValue(dcValues.get(0).getLanguage());                        	
+                        }
                         if (isAuth)
                         {
                             if (dcValues.get(0).getAuthority() == null || dcValues.get(0).getAuthority().equals(""))
@@ -1292,5 +1317,13 @@ public class DescribeStep extends AbstractSubmissionStep
                 }
 
                 return clean;
+        }
+
+        public void addLanguageOptions(Field field, DCInput dcInput) throws WingException
+        {
+        	if(dcInput.getLanguage())
+        	{
+        		field.setLanguagesList(dcInput.getValueLanguageList());        		
+        	}
         }
 }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Field.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Field.java
@@ -59,6 +59,7 @@ package org.dspace.app.xmlui.wing.element;
  */
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.dspace.app.xmlui.wing.AttributeMap;
@@ -486,6 +487,28 @@ public abstract class Field extends AbstractWingElement implements
             remove.dispose();
         }
     }
+
+    /**
+     * build the languages select for metadata values
+     * 
+     * @param options
+     * @throws WingException
+     */
+	public void setLanguagesList(List<String> options) throws WingException 
+	{
+	 
+		List<Option> langOptions = new ArrayList<Option>();
+		 
+		for (int i = 0; i < options.size(); i += 2)
+		{
+			String display = options.get(i);
+			String value   = options.get(i+1);
+			Option option = new Option(context, value);
+	     	option.addContent(display);
+	     	langOptions.add(option);
+		}
+       	this.params.setLanguageOptions(langOptions);
+	}
 
     /**
      * Translate this element and all contained elements into SAX events. The

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Instance.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Instance.java
@@ -224,6 +224,18 @@ public class Instance extends Container
         value.addContent(characters);
     }
     
+    /**
+    * Set the instance language value
+    */
+    public Value setLanguageValue(String lang) throws WingException
+    {
+        this.removeValueOfType(Value.TYPE_LANG);
+        Value value = new Value(context, Value.TYPE_LANG);
+        value.addContent(lang);
+        contents.add(value);
+        return value;
+    }
+    
     
     /**
      * Translate this element and all contained elements into SAX events. The

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Params.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Params.java
@@ -21,12 +21,19 @@ import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.ext.LexicalHandler;
 import org.xml.sax.helpers.NamespaceSupport;
+
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 
 public class Params extends AbstractWingElement implements StructuralElement
 {
     /** The name of the params element */
     public static final String E_PARAMS = "params";
+    
+    /** The name of the param elements inside params */
+    public static final String E_PARAM = "param";
 
     /** The name of the operations attribute */
     public static final String A_OPERATIONS = "operations";
@@ -71,6 +78,9 @@ public class Params extends AbstractWingElement implements StructuralElement
     /** The name of the field to use for a list of choices */
     public static final String A_CHOICES_CLOSED = "choicesClosed";
 
+    /** The name of the attribute that identifies a param element */
+    public static final String A_PARAM_NAME =  "name";
+       
     /** Possible operations */
     public static final String OPERATION_ADD = "add";
 
@@ -133,6 +143,9 @@ public class Params extends AbstractWingElement implements StructuralElement
     /** Value of choicesClosed option */
     protected boolean choicesClosed = false;
 
+    /** language options if metadata is internationalizable */
+    protected Collection<Option> langOptions = new ArrayList<Option>();
+   
     /**
      * Construct a new parameter's element
      *
@@ -340,7 +353,17 @@ public class Params extends AbstractWingElement implements StructuralElement
     {
         this.choicesClosed = value;
     }
-
+    
+    /**
+     * add a new language option
+     * 
+     * @param option
+     */
+    public void setLanguageOptions(List<Option> langOptions )
+    {
+       	this.langOptions=langOptions;
+    }
+    
     /**
      * Sets whether choices are "closed" to the set returned by plugin.
      */
@@ -465,6 +488,23 @@ public class Params extends AbstractWingElement implements StructuralElement
         }
 
         startElement(contentHandler, namespaces, E_PARAMS, attributes);
+        
+        /**
+         * if the metadata is internationalizable builds a param element inside 
+         * params with the diferent language options
+         */
+        if (langOptions.size()>0)
+        {
+        	AttributeMap  langAttributes = new AttributeMap();
+        	langAttributes.put(A_PARAM_NAME, "langs");
+        	startElement(contentHandler, namespaces, E_PARAM, langAttributes);
+        	for (Option option : langOptions)
+            {
+                option.toSAX(contentHandler, lexicalHandler, namespaces);
+            }
+        	endElement(contentHandler, namespaces, E_PARAM);
+        }
+        
         endElement(contentHandler, namespaces, E_PARAMS);
     }
 }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Text.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Text.java
@@ -91,8 +91,7 @@ public class Text extends Field
     {
         this.params.enableDeleteOperation();
     }
-    
-    
+
     /** ******************************************************************** */
     /** Raw Values * */
     /** ******************************************************************** */
@@ -164,5 +163,17 @@ public class Text extends Field
         Instance instance = new Instance(context);
         instances.add(instance);
         return instance;
+    }
+    
+    /**
+    * Set the value's language
+    */
+    public Value setLanguageValue(String lang) throws WingException
+    {
+    	this.removeValueOfType(Value.TYPE_LANG);
+    	Value value = new Value(context, Value.TYPE_LANG);
+    	value.addContent(lang);
+    	values.add(value);
+    	return value;
     }
 }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/TextArea.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/TextArea.java
@@ -92,8 +92,7 @@ public class TextArea extends Field
     {
         this.params.enableDeleteOperation();
     }
-    
-
+        
     /** ******************************************************************** */
     /** Raw Values * */
     /** ******************************************************************** */
@@ -157,7 +156,7 @@ public class TextArea extends Field
         values.add(value);
         return value;
     }
-
+    
     /**
      * Add a field instance
      * @return instance
@@ -168,4 +167,16 @@ public class TextArea extends Field
         instances.add(instance);
         return instance;
     }
+    
+    /**
+     * Set the value's language
+     */
+     public Value setLanguageValue(String lang) throws WingException
+     {
+     	this.removeValueOfType(Value.TYPE_LANG);
+     	Value value = new Value(context, Value.TYPE_LANG);
+     	value.addContent(lang);
+     	values.add(value);
+     	return value;
+     }
 }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Value.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Value.java
@@ -46,12 +46,14 @@ public class Value extends RichTextContainer
 
     public static final String TYPE_OPTION = "option";
 
+    public static final String TYPE_LANG = "lang";
+    
     /** value of the metadata authority code associated with a raw value */
     public static final String TYPE_AUTHORITY = "authority";
 
     /** All the possible value types collected into one array. */
     public static final String[] TYPES = { TYPE_RAW, TYPE_INTERPRETED,
-            TYPE_OPTION, TYPE_AUTHORITY};
+            TYPE_OPTION, TYPE_AUTHORITY, TYPE_LANG};
 
     /** The type of this value element */
     private String type;

--- a/dspace-xmlui/src/main/webapp/themes/dri2xhtml-alt/core/forms.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/dri2xhtml-alt/core/forms.xsl
@@ -776,15 +776,7 @@
                 <span class="ds-interpreted-field">No value submitted.</span>
             </xsl:otherwise>
         </xsl:choose>
-        <xsl:if test="../dri:params/dri:param[@name='langs']">
-        	<xsl:variable name="position">
-        		<xsl:number/>
-        	</xsl:variable>
-        	<xsl:call-template name="selectLangBuilder">
-        		<xsl:with-param name="name" select="concat(../@n, '_', $position)" />
-        		<xsl:with-param name="selected" select="./dri:value[@type='lang']"/>
-        	</xsl:call-template>
-        </xsl:if>
+        
     </xsl:template>
 
 	<!-- build the select field with the language options -->

--- a/dspace-xmlui/src/main/webapp/themes/dri2xhtml-alt/core/forms.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/dri2xhtml-alt/core/forms.xsl
@@ -471,6 +471,13 @@
             <input type="checkbox" value="{concat(@n,'_',$position)}" name="{concat(@n,'_selected')}"/>
             <xsl:apply-templates select="dri:instance[position()=$position]" mode="interpreted"/>
 
+			<xsl:if test="dri:params/dri:param[@name='langs']">
+	        	<xsl:call-template name="languageSelectBuilder">
+	         		<xsl:with-param name="name" select="concat(@n, '_', $position)" />
+	        		<xsl:with-param name="selected" select="dri:instance[position()=$position]/dri:value[@type='lang']"/>
+	        	</xsl:call-template>
+	        </xsl:if>
+ 
             <!-- look for authority value in instance. -->
             <xsl:if test="dri:instance[position()=$position]/dri:value[@type='authority']">
               <xsl:call-template name="authorityConfidenceIcon">
@@ -493,6 +500,7 @@
                 <xsl:value-of select="dri:value[@type='raw']"/>
             </xsl:attribute>
         </input>
+        
         <!-- XXX do we want confidence icon here?? -->
         <xsl:if test="dri:value[@type='authority']">
           <xsl:call-template name="authorityInputFields">
@@ -768,11 +776,36 @@
                 <span class="ds-interpreted-field">No value submitted.</span>
             </xsl:otherwise>
         </xsl:choose>
+        <xsl:if test="../dri:params/dri:param[@name='langs']">
+        	<xsl:variable name="position">
+        		<xsl:number/>
+        	</xsl:variable>
+        	<xsl:call-template name="selectLangBuilder">
+        		<xsl:with-param name="name" select="concat(../@n, '_', $position)" />
+        		<xsl:with-param name="selected" select="./dri:value[@type='lang']"/>
+        	</xsl:call-template>
+        </xsl:if>
     </xsl:template>
 
-
-
-
+	<!-- build the select field with the language options -->
+	<xsl:template name="languageSelectBuilder">
+		<xsl:param name="name"/>
+		<xsl:param name="selected"/>
+    	<select>
+    		<xsl:attribute name="name"><xsl:value-of select="concat($name, '[lang]')"/></xsl:attribute>
+	       	<xsl:for-each select="../dri:params/dri:param[@name='langs']/dri:option | ./dri:params/dri:param[@name='langs']/dri:option">
+	       		<option>
+	       			<xsl:attribute name="value">
+	       				<xsl:value-of select="@returnValue"/>
+	       			</xsl:attribute>       			
+	       			<xsl:if test="$selected = @returnValue">
+	       				<xsl:attribute name="selected" />
+	       			</xsl:if>
+	       			<xsl:value-of select="."/>
+	       		</option>
+	       	</xsl:for-each>
+	    </select>
+	</xsl:template>
 
     <xsl:template match="dri:value" mode="interpreted">
         <xsl:apply-templates />
@@ -1055,8 +1088,27 @@
                         </xsl:choose>
                     </xsl:otherwise>
         </xsl:choose>
-    </xsl:template>
 
+        <xsl:if test="dri:params/dri:param[@name = 'langs']">
+        <!-- if the field is repeatable is necessary to keep the position for the instance values -->
+			<xsl:variable name="nro" select="count(dri:instance)+1"/>
+			<xsl:variable name="name">
+				<xsl:choose>
+					<xsl:when test="dri:params[@operations='add delete']">
+						<xsl:value-of select="concat(@n, '_', $nro)"/>
+					</xsl:when>
+					<xsl:otherwise>
+						<xsl:value-of select="@n"/>
+					</xsl:otherwise>
+				</xsl:choose>
+			</xsl:variable>
+			<xsl:call-template name="languageSelectBuilder">
+	    		<xsl:with-param name="name" select="$name"/>
+	    		<xsl:with-param name="selected" select="dri:value[@type='lang']"/>
+	    	</xsl:call-template>
+        </xsl:if>
+    </xsl:template>
+    
     <!-- A set of standard attributes common to all fields -->
     <xsl:template name="fieldAttributes">
         <xsl:call-template name="standardAttributes">
@@ -1173,5 +1225,5 @@
             </span>
         </xsl:if>
     </xsl:template>
-    
+   
 </xsl:stylesheet>


### PR DESCRIPTION
I've extended the solution proposed in issue DS-2888
(https://github.com/DSpace/DSpace/pull/1166) to allow metadata
internalization on item submission in order to work in XMLUI.

I've just edited XMLUI classes and XSLT files so the dspace-api
behavior remains the same and keep compatibility with JSPUI

the usage of this feature is the same as with JSPUI, i.e. add the
<language value-pairs-name="common_iso_languages">true</language>
tag in the input forms and the corresponding value pair with the
languages options

please let me know if i should change something

regards
