### PR TITLE
[DS-3170] Allow Password Auth to be enabled for Rest Reports

### DIFF
--- a/dspace-rest/src/main/webapp/static/reports/authenticate.html
+++ b/dspace-rest/src/main/webapp/static/reports/authenticate.html
@@ -1,0 +1,58 @@
+<!--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+-->
+<html>
+<head>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.9.1/jquery-ui.min.js"></script>
+
+    <!-- sortable.js can be obtained at http://www.kryogenix.org/code/browser/sorttable/ -->
+    <!-- <script src="sorttable.js"></script> -->
+
+    <script src="restReport.js"></script>
+    <script type="text/javascript">
+    var AuthReport = function() {
+        Report.call(this);
+        this.makeAuthLink = function(){return false;};
+    }
+    $(document).ready(function(){
+        var myReport=new AuthReport();
+        $("#authenticate").on("click",function(){
+          myReport.init();  
+        });
+        $("#logout").on("click",function(){
+          myReport.myAuth.logout();            
+        });
+    });
+    </script>
+    <script src="spin.js"></script>
+    <link rel="stylesheet" type="text/css" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/themes/smoothness/jquery-ui.css"></link>
+    <link rel="stylesheet" type="text/css" href="restClient.css"></link>
+    <title>Authenticate for the REST Report Tools</title>
+</head>
+<body>
+<h2>Login for an Authenticated Report View</h2>
+<div>This is intended for sites with Password Authentication Enabled</div>
+<span id="currentUser"></span>
+<div id="password">
+  <div>
+  <label for="restemail">Email</label>
+  <input id="restemail" type="text" value="" size="30"/>
+  </div>
+  <div>
+  <label for="restpass">Password</label>
+  <input id="restpass" type="password" value=""/>
+  </div>
+  <div>
+  <button id="authenticate">Authenticate</button>
+  <button id="logout">Logout</button>
+  </div>
+</div>
+</body>
+</html>

--- a/dspace-rest/src/main/webapp/static/reports/index.html
+++ b/dspace-rest/src/main/webapp/static/reports/index.html
@@ -25,6 +25,7 @@
 </head>
 <body>
 <a href="query.html">Query Tool</a>
+<span id="currentUser"></span>
 <hr/>
 <h1>DSpace REST QC Client</h1>
 <div id='metadatadiv'>

--- a/dspace-rest/src/main/webapp/static/reports/query.html
+++ b/dspace-rest/src/main/webapp/static/reports/query.html
@@ -24,6 +24,7 @@
 </head>
 <body>
 <a href="index.html">Collection Filter</a>
+<span id="currentUser"></span>
 <hr/>
 <h1>DSpace REST Query Client</h1>
 <div id="querydiv">

