### PR TITLE
DS-3162 all existing export displayed in every user home page

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
@@ -808,7 +808,7 @@ public class ItemExportServiceImpl implements ItemExportService
                     "A dspace.cfg entry for 'org.dspace.app.itemexport.download.dir' does not exist.");
         }
         File result = new File(downloadDir + System.getProperty("file.separator") + ePerson.getID());
-        if(!result.exists())
+        if(!result.exists() && ePerson.getLegacyId()!=null)
         {
             //Check for the old identifier
             result = new File(downloadDir + System.getProperty("file.separator") + ePerson.getLegacyId());


### PR DESCRIPTION
exports were stored in folder 'null' if the user did not have a legacy id, and no previous export folder existed for the user. 

all exports in this 'null' folder were visible for users that did not have a legacy id and did not have exports of their own. 

jira ticket:
https://jira.duraspace.org/browse/DS-3162?jql=status%20%3D%20%22Volunteer%20Needed%22%20AND%20labels%20%3D%20testathon
