### PR TITLE
[DS-3197] SWORD v1 service crashes at first request

### DIFF
--- a/dspace-sword/src/main/java/org/purl/sword/server/DepositServlet.java
+++ b/dspace-sword/src/main/java/org/purl/sword/server/DepositServlet.java
@@ -47,7 +47,7 @@ import org.purl.sword.base.SWORDErrorException;
 public class DepositServlet extends HttpServlet {
 
 	/** Sword repository */
-	protected final transient SWORDServer myRepository;
+	protected transient SWORDServer myRepository;
 
 	/** Authentication type */
 	private String authN;
@@ -64,10 +64,15 @@ public class DepositServlet extends HttpServlet {
 	/** Logger */
 	private static final Logger log = Logger.getLogger(DepositServlet.class);
 
-    public DepositServlet()
-            throws ServletException
-    {
-		// Instantiate the correct SWORD Server class
+    /**
+	 * Initialise the servlet.
+	 *
+	 * @throws ServletException if there is trouble with the upload directory.
+	 */
+    @Override
+	public void init() throws ServletException {
+
+        // Instantiate the correct SWORD Server class
 		String className = getServletContext().getInitParameter("sword-server-class");
 		if (className == null) {
 			log.fatal("Unable to read value of 'sword-server-class' from Servlet context");
@@ -85,16 +90,8 @@ public class DepositServlet extends HttpServlet {
                     "Unable to instantiate class from 'sword-server-class': "
                             + className, e);
         }
-    }
 
-    /**
-	 * Initialise the servlet
-	 * 
-	 * @throws ServletException
-	 */
-    @Override
-	public void init() throws ServletException {
-		authN = getServletContext().getInitParameter("authentication-method");
+        authN = getServletContext().getInitParameter("authentication-method");
 		if ((authN == null) || (authN.equals(""))) {
 			authN = "None";
 		}
@@ -149,18 +146,28 @@ public class DepositServlet extends HttpServlet {
 
 	/**
 	 * Process the Get request. This will return an unimplemented response.
+     * @param request the request.
+     * @param response the response.
+     * @throws javax.servlet.ServletException passed through.
+     * @throws java.io.IOException passed through.
 	 */
     @Override
-	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+	protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
 		// Send a '501 Not Implemented'
 		response.sendError(HttpServletResponse.SC_NOT_IMPLEMENTED);
 	}
 
 	/**
 	 * Process a post request.
+     * @param request the request.
+     * @param response the response.
+     * @throws javax.servlet.ServletException passed through.
+     * @throws java.io.IOException passed through.
 	 */
     @Override
-	protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+	protected void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
 		// Create the Deposit request
 		Deposit d = new Deposit();
 		Date date = new Date();

--- a/dspace-sword/src/main/java/org/purl/sword/server/ServiceDocumentServlet.java
+++ b/dspace-sword/src/main/java/org/purl/sword/server/ServiceDocumentServlet.java
@@ -33,7 +33,7 @@ import org.purl.sword.base.ServiceDocumentRequest;
 public class ServiceDocumentServlet extends HttpServlet {
 
 	/** The repository */
-	private final transient SWORDServer myRepository;
+	private transient SWORDServer myRepository;
 
 	/** Authentication type. */
 	private String authN;
@@ -44,10 +44,15 @@ public class ServiceDocumentServlet extends HttpServlet {
 	/** Logger */
 	private static final Logger log = Logger.getLogger(ServiceDocumentServlet.class);
 
-    public ServiceDocumentServlet()
-            throws ServletException
-    {
-		// Instantiate the correct SWORD Server class
+    /**
+	 * Initialise the servlet.
+	 *
+	 * @throws ServletException if the server class cannot be instantiated.
+	 */
+    @Override
+	public void init() throws ServletException {
+
+        // Instantiate the correct SWORD Server class
 		String className = getServletContext().getInitParameter("sword-server-class");
 		if (className == null) {
 			log.fatal("Unable to read value of 'sword-server-class' from Servlet context");
@@ -65,15 +70,6 @@ public class ServiceDocumentServlet extends HttpServlet {
 								+ className, e);
 			}
 		}
-    }
-
-    /**
-	 * Initialise the servlet.
-	 * 
-	 * @throws ServletException
-	 */
-    @Override
-	public void init() throws ServletException {
 
 		// Set the authentication method
 		authN = getServletContext().getInitParameter("authentication-method");
@@ -100,7 +96,11 @@ public class ServiceDocumentServlet extends HttpServlet {
 	}
 
 	/**
-	 * Process the get request.
+	 * Process the GET request.
+     * @param request the request.
+     * @param response the response.
+     * @throws javax.servlet.ServletException passed through.
+     * @throws java.io.IOException passed through.
 	 */
     @Override
 	protected void doGet(HttpServletRequest request,
@@ -154,7 +154,7 @@ public class ServiceDocumentServlet extends HttpServlet {
 			// Return the relevant HTTP status code
 			response.sendError(see.getStatus(), see.getDescription());
 		} catch (SWORDException se) {
-			se.printStackTrace();
+            log.error("Internal error", se);
 			// Throw a HTTP 500
 			response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, se.getMessage());
 		}
@@ -162,6 +162,10 @@ public class ServiceDocumentServlet extends HttpServlet {
 
 	/**
 	 * Process the post request. This will return an unimplemented response.
+     * @param request the request.
+     * @param response the response.
+     * @throws javax.servlet.ServletException passed through.
+     * @throws java.io.IOException passed through.
 	 */
     @Override
 	protected void doPost(HttpServletRequest request,


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3197

I don't know what I was thinking when I turned this code into a constructor -- must've been punchy from staring at so many 'transient's.  This puts the code back into init() where the context is guaranteed to exist.

I don't actually _use_ SWORD, so my testing has been limited to browsing to the service document and inspecting it to see that it is sensible-looking XML.  Please test.
