### PR TITLE
[DS-3154] Maven release process fails when using Java 8 because of Javadocs errors

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/CurateForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/CurateForm.java
@@ -32,115 +32,121 @@ import org.dspace.authorize.AuthorizeException;
 
 /**
  * Generates the Administrative Curate Form, from which any DSpace object can
- * be curated. 
+ * be curated.
+ *
  * @author tdonohue
  */
 public class CurateForm extends AbstractDSpaceTransformer 
 {
-        private static final Message T_dspace_home = message("xmlui.general.dspace_home");
-        private static final Message T_submit_perform = message("xmlui.general.perform");
-        private static final Message T_submit_queue = message("xmlui.general.queue");
-        private static final Message T_title = message("xmlui.administrative.CurateForm.title");
-        private static final Message T_trail = message("xmlui.administrative.CurateForm.trail");
-        private static final Message T_task_label_name = message("xmlui.administrative.CurateForm.task_label_name");
-        private static final Message T_taskgroup_label_name = message("xmlui.administrative.CurateForm.taskgroup_label_name");
-        private static final Message T_object_label_name = message("xmlui.administrative.CurateForm.object_label_name");
-        private static final Message T_object_hint = message("xmlui.administrative.CurateForm.object_hint");
-        
-        public void setup(SourceResolver resolver, Map objectModel, String src,
-		          Parameters parameters) throws ProcessingException, SAXException, IOException
-		{
-        	super.setup(resolver, objectModel, src, parameters);
-        	FlowCurationUtils.setupCurationTasks();
-		}
-        
-        /**
-         * Initialize the page metadata & breadcrumb trail
-         *
-         * @param pageMeta
-         * @throws WingException
-         */
-        @Override
-        public void addPageMeta(PageMeta pageMeta) throws WingException
+    private static final Message T_dspace_home = message("xmlui.general.dspace_home");
+    private static final Message T_submit_perform = message("xmlui.general.perform");
+    private static final Message T_submit_queue = message("xmlui.general.queue");
+    private static final Message T_title = message("xmlui.administrative.CurateForm.title");
+    private static final Message T_trail = message("xmlui.administrative.CurateForm.trail");
+    private static final Message T_task_label_name = message("xmlui.administrative.CurateForm.task_label_name");
+    private static final Message T_taskgroup_label_name = message("xmlui.administrative.CurateForm.taskgroup_label_name");
+    private static final Message T_object_label_name = message("xmlui.administrative.CurateForm.object_label_name");
+    private static final Message T_object_hint = message("xmlui.administrative.CurateForm.object_hint");
+
+    @Override
+    public void setup(SourceResolver resolver, Map objectModel, String src,
+              Parameters parameters) throws ProcessingException, SAXException, IOException
+    {
+        super.setup(resolver, objectModel, src, parameters);
+        FlowCurationUtils.setupCurationTasks();
+    }
+
+    /**
+     * Initialize the page metadata and breadcrumb trail
+     *
+     * @param pageMeta
+     * @throws WingException
+     */
+    @Override
+    public void addPageMeta(PageMeta pageMeta) throws WingException
+    {
+            pageMeta.addMetadata("title").addContent(T_title);
+            pageMeta.addTrailLink(contextPath + "/", T_dspace_home);
+            pageMeta.addTrail().addContent(T_trail);
+    }
+
+    /** 
+     * Add object curation form
+     * 
+     * @param body body of the form.
+     * @throws WingException passed through.
+     * @throws SQLException passed through.
+     * @throws AuthorizeException passed through.
+     * @throws java.io.UnsupportedEncodingException passed through.
+     */
+    @Override
+    public void addBody(Body body)
+            throws WingException, SQLException,
+                   AuthorizeException, UnsupportedEncodingException
+    {
+        // Get our parameters and state;
+        String objectID = parameters.getParameter("identifier", null);
+        String taskSelected = parameters.getParameter("curate_task", null);
+
+        // DIVISION: curate
+        Division div = body.addInteractiveDivision("curate",
+                contextPath + "/admin/curate",
+                Division.METHOD_MULTIPART,
+                "primary administrative curate");
+        div.setHead(T_title);
+
+        // Curate Form
+        List form = div.addList("curate-form", List.TYPE_FORM);
+
+        // Object ID Textbox (required)
+        Text id = form.addItem().addText("identifier");
+        id.setAutofocus("autofocus");
+        id.setLabel(T_object_label_name);
+        if (objectID != null)
         {
-                pageMeta.addMetadata("title").addContent(T_title);
-                pageMeta.addTrailLink(contextPath + "/", T_dspace_home);
-                pageMeta.addTrail().addContent(T_trail);
+            id.setValue(objectID);
         }
-        
-        /** 
-         * Add object curation form
-         * 
-         * @param body
-         * @throws WingException
-         * @throws SQLException
-         * @throws AuthorizeException
-         */
-        @Override
-        public void addBody(Body body)
-                throws WingException, SQLException,
-                       AuthorizeException, UnsupportedEncodingException
+        id.setRequired();
+        id.setHelp(T_object_hint);
+
+        // Selectbox of Curation Task options (required)
+        String curateGroup = "";
+        try
         {
-                // Get our parameters and state;
-                String objectID = parameters.getParameter("identifier", null);
-                String taskSelected = parameters.getParameter("curate_task", null);
-                
-                // DIVISION: curate
-                Division div = body.addInteractiveDivision("curate", contextPath + "/admin/curate", Division.METHOD_MULTIPART,"primary administrative curate");
-                div.setHead(T_title);
-                
-                // Curate Form
-                List form = div.addList("curate-form", List.TYPE_FORM);
-		
-                // Object ID Textbox (required)
-                Text id = form.addItem().addText("identifier");
-                id.setAutofocus("autofocus");
-                id.setLabel(T_object_label_name);
-                if (objectID != null)
-                {
-                    id.setValue(objectID);
-                }
-                id.setRequired();
-                id.setHelp(T_object_hint);
-                
-                // Selectbox of Curation Task options (required)
-                String curateGroup = "";
-                try
-                {
-                	curateGroup = (parameters.getParameter("select_curate_group") != null) ? parameters.getParameter("select_curate_group") : FlowCurationUtils.UNGROUPED_TASKS;
-                }
-                catch (Exception pe)
-                {
-                	// noop
-                }
-                if (!FlowCurationUtils.groups.isEmpty())
-                {
-                    Select groupSelect = form.addItem().addSelect("select_curate_group");
-                    groupSelect = FlowCurationUtils.getGroupSelectOptions(groupSelect);
-                    groupSelect.setLabel(T_taskgroup_label_name); 
-                    groupSelect.setSize(1);
-                    groupSelect.setRequired();
-                    groupSelect.setEvtBehavior("submitOnChange");
-                    if (curateGroup.equals(""))
-                    {
-                    	curateGroup = (String) (FlowCurationUtils.groups.keySet().iterator().next());
-                    }
-                    groupSelect.setOptionSelected(curateGroup);
-                }
-                Select taskSelect = form.addItem().addSelect("curate_task");
-                taskSelect = FlowCurationUtils.getTaskSelectOptions(taskSelect, curateGroup);
-                taskSelect.setLabel(T_task_label_name);
-                taskSelect.setSize(1);
-                taskSelect.setRequired();
-                if(taskSelected!=null)
-                {    
-                    taskSelect.setOptionSelected(taskSelected);
-                }
-                
-                // Buttons: 'curate' and 'queue'
-                Para buttonList = div.addPara();
-                buttonList.addButton("submit_curate_task").setValue(T_submit_perform);
-                buttonList.addButton("submit_queue_task").setValue(T_submit_queue);
-                div.addHidden("administrative-continue").setValue(knot.getId());
+            curateGroup = (parameters.getParameter("select_curate_group") != null) ? parameters.getParameter("select_curate_group") : FlowCurationUtils.UNGROUPED_TASKS;
         }
+        catch (Exception pe)
+        {
+            // noop
+        }
+        if (!FlowCurationUtils.groups.isEmpty())
+        {
+            Select groupSelect = form.addItem().addSelect("select_curate_group");
+            groupSelect = FlowCurationUtils.getGroupSelectOptions(groupSelect);
+            groupSelect.setLabel(T_taskgroup_label_name); 
+            groupSelect.setSize(1);
+            groupSelect.setRequired();
+            groupSelect.setEvtBehavior("submitOnChange");
+            if (curateGroup.equals(""))
+            {
+                curateGroup = (String) (FlowCurationUtils.groups.keySet().iterator().next());
+            }
+            groupSelect.setOptionSelected(curateGroup);
+        }
+        Select taskSelect = form.addItem().addSelect("curate_task");
+        taskSelect = FlowCurationUtils.getTaskSelectOptions(taskSelect, curateGroup);
+        taskSelect.setLabel(T_task_label_name);
+        taskSelect.setSize(1);
+        taskSelect.setRequired();
+        if(taskSelected!=null)
+        {    
+            taskSelect.setOptionSelected(taskSelected);
+        }
+
+        // Buttons: 'curate' and 'queue'
+        Para buttonList = div.addPara();
+        buttonList.addButton("submit_curate_task").setValue(T_submit_perform);
+        buttonList.addButton("submit_queue_task").setValue(T_submit_queue);
+        div.addHidden("administrative-continue").setValue(knot.getId());
+    }
 }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowResult.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowResult.java
@@ -20,22 +20,22 @@ import org.dspace.app.xmlui.wing.Message;
  * and returns an object of type FlowResult, then the flow script can inspect
  * the results object to determine what the next course of action is.
  * 
- * Basically, this results object stores all the errors and continuation states
+ * <p>Basically, this results object stores all the errors and continuation states
  * that need to be represented. There are four types of information stored:
  * 
- * 1) Continuation, this is a simple boolean variable that indicates whether
+ * <p>1) Continuation, this is a simple boolean variable that indicates whether
  * the required operation is complete and the user may continue on to the next step.
  * 
- * 2) Notice information, this is a simple encoding of a notice message to be displayed
+ * <p>2) Notice information, this is a simple encoding of a notice message to be displayed
  * to the user on their next step. There are four parts: outcome, header, message, and
  * characters. See each field for more description on each part. Note: either a message
  * or characters are required.
  * 
- * 3) Errors, this is a list of errors that were encountered during processing. 
+ * <p>3) Errors, this is a list of errors that were encountered during processing.
  * Typically, it just consists of a list of errored fields. However occasionally there 
  * may be other specialized errors listed.
  * 
- * 4) Parameters, this is a map of attached parameters that may be relevant to the 
+ * <p>4) Parameters, this is a map of attached parameters that may be relevant to the
  * result. This should be used for things such as generated id's when objects are newly
  * created.
  * 
