### PR TITLE
Ds 3175 Testathon XMLUI VIEW14 RSS feeds are empty

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/OpenSearchServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/OpenSearchServiceImpl.java
@@ -127,7 +127,7 @@ public class OpenSearchServiceImpl implements OpenSearchService, InitializingBea
 
     @Override
     public String getResultsString(Context context, String format, String query, int totalResults, int start, int pageSize,
-    		                          	  DSpaceObject scope, DSpaceObject[] results,
+    		                          	  DSpaceObject scope, List<DSpaceObject> results,
     		                          	  Map<String, String> labels) throws IOException
     {
         try
@@ -143,7 +143,7 @@ public class OpenSearchServiceImpl implements OpenSearchService, InitializingBea
 
     @Override
     public Document getResultsDoc(Context context, String format, String query, int totalResults, int start, int pageSize,
-    		                          DSpaceObject scope, DSpaceObject[] results, Map<String, String> labels)
+    		                          DSpaceObject scope, List<DSpaceObject> results, Map<String, String> labels)
                                       throws IOException
     {
         try
@@ -158,7 +158,7 @@ public class OpenSearchServiceImpl implements OpenSearchService, InitializingBea
     }
 
     protected SyndicationFeed getResults(Context context, String format, String query, int totalResults, int start, int pageSize,
-                                          DSpaceObject scope, DSpaceObject[] results, Map<String, String> labels)
+                                          DSpaceObject scope, List<DSpaceObject> results, Map<String, String> labels)
     {
         // Encode results in requested format
         if ("rss".equals(format))

--- a/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
@@ -167,7 +167,7 @@ public class SyndicationFeed
      * Fills in the feed and entry-level metadata from DSpace objects.
      */
     public void populate(HttpServletRequest request, Context context, DSpaceObject dso,
-                         List<DSpaceObject> items, Map<String, String> labels)
+                         List<?extends DSpaceObject> items, Map<String, String> labels)
     {
         String logoURL = null;
         String objectURL = null;

--- a/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
@@ -167,7 +167,7 @@ public class SyndicationFeed
      * Fills in the feed and entry-level metadata from DSpace objects.
      */
     public void populate(HttpServletRequest request, Context context, DSpaceObject dso,
-                         DSpaceObject items[], Map<String, String> labels)
+                         List<DSpaceObject> items, Map<String, String> labels)
     {
         String logoURL = null;
         String objectURL = null;

--- a/dspace-api/src/main/java/org/dspace/app/util/service/OpenSearchService.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/service/OpenSearchService.java
@@ -83,7 +83,7 @@ public interface OpenSearchService {
      * @throws java.io.IOException
      */
     public String getResultsString(Context context, String format, String query, int totalResults, int start, int pageSize,
-                                          DSpaceObject scope, DSpaceObject[] results,
+                                          DSpaceObject scope, List<DSpaceObject> results,
                                           Map<String, String> labels) throws IOException;
     /**
      * Returns a formatted set of search results as a document
@@ -100,7 +100,7 @@ public interface OpenSearchService {
      * @throws IOException
      */
     public Document getResultsDoc(Context context, String format, String query, int totalResults, int start, int pageSize,
-                                         DSpaceObject scope, DSpaceObject[] results, Map<String, String> labels)
+                                         DSpaceObject scope, List<DSpaceObject> results, Map<String, String> labels)
             throws IOException;
 
     public DSpaceObject resolveScope(Context context, String scope) throws SQLException;

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/discovery/DiscoverySearchRequestProcessor.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/discovery/DiscoverySearchRequestProcessor.java
@@ -182,9 +182,7 @@ public class DiscoverySearchRequestProcessor implements SearchRequestProcessor
 
         // format and return results
         Map<String, String> labelMap = getLabels(request);
-        DSpaceObject[] dsoResults = new DSpaceObject[qResults
-                .getDspaceObjects().size()];
-        qResults.getDspaceObjects().toArray(dsoResults);
+        List<DSpaceObject> dsoResults = qResults.getDspaceObjects();
         Document resultsDoc = openSearchService.getResultsDoc(context, format, query,
                 (int) qResults.getTotalSearchResults(), qResults.getStart(),
                 qResults.getMaxResults(), container, dsoResults, labelMap);

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/FeedServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/FeedServlet.java
@@ -244,7 +244,7 @@ public class FeedServlet extends DSpaceServlet
         if (feed == null)
         {
                 feed = new SyndicationFeed(SyndicationFeed.UITYPE_JSPUI);
-                feed.populate(request, context, dso, getItems(context, dso), labelMap);
+                feed.populate(request, context, dso, new ArrayList<DSpaceObject>(getItems(context, dso)), labelMap);
         	if (feedCache != null)
         	{
                         cache(cacheKey, new CacheFeed(feed));
@@ -288,7 +288,7 @@ public class FeedServlet extends DSpaceServlet
     }
     
     // returns recently changed items, checking for accessibility
-    private Item[] getItems(Context context, DSpaceObject dso)
+    private List<Item> getItems(Context context, DSpaceObject dso)
     		throws IOException, SQLException
     {
     	try
@@ -326,12 +326,9 @@ public class FeedServlet extends DSpaceServlet
     		BrowseEngine be = new BrowseEngine(context);
     		BrowseInfo bi = be.browseMini(scope);
     		List<Item> results = bi.getResults();
-    		Item[] resultsArray;
             if (includeAll)
             {
-            	resultsArray = new Item[results.size()];
-            	resultsArray = results.toArray(resultsArray);
-                return resultsArray;
+                return results;
             }
             else
                 {
@@ -351,9 +348,7 @@ public class FeedServlet extends DSpaceServlet
                         }
                     }
                 }
-                resultsArray = new Item[items.size()];
-            	resultsArray = items.toArray(resultsArray);
-                return resultsArray;
+                return items;
                 }
             }
         catch (SortException se)

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/FeedServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/FeedServlet.java
@@ -244,7 +244,7 @@ public class FeedServlet extends DSpaceServlet
         if (feed == null)
         {
                 feed = new SyndicationFeed(SyndicationFeed.UITYPE_JSPUI);
-                feed.populate(request, context, dso, new ArrayList<DSpaceObject>(getItems(context, dso)), labelMap);
+                feed.populate(request, context, dso, getItems(context, dso), labelMap);
         	if (feedCache != null)
         	{
                         cache(cacheKey, new CacheFeed(feed));

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/DSpaceFeedGenerator.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/DSpaceFeedGenerator.java
@@ -234,7 +234,7 @@ public class DSpaceFeedGenerator extends AbstractGenerator
         
             SyndicationFeed feed = new SyndicationFeed(SyndicationFeed.UITYPE_XMLUI);
             feed.populate(ObjectModelHelper.getRequest(objectModel), context,
-                          dso, new ArrayList<DSpaceObject>(getRecentlySubmittedItems(context,dso)), FeedUtils.i18nLabels);
+                          dso, getRecentlySubmittedItems(context,dso), FeedUtils.i18nLabels);
             feed.setType(this.format);
             Document dom = feed.outputW3CDom();
             FeedUtils.unmangleI18N(dom);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/DSpaceFeedGenerator.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/DSpaceFeedGenerator.java
@@ -293,7 +293,8 @@ public class DSpaceFeedGenerator extends AbstractGenerator
             }
 
             BrowseEngine be = new BrowseEngine(context);
