### PR TITLE
[DS-3184] Adding a new bitstream format fails - JSPUI Test Plan Ref ADM18

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/BitstreamFormat.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamFormat.java
@@ -9,6 +9,7 @@ package org.dspace.content;
 
 import java.io.Serializable;
 import java.sql.SQLException;
+import java.util.LinkedList;
 import java.util.List;
 
 import org.dspace.content.factory.ContentServiceFactory;
@@ -102,7 +103,7 @@ public class BitstreamFormat implements Serializable
      */
     protected BitstreamFormat()
     {
-
+        fileExtensions = new LinkedList<>();
     }
 
     /**

--- a/dspace-jspui/src/main/webapp/dspace-admin/list-formats.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/list-formats.jsp
@@ -84,16 +84,19 @@
     for (BitstreamFormat format : formats)
     {
         List<String> extensions = format.getExtensions();
-        StringBuilder extValue = new StringBuilder(256);
-
-        for (String extension : extensions)
+        StringBuilder extValueBuilder = new StringBuilder(256);
+        if (null != extensions)
         {
-            if (extValue.length() > 0)
+            for (String extension : extensions)
             {
-                extValue.append(", ");
+                if (extValueBuilder.length() > 0)
+                {
+                    extValueBuilder.append(", ");
+                }
+                extValueBuilder.append(extension);
             }
-            extValue.append(extension);
         }
+        String extValue = extValueBuilder.toString();
 %>
         <tr>
             <td>

--- a/dspace-jspui/src/main/webapp/dspace-admin/list-formats.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/list-formats.jsp
@@ -21,7 +21,6 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt"
     prefix="fmt" %>
 
-
 <%@ taglib uri="http://www.dspace.org/dspace-tags.tld" prefix="dspace" %>
 
 <%@ page import="javax.servlet.jsp.jstl.fmt.LocaleSupport" %>
@@ -35,9 +34,10 @@
 
 
 <%
-    BitstreamFormatService bitstreamFormatService = ContentServiceFactory.getInstance().getBitstreamFormatService();
-    List<BitstreamFormat> formats =
-        (List<BitstreamFormat>) request.getAttribute("formats");
+    BitstreamFormatService bitstreamFormatService
+            = ContentServiceFactory.getInstance().getBitstreamFormatService();
+    List<BitstreamFormat> formats
+            = (List<BitstreamFormat>) request.getAttribute("formats");
 %>
 
 <dspace:layout style="submission" titlekey="jsp.dspace-admin.list-formats.title"
@@ -46,8 +46,11 @@
                parenttitlekey="jsp.administer"
                parentlink="/dspace-admin">
 
-    <h1><fmt:message key="jsp.dspace-admin.list-formats.title"/>
-    <dspace:popup page="<%= LocaleSupport.getLocalizedMessage(pageContext, \"help.site-admin\") + \"#bitstream\"%>"><fmt:message key="jsp.help"/></dspace:popup>
+    <h1>
+        <fmt:message key="jsp.dspace-admin.list-formats.title"/>
+        <dspace:popup page='<%= LocaleSupport.getLocalizedMessage(pageContext, "help.site-admin") + "#bitstream"%>'>
+            <fmt:message key="jsp.help"/>
+        </dspace:popup>
     </h1>
 
     <p class="alert alert-info"><fmt:message key="jsp.dspace-admin.list-formats.text1"/></p>
@@ -58,22 +61,22 @@
 
 %>
 
-        <table class="table" summary="Bitstream Format Registry data table">
-            <tr>
-                <th class="oddRowOddCol">
+    <table class="table" summary="Bitstream Format Registry data table">
+        <tr>
+            <th class="oddRowOddCol">
                 <span class="col-md-offset-3">
                     <strong>
-                            <fmt:message key="jsp.general.id" />
-                            / <fmt:message key="jsp.dspace-admin.list-formats.mime"/>
-                            / <fmt:message key="jsp.dspace-admin.list-formats.name"/>
-                            / <fmt:message key="jsp.dspace-admin.list-formats.description"/>
-                            / <fmt:message key="jsp.dspace-admin.list-formats.support"/>
-                            / <fmt:message key="jsp.dspace-admin.list-formats.internal"/>
-                            / <fmt:message key="jsp.dspace-admin.list-formats.extensions"/>
+                        <fmt:message key="jsp.general.id" />
+                        / <fmt:message key="jsp.dspace-admin.list-formats.mime"/>
+                        / <fmt:message key="jsp.dspace-admin.list-formats.name"/>
+                        / <fmt:message key="jsp.dspace-admin.list-formats.description"/>
+                        / <fmt:message key="jsp.dspace-admin.list-formats.support"/>
+                        / <fmt:message key="jsp.dspace-admin.list-formats.internal"/>
+                        / <fmt:message key="jsp.dspace-admin.list-formats.extensions"/>
                     </strong>
                  </span>
-                 </th>
-            </tr>
+             </th>
+        </tr>
 <%
 
     String row = "even";
@@ -91,57 +94,108 @@
             extValue = extValue + extensions.get(j);
         }
 %>
-             <tr>
-                 <td>
-				<form class="form-inline" method="post" action="">
-  					
-					<span class="col-md-1"><%= formats.get(i).getID() %></span>
+        <tr>
+            <td>
+                <form class="form-inline" method="post" action="">
+
+                    <span class="col-md-1"><%= formats.get(i).getID() %></span>
                     <div class="form-group">
-                    	<label class="sr-only" for="mimetype"><fmt:message key="jsp.dspace-admin.list-formats.mime"/></label>
-                    	<input class="form-control" type="text" name="mimetype" value="<%= formats.get(i).getMIMEType()!=null?formats.get(i).getMIMEType():"" %>" size="14" placeholder="<fmt:message key="jsp.dspace-admin.list-formats.mime"/>"/>
+                        <label class="sr-only" for="mimetype">
+                            <fmt:message key="jsp.dspace-admin.list-formats.mime"/>
+                        </label>
+                        <input class="form-control"
+                               type="text"
+                               name="mimetype"
+                               value='<%= formats.get(i).getMIMEType()!=null?formats.get(i).getMIMEType():"" %>'
+                               size="14"
+                               placeholder='<fmt:message key="jsp.dspace-admin.list-formats.mime"/>'/>
                     </div>
                     <div class="form-group">
-                    	  <label class="sr-only" for="short_description"><fmt:message key="jsp.dspace-admin.list-formats.name"/></label>
+                        <label class="sr-only"
+                               for="short_description">
+                            <fmt:message key="jsp.dspace-admin.list-formats.name"/>
+                        </label>
                     <%
-                      if (bitstreamFormatService.findUnknown(context).getID() == formats.get(i).getID()) {
+                        if (bitstreamFormatService.findUnknown(context).getID() == formats.get(i).getID()) {
                     %>
-                      		  <span class="form-control"><i><%= formats.get(i).getShortDescription() %></i></span>
-                    <% } else { %>                    	
-                              <input class="form-control" type="text" name="short_description" value="<%= formats.get(i).getShortDescription()!=null?formats.get(i).getShortDescription():"" %>" size="10" placeholder="<fmt:message key="jsp.dspace-admin.list-formats.name"/>"/>
+                            <span class="form-control"><i><%= formats.get(i).getShortDescription() %></i></span>
+                    <% } else { %>
+                            <input class="form-control"
+                                   type="text"
+                                   name="short_description"
+                                   value='<%= formats.get(i).getShortDescription()!=null?formats.get(i).getShortDescription():"" %>'
+                                   size="10"
+                                   placeholder='<fmt:message key="jsp.dspace-admin.list-formats.name"/>'/>
                     <% } %>
-                     </div>     
+                     </div>
                      <div class="form-group">
-                     		<label class="sr-only" for="description"><fmt:message key="jsp.dspace-admin.list-formats.description"/></label>     
-                              <input class="form-control" type="text" name="description" value="<%= formats.get(i).getDescription()!=null?formats.get(i).getDescription():"" %>" size="20" placeholder="<fmt:message key="jsp.dspace-admin.list-formats.description"/>"/>
+                        <label class="sr-only"
+                               for="description">
+                            <fmt:message key="jsp.dspace-admin.list-formats.description"/>
+                        </label>
+                        <input class="form-control"
+                               type="text"
+                               name="description"
+                               value='<%= formats.get(i).getDescription()!=null?formats.get(i).getDescription():"" %>'
+                               size="20"
+                               placeholder='<fmt:message key="jsp.dspace-admin.list-formats.description"/>'/>
                      </div>
-                     <div class="form-group">                     		
-                              <select class="form-control" name="support_level">
-                                  <option value="0" <%= formats.get(i).getSupportLevel() == 0 ? "selected=\"selected\"" : "" %>><fmt:message key="jsp.dspace-admin.list-formats.unknown"/></option>
-	    	                  <option value="1" <%= formats.get(i).getSupportLevel() == 1 ? "selected=\"selected\"" : "" %>><fmt:message key="jsp.dspace-admin.list-formats.known"/></option>
-                                  <option value="2" <%= formats.get(i).getSupportLevel() == 2 ? "selected=\"selected\"" : "" %>><fmt:message key="jsp.dspace-admin.list-formats.supported"/></option>
-                              </select>
+                     <div class="form-group">
+                        <select class="form-control" name="support_level">
+                            <option value="0"
+                                    <%= formats.get(i).getSupportLevel() == 0 ? "selected=\"selected\"" : "" %>>
+                                <fmt:message key="jsp.dspace-admin.list-formats.unknown"/>
+                            </option>
+                            <option value="1"
+                                    <%= formats.get(i).getSupportLevel() == 1 ? "selected=\"selected\"" : "" %>>
+                                <fmt:message key="jsp.dspace-admin.list-formats.known"/>
+                            </option>
+                            <option value="2"
+                                    <%= formats.get(i).getSupportLevel() == 2 ? "selected=\"selected\"" : "" %>>
+                                <fmt:message key="jsp.dspace-admin.list-formats.supported"/>
+                            </option>
+                        </select>
                      </div>
-                     <div class="form-group">     
-                              <input class="form-control" type="checkbox" name="internal" value="true"<%= formats.get(i).isInternal() ? " checked=\"checked\"" : "" %>/>
-                          </div>
-                          <div class="form-group">
-                          	  <label class="sr-only" for="extensions"><fmt:message key="jsp.dspace-admin.list-formats.extensions"/></label>
-                              <input class="form-control" type="text" name="extensions" value="<%= extValue %>" size="10" placeholder="<fmt:message key="jsp.dspace-admin.list-formats.extensions"/>"/>
-                          </div>
-                     <div class="btn-group pull-right">
-                              <input type="hidden" name="format_id" value="<%= formats.get(i).getID() %>" />
-                              <input class="btn btn-primary" type="submit" name="submit_update" value="<fmt:message key="jsp.dspace-admin.general.update"/>"/>
-                          
+                     <div class="form-group">
+                        <input class="form-control"
+                               type="checkbox"
+                               name="internal"
+                               value="true"
+                               <%= formats.get(i).isInternal() ? " checked=\"checked\"" : "" %>/>
+                    </div>
+                    <div class="form-group">
+                        <label class="sr-only"
+                               for="extensions">
+                            <fmt:message key="jsp.dspace-admin.list-formats.extensions"/>
+                        </label>
+                        <input class="form-control"
+                               type="text"
+                               name="extensions"
+                               value="<%= extValue %>"
+                               size="10"
+                               placeholder='<fmt:message key="jsp.dspace-admin.list-formats.extensions"/>'/>
+                    </div>
+                    <div class="btn-group pull-right">
+                        <input type="hidden"
+                               name="format_id"
+                               value="<%= formats.get(i).getID() %>" />
+                        <input class="btn btn-primary"
+                               type="submit"
+                               name="submit_update"
+                               value='<fmt:message key="jsp.dspace-admin.general.update"/>'/>
+
                     <%
-                      if (bitstreamFormatService.findUnknown(context).getID() != formats.get(i).getID()) {
+                        if (bitstreamFormatService.findUnknown(context).getID() != formats.get(i).getID()) {
                     %>
-                             <input class="btn btn-danger" type="submit" name="submit_delete" value="<fmt:message key="jsp.dspace-admin.general.delete-w-confirm"/>" />
-                     <% 
-                      } 
+                            <input class="btn btn-danger"
+                                   type="submit"
+                                   name="submit_delete"
+                                   value='<fmt:message key="jsp.dspace-admin.general.delete-w-confirm"/>' />
+                     <%
+                      }
                     %>
                     </div>
-		       
-		                  
+
                  </form>
              </td>
         </tr>
@@ -150,11 +204,14 @@
     }
 %>
 
-  </table>
+    </table>
 
-  <form method="post" action="">
-    
-    	<input class="btn btn-success col-md-offset-5" type="submit" name="submit_add" value="<fmt:message key="jsp.dspace-admin.general.addnew"/>" />
-    
-  </form>
+    <form method="post" action="">
+
+        <input class="btn btn-success col-md-offset-5"
+               type="submit"
+               name="submit_add"
+               value='<fmt:message key="jsp.dspace-admin.general.addnew"/>' />
+
+    </form>
 </dspace:layout>

--- a/dspace-jspui/src/main/webapp/dspace-admin/list-formats.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/list-formats.jsp
@@ -29,6 +29,7 @@
 <%@ page import="org.dspace.core.Context"%>
 <%@ page import="org.dspace.app.webui.util.UIUtil"%>
 <%@ page import="java.util.List" %>
+<%@ page import="java.lang.StringBuilder" %>
 <%@ page import="org.dspace.content.service.BitstreamFormatService" %>
 <%@ page import="org.dspace.content.factory.ContentServiceFactory" %>
 
@@ -80,25 +81,25 @@
 <%
 
     String row = "even";
-    for (int i = 0; i < formats.size(); i++)
+    for (BitstreamFormat format : formats)
     {
-        List<String> extensions = formats.get(i).getExtensions();
-        String extValue = "";
+        List<String> extensions = format.getExtensions();
+        StringBuilder extValue = new StringBuilder(256);
 
-        for (int j = 0 ; j < extensions.size(); j++)
+        for (String extension : extensions)
         {
-            if (j > 0)
+            if (extValue.length() > 0)
             {
-                extValue = extValue + ", ";
+                extValue.append(", ");
             }
-            extValue = extValue + extensions.get(j);
+            extValue.append(extension);
         }
 %>
         <tr>
             <td>
                 <form class="form-inline" method="post" action="">
 
-                    <span class="col-md-1"><%= formats.get(i).getID() %></span>
+                    <span class="col-md-1"><%= format.getID() %></span>
                     <div class="form-group">
                         <label class="sr-only" for="mimetype">
                             <fmt:message key="jsp.dspace-admin.list-formats.mime"/>
@@ -106,7 +107,7 @@
                         <input class="form-control"
                                type="text"
                                name="mimetype"
-                               value='<%= formats.get(i).getMIMEType()!=null?formats.get(i).getMIMEType():"" %>'
+                               value='<%= format.getMIMEType()!=null?format.getMIMEType():"" %>'
                                size="14"
                                placeholder='<fmt:message key="jsp.dspace-admin.list-formats.mime"/>'/>
                     </div>
@@ -116,14 +117,14 @@
                             <fmt:message key="jsp.dspace-admin.list-formats.name"/>
                         </label>
                     <%
-                        if (bitstreamFormatService.findUnknown(context).getID() == formats.get(i).getID()) {
+                        if (bitstreamFormatService.findUnknown(context).getID() == format.getID()) {
                     %>
-                            <span class="form-control"><i><%= formats.get(i).getShortDescription() %></i></span>
+                            <span class="form-control"><i><%= format.getShortDescription() %></i></span>
                     <% } else { %>
                             <input class="form-control"
                                    type="text"
                                    name="short_description"
-                                   value='<%= formats.get(i).getShortDescription()!=null?formats.get(i).getShortDescription():"" %>'
+                                   value='<%= format.getShortDescription()!=null?format.getShortDescription():"" %>'
                                    size="10"
                                    placeholder='<fmt:message key="jsp.dspace-admin.list-formats.name"/>'/>
                     <% } %>
@@ -136,22 +137,22 @@
                         <input class="form-control"
                                type="text"
                                name="description"
-                               value='<%= formats.get(i).getDescription()!=null?formats.get(i).getDescription():"" %>'
+                               value='<%= format.getDescription()!=null?format.getDescription():"" %>'
                                size="20"
                                placeholder='<fmt:message key="jsp.dspace-admin.list-formats.description"/>'/>
                      </div>
                      <div class="form-group">
                         <select class="form-control" name="support_level">
                             <option value="0"
-                                    <%= formats.get(i).getSupportLevel() == 0 ? "selected=\"selected\"" : "" %>>
+                                    <%= format.getSupportLevel() == 0 ? "selected=\"selected\"" : "" %>>
                                 <fmt:message key="jsp.dspace-admin.list-formats.unknown"/>
                             </option>
                             <option value="1"
-                                    <%= formats.get(i).getSupportLevel() == 1 ? "selected=\"selected\"" : "" %>>
+                                    <%= format.getSupportLevel() == 1 ? "selected=\"selected\"" : "" %>>
                                 <fmt:message key="jsp.dspace-admin.list-formats.known"/>
                             </option>
                             <option value="2"
-                                    <%= formats.get(i).getSupportLevel() == 2 ? "selected=\"selected\"" : "" %>>
+                                    <%= format.getSupportLevel() == 2 ? "selected=\"selected\"" : "" %>>
                                 <fmt:message key="jsp.dspace-admin.list-formats.supported"/>
                             </option>
                         </select>
@@ -161,7 +162,7 @@
                                type="checkbox"
                                name="internal"
                                value="true"
-                               <%= formats.get(i).isInternal() ? " checked=\"checked\"" : "" %>/>
+                               <%= format.isInternal() ? " checked=\"checked\"" : "" %>/>
                     </div>
                     <div class="form-group">
                         <label class="sr-only"
@@ -178,14 +179,14 @@
                     <div class="btn-group pull-right">
                         <input type="hidden"
                                name="format_id"
-                               value="<%= formats.get(i).getID() %>" />
+                               value="<%= format.getID() %>" />
                         <input class="btn btn-primary"
                                type="submit"
                                name="submit_update"
                                value='<fmt:message key="jsp.dspace-admin.general.update"/>'/>
 
                     <%
-                        if (bitstreamFormatService.findUnknown(context).getID() != formats.get(i).getID()) {
+                        if (bitstreamFormatService.findUnknown(context).getID() != format.getID()) {
                     %>
                             <input class="btn btn-danger"
                                    type="submit"


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3184

The actual problem was unconditional dereference of the null list of extensions in a brand-new BitstreamFormat.

I got a bit carried away with tidying up the code, so this one may be easier to review one commit at a time.