@@ -45,7 +45,7 @@ public class FlowResult {
 
 	/**
 	 * Determine whether the operation has been completed enough that the user
-	 * may successufully continue on to the next step.
+	 * may successfully continue on to the next step.
 	 */
 	private boolean continuep;
 	
@@ -73,7 +73,6 @@ public class FlowResult {
 	 */
 	private List<String> errors;
 	
-	
 	/**
 	 * Any parameters that may be attached to this result.
 	 */
@@ -82,6 +81,7 @@ public class FlowResult {
 	/**
 	 * Set the continuation parameter determining if the
 	 * user should progress to the next step in the flow.
+     * @param continuep true if should continue.
 	 */
 	public void setContinue(boolean continuep)
 	{
@@ -123,6 +123,7 @@ public class FlowResult {
 	/**
 	 * Get the notice outcome in string form, either success 
 	 * or failure. If the outcome is neutral then null is returned.
+     * @return the outcome.
 	 */
 	public String getOutcome()
 	{
@@ -141,6 +142,7 @@ public class FlowResult {
 	 * Set the notice header.
 	 * 
 	 * This must be an i18n dictionary key
+     * @param header the header.
 	 */
 	public void setHeader(Message header)
 	{
@@ -148,7 +150,8 @@ public class FlowResult {
 	}
 	
 	/**
-	 * Return the notice header
+	 * Return the notice header.
+     * @return the header.
 	 */
 	public String getHeader()
 	{
@@ -160,9 +163,10 @@ public class FlowResult {
 	}
 	
 	/**
-	 * Set the notice message
+	 * Set the notice message.
 	 * 
-	 * This must be an i18n dictionary key
+	 * This must be an i18n dictionary key.
+     * @param message the message.
 	 */
 	public void setMessage(Message message)
 	{
@@ -170,7 +174,8 @@ public class FlowResult {
 	}
 	
 	/**
-	 * return the notice message
+	 * return the notice message.
+     * @return the notice.
 	 */
 	public String getMessage()
 	{
@@ -182,7 +187,8 @@ public class FlowResult {
 	}
 	
 	/**
-	 * Set the notice characters
+	 * Set the notice characters.
+     * @param characters the notice.
 	 */
 	public void setCharacters(String characters)
 	{
@@ -191,6 +197,7 @@ public class FlowResult {
 	
 	/**
 	 * Return the notice characters
+     * @return the notice.
 	 */
 	public String getCharacters()
 	{
@@ -216,7 +223,7 @@ public class FlowResult {
 	{
 		if (this.errors == null)
         {
-            this.errors = new ArrayList<String>();
+            this.errors = new ArrayList<>();
         }
 		
 		this.errors.add(newError);
@@ -224,6 +231,7 @@ public class FlowResult {
 	
 	/**
 	 * Return the current list of errors.
+     * @return a list of errors.
 	 */
 	public List<String> getErrors()
 	{
@@ -233,10 +241,11 @@ public class FlowResult {
 	/**
 	 * Return the list of errors in string form, i.e. a comma-separated list
 	 * of errors. If there are no errors then null is returned.
+     * @return a list of errors.
 	 */
 	public String getErrorString()
 	{
-		if (errors == null || errors.size() == 0)
+		if (errors == null || errors.isEmpty())
         {
             return null;
         }
@@ -259,8 +268,8 @@ public class FlowResult {
 	
 	/**
 	 * Attach a new parameter to this result object with the specified
-	 * name & value.
-	 * 
+	 * name and value.
+	 *
 	 * @param name The parameter's name
 	 * @param value The parameter's value.
 	 */
@@ -268,7 +277,7 @@ public class FlowResult {
 	{
 		if (this.parameters == null)
         {
-            this.parameters = new HashMap<String, Object>();
+            this.parameters = new HashMap<>();
         }
 		
 		this.parameters.put(name, value);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/EditBitstreamForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/EditBitstreamForm.java
@@ -36,8 +36,9 @@ import org.xml.sax.SAXException;
 
 /**
  * 
- * Show a form allowing the user to edit a bitstream's metadata, the description & format.
- * 
+ * Show a form allowing the user to edit a bitstream's metadata, the description
+ * and format.
+ *
  * @author Scott Phillips
  */
 public class EditBitstreamForm extends AbstractDSpaceTransformer
@@ -73,6 +74,7 @@ public class EditBitstreamForm extends AbstractDSpaceTransformer
 	protected BitstreamService bitstreamService = ContentServiceFactory.getInstance().getBitstreamService();
 	protected BitstreamFormatService bitstreamFormatService = ContentServiceFactory.getInstance().getBitstreamFormatService();
 
+    @Override
 	public void addPageMeta(PageMeta pageMeta) throws WingException
 	{
 		pageMeta.addMetadata("title").addContent(T_title);
@@ -83,6 +85,7 @@ public class EditBitstreamForm extends AbstractDSpaceTransformer
         pageMeta.addMetadata("javascript", "static").addContent("static/js/editItemUtil.js");
 	}
 
+    @Override
 	public void addBody(Body body) throws SAXException, WingException,
 	UIException, SQLException, IOException, AuthorizeException
 	{

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemViewer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemViewer.java
@@ -100,6 +100,7 @@ public class ItemViewer extends AbstractDSpaceTransformer implements CacheablePr
     /**
      * Generate the unique caching key.
      * This key must be unique inside the space of this component.
+     * @return the key.
      */
     @Override
     public Serializable getKey() {
@@ -124,7 +125,8 @@ public class ItemViewer extends AbstractDSpaceTransformer implements CacheablePr
      * Generate the cache validity object.
      *
      * The validity object will include the item being viewed,
-     * along with all bundles & bitstreams.
+     * along with all bundles and bitstreams.
+     * @return validity.
      */
     @Override
     public SourceValidity getValidity()
@@ -136,9 +138,9 @@ public class ItemViewer extends AbstractDSpaceTransformer implements CacheablePr
 	        try {
 	            dso = HandleUtil.obtainHandle(objectModel);
 
-	            DSpaceValidity validity = new DSpaceValidity();
-	            validity.add(context, dso);
-	            this.validity =  validity.complete();
+	            DSpaceValidity newValidity = new DSpaceValidity();
+	            newValidity.add(context, dso);
+	            this.validity =  newValidity.complete();
 	        }
 	        catch (Exception e)
 	        {
@@ -159,6 +161,12 @@ public class ItemViewer extends AbstractDSpaceTransformer implements CacheablePr
 
     /**
      * Add the item's title and trail links to the page's metadata.
+     * @throws org.xml.sax.SAXException
+     * @throws org.dspace.app.xmlui.wing.WingException if a crosswalk fails.
+     * @throws org.dspace.app.xmlui.utils.UIException passed through.
+     * @throws java.sql.SQLException passed through.
+     * @throws java.io.IOException passed through.
+     * @throws org.dspace.authorize.AuthorizeException passed through.
      */
     @Override
     public void addPageMeta(PageMeta pageMeta) throws SAXException,
@@ -322,6 +330,12 @@ public class ItemViewer extends AbstractDSpaceTransformer implements CacheablePr
 
     /**
      * Display a single item
+     * @throws org.xml.sax.SAXException passed through.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
+     * @throws org.dspace.app.xmlui.utils.UIException passed through.
+     * @throws java.sql.SQLException passed through.
+     * @throws java.io.IOException passed through.
+     * @throws org.dspace.authorize.AuthorizeException passed through.
      */
     @Override
     public void addBody(Body body) throws SAXException, WingException,
@@ -413,23 +427,17 @@ public class ItemViewer extends AbstractDSpaceTransformer implements CacheablePr
 
     /**
      * Determine if the full item should be referenced or just a summary.
+     * @param objectModel to get the request.
+     * @return true if the full item should be shown.
      */
     public static boolean showFullItem(Map objectModel)
     {
         Request request = ObjectModelHelper.getRequest(objectModel);
         String show = request.getParameter("show");
 
-        if (show != null && show.length() > 0)
-        {
-            return true;
-        }
-
-        return false;
+        return show != null && show.length() > 0;
     }
 
-    /**
-     * Recycle
-     */
     @Override
     public void recycle() {
     	this.validity = null;

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/SendItemRequestAction.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/SendItemRequestAction.java
@@ -50,12 +50,13 @@ import org.dspace.handle.service.HandleService;
  */
 public class SendItemRequestAction extends AbstractAction
 {
-    private static Logger log = Logger.getLogger(SendItemRequestAction.class);
+    private static final Logger log = Logger.getLogger(SendItemRequestAction.class);
 
     protected HandleService handleService = HandleServiceFactory.getInstance().getHandleService();
     protected RequestItemService requestItemService = RequestItemServiceFactory.getInstance().getRequestItemService();
     protected BitstreamService bitstreamService = ContentServiceFactory.getInstance().getBitstreamService();
 
+    @Override
     public Map act(Redirector redirector, SourceResolver resolver, Map objectModel,
             String source, Parameters parameters) throws Exception
     {
@@ -81,7 +82,7 @@ public class SendItemRequestAction extends AbstractAction
         {
             // Either the user did not fill out the form or this is the
             // first time they are visiting the page.
-            Map<String,String> map = new HashMap<String,String>();
+            Map<String,String> map = new HashMap<>();
             map.put("bitstreamId",bitstreamId);
 
             if (StringUtils.isEmpty(requesterEmail))
@@ -141,19 +142,21 @@ public class SendItemRequestAction extends AbstractAction
 
     /**
      * Get the link to the author in RequestLink email.
-     * @param context
-     * @param requestItem
-     * @return
-     * @throws SQLException
+     * @param context DSpace session context.
+     * @param token token.
+     * @return the link.
+     * @throws SQLException passed through.
      */
     protected String getLinkTokenEmail(Context context, String token)
             throws SQLException
     {
         String base = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("dspace.url");
 
-        String specialLink = (new StringBuffer()).append(base).append(
-                base.endsWith("/") ? "" : "/").append(
-                "itemRequestResponse/").append(token)
+        String specialLink = new StringBuffer()
+                .append(base)
+                .append(base.endsWith("/") ? "" : "/")
+                .append("itemRequestResponse/")
+                .append(token)
                 .toString()+"/";
 
         return specialLink;

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/AbstractSearch.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/AbstractSearch.java
@@ -12,11 +12,9 @@ import org.apache.cocoon.environment.ObjectModelHelper;
 import org.apache.cocoon.environment.Request;
 import org.apache.cocoon.util.HashUtil;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.excalibur.source.SourceValidity;
 import org.apache.log4j.Logger;
-import org.dspace.app.util.MetadataExposureServiceImpl;
 import org.dspace.app.util.factory.UtilServiceFactory;
 import org.dspace.app.util.service.MetadataExposureService;
 import org.dspace.app.xmlui.cocoon.AbstractDSpaceTransformer;
@@ -43,7 +41,6 @@ import org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguratio
 import org.dspace.discovery.configuration.DiscoverySortConfiguration;
 import org.dspace.discovery.configuration.DiscoverySortConfiguration.SORT_ORDER;
 import org.dspace.discovery.configuration.DiscoverySortFieldConfiguration;
-import org.dspace.handle.HandleServiceImpl;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
 import org.xml.sax.SAXException;
@@ -58,7 +55,7 @@ import java.util.List;
  * This is an abstract search page. It is a collection of search methods that
  * are common between different search implementation. An implementer must
  * implement at least three methods: addBody(), getQuery(), and generateURL().
- * <p/>
+ * <p>
  * See the SimpleSearch implementation.
  *
  * @author Kevin Van de Velde (kevin at atmire dot com)
@@ -124,11 +121,12 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
     protected MetadataExposureService metadataExposureService = UtilServiceFactory.getInstance().getMetadataExposureService();
     protected HandleService handleService = HandleServiceFactory.getInstance().getHandleService();
 
-
     /**
      * Generate the unique caching key.
      * This key must be unique inside the space of this component.
+     * @return the key.
      */
+    @Override
     public Serializable getKey() {
         try {
             String key = "";
@@ -153,7 +151,7 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
             return HashUtil.hash(key);
         } catch (RuntimeException re) {
             throw re;
-        } catch (Exception e) {
+        } catch (SQLException | UIException e) {
             // Ignore all errors and just don't cache.
             return "0";
         }
@@ -161,30 +159,32 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
 
     /**
      * Generate the cache validity object.
-     * <p/>
+     * <p>
      * This validity object should never "over cache" because it will
      * perform the search, and serialize the results using the
      * DSpaceValidity object.
+     * @return the validity.
      */
+    @Override
     public SourceValidity getValidity() {
         if (this.validity == null) {
             try {
-                DSpaceValidity validity = new DSpaceValidity();
+                DSpaceValidity newValidity = new DSpaceValidity();
 
                 DSpaceObject scope = getScope();
-                validity.add(context, scope);
+                newValidity.add(context, scope);
 
                 performSearch(scope);
 
                 List<DSpaceObject> results = this.queryResults.getDspaceObjects();
 
                 if (results != null) {
-                    validity.add("total:"+this.queryResults.getTotalSearchResults());
-                    validity.add("start:"+this.queryResults.getStart());
-                    validity.add("size:" + results.size());
+                    newValidity.add("total:"+this.queryResults.getTotalSearchResults());
+                    newValidity.add("start:"+this.queryResults.getStart());
+                    newValidity.add("size:" + results.size());
 
                     for (DSpaceObject dso : results) {
-                        validity.add(context, dso);
+                        newValidity.add(context, dso);
                     }
                 }
 
@@ -193,15 +193,15 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
                     List<DiscoverResult.FacetResult> facetValues = facetResults.get(facetField);
                     for (DiscoverResult.FacetResult facetResult : facetValues)
                     {
-                        validity.add(facetField + facetResult.getAsFilterQuery() + facetResult.getCount());
+                        newValidity.add(facetField + facetResult.getAsFilterQuery() + facetResult.getCount());
                     }
                 }
 
-                this.validity = validity.complete();
+                this.validity = newValidity.complete();
             } catch (RuntimeException re) {
                 throw re;
             }
-            catch (Exception e) {
+            catch (SQLException | UIException | SearchServiceException e) {
                 this.validity = null;
             }
 
@@ -215,7 +215,14 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
 
     /**
      * Build the resulting search DRI document.
+     * @throws org.xml.sax.SAXException whenever.
+     * @throws org.dspace.app.xmlui.wing.WingException whenever.
+     * @throws org.dspace.app.xmlui.utils.UIException whenever.
+     * @throws java.sql.SQLException whenever.
+     * @throws java.io.IOException whenever.
+     * @throws org.dspace.authorize.AuthorizeException whenever.
      */
+    @Override
     public abstract void addBody(Body body) throws SAXException, WingException,
             UIException, SQLException, IOException, AuthorizeException;
 
@@ -224,6 +231,8 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
      * This form will be used for all discovery queries, filters, ....
      * At the moment however this form is only used to track search result hits
      * @param searchDiv the division to add the form to
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
+     * @throws java.sql.SQLException passed through.
      */
     protected void buildMainForm(Division searchDiv) throws WingException, SQLException {
         Request request = ObjectModelHelper.getRequest(objectModel);
@@ -284,6 +293,10 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
      * which contains results for this search query.
      *
      * @param search The search division to contain the search-results division.
+     * @throws java.io.IOException passed through.
+     * @throws java.sql.SQLException passed through.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
+     * @throws org.dspace.discovery.SearchServiceException passed through.
      */
     protected void buildSearchResultsDivision(Division search)
             throws IOException, SQLException, WingException, SearchServiceException {
@@ -299,7 +312,7 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
             log.error(e.getMessage(), e);
             queryResults = null;
         }
-        catch (Exception e) {
+        catch (SQLException | UIException | SearchServiceException e) {
             log.error(e.getMessage(), e);
             queryResults = null;
         }
@@ -345,9 +358,9 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
             //    lastItemIndex = itemsTotal;
             int currentPage = this.queryResults.getStart() / this.queryResults.getMaxResults() + 1;
             int pagesTotal = (int) ((this.queryResults.getTotalSearchResults() - 1) / this.queryResults.getMaxResults()) + 1;
-            Map<String, String> parameters = new HashMap<String, String>();
-            parameters.put("page", "{pageNum}");
-            String pageURLMask = generateURL(parameters);
+            Map<String, String> urlParameters = new HashMap<>();
+            urlParameters.put("page", "{pageNum}");
+            String pageURLMask = generateURL(urlParameters);
             pageURLMask = addFilterQueriesToUrl(pageURLMask);
 
             results.setMaskedPagination(itemsTotal, firstItemIndex,
@@ -360,8 +373,8 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
             dspaceObjectsList = results.addList("search-results-repository",
                     org.dspace.app.xmlui.wing.element.List.TYPE_DSO_LIST, "repository-search-results");
 
-            List<DSpaceObject> commCollList = new ArrayList<DSpaceObject>();
-            List<Item> itemList = new ArrayList<Item>();
+            List<DSpaceObject> commCollList = new ArrayList<>();
+            List<Item> itemList = new ArrayList<>();
             for (DSpaceObject resultDso : queryResults.getDspaceObjects())
             {
                 if(resultDso.getType() == Constants.COMMUNITY || resultDso.getType() == Constants.COLLECTION)
@@ -509,9 +522,13 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
      * Render the given collection, all collection metadata is added to the list
      * @param collection the collection to be rendered
      * @param highlightedResults the highlighted results
-     * @throws WingException
+     * @param collectionMetadata list of metadata values.
+     * @throws WingException passed through.
      */
-    protected void renderCollection(Collection collection, DiscoverResult.DSpaceObjectHighlightResult highlightedResults, org.dspace.app.xmlui.wing.element.List collectionMetadata) throws WingException {
+    protected void renderCollection(Collection collection,
+            DiscoverResult.DSpaceObjectHighlightResult highlightedResults,
+            org.dspace.app.xmlui.wing.element.List collectionMetadata)
+            throws WingException {
 
         String description = collectionService.getMetadata(collection, "introductory_text");
         String description_abstract = collectionService.getMetadata(collection, "short_description");
@@ -560,10 +577,14 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
      * Render the given collection, all collection metadata is added to the list
      * @param community the community to be rendered
      * @param highlightedResults the highlighted results
-     * @throws WingException
+     * @param communityMetadata list of metadata values.
+     * @throws WingException passed through.
      */
 
-    protected void renderCommunity(Community community, DiscoverResult.DSpaceObjectHighlightResult highlightedResults, org.dspace.app.xmlui.wing.element.List communityMetadata) throws WingException {
+    protected void renderCommunity(Community community,
+            DiscoverResult.DSpaceObjectHighlightResult highlightedResults,
+            org.dspace.app.xmlui.wing.element.List communityMetadata)
+            throws WingException {
         String description = communityService.getMetadata(community, "introductory_text");
         String description_abstract = communityService.getMetadata(community, "short_description");
         String description_table = communityService.getMetadata(community, "side_bar_text");
@@ -573,27 +594,39 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
 
         if(StringUtils.isNotBlank(description))
         {
-            addMetadataField(highlightedResults, "dc.description", communityMetadata.addList(community.getHandle() + ":dc.description"), description);
+            addMetadataField(highlightedResults, "dc.description",
+                    communityMetadata.addList(community.getHandle() + ":dc.description"),
+                    description);
         }
         if(StringUtils.isNotBlank(description_abstract))
         {
-            addMetadataField(highlightedResults, "dc.description.abstract", communityMetadata.addList(community.getHandle() + ":dc.description.abstract"), description_abstract);
+            addMetadataField(highlightedResults, "dc.description.abstract",
+                    communityMetadata.addList(community.getHandle() + ":dc.description.abstract"),
+                    description_abstract);
         }
         if(StringUtils.isNotBlank(description_table))
         {
-            addMetadataField(highlightedResults, "dc.description.tableofcontents", communityMetadata.addList(community.getHandle() + ":dc.description.tableofcontents"), description_table);
+            addMetadataField(highlightedResults, "dc.description.tableofcontents",
+                    communityMetadata.addList(community.getHandle() + ":dc.description.tableofcontents"),
+                    description_table);
         }
         if(StringUtils.isNotBlank(identifier_uri))
         {
-            addMetadataField(highlightedResults, "dc.identifier.uri", communityMetadata.addList(community.getHandle() + ":dc.identifier.uri"), identifier_uri);
+            addMetadataField(highlightedResults, "dc.identifier.uri",
+                    communityMetadata.addList(community.getHandle() + ":dc.identifier.uri"),
+                    identifier_uri);
         }
         if(StringUtils.isNotBlank(rights))
         {
-            addMetadataField(highlightedResults, "dc.rights", communityMetadata.addList(community.getHandle() + ":dc.rights"), rights);
+            addMetadataField(highlightedResults, "dc.rights",
+                    communityMetadata.addList(community.getHandle() + ":dc.rights"),
+                    rights);
         }
         if(StringUtils.isNotBlank(title))
         {
-            addMetadataField(highlightedResults, "dc.title", communityMetadata.addList(community.getHandle() + ":dc.title"), title);
+            addMetadataField(highlightedResults, "dc.title",
+                    communityMetadata.addList(community.getHandle() + ":dc.title"),
+                    title);
         }
     }
 
@@ -605,7 +638,12 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
      * @param value the metadata value
      * @throws WingException
      */
-    protected void addMetadataField(DiscoverResult.DSpaceObjectHighlightResult highlightedResults, String metadataKey, org.dspace.app.xmlui.wing.element.List metadataFieldList, String value) throws WingException {
+    protected void addMetadataField(
+            DiscoverResult.DSpaceObjectHighlightResult highlightedResults,
+            String metadataKey,
+            org.dspace.app.xmlui.wing.element.List metadataFieldList,
+            String value)
+            throws WingException {
         if(value == null){
             //In the unlikely event that the value is null, do not attempt to render this
             return;
@@ -648,10 +686,12 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
     }
 
     /**
-     * Add our metadata value, this value will might contain the highlight ("<em></em>") tags, these will be removed & rendered as highlight wing fields.
-     * @param metadataFieldList the metadata list we need to add the value to
+     * Add our metadata value.  This value will might contain the highlight
+     * ("{@code <em></em>}") tags.  These will be removed and rendered as highlight WING fields.
+     *
+     * @param metadataFieldList the metadata list we need to add the value to.
      * @param value the metadata value to be rendered
-     * @throws WingException
+     * @throws WingException passed through.
      */
     protected void addMetadataField(org.dspace.app.xmlui.wing.element.List metadataFieldList, String value) throws WingException {
         //We need to put everything in <em> tags in a highlight !
@@ -677,18 +717,19 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
     /**
      * Add options to the search scope field. This field determines in which
      * communities or collections to search for the query.
-     * <p/>
+     * <p>
      * The scope list will depend upon the current search scope. There are three
      * cases:
-     * <p/>
-     * No current scope: All top level communities are listed.
-     * <p/>
-     * The current scope is a community: All collections contained within the
-     * community are listed.
-     * <p/>
-     * The current scope is a collection: All parent communities are listed.
+     * <ul>
+     *  <li>No current scope: All top level communities are listed.
+     *  <li>The current scope is a community: All collections contained within the
+     *      community are listed.
+     *  <li>The current scope is a collection: All parent communities are listed.
+     * </ul>
      *
      * @param scope The current scope field.
+     * @throws java.sql.SQLException passed through.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected void buildScopeList(Select scope) throws SQLException,
             WingException {
@@ -729,10 +770,16 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
     /**
      *  Prepare DiscoverQuery given the current scope and query string
      * 
-     *  @param scope the dspace object parent
+     * @param scope the dspace object parent
+     * @param query the query.
+     * @param fqs the filter queries.
+     * @return the prepared query.
+     * @throws org.dspace.app.xmlui.utils.UIException passed through.
+     * @throws org.dspace.discovery.SearchServiceException passed through.
      */
-    public DiscoverQuery prepareQuery(DSpaceObject scope, String query, String[] fqs) throws UIException, SearchServiceException {
-    	
+    public DiscoverQuery prepareQuery(DSpaceObject scope, String query, String[] fqs)
+            throws UIException, SearchServiceException {
+
     	this.queryArgs = new DiscoverQuery();
     	
     	int page = getParameterPage();
@@ -740,7 +787,7 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
     	// Escape any special characters in this user-entered query
         query = DiscoveryUIUtils.escapeQueryChars(query);
 
-    	List<String> filterQueries = new ArrayList<String>();
+    	List<String> filterQueries = new ArrayList<>();
 
         if (fqs != null) {
             filterQueries.addAll(Arrays.asList(fqs));
@@ -835,8 +882,9 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
      * Query DSpace for a list of all items / collections / or communities that
      * match the given search query.
      *
-     *
      * @param scope the dspace object parent
+     * @throws org.dspace.app.xmlui.utils.UIException passed through.
+     * @throws org.dspace.discovery.SearchServiceException passed through.
      */
     public void performSearch(DSpaceObject scope) throws UIException, SearchServiceException {
 
@@ -854,7 +902,7 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
     protected Map<String, String[]> getParameterFilterQueries()
     {
         try {
-            Map<String, String[]> result = new HashMap<String, String[]>();
+            Map<String, String[]> result = new HashMap<>();
             result.put("fq", ObjectModelHelper.getRequest(objectModel).getParameterValues("fq"));
             return result;
         }
@@ -934,11 +982,12 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
     /**
      * Determine if the scope of the search should fixed or is changeable by the
      * user.
-     * <p/>
-     * The search scope when performed by url, i.e. they are at the url handle/xxxx/xx/search
+     * <p>
+     * The search scope when performed by URL, i.e. they are at the URL handle/xxxx/xx/search
      * then it is fixed. However at the global level the search is variable.
      *
      * @return true if the scope is variable, false otherwise.
+     * @throws java.sql.SQLException passed through.
      */
     protected boolean variableScope() throws SQLException {
         return (HandleUtil.obtainHandle(objectModel) == null);
@@ -946,33 +995,31 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
 
     /**
      * Extract the query string. Under most implementations this will be derived
-     * from the url parameters.
+     * from the URL parameters.
      *
      * @return The query string.
+     * @throws org.dspace.app.xmlui.utils.UIException whenever.
      */
     protected abstract String getQuery() throws UIException;
 
     /**
-     * Generate a url to the given search implementation with the associated
+     * Generate a URL to the given search implementation with the associated
      * parameters included.
      *
-     * @param parameters
+     * @param parameters URL query parameters.
      * @return The post URL
+     * @throws org.dspace.app.xmlui.utils.UIException whenever.
      */
     protected abstract String generateURL(Map<String, String> parameters)
             throws UIException;
 
-
-    /**
-     * Recycle
-     */
+    @Override
     public void recycle() {
         this.queryArgs = null;
         this.queryResults = null;
         this.validity = null;
         super.recycle();
     }
-
 
     protected void buildSearchControls(Division div)
             throws WingException, SQLException {
@@ -1043,6 +1090,7 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
      * specified then null is returned.
      *
      * @return The current scope.
+     * @throws java.sql.SQLException passed through.
      */
     protected DSpaceObject getScope() throws SQLException {
         Request request = ObjectModelHelper.getRequest(objectModel);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/AuthenticateAction.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/AuthenticateAction.java
@@ -28,23 +28,27 @@ import org.dspace.eperson.EPerson;
 
 /**
  * Attempt to authenticate the user based upon their presented credentials. 
- * This action uses the http parameters of login_email, login_password, and 
+ * This action uses the HTTP parameters of login_email, login_password, and
  * login_realm as credentials.
  * 
- * If the authentication attempt is successful then an HTTP redirect will be
+ * <p>If the authentication attempt is successful then an HTTP redirect will be
  * sent to the browser redirecting them to their original location in the 
  * system before authenticated or if none is supplied back to the DSpace 
- * homepage. The action will also return true, thus contents of the action will
- * be excuted.
- * 
- * If the authentication attempt fails, the action returns false.
- * 
- * Example use:
- * 
+ * home page. The action will also return true, thus contents of the action will
+ * be executed.
+ *
+ * <p>If the authentication attempt fails, the action returns false.
+ *
+ * <p>Example use:
+ *
+ * <pre>
+ * {@code
  * <map:act name="Authenticate">
  *   <map:serialize type="xml"/>
  * </map:act>
  * <map:transform type="try-to-login-again-transformer">
+ * }
+ * </pre>
  *
  * @author Scott Phillips
  */
@@ -54,7 +58,15 @@ public class AuthenticateAction extends AbstractAction
 
     /**
      * Attempt to authenticate the user. 
+     * @param redirector redirector.
+     * @param resolver source resolver.
+     * @param objectModel object model.
+     * @param source source
+     * @param parameters sitemap parameters.
+     * @return result of the action.
+     * @throws java.lang.Exception
      */
+    @Override
     public Map act(Redirector redirector, SourceResolver resolver, Map objectModel,
             String source, Parameters parameters) throws Exception
     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/LDAPAuthenticateAction.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/LDAPAuthenticateAction.java
@@ -28,20 +28,24 @@ import org.dspace.eperson.EPerson;
 
 /**
  * Attempt to authenticate the user based upon their presented credentials. This
- * action uses the http parameters of username, ldap_password, and login_realm
+ * action uses the HTTP parameters of username, ldap_password, and login_realm
  * as credentials.
  * 
- * If the authentication attempt is successful then an HTTP redirect will be
+ * <p>If the authentication attempt is successful then an HTTP redirect will be
  * sent to the browser redirecting them to their original location in the system
- * before authenticated or if none is supplied back to the DSpace homepage. The
- * action will also return true, thus contents of the action will be excuted.
+ * before authenticated or if none is supplied back to the DSpace home page. The
+ * action will also return true, thus contents of the action will be executed.
  * 
- * If the authentication attempt fails, the action returns false.
+ * <p>If the authentication attempt fails, the action returns false.
  * 
- * Example use:
- * 
+ * <p>Example use:
+ *
+ * <pre>
+ * {@code
  * <map:act name="LDAPAuthenticate"> <map:serialize type="xml"/> </map:act>
  * <map:transform type="try-to-login-again-transformer">
+ * }
+ * </pre>
  * 
  * @author Jay Paz
  */
@@ -50,10 +54,19 @@ public class LDAPAuthenticateAction extends AbstractAction {
 
 	/**
 	 * Attempt to authenticate the user.
+     * @param redirector redirector.
+     * @param resolver source resolver.
+     * @param objectModel object model.
+     * @param source source.
+     * @param parameters sitemap parameters.
+     * @return results of the action.
+     * @throws org.apache.cocoon.sitemap.PatternException if unable to authenticate.
+     * @throws java.lang.Exception passed through.
 	 */
+    @Override
 	public Map act(Redirector redirector, SourceResolver resolver,
 			Map objectModel, String source, Parameters parameters)
-			throws Exception {
+			throws PatternException, Exception {
 		// First check if we are performing a new login
 		Request request = ObjectModelHelper.getRequest(objectModel);
 
@@ -82,12 +95,12 @@ public class LDAPAuthenticateAction extends AbstractAction {
 					redirectURL += AuthenticationUtil
 							.resumeInterruptedRequest(objectModel);
 				}
-                                else
-                                {
-                                        // Otherwise direct the user to the specified 'loginredirect' page (or homepage by default)
-                                        String loginRedirect = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("xmlui.user.loginredirect");
-                                        redirectURL += (loginRedirect != null) ? loginRedirect.trim() : "/";	
-                                }
+                else
+                {
+                    // Otherwise direct the user to the specified 'loginredirect' page (or homepage by default)
+                    String loginRedirect = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("xmlui.user.loginredirect");
+                    redirectURL += (loginRedirect != null) ? loginRedirect.trim() : "/";	
+                }
 
 				// Authentication successful send a redirect.
 				final HttpServletResponse httpResponse = (HttpServletResponse) objectModel

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/ShibbolethAction.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/ShibbolethAction.java
@@ -28,23 +28,27 @@ import org.dspace.eperson.EPerson;
 
 /**
  * Attempt to authenticate the user based upon their presented shibboleth credentials. 
- * This action uses the http parameters as supplied by Shibboleth SP.
+ * This action uses the HTTP parameters as supplied by Shibboleth SP.
  * Read dspace.cfg for configuration detail.
- * 
- * If the authentication attempt is successful then an HTTP redirect will be
+ *
+ * <p>If the authentication attempt is successful then an HTTP redirect will be
  * sent to the browser redirecting them to their original location in the 
  * system before authenticated or if none is supplied back to the DSpace 
- * homepage. The action will also return true, thus contents of the action will
- * be excuted.
+ * home page. The action will also return true, thus contents of the action will
+ * be executed.
+ *
+ * <p>If the authentication attempt fails, the action returns false.
  * 
- * If the authentication attempt fails, the action returns false.
- * 
- * Example use:
- * 
+ * <p>Example use:
+ *
+ * <pre>
+ * {@code
  * <map:act name="Shibboleth">
  *   <map:serialize type="xml"/>
  * </map:act>
  * <map:transform type="try-to-login-again-transformer">
+ * }
+ * </pre>
  *
  * @author <a href="mailto:bliong@melcoe.mq.edu.au">Bruc Liong, MELCOE</a>
  */
@@ -53,10 +57,21 @@ public class ShibbolethAction extends AbstractAction
 {
 
     /**
-     * Attempt to authenticate the user. 
+     * Attempt to authenticate the user.
+     *
+     * @param redirector redirector.
+     * @param resolver source resolver.
+     * @param objectModel object model.
+     * @param source source.
+     * @param parameters sitemap parameters.
+     * @return result of the action.
+     * @throws org.apache.cocoon.sitemap.PatternException if authentication fails.
+     * @throws java.lang.Exception passed through.
      */
+    @Override
     public Map act(Redirector redirector, SourceResolver resolver, Map objectModel,
-            String source, Parameters parameters) throws Exception
+            String source, Parameters parameters)
+            throws PatternException, Exception
     {
         try
         {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/StartAuthenticationAction.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/StartAuthenticationAction.java
@@ -23,28 +23,32 @@ import org.dspace.app.xmlui.utils.AuthenticationUtil;
 /**
  * 
  * This action will start the necessary steps to authenticate a user. After the user 
- * successfuly authenticates, the user will resume this request with all parameters
+ * successfully authenticates, the user will resume this request with all parameters
  * and attributes intact. An optional message can be added that will be displayed
  * on the login form. This could be used to provide a reason why the user is being
  * queried for a user name and password.
- * 
- * Possible parameters are:
- * 
- * header: An i18n message that will be used as the header for the message.
- * 
- * message: An i18n message tag.
- * 
- * characters: Characters to be displayed, possibly for untranslated error messages
- * 
- * 
+ *
+ * <p>Possible parameters are:
+ *
+ * <ul>
+ *  <li>header: An i18n message that will be used as the header for the message.
+ *  <li>message: An i18n message tag.
+ *  <li>characters: Characters to be displayed, possibly for untranslated error messages
+ * </ul>
+ *
+ * <p>Example:
+ * <pre>
+ * {@code
  * <map:action name="StartAuthenticationAction" src="org.dspace.app.xmlui.eperson.StartAuthenticationAction"/>
  * 
- * 
  * <map:act type="StartAuthenticationAction"/>
- * 
+ * }
+ * </pre>
  * 
  * Typically, this is used in conjunction with the AuthenticatedSelector as:
- * 
+ *
+ * <pre>
+ * {@code
  * <map:select type="AuthenticatedSelector">
  *   <map:when test="eperson">
  *     ...
@@ -55,6 +59,8 @@ import org.dspace.app.xmlui.utils.AuthenticationUtil;
  *     </map:act>
  *   </map:otherwise>
  * </map:select>
+ * }
+ * </pre>
  * 
  * @author Scott Phillips
  */
@@ -63,7 +69,15 @@ public class StartAuthenticationAction extends AbstractAction
 {
     /**
      * Redirect the user to the login page.
+     * @param redirector redirector.
+     * @param resolver source resolver.
+     * @param objectModel object model.
+     * @param source source.
+     * @param parameters sitemap parameters.
+     * @return result of the action.
+     * @throws java.lang.Exception passed through.
      */
+    @Override
     public Map act(Redirector redirector, SourceResolver resolver,
             Map objectModel, String source, Parameters parameters)
             throws Exception

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/UnAuthenticateAction.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/UnAuthenticateAction.java
@@ -28,15 +28,19 @@ import org.dspace.eperson.EPerson;
  * Unauthenticate the current user. There is no way this action will fail, 
  * so any components inside the action will be executed.
  * 
- * This action will always send an HTTP redirect to the DSpace homepage.
- * 
- * Example: 
- * 
+ * <p>This action will always send an HTTP redirect to the DSpace home page.
+ *
+ * <p>Example:
+ *
+ * <pre>
+ * {@code
  * <map:action name="UnAuthenticateAction" src="org.dspace.app.xmlui.eperson.UnAuthenticateAction"/>
  * 
  * <map:act type="UnAuthenticateAction">
  *   <map:serialize type="xml"/>
  * </map:act>
+ * }
+ * </pre>
  * 
  * @author Scott Phillips
  */
@@ -47,13 +51,16 @@ public class UnAuthenticateAction extends AbstractAction
     /**
      * Logout the current user.
      * 
-     * @param redirector
-     * @param resolver
+     * @param redirector redirector.
+     * @param resolver source resolver.
      * @param objectModel
      *            Cocoon's object model
-     * @param source
-     * @param parameters
+     * @param source source.
+     * @param parameters sitemap parameters.
+     * @return result of the action.
+     * @throws java.lang.Exception passed through.
      */
+    @Override
     public Map act(Redirector redirector, SourceResolver resolver, Map objectModel,
             String source, Parameters parameters) throws Exception
     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/general/AuthenticatedSelector.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/general/AuthenticatedSelector.java
@@ -14,7 +14,6 @@ import org.apache.avalon.framework.parameters.Parameters;
 import org.apache.cocoon.selection.Selector;
 import org.apache.log4j.Logger;
 import org.dspace.app.xmlui.utils.ContextUtil;
-import org.dspace.authorize.AuthorizeServiceImpl;
 import org.dspace.authorize.factory.AuthorizeServiceFactory;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.core.Context;
@@ -23,10 +22,10 @@ import org.dspace.eperson.EPerson;
 /**
  * This simple selector operates on the authenticated DSpace user and selects
  * between two levels of access.
- * 
+ *
+ * <pre>
+ * {@code
  * <map:selector name="AuthenticatedSelector" src="org.dspace.app.xmlui.AuthenticatedSelector"/>
- * 
- * 
  * 
  * <map:select type="AuthenticatedSelector"> 
  *   <map:when test="administrator">
@@ -39,11 +38,13 @@ import org.dspace.eperson.EPerson;
  *     ...
  *   </map:otherwise> 
  * </map:select>
+ * }
+ * </pre>
  * 
  * There are only two defined test expressions: "administrator" and "eperson".
- * Remember an administrator is also an eperson so if you need to check for
+ * Remember that an administrator is also an eperson, so if you need to check for
  * administrators distinct from epersons that select must come first.
- * 
+ *
  * @author Scott Phillips
  */
 
@@ -51,9 +52,9 @@ public class AuthenticatedSelector extends AbstractLogEnabled implements
         Selector
 {
 
-    private static Logger log = Logger.getLogger(AuthenticatedSelector.class);
+    private static final Logger log = Logger.getLogger(AuthenticatedSelector.class);
 
-    /** Test expressiots */
+    /** Test expressions */
     public static final String EPERSON = "eperson";
 
     public static final String ADMINISTRATOR = "administrator";
@@ -62,7 +63,12 @@ public class AuthenticatedSelector extends AbstractLogEnabled implements
 
     /**
      * Determine if the authenticated eperson matches the given expression.
+     * @param expression the given expression.
+     * @param objectModel object model.
+     * @param parameters sitemap parameters.
+     * @return
      */
+    @Override
     public boolean select(String expression, Map objectModel,
             Parameters parameters)
     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/general/ChoiceLookupTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/general/ChoiceLookupTransformer.java
@@ -37,29 +37,44 @@ import org.xml.sax.SAXException;
  * back to the indicated form fields in the window that launched it.
  * Some necessary logic is in JavaScript, see choice-control.js.
  *
- * Expected Parameters:
- *  field - name of metadata field in "_" notation, eg: dc_contributor_author
- *  value - maybe-partial value of field
- *  formID - the @id of <form> tag in calling window containing the inputs we are to set.
- *  valueInput - @name of input field in DOM for value.
- *  authorityInput - @name of input field in DOM for authority value
- *  isRepeating - true if metadata value can be repeated
- *  isName - true if this is a name value (i.e. last/first boxes)
- *  start - starting index, default 0
- *  limit - maximum values to return, default 0 (none)
+ * <p>Expected Parameters:
+ * <dl>
+ *  <dt>field <dd>name of metadata field in "_" notation, eg: dc_contributor_author
+ *  <dt>value <dd>maybe-partial value of field
+ *  <dt>formID <dd>the @id of {@code <form>} tag in calling window containing the inputs we are to set.
+ *  <dt>valueInput <dd>@name of input field in DOM for value.
+ *  <dt>authorityInput <dd>@name of input field in DOM for authority value
+ *  <dt>isRepeating <dd>true if metadata value can be repeated
+ *  <dt>isName <dd>true if this is a name value (i.e. last/first boxes)
+ *  <dt>start <dd>starting index, default 0
+ *  <dt>limit <dd>maximum values to return, default 0 (none)
+ * </dl>
  *
- * Configuration Properties:
- *  xmlui.lookup.select.size = 12  (default, entries to show in SELECT widget.)
+ * <p>Configuration Properties:
+ * <ul>
+ *  <li>xmlui.lookup.select.size = 12  (default, entries to show in SELECT widget.)
+ * </ul>
  *
- * For each FIELD, e.g. dc.contributor.author, these message properties
+ * <p>For each FIELD, e.g. dc.contributor.author, these message properties
  * will OVERRIDE the corresponding i18n message catalog entries:
- *  xmlui.lookup.field.FIELD.title = title of lookup page
+ * <dl>
+ *  <dt>xmlui.lookup.field.FIELD.title
+ *  <dd>title of lookup page
  *   (e.g. xmlui.lookup.field.dc_contributor_author.title = Author..)
- *  xmlui.lookup.field.FIELD.nonauthority = template for "non-authority" label in options
- *  xmlui.lookup.field.FIELD.help = help message for single input
+ *
+ *  <dt>xmlui.lookup.field.FIELD.nonauthority
+ *  <dd>template for "non-authority" label in options
+ *
+ *  <dt>xmlui.lookup.field.FIELD.help
+ *  <dd>help message for single input
  *    (NOTE this is still required even for name inputs)
- *  xmlui.lookup.field.FIELD.help.last = help message for last name of Name-oriented input
- *  xmlui.lookup.field.FIELD.help.first = help message for first name of Name-oriented input
+ *
+ *  <dt>xmlui.lookup.field.FIELD.help.last
+ *  <dd>help message for last name of Name-oriented input
+ *
+ *  <dt>xmlui.lookup.field.FIELD.help.first
+ *  <dd>help message for first name of Name-oriented input
+ * </dl>
  *
  * @author  Larry Stone
  */
@@ -79,6 +94,7 @@ public class ChoiceLookupTransformer extends AbstractDSpaceTransformer
 
     protected ChoiceAuthorityService choicheAuthorityService = ContentAuthorityServiceFactory.getInstance().getChoiceAuthorityService();
 
+    @Override
     public void addBody(Body body) throws SAXException, WingException,
             UIException, SQLException, IOException, AuthorizeException
     {
@@ -250,6 +266,7 @@ public class ChoiceLookupTransformer extends AbstractDSpaceTransformer
         cancel.setValue(T_cancel);
     }
 
+    @Override
     public void addPageMeta(PageMeta pageMeta) throws SAXException,
             WingException, UIException, SQLException, IOException,
             AuthorizeException

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/general/IfModifiedSinceSelector.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/general/IfModifiedSinceSelector.java
@@ -24,8 +24,10 @@ import org.dspace.core.Constants;
  * returns true if the Item in the request has not been modified since that
  * date.  The expression is ignored since the test is inherent in the request.
  *
- * Typical sitemap usage:
+ * <p>Typical sitemap usage:
  *
+ * <pre>
+ * {@code
  *  <map:match type="HandleTypeMatcher" pattern="item">
  *    <map:select type="IfModifiedSinceSelector">
  *      <map:when test="true">
@@ -38,13 +40,15 @@ import org.dspace.core.Constants;
  *      </map:otherwise>
  *    </map:select>
  *  </map:match>
+ * }
+ * </pre>
  *
  * @author Larry Stone
  */
 public class IfModifiedSinceSelector implements Selector
 {
 
-    private static Logger log = Logger.getLogger(IfModifiedSinceSelector.class);
+    private static final Logger log = Logger.getLogger(IfModifiedSinceSelector.class);
 
     /**
      * Check for If-Modified-Since header on request,
@@ -53,9 +57,12 @@ public class IfModifiedSinceSelector implements Selector
      *
      * @param expression is ignored
      * @param objectModel
-     *            environment passed through via cocoon
+     *            environment passed through via Cocoon.
+     * @param parameters
+     *            sitemap parameters.
      * @return null or map containing value of sitemap parameter 'pattern'
      */
+    @Override
     public boolean select(String expression, Map objectModel,
             Parameters parameters)
     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/general/NoticeTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/general/NoticeTransformer.java
@@ -21,32 +21,34 @@ import org.dspace.authorize.AuthorizeException;
  * this transformer is used after an action has been performed to let the
  * user know if an operation succeeded or failed.
  * 
- * The possible paramaters are:
- * 
- * outcome: The outcome determines whether the notice is positive or negative. 
+ * <p>The possible parameters are:
+ *
+ * <p>outcome: The outcome determines whether the notice is positive or negative.
  * Possible values are: "success", "failure", or "neutral". If no values are 
  * supplied then neutral is assumed.
- * 
- * header: An i18n dictionary key referencing the text that should be used
+ *
+ * <p>header: An i18n dictionary key referencing the text that should be used
  * as a header for this notice.
  * 
- * message: An i18n dictionary key referencing the text that should be used as
+ * <p>message: An i18n dictionary key referencing the text that should be used as
  * the content for this notice. 
  * 
- * characters: Plain text string that should be used as the content for this
+ * <p>characters: Plain text string that should be used as the content for this
  * notice. Normally, all messages should be i18n dictionary keys, however this
  * parameter is useful for error messages that are not necessarily translated.
  * 
- * All parameters are optional but you must supply at least the message or the 
- * characters
+ * <p>All parameters are optional but you must supply at least the message or the
+ * characters.
  *
- *
- * 
- * Example:
+ * <p>Example:
+ * <pre>
+ * {@code
  * <map:transformer type="notice">
  *   <map:parameter name="outcome" value="success"/>
  *   <map:parameter name="message" value="xmlui.<aspect>.<class>.<type>"/>
  * </map:transformer>
+ * }
+ * </pre>
  * 
  * @author Scott Phillips
  * @author Alexey Maslov
@@ -60,7 +62,11 @@ public class NoticeTransformer extends AbstractDSpaceTransformer
 	
 	/**
 	 * Add the notice div to the body.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
+     * @throws java.sql.SQLException passed through.
+     * @throws org.dspace.authorize.AuthorizeException passed through.
 	 */
+    @Override
 	public void addBody(Body body) throws WingException, SQLException, AuthorizeException 
 	{
 		String outcome = parameters.getParameter("outcome",null);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/AbstractStep.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/AbstractStep.java
@@ -49,7 +49,7 @@ import org.xml.sax.SAXException;
  */
 public abstract class AbstractStep extends AbstractDSpaceTransformer 
 {
-	private static Logger log = Logger.getLogger(AbstractStep.class);
+	private static final Logger log = Logger.getLogger(AbstractStep.class);
 
     /** General Language Strings */
     protected static final Message T_submission_title = 
@@ -155,7 +155,16 @@ public abstract class AbstractStep extends AbstractDSpaceTransformer
 	 * 
 	 * If the implementer set any required parameters then ensure that 
 	 * they are all present.
+     *
+     * @param resolver source resolver.
+     * @param objectModel TBD
+     * @param src TBD
+     * @param parameters sitemap parameters.
+     * @throws org.apache.cocoon.ProcessingException
+     * @throws org.xml.sax.SAXException passed through.
+     * @throws java.io.IOException passed through.
 	 */
+    @Override
 	public void setup(SourceResolver resolver, Map objectModel, String src, Parameters parameters) 
 	throws ProcessingException, SAXException, IOException
 	{ 
@@ -217,10 +226,17 @@ public abstract class AbstractStep extends AbstractDSpaceTransformer
 
 	/** 
 	 * Base pageMeta that is added to ALL submission stages 
+     * @throws org.xml.sax.SAXException passed through.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
+     * @throws org.dspace.app.xmlui.utils.UIException passed through.
+     * @throws java.sql.SQLException passed through.
+     * @throws java.io.IOException passed through.
+     * @throws org.dspace.authorize.AuthorizeException passed through.
 	 */
-	public void addPageMeta(PageMeta pageMeta) throws SAXException,
-	WingException, UIException, SQLException, IOException,
-	AuthorizeException
+    @Override
+	public void addPageMeta(PageMeta pageMeta)
+            throws SAXException, WingException, UIException, SQLException,
+            IOException, AuthorizeException
 	{
 		if (submission instanceof WorkspaceItem)
 		{
@@ -258,6 +274,7 @@ public abstract class AbstractStep extends AbstractDSpaceTransformer
 	 * Add a submission progress list to the current div for this step. 
 	 * 
 	 * @param div The division to add the list to.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
 	 */
 	public void addSubmissionProgressList(Division div) throws WingException
 	{
@@ -303,6 +320,7 @@ public abstract class AbstractStep extends AbstractDSpaceTransformer
      * @param stepAndPage
      *          The step and page (a double of the form 'step.page', e.g. 1.2)
      *          which this button will jump back to
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addJumpButton(List list, Message buttonText, StepAndPage stepAndPage)
         throws WingException
@@ -318,9 +336,9 @@ public abstract class AbstractStep extends AbstractDSpaceTransformer
     }
     
     /**
-     * Adds the "<-Previous", "Save/Cancel" and "Next->" buttons 
-     * to a given form.  This method ensures that the same
-     * default control/paging buttons appear on each submission page.
+     * Adds the "{@literal <-Previous}", "{@literal Save/Cancel}" and
+     * "{@literal Next->}" buttons to a given form.  This method ensures that
+     * the same default control/paging buttons appear on each submission page.
      * <P>
      * Note: A given step may define its own buttons as necessary,
      * and not call this method (since it must be explicitly invoked by
@@ -328,6 +346,7 @@ public abstract class AbstractStep extends AbstractDSpaceTransformer
      *
      * @param controls
      *          The List which will contain all control buttons
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addControlButtons(List controls)
         throws WingException
@@ -430,6 +449,8 @@ public abstract class AbstractStep extends AbstractDSpaceTransformer
      * Find the maximum step and page that the user has 
      * reached in the submission processes. 
      * If this submission is a workflow then return max-int.
+     * @return the maximum step and page reached.
+     * @throws java.sql.SQLException passed through.
      */
     public StepAndPage getMaxStepAndPageReached() throws SQLException {
 
@@ -460,11 +481,12 @@ public abstract class AbstractStep extends AbstractDSpaceTransformer
 	 * Retrieve error fields from the list of parameters
 	 * and return a List of all fields which had errors
 	 *
-	 * @return java.util.List of field names with errors
+     * @param parameters the list to search for error fields.
+	 * @return {@link java.util.List} of field names with errors
 	 */
 	public java.util.List<String> getErrorFields(Parameters parameters)
 	{
-		java.util.List<String> fields = new ArrayList<String>();
+		java.util.List<String> fields = new ArrayList<>();
 		
 		String errors = parameters.getParameter("error_fields","");
 		
@@ -521,10 +543,7 @@ public abstract class AbstractStep extends AbstractDSpaceTransformer
         }  
 	}
 	
-	
-	/**
-	 * Recycle
-	 */
+    @Override
 	public void recycle() 
 	{
 		this.id = null;

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/AbstractDSpaceTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/AbstractDSpaceTransformer.java
@@ -224,18 +224,22 @@ public abstract class AbstractDSpaceTransformer extends AbstractWingTransformer
 
     /**
      * Generate a URL for the given base URL with the given parameters. This is
-     * a convenance method to make it easier to generate URL references with
+     * a convenience method to make it easier to generate URL references with
      * parameters.
      * 
-     * Example
+     * <p>Example:
+     *
+     * <pre>{@code
      * Map<String,String> parameters = new Map<String,String>();
      * parameters.put("arg1","value1");
      * parameters.put("arg2","value2");
      * parameters.put("arg3","value3");
      * String url = genrateURL("/my/url",parameters);
-     * 
+     * }</pre>
+     *
      * would result in the string:
-     * url == "/my/url?arg1=value1&arg2=value2&arg3=value3"
+     *
+     * <pre>{@code url == "/my/url?arg1=value1&arg2=value2&arg3=value3"}</pre>
      * 
      * @param baseURL The baseURL without any parameters.
      * @param parameters The parameters to be encoded on in the URL.

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/AbstractDSpaceTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/AbstractDSpaceTransformer.java
@@ -67,6 +67,7 @@ public abstract class AbstractDSpaceTransformer extends AbstractWingTransformer
     // Only access this through getObjectManager, so that we don't have to create one if we don't want to.
     private ObjectManager objectManager;
 
+    @Override
     public void setup(SourceResolver resolver, Map objectModel, String src,
             Parameters parameters) throws ProcessingException, SAXException,
             IOException
@@ -104,6 +105,7 @@ public abstract class AbstractDSpaceTransformer extends AbstractWingTransformer
         }
     }
 
+    @Override
     protected void handleException(Exception e) throws SAXException
     {
         throw new SAXException(
@@ -111,21 +113,21 @@ public abstract class AbstractDSpaceTransformer extends AbstractWingTransformer
                         + this.getClass().getName(), e);
     }
 
-    /** What to add at the end of the body */
+    @Override
     public void addBody(Body body) throws SAXException, WingException,
             UIException, SQLException, IOException, AuthorizeException, ProcessingException
     {
         // Do nothing
     }
 
-    /** What to add to the options list */
+    @Override
     public void addOptions(Options options) throws SAXException, WingException,
             UIException, SQLException, IOException, AuthorizeException
     {
         // Do nothing
     }
 
-    /** What user metadata to add to the document */
+    @Override
     public void addUserMeta(UserMeta userMeta) throws SAXException,
             WingException, UIException, SQLException, IOException,
             AuthorizeException
@@ -133,7 +135,7 @@ public abstract class AbstractDSpaceTransformer extends AbstractWingTransformer
         // Do nothing
     }
 
-    /** What page metadata to add to the document */
+    @Override
     public void addPageMeta(PageMeta pageMeta) throws SAXException,
             WingException, UIException, SQLException, IOException,
             AuthorizeException
@@ -141,6 +143,7 @@ public abstract class AbstractDSpaceTransformer extends AbstractWingTransformer
         // Do nothing
     }
     
+    @Override
     public ObjectManager getObjectManager() 
     {
         if (this.objectManager == null)
@@ -150,7 +153,7 @@ public abstract class AbstractDSpaceTransformer extends AbstractWingTransformer
         return this.objectManager;
     }
     
-    /** What is a unique name for this component? */
+    @Override
     public String getComponentName()
     {
         String name = this.getClass().getName();
@@ -167,6 +170,7 @@ public abstract class AbstractDSpaceTransformer extends AbstractWingTransformer
      * @param unencodedString
      *            The unencoded string.
      * @return The encoded string
+     * @throws org.dspace.app.xmlui.utils.UIException if the encoding is unsupported.
      */
     public static String encodeForURL(String unencodedString) throws UIException
     {
@@ -192,6 +196,7 @@ public abstract class AbstractDSpaceTransformer extends AbstractWingTransformer
      * @param encodedString
      *            The encoded string.
      * @return The unencoded string
+     * @throws org.dspace.app.xmlui.utils.UIException if the encoding is unsupported.
      */
     public static String decodeFromURL(String encodedString) throws UIException
     {
@@ -258,9 +263,7 @@ public abstract class AbstractDSpaceTransformer extends AbstractWingTransformer
     }
     
     
-    /**
-     * Recyle
-     */
+    @Override
     public void recycle() {
     	this.objectModel = null;
         this.context = null;
@@ -275,9 +278,7 @@ public abstract class AbstractDSpaceTransformer extends AbstractWingTransformer
     	super.recycle();
     }
 
-    /**
-     * Dispose
-     */
+    @Override
     public void dispose() {
     	this.objectModel = null;
         this.context = null;

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/configuration/XMLUIConfiguration.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/configuration/XMLUIConfiguration.java
@@ -30,13 +30,13 @@ public class XMLUIConfiguration
 {
 
     /** log4j category */
-    private static Logger log = Logger.getLogger(XMLUIConfiguration.class);
+    private static final Logger log = Logger.getLogger(XMLUIConfiguration.class);
     
     /** The configured Aspects */
-    private static List<Aspect> aspects = new ArrayList<Aspect>();
+    private static final List<Aspect> aspects = new ArrayList<>();
 
     /** The configured Theme rules */
-    private static List<Theme> themes = new ArrayList<Theme>(); 
+    private static final List<Theme> themes = new ArrayList<>();
 
     /**
      * Initialize the XMLUI Configuration.
@@ -46,10 +46,12 @@ public class XMLUIConfiguration
      * supplied but only the first valid file (exists and readable) will
      * be used.
      * 
-     * @param configPaths Multiple paths configuration paths may be specified
+     * @param configPaths Multiple configuration paths may be specified.
+     * @throws java.io.IOException if file access fails.
+     * @throws org.jdom.JDOMException if file cannot be parsed.
      */
-    public static void loadConfig(String ... configPaths) throws IOException,
-            JDOMException
+    public static void loadConfig(String ... configPaths)
+            throws IOException, JDOMException
     {
         if (configPaths == null || configPaths.length == 0)
         {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/AbstractAdapter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/AbstractAdapter.java
@@ -57,7 +57,7 @@ import org.xml.sax.helpers.NamespaceSupport;
 
 public abstract class AbstractAdapter
 {
-    /** Namespace declaration for METS & XLINK */
+    /** Namespace declaration for METS and XLINK */
     public static final String METS_URI = "http://www.loc.gov/METS/";
     public static final Namespace METS = new Namespace(METS_URI);
     public static final String XLINK_URI = "http://www.w3.org/TR/xlink/";

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/AbstractAdapter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/AbstractAdapter.java
@@ -32,25 +32,26 @@ import org.xml.sax.ext.LexicalHandler;
 import org.xml.sax.helpers.AttributesImpl;
 import org.xml.sax.helpers.NamespaceSupport;
 
-
 /**
  * This is the abstract adapter containing all the common elements between
  * the three types of adapters: item, container, and repository. Each adapter
  * translate a given type of DSpace object into a METS document for rendering
  * into the DRI document.
  * 
- * This class provides the chassis for those unique parts of the document to be
+ * <p>This class provides the chassis for those unique parts of the document to be
  * built upon. There are seven rendering methods that may be overridden for each
- * section of the METS document.
- * 
- * Header
- * Descriptive Section
- * Administrative Section
- * File Section
- * Structure Map
- * Structural Link
- * Behavioral Section
- * 
+ * section of the METS document:
+ *
+ * <ul>
+ * <li>Header</li>
+ * <li>Descriptive Section</li>
+ * <li>Administrative Section</li>
+ * <li>File Section</li>
+ * <li>Structure Map</li>
+ * <li>Structural Link</li>
+ * <li>Behavioral Section</li>
+ * </ul>
+ *
  * @author Scott Phillips
  */
 
@@ -98,11 +99,11 @@ public abstract class AbstractAdapter
     }
 
     /** The variables that dictate what part of the METS document to render */
-    List<String> sections = new ArrayList<String>();
-    List<String> dmdTypes = new ArrayList<String>();
-    Map<String,List> amdTypes = new HashMap<String,List>();
-    List<String> fileGrpTypes = new ArrayList<String>();
-    List<String> structTypes = new ArrayList<String>();
+    List<String> sections = new ArrayList<>();
+    List<String> dmdTypes = new ArrayList<>();
+    Map<String,List> amdTypes = new HashMap<>();
+    List<String> fileGrpTypes = new ArrayList<>();
+    List<String> structTypes = new ArrayList<>();
     
     /**
      * A comma-separated list of METS sections to render. If no value 
@@ -146,8 +147,8 @@ public abstract class AbstractAdapter
      * Store information about what will be rendered in the METS administrative
      * metadata section.  HashMap format: keys = amdSec, value = List of mdTypes
      *
-     * @param amdSec Section of <amdSec> where this administrative metadata
-     *                will be rendered
+     * @param amdSec Section of {@code <amdSec>} where this administrative metadata
+     *                will be rendered.
      * @param mdTypes Comma-separated list of METS metadata types.
      */
     public final void setAmdTypes(String amdSec, String mdTypes)
@@ -157,7 +158,7 @@ public abstract class AbstractAdapter
             return;
         }
 
-        List<String> mdTypeList = new ArrayList<String>();
+        List<String> mdTypeList = new ArrayList<>();
     	for (String mdType : mdTypes.split(","))
     	{
     		mdTypeList.add(mdType);
@@ -266,7 +267,8 @@ public abstract class AbstractAdapter
     
     
     /**
-     * @return the URL for this item in the interface
+     * @return the URL for this item in the interface.
+     * @throws org.dspace.app.xmlui.wing.WingException on error.
      */
     protected abstract String getMETSOBJID() throws WingException;
 
@@ -277,24 +279,36 @@ public abstract class AbstractAdapter
 
     /**
      * @return the METS ID of the mets document.
+     * @throws org.dspace.app.xmlui.wing.WingException on error.
      */
     protected abstract String getMETSID() throws WingException;
 
     /**
      * @return The Profile this METS document conforms to.
+     * @throws org.dspace.app.xmlui.wing.WingException on error.
      */
     protected abstract String getMETSProfile() throws WingException;
 
     /**
      * @return The label of this METS document.
+     * @throws org.dspace.app.xmlui.wing.WingException on error.
      */
     protected abstract String getMETSLabel() throws WingException;
 
     
 	/**
 	 * Render the complete METS document.
+     * @param context session context.
+     * @param contentHandler XML content handler.
+     * @param lexicalHandler XML lexical handler.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
+     * @throws org.xml.sax.SAXException passed through.
+     * @throws org.dspace.content.crosswalk.CrosswalkException passed through.
+     * @throws java.io.IOException passed through.
+     * @throws java.sql.SQLException passed through.
 	 */
-    public final void renderMETS(Context context, ContentHandler contentHandler, LexicalHandler lexicalHandler) throws WingException, SAXException, CrosswalkException, IOException, SQLException
+    public final void renderMETS(Context context, ContentHandler contentHandler, LexicalHandler lexicalHandler)
+            throws WingException, SAXException, CrosswalkException, IOException, SQLException
     {
     		this.contentHandler = contentHandler;
     		this.lexicalHandler = lexicalHandler;
@@ -333,7 +347,7 @@ public abstract class AbstractAdapter
     		startElement(METS,"METS",attributes);
 
     		// If the user requested no specific sections then render them all.
-    		boolean all = (sections.size() == 0);
+    		boolean all = (sections.isEmpty());
     		
     		if (all || sections.contains("metsHdr"))
             {
@@ -378,7 +392,7 @@ public abstract class AbstractAdapter
 
     }
 	
-    /**
+    /*
      * Each of the METS sections
      */
 	protected void renderHeader() throws WingException, SAXException, CrosswalkException, IOException, SQLException  {}
@@ -395,6 +409,8 @@ public abstract class AbstractAdapter
     /**
      * Generate a METS file element for a given bitstream.
      *
+     * @param context
+     *            Session context.
      * @param item
      *            If the bitstream is associated with an item provide the item
      *            otherwise leave null.
@@ -405,8 +421,11 @@ public abstract class AbstractAdapter
      * @param groupID
      *            The group id for this file, if it is derived from another file
      *            then they should share the same groupID.
+     * @throws org.xml.sax.SAXException passed through.
+     * @throws java.sql.SQLException passed through.
      */
-	protected final void renderFile(Context context, Item item, Bitstream bitstream, String fileID, String groupID) throws SAXException, SQLException
+	protected final void renderFile(Context context, Item item, Bitstream bitstream, String fileID, String groupID)
+            throws SAXException, SQLException
     {
        renderFile(context, item, bitstream, fileID, groupID, null);
     }
@@ -414,6 +433,7 @@ public abstract class AbstractAdapter
 	/**
      * Generate a METS file element for a given bitstream.
      * 
+     * @param context
      * @param item
      *            If the bitstream is associated with an item, provide the item,
      *            otherwise leave null.
@@ -427,8 +447,12 @@ public abstract class AbstractAdapter
      * @param admID
      *            The IDs of the administrative metadata sections which pertain
      *            to this file
+     * @throws org.xml.sax.SAXException passed through.
+     * @throws java.sql.SQLException passed through.
      */
-	protected final void renderFile(Context context, Item item, Bitstream bitstream, String fileID, String groupID, String admID) throws SAXException, SQLException
+	protected final void renderFile(Context context, Item item,
+            Bitstream bitstream, String fileID, String groupID, String admID)
+            throws SAXException, SQLException
     {
 		AttributeMap attributes;
 		
@@ -557,7 +581,8 @@ public abstract class AbstractAdapter
      * Return a dissemination crosswalk for the given name.
      * 
      * @param crosswalkName
-     * @return The crosswalk or throw an exception if not found.
+     * @return The crosswalk.
+     * @throws org.dspace.app.xmlui.wing.WingException if crosswalk not found.
      */
     public final DisseminationCrosswalk getDisseminationCrosswalk(String crosswalkName) throws WingException 
     {
@@ -621,6 +646,7 @@ public abstract class AbstractAdapter
      *            (Required) The local name of this element.
      * @param attributes
      *            (May be null) Attributes for this element
+     * @throws org.xml.sax.SAXException passed through.
      */
     protected final void startElement(Namespace namespace, String name,
             AttributeMap... attributes) throws SAXException
@@ -635,6 +661,7 @@ public abstract class AbstractAdapter
      * 
      * @param characters
      *            (May be null) Characters to send.
+     * @throws org.xml.sax.SAXException passed through.
      */
     protected final void sendCharacters(String characters) throws SAXException
     {
@@ -652,6 +679,7 @@ public abstract class AbstractAdapter
      *            (Required) The namespace of this element.
      * @param name
      *            (Required) The local name of this element.
+     * @throws org.xml.sax.SAXException passed through.
      */
     protected final void endElement(Namespace namespace, String name)
             throws SAXException

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/ContainerAdapter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/ContainerAdapter.java
@@ -59,13 +59,13 @@ public class ContainerAdapter extends AbstractAdapter
     private static final Logger log = Logger.getLogger(ContainerAdapter.class);
 
     /** The community or collection this adapter represents. */
-    private DSpaceObject dso;
+    private final DSpaceObject dso;
 
     /** A space-separated list of descriptive metadata sections */
     private StringBuffer dmdSecIDS;
     
     /** Current DSpace context **/
-    private Context dspaceContext;
+    private final Context dspaceContext;
 
     protected CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
    	protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
@@ -74,6 +74,7 @@ public class ContainerAdapter extends AbstractAdapter
     /**
      * Construct a new CommunityCollectionMETSAdapter.
      * 
+     * @param context session context.
      * @param dso
      *            A DSpace Community or Collection to adapt.
      * @param contextPath
@@ -86,7 +87,9 @@ public class ContainerAdapter extends AbstractAdapter
         this.dspaceContext = context;
     }
 
-    /** Return the container, community or collection, object */
+    /** Return the container, community or collection, object
+     * @return the contained object.
+     */
     public DSpaceObject getContainer()
     {
     	return this.dso;
@@ -103,8 +106,9 @@ public class ContainerAdapter extends AbstractAdapter
      */
     
     /**
-     * Return the URL of this community/collection in the interface
+     * @return the URL of this community/collection in the interface.
      */
+    @Override
     protected String getMETSOBJID()
     {
     	if (dso.getHandle() != null)
@@ -117,14 +121,17 @@ public class ContainerAdapter extends AbstractAdapter
     /**
      * @return Return the URL for editing this item
      */
+    @Override
     protected String getMETSOBJEDIT()
     {
         return null;
     }
     
     /**
-     * Use the handle as the id for this METS document
+     * Use the handle as the id for this METS document.
+     * @return the id.
      */
+    @Override
     protected String getMETSID()
     {
     	if (dso.getHandle() == null)
@@ -147,16 +154,20 @@ public class ContainerAdapter extends AbstractAdapter
     /**
      * Return the profile to use for communities and collections.
      * 
+     * @return the constant profile name.
+     * @throws org.dspace.app.xmlui.wing.WingException never.
      */
+    @Override
     protected String getMETSProfile() throws WingException
     {
     	return "DSPACE METS SIP Profile 1.0";
     }
 
     /**
-     * Return a friendly label for the METS document to say we are a community
+     * @return a friendly label for the METS document to say we are a community
      * or collection.
      */
+    @Override
     protected String getMETSLabel()
     {
         if (dso instanceof Community)
@@ -170,7 +181,8 @@ public class ContainerAdapter extends AbstractAdapter
     }
 
     /**
-     * Return a unique id for the given bitstream
+     * @param bitstream the bitstream to be identified.
+     * @return a unique id for the given bitstream.
      */
     protected String getFileID(Bitstream bitstream)
     {
@@ -178,7 +190,8 @@ public class ContainerAdapter extends AbstractAdapter
     }
 
     /**
-     * Return a group id for the given bitstream
+     * @param bitstream the bitstream to be queried.
+     * @return a group id for the given bitstream.
      */
     protected String getGroupFileID(Bitstream bitstream)
     {
@@ -204,15 +217,24 @@ public class ContainerAdapter extends AbstractAdapter
      * Render the METS descriptive section. This will create a new metadata
      * section for each crosswalk configured.
      * 
-     * Example:
+     * <p>Example:
+     *
+     * <pre>{@code
      * <dmdSec>
      *  <mdWrap MDTYPE="MODS">
      *    <xmlData>
      *      ... content from the crosswalk ...
      *    </xmlDate>
      *  </mdWrap>
-     * </dmdSec
+     * </dmdSec>
+     * } </pre>
+     * @throws org.dspace.app.xmlui.wing.WingException on XML errors.
+     * @throws org.xml.sax.SAXException passed through.
+     * @throws org.dspace.content.crosswalk.CrosswalkException passed through.
+     * @throws java.io.IOException if items could not be counted.
+     * @throws java.sql.SQLException passed through.
      */
+    @Override
     protected void renderDescriptiveSection() throws WingException, SAXException, CrosswalkException, IOException, SQLException 
     {
         AttributeMap attributes;
@@ -223,7 +245,7 @@ public class ContainerAdapter extends AbstractAdapter
         // Add DIM descriptive metadata if it was requested or if no metadata types 
         // were specified. Furthermore, since this is the default type we also use a 
         // faster rendering method that the crosswalk API.
-        if(dmdTypes.size() == 0 || dmdTypes.contains("DIM"))
+        if(dmdTypes.isEmpty() || dmdTypes.contains("DIM"))
         {
             // Metadata element's ID
             String dmdID = getGenericID("dmd_");
@@ -435,8 +457,10 @@ public class ContainerAdapter extends AbstractAdapter
      * Render the METS file section. If a logo is present for this
      * container then that single bitstream is listed in the 
      * file section.
-     * 
-     * Example:
+     *
+     * <p>Example:
+     *
+     * <pre>{@code
      * <fileSec>
      *   <fileGrp USE="LOGO">
      *     <file ... >
@@ -444,6 +468,10 @@ public class ContainerAdapter extends AbstractAdapter
      *     </file>
      *   </fileGrp>
      * </fileSec>
+     * }</pre>
+     * @param context session context.
+     * @throws org.xml.sax.SAXException passed through.
+     * @throws java.sql.SQLException passed through.
      */
     @Override
     protected void renderFileSection(Context context) throws SAXException, SQLException
@@ -483,13 +511,19 @@ public class ContainerAdapter extends AbstractAdapter
      * to the container's logo, if available, otherwise it is an empty 
      * division that just states it is a DSpace community or Collection.
      * 
-     * Example:
+     * <p>Example:
+     *
+     * <pre>{@code
      * <structMap TYPE="LOGICAL" LABEL="DSpace">
      *   <div TYPE="DSpace Collection" DMDID="space-separated list of ids">
      *     <fptr FILEID="logo id"/>
      *   </div>
      * </structMap>
+     * }</pre>
+     * @throws java.sql.SQLException passed through.
+     * @throws org.xml.sax.SAXException passed through.
      */
+    @Override
     protected void renderStructureMap() throws SQLException, SAXException
     {
     	AttributeMap attributes;
@@ -743,7 +777,7 @@ public class ContainerAdapter extends AbstractAdapter
 					
 					xmlDocument = document.getRootElement();
 	        	} 
-	        	catch (Exception e) 
+	        	catch (JDOMException | IOException e)
 				{
                     log.trace("Caught exception", e);
 				}

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/ContainerAdapter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/ContainerAdapter.java
@@ -38,7 +38,7 @@ import org.xml.sax.SAXException;
 
 /**
  * This is an adapter which translates DSpace containers 
- * (communities & collections) into METS documents. This adapter follows
+ * (communities and collections) into METS documents. This adapter follows
  * the DSpace METS profile, however that profile does not define how a
  * community or collection should be described, but we make the obvious 
  * decisions to deviate when necessary from the profile.

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/RepositoryAdapter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/RepositoryAdapter.java
@@ -48,8 +48,7 @@ public class RepositoryAdapter extends AbstractAdapter
     private String dmdSecIDS;
     
     /** Dspace context to be able to look up additional objects */
-    private Context context;
-
+    private final Context context;
 
     protected CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
     protected HandleService handleService = HandleServiceFactory.getInstance().getHandleService();
@@ -61,7 +60,7 @@ public class RepositoryAdapter extends AbstractAdapter
      *            The DSpace context to look up communities / collections.
      * 
      * @param contextPath
-     *            The contextPath of this webapplication.
+     *            The context Path of this web application.
      */
     public RepositoryAdapter(Context context, String contextPath)
     {
@@ -80,8 +79,9 @@ public class RepositoryAdapter extends AbstractAdapter
      */
 
     /**
-     * Return the handle prefix as the identifier.
+     * @return the handle prefix as the identifier.
      */
+    @Override
     protected String getMETSID()
     {
         return handleService.getPrefix();
@@ -90,7 +90,10 @@ public class RepositoryAdapter extends AbstractAdapter
 	/**
 	 * The OBJID is used to encode the URL to the object, in this
 	 * case the repository which is just at the contextPath.
+     * @return local path to the object.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
 	 */
+    @Override
 	protected String getMETSOBJID() throws WingException {
 		
 		if (contextPath == null)
@@ -106,25 +109,28 @@ public class RepositoryAdapter extends AbstractAdapter
     /**
      * @return  Return the URL for editing this item
      */
+    @Override
     protected String getMETSOBJEDIT()
     {
         return null;
     }
 
     /**
-     * Return the profile this METS document conforms to...
-     * 
+     * @return the profile this METS document conforms to...
+     *
      * FIXME: It doesn't conform to a profile. This needs to be fixed.
      */
+    @Override
     protected String getMETSProfile()
     {
         return "DRI DSPACE Repository Profile 1.0";
     }
 
     /**
-     * Return a friendly label for the METS document stating that this is a
+     * @return a friendly label for the METS document stating that this is a
      * DSpace repository.
      */
+    @Override
     protected String getMETSLabel()
     {
         return "DSpace Repository";
@@ -149,7 +155,9 @@ public class RepositoryAdapter extends AbstractAdapter
      * section, such as the name, hostname, handle prefix, and 
      * default language.
      * 
+     * @throws org.xml.sax.SAXException passed through.
      */
+    @Override
 	protected void renderDescriptiveSection() throws SAXException
     {
     	AttributeMap attributes;
@@ -232,7 +240,10 @@ public class RepositoryAdapter extends AbstractAdapter
      * Render the repository's structure map. This map will include a reference to
      * all the community and collection objects showing how they are related to
      * one another. 
+     * @throws java.sql.SQLException passed through.
+     * @throws org.xml.sax.SAXException passed through.
      */
+    @Override
 	protected void renderStructureMap() throws SQLException, SAXException
     {
     	AttributeMap attributes;

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/RepositoryAdapter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/RepositoryAdapter.java
@@ -29,10 +29,10 @@ import org.xml.sax.SAXException;
  * document. Unfortunately, there is no real definition of what this is. So
  * we just kind of made it up based upon what we saw for the item profile.
  * 
- * The basic structure is simply two parts, the descriptive metadata and a 
+ * The basic structure is simply two parts:  the descriptive metadata and a
  * structural map. The descriptive metadata is a place to put metadata about 
  * the whole repository. The structural map is used to map relationships
- * between communities & collections in dspace. 
+ * between communities and collections in DSpace.
  * 
  * @author Scott Phillips
  */

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/DSpaceValidity.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/DSpaceValidity.java
@@ -26,19 +26,18 @@ import org.dspace.eperson.Group;
  * This is a validity object specifically implemented for the caching 
  * needs of DSpace, Manakin, and Cocoon.
  * 
- * The basic idea is that each time a DSpace object rendered by a cocoon 
+ * <p>The basic idea is that each time a DSpace object rendered by a Cocoon
  * component the object and everything about it that makes it unique should 
  * be reflected in the validity object for the component. By following this 
  * principle if the object has been updated externally then the cache will be
  * invalidated.
  * 
- * This DSpaceValidity object makes this processes easier by abstracting out
+ * <p>This DSpaceValidity object makes this processes easier by abstracting out
  * the processes of determining what is unique about a DSpace object. A class
  * is expected to create a new DSpaceValidity object and add() to it all 
  * DSpaceObjects that are rendered by the component. This validity object will 
  * serialize all those objects to a string, take a hash of the string and compare
  * the hash of the string for any updates.
- * 
  * 
  * @author Scott Phillips
  */
@@ -94,6 +93,7 @@ public class DSpaceValidity implements SourceValidity
      * Complete this validity object. After the completion no more
      * objects may be added to the validity object and the object
      * will return as valid.
+     * @return this.
      */
     public DSpaceValidity complete() 
     {    
@@ -128,19 +128,19 @@ public class DSpaceValidity implements SourceValidity
     	// Also add the delay time to the validity hash so if the
     	// admin changes the delay time then all the previous caches
     	// are invalidated.
-    	this.validityKey.append("AssumedValidityDelay:"+milliseconds);
+    	this.validityKey.append("AssumedValidityDelay:").append(milliseconds);
     }
     
     /**
      * Set the time delay for how long this cache will be assumed to be valid.
      * 
-     * This method takes a string which is parsed for the delay time, the string 
-     * must be of the following form: "<integer> <scale>" where scale is days,
+     * <p>This method takes a string which is parsed for the delay time.  The string
+     * must be of the following form: "{@code <integer> <scale>}" where scale is days,
      * hours, minutes, or seconds.
      * 
-     * Examples: "1 day" or "12 hours" or "1 hour" or "30 minutes"
+     * <p>Examples: "1 day" or "12 hours" or "1 hour" or "30 minutes"
      * 
-     * See the setAssumedValidityDelay(long) for more information.
+     * @see setAssumedValidityDelay(long)
      * 
      * @param delay The delay time in a variable scale.
      */
@@ -224,8 +224,11 @@ public class DSpaceValidity implements SourceValidity
      * Bundles -> bitstreams
      * EPeople -> groups
      * 
+     * @param context
+     *          session context.
      * @param dso
      *          The object to add to the validity.
+     * @throws java.sql.SQLException passed through.
      */
     public void add(Context context, DSpaceObject dso) throws SQLException
     {
@@ -362,20 +365,14 @@ public class DSpaceValidity implements SourceValidity
      *
      * @param nonDSpaceObject
      *          The non-DSpace object to add to the validity.
+     * @throws java.sql.SQLException passed through.
      */
     public void add(String nonDSpaceObject) throws SQLException
     {
         validityKey.append("String:");
         validityKey.append(nonDSpaceObject);
     }
-    
-    
-    
-    
-    
-    
-    
-    
+
     /**
      * This method is used during serializion. When Tomcat is shutdown, Cocoon's in-memory 
      * cache is serialized and written to disk to later be read back into memory on start 
@@ -401,7 +398,6 @@ public class DSpaceValidity implements SourceValidity
     	this.assumedValidityTime = 0;
     }
     
-    
     /**
      * Reset the assume validity time. This should be called only when the validity of this cache
      * has been confirmed to be accurate. This will reset the assume valid timer based upon the
@@ -414,7 +410,10 @@ public class DSpaceValidity implements SourceValidity
     
     /**
      * Determine if the cache is still valid
+     * @return {@link SourceValidity.VALID}, {@link SourceValidity.UNKNOWN},
+     *          or {@link SourceValidity.INVALID}.
      */
+    @Override
     public int isValid()
     {
         // Return true if we have a hash.
@@ -447,7 +446,9 @@ public class DSpaceValidity implements SourceValidity
      * 
      * @param otherObject 
      *          The other validity object.
+     * @return {@link SourceValidity.VALID} or {@link SourceValidity.INVALID}.
      */
+    @Override
     public int isValid(SourceValidity otherObject)
     {
         if (this.completed && otherObject instanceof DSpaceValidity)

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/DSpaceValidity.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/DSpaceValidity.java
@@ -26,10 +26,10 @@ import org.dspace.eperson.Group;
  * This is a validity object specifically implemented for the caching 
  * needs of DSpace, Manakin, and Cocoon.
  * 
- * <p>The basic idea is that each time a DSpace object rendered by a Cocoon
- * component the object and everything about it that makes it unique should 
+ * <p>The basic idea is that, each time a DSpace object is rendered by a Cocoon
+ * component, the object and everything about it that makes it unique should
  * be reflected in the validity object for the component. By following this 
- * principle if the object has been updated externally then the cache will be
+ * principle, if the object has been updated externally then the cache will be
  * invalidated.
  * 
  * <p>This DSpaceValidity object makes this processes easier by abstracting out
@@ -215,14 +215,19 @@ public class DSpaceValidity implements SourceValidity
      * validity object is created.
      * 
      * Below are the following transitive rules for adding 
-     * objects, i.e. if an item is added then all the items 
-     * bundles & bitstreams will also be added.
+     * objects, i.e. if an item is added then all the item's
+     * bundles and bitstreams will also be added.
      * 
-     * Communities -> logo bitstream
-     * Collection -> logo bitstream
-     * Item -> bundles -> bitstream
-     * Bundles -> bitstreams
-     * EPeople -> groups
+     * <p>
+     * {@literal Communities -> logo bitstream}
+     * <br>
+     * {@literal Collection -> logo bitstream}
+     * <br>
+     * {@literal Item -> bundles -> bitstream}
+     * <br>
+     * {@literal Bundles -> bitstreams}
+     * <br>
+     * {@literal EPeople -> groups}
      * 
      * @param context
      *          session context.
@@ -410,8 +415,9 @@ public class DSpaceValidity implements SourceValidity
     
     /**
      * Determine if the cache is still valid
-     * @return {@link SourceValidity.VALID}, {@link SourceValidity.UNKNOWN},
-     *          or {@link SourceValidity.INVALID}.
+     * @return {@link org.apache.excalibur.source.SourceValidity#VALID},
+     *         {@link org.apache.excalibur.source.SourceValidity#UNKNOWN},
+     *         or {@link org.apache.excalibur.source.SourceValidity#INVALID}.
      */
     @Override
     public int isValid()
@@ -446,7 +452,8 @@ public class DSpaceValidity implements SourceValidity
      * 
      * @param otherObject 
      *          The other validity object.
-     * @return {@link SourceValidity.VALID} or {@link SourceValidity.INVALID}.
+     * @return {@link org.apache.excalibur.source.SourceValidity#VALID}
+     *         or {@link org.apache.excalibur.source.SourceValidity#INVALID}.
      */
     @Override
     public int isValid(SourceValidity otherObject)

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/AbstractWingTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/AbstractWingTransformer.java
@@ -80,6 +80,7 @@ public abstract class AbstractWingTransformer extends AbstractTransformer
      * framework. It must be called after the component's setup has been called
      * and the implementing object setup.
      * 
+     * @throws org.dspace.app.xmlui.wing.WingException if setup is impossible.
      */
     public void setupWing() throws WingException
     {
@@ -89,12 +90,14 @@ public abstract class AbstractWingTransformer extends AbstractTransformer
         this.wingContext.setObjectManager(this.getObjectManager());
 
         feederDocument = this.createWingDocument(wingContext);
-        this.stack = new Stack<WingMergeableElement>();
+        this.stack = new Stack<>();
     }
 
     /**
      * Receive notification of the beginning of a document.
+     * @throws org.xml.sax.SAXException if document is malformed.
      */
+    @Override
     public void startDocument() throws SAXException
     {
         needNewNamespaceContext = true;
@@ -105,7 +108,9 @@ public abstract class AbstractWingTransformer extends AbstractTransformer
 
     /**
      * Receive notification of the end of a document.
+     * @throws org.xml.sax.SAXException if document is malformed.
      */
+    @Override
     public void endDocument() throws SAXException
     {
         wingContext.dispose();
@@ -119,7 +124,9 @@ public abstract class AbstractWingTransformer extends AbstractTransformer
      *            The Namespace prefix being declared.
      * @param uri
      *            The Namespace URI the prefix is mapped to.
+     * @throws org.xml.sax.SAXException if document is malformed.
      */
+    @Override
     public void startPrefixMapping(String prefix, String uri)
             throws SAXException
     {
@@ -138,7 +145,9 @@ public abstract class AbstractWingTransformer extends AbstractTransformer
      * 
      * @param prefix
      *            The prefix that was being mapping.
+     * @throws org.xml.sax.SAXException if document is malformed.
      */
+    @Override
     public void endPrefixMapping(String prefix) throws SAXException
     {
         if (!needNewNamespaceContext)
@@ -165,7 +174,9 @@ public abstract class AbstractWingTransformer extends AbstractTransformer
      * @param attributes
      *            The attributes attached to the element. If there are no
      *            attributes, it shall be an empty Attributes object.
+     * @throws org.xml.sax.SAXException if document is malformed.
      */
+    @Override
     public void startElement(String namespaceURI, String localName,
             String qName, Attributes attributes) throws SAXException
     {
@@ -181,7 +192,7 @@ public abstract class AbstractWingTransformer extends AbstractTransformer
             
             // Deal with the stack jump start issue of having a document all
             // ready on the stack.
-            if (stack.size() == 0)
+            if (stack.isEmpty())
             {
                 if (feederDocument.mergeEqual(namespaceURI, localName, qName,
                         attributes))
@@ -263,7 +274,9 @@ public abstract class AbstractWingTransformer extends AbstractTransformer
      * @param qName
      *            The raw XML 1.0 name (with prefix), or the empty string if raw
      *            names are not available.
+     * @throws org.xml.sax.SAXException if document is malformed.
      */
+    @Override
     public void endElement(String namespaceURI, String localName, String qName)
             throws SAXException
     {
@@ -300,12 +313,13 @@ public abstract class AbstractWingTransformer extends AbstractTransformer
      * 
      * @param e
      *            The thrown exception
+     * @throws org.xml.sax.SAXException unconditionally.
      */
 
     protected void handleException(Exception e) throws SAXException
     {
         throw new SAXException(
-                "An error was incountered while processing the Wing based component: "
+                "An error was encountered while processing the Wing based component: "
                         + this.getClass().getName(), e);
     }
 
@@ -314,6 +328,8 @@ public abstract class AbstractWingTransformer extends AbstractTransformer
      * 
      * @param wingContext
      *            The current wing context this transformer is operating under.
+     * @return an empty document.
+     * @throws org.dspace.app.xmlui.wing.WingException if it can't.
      */
     protected WingDocument createWingDocument(WingContext wingContext)
             throws WingException
@@ -321,23 +337,44 @@ public abstract class AbstractWingTransformer extends AbstractTransformer
         return new WingDocument(wingContext);
     }
 
-    /** Abstract implementations of WingTransformer */
-
+    /** Abstract implementations of WingTransformer.
+     * @param body to be added.
+     * @throws java.lang.Exception if something went wrong.
+     */
+    @Override
     public void addBody(Body body) throws Exception
     {
         // Do nothing
     }
 
+    /**
+     * Abstract implementation of WingTransformer.
+     * @param options to be added.
+     * @throws Exception if something went wrong.
+     */
+    @Override
     public void addOptions(Options options) throws Exception
     {
         // do nothing
     }
 
+    /**
+     * Abstract implementation of WingTransformer.
+     * @param userMeta to be added.
+     * @throws Exception if something went wrong.
+     */
+    @Override
     public void addUserMeta(UserMeta userMeta) throws Exception
     {
         // Do nothing
     }
 
+    /**
+     * Abstract implementation of WingTransformer.
+     * @param pageMeta to be added.
+     * @throws Exception if something went wrong.
+     */
+    @Override
     public void addPageMeta(PageMeta pageMeta) throws Exception
     {
         // Do nothing
@@ -346,6 +383,7 @@ public abstract class AbstractWingTransformer extends AbstractTransformer
     /** 
      * Return the ObjectManager associated with this component. If no 
      * objectManager needed then return null.
+     * @return the ObjectManager, or null.
      */
     public ObjectManager getObjectManager()
     {
@@ -355,7 +393,9 @@ public abstract class AbstractWingTransformer extends AbstractTransformer
     /**
      * Return the name of this component. Typically the name is just 
      * the class name of the component.
+     * @return the name.
      */
+    @Override
     public String getComponentName()
     {
         return this.getClass().getName();
@@ -364,6 +404,7 @@ public abstract class AbstractWingTransformer extends AbstractTransformer
     /**
      * Return the default i18n message catalogue that should be used 
      * when no others are specified.
+     * @return the default catalog.
      */
     public static String getDefaultMessageCatalogue()
     {
@@ -402,8 +443,9 @@ public abstract class AbstractWingTransformer extends AbstractTransformer
     }
     
     /**
-     * Recyle
+     * Recycle.
      */
+    @Override
     public void recycle() 
     {
         this.namespaces = null;
@@ -414,7 +456,7 @@ public abstract class AbstractWingTransformer extends AbstractTransformer
     }
 
     /**
-     * Dispose
+     * Dispose.
      */
     public void dispose() {
         this.namespaces = null;

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/AttributeMap.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/AttributeMap.java
@@ -67,8 +67,8 @@ public class AttributeMap extends HashMap<String, String>
      * strings. The values "yes" or "no" will be used in replacement of the
      * boolean value.
      * 
-     * @param key
-     * @param value
+     * @param key the attribute's name.
+     * @param value the value of the attribute.
      * @return previous value bound to the key, if any.
      */
     public String put(String key, boolean value)

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/IncludePageMeta.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/IncludePageMeta.java
@@ -30,25 +30,27 @@ import java.util.Map;
  * Include metadata in the resulting DRI document as derived from the sitemap
  * parameters.
  *
- * Parameters should consist of a dublin core name and value. The format for
- * a parameter name must follow the form: "<element>.<qualifier>.<language>#order"
+ * <p>Parameters should consist of a Dublin Core name and value. The format for
+ * a parameter name must follow the form: "{@code <element>.<qualifier>.<language>#order}"
  * The qualifier, language, and order are all optional components. The order
  * component is an integer and is needed to ensure that parameter names are
- * unique. Since Cocoon's parameters are Hashes duplicate names are not allowed
- * the order syntax allows the sitemap programer to specify an order in which
+ * unique. Since Cocoon's parameters are {@code Hash}es, duplicate names are not allowed.
+ * The {@code order} syntax allows the sitemap programmer to specify an order in which
  * these metadata values should be placed inside the document.
  *
- * The following are a valid examples:
+ * <p>The following are a valid examples:
  *
- * <map:parameter name="theme.name.en" value="My Theme"/>
+ * <ul>
+ *  <li>{@code <map:parameter name="theme.name.en" value="My Theme"/>}</li>
  *
- * <map:parameter name="theme.path" value="/MyTheme/"/>
+ *  <li>{@code <map:parameter name="theme.path" value="/MyTheme/"/>}</li>
  *
- * <map:parameter name="theme.css#1" value="style.css"/>
+ *  <li>{@code <map:parameter name="theme.css#1" value="style.css"/>}</li>
  *
- * <map:parameter name="theme.css#2" value="style.css-ie"/>
+ *  <li>{@code <map:parameter name="theme.css#2" value="style.css-ie"/>}</li>
  *
- * <map:parameter name="theme.css#2" value="style.css-ff"/>
+ *  <li>{@code <map:parameter name="theme.css#2" value="style.css-ff"/>}</li>
+ * </ul>
  *
  * @author Scott Phillips
  * @author Roel Van Reeth (roel at atmire dot com)
@@ -67,6 +69,7 @@ public class IncludePageMeta extends AbstractWingTransformer implements Cacheabl
      *
      * @return The generated key hashes the src
      */
+    @Override
     public Serializable getKey()
     {
         String key = "";
@@ -84,6 +87,7 @@ public class IncludePageMeta extends AbstractWingTransformer implements Cacheabl
      * @return The generated validity object or <code>null</code> if the
      *         component is currently not cacheable.
      */
+    @Override
     public SourceValidity getValidity()
     {
         return NOPValidity.SHARED_INSTANCE;
@@ -93,7 +97,15 @@ public class IncludePageMeta extends AbstractWingTransformer implements Cacheabl
 
     /**
      * Extract the metadata name value pairs from the sitemap parameters.
+     * @param resolver resolver.
+     * @param objectModel objectModel.
+     * @param src source.
+     * @param parameters parameters.
+     * @throws org.apache.cocoon.ProcessingException passed through.
+     * @throws org.xml.sax.SAXException passed through.
+     * @throws java.io.IOException passed through.
      */
+    @Override
     public void setup(SourceResolver resolver, Map objectModel, String src,
             Parameters parameters) throws ProcessingException, SAXException,
             IOException
@@ -101,49 +113,46 @@ public class IncludePageMeta extends AbstractWingTransformer implements Cacheabl
         try
         {
             String[] names = parameters.getNames();
-            metadataList = new ArrayList<Metadata>();
+            metadataList = new ArrayList<>();
             for (String name : names)
             {
             	String[] nameParts = name.split("#");
 
             	String dcName = null;
             	int order = -1;
-            	if (nameParts.length == 1)
-            	{
-            		dcName = nameParts[0];
-            		order = 1;
-            	}
-            	else if (nameParts.length == 2)
-            	{
-            		dcName = nameParts[0];
-            		order = Integer.valueOf(nameParts[1]);
-            	}
-            	else
-            	{
-            		throw new ProcessingException("Unable to parse page metadata name, '" + name + "', into parts.");
-            	}
+                switch (nameParts.length)
+                {
+                case 1:
+                    dcName = nameParts[0];
+                    order = 1;
+                    break;
+                case 2:
+                    dcName = nameParts[0];
+                    order = Integer.valueOf(nameParts[1]);
+                    break;
+                default:
+                    throw new ProcessingException("Unable to parse page metadata name, '" + name + "', into parts.");
+                }
 
                 String[] dcParts = dcName.split("\\.");
                 String element = null;
                 String qualifier = null;
                 String language = null;
-                if (dcParts.length == 1)
+                switch (dcParts.length)
                 {
+                case 1:
                     element = dcParts[0];
-                }
-                else if (dcParts.length == 2)
-                {
+                    break;
+                case 2:
                     element = dcParts[0];
                     qualifier = dcParts[1];
-                }
-                else if (dcParts.length == 3)
-                {
+                    break;
+                case 3:
                     element = dcParts[0];
                     qualifier = dcParts[1];
                     language = dcParts[2];
-                }
-                else
-                {
+                    break;
+                default:
                     throw new ProcessingException("Unable to parse page metadata name, '" + name + "', into parts.");
                 }
 
@@ -183,7 +192,7 @@ public class IncludePageMeta extends AbstractWingTransformer implements Cacheabl
      */
     private List<Metadata> enableConcatenation() {
         Metadata last = null;
-        List<Metadata> newMetadataList = new ArrayList<Metadata>();
+        List<Metadata> newMetadataList = new ArrayList<>();
 
         for (Metadata metadata : metadataList)
         {
@@ -279,17 +288,15 @@ public class IncludePageMeta extends AbstractWingTransformer implements Cacheabl
         }
 
         // only valid nonempty query string is "nominify"
-        if(curval.lastIndexOf('?') != -1
-                && !"?nominify".equals(curval.substring(curval.lastIndexOf('?')))) {
-            return false;
-        }
-
-        return true;
+        return !(curval.lastIndexOf('?') != -1
+                && !"?nominify".equals(curval.substring(curval.lastIndexOf('?'))));
 
     }
     /**
      * Include the metadata in the page metadata.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
+    @Override
     public void addPageMeta(PageMeta pageMeta) throws WingException
     {
         for (Metadata metadata : metadataList)
@@ -311,10 +318,10 @@ public class IncludePageMeta extends AbstractWingTransformer implements Cacheabl
      */
     static class Metadata implements Comparable<Metadata> {
 
-    	private String element;
-    	private String qualifier;
-    	private String language;
-    	private int order;
+    	private final String element;
+    	private final String qualifier;
+    	private final String language;
+    	private final int order;
     	private String value;
 
     	public Metadata(String element,String qualifier, String language, int order, String value)
@@ -367,7 +374,7 @@ public class IncludePageMeta extends AbstractWingTransformer implements Cacheabl
     		return this.value;
     	}
 
-
+        @Override
     	public int compareTo(Metadata other)
     	{
     		String myName = this.element     + "." +this.qualifier   + "." + this.language;

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/Message.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/Message.java
@@ -10,18 +10,18 @@ package org.dspace.app.xmlui.wing;
 import java.io.Serializable;
 
 /**
- * 
+ *
  * This class represents an i18n message, which is composed of three parts: a 
  * catalogue, a key, and a set of dictionary parameters. The catalogue tells 
  * the translator where to find the key, the key tells the transformer which 
  * specific text should be used, and the parameters are provided for non-translated 
  * data to be inserted into the resulting string.
- * 
- * This class is designed in such a way that the Message object can be made static by any 
- * class that needs to use it. If dicionary parameters are used then a new 
- * instance is created specifically for those parameters, this prevents 
- * concurrent threads from overwriting each other's parameters.
- * 
+ *
+ * <p>This class is designed in such a way that the Message object can be made
+ * {@code static} by any class that needs to use it. If dictionary parameters
+ * are used then a new instance is created specifically for those parameters --
+ * this prevents concurrent threads from overwriting each other's parameters.
+ *
  * @author Scott Phillips
  */
 
@@ -73,6 +73,7 @@ public class Message implements Serializable
      * cloned copy that has been parameterized.
      * 
      * @param dictionaryParameters The dictionary parameters
+     * @return the message with parameters replaced.
      */
     public Message parameterize(Object ... dictionaryParameters)
     {
@@ -105,7 +106,7 @@ public class Message implements Serializable
      *
      * No one outside of this class should even know this class exists,
      * hence the privacy, but having two implementations allows us to
-     * separate all the functionality for paramaterization into this
+     * separate all the functionality for parameterization into this
      * one place. Since most of the messages used are unparameterized
      * this is not wasted on them and is only invoked when needed. There 
      * may be some performance increase by doing this but I doubt it is 
@@ -137,10 +138,11 @@ public class Message implements Serializable
         }
         
         /**
-         * Return the dicionary parameters for this message.
+         * Return the dictionary parameters for this message.
          * 
          * @return Any parameters to the catalogue key
          */
+        @Override
         public Object[] getDictionaryParameters()
         {
             return dictionaryParameters;

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/ObjectManager.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/ObjectManager.java
@@ -16,7 +16,7 @@ import java.util.Map;
  * are referenced.
  *
  * <p>The specific implementation of ObjectManager that is used is determined by the
- * {@link WingComponent} that is creating the reference.
+ * Wing component that is creating the reference.
  *
  * @author Scott Phillips
  */

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/ObjectManager.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/ObjectManager.java
@@ -14,10 +14,10 @@ import java.util.Map;
  * implementation that identifies referenced objects. Since the DRI document includes 
  * references to external resources implementers of this class must know how objects 
  * are referenced.
- * 
- * The specefic implementation of ObjectManager that is used is determened by the
- * WingComponent that is creating the reference.
- * 
+ *
+ * <p>The specific implementation of ObjectManager that is used is determined by the
+ * {@link WingComponent} that is creating the reference.
+ *
  * @author Scott Phillips
  */
 
@@ -30,30 +30,37 @@ public interface ObjectManager
      * @param object
      *            The object to be managed.
      * @return true if the object can be managed, otherwise false.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public boolean manageObject(Object object) throws WingException;  
 	
 	/**
-	 * Return a url referencing the object's metadata. If this is unabvailable 
+	 * Return a URL referencing the object's metadata. If this is unavailable
 	 * return null.
 	 * 
 	 * @param object The object being managed.
+     * @return the URL.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
 	 */
 	public String getObjectURL(Object object) throws WingException;
 	
 	/**
-	 * Return a descriptive, repository specfic, type for the object. If 
-	 * this is unabvailable return null.
+	 * Return a descriptive, repository specific, type for the object. If
+	 * this is unavailable return null.
 	 * 
 	 * @param object The object being managed.
+     * @return name of the object's type.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
 	 */
 	public String getObjectType(Object object) throws WingException;
 	
 	/**
 	 * Return a unique identifier of the repository this object is contained 
-	 * in. If this is unabvailable return null.
+	 * in. If this is unavailable return null.
 	 * 
 	 * @param object The object being managed.
+     * @return the repository identifier.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
 	 */
 	public String getRepositoryIdentifier(Object object) throws WingException;
 	
@@ -62,6 +69,8 @@ public interface ObjectManager
 	 * Return a list of all repositories managed by this manager. The 
 	 * hash should be of the form repository identifier as the key, 
 	 * and the value for each key is a metadata URL.
+     * @return a collection of repositories.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
 	 */
 	public Map<String,String> getAllManagedRepositories() throws WingException;
 }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/WingContext.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/WingContext.java
@@ -7,17 +7,16 @@
  */
 package org.dspace.app.xmlui.wing;
 
-/**
- * A class representing the framework's context, what component is generationg
- * content, where should we log. It's basically a grab bag for framework-wide
- * communication, if all elements need to know about something then it should go
- * here.
- * 
- * @author Scott Phillips
- */
-
 import org.apache.commons.logging.Log;
 
+/**
+ * A class representing the framework's context, what component is generating
+ * content, where should we log. It's basically a grab bag for framework-wide
+ * communication.  If all elements need to know about something then it should go
+ * here.
+ *
+ * @author Scott Phillips
+ */
 public class WingContext
 {
     /** The naming divider */
@@ -51,6 +50,7 @@ public class WingContext
 
     /**
      * Return the current transformer's name.
+     * @return the name.
      */
     public String getComponentName()
     {
@@ -81,13 +81,13 @@ public class WingContext
     /**
      * Generate a unique id based upon the locally unique name and the
      * application.
-     * 
-     * The format of the unique id typically is:
-     * 
-     * <componentName> dot <application> dot <unique name>
-     * 
-     * typically the componentName is the Java class path of the Wing component.
-     * 
+     *
+     * <p>The format of the unique id typically is:
+     *
+     * <p>{@literal <componentName>} dot {@literal <application>} dot {@literal <unique name>}
+     *
+     * <p>Typically the componentName is the Java class path of the Wing component.
+     *
      * @param application
      *            The application of this element, typically this is the element
      *            type that is being identified. Such as p, div, table, field,
@@ -118,6 +118,7 @@ public class WingContext
      * @param subName
      *            An additional name to the original name to further identify it
      *            in cases when just the name alone does not accomplish this.
+     * @return the ID.
      */
     public String generateID(String application, String name, String subName)
     {
@@ -132,6 +133,7 @@ public class WingContext
      * @param name
      *            A locally unique name that distinguished this element from
      *            among it's siblings.
+     * @return the name.
      */
     public String generateName(String name)
     {
@@ -195,7 +197,8 @@ public class WingContext
     
     /**
      * Check that the context is valid, and able to be used. An error should be
-     * thrown if it is not in a valid sate.
+     * thrown if it is not in a valid state.
+     * @throws org.dspace.app.xmlui.wing.WingException never.
      */
     public void checkValidity() throws WingException
     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/WingTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/WingTransformer.java
@@ -29,18 +29,32 @@ import org.dspace.app.xmlui.wing.element.UserMeta;
 public interface WingTransformer
 {
 
-    /** What to add at the end of the body */
+    /** What to add at the end of the body
+     * @param body to be added.
+     * @throws java.lang.Exception on error.
+     */
     public void addBody(Body body) throws Exception;
 
-    /** What to add to the options list */
+    /** What to add to the options list
+     * @param options to be added.
+     * @throws java.lang.Exception on error.
+     */
     public void addOptions(Options options) throws Exception;
 
-    /** What user metadata to add to the document */
+    /** What user metadata to add to the document
+     * @param userMeta to be added.
+     * @throws java.lang.Exception on error.
+     */
     public void addUserMeta(UserMeta userMeta) throws Exception;
 
-    /** What page metadata to add to the document */
+    /** What page metadata to add to the document
+     * @param pageMeta to be added.
+     * @throws java.lang.Exception on error.
+     */
     public void addPageMeta(PageMeta pageMeta) throws Exception;
 
-    /** What is a unique name for this component? */
+    /** What is a unique name for this component?
+     * @return the name.
+     */
     public String getComponentName();
 }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/AbstractWingElement.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/AbstractWingElement.java
@@ -30,7 +30,7 @@ import java.util.Map;
  * methods for sending SAX events that handle namespaces and attributes so that
  * each individual wing element does not.
  * 
- * There are also a set of utility methods for checking method parameters.
+ * <p>There are also a set of utility methods for checking method parameters.
  * 
  * @author Scott Phillips
  */
@@ -76,6 +76,7 @@ public abstract class AbstractWingElement implements WingElement
     /**
      * Return the currently registered wing context.
      * 
+     * @return the context.
      */
     protected WingContext getWingContext()
     {
@@ -108,6 +109,8 @@ public abstract class AbstractWingElement implements WingElement
      *            A non null and none empty string
      * @param message
      *            The exception message thrown if parameter is invalid.
+     * @throws org.dspace.app.xmlui.wing.WingInvalidArgument
+     *            if parameter is null or 0-length.
      */
     protected void require(String parameter, String message)
             throws WingInvalidArgument
@@ -125,6 +128,8 @@ public abstract class AbstractWingElement implements WingElement
      *            A non null and none empty string
      * @param message
      *            The exception message thrown if parameter is invalid.
+     * @throws org.dspace.app.xmlui.wing.WingInvalidArgument
+     *            if parameter is null.
      */
     protected void require(Message parameter, String message)
             throws WingInvalidArgument
@@ -147,6 +152,8 @@ public abstract class AbstractWingElement implements WingElement
      *            A list of possible values for the parameter.
      * @param message
      *            The exception message thrown if the parameter is invalid.
+     * @throws org.dspace.app.xmlui.wing.WingInvalidArgument
+     *            if {@code parameter} is not among {@code options}.
      */
     protected void restrict(String parameter, String[] options, String message)
             throws WingInvalidArgument
@@ -177,6 +184,8 @@ public abstract class AbstractWingElement implements WingElement
      *            An int who's value is lesser that greater.
      * @param message
      *            The exception message thrown if the parameter is invalid.
+     * @throws org.dspace.app.xmlui.wing.WingInvalidArgument
+     *            if parameter is too small.
      */
     protected void greater(int parameter, int greater, String message)
             throws WingInvalidArgument
@@ -197,6 +206,8 @@ public abstract class AbstractWingElement implements WingElement
      *            An int who's value is greater that lesser.
      * @param message
      *            The exception message thrown if the parameter is invalid.
+     * @throws org.dspace.app.xmlui.wing.WingInvalidArgument
+     *            if parameter is too large.
      */
     protected void lesser(int parameter, int lesser, String message)
             throws WingInvalidArgument
@@ -214,6 +225,8 @@ public abstract class AbstractWingElement implements WingElement
      *            A false value.
      * @param message
      *            The exception message thrown if "test" is invalid.
+     * @throws org.dspace.app.xmlui.wing.WingInvalidArgument
+     *            if true.
      */
     protected void requireFalse(boolean test, String message)
             throws WingInvalidArgument
@@ -231,6 +244,8 @@ public abstract class AbstractWingElement implements WingElement
      *            A true value.
      * @param message
      *            The exception message thrown if "test" is invalid.
+     * @throws org.dspace.app.xmlui.wing.WingInvalidArgument
+     *            if false.
      */
     protected void requireTrue(boolean test, String message)
             throws WingInvalidArgument
@@ -256,6 +271,8 @@ public abstract class AbstractWingElement implements WingElement
      *            (Required) The element's localName
      * @param attributes
      *            (May be null) Attributes for this element.
+     * @throws org.xml.sax.SAXException
+     *            passed through.
      */
     protected void startElement(ContentHandler contentHandler,
             NamespaceSupport namespaces, String name, AttributeMap attributes)
@@ -280,6 +297,8 @@ public abstract class AbstractWingElement implements WingElement
      *            (Required) The local name of this element.
      * @param attributes
      *            (May be null) Attributes for this element
+     * @throws org.xml.sax.SAXException
+     *            passed through.
      */
     protected void startElement(ContentHandler contentHandler,
             NamespaceSupport namespaces, Namespace namespace, String name,
@@ -299,6 +318,8 @@ public abstract class AbstractWingElement implements WingElement
      *            should be routed too.
      * @param characters
      *            (May be null) Characters to send.
+     * @throws org.xml.sax.SAXException
+     *            passed through.
      */
     protected void sendCharacters(ContentHandler contentHandler,
             String characters) throws SAXException
@@ -323,6 +344,8 @@ public abstract class AbstractWingElement implements WingElement
      *            to determine the correct prefix for a given namespace URI.
      * @param name
      *            (Required) The localName of this element.
+     * @throws org.xml.sax.SAXException
+     *            passed through.
      */
     protected void endElement(ContentHandler contentHandler,
             NamespaceSupport namespaces, String name) throws SAXException
@@ -343,6 +366,8 @@ public abstract class AbstractWingElement implements WingElement
      *            (Required) The namespace of this element.
      * @param name
      *            (Required) The local name of this element.
+     * @throws org.xml.sax.SAXException
+     *            passed through.
      */
     protected void endElement(ContentHandler contentHandler,
             NamespaceSupport namespaces, Namespace namespace, String name)
@@ -460,6 +485,7 @@ public abstract class AbstractWingElement implements WingElement
     /**
      * Dispose
      */
+    @Override
     public void dispose()
     {
         this.context = null;

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Body.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Body.java
@@ -21,10 +21,10 @@ import org.xml.sax.helpers.NamespaceSupport;
 
 /**
  * A class representing the page division.
- * 
- * The body contains any number of divisions (div elements) which group content
- * into interactive and non interactive display blocks.
- * 
+ *
+ * <p>The body contains any number of divisions ({@code div} elements) which
+ * group content into interactive and non interactive display blocks.
+ *
  * @author Scott Phillips
  */
 public class Body extends AbstractWingElement implements WingMergeableElement
@@ -36,7 +36,7 @@ public class Body extends AbstractWingElement implements WingMergeableElement
     private boolean merged = false;
 
     /** The divisions contained within this body */
-    private List<Division> divisions = new ArrayList<Division>();
+    private final List<Division> divisions = new ArrayList<>();
 
     /**
      * Generate a new Body framework element. This method will NOT open or close
@@ -46,6 +46,8 @@ public class Body extends AbstractWingElement implements WingMergeableElement
      * 
      * @param context
      *            (Required) The context this element is contained in.
+     * @throws org.dspace.app.xmlui.wing.WingException
+     *            passed through.
      */
     protected Body(WingContext context) throws WingException
     {
@@ -64,6 +66,8 @@ public class Body extends AbstractWingElement implements WingMergeableElement
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
      * @return a new division.
+     * @throws org.dspace.app.xmlui.wing.WingException
+     *            passed through.
      */
     public Division addDivision(String name, String rend) throws WingException
     {
@@ -83,6 +87,8 @@ public class Body extends AbstractWingElement implements WingMergeableElement
      *            a local identifier used to differentiate the element from its
      *            siblings
      * @return A new division.
+     * @throws org.dspace.app.xmlui.wing.WingException
+     *            passed through.
      */
     public Division addDivision(String name) throws WingException
     {
@@ -110,6 +116,8 @@ public class Body extends AbstractWingElement implements WingMergeableElement
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
      * @return A new division.
+     * @throws org.dspace.app.xmlui.wing.WingException
+     *            passed through.
      */
     public Division addInteractiveDivision(String name, String action,
             String method, String rend) throws WingException
@@ -117,7 +125,6 @@ public class Body extends AbstractWingElement implements WingMergeableElement
         Division div = new Division(context, name, action, method, rend);
         divisions.add(div);
         return div;
-
     }
 
     /**
@@ -132,7 +139,12 @@ public class Body extends AbstractWingElement implements WingMergeableElement
      * @param attributes
      *            The element's attributes
      * @return True if it is equivalent.
+     * @throws org.xml.sax.SAXException
+     *            passed through.
+     * @throws org.dspace.app.xmlui.wing.WingException
+     *            passed through.
      */
+    @Override
     public boolean mergeEqual(String namespace, String localName, String qName,
             Attributes attributes) throws SAXException, WingException
     {
@@ -140,11 +152,7 @@ public class Body extends AbstractWingElement implements WingMergeableElement
         {
             return false;
         }
-        if (!E_BODY.equals(localName))
-        {
-            return false;
-        }
-        return true;
+        return E_BODY.equals(localName);
     }
 
     /**
@@ -159,7 +167,12 @@ public class Body extends AbstractWingElement implements WingMergeableElement
      * @param attributes
      *            The element's attributes
      * @return the matching Division, or null.
+     * @throws org.xml.sax.SAXException
+     *            passed through.
+     * @throws org.dspace.app.xmlui.wing.WingException
+     *            passed through.
      */
+    @Override
     public WingMergeableElement mergeChild(String namespace, String localName,
             String qName, Attributes attributes)
 	throws SAXException, WingException
@@ -182,7 +195,10 @@ public class Body extends AbstractWingElement implements WingMergeableElement
      * 
      * @param attributes
      *            The to-be-merged attributes
+     * @throws org.xml.sax.SAXException never.
+     * @throws org.dspace.app.xmlui.wing.WingException never.
      */
+    @Override
     public Attributes merge(Attributes attributes) throws SAXException,
             WingException
     {
@@ -203,6 +219,7 @@ public class Body extends AbstractWingElement implements WingMergeableElement
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
      */
+    @Override
     public void toSAX(ContentHandler contentHandler,
             LexicalHandler lexicalHandler, NamespaceSupport namespaces)
             throws SAXException
@@ -226,6 +243,7 @@ public class Body extends AbstractWingElement implements WingMergeableElement
     /**
      * dispose
      */
+    @Override
     public void dispose()
     {
         for (Division division : divisions)

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Button.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Button.java
@@ -7,18 +7,17 @@
  */
 package org.dspace.app.xmlui.wing.element;
 
-/**
- * A class representing the Button input control. The button input control
- * allows the user to activate a form submit, where the form information is sent
- * back to the server.
- * 
- * @author Scott Phillips
- */
-
 import org.dspace.app.xmlui.wing.Message;
 import org.dspace.app.xmlui.wing.WingContext;
 import org.dspace.app.xmlui.wing.WingException;
 
+/**
+ * A class representing the Button input control. The button input control
+ * allows the user to activate a form submit, where the form information is sent
+ * back to the server.
+ *
+ * @author Scott Phillips
+ */
 public class Button extends Field
 {
     /**
@@ -36,6 +35,7 @@ public class Button extends Field
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
+     * @throws org.dspace.app.xmlui.wing.WingException on error.
      */
     protected Button(WingContext context, String name, String rend)
             throws WingException
@@ -49,6 +49,7 @@ public class Button extends Field
      * Set the button's label, removing any previous label's
      * 
      * @return A button label's value.
+     * @throws org.dspace.app.xmlui.wing.WingException on error.
      */
     public Value setValue() throws WingException
     {
@@ -63,6 +64,7 @@ public class Button extends Field
      * 
      * @param characters
      *            (May be null) The button's label as a string.
+     * @throws org.dspace.app.xmlui.wing.WingException on error.
      */
     public void setValue(String characters) throws WingException
     {
@@ -76,6 +78,7 @@ public class Button extends Field
      * @param translated
      *            (Required) A key into the i18n catalogue for translation into
      *            the user's preferred language.
+     * @throws org.dspace.app.xmlui.wing.WingException on error.
      */
     public void setValue(Message translated) throws WingException
     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Cell.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Cell.java
@@ -7,17 +7,6 @@
  */
 package org.dspace.app.xmlui.wing.element;
 
-/**
- * A class representing a table cell.
- * 
- * The cell element contained in a row of a table carries content for that
- * table. It is a character container, just like p, item, and hi, and its
- * primary purpose is to display textual data, possibly enhanced with
- * hyperlinks, emphasized blocks of text, images and form fields.
- * 
- * @author Scott Phillips
- */
-
 import org.dspace.app.xmlui.wing.AttributeMap;
 import org.dspace.app.xmlui.wing.WingContext;
 import org.dspace.app.xmlui.wing.WingException;
@@ -26,6 +15,16 @@ import org.xml.sax.SAXException;
 import org.xml.sax.ext.LexicalHandler;
 import org.xml.sax.helpers.NamespaceSupport;
 
+/**
+ * A class representing a table cell.
+ * 
+ * <p>The cell element contained in a row of a table carries content for that
+ * table. It is a character container, just like p, item, and hi, and its
+ * primary purpose is to display textual data, possibly enhanced with
+ * hyperlinks, emphasized blocks of text, images and form fields.
+ * 
+ * @author Scott Phillips
+ */
 public class Cell extends RichTextContainer implements StructuralElement
 {
     /** The name of the cell element */
@@ -41,19 +40,19 @@ public class Cell extends RichTextContainer implements StructuralElement
     public static final String A_COLS = "cols";
 
     /** The name of this cell */
-    private String name;
+    private final String name;
 
     /** The role of this cell, see ROLES below */
-    private String role;
+    private final String role;
 
     /** How many rows does this table span */
-    private int rows;
+    private final int rows;
 
     /** How many cols does this table span */
-    private int cols;
+    private final int cols;
 
     /** Special rendering instructions */
-    private String rend;
+    private final String rend;
 
     /** The possible cell role types */
     public static final String ROLE_DATA = "data";
@@ -84,6 +83,7 @@ public class Cell extends RichTextContainer implements StructuralElement
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected Cell(WingContext context, String name, String role, int rows,
             int cols, String rend) throws WingException
@@ -116,7 +116,9 @@ public class Cell extends RichTextContainer implements StructuralElement
      * @param namespaces
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
+     * @throws org.xml.sax.SAXException passed through.
      */
+    @Override
     public void toSAX(ContentHandler contentHandler, LexicalHandler lexicalHandler,
             NamespaceSupport namespaces) throws SAXException
     {
@@ -151,9 +153,7 @@ public class Cell extends RichTextContainer implements StructuralElement
         endElement(contentHandler, namespaces, E_CELL);
     }
 
-    /**
-     * dispose
-     */
+    @Override
     public void dispose()
     {
         if (contents != null)

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/CheckBox.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/CheckBox.java
@@ -7,6 +7,10 @@
  */
 package org.dspace.app.xmlui.wing.element;
 
+import org.dspace.app.xmlui.wing.Message;
+import org.dspace.app.xmlui.wing.WingContext;
+import org.dspace.app.xmlui.wing.WingException;
+
 /**
  * A class representing a CheckBox input control. The checkbox input control is
  * a boolean control which may be toggled by the user. A checkbox may have
@@ -16,11 +20,6 @@ package org.dspace.app.xmlui.wing.element;
  * 
  * @author Scott Phillips
  */
-
-import org.dspace.app.xmlui.wing.Message;
-import org.dspace.app.xmlui.wing.WingContext;
-import org.dspace.app.xmlui.wing.WingException;
-
 public class CheckBox extends Field
 {
 
@@ -39,6 +38,7 @@ public class CheckBox extends Field
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected CheckBox(WingContext context, String name, String rend)
             throws WingException
@@ -51,6 +51,7 @@ public class CheckBox extends Field
      * Enable the add operation for this field. When this is enabled the
      * front end will add a button to add more items to the field.
      * 
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void enableAddOperation() throws WingException
     {
@@ -62,22 +63,21 @@ public class CheckBox extends Field
      * the front end will provide a way for the user to select fields (probably
      * checkboxes) along with a submit button to delete the selected fields.
      * 
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void enableDeleteOperation()throws WingException
     {
         this.params.enableDeleteOperation();
     }
-    
-    
-    
-    
-    
+
     /**
      * Add an option.
      * 
      * @param returnValue
      *            (Required) The value to be passed back if this option is
      *            selected.
+     * @return a new Option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Option addOption(String returnValue)
             throws WingException
@@ -94,6 +94,8 @@ public class CheckBox extends Field
      * @param returnValue
      *            (Required) The value to be passed back if this option is
      *            selected.
+     * @return a new Option.
+     * @throws org.dspace.app.xmlui.wing.WingException  passed through.
      */
     public Option addOption(int returnValue)
             throws WingException
@@ -109,6 +111,8 @@ public class CheckBox extends Field
      * @param returnValue
      *            (Required) The value to be passed back if this option is
      *            checked.
+     * @return a new Option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Option addOption(boolean selected, String returnValue)
             throws WingException
@@ -128,6 +132,7 @@ public class CheckBox extends Field
      *            checked.
      * @param characters
      *            (Required) The text to set as the visible option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addOption(String returnValue, String characters) throws WingException
     {
@@ -145,6 +150,7 @@ public class CheckBox extends Field
      *            checked.
      * @param characters
      *            (Required) The text to set as the visible option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addOption(boolean selected,String returnValue, String characters) throws WingException
     {
@@ -163,6 +169,7 @@ public class CheckBox extends Field
      *            checked.
      * @param characters
      *            (Required) The text to set as the visible option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addOption(int returnValue, String characters) throws WingException
     {
@@ -180,6 +187,7 @@ public class CheckBox extends Field
      *            selected.
      * @param characters
      *            (Required) The text to set as the visible option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addOption(boolean selected, int returnValue, String characters) throws WingException
     {
@@ -197,7 +205,8 @@ public class CheckBox extends Field
      *            (Required) The value to be passed back if this option is
      *            selected.
      * @param message
-     *            (Required) The transalted text to set as the visible option.
+     *            (Required) The translated text to set as the visible option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addOption(String returnValue, Message message) throws WingException
     {
@@ -214,7 +223,8 @@ public class CheckBox extends Field
      *            (Required) The value to be passed back if this option is
      *            selected.
      * @param message
-     *            (Required) The transalted text to set as the visible option.
+     *            (Required) The translated text to set as the visible option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addOption(boolean selected, String returnValue, Message message) throws WingException
     {
@@ -232,7 +242,8 @@ public class CheckBox extends Field
      *            (Required) The value to be passed back if this option is
      *            selected.
      * @param message
-     *            (Required) The transalted text to set as the visible option.
+     *            (Required) The translated text to set as the visible option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addOption(int returnValue, Message message) throws WingException
     {
@@ -249,7 +260,8 @@ public class CheckBox extends Field
      *            (Required) The value to be passed back if this option is
      *            selected.
      * @param message
-     *            (Required) The transalted text to set as the visible option.
+     *            (Required) The translated text to set as the visible option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addOption(boolean selected, int returnValue, Message message) throws WingException
     {
@@ -260,17 +272,12 @@ public class CheckBox extends Field
         addOption(returnValue,message);
     }
 
-
-    
-    
-    
-    
-    
     /**
      * Set the given option as checked.
      * 
      * @param returnValue
      *            (Required) The return value of the option to be selected.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setOptionSelected(String returnValue) throws WingException
     {
@@ -283,23 +290,18 @@ public class CheckBox extends Field
      * 
      * @param returnValue
      *            (Required) The return value of the option to be selected.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setOptionSelected(int returnValue) throws WingException
     {
         Value value = new Value(context,Value.TYPE_OPTION,String.valueOf(returnValue));
         values.add(value);
     }
-    
-    
-    
-    
-    
-    
-    
-    
+
     /**
      * Add a field instance
      * @return instance
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Instance addInstance() throws WingException
     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Composite.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Composite.java
@@ -7,21 +7,20 @@
  */
 package org.dspace.app.xmlui.wing.element;
 
+import org.dspace.app.xmlui.wing.WingContext;
+import org.dspace.app.xmlui.wing.WingException;
+
 /**
  * A class representing a composite input control. The composite input control
- * enables multiple input conrols to be combined together into a single control.
+ * enables multiple input controls to be combined together into a single control.
  * Some example uses would be names, that are broken up into both a first and
  * last name. Together they represent a single value but the user can interacts
  * two separate text boxes for each part of the name.
  * 
  * @author Scott Phillips
  */
-import org.dspace.app.xmlui.wing.WingContext;
-import org.dspace.app.xmlui.wing.WingException;
-
 public class Composite extends Field
 {
-
     /**
      * Construct a new field.
      * 
@@ -37,6 +36,7 @@ public class Composite extends Field
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected Composite(WingContext context, String name, String rend)
             throws WingException
@@ -49,6 +49,7 @@ public class Composite extends Field
      * Enable the add operation for this field. When this is enabled the
      * front end will add a button to add more items to the field.
      * 
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void enableAddOperation() throws WingException
     {
@@ -60,6 +61,7 @@ public class Composite extends Field
      * the front end will provide a way for the user to select fields (probably
      * checkboxes) along with a submit button to delete the selected fields.
      * 
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void enableDeleteOperation()throws WingException
     {
@@ -81,6 +83,7 @@ public class Composite extends Field
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
      * @return a new checkbox field
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public CheckBox addCheckBox(String name, String rend) throws WingException
     {
@@ -101,6 +104,7 @@ public class Composite extends Field
      *            This is the name of the field use when data is submitted back
      *            to the server.
      * @return A new checkbox field
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public CheckBox addCheckBox(String name) throws WingException
     {
@@ -122,6 +126,7 @@ public class Composite extends Field
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
      * @return a new radio field.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Radio addRadio(String name, String rend) throws WingException
     {
@@ -143,6 +148,7 @@ public class Composite extends Field
      *            to the server.
      * 
      * @return a new radio field
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Radio addRadio(String name) throws WingException
     {
@@ -162,6 +168,7 @@ public class Composite extends Field
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
      * @return a new select field
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Select addSelect(String name, String rend) throws WingException
     {
@@ -180,6 +187,7 @@ public class Composite extends Field
      *            This is the name of the field use when data is submitted back
      *            to the server.
      * @return a new select field
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Select addSelect(String name) throws WingException
     {
@@ -198,6 +206,7 @@ public class Composite extends Field
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
      * @return A new text field
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Text addText(String name, String rend) throws WingException
     {
@@ -216,6 +225,7 @@ public class Composite extends Field
      *            This is the name of the field use when data is submitted back
      *            to the server.
      * @return a new text field
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Text addText(String name) throws WingException
     {
@@ -234,6 +244,7 @@ public class Composite extends Field
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
      * @return a new text area field
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public TextArea addTextArea(String name, String rend) throws WingException
     {
@@ -251,6 +262,7 @@ public class Composite extends Field
      *            This is the name of the field use when data is submitted back
      *            to the server.
      * @return a new text area field
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public TextArea addTextArea(String name) throws WingException
     {
@@ -260,6 +272,7 @@ public class Composite extends Field
     /**
      * Add a field instance
      * @return instance
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Instance addInstance() throws WingException
     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Container.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Container.java
@@ -9,7 +9,7 @@ package org.dspace.app.xmlui.wing.element;
 
 /**
  * This class represents a generic Wing Container. The Container class adds a
- * simlpe contents list which may be modified by the extending concret classes.
+ * simple contents list which may be modified by the extending concrete classes.
  * When it comes time to process the element a toSAX method is provided that
  * will iterate over the contents. 
  * 
@@ -30,11 +30,12 @@ public abstract class Container extends AbstractWingElement
 {
 
     /** The internal contents of this container */
-    protected List<AbstractWingElement> contents = new ArrayList<AbstractWingElement>();
+    protected List<AbstractWingElement> contents = new ArrayList<>();
 
     /**
      * @param context
      *            (Required) The context this element is contained in.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected Container(WingContext context) throws WingException
     {
@@ -58,7 +59,9 @@ public abstract class Container extends AbstractWingElement
      * @param namespaces
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
+     * @throws org.xml.sax.SAXException passed through.
      */
+    @Override
     public void toSAX(ContentHandler contentHandler,
             LexicalHandler lexicalHandler, NamespaceSupport namespaces)
             throws SAXException
@@ -69,9 +72,7 @@ public abstract class Container extends AbstractWingElement
         }
     }
 
-    /**
-     * Dispose
-     */
+    @Override
     public void dispose()
     {
 

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Data.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Data.java
@@ -24,7 +24,7 @@ import org.xml.sax.helpers.NamespaceSupport;
  * This class represents data, by data we mean the translated and untranslated
  * characters in between XML elements.
  * 
- * When data needs to be translated it is enclosed inside the cocoon i18n schema
+ * <p>When data needs to be translated it is enclosed inside the cocoon i18n schema
  * while untranslated data is enclosed inside nothing.
  * 
  * @author Scott Phillips
@@ -38,7 +38,7 @@ public class Data extends AbstractWingElement
     /** The name of the translate element */
     public static final String E_TRANSLATE = "translate";
 
-    /** The name of the param element */
+    /** The name of the {@code param} element */
     public static final String E_PARAM = "param";
 
     /** The name of the catalogue attribute (used inside text or i18n message) */
@@ -110,7 +110,9 @@ public class Data extends AbstractWingElement
      * @param namespaces
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
+     * @throws org.xml.sax.SAXException passed through.
      */
+    @Override
     public void toSAX(ContentHandler contentHandler, LexicalHandler lexicalHandler,
             NamespaceSupport namespaces)throws SAXException
     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Data.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Data.java
@@ -71,7 +71,7 @@ public class Data extends AbstractWingElement
      *            where to route SAX events and what i18n catalogue to use.
      * @param message
      *            (Required) translatable data
-     * @throws WingException
+     * @throws WingException passed through.
      */
     protected Data(WingContext context, Message message)
             throws WingException
@@ -89,7 +89,7 @@ public class Data extends AbstractWingElement
      *            where to route SAX events and what i18n catalogue to use.
      * @param characters
      *            (Required) Untranslated character data.
-     * @throws WingException
+     * @throws WingException passed through.
      */
     protected Data(WingContext context, String characters) throws WingException
     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Division.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Division.java
@@ -7,18 +7,6 @@
  */
 package org.dspace.app.xmlui.wing.element;
 
-/**
- * Class representing a Division, or the div element, in the XML UI schema.
- * 
- * The div element represents a major section of content and can contain a wide
- * variety of other elements to present that content to the user. It can contain
- * TEI style paragraphs, tables, and lists, as well as references to artifact
- * information stored in artifactMeta. The div element is also recursive,
- * allowing it to be further divided into other divs.
- * 
- * @author Scott Phillips
- */
-
 import java.util.ArrayList;
 
 import org.dspace.app.xmlui.wing.AttributeMap;
@@ -32,6 +20,17 @@ import org.xml.sax.SAXException;
 import org.xml.sax.ext.LexicalHandler;
 import org.xml.sax.helpers.NamespaceSupport;
 
+/**
+ * Class representing a Division, or the div element, in the XML UI schema.
+ *
+ * <p>The {@code div} element represents a major section of content and can contain a wide
+ * variety of other elements to present that content to the user. It can contain
+ * TEI style paragraphs, tables, and lists, as well as references to artifact
+ * information stored in artifactMeta. The {@code div} element is also recursive,
+ * allowing it to be further divided into other {@code div}s.
+ *
+ * @author Scott Phillips
+ */
 public class Division extends AbstractWingElement implements StructuralElement, WingMergeableElement
 {
     /** The name of the division element */
@@ -83,7 +82,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
     private boolean merged = false;
     
     /** The name assigned to this div */
-    private String name;
+    private final String name;
 
     /** Is this division interactive if so then action & method must be defined */
     private boolean interactive;
@@ -96,12 +95,12 @@ public class Division extends AbstractWingElement implements StructuralElement, 
 
     /** Does this interactive division support the AJAX behavior? */
     private boolean behaviorAJAXenabled = false;
-    
+
     /** A list of fields which need to be handled specially when using behavior */
     private String behaviorSensitiveFields;
     
     /** Special rendering instructions */
-    private String rend;
+    private final String rend;
 
     /** The head, or label of this division */
     private Head head;
@@ -175,7 +174,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
             PAGINATION_MASKED };
 
     /** All content of this container, items & lists */
-    private java.util.List<AbstractWingElement> contents = new ArrayList<AbstractWingElement>();
+    private java.util.List<AbstractWingElement> contents = new ArrayList<>();
 
     /**
      * Construct a non-interactive division.
@@ -190,6 +189,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected Division(WingContext context, String name, String rend)
             throws WingException
@@ -226,6 +226,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected Division(WingContext context, String name, String action,
             String method, String rend) throws WingException
@@ -263,6 +264,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      * 
      * @param fieldName
      *            (Required) The name of a single field (with no spaces).
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addBehaviorSensitiveField(String fieldName) throws WingException
     {
@@ -341,12 +343,13 @@ public class Division extends AbstractWingElement implements StructuralElement, 
 
     /**
      * Set the head element which is the label associated with this division.
+     * @return the new Head.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Head setHead() throws WingException
     {
         this.head = new Head(context, null);
         return head;
-
     }
 
     /**
@@ -354,12 +357,12 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      * 
      * @param characters
      *            (May be null) Unprocessed characters to be included
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setHead(String characters) throws WingException
     {
-        Head head = this.setHead();
-        head.addContent(characters);
-
+        Head theHead = this.setHead();
+        theHead.addContent(characters);
     }
 
     /**
@@ -368,11 +371,12 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      * @param message
      *            (Required) A key into the i18n catalogue for translation into
      *            the user's preferred language.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setHead(Message message) throws WingException
     {
-        Head head = this.setHead();
-        head.addContent(message);
+        Head theHead = this.setHead();
+        theHead.addContent(message);
     }
 
     /**
@@ -385,6 +389,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
      * @return A new sub Division
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Division addDivision(String name, String rend) throws WingException
     {
@@ -401,6 +406,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      *            (Required) a local identifier used to differentiate the
      *            element from its siblings.
      * @return A new sub division
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Division addDivision(String name) throws WingException
     {
@@ -428,6 +434,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
      * @return A new interactive sub division
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Division addInteractiveDivision(String name, String action,
             String method, String rend) throws WingException
@@ -456,6 +463,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      *            method should be used if there are any file fields used within
      *            the division.
      * @return A new interactive sub division
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Division addInteractiveDivision(String name, String action,
             String method) throws WingException
@@ -473,6 +481,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
      * @return A new paragraph.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Para addPara(String name, String rend) throws WingException
     {
@@ -485,6 +494,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      * Append an unnamed paragraph to the division
      * 
      * @return A new unnamed paragraph.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Para addPara() throws WingException
     {
@@ -497,6 +507,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      * @param characters
      *            (May be null) Untranslated character data to be included as
      *            the contents of this para.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addPara(String characters) throws WingException
     {
@@ -510,6 +521,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      * @param message
      *            (Required) Key to the i18n catalogue to translate the content
      *            into the language preferred by the user.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through
      */
     public void addPara(Message message) throws WingException
     {
@@ -535,6 +547,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      *            display of the element.
      * 
      * @return A new List
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public List addList(String name, String type, String rend)
             throws WingException
@@ -556,9 +569,10 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      *            type of list. In the absence of this attribute, the type of a
      *            list will be inferred from the presence and content of labels
      *            on its items. Accepted values are found at
-     *            org.dspace.app.xmlui.xmltool.List.TYPES
-     * 
+     *            {@link org.dspace.app.xmlui.xmltool.List.TYPES}
+     *
      * @return A new List
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public List addList(String name, String type) throws WingException
     {
@@ -573,6 +587,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      *            (Required) a local identifier used to differentiate the
      *            element from its siblings.
      * @return A new List
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public List addList(String name) throws WingException
     {
@@ -597,6 +612,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      *            display of the element.
      * 
      * @return A new table.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Table addTable(String name, int rows, int cols, String rend)
             throws WingException
@@ -621,6 +637,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      *            (Required) The number of columns in the table.
      * 
      * @return A new table.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Table addTable(String name, int rows, int cols) throws WingException
     {
@@ -640,6 +657,8 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
+     * @return a new ReferenceSet.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public ReferenceSet addReferenceSet(String name, String type, String orderBy,
             String rend) throws WingException
@@ -657,6 +676,8 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      *            element from its siblings.
      * @param type
      *            (Required) The include type, see IncludeSet.TYPES
+     * @return a new ReferenceSet.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public ReferenceSet addReferenceSet(String name, String type)
             throws WingException
@@ -673,6 +694,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      * @param name 
      *              (Required) The hidden fields name.
      * @return A new hidden field.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Hidden addHidden(String name) throws WingException
     {
@@ -683,19 +705,20 @@ public class Division extends AbstractWingElement implements StructuralElement, 
         
         return hiddenFieldsPara.addHidden(name);
     }
-    
-    
+
     /**
      * Add a section of translated HTML to the DRI document. This will only handle 
-     * simple transformations such as <p>, <b>, <i> and <a> tags.
-     * 
-     * Depending on the given HTML this may result in multiple paragraphs being 
+     * simple transformations such as {@literal <p>}, {@literal <b>},
+     * {@literal <i>} and {@literal <a>} tags.
+     *
+     * <p>Depending on the given HTML this may result in multiple paragraphs being
      * opened and several bold tags being included.
      * 
      * @param blankLines
      * 				(Required) Treat blank lines as paragraphs delimiters.
      * @param HTML 
      * 				(Required) The HTML content
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addSimpleHTMLFragment(boolean blankLines, String HTML) throws WingException
     {
@@ -716,6 +739,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      *            The element's attributes
      * @return True if this WingElement is equivalent to the given SAX Event.
      */
+    @Override
     public boolean mergeEqual(String namespace, String localName, String qName,
             Attributes attributes) throws SAXException, WingException
     {
@@ -732,18 +756,23 @@ public class Division extends AbstractWingElement implements StructuralElement, 
 
         context.getLogger().debug("Merging a division");
         
-        String name = attributes.getValue(A_NAME);
-        String interactive = attributes.getValue(A_INTERACTIVE);
-        String action = attributes.getValue(A_ACTION);
-        String method = attributes.getValue(A_METHOD);
+        String aName = attributes.getValue(A_NAME);
+        String isInteractive = attributes.getValue(A_INTERACTIVE);
+        String anAction = attributes.getValue(A_ACTION);
+        String aMethod = attributes.getValue(A_METHOD);
         String render = attributes.getValue(A_RENDER);
         String pagination = attributes.getValue(A_PAGINATION);
         String behavior = attributes.getValue(A_BEHAVIOR);
 
-        context.getLogger().debug("Merging got parameters name="+name+", interactive="+interactive+", action="+action+", method="+method+", render="+render+", pagination="+pagination);
-        
+        context.getLogger().debug("Merging got parameters name=" + aName
+                + ", interactive=" + isInteractive
+                + ", action=" + anAction
+                + ", method=" + aMethod
+                + ", render=" + render
+                + ", pagination=" + pagination);
+
         // The name must be identical (but id's can differ)
-        if (!this.name.equals(name))
+        if (!this.name.equals(aName))
         {
             return false;
         }
@@ -764,15 +793,15 @@ public class Division extends AbstractWingElement implements StructuralElement, 
         if (this.interactive)
         {
             // Ensure all the interactive fields are identical.
-            if (!"yes".equals(interactive))
+            if (!"yes".equals(isInteractive))
             {
                 return false;
             }
-            if (!this.action.equals(action))
+            if (!this.action.equals(anAction))
             {
                 return false;
             }
-            if (!this.method.equals(method))
+            if (!this.method.equals(aMethod))
             {
                 return false;
             }
@@ -785,7 +814,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
             
         } else {
             // Else, ensure that it is also not interactive.
-            if (!(interactive == null || "no".equals(interactive)))
+            if (!(isInteractive == null || "no".equals(isInteractive)))
             {
                 return false;
             }
@@ -807,6 +836,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      *            The element's attributes
      * @return The child element
      */
+    @Override
     public WingMergeableElement mergeChild(String namespace, String localName,
             String qName, Attributes attributes) throws SAXException,
             WingException
@@ -833,6 +863,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      * 
      * @return The attributes for this merged element
      */
+    @Override
     public Attributes merge(Attributes attributes) throws SAXException,
             WingException
     {
@@ -853,6 +884,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
      */
+    @Override
     public void toSAX(ContentHandler contentHandler, LexicalHandler lexicalHandler, 
             NamespaceSupport namespaces) throws SAXException
     {
@@ -932,6 +964,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
     /**
      * dispose
      */
+    @Override
     public void dispose()
     {
 

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Division.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Division.java
@@ -541,7 +541,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      *            type of list. In the absence of this attribute, the type of a
      *            list will be inferred from the presence and content of labels
      *            on its items. Accepted values are found at
-     *            org.dspace.app.xmlui.xmltool.List.TYPES
+     *            {@link org.dspace.app.xmlui.wing.element.List#TYPES}
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
@@ -569,7 +569,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
      *            type of list. In the absence of this attribute, the type of a
      *            list will be inferred from the presence and content of labels
      *            on its items. Accepted values are found at
-     *            {@link org.dspace.app.xmlui.xmltool.List.TYPES}
+     *            {@link org.dspace.app.xmlui.wing.element.List#TYPES}
      *
      * @return A new List
      * @throws org.dspace.app.xmlui.wing.WingException passed through.

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Division.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Division.java
@@ -164,7 +164,7 @@ public class Division extends AbstractWingElement implements StructuralElement, 
     public static final String[] METHODS = { METHOD_GET, METHOD_POST,
             METHOD_MULTIPART };
 
-    /** The possible pagination types: simple & masked */
+    /** The possible pagination types: simple and masked */
     public static final String PAGINATION_SIMPLE = "simple";
 
     public static final String PAGINATION_MASKED = "masked";

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Error.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Error.java
@@ -29,6 +29,7 @@ public class Error extends TextContainer implements StructuralElement
      * 
      * @param context
      *            (Required) The context this element is contained in
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected Error(WingContext context) throws WingException
     {
@@ -48,8 +49,10 @@ public class Error extends TextContainer implements StructuralElement
      * @param namespaces
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
+     * @throws org.xml.sax.SAXException passed through.
      */
 
+    @Override
     public void toSAX(ContentHandler contentHandler, LexicalHandler lexicalHandler,
             NamespaceSupport namespaces) throws SAXException
     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Field.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Field.java
@@ -7,57 +7,6 @@
  */
 package org.dspace.app.xmlui.wing.element;
 
-/**
- * A class representing an an abstract input control (which is just a fancy name
- * for a field :) )
- *
- * The field element is a container for all information necessary to create a
- * form field. The required "type" attribute determines the type of the field,
- * while the children tags carry the information on how to build it. Fields can
- * only occur in divisions of type "interactive".
- *
- * There are several types of possible fields and each of these field types
- * determine the appropriate parameters on the parameter object. This is the
- * only place in the schema where this design pattern is used. It limits the
- * proliferation of elements, such as a special element for textarea, select
- * lists, text fields etc... as HTML does. It also forces us to treat all fields
- * the same.
- *
- * text: A single-line text input control.
- *
- * textarea: A multi-line text input control.
- *
- * password: A single-line text input control where the input text is rendered
- * in such a way as to hide the characters from the user.
- *
- * hidden: An input control that is not rendered on the screen and hidden from
- * the user.
- *
- * button: A button input control that when activated by the user will submit
- * the form, including all the fields, back to the server for processing.
- *
- * checkbox: A boolean input control which may be toggled by the user. A
- * checkbox may have several fields which share the same name and each of those
- * fields may be toggled independently. This is distinct from a radio button
- * where only one field may be toggled.
- *
- * file: An input control that allows the user to select files to be submitted
- * with the form. Note that a form which uses a file field must use the
- * multipart method.
- *
- * radio: A boolean input control which may be toggled by the user. Multiple
- * radio button fields may share the same name. When this occurs only one field
- * may be selected to be true. This is distinct from a checkbox where multiple
- * fields may be toggled.
- *
- * select: A menu input control which allows the user to select from a list of
- * available options.
- *
- * composite: A combination of multile fields into one input control.
- *
- * @author Scott Phillips
- */
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -71,6 +20,58 @@ import org.xml.sax.SAXException;
 import org.xml.sax.ext.LexicalHandler;
 import org.xml.sax.helpers.NamespaceSupport;
 
+/**
+ * A class representing an an abstract input control (which is just a fancy name
+ * for a field :) )
+ *
+ * <p>The field element is a container for all information necessary to create a
+ * form field. The required "type" attribute determines the type of the field,
+ * while the children tags carry the information on how to build it. Fields can
+ * only occur in divisions of type "interactive".
+ *
+ * <p>There are several types of possible fields and each of these field types
+ * determine the appropriate parameters on the parameter object. This is the
+ * only place in the schema where this design pattern is used. It limits the
+ * proliferation of elements, such as a special element for textarea, select
+ * lists, text fields etc... as HTML does. It also forces us to treat all fields
+ * the same.
+ *
+ * <ul>
+ * <li>text: A single-line text input control.</li>
+ *
+ * <li>textarea: A multi-line text input control.</li>
+ *
+ * <li>password: A single-line text input control where the input text is rendered
+ * in such a way as to hide the characters from the user.</li>
+ *
+ * <li>hidden: An input control that is not rendered on the screen and hidden from
+ * the user.</li>
+ *
+ * <li>button: A button input control that when activated by the user will submit
+ * the form, including all the fields, back to the server for processing.</li>
+ *
+ * <li>checkbox: A boolean input control which may be toggled by the user. A
+ * checkbox may have several fields which share the same name and each of those
+ * fields may be toggled independently. This is distinct from a radio button
+ * where only one field may be toggled.</li>
+ *
+ * <li>file: An input control that allows the user to select files to be submitted
+ * with the form. Note that a form which uses a file field must use the
+ * multipart method.</li>
+ *
+ * <li>radio: A boolean input control which may be toggled by the user. Multiple
+ * radio button fields may share the same name. When this occurs only one field
+ * may be selected to be true. This is distinct from a checkbox where multiple
+ * fields may be toggled.</li>
+ *
+ * <li>select: A menu input control which allows the user to select from a list of
+ * available options.</li>
+ *
+ * <li>composite: A combination of multiple fields into one input control.</li>
+ * </ul>
+ *
+ * @author Scott Phillips
+ */
 public abstract class Field extends AbstractWingElement implements
         StructuralElement
 {
@@ -145,19 +146,19 @@ public abstract class Field extends AbstractWingElement implements
     protected Help help;
     
     /** Error instructions for this field */
-    protected List<Error> errors = new ArrayList<Error>();
+    protected List<Error> errors = new ArrayList<>();
     
     /** All sub fields contained within a composite field */
-    protected List<Field> fields = new ArrayList<Field>();
+    protected List<Field> fields = new ArrayList<>();
     
     /** The value of this field */
-    protected List<Option> options = new ArrayList<Option>();
+    protected List<Option> options = new ArrayList<>();
     
     /** The value of this field */
-    protected List<Value> values = new ArrayList<Value>();
+    protected List<Value> values = new ArrayList<>();
     
     /** The set of stored values */
-    protected List<Instance> instances = new ArrayList<Instance>();
+    protected List<Instance> instances = new ArrayList<>();
 
     /**
      * Construct a new field.
@@ -177,6 +178,7 @@ public abstract class Field extends AbstractWingElement implements
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected Field(WingContext context, String name, String type,
             String rend) throws WingException
@@ -305,6 +307,7 @@ public abstract class Field extends AbstractWingElement implements
      * select vs. suggest.  Value must match one of the PRESENTATIONS.
      *
      * @param value pre-determined metadata field key
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setChoicesPresentation(String value)
         throws WingException
@@ -335,6 +338,8 @@ public abstract class Field extends AbstractWingElement implements
      * The help element provides help instructions to assist the user in using
      * this field.
      *
+     * @return a new Help.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Help setHelp() throws WingException
     {
@@ -349,6 +354,7 @@ public abstract class Field extends AbstractWingElement implements
      * @param characters
      *            (May be null) Direct content or a dictionary tag to be
      *            inserted into the element.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setHelp(String characters) throws WingException
     {
@@ -363,6 +369,7 @@ public abstract class Field extends AbstractWingElement implements
      * @param message
      *            (Required) A key into the i18n catalogue for translation into
      *            the user's preferred language.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setHelp(Message message) throws WingException
     {
@@ -379,6 +386,8 @@ public abstract class Field extends AbstractWingElement implements
      * context. The message contained within the error message will provide
      * assistance to the user in correcting the problem.
      *
+     * @return the new Error.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Error addError() throws WingException
     {
@@ -395,6 +404,7 @@ public abstract class Field extends AbstractWingElement implements
      * @param characters
      *            (May be null) Direct content or a dictionary tag to be
      *            inserted into the element.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addError(String characters) throws WingException
     {
@@ -411,6 +421,7 @@ public abstract class Field extends AbstractWingElement implements
      * @param message
      *            (Required) A key into the i18n catalogue for translation into
      *            the user's preferred language.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addError(Message message) throws WingException
     {
@@ -427,6 +438,8 @@ public abstract class Field extends AbstractWingElement implements
      * The help element provides help instructions to assist the user in using
      * this field.
      *
+     * @return the new Label.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Label setLabel() throws WingException
     {
@@ -441,6 +454,7 @@ public abstract class Field extends AbstractWingElement implements
      * @param characters
      *            (May be null) Direct content or a dictionary tag to be
      *            inserted into the element.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setLabel(String characters) throws WingException
     {
@@ -455,6 +469,7 @@ public abstract class Field extends AbstractWingElement implements
      * @param message
      *            (Required) A key into the i18n catalogue for translation into
      *            the user's preferred language.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setLabel(Message message) throws WingException
     {
@@ -471,7 +486,7 @@ public abstract class Field extends AbstractWingElement implements
      */
     protected void removeValueOfType(String removeType)
     {
-        List<Value> found = new ArrayList<Value>();
+        List<Value> found = new ArrayList<>();
         for (Value value : values)
         {
             if (value.getType().equals(removeType))
@@ -500,7 +515,9 @@ public abstract class Field extends AbstractWingElement implements
      * @param namespaces
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
+     * @throws org.xml.sax.SAXException passed through.
      */
+    @Override
     public void toSAX(ContentHandler contentHandler,
             LexicalHandler lexicalHandler, NamespaceSupport namespaces)
             throws SAXException
@@ -571,6 +588,7 @@ public abstract class Field extends AbstractWingElement implements
     /**
      * Dispose
      */
+    @Override
     public void dispose()
     {
         if (params != null)

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Figure.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Figure.java
@@ -38,22 +38,18 @@ public class Figure extends TextContainer implements StructuralElement
     /** The name of the title attribute */
     public static final String A_TITLE = "title";
 
-    /** The name of the class attribute */
-    public static final String A_RENDER = "rend";
-
-
     /** The figure's source */
-    private String source;
+    private final String source;
 
     /** The figure's xref target */
-    private String target;
+    private final String target;
 
 
     /** The figure's xref title */
     private String title;
 
     /** Special rendering hints */
-    private String rend;
+    private final String rend;
 
     /**
      * Construct a new figure.
@@ -104,7 +100,9 @@ public class Figure extends TextContainer implements StructuralElement
      * @param namespaces
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
+     * @throws org.xml.sax.SAXException passed through.
      */
+    @Override
     public void toSAX(ContentHandler contentHandler, LexicalHandler lexicalHandler,
             NamespaceSupport namespaces) throws SAXException
     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Figure.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Figure.java
@@ -64,7 +64,7 @@ public class Figure extends TextContainer implements StructuralElement
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
-     * @throws WingException
+     * @throws WingException passed through.
      */
     protected Figure(WingContext context, String source, String target,
             String rend) throws WingException

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/File.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/File.java
@@ -35,6 +35,7 @@ public class File extends Field
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected File(WingContext context, String name, String rend)
             throws WingException

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Head.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Head.java
@@ -27,7 +27,7 @@ public class Head extends TextContainer implements StructuralElement
     public static final String E_HEAD = "head";
 
     /** The head's name */
-    private String name;
+    private final String name;
 
     /**
      * Construct a new head.
@@ -37,6 +37,7 @@ public class Head extends TextContainer implements StructuralElement
      * @param name
      *            (May be null) a local identifier used to differentiate the
      *            element from its siblings.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected Head(WingContext context, String name) throws WingException
     {
@@ -57,7 +58,9 @@ public class Head extends TextContainer implements StructuralElement
      * @param namespaces
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
+     * @throws org.xml.sax.SAXException passed through.
      */
+    @Override
     public void toSAX(ContentHandler contentHandler, LexicalHandler lexicalHandler,
             NamespaceSupport namespaces) throws SAXException
     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Help.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Help.java
@@ -29,6 +29,7 @@ public class Help extends TextContainer implements StructuralElement
      * 
      * @param context
      *            (Required) The context this element is contained in
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected Help(WingContext context) throws WingException
     {
@@ -48,8 +49,9 @@ public class Help extends TextContainer implements StructuralElement
      * @param namespaces
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
+     * @throws org.xml.sax.SAXException passed through.
      */
-
+    @Override
     public void toSAX(ContentHandler contentHandler, LexicalHandler lexicalHandler,
             NamespaceSupport namespaces) throws SAXException
     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Hidden.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Hidden.java
@@ -37,6 +37,7 @@ public class Hidden extends Field
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected Hidden(WingContext context, String name, String rend)
             throws WingException
@@ -51,6 +52,8 @@ public class Hidden extends Field
 
     /**
      * Set the raw value of the field removing any previous raw values.
+     * @return a new Value.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Value setValue() throws WingException
     {
@@ -65,6 +68,7 @@ public class Hidden extends Field
      * 
      * @param characters
      *            (May be null) Field value as a string
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setValue(String characters) throws WingException
     {
@@ -77,6 +81,7 @@ public class Hidden extends Field
      * 
      * @param integer
      *            Field value as an integer
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setValue(int integer) throws WingException
     {
@@ -89,6 +94,7 @@ public class Hidden extends Field
      * @param message
      *            (Required) A key into the i18n catalogue for translation into
      *            the user's preferred language.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setValue(Message message) throws WingException
     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Highlight.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Highlight.java
@@ -58,11 +58,11 @@ public class Highlight extends RichTextContainer implements StructuralElement
      * events should be routed to the contentHandler found in the WingContext.
      * 
      * @param contentHandler
-     *            (Required) The registered contentHandler where SAX events
-     *            should be routed too.
+     *            (Required) The registered contentHandler to which SAX events
+     *            should be routed.
      * @param lexicalHandler
-     *            (Required) The registered lexicalHandler where lexical 
-     *            events (such as CDATA, DTD, etc) should be routed too.
+     *            (Required) The registered lexicalHandler to which lexical
+     *            events (such as CDATA, DTD, etc) should be routed.
      * @param namespaces
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Highlight.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Highlight.java
@@ -34,7 +34,7 @@ public class Highlight extends RichTextContainer implements StructuralElement
     public static final String E_HIGHLIGHT = "hi";
 
     /** Special rendering instructions for this highlight */
-    private String rend;
+    private final String rend;
 
     /**
      * Construct a new highlight element.
@@ -44,6 +44,7 @@ public class Highlight extends RichTextContainer implements StructuralElement
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected Highlight(WingContext context, String rend) throws WingException
     {
@@ -65,7 +66,9 @@ public class Highlight extends RichTextContainer implements StructuralElement
      * @param namespaces
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
+     * @throws org.xml.sax.SAXException passed through.
      */
+    @Override
     public void toSAX(ContentHandler contentHandler, LexicalHandler lexicalHandler,
             NamespaceSupport namespaces) throws SAXException
     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Instance.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Instance.java
@@ -34,7 +34,8 @@ public class Instance extends Container
      * Construct a new field value, when used in a multiple value context
      *
      * @param context
-     *            (Required) The context this element is contained in
+     *            (Required) The context this element is contained in.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected Instance(WingContext context) throws WingException
     {
@@ -48,6 +49,8 @@ public class Instance extends Container
 
     /**
      * Set the raw value of the field removing any previous raw values.
+     * @return the new Value.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Value setValue() throws WingException
     {
@@ -62,6 +65,7 @@ public class Instance extends Container
      *
      * @param characters
      *            (May be null) Field value as a string
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setValue(String characters) throws WingException
     {
@@ -75,6 +79,7 @@ public class Instance extends Container
      * @param message
      *            (Required) A key into the i18n catalogue for translation into
      *            the user's preferred language.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setValue(Message message) throws WingException
     {
@@ -89,6 +94,7 @@ public class Instance extends Container
      *
      * @param checked
      *            (Required) Whether the checkbox is checked or not.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setValue(boolean checked) throws WingException
     {
@@ -100,6 +106,8 @@ public class Instance extends Container
     /**
      * Set the authority value of the field removing any previous authority values.
      * Initialized to an empty value.
+     * @return the new authority Value.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Value setAuthorityValue() throws WingException
     {
@@ -111,6 +119,9 @@ public class Instance extends Container
      *
      * @param characters
      *            (May be null) Field value as a string
+     * @param confidence measure of confidence.
+     * @return the new Value.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Value setAuthorityValue(String characters, String confidence) throws WingException
     {
@@ -126,6 +137,7 @@ public class Instance extends Container
      *
      * @param returnValue
      *            (Required) The return value of the option to be selected.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setOptionSelected(String returnValue) throws WingException
     {
@@ -138,6 +150,7 @@ public class Instance extends Container
      *
      * @param returnValue
      *            (Required) The return value of the option to be selected.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setOptionSelected(int returnValue) throws WingException
     {
@@ -151,6 +164,8 @@ public class Instance extends Container
     /**
      * Set the interpreted value of the field removing any previous interpreted
      * values.
+     * @return the new Value.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Value setInterpretedValue() throws WingException
     {
@@ -166,6 +181,7 @@ public class Instance extends Container
      *
      * @param characters
      *            (May be null) Field value as a string
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setInterpretedValue(String characters) throws WingException
     {
@@ -180,6 +196,7 @@ public class Instance extends Container
      * @param message
      *            (Required) A key into the i18n catalogue for translation into
      *            the user's preferred language.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setInterpretedValue(Message message) throws WingException
     {
@@ -198,6 +215,8 @@ public class Instance extends Container
      *
      * @param option
      *            (Required) The return value of the selected option.
+     * @return the new Value.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Value addOptionValue(String option) throws WingException
     {
@@ -215,6 +234,7 @@ public class Instance extends Container
      *            (Required) determine if the value is selected or not.
      * @param characters
      *            (may be null) The returned value for this field, if selected.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setCheckedValue(boolean checked, String characters) throws WingException
     {
@@ -238,8 +258,10 @@ public class Instance extends Container
      * @param namespaces
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
+     * @throws org.xml.sax.SAXException passed through.
      */
 
+    @Override
     public void toSAX(ContentHandler contentHandler,
             LexicalHandler lexicalHandler, NamespaceSupport namespaces)
             throws SAXException
@@ -257,7 +279,7 @@ public class Instance extends Container
      */
     private void removeValueOfType(String removeType)
     {
-        List<Value> found = new ArrayList<Value>();
+        List<Value> found = new ArrayList<>();
         for (AbstractWingElement awe : contents)
         {
             if (awe instanceof Value)

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Item.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Item.java
@@ -33,10 +33,10 @@ public class Item extends RichTextContainer implements StructuralElement
     public static final String E_ITEM = "item";
 
     /** the item's name */
-    private String name;
+    private final String name;
 
     /** Special rendering hints for this item */
-    private String rend;
+    private final String rend;
 
     /**
      * Construct a new item.
@@ -49,6 +49,7 @@ public class Item extends RichTextContainer implements StructuralElement
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected Item(WingContext context, String name, String rend)
             throws WingException
@@ -72,7 +73,9 @@ public class Item extends RichTextContainer implements StructuralElement
      * @param namespaces
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
+     * @throws org.xml.sax.SAXException passed through.
      */
+    @Override
     public void toSAX(ContentHandler contentHandler, LexicalHandler lexicalHandler, 
             NamespaceSupport namespaces) throws SAXException
     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Label.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Label.java
@@ -29,10 +29,10 @@ public class Label extends TextContainer implements StructuralElement
     public static final String E_LABEL = "label";
 
     /** The label's name */
-    private String name;
+    private final String name;
 
     /** Special rendering hints */
-    private String rend;
+    private final String rend;
 
     /**
      * Construct a new label.
@@ -44,7 +44,7 @@ public class Label extends TextContainer implements StructuralElement
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
-     * @throws WingException
+     * @throws WingException passed through.
      */
     protected Label(WingContext context, String name, String rend)
             throws WingException
@@ -67,7 +67,9 @@ public class Label extends TextContainer implements StructuralElement
      * @param namespaces
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
+     * @throws org.xml.sax.SAXException passed through.
      */
+    @Override
     public void toSAX(ContentHandler contentHandler, LexicalHandler lexicalHandler,
             NamespaceSupport namespaces) throws SAXException
     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/List.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/List.java
@@ -91,19 +91,19 @@ public class List extends AbstractWingElement implements WingMergeableElement,
             TYPE_BULLETED, TYPE_GLOSS, TYPE_PROGRESS, TYPE_FORM, TYPE_DSO_LIST };
 
     /** The list's name */
-    private String name;
+    private final String name;
 
     /** The list's type, see types above. * */
-    private String type;
+    private final String type;
 
     /** Any special rendering instructions * */
-    private String rend;
+    private final String rend;
 
     /** The lists head * */
     private Head head;
 
     /** All content of this container, items & lists */
-    private java.util.List<AbstractWingElement> contents = new ArrayList<AbstractWingElement>();
+    private java.util.List<AbstractWingElement> contents = new ArrayList<>();
 
     /**
      * Construct a new list.
@@ -123,6 +123,7 @@ public class List extends AbstractWingElement implements WingMergeableElement,
      *            (May be null) a rendering hint used to override the default
      *            display of the element. There are a set of predefined
      *            rendering values, see the class documentation above.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected List(WingContext context, String name, String type, String rend)
             throws WingException
@@ -143,12 +144,14 @@ public class List extends AbstractWingElement implements WingMergeableElement,
      * Set the head element which is the label associated with this list. This
      * method should be called before any other elements have been added to the
      * list.
+     * @return the new Head.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Head setHead() throws WingException
     {
-        Head head = new Head(context, null);
-        this.head = head;
-        return head;
+        Head newHead = new Head(context, null);
+        this.head = newHead;
+        return newHead;
     }
 
     /**
@@ -159,11 +162,12 @@ public class List extends AbstractWingElement implements WingMergeableElement,
      * @param characters
      *            (Required) Untranslated character data to be included as the
      *            list's head.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setHead(String characters) throws WingException
     {
-        Head head = setHead();
-        head.addContent(characters);
+        Head newHead = setHead();
+        newHead.addContent(characters);
     }
 
     /**
@@ -174,11 +178,12 @@ public class List extends AbstractWingElement implements WingMergeableElement,
      * @param key
      *            (Required) Key to the i18n catalogue to translate the content
      *            into the language preferred by the user.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setHead(Message key) throws WingException
     {
-        Head head = setHead();
-        head.addContent(key);
+        Head newHead = setHead();
+        newHead.addContent(key);
     }
 
     /**
@@ -192,6 +197,8 @@ public class List extends AbstractWingElement implements WingMergeableElement,
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
+     * @return the new Label.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Label addLabel(String name, String rend) throws WingException
     {
@@ -207,6 +214,7 @@ public class List extends AbstractWingElement implements WingMergeableElement,
      * 
      * @param characters
      *            (Required) Untranslated character data to be included.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addLabel(String characters) throws WingException
     {
@@ -224,6 +232,7 @@ public class List extends AbstractWingElement implements WingMergeableElement,
      * bullet. This version of label provides no textual label but may be used 
      * to indicate some implicit labeling such as ordered lists.
      * 
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addLabel() throws WingException
     {
@@ -239,6 +248,7 @@ public class List extends AbstractWingElement implements WingMergeableElement,
      * @param key
      *            (Required) Key to the i18n catalogue to translate the content
      *            into the language preferred by the user.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addLabel(Message key) throws WingException
     {
@@ -253,6 +263,7 @@ public class List extends AbstractWingElement implements WingMergeableElement,
      * Add an empty unnamed item.
      * 
      * @return a new Item
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Item addItem() throws WingException
     {
@@ -273,6 +284,7 @@ public class List extends AbstractWingElement implements WingMergeableElement,
      *            (May be null) a rendering hint used to override the default
      *            display of the element. *
      * @return a new Item
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Item addItem(String name, String rend) throws WingException
     {
@@ -286,6 +298,7 @@ public class List extends AbstractWingElement implements WingMergeableElement,
      * 
      * @param characters
      *            (Required) Untranslated character data to be included.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addItem(String characters) throws WingException
     {
@@ -302,6 +315,7 @@ public class List extends AbstractWingElement implements WingMergeableElement,
      * @param key
      *            (Required) Key to the i18n catalogue to translate the content
      *            into the language preferred by the user.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addItem(Message key) throws WingException
     {
@@ -320,6 +334,7 @@ public class List extends AbstractWingElement implements WingMergeableElement,
      * @param characters
      *            (Required) Untranslated character data to be included as the
      *            link's body.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addItemXref(String target, String characters)
             throws WingException
@@ -337,6 +352,7 @@ public class List extends AbstractWingElement implements WingMergeableElement,
      * @param key
      *            (Required) i18n key for translating content into the user's
      *            preferred language.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addItemXref(String target, Message key) throws WingException
     {
@@ -358,6 +374,7 @@ public class List extends AbstractWingElement implements WingMergeableElement,
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
      * @return A new sub list.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public List addList(String name, String type, String rend)
             throws WingException
@@ -377,6 +394,7 @@ public class List extends AbstractWingElement implements WingMergeableElement,
      *            (May be null) determines the list type. If this is blank the
      *            list type is inferred from the context and use.
      * @return A new sub list.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public List addList(String name, String type)
             throws WingException
@@ -393,14 +411,13 @@ public class List extends AbstractWingElement implements WingMergeableElement,
      *            (Required) a local identifier used to differentiate the
      *            element from its siblings.
      * @return A new sub list.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public List addList(String name) throws WingException
     {
         return addList(name, null, null);
     }
-    
-    
-    
+
     /**
      * Determine if the given SAX startElement event is equivalent to this list.
      * 
@@ -414,6 +431,7 @@ public class List extends AbstractWingElement implements WingMergeableElement,
      *            The element's attributes
      * @return True if this list is equivalent to the given SAX Event.
      */
+    @Override
     public boolean mergeEqual(String namespace, String localName, String qName,
             Attributes attributes)
     {
@@ -426,16 +444,12 @@ public class List extends AbstractWingElement implements WingMergeableElement,
         {
             return false;
         }
-        String name = attributes.getValue(A_NAME);
-        if (name == null)
+        String theName = attributes.getValue(A_NAME);
+        if (theName == null)
         {
             return false;
         }
-        if (!name.equals(this.name))
-        {
-            return false;
-        }
-        return true;
+        return theName.equals(this.name);
     }
 
     /**
@@ -455,6 +469,7 @@ public class List extends AbstractWingElement implements WingMergeableElement,
      *            The element's attributes
      * @return The child element
      */
+    @Override
     public WingMergeableElement mergeChild(String namespace, String localName,
             String qName, Attributes attributes) throws SAXException,
             WingException
@@ -491,6 +506,7 @@ public class List extends AbstractWingElement implements WingMergeableElement,
      * 
      * @return The attributes for this merged element
      */
+    @Override
     public Attributes merge(Attributes attributes) throws SAXException,
             WingException
     {
@@ -512,6 +528,7 @@ public class List extends AbstractWingElement implements WingMergeableElement,
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
      */
+    @Override
     public void toSAX(ContentHandler contentHandler, LexicalHandler lexicalHandler, 
             NamespaceSupport namespaces) throws SAXException
     {
@@ -550,9 +567,7 @@ public class List extends AbstractWingElement implements WingMergeableElement,
         }
     }
 
-    /**
-     * dispose
-     */
+    @Override
     public void dispose()
     {
         if (head != null)

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Meta.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Meta.java
@@ -55,6 +55,7 @@ public class Meta extends AbstractWingElement implements WingMergeableElement
      * Set a new user oriented metadata set.
      * 
      * @return The user oriented metadata set.
+     * @throws org.dspace.app.xmlui.wing.WingException never.
      */
     public UserMeta setUserMeta() throws WingException
     {
@@ -65,6 +66,7 @@ public class Meta extends AbstractWingElement implements WingMergeableElement
      * Set a new page oriented metadata set.
      * 
      * @return The page oriented metadata set.
+     * @throws org.dspace.app.xmlui.wing.WingException never.
      */
     public PageMeta setPageMeta() throws WingException
     {
@@ -75,6 +77,7 @@ public class Meta extends AbstractWingElement implements WingMergeableElement
      * Set a new repository oriented metadata set.
      * 
      * @return The repository oriented metadata set.
+     * @throws org.dspace.app.xmlui.wing.WingException never.
      */
     public RepositoryMeta setRepositoryMeta() throws WingException
     {
@@ -94,6 +97,7 @@ public class Meta extends AbstractWingElement implements WingMergeableElement
      *            The element's attributes
      * @return True if this WingElement is equivalent to the given SAX Event.
      */
+    @Override
     public boolean mergeEqual(String namespace, String localName, String qName,
             Attributes attributes) throws SAXException, WingException
     {
@@ -102,12 +106,7 @@ public class Meta extends AbstractWingElement implements WingMergeableElement
             return false;
         }
 
-        if (!E_META.equals(localName))
-        {
-            return false;
-        }
-        
-        return true;
+        return E_META.equals(localName);
     }
 
     /**
@@ -123,6 +122,7 @@ public class Meta extends AbstractWingElement implements WingMergeableElement
      *            The element's attributes
      * @return The child element
      */
+    @Override
     public WingMergeableElement mergeChild(String namespace, String localName,
             String qName, Attributes attributes) throws SAXException,
             WingException
@@ -132,9 +132,9 @@ public class Meta extends AbstractWingElement implements WingMergeableElement
                 && this.userMeta.mergeEqual(namespace, localName, qName,
                         attributes))
         {
-            UserMeta userMeta = this.userMeta;
+            UserMeta thisUserMeta = this.userMeta;
             this.userMeta = null;
-            return userMeta;
+            return thisUserMeta;
         }
 
         // page
@@ -142,9 +142,9 @@ public class Meta extends AbstractWingElement implements WingMergeableElement
                 && this.pageMeta.mergeEqual(namespace, localName, qName,
                         attributes))
         {
-            PageMeta pageMeta = this.pageMeta;
+            PageMeta thisPageMeta = this.pageMeta;
             this.pageMeta = null;
-            return pageMeta;
+            return thisPageMeta;
         }
         
         // repository
@@ -152,9 +152,9 @@ public class Meta extends AbstractWingElement implements WingMergeableElement
                 && this.repositoryMeta.mergeEqual(namespace, localName, qName,
                         attributes))
         {
-            RepositoryMeta repositoryMeta = this.repositoryMeta;
+            RepositoryMeta thisRepositoryMeta = this.repositoryMeta;
             this.repositoryMeta = null;
-            return repositoryMeta;
+            return thisRepositoryMeta;
         }
         
         return null;
@@ -165,6 +165,7 @@ public class Meta extends AbstractWingElement implements WingMergeableElement
      * 
      * @return The attributes for this merged element
      */
+    @Override
     public Attributes merge(Attributes attributes) throws SAXException,
             WingException
     {
@@ -185,6 +186,7 @@ public class Meta extends AbstractWingElement implements WingMergeableElement
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
      */
+    @Override
     public void toSAX(ContentHandler contentHandler, LexicalHandler lexicalHandler, 
             NamespaceSupport namespaces) throws SAXException
     {
@@ -212,9 +214,7 @@ public class Meta extends AbstractWingElement implements WingMergeableElement
         }
     }
 
-    /**
-     * dispose
-     */
+    @Override
     public void dispose()
     {
         if (this.userMeta != null)

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Metadata.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Metadata.java
@@ -38,24 +38,26 @@ public class Metadata extends TextContainer implements MetadataElement
     public static final String A_LANGUAGE = "lang";
 
     /** The metadata's element */
-    private String element;
+    private final String element;
 
     /** The metadata's qualifier */
-    private String qualifier;
+    private final String qualifier;
 
     /** The metadata's language */
-    private String language;
+    private final String language;
     
     /** 
      * Determine the additive model for the metadata, should 
      * the metadata always be added to the document or only if 
      * it does not already exist?
      */
-    private boolean allowMultiple;
+    private final boolean allowMultiple;
 
     /**
 	 * Construct a new metadata.
 	 * 
+     * @param context
+     *            (Required) The request context.
 	 * @param element
 	 *            (Required) The element of this metadata
 	 * @param qualifier
@@ -65,6 +67,7 @@ public class Metadata extends TextContainer implements MetadataElement
 	 * @param allowMultiple
 	 *            (Required) Are multiple metadata elements with the same element,
 	 *            qualifier, and language allowed?
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
 	 */
     protected Metadata(WingContext context, String element, String qualifier,
             String language, boolean allowMultiple) throws WingException
@@ -80,6 +83,8 @@ public class Metadata extends TextContainer implements MetadataElement
      * If an metadata with the same element, qualifier, and language exist
      * within the document should this metadata element be added into the
      * document or should only one metadata be allowed.
+     *
+     * @return true if multiple values are allowed.
      */
     protected boolean allowMultiple()
     {
@@ -162,7 +167,9 @@ public class Metadata extends TextContainer implements MetadataElement
      * @param namespaces
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
+     * @throws org.xml.sax.SAXException passed through.
      */
+    @Override
     public void toSAX(ContentHandler contentHandler, LexicalHandler lexicalHandler,
             NamespaceSupport namespaces) throws SAXException
     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Option.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Option.java
@@ -27,10 +27,9 @@ public class Option extends TextContainer
 
     /** The name of the return value attribute */
     public static final String A_RETURN_VALUE = "returnValue";
-    
-   
-    /** The submited value for this option */
-    private String returnValue;
+
+    /** The submitted value for this option */
+    private final String returnValue;
 
     /**
      *
@@ -39,6 +38,7 @@ public class Option extends TextContainer
      *            (Required) The context this element is contained in
      * @param returnValue
      *            (may be null) The options return value.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected Option(WingContext context, String returnValue) throws WingException
     {
@@ -60,8 +60,9 @@ public class Option extends TextContainer
      * @param namespaces
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
+     * @throws org.xml.sax.SAXException passed through.
      */
-
+    @Override
     public void toSAX(ContentHandler contentHandler,
             LexicalHandler lexicalHandler, NamespaceSupport namespaces)
             throws SAXException

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Options.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Options.java
@@ -49,7 +49,7 @@ public class Options extends AbstractWingElement implements
 
     /**
      * Add a new sublist to this item. Note that an item may contain either
-     * characters (with formating & fields) or lists but not both.
+     * characters (with formating and fields) or lists but not both.
      * 
      * @param name
      *            (Required) a local identifier used to differentiate the
@@ -74,7 +74,7 @@ public class Options extends AbstractWingElement implements
 
     /**
      * Add a new sublist to this item. Note that an item may contain either
-     * characters (with formating & fields) or lists but not both.
+     * characters (with formating and fields) or lists but not both.
      * 
      * @param name
      *            (Required) a local identifier used to differentiate the

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Options.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Options.java
@@ -33,13 +33,14 @@ public class Options extends AbstractWingElement implements
     private boolean merged = false;
 
     /** The lists contained in this Options element */
-    private java.util.List<AbstractWingElement> contents = new ArrayList<AbstractWingElement>();
+    private java.util.List<AbstractWingElement> contents = new ArrayList<>();
 
     /**
      * Generate a new Options framework element.
      * 
      * @param context
      *            (Required) The context this element is contained in.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected Options(WingContext context) throws WingException
     {
@@ -56,11 +57,12 @@ public class Options extends AbstractWingElement implements
      * 
      * @param type
      *            (May be null) determines the list type. If this is blank the
-     *            list type is infered from the context and use.
+     *            list type is inferred from the context and use.
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
      * @return A new sub list.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public List addList(String name, String type, String rend)
             throws WingException
@@ -78,6 +80,7 @@ public class Options extends AbstractWingElement implements
      *            (Required) a local identifier used to differentiate the
      *            element from its siblings.
      * @return A new sub list.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public List addList(String name) throws WingException
     {
@@ -98,6 +101,7 @@ public class Options extends AbstractWingElement implements
      *            The element's attributes
      * @return Return true if this SAX Event an options element?
      */
+    @Override
     public boolean mergeEqual(String namespace, String localName, String qName,
             Attributes attributes)
     {
@@ -106,11 +110,7 @@ public class Options extends AbstractWingElement implements
         {
             return false;
         }
-        if (!E_OPTIONS.equals(localName))
-        {
-            return false;
-        }
-        return true;
+        return E_OPTIONS.equals(localName);
     }
 
     /**
@@ -126,6 +126,7 @@ public class Options extends AbstractWingElement implements
      *            The element's attributes
      * @return Return the sublist
      */
+    @Override
     public WingMergeableElement mergeChild(String namespace, String localName,
             String qName, Attributes attributes) throws SAXException,
             WingException
@@ -152,6 +153,7 @@ public class Options extends AbstractWingElement implements
      * 
      * @return The attributes for this merged element
      */
+    @Override
     public Attributes merge(Attributes attributes) throws SAXException,
             WingException
     {
@@ -173,7 +175,7 @@ public class Options extends AbstractWingElement implements
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
      */
-
+    @Override
     public void toSAX(ContentHandler contentHandler, LexicalHandler lexicalHandler,
             NamespaceSupport namespaces) throws SAXException
     {
@@ -196,6 +198,7 @@ public class Options extends AbstractWingElement implements
     /**
      * dispose
      */
+    @Override
     public void dispose()
     {
         for (AbstractWingElement content : contents)

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/PageMeta.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/PageMeta.java
@@ -40,8 +40,8 @@ public class PageMeta extends AbstractWingElement implements
      * metadata. Each of these types are separated so that 
      * we can search through each time as we merge documents.
      */
-    private List<Metadata> metadatum = new ArrayList<Metadata>();
-    private List<Trail> trails = new ArrayList<Trail>();
+    private List<Metadata> metadatum = new ArrayList<>();
+    private List<Trail> trails = new ArrayList<>();
 
     /**
      * Construct a new pageMeta
@@ -49,6 +49,7 @@ public class PageMeta extends AbstractWingElement implements
      * @param context
      *            (Required) The context this element is contained in, such as
      *            where to route SAX events and what i18n catalogue to use.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected PageMeta(WingContext context) throws WingException
     {
@@ -68,6 +69,7 @@ public class PageMeta extends AbstractWingElement implements
 	 *            (Required) determine if multiple metadata elements with the same
 	 *            element, qualifier and language are allowed.
 	 * @return A new metadata
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
 	 */
     public Metadata addMetadata(String element, String qualifier,
             String language, boolean allowMultiple) throws WingException
@@ -87,6 +89,7 @@ public class PageMeta extends AbstractWingElement implements
 	 * @param language
 	 *            (May be null) The metadata language
 	 * @return A new metadata
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
 	 */
     public Metadata addMetadata(String element, String qualifier, String language)
             throws WingException
@@ -102,6 +105,7 @@ public class PageMeta extends AbstractWingElement implements
      * @param qualifier
      *            (May be null) The metadata qualifier.
      * @return A new metadata
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Metadata addMetadata(String element, String qualifier)
             throws WingException
@@ -115,6 +119,7 @@ public class PageMeta extends AbstractWingElement implements
      * @param element
      *            (Required) The metadata element.
      * @return A new metadata
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Metadata addMetadata(String element) throws WingException
     {
@@ -129,6 +134,7 @@ public class PageMeta extends AbstractWingElement implements
      * @param rend
      *            (May be null) Special rendering instructions
      * @return a new trail
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Trail addTrail(String target, String rend)
             throws WingException
@@ -142,6 +148,7 @@ public class PageMeta extends AbstractWingElement implements
      * Add a new trail to the page without a link or render attribute.
      * 
      * @return a new trail
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Trail addTrail()
             throws WingException
@@ -156,6 +163,7 @@ public class PageMeta extends AbstractWingElement implements
      *            (May be null) The Target URL for this trail item.
      * @param characters
      *            (May be null) The textual contents of this trail item.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addTrailLink(String target, String characters)
             throws WingException
@@ -172,6 +180,7 @@ public class PageMeta extends AbstractWingElement implements
      * @param message
      *            (Required) The textual contents of this trail item to be
      *            translated
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addTrailLink(String target, Message message)
             throws WingException
@@ -193,6 +202,7 @@ public class PageMeta extends AbstractWingElement implements
      *            The element's attributes
      * @return True if this WingElement is equivalent to the given SAX Event.
      */
+    @Override
     public boolean mergeEqual(String namespace, String localName, String qName,
             Attributes attributes) throws SAXException, WingException
     {
@@ -202,17 +212,13 @@ public class PageMeta extends AbstractWingElement implements
             return false;
         }
 
-        if (!E_PAGE_META.equals(localName))
-        {
-            return false;
-        }
-        return true;
+        return E_PAGE_META.equals(localName);
     }
 
     /**
      * Since metadata can not be merged there are no mergeable children. This
-     * just return's null.
-     * 
+     * just returns null.
+     *
      * @param namespace
      *            The element's name space
      * @param localName
@@ -223,6 +229,7 @@ public class PageMeta extends AbstractWingElement implements
      *            The element's attributes
      * @return The child element
      */
+    @Override
     public WingMergeableElement mergeChild(String namespace, String localName,
             String qName, Attributes attributes) throws SAXException,
             WingException
@@ -245,7 +252,7 @@ public class PageMeta extends AbstractWingElement implements
     		String qualifier = attributes.getValue(Metadata.A_QUALIFIER);
     		String language = attributes.getValue(Metadata.A_LANGUAGE);
     		
-    		List<Metadata> remove = new ArrayList<Metadata>();
+    		List<Metadata> remove = new ArrayList<>();
     		for (Metadata metadata : metadatum)
     		{
     			if (metadata.equals(element,qualifier,language) && !metadata.allowMultiple())
@@ -268,6 +275,7 @@ public class PageMeta extends AbstractWingElement implements
     /**
      * Inform this element that it is being merged with an existing element.
      */
+    @Override
     public Attributes merge(Attributes attributes) throws SAXException,
             WingException
     {
@@ -288,6 +296,7 @@ public class PageMeta extends AbstractWingElement implements
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
      */
+    @Override
     public void toSAX(ContentHandler contentHandler, LexicalHandler lexicalHandler, 
             NamespaceSupport namespaces) throws SAXException
     {
@@ -312,9 +321,7 @@ public class PageMeta extends AbstractWingElement implements
         }
     }
 
-    /**
-     * dispose
-     */
+    @Override
     public void dispose()
     {
     	for (Metadata metadata : metadatum)

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Para.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Para.java
@@ -31,10 +31,10 @@ public class Para extends RichTextContainer implements StructuralElement
     public static final String E_PARA = "p";
 
     /** The para's name */
-    private String name;
+    private final String name;
 
     /** Any special rendering instructions for the para */
-    private String rend;
+    private final String rend;
 
     /**
      * Construct a new paragraph. Typically names for paragraphs are not
@@ -52,6 +52,7 @@ public class Para extends RichTextContainer implements StructuralElement
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected Para(WingContext context, String name, String rend)
             throws WingException
@@ -75,8 +76,10 @@ public class Para extends RichTextContainer implements StructuralElement
      * @param namespaces
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
+     * @throws org.xml.sax.SAXException passed through.
      */
 
+    @Override
     public void toSAX(ContentHandler contentHandler, LexicalHandler lexicalHandler, 
             NamespaceSupport namespaces) throws SAXException
     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Params.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Params.java
@@ -139,6 +139,7 @@ public class Params extends AbstractWingElement implements StructuralElement
      * @param context
      *            (Required) The context this element is contained in, such as
      *            where to route SAX events and what i18n catalogue to use.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      *
      */
     protected Params(WingContext context) throws WingException
@@ -150,6 +151,7 @@ public class Params extends AbstractWingElement implements StructuralElement
      * Enable the add operation for this field set. When this is enabled the
      * front end will add a button to add more items to the field.
      *
+     * @throws org.dspace.app.xmlui.wing.WingException never.
      */
     public void enableAddOperation() throws WingException
     {
@@ -161,6 +163,7 @@ public class Params extends AbstractWingElement implements StructuralElement
      * the front end will provide a way for the user to select fields (probably
      * checkboxes) along with a submit button to delete the selected fields.
      *
+     * @throws org.dspace.app.xmlui.wing.WingException never.
      */
     public void enableDeleteOperation()throws WingException
     {
@@ -301,7 +304,7 @@ public class Params extends AbstractWingElement implements StructuralElement
     /**
      * Set the field's autofocus attribute, an HTML5 feature.
      * Valid input values to enable autofocus are: autofocus, and empty string.
-     * @param value
+     * @param value "autofocus" or empty.
      */
     public void setAutofocus(String value)
     {
@@ -322,6 +325,7 @@ public class Params extends AbstractWingElement implements StructuralElement
      * select vs. suggest.  Value must match one of the PRESENTATIONS.
      *
      * @param value pre-determined metadata field key
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setChoicesPresentation(String value)
         throws WingException
@@ -364,7 +368,9 @@ public class Params extends AbstractWingElement implements StructuralElement
      * @param namespaces
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
+     * @throws org.xml.sax.SAXException passed through.
      */
+    @Override
     public void toSAX(ContentHandler contentHandler,
             LexicalHandler lexicalHandler, NamespaceSupport namespaces)
             throws SAXException
@@ -400,8 +406,6 @@ public class Params extends AbstractWingElement implements StructuralElement
             attributes.put(A_OPERATIONS, operations);
         }
 
-        
-        
         if (this.returnValue != null)
         {
             attributes.put(A_RETURN_VALUE, this.returnValue);
@@ -411,7 +415,6 @@ public class Params extends AbstractWingElement implements StructuralElement
         {
             attributes.put(A_SIZE, this.size);
         }
-
 
         if (!this.evtBehavior.equals(""))
         {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Password.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Password.java
@@ -35,6 +35,7 @@ public class Password extends Field
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected Password(WingContext context, String name, String rend)
             throws WingException

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Radio.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Radio.java
@@ -37,6 +37,7 @@ public class Radio extends Field
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected Radio(WingContext context, String name, String rend)
             throws WingException
@@ -49,6 +50,7 @@ public class Radio extends Field
      * Enable the add operation for this field. When this is enabled the
      * front end will add a button to add more items to the field.
      * 
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void enableAddOperation() throws WingException
     {
@@ -60,24 +62,21 @@ public class Radio extends Field
      * the front end will provide a way for the user to select fields (probably
      * checkboxes) along with a submit button to delete the selected fields.
      * 
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void enableDeleteOperation()throws WingException
     {
         this.params.enableDeleteOperation();
     }
-    
-    
-    
-    
-    
-    
-    
+
     /**
      * Add an option.
      * 
      * @param returnValue
      *            (Required) The value to be passed back if this option is
      *            selected.
+     * @return the new option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through
      */
     public Option addOption(String returnValue)
             throws WingException
@@ -96,6 +95,8 @@ public class Radio extends Field
      * @param returnValue
      *            (Required) The value to be passed back if this option is
      *            selected.
+     * @return the new option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Option addOption(boolean selected, String returnValue)
             throws WingException
@@ -115,6 +116,7 @@ public class Radio extends Field
      *            selected.
      * @param characters
      *            (Required) The text to set as the visible option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addOption(String returnValue, String characters) throws WingException
     {
@@ -132,6 +134,7 @@ public class Radio extends Field
      *            selected.
      * @param characters
      *            (Required) The text to set as the visible option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addOption(boolean selected,String returnValue, String characters) throws WingException
     {
@@ -150,6 +153,7 @@ public class Radio extends Field
      *            selected.
      * @param characters
      *            (Required) The text to set as the visible option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addOption(int returnValue, String characters) throws WingException
     {
@@ -167,6 +171,7 @@ public class Radio extends Field
      *            selected.
      * @param characters
      *            (Required) The text to set as the visible option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addOption(boolean selected, int returnValue, String characters) throws WingException
     {
@@ -184,7 +189,8 @@ public class Radio extends Field
      *            (Required) The value to be passed back if this option is
      *            selected.
      * @param message
-     *            (Required) The transalted text to set as the visible option.
+     *            (Required) The translated text to set as the visible option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addOption(String returnValue, Message message) throws WingException
     {
@@ -201,7 +207,8 @@ public class Radio extends Field
      *            (Required) The value to be passed back if this option is
      *            selected.
      * @param message
-     *            (Required) The transalted text to set as the visible option.
+     *            (Required) The translated text to set as the visible option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addOption(boolean selected, String returnValue, Message message) throws WingException
     {
@@ -219,7 +226,8 @@ public class Radio extends Field
      *            (Required) The value to be passed back if this option is
      *            selected.
      * @param message
-     *            (Required) The transalted text to set as the visible option.
+     *            (Required) The translated text to set as the visible option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addOption(int returnValue, Message message) throws WingException
     {
@@ -236,7 +244,8 @@ public class Radio extends Field
      *            (Required) The value to be passed back if this option is
      *            selected.
      * @param message
-     *            (Required) The transalted text to set as the visible option.
+     *            (Required) The translated text to set as the visible option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addOption(boolean selected, int returnValue, Message message) throws WingException
     {
@@ -252,6 +261,7 @@ public class Radio extends Field
      * 
      * @param returnValue
      *            (Required) The return value of the option to be selected.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setOptionSelected(String returnValue) throws WingException
     {
@@ -264,20 +274,18 @@ public class Radio extends Field
      * 
      * @param returnValue
      *            (Required) The return value of the option to be selected.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setOptionSelected(int returnValue) throws WingException
     {
         Value value = new Value(context,Value.TYPE_OPTION,String.valueOf(returnValue));
         values.add(value);
     }
-    
-    
-    
-    
-    
+
     /**
      * Add a field instance
      * @return instance
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Instance addInstance() throws WingException
     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Reference.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Reference.java
@@ -51,7 +51,7 @@ public class Reference extends AbstractWingElement implements
     private String type;
 
     /** All content of this container */
-    private java.util.List<AbstractWingElement> contents = new ArrayList<AbstractWingElement>();
+    private java.util.List<AbstractWingElement> contents = new ArrayList<>();
 
     /**
      * Construct a new object reference.
@@ -62,6 +62,8 @@ public class Reference extends AbstractWingElement implements
      * 
      * @param object
      *            (Required) The referenced object.
+     * @throws org.dspace.app.xmlui.wing.WingException
+     *            if the object cannot be managed.
      */
     protected Reference(WingContext context, Object object)
             throws WingException
@@ -98,6 +100,8 @@ public class Reference extends AbstractWingElement implements
      * @param render
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
+     * @return the new set.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public ReferenceSet addReferenceSet(String type, String orderBy, String render)
             throws WingException
@@ -115,6 +119,8 @@ public class Reference extends AbstractWingElement implements
      *            (required) The reference type, see referenceSet.TYPES
      * @param orderBy
      *            (May be null) A statement of ordering for reference sets.
+     * @return the new set.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public ReferenceSet addReferenceSet(String type, String orderBy)
             throws WingException
@@ -127,6 +133,8 @@ public class Reference extends AbstractWingElement implements
      * 
      * @param type
      *            (required) The include type, see includeSet.TYPES
+     * @return the new set.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public ReferenceSet addReferenceSet(String type) throws WingException
     {
@@ -145,7 +153,9 @@ public class Reference extends AbstractWingElement implements
      * @param namespaces
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
+     * @throws org.xml.sax.SAXException passed through.
      */
+    @Override
     public void toSAX(ContentHandler contentHandler, LexicalHandler lexicalHandler, 
             NamespaceSupport namespaces) throws SAXException
     {
@@ -167,9 +177,7 @@ public class Reference extends AbstractWingElement implements
         endElement(contentHandler, namespaces, E_REFERENCE);
     }
 
-    /**
-     * dispose
-     */
+    @Override
     public void dispose()
     {
         if (contents != null)

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/ReferenceSet.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/ReferenceSet.java
@@ -49,22 +49,22 @@ public class ReferenceSet extends AbstractWingElement implements
     public static final String[] TYPES = { TYPE_SUMMARY_LIST, TYPE_SUMMARY_VIEW, TYPE_DETAIL_LIST, TYPE_DETAIL_VIEW };
 
     /** The name assigned to this metadata set */
-    private String name;
+    private final String name;
 
     /** The ordering mechanism to use. */
-    private String orderBy;
+    private final String orderBy;
 
     /** The reference type, see TYPES defined above */
-    private String type;
+    private final String type;
 
     /** Special rendering instructions */
-    private String rend;
+    private final String rend;
 
-    /** The head label for this referenceset */
+    /** The head label for this reference set */
     private Head head;
 
     /** All content of this container, items & lists */
-    private java.util.List<AbstractWingElement> contents = new ArrayList<AbstractWingElement>();
+    private java.util.List<AbstractWingElement> contents = new ArrayList<>();
 
     /**
      * Construct a new referenceSet
@@ -86,6 +86,7 @@ public class ReferenceSet extends AbstractWingElement implements
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected ReferenceSet(WingContext context, boolean childreference, String name, String type, String orderBy, String rend)
             throws WingException
@@ -109,25 +110,26 @@ public class ReferenceSet extends AbstractWingElement implements
 
     /**
      * Set the head element which is the label associated with this referenceset.
+     * @return the new head.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Head setHead() throws WingException
     {
         this.head = new Head(context, null);
         return head;
-
     }
 
     /**
-     * Set the head element which is the label associated with this referenceset.
+     * Set the head element which is the label associated with this reference set.
      * 
      * @param characters
      *            (May be null) Unprocessed characters to be referenced
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setHead(String characters) throws WingException
     {
-        Head head = this.setHead();
-        head.addContent(characters);
-
+        Head newHead = this.setHead();
+        newHead.addContent(characters);
     }
 
     /**
@@ -136,11 +138,12 @@ public class ReferenceSet extends AbstractWingElement implements
      * @param message
      *            (Required) A key into the i18n catalogue for translation into
      *            the user's preferred language.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setHead(Message message) throws WingException
     {
-        Head head = this.setHead();
-        head.addContent(message);
+        Head newHead = this.setHead();
+        newHead.addContent(message);
     }
 
     /**
@@ -148,6 +151,8 @@ public class ReferenceSet extends AbstractWingElement implements
      * 
      * @param object
      *            (Required) The referenced object.
+     * @return the reference.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Reference addReference(Object object)
             throws WingException
@@ -169,7 +174,9 @@ public class ReferenceSet extends AbstractWingElement implements
      * @param namespaces
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
+     * @throws org.xml.sax.SAXException passed through.
      */
+    @Override
     public void toSAX(ContentHandler contentHandler, LexicalHandler lexicalHandler, 
             NamespaceSupport namespaces) throws SAXException
     {
@@ -208,9 +215,7 @@ public class ReferenceSet extends AbstractWingElement implements
         endElement(contentHandler, namespaces, E_REFERENCE_SET);
     }
 
-    /**
-     * dispose
-     */
+    @Override
     public void dispose()
     {
         if (contents != null)

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/RepositoryMeta.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/RepositoryMeta.java
@@ -44,7 +44,7 @@ public class RepositoryMeta extends AbstractWingElement implements WingMergeable
     private boolean merged = false;
     
     /** The registered repositories on this page */
-    private Map<String,String> repositories = new HashMap<String,String>();
+    private Map<String,String> repositories = new HashMap<>();
 
     /**
      * Construct a new RepositoryMeta
@@ -52,6 +52,7 @@ public class RepositoryMeta extends AbstractWingElement implements WingMergeable
      * @param context
      *            (Required) The context this element is contained in, such as
      *            where to route SAX events and what i18n catalogue to use.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected RepositoryMeta(WingContext context) throws WingException
     {
@@ -78,6 +79,7 @@ public class RepositoryMeta extends AbstractWingElement implements WingMergeable
      *            The element's attributes
      * @return True if this WingElement is equivalent to the given SAX Event.
      */
+    @Override
     public boolean mergeEqual(String namespace, String localName, String qName,
             Attributes attributes) throws SAXException, WingException
     {
@@ -87,11 +89,7 @@ public class RepositoryMeta extends AbstractWingElement implements WingMergeable
             return false;
         }
 
-        if (!E_REPOSITORY_META.equals(localName))
-        {
-            return false;
-        }
-        return true;
+        return E_REPOSITORY_META.equals(localName);
     }
 
     /**
@@ -111,6 +109,7 @@ public class RepositoryMeta extends AbstractWingElement implements WingMergeable
      *            The element's attributes
      * @return The child element
      */
+    @Override
     public WingMergeableElement mergeChild(String namespace, String localName,
             String qName, Attributes attributes) throws SAXException,
             WingException
@@ -140,6 +139,7 @@ public class RepositoryMeta extends AbstractWingElement implements WingMergeable
     /**
      * Inform this element that it is being merged with an existing element.
      */
+    @Override
     public Attributes merge(Attributes attributes) throws SAXException,
             WingException
     {
@@ -161,6 +161,7 @@ public class RepositoryMeta extends AbstractWingElement implements WingMergeable
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
      */
+    @Override
     public void toSAX(ContentHandler contentHandler,
             LexicalHandler lexicalHandler, NamespaceSupport namespaces)
             throws SAXException

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/RichTextContainer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/RichTextContainer.java
@@ -7,22 +7,20 @@
  */
 package org.dspace.app.xmlui.wing.element;
 
+import org.dspace.app.xmlui.wing.Message;
+import org.dspace.app.xmlui.wing.WingContext;
+import org.dspace.app.xmlui.wing.WingException;
+
 /**
  * A class representing a character container, such as "p", "hi", "item", or
- * "cell"
+ * "cell".
  * 
- * This class may not be instantiated on it's own instead you must use one of
+ * <p>This class may not be instantiated on its own; instead you must use one of
  * the extending classes listed above. This abstract class implements the
  * methods common to each of those elements.
  * 
  * @author Scott Phillips
  */
-
-
-import org.dspace.app.xmlui.wing.Message;
-import org.dspace.app.xmlui.wing.WingContext;
-import org.dspace.app.xmlui.wing.WingException;
-
 public abstract class RichTextContainer extends TextContainer
 {
     /**
@@ -35,6 +33,7 @@ public abstract class RichTextContainer extends TextContainer
      * 
      * @param context
      *            (Required) The context this element is contained in.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected RichTextContainer(WingContext context) throws WingException
     {
@@ -48,6 +47,7 @@ public abstract class RichTextContainer extends TextContainer
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
      * @return A new Highlight
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Highlight addHighlight(String rend) throws WingException
     {
@@ -57,13 +57,15 @@ public abstract class RichTextContainer extends TextContainer
     }
 
     /**
-     * Add a new reference to the character container. The xref element is a
+     * Add a new reference to the character container. The {@code xref} element is a
      * reference to an external document. The content will be used as part of
      * the link's visual body.
      * 
      * @param target
      *            (Required) A target URL for the references a destination for
-     *            the xref.
+     *            the {@code xref}.
+     * @return the new xref.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Xref addXref(String target) throws WingException
     {
@@ -73,15 +75,16 @@ public abstract class RichTextContainer extends TextContainer
     }
 
     /**
-     * Add a new reference to the character container. The xref element is a
+     * Add a new reference to the character container. The {@code xref} element is a
      * reference to an external document. The characters will be used as the
      * visual part of the link's body
      * 
      * @param target
      *            (Required) A target URL for the references a destination for
-     *            the xref.
+     *            the {@code xref}.
      * @param characters
      *            (May be null) The link's body
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addXref(String target, String characters) throws WingException
     {
@@ -90,17 +93,18 @@ public abstract class RichTextContainer extends TextContainer
     }
     
     /**
-     * Add a new reference to the character container. The xref element is a
+     * Add a new reference to the character container. The {@code xref} element is a
      * reference to an external document. The characters will be used as the
      * visual part of the link's body
      * 
      * @param target
      *            (Required) A target URL for the references a destination for
-     *            the xref.
+     *            the {@code xref}.
      * @param characters
      *            (May be null) The link's body
      * @param rend
      * 			  (May be null) Special rendering instructions.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addXref(String target, String characters, String rend) throws WingException
     {
@@ -110,19 +114,20 @@ public abstract class RichTextContainer extends TextContainer
     }
     
     /**
-     * Add a new reference to the character container. The xref element is a
+     * Add a new reference to the character container. The {@code xref} element is a
      * reference to an external document. The characters will be used as the
      * visual part of the link's body
      * 
      * @param target
      *            (Required) A target URL for the references a destination for
-     *            the xref.
+     *            the {@code xref}.
      * @param characters
      *            (May be null) The link's body
      * @param rend
      *            (May be null) Special rendering instructions.
      * @param name
      *            (May be null) local identifier
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addXref(String target, String characters, String rend, String name) throws WingException
     {
@@ -132,15 +137,16 @@ public abstract class RichTextContainer extends TextContainer
     }
 
     /**
-     * Add a new reference to the character container. The xref element is a
+     * Add a new reference to the character container. The {@code xref} element is a
      * reference to an external document. The translated i18n key will be used
      * as the visual part of the link's body
      * 
      * @param target
      *            (Required) A target URL for the references a destination for
-     *            the xref.
+     *            the {@code xref}.
      * @param key
      *            (Required) The link's body
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addXref(String target, Message key) throws WingException
     {
@@ -149,17 +155,18 @@ public abstract class RichTextContainer extends TextContainer
     }
     
     /**
-     * Add a new reference to the character container. The xref element is a
+     * Add a new reference to the character container. The {@code xref} element is a
      * reference to an external document. The translated i18n key will be used
      * as the visual part of the link's body
      * 
      * @param target
      *            (Required) A target URL for the references a destination for
-     *            the xref.
+     *            the {@code xref}.
      * @param key
      *            (Required) The link's body
      * @param rend
      *  		  (May be null) Special rendering instructions
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addXref(String target, Message key, String rend) throws WingException
     {
@@ -169,17 +176,20 @@ public abstract class RichTextContainer extends TextContainer
     }
 
     /**
-     * Add a new reference to the character container. The xref element is a
+     * Add a new reference to the character container. The {@code xref} element is a
      * reference to an external document. The translated i18n key will be used
      * as the visual part of the link's body
      *
      * @param target
      *            (Required) A target URL for the references a destination for
-     *            the xref.
+     *            the {@code xref}.
      * @param key
      *            (Required) The link's body
      * @param rend
      *  		  (May be null) Special rendering instructions
+     * @param name
+     *            Name of the link.
+     * @throws org.dspace.app.xmlui.wing.WingException
      */
     public void addXref(String target, Message key, String rend, String name) throws WingException
     {
@@ -204,6 +214,8 @@ public abstract class RichTextContainer extends TextContainer
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
+     * @return the new Figure.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Figure addFigure(String source, String target, String rend)
             throws WingException
@@ -230,6 +242,8 @@ public abstract class RichTextContainer extends TextContainer
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
+     * @return the new Figure.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Figure addFigure(String source, String target, String title, String rend)
             throws WingException
@@ -252,6 +266,7 @@ public abstract class RichTextContainer extends TextContainer
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
      * @return A new button field.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Button addButton(String name, String rend) throws WingException
     {
@@ -270,6 +285,7 @@ public abstract class RichTextContainer extends TextContainer
      *            This is the name of the field use when data is submitted back
      *            to the server.
      * @return a new button field
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Button addButton(String name) throws WingException
     {
@@ -291,6 +307,7 @@ public abstract class RichTextContainer extends TextContainer
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
      * @return a new checkbox field
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public CheckBox addCheckBox(String name, String rend) throws WingException
     {
@@ -311,6 +328,7 @@ public abstract class RichTextContainer extends TextContainer
      *            This is the name of the field use when data is submitted back
      *            to the server.
      * @return A new checkbox field
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public CheckBox addCheckBox(String name) throws WingException
     {
@@ -331,6 +349,7 @@ public abstract class RichTextContainer extends TextContainer
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
      * @return a new composite field.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Composite addComposite(String name, String rend) throws WingException
     {
@@ -350,6 +369,7 @@ public abstract class RichTextContainer extends TextContainer
      *            (Required) a non-unique local identifier used to differentiate
      *            the element from its siblings within an interactive division.
      * @return a new composite field.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Composite addComposite(String name) throws WingException
     {
@@ -370,6 +390,7 @@ public abstract class RichTextContainer extends TextContainer
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
      * @return A new file field
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public File addFile(String name, String rend) throws WingException
     {
@@ -389,6 +410,7 @@ public abstract class RichTextContainer extends TextContainer
      *            This is the name of the field use when data is submitted back
      *            to the server.
      * @return a new file field
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public File addFile(String name) throws WingException
     {
@@ -408,6 +430,7 @@ public abstract class RichTextContainer extends TextContainer
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
      * @return a new hidden field
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Hidden addHidden(String name, String rend) throws WingException
     {
@@ -427,6 +450,7 @@ public abstract class RichTextContainer extends TextContainer
      *            This is the name of the field use when data is submitted back
      *            to the server.
      * @return a new hidden field.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Hidden addHidden(String name) throws WingException
     {
@@ -446,6 +470,7 @@ public abstract class RichTextContainer extends TextContainer
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
      * @return A new password field
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Password addPassword(String name, String rend) throws WingException
     {
@@ -464,6 +489,7 @@ public abstract class RichTextContainer extends TextContainer
      *            This is the name of the field use when data is submitted back
      *            to the server.
      * @return a new password field
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Password addPassword(String name) throws WingException
     {
@@ -485,6 +511,7 @@ public abstract class RichTextContainer extends TextContainer
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
      * @return a new radio field.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Radio addRadio(String name, String rend) throws WingException
     {
@@ -506,6 +533,7 @@ public abstract class RichTextContainer extends TextContainer
      *            to the server.
      * 
      * @return a new radio field
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Radio addRadio(String name) throws WingException
     {
@@ -525,6 +553,7 @@ public abstract class RichTextContainer extends TextContainer
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
      * @return a new select field
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Select addSelect(String name, String rend) throws WingException
     {
@@ -543,6 +572,7 @@ public abstract class RichTextContainer extends TextContainer
      *            This is the name of the field use when data is submitted back
      *            to the server.
      * @return a new select field
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Select addSelect(String name) throws WingException
     {
@@ -561,6 +591,7 @@ public abstract class RichTextContainer extends TextContainer
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
      * @return A new text field
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Text addText(String name, String rend) throws WingException
     {
@@ -579,6 +610,7 @@ public abstract class RichTextContainer extends TextContainer
      *            This is the name of the field use when data is submitted back
      *            to the server.
      * @return a new text field
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Text addText(String name) throws WingException
     {
@@ -597,6 +629,7 @@ public abstract class RichTextContainer extends TextContainer
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
      * @return a new text area field
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public TextArea addTextArea(String name, String rend) throws WingException
     {
@@ -614,14 +647,10 @@ public abstract class RichTextContainer extends TextContainer
      *            This is the name of the field use when data is submitted back
      *            to the server.
      * @return a new text area field
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public TextArea addTextArea(String name) throws WingException
     {
         return addTextArea(name, null);
     }
-    
-    
-    
-    
-    
 }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/RichTextContainer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/RichTextContainer.java
@@ -189,7 +189,7 @@ public abstract class RichTextContainer extends TextContainer
      *  		  (May be null) Special rendering instructions
      * @param name
      *            Name of the link.
-     * @throws org.dspace.app.xmlui.wing.WingException
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addXref(String target, Message key, String rend, String name) throws WingException
     {
@@ -239,6 +239,7 @@ public abstract class RichTextContainer extends TextContainer
      *            (May be null) The target reference for the image if the image
      *            is to operate as a link.
      * @param title
+     *            Title for the figure.
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Row.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Row.java
@@ -38,13 +38,13 @@ public class Row extends AbstractWingElement implements StructuralElement
     public static final String A_ROLE = "role";
 
     /** The row's name */
-    private String name;
+    private final String name;
 
     /** The row's role, see ROLES below */
-    private String role;
+    private final String role;
 
     /** Special rendering instructions */
-    private String rend;
+    private final String rend;
 
     /** The row (and cell) role types: */
     public static final String ROLE_DATA = "data";
@@ -55,7 +55,7 @@ public class Row extends AbstractWingElement implements StructuralElement
     public static final String[] ROLES = { ROLE_DATA, ROLE_HEADER };
 
     /** The contents of this row */
-    List<AbstractWingElement> contents = new ArrayList<AbstractWingElement>();
+    List<AbstractWingElement> contents = new ArrayList<>();
 
     /**
      * Construct a new table row.
@@ -72,6 +72,7 @@ public class Row extends AbstractWingElement implements StructuralElement
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected Row(WingContext context, String name, String role, String rend)
             throws WingException
@@ -108,6 +109,7 @@ public class Row extends AbstractWingElement implements StructuralElement
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
      * @return a new table cell.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Cell addCell(String name, String role, int rows, int cols,
             String rend) throws WingException
@@ -131,6 +133,7 @@ public class Row extends AbstractWingElement implements StructuralElement
      *            (May be zero for no defined value) determines how many columns
      *            does this cell span.
      * @return a new table cell.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Cell addCell(int rows, int cols) throws WingException
     {
@@ -156,6 +159,7 @@ public class Row extends AbstractWingElement implements StructuralElement
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
      * @return a new table cell.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Cell addCell(String name, String role, String rend)
             throws WingException
@@ -174,6 +178,7 @@ public class Row extends AbstractWingElement implements StructuralElement
      *            (May be null) determines what kind of information the cell
      *            carries, either header or data. See cell.ROLES
      * @return a new table cell.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Cell addCell(String role) throws WingException
     {
@@ -188,6 +193,7 @@ public class Row extends AbstractWingElement implements StructuralElement
      * form fields.
      * 
      * @return a new table cell.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Cell addCell() throws WingException
     {
@@ -206,6 +212,7 @@ public class Row extends AbstractWingElement implements StructuralElement
      * 
      * @param characters
      *            (Required) Untranslated character data to be included.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addCellContent(String characters) throws WingException
     {
@@ -226,6 +233,7 @@ public class Row extends AbstractWingElement implements StructuralElement
      * @param message
      *            (Required) Key to the i18n catalogue to translate the content
      *            into the language preferred by the user.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addCellContent(Message message) throws WingException
     {
@@ -246,7 +254,9 @@ public class Row extends AbstractWingElement implements StructuralElement
      * @param namespaces
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
+     * @throws org.xml.sax.SAXException passed through.
      */
+    @Override
     public void toSAX(ContentHandler contentHandler, LexicalHandler lexicalHandler,
             NamespaceSupport namespaces) throws SAXException
     {
@@ -275,9 +285,7 @@ public class Row extends AbstractWingElement implements StructuralElement
         endElement(contentHandler, namespaces, E_ROW);
     }
 
-    /**
-     * dispose
-     */
+    @Override
     public void dispose()
     {
         for (AbstractWingElement content : contents)

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Select.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Select.java
@@ -37,6 +37,7 @@ public class Select extends Field
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected Select(WingContext context, String name, String rend)
             throws WingException
@@ -90,6 +91,7 @@ public class Select extends Field
      * Enable the add operation for this field. When this is enabled the
      * front end will add a button to add more items to the field.
      * 
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void enableAddOperation() throws WingException
     {
@@ -101,6 +103,7 @@ public class Select extends Field
      * the front end will provide a way for the user to select fields (probably
      * checkboxes) along with a submit button to delete the selected fields.
      * 
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void enableDeleteOperation()throws WingException
     {
@@ -114,6 +117,8 @@ public class Select extends Field
      * @param returnValue
      *            (Required) The value to be passed back if this option is
      *            selected.
+     * @return the new option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Option addOption(String returnValue)
             throws WingException
@@ -132,6 +137,8 @@ public class Select extends Field
      * @param returnValue
      *            (Required) The value to be passed back if this option is
      *            selected.
+     * @return the new option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Option addOption(boolean selected, String returnValue)
             throws WingException
@@ -151,6 +158,7 @@ public class Select extends Field
      *            selected.
      * @param characters
      *            (Required) The text to set as the visible option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addOption(String returnValue, String characters) throws WingException
     {
@@ -168,6 +176,7 @@ public class Select extends Field
      *            selected.
      * @param characters
      *            (Required) The text to set as the visible option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addOption(boolean selected,String returnValue, String characters) throws WingException
     {
@@ -186,6 +195,7 @@ public class Select extends Field
      *            selected.
      * @param characters
      *            (Required) The text to set as the visible option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addOption(int returnValue, String characters) throws WingException
     {
@@ -203,6 +213,7 @@ public class Select extends Field
      *            selected.
      * @param characters
      *            (Required) The text to set as the visible option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addOption(boolean selected, int returnValue, String characters) throws WingException
     {
@@ -220,7 +231,8 @@ public class Select extends Field
      *            (Required) The value to be passed back if this option is
      *            selected.
      * @param message
-     *            (Required) The transalted text to set as the visible option.
+     *            (Required) The translated text to set as the visible option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addOption(String returnValue, Message message) throws WingException
     {
@@ -237,7 +249,8 @@ public class Select extends Field
      *            (Required) The value to be passed back if this option is
      *            selected.
      * @param message
-     *            (Required) The transalted text to set as the visible option.
+     *            (Required) The translated text to set as the visible option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addOption(boolean selected, String returnValue, Message message) throws WingException
     {
@@ -255,7 +268,8 @@ public class Select extends Field
      *            (Required) The value to be passed back if this option is
      *            selected.
      * @param message
-     *            (Required) The transalted text to set as the visible option.
+     *            (Required) The translated text to set as the visible option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addOption(int returnValue, Message message) throws WingException
     {
@@ -272,7 +286,8 @@ public class Select extends Field
      *            (Required) The value to be passed back if this option is
      *            selected.
      * @param message
-     *            (Required) The transalted text to set as the visible option.
+     *            (Required) The translated text to set as the visible option.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addOption(boolean selected, int returnValue, Message message) throws WingException
     {
@@ -288,6 +303,7 @@ public class Select extends Field
      * 
      * @param returnValue
      *            (Required) The return value of the option to be selected.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setOptionSelected(String returnValue) throws WingException
     {
@@ -300,6 +316,7 @@ public class Select extends Field
      * 
      * @param returnValue
      *            (Required) The return value of the option to be selected.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setOptionSelected(int returnValue) throws WingException
     {
@@ -310,6 +327,7 @@ public class Select extends Field
     /**
      * Add a field instance
      * @return instance
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Instance addInstance() throws WingException
     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/SimpleHTMLFragment.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/SimpleHTMLFragment.java
@@ -68,7 +68,7 @@ public class SimpleHTMLFragment extends AbstractWingElement {
 	 *            paragraphs delimeters.
 	 * @param fragment
 	 *            (Required) The HTML Fragment to be translated into DRI.
-	 * @throws WingException
+	 * @throws WingException passed through.
 	 */
 	protected SimpleHTMLFragment(WingContext context, boolean blankLines,
 			String fragment) throws WingException {
@@ -522,7 +522,7 @@ public class SimpleHTMLFragment extends AbstractWingElement {
 	 * following email, point #1:
 	 *
 	 * <a href="http://www.servlets.com/archive/servlet/ReadMsg?msgId=491592&listName=jdom-interest">
-     *   http://www.servlets.com/archive/servlet/ReadMsg?msgId=491592&listName=jdom-interest
+     *   {@literal http://www.servlets.com/archive/servlet/ReadMsg?msgId=491592&listName=jdom-interest}
      * </a>
 	 *
 	 * <p>I, Scott Phillips, checked the JDOM CVS source tree on 3-8-2006 and the

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/SimpleHTMLFragment.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/SimpleHTMLFragment.java
@@ -10,7 +10,6 @@ package org.dspace.app.xmlui.wing.element;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,28 +35,27 @@ import org.xml.sax.helpers.NamespaceSupport;
 /**
  * This class represents data that is translated from simple HTML or plain text.
  * 
- * This class represents a simple HTML fragment. It allows for user-supplied
+ * <p>This class represents a simple HTML fragment. It allows for user-supplied
  * HTML to be translated on the fly into DRI.
  * 
- * At the present time it only supports the following tags: h1, h2, h3, h4, h5,
- * p, a, b, i, u, ol, li and img. Each are translated into their DRI equivalents, note
- * the "h" tags are translated into a paragraph of rend=heading.
+ * <p>At the present time it only supports the following tags: h1, h2, h3, h4, h5,
+ * p, a, b, i, u, ol, li and img. Each are translated into their DRI equivalents.
+ * Note that the "h" tags are translated into a paragraph of rend=heading.
  * 
- * If the linkbreaks flag is set then line breaks are treated as paragraphs. This 
+ * <p>If the {@code linkbreaks} flag is set then line breaks are treated as paragraphs. This
  * allows plain text files to also be included and they will be mapped into DRI as 
  * well.
  * 
  * @author Scott Phillips
  * @author Jay Paz
  */
-
 public class SimpleHTMLFragment extends AbstractWingElement {
 
 	/** The HTML Fragment */
-	private String fragment;
+	private final String fragment;
 
 	/** Determine if blank lines mark a new paragraph */
-	private boolean blankLines;
+	private final boolean blankLines;
 
 	/**
 	 * Construct a fragment object for translating into DRI.
@@ -91,7 +89,9 @@ public class SimpleHTMLFragment extends AbstractWingElement {
 	 * @param namespaces
 	 *            (Required) SAX Helper class to keep track of namespaces able
 	 *            to determine the correct prefix for a given namespace URI.
+     * @throws org.xml.sax.SAXException on I/O error.
 	 */
+    @Override
 	public void toSAX(ContentHandler contentHandler,
 			LexicalHandler lexicalHandler, NamespaceSupport namespaces)
 			throws SAXException {
@@ -153,7 +153,7 @@ public class SimpleHTMLFragment extends AbstractWingElement {
 			// If it's an element replace the content with a text node.
 			Element element = (Element) content;
 
-			if (element.getContent().size() == 0) {
+			if (element.getContent().isEmpty()) {
 				// The element contains nothing, we can use shorthand notation
 				// for it.
 				StringBuilder replacement = new StringBuilder().append("<").append(element.getName());
@@ -273,7 +273,7 @@ public class SimpleHTMLFragment extends AbstractWingElement {
 	 *            removed.
 	 */
 	private void limitAttributes(Element element, String... names) {
-		Map<String, String> attributes = new HashMap<String, String>();
+		Map<String, String> attributes = new HashMap<>();
 		for (String name : names) {
 			String value = element.getAttributeValue(name);
 			if (value != null)
@@ -451,7 +451,7 @@ public class SimpleHTMLFragment extends AbstractWingElement {
 		// Ensure that all top level elements are encapsulated inside
 		// a block level element (i.e. a paragraph)
 		if (parent.isRootElement()) {
-			List<Content> removed = new ArrayList<Content>();
+			List<Content> removed = new ArrayList<>();
 			for (int i = 0; i < parent.getContentSize(); i++) {
 				Content current = parent.getContent(i);
 				
@@ -517,24 +517,25 @@ public class SimpleHTMLFragment extends AbstractWingElement {
 	 * from the originating HTML fragment, 2) to get around a JDOM bug where it
 	 * can not output SAX events for just a document fragment. Since it only
 	 * works with documents this class was created to filter out the events.
-	 * 
-	 * As far as I can tell, the first time the bug was identified is in the
+	 *
+	 * <p>As far as I can tell, the first time the bug was identified is in the
 	 * following email, point #1:
-	 * 
-	 * http://www.servlets.com/archive/servlet/ReadMsg?msgId=491592&listName=jdom-interest
-	 * 
-	 * I, Scott Phillips, checked the JDOM CVS source tree on 3-8-2006 and the
-	 * bug had not been patch at that time.
-	 * 
+	 *
+	 * <a href="http://www.servlets.com/archive/servlet/ReadMsg?msgId=491592&listName=jdom-interest">
+     *   http://www.servlets.com/archive/servlet/ReadMsg?msgId=491592&listName=jdom-interest
+     * </a>
+	 *
+	 * <p>I, Scott Phillips, checked the JDOM CVS source tree on 3-8-2006 and the
+	 * bug had not been patched at that time.
 	 */
 	public static class SAXFilter implements ContentHandler, LexicalHandler {
 
 		private final String URI = WingConstants.DRI.URI;
 
-		private ContentHandler contentHandler;
+		private final ContentHandler contentHandler;
 
 		// private LexicalHandler lexicalHandler; may be used in the future
-		private NamespaceSupport namespaces;
+		private final NamespaceSupport namespaces;
 
 		public SAXFilter(ContentHandler contentHandler,
 				LexicalHandler lexicalHandler, NamespaceSupport namespaces) {
@@ -566,84 +567,102 @@ public class SimpleHTMLFragment extends AbstractWingElement {
 
 		/** ContentHandler methods: */
 
+        @Override
 		public void endDocument() {
 			// Filter out endDocument events
 		}
 
+        @Override
 		public void startDocument() {
 			// filter out startDocument events
 		}
 
+        @Override
 		public void characters(char[] ch, int start, int length)
 				throws SAXException {
 			contentHandler.characters(ch, start, length);
 		}
 
+        @Override
 		public void endElement(String uri, String localName, String qName)
 				throws SAXException {
 
 			contentHandler.endElement(URI, localName, qName(localName));
 		}
 
+        @Override
 		public void endPrefixMapping(String prefix) throws SAXException {
 			// No namespaces may be declared.
 		}
 
+        @Override
 		public void ignorableWhitespace(char[] ch, int start, int length)
 				throws SAXException {
 			contentHandler.ignorableWhitespace(ch, start, length);
 		}
 
+        @Override
 		public void processingInstruction(String target, String data)
 				throws SAXException {
 			// filter out processing instructions
 		}
 
+        @Override
 		public void setDocumentLocator(Locator locator) {
 			// filter out document locators
 		}
 
+        @Override
 		public void skippedEntity(String name) throws SAXException {
 			contentHandler.skippedEntity(name);
 		}
 
+        @Override
 		public void startElement(String uri, String localName, String qName,
 				Attributes atts) throws SAXException {
 			contentHandler.startElement(URI, localName, qName(localName), atts);
 		}
 
+        @Override
 		public void startPrefixMapping(String prefix, String uri)
 				throws SAXException {
 			// No namespaces can be declared.
 		}
 
-		/** Lexical Handler methods: */
+		/* Lexical Handler methods: */
 
+        @Override
 		public void startDTD(String name, String publicId, String systemId)
 				throws SAXException {
 			// filter out DTDs
 		}
 
+        @Override
 		public void endDTD() throws SAXException {
 			// filter out DTDs
 		}
 
+        @Override
 		public void startEntity(String name) throws SAXException {
 			// filter out Entities
 		}
 
+        @Override
 		public void endEntity(String name) throws SAXException {
 			// filter out Entities
 		}
 
+        @Override
 		public void startCDATA() throws SAXException {
 			// filter out CDATA
 		}
 
+        @Override
 		public void endCDATA() throws SAXException {
 			// filter out CDATA
 		}
 
+        @Override
 		public void comment(char[] ch, int start, int length)
 				throws SAXException {
 			// filter out comments;

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Table.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Table.java
@@ -40,22 +40,22 @@ public class Table extends AbstractWingElement implements StructuralElement
     public static final String A_COLS = "cols";
 
     /** The name assigned to this table */
-    private String name;
+    private final String name;
 
     /** Special rendering instructions for this table */
-    private String rend;
+    private final String rend;
 
     /** The number of rows in the table */
-    private int rows;
+    private final int rows;
 
     /** The number of cols in the table */
-    private int cols;
+    private final int cols;
 
     /** The table's head */
     private Head head;
 
     /** the rows contained in the table */
-    private List<AbstractWingElement> contents = new ArrayList<AbstractWingElement>();
+    private List<AbstractWingElement> contents = new ArrayList<>();
 
     /**
      * Construct a new row.
@@ -75,6 +75,7 @@ public class Table extends AbstractWingElement implements StructuralElement
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected Table(WingContext context, String name, int rows, int cols,
             String rend) throws WingException
@@ -92,6 +93,8 @@ public class Table extends AbstractWingElement implements StructuralElement
 
     /**
      * Set the head element which is the label associated with this table.
+     * @return the new head.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Head setHead() throws WingException
     {
@@ -105,11 +108,12 @@ public class Table extends AbstractWingElement implements StructuralElement
      * 
      * @param characters
      *            (May be null) Unprocessed characters to be included
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setHead(String characters) throws WingException
     {
-        Head head = this.setHead();
-        head.addContent(characters);
+        Head newHead = this.setHead();
+        newHead.addContent(characters);
 
     }
 
@@ -119,11 +123,12 @@ public class Table extends AbstractWingElement implements StructuralElement
      * @param message
      *            (Required) A key into the i18n catalogue for translation into
      *            the user's preferred language.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setHead(Message message) throws WingException
     {
-        Head head = this.setHead();
-        head.addContent(message);
+        Head newHead = this.setHead();
+        newHead.addContent(message);
     }
 
     /**
@@ -143,6 +148,7 @@ public class Table extends AbstractWingElement implements StructuralElement
      *            display of the element.
      * 
      * @return a new table row
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Row addRow(String name, String role, String rend)
             throws WingException
@@ -162,6 +168,7 @@ public class Table extends AbstractWingElement implements StructuralElement
      *            carries, either header or data. See row.ROLES
      * 
      * @return a new table row
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Row addRow(String role) throws WingException
     {
@@ -173,6 +180,7 @@ public class Table extends AbstractWingElement implements StructuralElement
      * and serves as a container of cell elements.
      * 
      * @return a new table row
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Row addRow() throws WingException
     {
@@ -192,8 +200,9 @@ public class Table extends AbstractWingElement implements StructuralElement
      * @param namespaces
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
+     * @throws org.xml.sax.SAXException passed through.
      */
-
+    @Override
     public void toSAX(ContentHandler contentHandler, LexicalHandler lexicalHandler, 
             NamespaceSupport namespaces) throws SAXException
     {
@@ -219,9 +228,7 @@ public class Table extends AbstractWingElement implements StructuralElement
         endElement(contentHandler, namespaces, E_TABLE);
     }
 
-    /**
-     * dispose
-     */
+    @Override
     public void dispose()
     {
         if (head != null)

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Text.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Text.java
@@ -35,6 +35,7 @@ public class Text extends Field
      * @param rend
      *            (May be null) a rendering hint used to override the default
      *            display of the element.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected Text(WingContext context, String name, String rend)
             throws WingException
@@ -75,6 +76,7 @@ public class Text extends Field
      * Enable the add operation for this field. When this is enabled the
      * front end will add a button to add more items to the field.
      *
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void enableAddOperation() throws WingException
     {
@@ -86,6 +88,7 @@ public class Text extends Field
      * the front end will provide a way for the user to select fields (probably
      * checkboxes) along with a submit button to delete the selected fields.
      *
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void enableDeleteOperation()throws WingException
     {
@@ -99,6 +102,8 @@ public class Text extends Field
 
     /**
      * Set the raw value of the field removing any previous raw values.
+     * @return the new value.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Value setValue() throws WingException
     {
@@ -113,6 +118,7 @@ public class Text extends Field
      *
      * @param characters
      *            (May be null) Field value as a string
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setValue(String characters) throws WingException
     {
@@ -126,6 +132,7 @@ public class Text extends Field
      * @param message
      *            (Required) A key into the i18n catalogue for translation into
      *            the user's preferred language.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void setValue(Message message) throws WingException
     {
@@ -136,6 +143,8 @@ public class Text extends Field
     /**
      * Set the authority value of the field removing any previous authority values.
      * Initialized to an empty value.
+     * @return the new value.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Value setAuthorityValue() throws WingException
     {
@@ -145,6 +154,10 @@ public class Text extends Field
     /**
      * Set the authority value of the field removing any previous authority values.
      * Initialized to an empty value.
+     * @param characters new value.
+     * @param confidence confidence in this value
+     * @return the new value.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Value setAuthorityValue(String characters, String confidence) throws WingException
     {
@@ -158,6 +171,7 @@ public class Text extends Field
     /**
      * Add a field instance
      * @return instance
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public Instance addInstance() throws WingException
     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/TextContainer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/TextContainer.java
@@ -7,7 +7,6 @@
  */
 package org.dspace.app.xmlui.wing.element;
 
-
 import org.dspace.app.xmlui.wing.Message;
 import org.dspace.app.xmlui.wing.WingContext;
 import org.dspace.app.xmlui.wing.WingException;
@@ -36,6 +35,7 @@ public abstract class TextContainer extends Container
      * 
      * @param context
      *            (Required) The context this element is contained in.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     protected TextContainer(WingContext context) throws WingException
     {
@@ -48,6 +48,7 @@ public abstract class TextContainer extends Container
      * @param characters
      *            (Required) Direct content or a dictionary tag to be inserted
      *            into the element.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addContent(String characters) throws WingException
     {
@@ -60,6 +61,7 @@ public abstract class TextContainer extends Container
      * 
      * @param integer
      *            (Required) Add the integer into the element's container.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addContent(int integer) throws WingException
     {
@@ -73,6 +75,7 @@ public abstract class TextContainer extends Container
      * @param message
      *            (Required) A key into the i18n catalogue for translation into
      *            the user's preferred language.
+     * @throws org.dspace.app.xmlui.wing.WingException passed through.
      */
     public void addContent(Message message) throws WingException
     {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/WingElement.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/WingElement.java
@@ -13,7 +13,7 @@ import org.xml.sax.ext.LexicalHandler;
 import org.xml.sax.helpers.NamespaceSupport;
 
 /**
- * This basic interface is implemented by all WingElements, once an element has
+ * This basic interface is implemented by all WingElements.  Once an element has
  * been created it can be translated into SAX events and disposed of.
  * 
  * @author Scott Phillips
@@ -35,6 +35,8 @@ public interface WingElement
      * @param namespaces
      *            (Required) SAX Helper class to keep track of namespaces able
      *            to determine the correct prefix for a given namespace URI.
+     * @throws org.xml.sax.SAXException
+     *            on error.
      */
     public abstract void toSAX(ContentHandler contentHandler, LexicalHandler lexicalHandler,
             NamespaceSupport namespaces) throws SAXException;

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/WingMergeableElement.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/WingMergeableElement.java
@@ -33,6 +33,8 @@ public interface WingMergeableElement extends WingElement
      * @param attributes
      *            The element's attributes
      * @return True if this WingElement is equivalent to the given SAX Event.
+     * @throws org.xml.sax.SAXException whenever.
+     * @throws org.dspace.app.xmlui.wing.WingException whenever.
      */
     public boolean mergeEqual(String namespace, String localName, String qName,
             Attributes attributes) throws SAXException, WingException;
@@ -53,6 +55,8 @@ public interface WingMergeableElement extends WingElement
      * @param attributes
      *            The element's attributes
      * @return The child element
+     * @throws org.xml.sax.SAXException whenever.
+     * @throws org.dspace.app.xmlui.wing.WingException whenever.
      */
     public WingMergeableElement mergeChild(String namespace, String localName,
             String qName, Attributes attributes) throws SAXException,
@@ -69,7 +73,10 @@ public interface WingMergeableElement extends WingElement
      * startElement event it may modify the attributes object passed to make
      * changes.
      * 
+     * @param attributes attributes.
      * @return The attributes for this merged element
+     * @throws org.xml.sax.SAXException whenever.
+     * @throws org.dspace.app.xmlui.wing.WingException whenever.
      */
     public Attributes merge(Attributes attributes) throws SAXException,
             WingException;


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3154
I couldn't stand it.  XMLUI also needs a lot of javadoc fixing.  I hope you don't mind my butting in.

While fixing javadoc, I'm also very liberally accepting NetBeans' other minor suggestions, and trying to make the javadoc output look like it does in the source.  A lot of text was written without recalling that javadoc is treated as (sort of) HTML:  smooshed into a rectangle unless marked up, pruned of unrecognized XML-ish things, and the like.  Things that bother the spell-checker tend to be things that render better as `{@code}` anyway.  And so on.

I'm ruthlessly removing from overriding implementations any doc comment that adds nothing of substance.  In such cases, documentation will be supplied by the overridden method.