-            this.recentSubmissionItems = be.browseMini(scope).getItemResults();
+            List<Item> browseItemResults = be.browseMini(scope).getBrowseItemResults();
+            this.recentSubmissionItems = browseItemResults.toArray(new Item[browseItemResults.size()]);
 
             // filter out Items that are not world-readable
             if (!includeRestrictedItems)

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/DSpaceFeedGenerator.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/DSpaceFeedGenerator.java
@@ -121,7 +121,7 @@ public class DSpaceFeedGenerator extends AbstractGenerator
     private DSpaceValidity validity = null;
     
     /** The cache of recently submitted items */
-    private Item recentSubmissionItems[];
+    private List<Item> recentSubmissionItems;
 
     protected AuthorizeService authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();
     protected HandleService handleService = HandleServiceFactory.getInstance().getHandleService();
@@ -234,7 +234,7 @@ public class DSpaceFeedGenerator extends AbstractGenerator
         
             SyndicationFeed feed = new SyndicationFeed(SyndicationFeed.UITYPE_XMLUI);
             feed.populate(ObjectModelHelper.getRequest(objectModel), context,
-                          dso, getRecentlySubmittedItems(context,dso), FeedUtils.i18nLabels);
+                          dso, new ArrayList<DSpaceObject>(getRecentlySubmittedItems(context,dso)), FeedUtils.i18nLabels);
             feed.setType(this.format);
             Document dom = feed.outputW3CDom();
             FeedUtils.unmangleI18N(dom);
