### PR TITLE
Ds 2962 Robots.txt disallows site /discovery but not /handle/*/disover

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/core/page-structure.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/core/page-structure.xsl
@@ -177,6 +177,14 @@
                 </xsl:attribute>
             </meta>
 
+            <xsl:if test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='ROBOTS']">
+                <meta name="ROBOTS">
+                    <xsl:attribute name="content">
+                        <xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='ROBOTS']"/>
+                    </xsl:attribute>
+                </meta>
+            </xsl:if>
+
             <!-- Add stylesheets -->
 
             <!--TODO figure out a way to include these in the concat & minify-->

--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/core/page-structure.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/core/page-structure.xsl
@@ -177,7 +177,7 @@
                 </xsl:attribute>
             </meta>
 
-            <xsl:if test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='ROBOTS']">
+            <xsl:if test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='ROBOTS'][not(@qualifier)]">
                 <meta name="ROBOTS">
                     <xsl:attribute name="content">
                         <xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='ROBOTS']"/>

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/RobotsNoIndexTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/RobotsNoIndexTransformer.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.app.xmlui.aspect.discovery;
 
 import java.io.*;
@@ -10,6 +17,10 @@ import org.dspace.authorize.*;
 import org.xml.sax.*;
 
 /**
+ * Robots can not be blocked from dynamic URLs using robots.txt. This transformer is used instead to add
+ * a meta tag that tells robots not to index the content of a page.
+ * Information about this meta tag can be found here: http://www.robotstxt.org/meta.html
+ *
  * @author philip at atmire.com
  */
 public class RobotsNoIndexTransformer extends AbstractDSpaceTransformer {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/RobotsNoIndexTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/RobotsNoIndexTransformer.java
@@ -1,0 +1,25 @@
+package org.dspace.app.xmlui.aspect.discovery;
+
+import java.io.*;
+import java.sql.*;
+import org.dspace.app.xmlui.cocoon.*;
+import org.dspace.app.xmlui.utils.*;
+import org.dspace.app.xmlui.wing.*;
+import org.dspace.app.xmlui.wing.element.*;
+import org.dspace.authorize.*;
+import org.xml.sax.*;
+
+/**
+ * @author philip at atmire.com
+ */
+public class RobotsNoIndexTransformer extends AbstractDSpaceTransformer {
+
+    @Override
+    public void addPageMeta(PageMeta pageMeta) throws SAXException, WingException, UIException, SQLException, IOException, AuthorizeException {
+        super.addPageMeta(pageMeta);
+
+        pageMeta.addMetadata("ROBOTS").addContent("NOINDEX, FOLLOW");
+    }
+
+
+}

--- a/dspace-xmlui/src/main/resources/aspects/Discovery/sitemap.xmap
+++ b/dspace-xmlui/src/main/resources/aspects/Discovery/sitemap.xmap
@@ -42,6 +42,8 @@ and the recent submissions listing
 
             <map:transformer name="RestrictedItem" src="org.dspace.app.xmlui.aspect.artifactbrowser.RestrictedItem"/>
             <map:transformer name="RecentSubmissionTransformer" src="org.dspace.app.xmlui.aspect.discovery.recentSubmissions.RecentSubmissionTransformer"/>
+
+            <map:transformer name="RobotsNoIndexTransformer" src="org.dspace.app.xmlui.aspect.discovery.RobotsNoIndexTransformer"/>
         </map:transformers>
                
         <map:actions>
@@ -157,11 +159,13 @@ and the recent submissions listing
                                 <map:parameter name="javascript.static#1" value="loadJQuery.js"/>
                                 <map:parameter name="javascript.static#2" value="static/js/discovery/search-controls.js"/>
                             </map:transform>
+                            <map:transform type="RobotsNoIndexTransformer"/>
                             <map:serialize type="xml"/>
 						</map:match>
 
                         <map:match pattern="handle/*/*/search-filter">
                             <map:transform type="SearchFacetFilter"/>
+                            <map:transform type="RobotsNoIndexTransformer"/>
                             <map:serialize type="xml"/>
                         </map:match>
 

--- a/dspace-xmlui/src/main/resources/aspects/Discovery/sitemap.xmap
+++ b/dspace-xmlui/src/main/resources/aspects/Discovery/sitemap.xmap
@@ -159,12 +159,16 @@ and the recent submissions listing
                                 <map:parameter name="javascript.static#1" value="loadJQuery.js"/>
                                 <map:parameter name="javascript.static#2" value="static/js/discovery/search-controls.js"/>
                             </map:transform>
+
+                            <!--adds the "no index" robots meta tag to the page-->
                             <map:transform type="RobotsNoIndexTransformer"/>
                             <map:serialize type="xml"/>
 						</map:match>
 
                         <map:match pattern="handle/*/*/search-filter">
                             <map:transform type="SearchFacetFilter"/>
+
+                            <!--adds the "no index" robots meta tag to the page-->
                             <map:transform type="RobotsNoIndexTransformer"/>
                             <map:serialize type="xml"/>
                         </map:match>

--- a/dspace-xmlui/src/main/webapp/static/robots.txt
+++ b/dspace-xmlui/src/main/webapp/static/robots.txt
@@ -11,9 +11,8 @@ Sitemap: ${dspace.url}/htmlmap
 User-agent: *
 # Disable access to Discovery search and filters
 Disallow: /discover
-Disallow: /handle/${handle.prefix}/*/discover
 Disallow: /search-filter
-Disallow: /handle/${handle.prefix}/*/search-filter
+
 #
 # Optionally uncomment the following line ONLY if sitemaps are working
 # and you have verified that your site is being indexed correctly.

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
@@ -167,6 +167,15 @@
                 </xsl:if>
               </xsl:attribute>
             </meta>
+
+            <xsl:if test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='ROBOTS']">
+                <meta name="ROBOTS">
+                    <xsl:attribute name="content">
+                        <xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='ROBOTS']"/>
+                    </xsl:attribute>
+                </meta>
+            </xsl:if>
+
             <!-- Add stylesheets -->
             <xsl:for-each select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='stylesheet']">
                 <link rel="stylesheet" type="text/css">

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
@@ -168,7 +168,7 @@
               </xsl:attribute>
             </meta>
 
-            <xsl:if test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='ROBOTS']">
+            <xsl:if test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='ROBOTS'][not(@qualifier)]">
                 <meta name="ROBOTS">
                     <xsl:attribute name="content">
                         <xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='ROBOTS']"/>


### PR DESCRIPTION
Implemented a transformer that adds the meta tag described at http://www.robotstxt.org/meta.html to the pagemeta. Also updated themes Mirage and Mirage2 to add this meta tag to the page. 

The transformer is configured to replace the dynamic URLs from robots.txt.

jira ticket: https://jira.duraspace.org/browse/DS-2962?jql=text%20~%20%22robots.txt%22
