### PR TITLE
[DS-3145] Configure rootpath in REST Reports (/handle, /xmlui/handle, /jspui/handle)

### DIFF
--- a/dspace-rest/src/main/webapp/static/reports/restCollReport.js
+++ b/dspace-rest/src/main/webapp/static/reports/restCollReport.js
@@ -127,10 +127,10 @@ var CollReport = function() {
 		var tr = self.myHtmlUtil.addTr(tbody);
 		tr.attr("cid", coll.id).attr("index",index).addClass(index % 2 == 0 ? "odd data" : "even data");
 		self.myHtmlUtil.addTd(tr, index + 1).addClass("num");
-		var parval = self.myHtmlUtil.getAnchor(top.name, "/handle/" + top.handle); 
+		var parval = self.myHtmlUtil.getAnchor(top.name, self.ROOTPATH + top.handle); 
 		
 		self.myHtmlUtil.addTd(tr, parval).addClass("title comm");
-		self.myHtmlUtil.addTdAnchor(tr, coll.name, "/handle/" + coll.handle).addClass("title");
+		self.myHtmlUtil.addTdAnchor(tr, coll.name, self.ROOTPATH + coll.handle).addClass("title");
 		var td = self.myHtmlUtil.addTd(tr, "").addClass("num").addClass("link").addClass("numCount");
 		td = self.myHtmlUtil.addTd(tr, "").addClass("num").addClass("numFiltered");
 	};
@@ -422,7 +422,7 @@ var CollReport = function() {
 					tr.addClass(index % 2 == 0 ? "odd data" : "even data");
 					self.myHtmlUtil.addTd(tr, offset+index+1).addClass("num");
 					self.myHtmlUtil.addTd(tr, self.getId(item));
-					self.myHtmlUtil.addTdAnchor(tr, item.handle, "/handle/" + item.handle);
+					self.myHtmlUtil.addTdAnchor(tr, item.handle, self.ROOTPATH + item.handle);
 					self.myHtmlUtil.addTd(tr, item.name).addClass("ititle");
 					if (fields != null) {
 						$.each(fields, function(index, field){

--- a/dspace-rest/src/main/webapp/static/reports/restQueryReport.js
+++ b/dspace-rest/src/main/webapp/static/reports/restQueryReport.js
@@ -108,9 +108,9 @@ var QueryReport = function() {
 			if (item.parentCollection == null) {
 				self.myHtmlUtil.addTd(tr, "--");			
 			} else {
-				self.myHtmlUtil.addTdAnchor(tr, item.parentCollection.name, "/handle/" + item.parentCollection.handle);
+				self.myHtmlUtil.addTdAnchor(tr, item.parentCollection.name, self.ROOTPATH + item.parentCollection.handle);
 			}
-			self.myHtmlUtil.addTdAnchor(tr, item.handle, "/handle/" + item.handle);
+			self.myHtmlUtil.addTdAnchor(tr, item.handle, self.ROOTPATH + item.handle);
 			self.myHtmlUtil.addTd(tr, item.name);
 			
 			for(var i=0; i<mdCols.length; i++) {
@@ -156,7 +156,7 @@ var QueryReport = function() {
 		
 		if (colnum == 2) {
 			var anchor = $(col).find("a");
-			var href = anchor.is("a") ? anchor.attr("href").replace(/\/handle\//,"") : $(col).text();
+			var href = anchor.is("a") ? anchor.attr("href").replace(self.ROOTPATH,"") : $(col).text();
 			data += "\"" + href + "\"";
 		} else {
 			data += self.exportCell(col);		}

--- a/dspace-rest/src/main/webapp/static/reports/restReport.js
+++ b/dspace-rest/src/main/webapp/static/reports/restReport.js
@@ -10,6 +10,9 @@ var Report = function() {
 	this.COLL_LIMIT = 500;
 	this.COUNT_LIMIT = 500;
 	this.ITEM_LIMIT = 100;
+    //this.ROOTPATH = "/xmlui/handle/"
+    //this.ROOTPATH = "/jspui/handle/"
+	this.ROOTPATH = "/handle/"
 
 	//Override this to return obj.id for DSpace 5 versions
 	this.getId = function(obj) {

--- a/dspace-rest/src/main/webapp/static/reports/restReport.js
+++ b/dspace-rest/src/main/webapp/static/reports/restReport.js
@@ -10,9 +10,9 @@ var Report = function() {
 	this.COLL_LIMIT = 500;
 	this.COUNT_LIMIT = 500;
 	this.ITEM_LIMIT = 100;
-    //this.ROOTPATH = "/xmlui/handle/"
-    //this.ROOTPATH = "/jspui/handle/"
-	this.ROOTPATH = "/handle/"
+        this.ROOTPATH = "/xmlui/handle/"
+        //this.ROOTPATH = "/jspui/handle/"
+	//this.ROOTPATH = "/handle/"
 
 	//Override this to return obj.id for DSpace 5 versions
 	this.getId = function(obj) {


### PR DESCRIPTION
See https://jira.duraspace.org/browse/DS-3145

If this solution looks good, I will update the following page to recommend that a user set ROOTPATH in restReport.js to match their installation.

https://wiki.duraspace.org/display/DSDOC6x/REST+Based+Quality+Control+Reports