--- a/dspace-rest/src/main/webapp/static/reports/restCollReport.js
+++ b/dspace-rest/src/main/webapp/static/reports/restCollReport.js
@@ -6,361 +6,360 @@
  * http://www.dspace.org/license/
  */
 var CollReport = function() {
-	Report.call(this);
-	//If sortable.js is included, uncomment the following
-	//this.hasSorttable = function(){return true;}
-	
-	this.COLL_LIMIT = 20;
-	this.TOOBIG = 10000;
-	this.loadId = 0;
-	this.THREADS =11;
-	this.THREADSP = 11;
-	this.ACCIDX_COLL = 1;
-	this.ACCIDX_ITEM = 2;
-	this.getDefaultParameters = function(){
-		return {
-	    	"show_fields[]" : [],
-		    filters       : "",
-		    limit         : this.COUNT_LIMIT,
-		    offset        : 0,
-		    icollection   : "",
-		    ifilter       : "",
-	    };
-	}
-	this.getCurrentParameters = function(){
-		return {
-			"show_fields[]" : this.myMetadataFields.getShowFields(),
-			filters         : this.myFilters.getFilterList(),
-			limit           : this.myReportParameters.getLimit(),
-			offset          : this.myReportParameters.getOffset(),
-		    icollection    : $("#icollection").val(),
-		    ifilter        : $("#ifilter").val(),
-	    };
-	}
-	var self = this;
+    Report.call(this);
+    //If sortable.js is included, uncomment the following
+    //this.hasSorttable = function(){return true;}
+    
+    this.COLL_LIMIT = 20;
+    this.TOOBIG = 10000;
+    this.loadId = 0;
+    this.THREADS =11;
+    this.THREADSP = 11;
+    this.ACCIDX_COLL = 1;
+    this.ACCIDX_ITEM = 2;
+    this.getDefaultParameters = function(){
+        return {
+            "show_fields[]" : [],
+            filters       : "",
+            limit         : this.COUNT_LIMIT,
+            offset        : 0,
+            icollection   : "",
+            ifilter       : "",
+        };
+    }
+    this.getCurrentParameters = function(){
+        return {
+            "show_fields[]" : this.myMetadataFields.getShowFields(),
+            filters         : this.myFilters.getFilterList(),
+            limit           : this.myReportParameters.getLimit(),
+            offset          : this.myReportParameters.getOffset(),
+            icollection    : $("#icollection").val(),
+            ifilter        : $("#ifilter").val(),
+        };
+    }
+    var self = this;
 
-	this.init = function() {
-	    this.baseInit();	
-		$("#icollection").val(self.myReportParameters.params.icollection);
-		$("#ifilter").val(self.myReportParameters.params.ifilter);
-		$("#itemResults").accordion({
-	        heightStyle: "content",
-	        collapsible: true,
-	        active: 1
-	    });
-	}
-	
-	this.myAuth.callback = function(data) {
-		self.createCollectionTable();		
-		$(".showCollections").bind("click", function(){
-			self.loadData();
-		});
-		$("#refresh-fields").bind("click", function(){
-			self.drawItemTable($("#icollection").val(), $("#ifilter").val(), 0);
-		});
-	}
+    this.init = function() {
+        this.baseInit();    
+        $("#icollection").val(self.myReportParameters.params.icollection);
+        $("#ifilter").val(self.myReportParameters.params.ifilter);
+        $("#itemResults").accordion({
+            heightStyle: "content",
+            collapsible: true,
+            active: 1
+        });
+    }
+    
+    this.myAuth.callback = function(data) {
+        self.createCollectionTable();
+        $("#table tbody tr").remove();
+        $(".showCollections").bind("click", function(){
+            self.loadData();
+        });
+        $("#refresh-fields").bind("click", function(){
+            self.drawItemTable($("#icollection").val(), $("#ifilter").val(), 0);
+        });
+    }
 
-	this.createCollectionTable = function() {
-		var self = this;
-		var tbl = $("<table/>");
-		tbl.attr("id","table");
-		$("#report").replaceWith(tbl);
+    this.createCollectionTable = function() {
+        var self = this;
+         var tbl = $("<table/>");
+        tbl.attr("id","table");
+        $("#report").replaceWith(tbl);
 
-		var thead = $("<thead/>");
-		tbl.append(thead);
-		var tbody = $("<tbody/>");
-		tbl.append(tbody);
-		var tr = self.myHtmlUtil.addTr(thead).addClass("header");
-		self.myHtmlUtil.addTh(tr, "Num").addClass("num").addClass("sorttable_numeric");
-		self.myHtmlUtil.addTh(tr, "Community").addClass("title");
-		self.myHtmlUtil.addTh(tr, "Collection").addClass("title");
-		var thn = self.myHtmlUtil.addTh(tr, "Num Items").addClass("sorttable_numeric");
-		self.myHtmlUtil.makeTotalCol(thn);
-		thn = self.myHtmlUtil.addTh(tr, "Num Filtered").addClass("sorttable_numeric");
-		self.myHtmlUtil.makeTotalCol(thn);
-		
-		self.addCollections();
-	}
+        var thead = $("<thead/>");
+        tbl.append(thead);
+        var tbody = $("<tbody/>");
+        tbl.append(tbody);
+        var tr = self.myHtmlUtil.addTr(thead).addClass("header");
+        self.myHtmlUtil.addTh(tr, "Num").addClass("num").addClass("sorttable_numeric");
+        self.myHtmlUtil.addTh(tr, "Community").addClass("title");
+        self.myHtmlUtil.addTh(tr, "Collection").addClass("title");
+        var thn = self.myHtmlUtil.addTh(tr, "Num Items").addClass("sorttable_numeric");
+        self.myHtmlUtil.makeTotalCol(thn);
+        thn = self.myHtmlUtil.addTh(tr, "Num Filtered").addClass("sorttable_numeric");
+        self.myHtmlUtil.makeTotalCol(thn);
+        
+        self.addCollections();
+    }
 
-	this.addCollections = function() {
-		var self = this;
-		
-		$.ajax({
-			url: "/rest/hierarchy",
-			dataType: "json",
-			headers: self.myAuth.getHeaders(),
-			success: function(data){
-				if (data.community != null) {
-					$.each(data.community, function(index, comm){
-						self.addCommunity(comm, comm);
-					});					
-				}
-				self.setCollectionCounts(0);
-			},
-			error: function(xhr, status, errorThrown) {
-				alert("Error in /rest/hierarchy "+ status+ " " + errorThrown);
-			}
-		});
-	};
+    this.addCollections = function() {
+        var self = this;
+        
+        $.ajax({
+            url: "/rest/hierarchy",
+            dataType: "json",
+            headers: self.myAuth.getHeaders(),
+            success: function(data){
+                if (data.community != null) {
+                    $.each(data.community, function(index, comm){
+                        self.addCommunity(comm, comm);
+                    });                    
+                }
+                self.setCollectionCounts(0);
+            },
+            error: function(xhr, status, errorThrown) {
+                alert("Error in /rest/hierarchy "+ status+ " " + errorThrown);
+            }
+        });
+    };
 
-	this.addCommunity = function(top, comm) {
-		var self = this;
+    this.addCommunity = function(top, comm) {
+        var self = this;
 
-		if (comm.collection != null) {
-			$.each(comm.collection, function(index, coll){
-				self.addCollection(top, coll);
-			});					
-		}
-		if (comm.community != null) {
-			$.each(comm.community, function(index, scomm){
-				self.addCommunity(top, scomm);
-			});					
-	}
-	};
+        if (comm.collection != null) {
+            $.each(comm.collection, function(index, coll){
+                self.addCollection(top, coll);
+            });                    
+        }
+        if (comm.community != null) {
+            $.each(comm.community, function(index, scomm){
+            self.addCommunity(top, scomm);
+        });                    
+    }
+    };
 
-	this.addCollection = function(top, coll) {
-		var self = this;
+    this.addCollection = function(top, coll) {
+        var self = this;
 
-		var tbody = $("#table tbody");
-		var index = tbody.find("tr").length;
+        var tbody = $("#table tbody");
+        var index = tbody.find("tr").length;
 
-		var tr = self.myHtmlUtil.addTr(tbody);
-		tr.attr("cid", coll.id).attr("index",index).addClass(index % 2 == 0 ? "odd data" : "even data");
-		self.myHtmlUtil.addTd(tr, index + 1).addClass("num");
-		var parval = self.myHtmlUtil.getAnchor(top.name, self.ROOTPATH + top.handle); 
-		
-		self.myHtmlUtil.addTd(tr, parval).addClass("title comm");
-		self.myHtmlUtil.addTdAnchor(tr, coll.name, self.ROOTPATH + coll.handle).addClass("title");
-		var td = self.myHtmlUtil.addTd(tr, "").addClass("num").addClass("link").addClass("numCount");
-		td = self.myHtmlUtil.addTd(tr, "").addClass("num").addClass("numFiltered");
-	};
-	
-	
-	this.setCollectionCounts = function(offset) {
-		var self = this;
+        var tr = self.myHtmlUtil.addTr(tbody);
+        tr.attr("cid", coll.id).attr("index",index).addClass(index % 2 == 0 ? "odd data" : "even data");
+        self.myHtmlUtil.addTd(tr, index + 1).addClass("num");
+        var parval = self.myHtmlUtil.getAnchor(top.name, self.ROOTPATH + top.handle); 
+        
+        self.myHtmlUtil.addTd(tr, parval).addClass("title comm");
+        self.myHtmlUtil.addTdAnchor(tr, coll.name, self.ROOTPATH + coll.handle).addClass("title");
+        var td = self.myHtmlUtil.addTd(tr, "").addClass("num").addClass("link").addClass("numCount");
+        td = self.myHtmlUtil.addTd(tr, "").addClass("num").addClass("numFiltered");
+    };
+    
+    
+    this.setCollectionCounts = function(offset) {
+        var self = this;
 
-		$.ajax({
-			url: "/rest/filtered-collections",
-			data: {
-				limit  : self.COLL_LIMIT,
-				offset : offset
- 			},
-			dataType: "json",
-			headers: self.myAuth.getHeaders(),
-			success: function(data){
-				$.each(data, function(index, coll){
-					var id = self.getId(coll);
-					var tr = $("#table tbody").find("tr[cid="+id+"]");
-					var td = tr.find("td.numCount");
-					td.text(coll.numberItems);
-					td.on("click", function(){
-						self.drawItemTable(self.getId(coll),'',0);
-						$("#icollection").val(self.getId(coll));
-						$("#ifilter").val("");
-					});
-				});
-				
-				//cannot assume data returned is full amount in case some items are restricted
-				//if (data.length == self.COLL_LIMIT) {
-				if (data.length > 0) {
-					self.setCollectionCounts(offset + self.COLL_LIMIT);
-					return;
-				}  
-				self.myHtmlUtil.totalCol(3);
-				$("#table").addClass("sortable");
-		  		
-		  		if (self.myFilters.getFilterList() != "") {
-		  			self.loadData();
-		  			if ($("#icollection").val() != "") {
-		  				self.drawItemTable($("#icollection").val(), $("#ifilter").val(), 0);
-		  			}
-		  		}
-			},
-			error: function(xhr, status, errorThrown) {
-				alert("Error in /rest/collections "+ status+ " " + errorThrown);
-			},
-			complete: function(xhr, status) {
-				self.spinner.stop();
-		  		$(".showCollections").attr("disabled", false);
-			}
-		});	
-	}
-	
-	this.loadData = function() {
-		self.spinner.spin($("h1")[0]);
-		$(".showCollections").attr("disabled", true);
-		$("#metadatadiv").accordion("option", "active", self.ACCIDX_COLL);
-		self.loadId++;
-		$("td.datacol,th.datacol").remove();
-		$("#table tr.data").addClass("processing");
-		self.myFilters.filterString = self.myFilters.getFilterList();
-		self.doRow(0, self.THREADS, self.loadId);
-	}
-	
-	this.doRow = function(row, threads, curLoadId) {
-		if (self.loadId != curLoadId) return;
-		var tr = $("tr[index="+row+"]");
-		if (!tr.is("*")){
-			return; 
-		}
-			
-		var cid = tr.attr("cid");
-		$.ajax({
-			url: "/rest/filtered-collections/"+cid,
-			data: {
-				limit : self.COUNT_LIMIT,
-				filters : self.myFilters.filterString,
-			},
-			dataType: "json",
-			headers: self.myAuth.getHeaders(),
-			success: function(data) {
-				var numItems = data.numberItems;
-				var numItemsProcessed = data.numberItemsProcessed;
-				$.each(data.itemFilters, function(index, itemFilter){
-					if (self.loadId != curLoadId) {
-						return;
-					}
-					var trh = $("#table tr.header");
-					var filterName = itemFilter["filter-name"];
-					var filterTitle = itemFilter.title == null ? filterName : itemFilter.title;
-					if (!trh.find("th."+filterName).is("*")) {
-						var th = self.myHtmlUtil.addTh(trh, filterTitle);
-						th.addClass(filterName).addClass("datacol").addClass("sorttable_numeric");
-						self.myHtmlUtil.makeTotalCol(th);
-						
-						if (itemFilter.description != null) {
-							th.attr("title", itemFilter.description);											
-						}
-
-						$("tr.data").each(function(){
-							var td = self.myHtmlUtil.addTd($(this), "");
-							td.addClass(filterName).addClass("num").addClass("datacol");
-						});
-					}
-					
-					self.setCellCount(tr, cid, 0, (numItems != numItemsProcessed), itemFilter);
-					self.setFilteredCount(tr, cid, 0, numItems, numItemsProcessed);
-				});
-				
-				tr.removeClass("processing");
-				if (!$("#table tr.processing").is("*")) {
-					self.updateSortable();
-					self.totalFilters();
-					self.spinner.stop();
-	  	  		    $(".showCollections").attr("disabled", false);
-					return;
+        $.ajax({
+            url: "/rest/filtered-collections",
+            data: {
+                limit  : self.COLL_LIMIT,
+                offset : offset
+             },
+            dataType: "json",
+            headers: self.myAuth.getHeaders(),
+            success: function(data){
+                $.each(data, function(index, coll){
+                    var id = self.getId(coll);
+                    var tr = $("#table tbody").find("tr[cid="+id+"]");
+                    var td = tr.find("td.numCount");
+                    td.text(coll.numberItems);
+                    td.on("click", function(){
+                        self.drawItemTable(self.getId(coll),'',0);
+                        $("#icollection").val(self.getId(coll));
+                        $("#ifilter").val("");
+                    });
+                });
+                
+                //cannot assume data returned is full amount in case some items are restricted
+                //if (data.length == self.COLL_LIMIT) {
+                if (data.length > 0) {
+                    self.setCollectionCounts(offset + self.COLL_LIMIT);
+                    return;
+                }  
+                self.myHtmlUtil.totalCol(3);
+                $("#table").addClass("sortable");
+                  
+                  if (self.myFilters.getFilterList() != "") {
+                      self.loadData();
+                      if ($("#icollection").val() != "") {
+                          self.drawItemTable($("#icollection").val(), $("#ifilter").val(), 0);
+                      }
+                  }
+            },
+            error: function(xhr, status, errorThrown) {
+                alert("Error in /rest/collections "+ status+ " " + errorThrown);
+            },
+            complete: function(xhr, status) {
+                self.spinner.stop();
+                  $(".showCollections").attr("disabled", false);
+            }
+        });    
+    }
+    
+    this.loadData = function() {
+        self.spinner.spin($("h1")[0]);
+        $(".showCollections").attr("disabled", true);
+        $("#metadatadiv").accordion("option", "active", self.ACCIDX_COLL);
+        self.loadId++;
+        $("td.datacol,th.datacol").remove();
+        $("#table tr.data").addClass("processing");
+        self.myFilters.filterString = self.myFilters.getFilterList();
+        self.doRow(0, self.THREADS, self.loadId);
+    }
+    
+    this.doRow = function(row, threads, curLoadId) {
+        if (self.loadId != curLoadId) return;
+        var tr = $("tr[index="+row+"]");
+        if (!tr.is("*")){
+            return; 
+        }
+            
+        var cid = tr.attr("cid");
+        $.ajax({
+            url: "/rest/filtered-collections/"+cid,
+            data: {
+                limit : self.COUNT_LIMIT,
+                filters : self.myFilters.filterString,
+            },
+            dataType: "json",
+            headers: self.myAuth.getHeaders(),
+            success: function(data) {
+                var numItems = data.numberItems;
+                var numItemsProcessed = data.numberItemsProcessed;
+                $.each(data.itemFilters, function(index, itemFilter){
+                    if (self.loadId != curLoadId) {
+                        return;
                     }
-				if (row % threads == 0 || threads == 1) {
-					for(var i=1; i<=threads; i++) {
-						self.doRow(row+i, threads, curLoadId);
-					}					
-						}
-	 		},
-			error: function(xhr, status, errorThrown) {
-				alert("Error in /rest/filtered-collections "+ status+ " " + errorThrown);
-			},
-			complete: function(xhr, status) {
-				self.spinner.stop();
-		  		$(".showCollections").attr("disabled", false);
-					}
-					
-					
-				});
-	};			
-				
-	this.updateSortable = function() {
-					if (self.hasSorttable()) {
-						$("#table").removeClass("sortable");
-						$("#table").addClass("sortable");
-						sorttable.makeSortable($("#table")[0]);						
-					}
-	}
-	
-	this.totalFilters = function() {
-					var colcount = $("#table tr th").length;
-					for(var i=4; i<colcount; i++) {
-						self.myHtmlUtil.totalCol(i);
-					}
-				}
+                    var trh = $("#table tr.header");
+                    var filterName = itemFilter["filter-name"];
+                    var filterTitle = itemFilter.title == null ? filterName : itemFilter.title;
+                    if (!trh.find("th."+filterName).is("*")) {
+                        var th = self.myHtmlUtil.addTh(trh, filterTitle);
+                        th.addClass(filterName).addClass("datacol").addClass("sorttable_numeric");
+                        self.myHtmlUtil.makeTotalCol(th);
+                        
+                        if (itemFilter.description != null) {
+                            th.attr("title", itemFilter.description);                                            
+                        }
 
-	this.updateRow = function(cid, offset) {
-		var tr = $("tr[cid="+cid+"]");
-		$.ajax({
-			url: "/rest/filtered-collections/"+cid,
-			data: {
-				limit : self.COUNT_LIMIT,
-				offset : offset,
-				filters : self.myFilters.filterString,
-			},
-			dataType: "json",
-			headers: self.myAuth.getHeaders(),
-			success: function(data) {
-				var numItems = data.numberItems;
-				var numItemsProcessed = data.numberItemsProcessed;
-				$.each(data.itemFilters, function(index, itemFilter){
-					self.setCellCount(tr, cid, offset, (numItems != numItemsProcessed + offset),itemFilter);
-				});
-				self.setFilteredCount(tr, cid, offset, numItems, numItemsProcessed);				
-	 		},
-			error: function(xhr, status, errorThrown) {
-				alert("Error in /rest/filtered-collections/ " + cid+ status+ " " + errorThrown);
-			},
-			complete: function(xhr, status) {
-				self.spinner.stop();
-		  		$(".showCollections").attr("disabled", false);
-			}
-		});
-	};			
+                        $("tr.data").each(function(){
+                            var td = self.myHtmlUtil.addTd($(this), "");
+                            td.addClass(filterName).addClass("num").addClass("datacol");
+                        });
+                    }
+                    
+                    self.setCellCount(tr, cid, 0, (numItems != numItemsProcessed), itemFilter);
+                    self.setFilteredCount(tr, cid, 0, numItems, numItemsProcessed);
+                });
+                
+                tr.removeClass("processing");
+                if (!$("#table tr.processing").is("*")) {
+                    self.updateSortable();
+                    self.totalFilters();
+                    self.spinner.stop();
+                        $(".showCollections").attr("disabled", false);
+                    return;
+                }
+                if (row % threads == 0 || threads == 1) {
+                    for(var i=1; i<=threads; i++) {
+                        self.doRow(row+i, threads, curLoadId);
+                    }                    
+                }
+             },
+            error: function(xhr, status, errorThrown) {
+                alert("Error in /rest/filtered-collections "+ status+ " " + errorThrown);
+            },
+            complete: function(xhr, status) {
+                self.spinner.stop();
+                $(".showCollections").attr("disabled", false);
+            }
+        });
+    };            
+                
+    this.updateSortable = function() {
+                    if (self.hasSorttable()) {
+                        $("#table").removeClass("sortable");
+                        $("#table").addClass("sortable");
+                        sorttable.makeSortable($("#table")[0]);                        
+                    }
+    }
+    
+    this.totalFilters = function() {
+                    var colcount = $("#table tr th").length;
+                    for(var i=4; i<colcount; i++) {
+                        self.myHtmlUtil.totalCol(i);
+                    }
+                }
 
-	this.setFilteredCount = function(tr, cid, offset, numItems, numItemsProcessed) {
+    this.updateRow = function(cid, offset) {
+        var tr = $("tr[cid="+cid+"]");
+        $.ajax({
+            url: "/rest/filtered-collections/"+cid,
+            data: {
+                limit : self.COUNT_LIMIT,
+                offset : offset,
+                filters : self.myFilters.filterString,
+            },
+            dataType: "json",
+            headers: self.myAuth.getHeaders(),
+            success: function(data) {
+                var numItems = data.numberItems;
+                var numItemsProcessed = data.numberItemsProcessed;
+                $.each(data.itemFilters, function(index, itemFilter){
+                    self.setCellCount(tr, cid, offset, (numItems != numItemsProcessed + offset),itemFilter);
+                });
+                self.setFilteredCount(tr, cid, offset, numItems, numItemsProcessed);                
+             },
+            error: function(xhr, status, errorThrown) {
+                alert("Error in /rest/filtered-collections/ " + cid+ status+ " " + errorThrown);
+            },
+            complete: function(xhr, status) {
+                self.spinner.stop();
+                  $(".showCollections").attr("disabled", false);
+            }
+        });
+    };            
+
+    this.setFilteredCount = function(tr, cid, offset, numItems, numItemsProcessed) {
         var td = tr.find("td.numFiltered");
         var total = numItemsProcessed + offset; 
         td.text(total);
         td.removeClass("partial");
         td.removeClass("toobig");
         if (numItems != numItemsProcessed + offset) {
-        	if (offset == 0) {
+            if (offset == 0) {
                 td.addClass("button");
-				td.off();
-    			td.on("click", function(){
-    				if ($(this).hasClass("toobig")) {
-    					if (!confirm("A large number of items are present in this collection.\n\n" + 
-    							"If you choose to load this data, it will take some time to load and may impact server performance.")) {
-    						return;
-    					}
-    				}
-    				$(this).off();
-    				$(this).removeClass("button");
-    				self.updateRow(cid, offset + self.COUNT_LIMIT);
-    			});							        		
-        	} else {
-        		self.updateRow(cid, offset + self.COUNT_LIMIT);
-        	}
+                td.off();
+                td.on("click", function(){
+                    if ($(this).hasClass("toobig")) {
+                        if (!confirm("A large number of items are present in this collection.\n\n" + 
+                                "If you choose to load this data, it will take some time to load and may impact server performance.")) {
+                            return;
+                        }
+                    }
+                    $(this).off();
+                    $(this).removeClass("button");
+                    self.updateRow(cid, offset + self.COUNT_LIMIT);
+                });                                            
+            } else {
+                self.updateRow(cid, offset + self.COUNT_LIMIT);
+            }
             td.addClass("partial");
             var title = "Collection partially processed, item counts are incomplete. ";
             if (numItems >= self.TOOBIG) {
                 td.addClass("toobig");
                 title+= "\nIt will take significant time to apply this filter to the entire collection."
-	}			
+            }            
             td.attr("title", title);
             return false;
         } else {
-			self.totalFilters();
+            self.totalFilters();
         }
         return true;
     }
-	
-	this.setCellCount = function(tr, cid, offset, isPartial, itemFilter) {
-		var filterName = itemFilter["filter-name"];
-		var icount = itemFilter["item-count"];
+    
+    this.setCellCount = function(tr, cid, offset, isPartial, itemFilter) {
+        var filterName = itemFilter["filter-name"];
+        var icount = itemFilter["item-count"];
 
-		var td = tr.find("td."+filterName);
+        var td = tr.find("td."+filterName);
         if (icount == null) {
-        	icount = 0;
+            icount = 0;
         }
         var cur = parseInt(td.text());
         if (!isNaN(cur)) {
-            icount += cur;        	
+            icount += cur;            
         }
         
         td.removeClass("partial");
@@ -368,113 +367,113 @@ var CollReport = function() {
         td.removeAttr("title");
         td.off();
         td.text(icount);
-		if (icount != 0) {
-			td.addClass("link");
-			if (isPartial) {
-				td.addClass("partial");
-				td.attr("title", "Collection partially processed, item counts are incomplete");
-			}	
-			td.on("click", function(){
-				self.drawItemTable(cid,filterName,0);
-				$("#icollection").val(cid);
-				$("#ifilter").val(filterName);
-			});							
-		}		
-	}
-	
-				
-	this.drawItemTable = function(cid, filter, offset) {
-		self = this;
-		self.spinner.spin($("h1")[0]);
-		$("#itemtable").replaceWith($('<table id="itemtable" class="sortable"></table>'));
-		var itbl = $("#itemtable");
-		//itbl.find("tr").remove("*");
-		var tr = self.myHtmlUtil.addTr(itbl).addClass("header");
-		self.myHtmlUtil.addTh(tr, "Num").addClass("num").addClass("sorttable_numeric");
-		self.myHtmlUtil.addTh(tr, "id");
-		self.myHtmlUtil.addTh(tr, "Handle");
-		self.myHtmlUtil.addTh(tr, "dc.title"  + self.getLangSuffix()).addClass("title");
-		var fields = $("#show-fields select").val();
-		if (fields != null) {
-			$.each(fields, function(index, field){
-				self.myHtmlUtil.addTh(tr, field + self.getLangSuffix());		
-			});		
-		}
+        if (icount != 0) {
+            td.addClass("link");
+            if (isPartial) {
+                td.addClass("partial");
+                td.attr("title", "Collection partially processed, item counts are incomplete");
+            }    
+            td.on("click", function(){
+                self.drawItemTable(cid,filterName,0);
+                $("#icollection").val(cid);
+                $("#ifilter").val(filterName);
+            });                            
+        }        
+    }
+    
+                
+    this.drawItemTable = function(cid, filter, offset) {
+        self = this;
+        self.spinner.spin($("h1")[0]);
+        $("#itemtable").replaceWith($('<table id="itemtable" class="sortable"></table>'));
+        var itbl = $("#itemtable");
+        //itbl.find("tr").remove("*");
+        var tr = self.myHtmlUtil.addTr(itbl).addClass("header");
+        self.myHtmlUtil.addTh(tr, "Num").addClass("num").addClass("sorttable_numeric");
+        self.myHtmlUtil.addTh(tr, "id");
+        self.myHtmlUtil.addTh(tr, "Handle");
+        self.myHtmlUtil.addTh(tr, "dc.title"  + self.getLangSuffix()).addClass("title");
+        var fields = $("#show-fields select").val();
+        if (fields != null) {
+            $.each(fields, function(index, field){
+                self.myHtmlUtil.addTh(tr, field + self.getLangSuffix());        
+            });        
+        }
 
-		var params = {
-			expand: fields == null ? "items" : "items,metadata",
-			limit: self.ITEM_LIMIT,
-			filters: filter,
-			offset: offset,
-			"show_fields[]" : fields,
-		}
-		
-		$.ajax({
-			url: "/rest/filtered-collections/"+cid,
-			data: params,
-			dataType: "json",
-			headers: self.myAuth.getHeaders(),
-			success: function(data){
-				var source = filter == "" ? data.items : data.itemFilters[0].items;
-				
-				$.each(source, function(index, item){
-					var tr = self.myHtmlUtil.addTr(itbl);
-					tr.addClass(index % 2 == 0 ? "odd data" : "even data");
-					self.myHtmlUtil.addTd(tr, offset+index+1).addClass("num");
-					self.myHtmlUtil.addTd(tr, self.getId(item));
-					self.myHtmlUtil.addTdAnchor(tr, item.handle, self.ROOTPATH + item.handle);
-					self.myHtmlUtil.addTd(tr, item.name).addClass("ititle");
-					if (fields != null) {
-						$.each(fields, function(index, field){
-							var text = "";		
-							$.each(item.metadata, function(mindex,mv){
-								if (mv.key == field) {
-									if (text != "") {
-										text += "<hr/>";
-									}
-									text += mv.value;
-								}
-							});
-							self.myHtmlUtil.addTd(tr, text);
-						});		
-					}
-				});
-				self.displayItems(filter + " Items in " + data.name, 
-					offset,
-					self.ITEM_LIMIT,
-					data.numberItems,
-					function(){self.drawItemTable(cid, filter, (offset - self.ITEM_LIMIT < 0) ? 0 : offset - self.ITEM_LIMIT);},
-					function(){self.drawItemTable(cid, filter, offset + self.ITEM_LIMIT);}
-				);
-				
-				if (self.hasSorttable()){
-					sorttable.makeSortable(itbl[0]);					
-				}
-				$("#metadatadiv").accordion("option", "active", self.ACCIDX_ITEM); 
-			},
-			error: function(xhr, status, errorThrown) {
-				alert("Error in /rest/filtered-collections "+ status+ " " + errorThrown);
-			},
-			complete: function(xhr, status) {
-				self.spinner.stop();
-	  			$(".showCollections").attr("disabled", false);
-			}
-		});
-	}
+        var params = {
+            expand: fields == null ? "items" : "items,metadata",
+            limit: self.ITEM_LIMIT,
+            filters: filter,
+            offset: offset,
+            "show_fields[]" : fields,
+        }
+        
+        $.ajax({
+            url: "/rest/filtered-collections/"+cid,
+            data: params,
+            dataType: "json",
+            headers: self.myAuth.getHeaders(),
+            success: function(data){
+                var source = filter == "" ? data.items : data.itemFilters[0].items;
+                
+                $.each(source, function(index, item){
+                    var tr = self.myHtmlUtil.addTr(itbl);
+                    tr.addClass(index % 2 == 0 ? "odd data" : "even data");
+                    self.myHtmlUtil.addTd(tr, offset+index+1).addClass("num");
+                    self.myHtmlUtil.addTd(tr, self.getId(item));
+                    self.myHtmlUtil.addTdAnchor(tr, item.handle, self.ROOTPATH + item.handle);
+                    self.myHtmlUtil.addTd(tr, item.name).addClass("ititle");
+                    if (fields != null) {
+                        $.each(fields, function(index, field){
+                            var text = "";        
+                            $.each(item.metadata, function(mindex,mv){
+                                if (mv.key == field) {
+                                    if (text != "") {
+                                        text += "<hr/>";
+                                    }
+                                    text += mv.value;
+                                }
+                            });
+                            self.myHtmlUtil.addTd(tr, text);
+                        });        
+                    }
+                });
+                self.displayItems(filter + " Items in " + data.name, 
+                    offset,
+                    self.ITEM_LIMIT,
+                    data.numberItems,
+                    function(){self.drawItemTable(cid, filter, (offset - self.ITEM_LIMIT < 0) ? 0 : offset - self.ITEM_LIMIT);},
+                    function(){self.drawItemTable(cid, filter, offset + self.ITEM_LIMIT);}
+                );
+                
+                if (self.hasSorttable()){
+                    sorttable.makeSortable(itbl[0]);                    
+                }
+                $("#metadatadiv").accordion("option", "active", self.ACCIDX_ITEM); 
+            },
+            error: function(xhr, status, errorThrown) {
+                alert("Error in /rest/filtered-collections "+ status+ " " + errorThrown);
+            },
+            complete: function(xhr, status) {
+                self.spinner.stop();
+                  $(".showCollections").attr("disabled", false);
+            }
+        });
+    }
 
-	//Ignore the first column containing a row number and the item handle
-	this.exportCol = function(colnum, col) {
-		var data = "";
-		if (colnum == 0) return "";
-		if (colnum == 2) return "";
-		data += (colnum == 1) ? "" : ",";
-		data += self.exportCell(col);
-		return data;
-	}
+    //Ignore the first column containing a row number and the item handle
+    this.exportCol = function(colnum, col) {
+        var data = "";
+        if (colnum == 0) return "";
+        if (colnum == 2) return "";
+        data += (colnum == 1) ? "" : ",";
+        data += self.exportCell(col);
+        return data;
+    }
 }
 CollReport.prototype = Object.create(Report.prototype);
 
 $(document).ready(function(){
-	var myReport=new CollReport();
-	myReport.init();
+    var myReport=new CollReport();
+    myReport.init();
 });

--- a/dspace-rest/src/main/webapp/static/reports/restQueryReport.js
+++ b/dspace-rest/src/main/webapp/static/reports/restQueryReport.js
@@ -6,318 +6,318 @@
  * http://www.dspace.org/license/
  */
 var QueryReport = function() {
-	Report.call(this);
-	
-	//If sortable.js is included, uncomment the following
-	//this.hasSorttable = function(){return true;}
-	
-	this.getDefaultParameters = function(){
-		return {
-			"collSel[]"     : [],
-			"query_field[]" : [],
-			"query_op[]"    : [],
-			"query_val[]"   : [],
-			"show_fields[]" : [],
-			"filters"       : "",
-			"limit"         : this.ITEM_LIMIT,
-			"offset"        : 0,		  
-	    };
-	}
-	this.getCurrentParameters = function(){
-		var params = {
-			"query_field[]" : [],
-			"query_op[]"    : [],
-			"query_val[]"   : [],
-			"collSel[]"     : ($("#collSel").val() == null) ? [""] : $("#collSel").val(),
-			limit           : this.myReportParameters.getLimit(),
-			offset          : this.myReportParameters.getOffset(),
-			"expand"        : "parentCollection,metadata",
-			filters         : this.myFilters.getFilterList(),
-			"show_fields[]" : this.myMetadataFields.getShowFields(),
-	    };
-		$("select.query-tool,input.query-tool").each(function() {
-			var paramArr = params[$(this).attr("name")];
-			paramArr[paramArr.length] = $(this).val();
-		});
-		return params;
-	}
-	var self = this;
+    Report.call(this);
+    
+    //If sortable.js is included, uncomment the following
+    //this.hasSorttable = function(){return true;}
+    
+    this.getDefaultParameters = function(){
+        return {
+            "collSel[]"     : [],
+            "query_field[]" : [],
+            "query_op[]"    : [],
+            "query_val[]"   : [],
+            "show_fields[]" : [],
+            "filters"       : "",
+            "limit"         : this.ITEM_LIMIT,
+            "offset"        : 0,          
+        };
+    }
+    this.getCurrentParameters = function(){
+        var params = {
+            "query_field[]" : [],
+            "query_op[]"    : [],
+            "query_val[]"   : [],
+            "collSel[]"     : ($("#collSel").val() == null) ? [""] : $("#collSel").val(),
+            limit           : this.myReportParameters.getLimit(),
+            offset          : this.myReportParameters.getOffset(),
+            "expand"        : "parentCollection,metadata",
+            filters         : this.myFilters.getFilterList(),
+            "show_fields[]" : this.myMetadataFields.getShowFields(),
+        };
+        $("select.query-tool,input.query-tool").each(function() {
+            var paramArr = params[$(this).attr("name")];
+            paramArr[paramArr.length] = $(this).val();
+        });
+        return params;
+    }
+    var self = this;
 
-	this.init = function() {
-	    this.baseInit();	
-		var communitySelector = new CommunitySelector(this, $("#collSelector"), this.myReportParameters.params["collSel[]"]);
-	}
-	
-	this.initMetadataFields = function() {
-		this.myMetadataFields = new QueryableMetadataFields(self);
-	    this.myMetadataFields.load();		
-	}
-	this.myAuth.callback = function(data) {
-		$(".query-button").click(function(){self.runQuery();})
-	}
+    this.init = function() {
+        this.baseInit();    
+    }
+    
+    this.initMetadataFields = function() {
+        this.myMetadataFields = new QueryableMetadataFields(self);
+        this.myMetadataFields.load();        
+    }
+    this.myAuth.callback = function(data) {
+        var communitySelector = new CommunitySelector(self, $("#collSelector"), self.myReportParameters.params["collSel[]"]);
+        $(".query-button").click(function(){self.runQuery();})
+    }
 
-	this.runQuery = function() {
-		this.spinner.spin($("body")[0]);
-		$("button").attr("disabled", true);
-		$.ajax({
-			url: "/rest/filtered-items", 
-			data: this.getCurrentParameters(), 
-			dataType: "json",
-			headers: self.myAuth.getHeaders(),
-			success: function(data){
-			    data.metadata = $("#show-fields select").val();
-			    self.drawItemFilterTable(data);
-			    self.spinner.stop();
-	  		    $("button").not("#next,#prev").attr("disabled", false);
-			},
-			error: function(xhr, status, errorThrown) {
-				alert("Error in /rest/filtered-items "+ status+ " " + errorThrown);
-			},
-			complete: function(xhr, status, errorThrown) {
-			    self.spinner.stop();
-	  		    $("button").not("#next,#prev").attr("disabled", false);
-			}
-		});
-	}
-	
-	this.drawItemFilterTable = function(data) {
-		$("#itemtable").replaceWith($('<table id="itemtable" class="sortable"></table>'));
-		var itbl = $("#itemtable");
-		var tr = self.myHtmlUtil.addTr(itbl).addClass("header");
-		self.myHtmlUtil.addTh(tr, "Num").addClass("num").addClass("sorttable_numeric");
-		self.myHtmlUtil.addTh(tr, "id");
-		self.myHtmlUtil.addTh(tr, "collection");
-		self.myHtmlUtil.addTh(tr, "Item Handle");
-		self.myHtmlUtil.addTh(tr, "dc.title" + self.getLangSuffix());
-		
-		var mdCols = [];
-		if (data.metadata) {
-			$.each(data.metadata, function(index, field) {
-				if (field != "") {
-					self.myHtmlUtil.addTh(tr,field + self.getLangSuffix()).addClass("returnFields");
-					mdCols[mdCols.length] = field;			
-				}
-			});			
-		}
-		
-		$.each(data.items, function(index, item){
-			var tr = self.myHtmlUtil.addTr(itbl);
-			tr.addClass(index % 2 == 0 ? "odd data" : "even data");
-			self.myHtmlUtil.addTd(tr, self.myReportParameters.getOffset()+index+1).addClass("num");
-			self.myHtmlUtil.addTd(tr, self.getId(item));
-			if (item.parentCollection == null) {
-				self.myHtmlUtil.addTd(tr, "--");			
-			} else {
-				self.myHtmlUtil.addTdAnchor(tr, item.parentCollection.name, self.ROOTPATH + item.parentCollection.handle);
-			}
-			self.myHtmlUtil.addTdAnchor(tr, item.handle, self.ROOTPATH + item.handle);
-			self.myHtmlUtil.addTd(tr, item.name);
-			
-			for(var i=0; i<mdCols.length; i++) {
-				var key =  mdCols[i];
-				var td = self.myHtmlUtil.addTd(tr, "");
-				$.each(item.metadata, function(colindex, metadata) {
-					if (metadata.key == key) {
-						if (metadata.value != null) {
-							var div = $("<div>"+metadata.value+"</div>");
-							td.append(div);
-						}
-					}
-				});
-			}
-		});
-		
-		this.displayItems(data["query-annotation"],
-			this.myReportParameters.getOffset(),
-			this.myReportParameters.getLimit(),
-			data["unfiltered-item-count"],
-			function(){
-			    self.myReportParameters.updateOffset(false);
-			    self.runQuery();
-			}, 
-			function(){
-				self.myReportParameters.updateOffset(true);
-			    self.runQuery();
-			}
-		);
-		
-		if (this.hasSorttable()) {
-			sorttable.makeSortable(itbl[0]);			
-		}
-		$("#metadatadiv").accordion("option", "active", $("#metadatadiv > h3").length - 1); 
-	}
-	
-	//Ignore the first column containing a row number and the item handle, get handle for the collection
-	this.exportCol = function(colnum, col) {
-		var data = "";
-		if (colnum == 0) return "";
-		if (colnum == 3) return "";
-		data += (colnum == 1) ? "" : ",";
-		
-		if (colnum == 2) {
-			var anchor = $(col).find("a");
-			var href = anchor.is("a") ? anchor.attr("href").replace(self.ROOTPATH,"") : $(col).text();
-			data += "\"" + href + "\"";
-		} else {
-			data += self.exportCell(col);		}
-		return data;
-	}
+    this.runQuery = function() {
+        this.spinner.spin($("body")[0]);
+        $("button").attr("disabled", true);
+        $.ajax({
+            url: "/rest/filtered-items", 
+            data: this.getCurrentParameters(), 
+            dataType: "json",
+            headers: self.myAuth.getHeaders(),
+            success: function(data){
+                data.metadata = $("#show-fields select").val();
+                self.drawItemFilterTable(data);
+                self.spinner.stop();
+                  $("button").not("#next,#prev").attr("disabled", false);
+            },
+            error: function(xhr, status, errorThrown) {
+                alert("Error in /rest/filtered-items "+ status+ " " + errorThrown);
+            },
+            complete: function(xhr, status, errorThrown) {
+                self.spinner.stop();
+                  $("button").not("#next,#prev").attr("disabled", false);
+            }
+        });
+    }
+    
+    this.drawItemFilterTable = function(data) {
+        $("#itemtable").replaceWith($('<table id="itemtable" class="sortable"></table>'));
+        var itbl = $("#itemtable");
+        var tr = self.myHtmlUtil.addTr(itbl).addClass("header");
+        self.myHtmlUtil.addTh(tr, "Num").addClass("num").addClass("sorttable_numeric");
+        self.myHtmlUtil.addTh(tr, "id");
+        self.myHtmlUtil.addTh(tr, "collection");
+        self.myHtmlUtil.addTh(tr, "Item Handle");
+        self.myHtmlUtil.addTh(tr, "dc.title" + self.getLangSuffix());
+        
+        var mdCols = [];
+        if (data.metadata) {
+            $.each(data.metadata, function(index, field) {
+                if (field != "") {
+                    self.myHtmlUtil.addTh(tr,field + self.getLangSuffix()).addClass("returnFields");
+                    mdCols[mdCols.length] = field;            
+                }
+            });            
+        }
+        
+        $.each(data.items, function(index, item){
+            var tr = self.myHtmlUtil.addTr(itbl);
+            tr.addClass(index % 2 == 0 ? "odd data" : "even data");
+            self.myHtmlUtil.addTd(tr, self.myReportParameters.getOffset()+index+1).addClass("num");
+            self.myHtmlUtil.addTd(tr, self.getId(item));
+            if (item.parentCollection == null) {
+                self.myHtmlUtil.addTd(tr, "--");            
+            } else {
+                self.myHtmlUtil.addTdAnchor(tr, item.parentCollection.name, self.ROOTPATH + item.parentCollection.handle);
+            }
+            self.myHtmlUtil.addTdAnchor(tr, item.handle, self.ROOTPATH + item.handle);
+            self.myHtmlUtil.addTd(tr, item.name);
+            
+            for(var i=0; i<mdCols.length; i++) {
+                var key =  mdCols[i];
+                var td = self.myHtmlUtil.addTd(tr, "");
+                $.each(item.metadata, function(colindex, metadata) {
+                    if (metadata.key == key) {
+                        if (metadata.value != null) {
+                            var div = $("<div>"+metadata.value+"</div>");
+                            td.append(div);
+                        }
+                    }
+                });
+            }
+        });
+        
+        this.displayItems(data["query-annotation"],
+            this.myReportParameters.getOffset(),
+            this.myReportParameters.getLimit(),
+            data["unfiltered-item-count"],
+            function(){
+                self.myReportParameters.updateOffset(false);
+                self.runQuery();
+            }, 
+            function(){
+                self.myReportParameters.updateOffset(true);
+                self.runQuery();
+            }
+        );
+        
+        if (this.hasSorttable()) {
+            sorttable.makeSortable(itbl[0]);            
+        }
+        $("#metadatadiv").accordion("option", "active", $("#metadatadiv > h3").length - 1); 
+    }
+    
+    //Ignore the first column containing a row number and the item handle, get handle for the collection
+    this.exportCol = function(colnum, col) {
+        var data = "";
+        if (colnum == 0) return "";
+        if (colnum == 3) return "";
+        data += (colnum == 1) ? "" : ",";
+        
+        if (colnum == 2) {
+            var anchor = $(col).find("a");
+            var href = anchor.is("a") ? anchor.attr("href").replace(self.ROOTPATH,"") : $(col).text();
+            data += "\"" + href + "\"";
+        } else {
+            data += self.exportCell(col);        }
+        return data;
+    }
 }
 QueryReport.prototype = Object.create(Report.prototype);
 
 $(document).ready(function(){
-	var myReport=new QueryReport();
-	myReport.init();
+    var myReport=new QueryReport();
+    myReport.init();
 });
 
 var QueryableMetadataFields = function(report) {
-	MetadataFields.call(this, report);
+    MetadataFields.call(this, report);
     var self = this;
-	
-	this.initFields = function(data, report) {
-		self.metadataSchemas = data;
-		var params = report.myReportParameters.params;
-	    var fields = params["query_field[]"];
-	    var ops = params["query_op[]"];
-	    var vals = params["query_val[]"];
-	    if (fields && ops && vals) {
-		    if (fields.length == 0) {
-				self.drawFilterQuery("*","exists","");
-		    } else {
-		    	for(var i=0; i<fields.length; i++) {
-		    		var op = ops.length > i ? ops[i] : "";
-		    		var val = vals.length > i ? vals[i] : "";
-					self.drawFilterQuery(fields[i],op,val);
-		    	} 
-		    }		    	
-	    }
-		self.drawShowFields(params["show_fields[]"]);
-		self.initQueries();		
-		report.spinner.stop();
-		$(".query-button").attr("disabled", false);
-	}
-	
-	this.initQueries = function() {
-		$("#predefselect")
-		  .append($("<option value='new'>New Query</option>"))
-		  .append($("<option value='q1'>Has No Title</option>"))
-		  .append($("<option value='q2'>Has No dc.identifier.uri</option>"))
-		  .append($("<option value='q3'>Has compound subject</option>"))
-		  .append($("<option value='q4'>Has compound dc.contributor.author</option>"))
-		  .append($("<option value='q5'>Has compound dc.creator</option>"))
-		  .append($("<option value='q6'>Has URL in dc.description</option>"))
-		  .append($("<option value='q7'>Has full text in dc.description.provenance</option>"))
-		  .append($("<option value='q8'>Has non-full text in dc.description.provenance</option>"))
-		  .append($("<option value='q9'>Has empty metadata</option>"))
-		  .append($("<option value='q10'>Has unbreaking metadata in description</option>"))
-		  .append($("<option value='q12'>Has XML entity in metadata</option>"))
-		  .append($("<option value='q13'>Has non-ascii character in metadata</option>"))
-	      .on("change",function(){
-			  $("div.metadata").remove();
-			  var val = $("#predefselect").val();
-			  if (val ==  'new') {
-				  self.drawFilterQuery("","","");			
-			  } else if (val ==  'q1') {
-				  self.drawFilterQuery("dc.title","doesnt_exist","");						
-			  } else if (val ==  'q2') {
-				  self.drawFilterQuery("dc.identifier.uri","doesnt_exist","");						
-			  } else if (val ==  'q3') {
-				  self.drawFilterQuery("dc.subject.*","like","%;%");						
-			  } else if (val ==  'q4') {
-				  self.drawFilterQuery("dc.contributor.author","like","% and %");						
-			  } else if (val ==  'q5') {
-				  self.drawFilterQuery("dc.creator","like","% and %");						
-			  } else if (val ==  'q6') {
-				  self.drawFilterQuery("dc.description","matches","^.*(http://|https://|mailto:).*$");						
-			  } else if (val ==  'q7') {
-				  self.drawFilterQuery("dc.description.provenance","matches","^.*No\\. of bitstreams(.|\\r|\\n|\\r\\n)*\\.(PDF|pdf|DOC|doc|PPT|ppt|DOCX|docx|PPTX|pptx).*$");						
-			  } else if (val ==  'q8') {
-				  self.drawFilterQuery("dc.description.provenance","doesnt_match","^.*No\\. of bitstreams(.|\\r|\\n|\\r\\n)*\\.(PDF|pdf|DOC|doc|PPT|ppt|DOCX|docx|PPTX|pptx).*$");						
-			  } else if (val ==  'q9') {
-				  self.drawFilterQuery("*","matches","^\\s*$");						
-			  } else if (val ==  'q10') {
-				  self.drawFilterQuery("dc.description.*","matches","^.*[^\\s]{50,}.*$");						
-			  } else if (val ==  'q12') {
-				  self.drawFilterQuery("*","matches","^.*&#.*$");						
-			  } else if (val ==  'q13') {
-				  self.drawFilterQuery("*","matches","^.*[^[:ascii:]].*$");						
-			  }
-		  });
-	}
+    
+    this.initFields = function(data, report) {
+        self.metadataSchemas = data;
+        var params = report.myReportParameters.params;
+        var fields = params["query_field[]"];
+        var ops = params["query_op[]"];
+        var vals = params["query_val[]"];
+        if (fields && ops && vals) {
+            if (fields.length == 0) {
+                self.drawFilterQuery("*","exists","");
+            } else {
+                for(var i=0; i<fields.length; i++) {
+                    var op = ops.length > i ? ops[i] : "";
+                    var val = vals.length > i ? vals[i] : "";
+                    self.drawFilterQuery(fields[i],op,val);
+                } 
+            }                
+        }
+        self.drawShowFields(params["show_fields[]"]);
+        self.initQueries();        
+        report.spinner.stop();
+        $(".query-button").attr("disabled", false);
+    }
+    
+    this.initQueries = function() {
+        $("#predefselect")
+          .append($("<option value='new'>New Query</option>"))
+          .append($("<option value='q1'>Has No Title</option>"))
+          .append($("<option value='q2'>Has No dc.identifier.uri</option>"))
+          .append($("<option value='q3'>Has compound subject</option>"))
+          .append($("<option value='q4'>Has compound dc.contributor.author</option>"))
+          .append($("<option value='q5'>Has compound dc.creator</option>"))
+          .append($("<option value='q6'>Has URL in dc.description</option>"))
+          .append($("<option value='q7'>Has full text in dc.description.provenance</option>"))
+          .append($("<option value='q8'>Has non-full text in dc.description.provenance</option>"))
+          .append($("<option value='q9'>Has empty metadata</option>"))
+          .append($("<option value='q10'>Has unbreaking metadata in description</option>"))
+          .append($("<option value='q12'>Has XML entity in metadata</option>"))
+          .append($("<option value='q13'>Has non-ascii character in metadata</option>"))
+          .on("change",function(){
+              $("div.metadata").remove();
+              var val = $("#predefselect").val();
+              if (val ==  'new') {
+                  self.drawFilterQuery("","","");            
+              } else if (val ==  'q1') {
+                  self.drawFilterQuery("dc.title","doesnt_exist","");                        
+              } else if (val ==  'q2') {
+                  self.drawFilterQuery("dc.identifier.uri","doesnt_exist","");                        
+              } else if (val ==  'q3') {
+                  self.drawFilterQuery("dc.subject.*","like","%;%");                        
+              } else if (val ==  'q4') {
+                  self.drawFilterQuery("dc.contributor.author","like","% and %");                        
+              } else if (val ==  'q5') {
+                  self.drawFilterQuery("dc.creator","like","% and %");                        
+              } else if (val ==  'q6') {
+                  self.drawFilterQuery("dc.description","matches","^.*(http://|https://|mailto:).*$");                        
+              } else if (val ==  'q7') {
+                  self.drawFilterQuery("dc.description.provenance","matches","^.*No\\. of bitstreams(.|\\r|\\n|\\r\\n)*\\.(PDF|pdf|DOC|doc|PPT|ppt|DOCX|docx|PPTX|pptx).*$");                        
+              } else if (val ==  'q8') {
+                  self.drawFilterQuery("dc.description.provenance","doesnt_match","^.*No\\. of bitstreams(.|\\r|\\n|\\r\\n)*\\.(PDF|pdf|DOC|doc|PPT|ppt|DOCX|docx|PPTX|pptx).*$");                        
+              } else if (val ==  'q9') {
+                  self.drawFilterQuery("*","matches","^\\s*$");                        
+              } else if (val ==  'q10') {
+                  self.drawFilterQuery("dc.description.*","matches","^.*[^\\s]{50,}.*$");                        
+              } else if (val ==  'q12') {
+                  self.drawFilterQuery("*","matches","^.*&#.*$");                        
+              } else if (val ==  'q13') {
+                  self.drawFilterQuery("*","matches","^.*[^[:ascii:]].*$");                        
+              }
+          });
+    }
 
-	this.drawFilterQuery = function(pField, pOp, pVal) {
-		var div = $("<div class='metadata'/>").appendTo("#queries");
-		var sel = $("<select class='query-tool' name='query_field[]'/>");
-		var opt = $("<option value='*'>Any Field</option>");
-		sel.append(opt);
-		$.each(self.metadataSchemas, function(index, schema){
-			if (schema.prefix == 'eperson') {
-				return;
-			}
-			$.each(schema.fields, function(findex, field) {
-				var name = field.name;
-				var parts = name.match(/^([^\.]+)\.([^\.]+)\.([^\.]+)$/);
-				if (parts == null) {
-					var wildname = name + ".*";
-					var opt = $("<option/>");
-					opt.attr("value",wildname).text(wildname);
-					sel.append(opt);				
-				}
-				var opt = $("<option/>");
-				opt.attr("value",name).text(name);
-				sel.append(opt);
-			});
-		});
-		sel.val(pField);
-		div.append(sel);
-		var opsel = $("<select class='query-tool' name='query_op[]'/>");
-		$("<option>exists</option>").val("exists").appendTo(opsel);
-		$("<option>does not exist</option>").val("doesnt_exist").appendTo(opsel);
-		$("<option selected>equals</option>").val("equals").appendTo(opsel);
-		$("<option>does not equal</option>").val("not_equals").appendTo(opsel);
-		$("<option>like</option>").val("like").appendTo(opsel);
-		$("<option>not like</option>").val("not_like").appendTo(opsel);
-		$("<option>contains</option>").val("contains").appendTo(opsel);
-		$("<option>does not contain</option>").val("doesnt_contain").appendTo(opsel);
-		$("<option>matches</option>").val("matches").appendTo(opsel);
-		$("<option>does not match</option>").val("doesnt_match").appendTo(opsel);
-		opsel.val(pOp);
-		opsel.change(function(){
-			self.valField($(this));
-		});
-		div.append(opsel);
-		var input = $("<input class='query-tool' name='query_val[]'/>");
-		div.append(input);
-		input.val(pVal);
-		self.valField(opsel);
-		$("<button class='field_plus'>+</button>").appendTo(div).click(function(){
-			self.drawFilterQuery();
-			self.queryButtons();
-		});
-		$("<button class='field_minus'>-</button>").appendTo(div).click(function(){
-			$(this).parent("div.metadata").remove();
-			self.queryButtons();
-		});
-		self.queryButtons();
-	}
+    this.drawFilterQuery = function(pField, pOp, pVal) {
+        var div = $("<div class='metadata'/>").appendTo("#queries");
+        var sel = $("<select class='query-tool' name='query_field[]'/>");
+        var opt = $("<option value='*'>Any Field</option>");
+        sel.append(opt);
+        $.each(self.metadataSchemas, function(index, schema){
+            if (schema.prefix == 'eperson') {
+                return;
+            }
+            $.each(schema.fields, function(findex, field) {
+                var name = field.name;
+                var parts = name.match(/^([^\.]+)\.([^\.]+)\.([^\.]+)$/);
+                if (parts == null) {
+                    var wildname = name + ".*";
+                    var opt = $("<option/>");
+                    opt.attr("value",wildname).text(wildname);
+                    sel.append(opt);                
+                }
+                var opt = $("<option/>");
+                opt.attr("value",name).text(name);
+                sel.append(opt);
+            });
+        });
+        sel.val(pField);
+        div.append(sel);
+        var opsel = $("<select class='query-tool' name='query_op[]'/>");
+        $("<option>exists</option>").val("exists").appendTo(opsel);
+        $("<option>does not exist</option>").val("doesnt_exist").appendTo(opsel);
+        $("<option selected>equals</option>").val("equals").appendTo(opsel);
+        $("<option>does not equal</option>").val("not_equals").appendTo(opsel);
+        $("<option>like</option>").val("like").appendTo(opsel);
+        $("<option>not like</option>").val("not_like").appendTo(opsel);
+        $("<option>contains</option>").val("contains").appendTo(opsel);
+        $("<option>does not contain</option>").val("doesnt_contain").appendTo(opsel);
+        $("<option>matches</option>").val("matches").appendTo(opsel);
+        $("<option>does not match</option>").val("doesnt_match").appendTo(opsel);
+        opsel.val(pOp);
+        opsel.change(function(){
+            self.valField($(this));
+        });
+        div.append(opsel);
+        var input = $("<input class='query-tool' name='query_val[]'/>");
+        div.append(input);
+        input.val(pVal);
+        self.valField(opsel);
+        $("<button class='field_plus'>+</button>").appendTo(div).click(function(){
+            self.drawFilterQuery();
+            self.queryButtons();
+        });
+        $("<button class='field_minus'>-</button>").appendTo(div).click(function(){
+            $(this).parent("div.metadata").remove();
+            self.queryButtons();
+        });
+        self.queryButtons();
+    }
 
-	this.valField = function(valop) {
-		var val = valop.val();
-		var disableval = (val == "exists" || val == "not_exists");
-		var valinput = valop.parent("div.metadata").find("input[name='query_val[]']");
-		valinput.attr("readonly",disableval);
-		if (disableval) {
-			valinput.val("");		
-		}
-	}
+    this.valField = function(valop) {
+        var val = valop.val();
+        var disableval = (val == "exists" || val == "not_exists");
+        var valinput = valop.parent("div.metadata").find("input[name='query_val[]']");
+        valinput.attr("readonly",disableval);
+        if (disableval) {
+            valinput.val("");        
+        }
+    }
 
-	this.queryButtons = function() {
-		$("button.field_plus").attr("disabled",true);
-		$("button.field_plus:last").attr("disabled",false);
-		$("button.field_minus").attr("disabled",false);
-		if ($("button.field_minus").length == 1) {
-			$("button.field_minus").attr("disabled",true);				
-		}
-	}
+    this.queryButtons = function() {
+        $("button.field_plus").attr("disabled",true);
+        $("button.field_plus:last").attr("disabled",false);
+        $("button.field_minus").attr("disabled",false);
+        if ($("button.field_minus").length == 1) {
+            $("button.field_minus").attr("disabled",true);                
+        }
+    }
 }
 QueryableMetadataFields.prototype = Object.create(MetadataFields.prototype);

--- a/dspace-rest/src/main/webapp/static/reports/restReport.js
+++ b/dspace-rest/src/main/webapp/static/reports/restReport.js
@@ -6,49 +6,63 @@
  * http://www.dspace.org/license/
  */
 var Report = function() {
-	var self = this;
-	this.COLL_LIMIT = 500;
-	this.COUNT_LIMIT = 500;
-	this.ITEM_LIMIT = 100;
-        this.ROOTPATH = "/xmlui/handle/"
-        //this.ROOTPATH = "/jspui/handle/"
-	//this.ROOTPATH = "/handle/"
+    var self = this;
+    this.COLL_LIMIT = 500;
+    this.COUNT_LIMIT = 500;
+    this.ITEM_LIMIT = 100;
 
-	//Override this to return obj.id for DSpace 5 versions
-	this.getId = function(obj) {
-		return obj.uuid;
-	}
-	
-	//Override this method is sortable.js has been included
-	this.hasSorttable = function() {
-		return false;
-	}
-	
-	this.getDefaultParameters = function(){
-		return {};
-	}
-	this.getCurrentParameters = function(){
-		return {};
-	}
-	
-	this.saveUrl = function() {
-		this.myReportParameters.saveAsUrl(this.getCurrentParameters());
-	}
-	
-	this.getLoginPayload = function() {
-		//Example of how to pass credentials to the service
-		//return {"email" : "Email@my.edu","password" : "my-password"};
-		return undefined;
-	}
-	this.getLangSuffix = function(){
-		return "";
-	}
-	this.myAuth = new Auth(this.getLoginPayload());
-	this.myAuth.callback = function(data) {
-		self.spinner.stop();
-	}
-	this.myHtmlUtil = new HtmlUtil();
-	this.spinner = new Spinner({
+    //set default to work on demo.dspace.org
+    this.ROOTPATH = "/xmlui/handle/"
+    //this.ROOTPATH = "/jspui/handle/"
+    //this.ROOTPATH = "/handle/"
+    
+    //disable this setting if Password Authentication is not supported
+    this.makeAuthLink = function(){return false;};
+
+    //Override this to return obj.id for DSpace 5 versions
+    this.getId = function(obj) {
+        return obj.uuid;
+    }
+    
+    //Override this method is sortable.js has been included
+    this.hasSorttable = function() {
+        return false;
+    }
+    
+    this.getDefaultParameters = function(){
+        return {};
+    }
+    this.getCurrentParameters = function(){
+        return {};
+    }
+    
+    this.saveUrl = function() {
+        this.myReportParameters.saveAsUrl(this.getCurrentParameters());
+    }
+    
+    this.getLoginPayload = function() {
+        //Placeholder to allow a customized report to prompt for email/password
+        //If not enabled, the authenticaton callback will be called immediately
+        var email = $("#restemail").val();
+        var pass = $("#restpass").val();
+        if (email == "" || pass == "") {
+          return undefined;  
+        } else if (email == null || pass == null) {
+           return undefined;  
+        } else {
+           return {email: email, password: pass};      
+        }
+    }
+    this.getLangSuffix = function(){
+        return "";
+    }
+    this.myAuth = new Auth(this);
+    this.myAuth.authStat();
+    this.myAuth.callback = function(data) {
+        self.spinner.stop();
+    }
+    this.myHtmlUtil = new HtmlUtil();
+    this.spinner = new Spinner({
         lines: 13, // The number of lines to draw
         length: 20, // The length of each line
         width: 10, // The line thickness
@@ -64,475 +78,514 @@ var Report = function() {
         className: 'spinner', // The CSS class to assign to the spinner
         zIndex: 2e9, // The z-index (defaults to 2000000000)
         top:  '400px', // Top position relative to parent
-        left: '600px' // Left position relative to parent		
-	});
-	
-	this.displayItems = function(itemsTitle, offset, limit, total, funcdec, funcinc) {
-		var count = $("#itemtable tr.data").length;
-		
-		var last = offset + limit;
-		var suff = "";
-		
-		if (total == null) {
-			last = offset + count;
-			suff = (count == limit) ? " of " + last + "+ " : " of " + last;
-		} else if (limit == total) {
-			//total may only be accurate to page size
-			suff = " of " + total + "+ ";
-		} else {
-			last = (last > total) ? total : last;
-			suff = " of " + total;
-		}
-		suff += " unfiltered; displaying " + count + " filtered" ;
-		
-		itemsTitle += " (" + (offset+1) + " - " + last + suff + ")";
-		$("#prev,#next").attr("disabled",true);
-		$("#itemdiv h3").text(itemsTitle);
-		if (offset > 0) $("#prev").attr("disabled", false);
-		$("#prev").off("click").on("click", funcdec);
-		//in case of filters, always allow next
-		
-		if (total == null) {
-			$("#next").attr("disabled", false);				
-		} else if (offset + limit  < total) {
-			$("#next").attr("disabled", false);			
-		} else if (limit == total) {
-			//total may only be accurate to one page
-			$("#next").attr("disabled", false);			
-		}
-		$("#next").off("click").on("click", funcinc);
-	}
-	
-	this.myReportParameters = undefined;
-	this.myFilters = undefined;
-	this.myMetadataFields = undefined;
-	
-	this.initMetadataFields = function() {
-		this.myMetadataFields = new MetadataFields(self);
-	    this.myMetadataFields.load();		
-	}
-	
-	this.baseInit = function() {
-		this.myReportParameters = new ReportParameters(
-				this.getDefaultParameters(),
-				window.location.search.substr(1)
-		);
-		this.spinner.spin($("h1")[0]);
-		this.myFilters = new Filters(this.myReportParameters.params["filters"]);
-		this.initMetadataFields();
-		$("#metadatadiv").accordion({
-	        heightStyle: "content",
-	        collapsible: true,
-	        active: $("#metadatadiv > h3").length - 2
-	    });
-		$("#export").click(function(){
-			self.export($("#itemtable tr"));
-	    });
-		$("a.this-search").on("click",function(){
-			self.saveUrl();
-		});
-		this.myFilters.createFilterTable(this.myReportParameters.params.filters);
-		this.myAuth.init();
-	}
-	
-	this.export = function(rows) {
-		var itemdata = "data:text/csv;charset=utf-8,";
-		rows.each(function(rownum, row){
-			itemdata += (rownum == 0) ? "" : "\r\n";
-			$(row).find("td,th").each(function(colnum, col){
-				itemdata += self.exportCol(colnum, col);
-			});
-		});
-		var encodedUri = encodeURI(itemdata);
-        window.open(encodedUri);		
-	}
-	
-	//this is meant to be overridden for each report
-	this.exportCol = function(colnum, col) {
-		var data = "";
-		data += (colnum == 0) ? "" : ",";
-		data += self.exportCell(col);
-		return data;
-	}
-	
-	this.exportCell = function(col) {
-		data = "\"";
-		$(col).contents().each(function(i, node){
-			if ($(node).is("hr")) {
-				data += "||";
-			} else {
-				data += $(node).text().replace(/\n/g," ").replace(/"/g,"\"\"");
-				if ($(node).is("div:not(:last-child)")) {
-					data += "||";
-				}
-			}		
-		});
-		data += "\"";
-		return data;
-	}
-	
-	this.init = function() {
-	    this.baseInit();	
-	}
+        left: '600px' // Left position relative to parent        
+    });
+    
+    this.displayItems = function(itemsTitle, offset, limit, total, funcdec, funcinc) {
+        var count = $("#itemtable tr.data").length;
+        
+        var last = offset + limit;
+        var suff = "";
+        
+        if (total == null) {
+            last = offset + count;
+            suff = (count == limit) ? " of " + last + "+ " : " of " + last;
+        } else if (limit == total) {
+            //total may only be accurate to page size
+            suff = " of " + total + "+ ";
+        } else {
+            last = (last > total) ? total : last;
+            suff = " of " + total;
+        }
+        suff += " unfiltered; displaying " + count + " filtered" ;
+        
+        itemsTitle += " (" + (offset+1) + " - " + last + suff + ")";
+        $("#prev,#next").attr("disabled",true);
+        $("#itemdiv h3").text(itemsTitle);
+        if (offset > 0) $("#prev").attr("disabled", false);
+        $("#prev").off("click").on("click", funcdec);
+        //in case of filters, always allow next
+        
+        if (total == null) {
+            $("#next").attr("disabled", false);                
+        } else if (offset + limit  < total) {
+            $("#next").attr("disabled", false);            
+        } else if (limit == total) {
+            //total may only be accurate to one page
+            $("#next").attr("disabled", false);            
+        }
+        $("#next").off("click").on("click", funcinc);
+    }
+    
+    this.myReportParameters = undefined;
+    this.myFilters = undefined;
+    this.myMetadataFields = undefined;
+    
+    this.initMetadataFields = function() {
+        this.myMetadataFields = new MetadataFields(self);
+        this.myMetadataFields.load();        
+    }
+    
+    this.baseInit = function() {
+        this.myReportParameters = new ReportParameters(
+                this.getDefaultParameters(),
+                window.location.search.substr(1)
+        );
+        this.spinner.spin($("h1")[0]);
+        this.myFilters = new Filters(this.myReportParameters.params["filters"]);
+        this.initMetadataFields();
+        $("#metadatadiv").accordion({
+            heightStyle: "content",
+            collapsible: true,
+            active: $("#metadatadiv > h3").length - 2
+        });
+        $("#export").click(function(){
+            self.export($("#itemtable tr"));
+        });
+        $("a.this-search").on("click",function(){
+            self.saveUrl();
+        });
+        this.myFilters.createFilterTable(this.myReportParameters.params.filters);
+        this.myAuth.init();
+    }
+
+    this.export = function(rows) {
+        var itemdata = "data:text/csv;charset=utf-8,";
+        rows.each(function(rownum, row){
+            itemdata += (rownum == 0) ? "" : "\r\n";
+            $(row).find("td,th").each(function(colnum, col){
+                itemdata += self.exportCol(colnum, col);
+            });
+        });
+        var encodedUri = encodeURI(itemdata);
+        window.open(encodedUri);        
+    }
+    
+    //this is meant to be overridden for each report
+    this.exportCol = function(colnum, col) {
+        var data = "";
+        data += (colnum == 0) ? "" : ",";
+        data += self.exportCell(col);
+        return data;
+    }
+    
+    this.exportCell = function(col) {
+        data = "\"";
+        $(col).contents().each(function(i, node){
+            if ($(node).is("hr")) {
+                data += "||";
+            } else {
+                data += $(node).text().replace(/\n/g," ").replace(/"/g,"\"\"");
+                if ($(node).is("div:not(:last-child)")) {
+                    data += "||";
+                }
+            }        
+        });
+        data += "\"";
+        return data;
+    }
+    
+    this.init = function() {
+        this.baseInit();    
+    }
+    
 }
 
-var Auth = function(loginPayload) {
-	this.TOKEN = undefined;
-	this.callback = function(data) {
-		alert("auth complete " + this.TOKEN);		
-	};
-	this.saveToken = function(data) {
-		this.TOKEN = data;
-	}
-	this.init = function() {
-		if (loginPayload == undefined) {
-			this.callback();
-			return;
-		}
+var Auth = function(report) {
+    this.report = report;
+    this.TOKEN = undefined;
+    this.callback = function(data) {
+    };
+    this.saveToken = function(data) {
+        this.TOKEN = data;
+    }
+    this.init = function() {
+        var loginPayload = report.getLoginPayload();
+        if (loginPayload == undefined) {
+            this.callback();
+            return;
+        }
 
-		var self = this;
-		$.ajax({
-			url : "/rest/login",
-			contentType : "application/json",
-			accepts : "application/json",
-			type : "POST",
-			data : JSON.stringify(loginPayload),
-			success : function(data){
-				self.saveToken(data);
-				self.callback();
-			},
-			error: function(xhr, status, errorThrown) {
-				alert("Error in /rest/login "+ status+ " " + errorThrown);
-			},
-			complete: function(xhr, status) {
-				self.callback();
-			}
-		});		
-	}
-	this.getHeaders = function() {
-		var HEADERS = {};
-		if (this.TOKEN != null) {
-			HEADERS['rest-dspace-token'] = this.TOKEN;
-		}
-		return HEADERS;
-	}
+        var self = this;
+        $.ajax({
+            url : "/rest/login",
+            contentType : "application/x-www-form-urlencoded",
+            accepts : "application/json",
+            type : "POST",
+            data : loginPayload,
+            success : function(data){
+                self.saveToken(data);
+               },
+            error: function(xhr, status, errorThrown) {
+                alert("Error in /rest/login "+ status+ " " + errorThrown);
+            },
+            complete: function(xhr, status) {
+                self.authStat();
+                self.callback();
+            }
+        });        
+    }
+    this.authStat = function() {
+        var self = this;
+        $.ajax({
+            url : "/rest/status",
+            dataType : "json",
+            error: function(xhr, status, errorThrown) {
+                alert("Error in /rest/status "+ status+ " " + errorThrown);
+            },
+            success: function(data) {
+              var user = "";
+              if (data.email != undefined) {
+                user = data.email;                  
+              } else {
+                user = "You are not logged in.  Some items may be excluded from reports.";
+              }
+              var anchor = $("<a/>").text(user);
+              if (self.report.makeAuthLink()) {
+                  anchor.attr("href","javascript:window.open('authenticate.html','Authenticate (Password Auth Only)','height=200,width=500')");
+              }
+              $("#currentUser").empty().append("<b>Current User: </b>").append(anchor);
+            }
+        });     
+    }
+    this.logout = function() {
+        var self = this;
+        $.ajax({
+            url : "/rest/logout",
+            error: function(xhr, status, errorThrown) {
+                alert("Error in /rest/logout "+ status+ " " + errorThrown);
+            },
+            complete: function(xhr, status) {
+                self.authStat();
+            }
+        });     
+    }
+    this.getHeaders = function() {
+        var HEADERS = {};
+        if (this.TOKEN != null) {
+            HEADERS['rest-dspace-token'] = this.TOKEN;
+        }
+        return HEADERS;
+    }
 }
 
 var ReportParameters = function(defaultParams, prmstr) {
-	this.params = defaultParams;
+    this.params = defaultParams;
 
     if (prmstr == null) prmstr = "";
-	var prmarr = prmstr.split("&");
-	for ( var i = 0; i < prmarr.length; i++) {
+    var prmarr = prmstr.split("&");
+    for ( var i = 0; i < prmarr.length; i++) {
         var tmparr = prmarr[i].split("=");
-		var field = tmparr[0];
-		var val = decodeURIComponent(tmparr[1]);
-		var pval = this.params[field];
-		      
-		if ($.isArray(pval)) {
-		    pval[pval.length] = val;    	  
-		} else {
-		    this.params[field] = val;
-		}
-	}
-	$("#limit").val(this.params.limit);  
+        var field = tmparr[0];
+        var val = decodeURIComponent(tmparr[1]);
+        var pval = this.params[field];
+              
+        if ($.isArray(pval)) {
+            pval[pval.length] = val;          
+        } else {
+            this.params[field] = val;
+        }
+    }
+    $("#limit").val(this.params.limit);  
     $("#offset").val(this.params.offset);
     this.limit = this.params.limit;
     this.offset = this.params.offset;
 
-	this.getOffset = function() {
-		var offset = $("#offset").val();
-		return $.isNumeric(offset) ? Number(offset) : this.offset;
-	}
+    this.getOffset = function() {
+        var offset = $("#offset").val();
+        return $.isNumeric(offset) ? Number(offset) : this.offset;
+    }
 
-	this.getNextOffset = function() {
-		return this.getOffset() + this.getLimit();
-	}
+    this.getNextOffset = function() {
+        return this.getOffset() + this.getLimit();
+    }
 
-	this.getPrevOffset = function() {
-		var v = this.getOffset() - this.getLimit();
-		return v < 0 ? 0 : v;
-	}
+    this.getPrevOffset = function() {
+        var v = this.getOffset() - this.getLimit();
+        return v < 0 ? 0 : v;
+    }
 
-	this.getLimit = function() {
-		var limit = $("#limit").val();
-		return $.isNumeric(limit) ? Number(limit) : this.limit;
-	}
+    this.getLimit = function() {
+        var limit = $("#limit").val();
+        return $.isNumeric(limit) ? Number(limit) : this.limit;
+    }
 
-	this.updateOffset = function(increment) {
-		var val = $("#offset").val();
-		var lim = $("#limit").val();
-		if ($.isNumeric(val) && $.isNumeric(lim)) {
-			if (increment) {
-				$("#offset").val(this.getNextOffset());				
-			} else {
-				$("#offset").val(this.getPrevOffset());				
-			}
-		}		
-	}
+    this.updateOffset = function(increment) {
+        var val = $("#offset").val();
+        var lim = $("#limit").val();
+        if ($.isNumeric(val) && $.isNumeric(lim)) {
+            if (increment) {
+                $("#offset").val(this.getNextOffset());                
+            } else {
+                $("#offset").val(this.getPrevOffset());                
+            }
+        }        
+    }
 
-	this.saveAsUrl = function(params) {
-		var pstr = $.param(params).replace(/%5B%5D/g,"[]");
-		window.location.search = pstr;
-	}
+    this.saveAsUrl = function(params) {
+        var pstr = $.param(params).replace(/%5B%5D/g,"[]");
+        window.location.search = pstr;
+    }
 }
 
 
 var Filters = function() {
-	this.createFilterTable = function(filterList) {
-		self = this;
-		var paramFilterSel = filterList == null ? new Array() : filterList.split(",");
-		var categories = new Array();
-		self.addFilter("", categories, "General", "None", "De-select all filters", "none").click(
-			function(){
-				$("input.filter,input.all").attr("checked",false);
-				$("#filter-reload").attr("disabled", false);
-			}
-		);
-		self.addFilter("all", categories, "General", "All", "Show all filters", "all").click(
-			function(){
-				$("input.filter,input.none").attr("checked",false);
-				$("#filter-reload").attr("disabled", false);
-			}
-		);
-		
-		$.getJSON(
-			"/rest/filters",
-			function(data){
-				$.each(data, function(index, filter){
-					var checkbox = self.addFilter(filter["filter-name"], categories, filter.category, filter.title, filter.description, "filter").click(
-						function(){
-							$("input.none,input.all").attr("checked",false);
-							$("#filter-reload").attr("disabled", false);
-						}
-					);
-					$.each(paramFilterSel, function(index, filtername){
-						if (filtername == filter["filter-name"]) {
-							checkbox.attr("checked", true);
-						}
-					});
-				});
-			}
-		);
-	}
+    this.createFilterTable = function(filterList) {
+        self = this;
+        var paramFilterSel = filterList == null ? new Array() : filterList.split(",");
+        var categories = new Array();
+        self.addFilter("", categories, "General", "None", "De-select all filters", "none").click(
+            function(){
+                $("input.filter,input.all").attr("checked",false);
+                $("#filter-reload").attr("disabled", false);
+            }
+        );
+        self.addFilter("all", categories, "General", "All", "Show all filters", "all").click(
+            function(){
+                $("input.filter,input.none").attr("checked",false);
+                $("#filter-reload").attr("disabled", false);
+            }
+        );
+        
+        $.getJSON(
+            "/rest/filters",
+            function(data){
+                $.each(data, function(index, filter){
+                    var checkbox = self.addFilter(filter["filter-name"], categories, filter.category, filter.title, filter.description, "filter").click(
+                        function(){
+                            $("input.none,input.all").attr("checked",false);
+                            $("#filter-reload").attr("disabled", false);
+                        }
+                    );
+                    $.each(paramFilterSel, function(index, filtername){
+                        if (filtername == filter["filter-name"]) {
+                            checkbox.attr("checked", true);
+                        }
+                    });
+                });
+            }
+        );
+    }
 
-	this.addFilter = function(val, categories, category, title, description, cname) {
-		var catdiv = null;
-		for(var i=0; i<categories.length; i++) {
-			if (categories[i].name == category) {
-				catdiv = categories[i].div;
-				break;
-			}
-		}
-		if (catdiv == null) {
-			catdiv = $("<fieldset class='catdiv'/>");
-			catdiv.append($("<legend>"+category+"</legend>"));
-			$("#filterdiv").append(catdiv);
-			categories[categories.length] = {name: category, div: catdiv};
-		}
-		var div = $("<div/>");
-		var input = $("<input name='filters[]' type='checkbox'/>");
-		input.attr("id",val);
-		input.val(val);
-		input.addClass(cname);
-		div.append(input);
-		var ftitle = (title == null) ? val : title;
-		var label = $("<label>" + ftitle + "</label>");
-		label.attr("title", description);
-		div.append(label);
-		catdiv.append(div);
-		return input;
-	}
+    this.addFilter = function(val, categories, category, title, description, cname) {
+        var catdiv = null;
+        for(var i=0; i<categories.length; i++) {
+            if (categories[i].name == category) {
+                catdiv = categories[i].div;
+                break;
+            }
+        }
+        if (catdiv == null) {
+            catdiv = $("<fieldset class='catdiv'/>");
+            catdiv.append($("<legend>"+category+"</legend>"));
+            $("#filterdiv").append(catdiv);
+            categories[categories.length] = {name: category, div: catdiv};
+        }
+        var div = $("<div/>");
+        var input = $("<input name='filters[]' type='checkbox'/>");
+        input.attr("id",val);
+        input.val(val);
+        input.addClass(cname);
+        div.append(input);
+        var ftitle = (title == null) ? val : title;
+        var label = $("<label>" + ftitle + "</label>");
+        label.attr("title", description);
+        div.append(label);
+        catdiv.append(div);
+        return input;
+    }
 
-	this.getFilterList = function() {
-		var list="";
-		$("input:checked[name='filters[]']").each(
-			function(){
-				if (list != "") {
-					list += ",";
-				}
-				list += $(this).val();
-			}
-		);
-		if (list == "") {
-			list = "none";
-		}
-		return list;
-	}	
+    this.getFilterList = function() {
+        var list="";
+        $("input:checked[name='filters[]']").each(
+            function(){
+                if (list != "") {
+                    list += ",";
+                }
+                list += $(this).val();
+            }
+        );
+        if (list == "") {
+            list = "none";
+        }
+        return list;
+    }    
 }
 
 var MetadataFields = function(report) {
-	this.metadataSchemas = undefined;
-	var self = this;
-	
-	this.load = function(){
-		$.ajax({
-			url: "/rest/registries/schema",
-			dataType: "json",
-			success: function(data){
-				self.initFields(data, report);
-			},
-			error: function(xhr, status, errorThrown) {
-				alert("Error in /rest/registries/schema "+ status+ " " + errorThrown);
-			},
-			complete: function(xhr, status) {
-			}
-		});		
-	}
-	
-	this.initFields = function(data, report) {
-		var params = report.myReportParameters.params;
-		self.metadataSchemas = data;
-		self.drawShowFields(params["show_fields[]"]);
-	}
-	
-	this.getShowFields = function(){
-		var val = $("#show-fields select").val();
-		return val == null ? Array() : val;
-	}
+    this.metadataSchemas = undefined;
+    var self = this;
+    
+    this.load = function(){
+        $.ajax({
+            url: "/rest/registries/schema",
+            dataType: "json",
+            success: function(data){
+                self.initFields(data, report);
+            },
+            error: function(xhr, status, errorThrown) {
+                alert("Error in /rest/registries/schema "+ status+ " " + errorThrown);
+            },
+            complete: function(xhr, status) {
+            }
+        });        
+    }
+    
+    this.initFields = function(data, report) {
+        var params = report.myReportParameters.params;
+        self.metadataSchemas = data;
+        self.drawShowFields(params["show_fields[]"]);
+    }
+    
+    this.getShowFields = function(){
+        var val = $("#show-fields select").val();
+        return val == null ? Array() : val;
+    }
 
-	this.drawShowFields = function(pfields) {
-		var self = this;
-		var sel = $("<select name='show_fields'/>").attr("multiple","true").attr("size","8").appendTo("#show-fields");
-		$.each(this.metadataSchemas, function(index, schema){
-			if (schema.prefix == 'eperson') {
-				return;
-			}
-			$.each(schema.fields, function(findex, field) {
-				var name = field.name;
-				var opt = $("<option/>");
-				opt.attr("value",name).text(name);
-				for(var i=0; i<pfields.length; i++) {
-					if (pfields[i] == name) {
-						opt.attr("selected", true);
-					}
-				}
-				sel.append(opt);
-			});
-		});
-	}
-	
-	this.initQueries = function(){};
+    this.drawShowFields = function(pfields) {
+        if (pfields == null) return;
+        var self = this;
+        var sel = $("<select name='show_fields'/>").attr("multiple","true").attr("size","8").appendTo("#show-fields");
+        $.each(this.metadataSchemas, function(index, schema){
+            if (schema.prefix == 'eperson') {
+                return;
+            }
+            $.each(schema.fields, function(findex, field) {
+                var name = field.name;
+                var opt = $("<option/>");
+                opt.attr("value",name).text(name);
+                for(var i=0; i<pfields.length; i++) {
+                    if (pfields[i] == name) {
+                        opt.attr("selected", true);
+                    }
+                }
+                sel.append(opt);
+            });
+        });
+    }
+    
+    this.initQueries = function(){};
 }
 
 var HtmlUtil = function() {
-	this.addTr = function(tbl) {
-		var tr = $("<tr/>");
-		tbl.append(tr);
-		return tr;
-	}
+    this.addTr = function(tbl) {
+        var tr = $("<tr/>");
+        tbl.append(tr);
+        return tr;
+    }
 
-	this.addTd = function(tr, val) {
-		var td = $("<td/>");
-		if (val != null) {
-			td.append(val);
-		}
-		tr.append(td);
-		return td;
-	}
+    this.addTd = function(tr, val) {
+        var td = $("<td/>");
+        if (val != null) {
+            td.append(val);
+        }
+        tr.append(td);
+        return td;
+    }
 
-	this.addTh = function(tr, val) {
-		var th = $("<th/>");
-		if (val != null) {
-			th.append(val);
-		}
-		tr.append(th);
-		return th;
-	}
+    this.addTh = function(tr, val) {
+        var th = $("<th/>");
+        if (val != null) {
+            th.append(val);
+        }
+        tr.append(th);
+        return th;
+    }
 
 
-	this.addTdAnchor = function(tr, val, href) {
-		return this.addTd(tr, this.getAnchor(val, href));
-	}
+    this.addTdAnchor = function(tr, val, href) {
+        return this.addTd(tr, this.getAnchor(val, href));
+    }
 
-	this.getAnchor = function(val, href) {
-		var a = $("<a/>");
-		a.append(val);
-		a.attr("href", href);
-		a.attr("target", "_blank");
-		return a;
-	}
+    this.getAnchor = function(val, href) {
+        var a = $("<a/>");
+        a.append(val);
+        a.attr("href", href);
+        a.attr("target", "_blank");
+        return a;
+    }
 
-	this.createOpt = function(name, val) {
-		var opt = $("<option/>");
-		opt.attr("value", val).text(name);
-		return opt;
-	}
+    this.createOpt = function(name, val) {
+        var opt = $("<option/>");
+        opt.attr("value", val).text(name);
+        return opt;
+    }
 
-	this.addOpt = function(sel, name, val) {
-		var opt = this.createOpt(name, val);
-		sel.append(opt);
-		return opt;
-	}
+    this.addOpt = function(sel, name, val) {
+        var opt = this.createOpt(name, val);
+        sel.append(opt);
+        return opt;
+    }
 
-	this.addDisabledOpt = function(sel, name, val) {
-		var opt = this.createOpt(name, val).attr("disabled",true);
-		sel.append(opt);
-		return opt;
-	}
+    this.addDisabledOpt = function(sel, name, val) {
+        var opt = this.createOpt(name, val).attr("disabled",true);
+        sel.append(opt);
+        return opt;
+    }
 
-	this.makeTotalCol = function(th) {
-		th.append($("<hr><span class='num'>-</span>"));
-	}
+    this.makeTotalCol = function(th) {
+        th.append($("<hr><span class='num'>-</span>"));
+    }
 
-	this.totalCol = function(index){
-		var total = 0;
-		$("#table tr.data").each(function(){
-			var val = $($(this).find("td")[index]).text();
-			if ($.isNumeric(val)) {
-				total += Number(val);
-			}
-		});
-		$($("#table tr.header th")[index]).find("span.num").text(total);
-	}
+    this.totalCol = function(index){
+        var total = 0;
+        $("#table tr.data").each(function(){
+            var val = $($(this).find("td")[index]).text();
+            if ($.isNumeric(val)) {
+                total += Number(val);
+            }
+        });
+        $($("#table tr.header th")[index]).find("span.num").text(total);
+    }
 
 }
 
 var CommunitySelector = function(report, parent, paramCollSel) {
-	var self = this;
-	var collSel = $("<select/>").attr("id","collSel").attr("name","collSel").attr("multiple", true).attr("size",15);
-	parent.append(collSel);
-	report.myHtmlUtil.addOpt(collSel, "Whole Repository", "");
-	
-	$.ajax({
-		url: "/rest/hierarchy",
-		dataType: "json",
-		headers: report.myAuth.getHeaders(),
-		success: function(data){
-			var collSel = $("#collSel");
-			if (data.community != null) {
-			    $.each(data.community, function(index, comm){
-				    self.addCommLabel(collSel, comm, 0, paramCollSel);
-			    });
-			}
-		},
-		error: function(xhr, status, errorThrown) {
-			alert("Error in /rest/communities "+ status+ " " + errorThrown);
-		},
-		complete: function(xhr, status) {
-		}
-	});	
+    var self = this;
+    $("#collSel,#collSel option").remove();
+    var collSel = $("<select/>").attr("id","collSel").attr("name","collSel").attr("multiple", true).attr("size",15);
+    parent.append(collSel);
+    report.myHtmlUtil.addOpt(collSel, "Whole Repository", "");
+    
+    $.ajax({
+        url: "/rest/hierarchy",
+        dataType: "json",
+        headers: report.myAuth.getHeaders(),
+        success: function(data){
+            var collSel = $("#collSel");
+            if (data.community != null) {
+                $.each(data.community, function(index, comm){
+                    self.addCommLabel(collSel, comm, 0, paramCollSel);
+                });
+            }
+        },
+        error: function(xhr, status, errorThrown) {
+            alert("Error in /rest/communities "+ status+ " " + errorThrown);
+        },
+        complete: function(xhr, status) {
+        }
+    });    
 
-	this.addCommLabel = function(collSel, comm, indent, paramCollSel) {
-		var prefix = "";
-		for(var i=0; i<indent; i++) {
-			prefix += "--";
-		}
-		report.myHtmlUtil.addDisabledOpt(collSel, prefix + comm.name, comm.id);
-		if (comm.collection != null) {
-			$.each(comm.collection, function(index, coll) {
-				var opt = report.myHtmlUtil.addOpt(collSel, prefix + "--" + coll.name, coll.id);
-				$.each(paramCollSel, function(index, collid){
-					if (collid == coll.id) {
-						opt.attr("selected", true);
-					}
-				});
-			});		
-		}
-		if (comm.community != null) {
-			$.each(comm.community, function(index, scomm) {
-				self.addCommLabel(collSel, scomm, indent + 1, paramCollSel);
-			});		
-		}
-	}
+    this.addCommLabel = function(collSel, comm, indent, paramCollSel) {
+        var prefix = "";
+        for(var i=0; i<indent; i++) {
+            prefix += "--";
+        }
+        report.myHtmlUtil.addDisabledOpt(collSel, prefix + comm.name, comm.id);
+        if (comm.collection != null) {
+            $.each(comm.collection, function(index, coll) {
+                var opt = report.myHtmlUtil.addOpt(collSel, prefix + "--" + coll.name, coll.id);
+                $.each(paramCollSel, function(index, collid){
+                    if (collid == coll.id) {
+                        opt.attr("selected", true);
+                    }
+                });
+            });        
+        }
+        if (comm.community != null) {
+            $.each(comm.community, function(index, scomm) {
+                self.addCommLabel(collSel, scomm, indent + 1, paramCollSel);
+            });        
+        }
+    }
 }


### PR DESCRIPTION
See https://jira.duraspace.org/browse/DS-3170

This change will create a configurable setting that can enable/disable password authentication from the  rest reports.

Note: incorporated comments from PR review at the 4/27 DSpace meeting.  Also normalized whitespace in the javascript files.

To activate the authentication code, see https://wiki.duraspace.org/display/DSDOC6x/REST+Based+Quality+Control+Reports#RESTBasedQualityControlReports-EnableUserAuthentication(PasswordAuthNonly)forRESTreports.

Note that the user is not logged in.
![image](https://cloud.githubusercontent.com/assets/1111057/14838842/4ae2b5e0-0bda-11e6-8451-fd2fb2dc6906.png)

Click the not logged in link to open an authentication window.
![image](https://cloud.githubusercontent.com/assets/1111057/14838845/52c3c768-0bda-11e6-871d-3ea77721359d.png)

Authenticate the user
![image](https://cloud.githubusercontent.com/assets/1111057/14838853/6b926e66-0bda-11e6-9cdc-6f5babf514a1.png)

Refresh the report, note the presence of restricted collections
![image](https://cloud.githubusercontent.com/assets/1111057/14838863/7c4e4e3c-0bda-11e6-9cc0-d0b6a3bcc7e5.png)