@@ -259,7 +259,7 @@ public class DSpaceFeedGenerator extends AbstractGenerator
      * @return recently submitted Items within the indicated scope
      */
     @SuppressWarnings("unchecked")
-    private Item[] getRecentlySubmittedItems(Context context, DSpaceObject dso)
+    private List<Item> getRecentlySubmittedItems(Context context, DSpaceObject dso)
             throws SQLException
     {
         if (recentSubmissionItems != null)
@@ -294,7 +294,7 @@ public class DSpaceFeedGenerator extends AbstractGenerator
 
             BrowseEngine be = new BrowseEngine(context);
             List<Item> browseItemResults = be.browseMini(scope).getBrowseItemResults();
-            this.recentSubmissionItems = browseItemResults.toArray(new Item[browseItemResults.size()]);
+            this.recentSubmissionItems = browseItemResults;
 
             // filter out Items that are not world-readable
             if (!includeRestrictedItems)
@@ -312,7 +312,7 @@ public class DSpaceFeedGenerator extends AbstractGenerator
                         }
                     }
                 }
-                this.recentSubmissionItems = result.toArray(new Item[result.size()]);
+                this.recentSubmissionItems = result;
             }
         }
         catch (BrowseException bex)

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/opensearch/DiscoveryOpenSearchGenerator.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/opensearch/DiscoveryOpenSearchGenerator.java
@@ -7,30 +7,22 @@
  */
 package org.dspace.app.xmlui.opensearch;
 
-import java.io.IOException;
-import java.sql.SQLException;
-import java.util.Map;
-
-import org.apache.avalon.excalibur.pool.Recyclable;
-import org.apache.avalon.framework.parameters.Parameters;
-import org.apache.cocoon.ProcessingException;
-import org.apache.cocoon.caching.CacheableProcessingComponent;
-import org.apache.cocoon.environment.ObjectModelHelper;
-import org.apache.cocoon.environment.Request;
-import org.apache.cocoon.environment.SourceResolver;
-import org.apache.cocoon.xml.dom.DOMStreamer;
-import org.dspace.app.xmlui.utils.ContextUtil;
-import org.dspace.app.xmlui.utils.FeedUtils;
-import org.dspace.content.DSpaceObject;
+import java.io.*;
+import java.sql.*;
+import java.util.*;
+import org.apache.avalon.excalibur.pool.*;
+import org.apache.avalon.framework.parameters.*;
+import org.apache.cocoon.*;
+import org.apache.cocoon.caching.*;
+import org.apache.cocoon.environment.*;
+import org.apache.cocoon.xml.dom.*;
+import org.dspace.app.xmlui.utils.*;
+import org.dspace.content.*;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.discovery.DiscoverQuery;
-import org.dspace.discovery.DiscoverResult;
-import org.dspace.discovery.SearchService;
-import org.dspace.discovery.SearchServiceException;
-import org.dspace.discovery.SearchUtils;
-import org.dspace.sort.SortOption;
-import org.xml.sax.SAXException;
+import org.dspace.discovery.*;
+import org.dspace.sort.*;
+import org.xml.sax.*;
 
 
 /**
@@ -115,8 +107,7 @@ public class DiscoveryOpenSearchGenerator extends AbstractOpenSearchGenerator
                     queryResults = SearchUtils.getSearchService().search(context, scope, queryArgs);
 
 	            // creates the results array and generates the OpenSearch result
-	            DSpaceObject[] results = new DSpaceObject[queryResults.getDspaceObjects().size()];
-	            queryResults.getDspaceObjects().toArray(results);
+	            List<DSpaceObject> results = queryResults.getDspaceObjects();
 	            
 	            resultsDoc = openSearchService.getResultsDoc(context, format, query, (int) queryResults.getTotalSearchResults(), start, rpp, scope, results, FeedUtils.i18nLabels);
                 FeedUtils.unmangleI18N(resultsDoc);


### PR DESCRIPTION
Updated DSpaceFeedGenerator to use the right method to get items. 
Also replaced some arrays with lists to prevent the need to turn the List returned by the new method into an array. 

jira ticket: https://jira.duraspace.org/browse/DS-3175
