### PR TITLE
[DS-3003] Make the constructors of 2 services protected instead of private

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/authority/ChoiceAuthorityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/ChoiceAuthorityServiceImpl.java
@@ -62,7 +62,7 @@ public final class ChoiceAuthorityServiceImpl implements ChoiceAuthorityService
     private final String CHOICES_PRESENTATION_PREFIX = "choices.presentation.";
     private final String CHOICES_CLOSED_PREFIX = "choices.closed.";
 
-    private ChoiceAuthorityServiceImpl() {
+    protected ChoiceAuthorityServiceImpl() {
     }
 
     // translate tail of configuration key (supposed to be schema.element.qual)

--- a/dspace-api/src/main/java/org/dspace/core/LegacyPluginServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/core/LegacyPluginServiceImpl.java
@@ -90,7 +90,7 @@ public class LegacyPluginServiceImpl implements PluginService
     @Autowired(required = true)
     protected ConfigurationService configurationService;
 
-    private LegacyPluginServiceImpl() {
+    protected LegacyPluginServiceImpl() {
     }
 
     /**


### PR DESCRIPTION
Follow up for: https://jira.duraspace.org/browse/DS-3003

Make the constructors of ChoiceAuthorityServiceImpl & LegacyPluginServiceImpl protected instead of private because else we cannot override the behavior of these services.
