### PR TITLE
DS-2654: Add necessary prefix to commented out config

### DIFF
--- a/dspace/config/modules/solrauthority.cfg
+++ b/dspace/config/modules/solrauthority.cfg
@@ -6,4 +6,4 @@
 
 # Update item metadata displayed values (not the authority keys)
 # with the lasted cached versions when running the UpdateAuthorities index script
-#auto-update-items=false
+#solrauthority.auto-update-items=false


### PR DESCRIPTION
Tiny, obvious PR.

`solrauthority.cfg` has a commented out config which doesn't have the necessary prefix (per #1104).

Here's where it is used, and referenced as `solrauthority.auto-update-items`:
https://github.com/DSpace/DSpace/blob/master/dspace-api/src/main/java/org/dspace/authority/UpdateAuthorities.java#L147
