### PR TITLE
[DS-3179] Collection admin, edit item no authorization to remove file

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -247,7 +247,13 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
         context.addEvent(new Event(Event.DELETE, Constants.BITSTREAM, bitstream.getID(),
                 String.valueOf(bitstream.getSequenceID()), getIdentifiers(context, bitstream)));
 
-        bitstream.getBundles().clear();
+        //Remove our bitstream from all our bundles
+        final List<Bundle> bundles = bitstream.getBundles();
+        for (Bundle bundle : bundles) {
+            bundle.getBitstreams().remove(bitstream);
+        }
+        //Remove all bundles from the bitstream object, clearing the connection in 2 ways
+        bundles.clear();
 
         deleteMetadata(context, bitstream);
 

--- a/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
@@ -170,8 +170,6 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
         log.info(LogManager.getHeader(context, "remove_bitstream",
                 "bundle_id=" + bundle.getID() + ",bitstream_id=" + bitstream.getID()));
 
-        bundle.getBitstreams().remove(bitstream);
-        bitstream.getBundles().remove(bundle);
 
         context.addEvent(new Event(Event.REMOVE, Constants.BUNDLE, bundle.getID(),
                 Constants.BITSTREAM, bitstream.getID(), String.valueOf(bitstream.getSequenceID()),
@@ -193,7 +191,16 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
             bundle.unsetPrimaryBitstreamID();
         }
 
-        bitstreamService.delete(context, bitstream);
+        // Check if we our bitstream is part of a single bundle:
+        // If so delete it, if not then remove the link between bundle & bitstream
+        if(bitstream.getBundles().size() == 1)
+        {
+            // We don't need to remove the link between bundle & bitstream, this will be handled in the delete() method.
+            bitstreamService.delete(context, bitstream);
+        }else{
+            bundle.getBitstreams().remove(bitstream);
+            bitstream.getBundles().remove(bundle);
+        }
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -547,17 +547,18 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
 
     @Override
     public void removeItem(Context context, Collection collection, Item item) throws SQLException, AuthorizeException, IOException {
-                // Check authorisation
+        // Check authorisation
         authorizeService.authorizeAction(context, collection, Constants.REMOVE);
 
-        //Remove the item from the collection
-        item.removeCollection(collection);
-
         //Check if we orphaned our poor item
-        if (item.getCollections().isEmpty())
+        if (item.getCollections().size() == 1)
         {
             // Orphan; delete it
             itemService.delete(context, item);
+        } else {
+            //Remove the item from the collection if we have multiple collections
+            item.removeCollection(collection);
+
         }
 
         context.addEvent(new Event(Event.REMOVE, Constants.COLLECTION,

--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -668,9 +668,6 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
         // Delete bitstream logo
         setLogo(context, collection, null);
 
-        // Remove all authorization policies
-        authorizeService.removeAllPolicies(context, collection);
-
         Iterator<WorkspaceItem> workspaceItems = workspaceItemService.findByCollection(context, collection).iterator();
         while (workspaceItems.hasNext()) {
             WorkspaceItem workspaceItem = workspaceItems.next();
@@ -737,6 +734,9 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
             owningCommunities.remove();
             owningCommunity.getCollections().remove(collection);
         }
+
+        // Remove all authorization policies
+        authorizeService.removeAllPolicies(context, collection);
 
         collectionDAO.delete(context, collection);
     }

--- a/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
@@ -395,15 +395,16 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
         // Check authorisation
         authorizeService.authorizeAction(context, community, Constants.REMOVE);
 
-        community.removeCollection(collection);
         ArrayList<String> removedIdentifiers = collectionService.getIdentifiers(context, collection);
         String removedHandle = collection.getHandle();
         UUID removedId = collection.getID();
 
-
-        collection.removeCommunity(community);
-        if(CollectionUtils.isEmpty(collection.getCommunities())){
+        if(collection.getCommunities().size() == 1)
+        {
             collectionService.delete(context, collection);
+        }else{
+            community.removeCollection(collection);
+            collection.removeCommunity(community);
         }
 
         log.info(LogManager.getHeader(context, "remove_collection",

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -578,8 +578,6 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
     @Override
     public void delete(Context context, Item item) throws SQLException, AuthorizeException, IOException {
         authorizeService.authorizeAction(context, item, Constants.DELETE);
-        item.getCollections().clear();
-        item.setOwningCollection(null);
         rawDelete(context,  item);
     }
 
@@ -603,14 +601,19 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         // Remove bundles
         removeAllBundles(context, item);
 
+        // remove version attached to the item
+        removeVersion(context, item);
+
+        //Only clear collections after we have removed everything else from the item
+        item.getCollections().clear();
+        item.setOwningCollection(null);
+
         // remove all of our authorization policies
         authorizeService.removeAllPolicies(context, item, false);
 
         // Remove any Handle
         handleService.unbindHandle(context, item);
 
-                // remove version attached to the item
-        removeVersion(context, item);
 
         // Finally remove item row
         itemDAO.delete(context, item);

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/DSpaceServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/DSpaceServlet.java
@@ -136,7 +136,7 @@ public class DSpaceServlet extends HttpServlet
             // Also email an alert
             UIUtil.sendAlert(request, se);
 
-            context.abort();
+            abortContext(context);
             JSPManager.showInternalError(request, response);
         }
         catch (AuthorizeException ae)
@@ -158,6 +158,15 @@ public class DSpaceServlet extends HttpServlet
 
                 JSPManager.showAuthorizeError(request, response, ae);
             }
+            abortContext(context);
+        }
+        catch (Exception e)
+        {
+            log.warn(LogManager.getHeader(context, "general_jspui_error", e
+                    .toString()), e);
+
+            abortContext(context);
+            JSPManager.showInternalError(request, response);
         }
         finally
         {
@@ -172,6 +181,13 @@ public class DSpaceServlet extends HttpServlet
                     JSPManager.showInternalError(request, response);
                 }
             }
+        }
+    }
+
+    private void abortContext(Context context) {
+        if(context != null && context.isValid())
+        {
+            context.abort();
         }
     }
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3179

This PR will fix the issue by checking if the bitstream is linked to multiple bundles, if so it will remove it from the bundle.
If we have a single bundle then the bitstream will deleted, the link between bundle/bitstream will be deleted in the bitstream delete method.

Also added some code that will abort the context on any exception, this will prevent partial database changes in case of an exception.

**Tests to be made before merging**
- [ ] Delete file as a community/collection admin
- [ ] Delete an item as a community/collection admin
- [ ] Delete a collection as a community admin
- [ ] Delete a sub community as a community admin
