### PR TITLE
DS-3140 METSRightsCrosswalk NPE During AIP Restore - No Anonymous Read

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/METSRightsCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/METSRightsCrosswalk.java
@@ -500,7 +500,7 @@ public class METSRightsCrosswalk
                     if(ANONYMOUS_CONTEXTCLASS.equals(contextClass))
                     {
                         //get DSpace Anonymous group, ID=0
-                        Group anonGroup = groupService.findByName(context, Group.ANONYMOUS);;
+                        Group anonGroup = groupService.findByName(context, Group.ANONYMOUS);
                         if(anonGroup==null)
                         {
                             throw new CrosswalkInternalException("The DSpace database has not been properly initialized.  The Anonymous Group is missing from the database.");
@@ -511,7 +511,7 @@ public class METSRightsCrosswalk
                     else if(ADMIN_CONTEXTCLASS.equals(contextClass))
                     {
                         //get DSpace Administrator group, ID=1
-                        Group adminGroup = groupService.findByName(context, Group.ADMIN);;
+                        Group adminGroup = groupService.findByName(context, Group.ADMIN);
                         if(adminGroup==null)
                         {
                             throw new CrosswalkInternalException("The DSpace database has not been properly initialized.  The Administrator Group is missing from the database.");

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/METSRightsCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/METSRightsCrosswalk.java
@@ -472,134 +472,135 @@ public class METSRightsCrosswalk
                 //get what class of context this is
                 String contextClass = element.getAttributeValue("CONTEXTCLASS");
                 
+                ResourcePolicy rp = resourcePolicyService.create(context);
+        		SimpleDateFormat sdf = new SimpleDateFormat( "yyyy-MM-dd" );
+        		
+        		// get reference to the <Permissions> element
+        		// Note: we are assuming here that there will only ever be ONE <Permissions>
+        		//  element. Currently there are no known use cases for multiple.
+                Element permsElement = element.getChild("Permissions", METSRights_NS);
+                if(permsElement == null) {
+                	log.error("No <Permissions> element was found. Skipping this <Context> element.");
+                	continue;
+                }
+                
+                if (element.getAttributeValue("rpName") != null)
+                {
+                    rp.setRpName(element.getAttributeValue("rpName"));
+                }
                 try {
-                	ResourcePolicy rp = resourcePolicyService.create(context);
-            		SimpleDateFormat sdf = new SimpleDateFormat( "yyyy-MM-dd" );
-            		
-            		// get reference to the <Permissions> element
-            		// Note: we are assuming here that there will only ever be ONE <Permissions>
-            		//  element. Currently there are no known use cases for multiple.
-                    Element permsElement = element.getChild("Permissions", METSRights_NS);
-                    
-                    if (element.getAttributeValue("rpName") != null)
+                    if (element.getAttributeValue("start-date") != null)
                     {
-                        rp.setRpName(element.getAttributeValue("rpName"));
+                        rp.setStartDate(sdf.parse(element.getAttributeValue("start-date")));
                     }
-                    try {
-                        if (element.getAttributeValue("start-date") != null)
-                        {
-                            rp.setStartDate(sdf.parse(element.getAttributeValue("start-date")));
-                        }
-                        if (element.getAttributeValue("end-date") != null)
-                        {
-                        	rp.setEndDate(sdf.parse(element.getAttributeValue("end-date")));
-                        }
-                    }catch (ParseException ex) {
-                        java.util.logging.Logger.getLogger(METSRightsCrosswalk.class.getName()).log(Level.SEVERE, null, ex);
+                    if (element.getAttributeValue("end-date") != null)
+                    {
+                    	rp.setEndDate(sdf.parse(element.getAttributeValue("end-date")));
                     }
-                    
-                    //Check if this permission pertains to Anonymous users
-                    if(ANONYMOUS_CONTEXTCLASS.equals(contextClass))
+                }catch (ParseException ex) {
+                    log.error("Failed to parse embargo date. The date needs to be in the format 'yyyy-MM-dd'.", ex);
+                }
+                
+                //Check if this permission pertains to Anonymous users
+                if(ANONYMOUS_CONTEXTCLASS.equals(contextClass))
+                {
+                    //get DSpace Anonymous group, ID=0
+                    Group anonGroup = groupService.findByName(context, Group.ANONYMOUS);
+                    if(anonGroup==null)
                     {
-                        //get DSpace Anonymous group, ID=0
-                        Group anonGroup = groupService.findByName(context, Group.ANONYMOUS);
-                        if(anonGroup==null)
-                        {
-                            throw new CrosswalkInternalException("The DSpace database has not been properly initialized.  The Anonymous Group is missing from the database.");
-                        }
+                        throw new CrosswalkInternalException("The DSpace database has not been properly initialized.  The Anonymous Group is missing from the database.");
+                    }
 
-                        rp.setGroup(anonGroup);
-                    } // else if this permission declaration pertains to Administrators
-                    else if(ADMIN_CONTEXTCLASS.equals(contextClass))
+                    rp.setGroup(anonGroup);
+                } // else if this permission declaration pertains to Administrators
+                else if(ADMIN_CONTEXTCLASS.equals(contextClass))
+                {
+                    //get DSpace Administrator group, ID=1
+                    Group adminGroup = groupService.findByName(context, Group.ADMIN);
+                    if(adminGroup==null)
                     {
-                        //get DSpace Administrator group, ID=1
-                        Group adminGroup = groupService.findByName(context, Group.ADMIN);
-                        if(adminGroup==null)
-                        {
-                            throw new CrosswalkInternalException("The DSpace database has not been properly initialized.  The Administrator Group is missing from the database.");
-                        }
+                        throw new CrosswalkInternalException("The DSpace database has not been properly initialized.  The Administrator Group is missing from the database.");
+                    }
 
-                        rp.setGroup(adminGroup);
-                    } // else if this permission pertains to another DSpace group
-                    else if(GROUP_CONTEXTCLASS.equals(contextClass))
+                    rp.setGroup(adminGroup);
+                } // else if this permission pertains to another DSpace group
+                else if(GROUP_CONTEXTCLASS.equals(contextClass))
+                {
+                    try
                     {
-                        try
+                        //we need to find the name of DSpace group it pertains to
+                        //Get the text within the <UserName> child element,
+                        // this is the group's name
+                        String groupName = element.getChildTextTrim("UserName", METSRights_NS);
+
+                        //Translate Group name back to internal ID format (e.g. COLLECTION_<ID>_ADMIN)
+                        // from its external format (e.g. COLLECTION_<handle>_ADMIN)
+                        groupName = PackageUtils.translateGroupNameForImport(context, groupName);
+
+                        //Check if this group exists in DSpace already
+                        Group group = groupService.findByName(context, groupName);
+
+                        //if not found, throw an error -- user should restore group from the SITE AIP
+                        if(group==null)
                         {
-                            //we need to find the name of DSpace group it pertains to
-                            //Get the text within the <UserName> child element,
-                            // this is the group's name
-                            String groupName = element.getChildTextTrim("UserName", METSRights_NS);
-
-                            //Translate Group name back to internal ID format (e.g. COLLECTION_<ID>_ADMIN)
-                            // from its external format (e.g. COLLECTION_<handle>_ADMIN)
-                            groupName = PackageUtils.translateGroupNameForImport(context, groupName);
-
-                            //Check if this group exists in DSpace already
-                            Group group = groupService.findByName(context, groupName);
-
-                            //if not found, throw an error -- user should restore group from the SITE AIP
-                            if(group==null)
-                            {
-                                throw new CrosswalkInternalException("Cannot restore Group permissions on object ("
-                                        + "type=" + Constants.typeText[dso.getType()] + ", "
-                                        + "handle=" + dso.getHandle() + ", "
-                                        + "ID=" + dso.getID()
-                                        + "). The Group named '" + groupName + "' is missing from DSpace. "
-                                        + "Please restore this group using the SITE AIP, or recreate it.");
-                            }
-
-                            //assign group to policy
-                            rp.setGroup(group);
-                        }
-                        catch(PackageException pe)
-                        {
-                            //A PackageException will only be thrown if translateDefaultGroupName() fails
-                            //We'll just wrap it as a CrosswalkException and throw it upwards
-                            throw new CrosswalkException(pe);
-                        }
-                    }// else if this permission pertains to a DSpace person
-                    else if(PERSON_CONTEXTCLASS.equals(contextClass))
-                    {
-                        //we need to find the person it pertains to
-                        // Get the text within the <UserName> child element,
-                        // this is the person's email address
-                        String personEmail = element.getChildTextTrim("UserName", METSRights_NS);
-
-                        //Check if this person exists in DSpace already
-                        EPerson person = ePersonService.findByEmail(context, personEmail);
-
-                        //If cannot find by email, try by netID
-                        //(though METSRights should contain email if it was exported by DSpace)
-                        if(person==null)
-                        {
-                            person = ePersonService.findByNetid(context, personEmail);
-                        }
-
-                        //if not found, throw an error -- user should restore person from the SITE AIP
-                        if(person==null)
-                        {
-                            throw new CrosswalkInternalException("Cannot restore Person permissions on object ("
+                            throw new CrosswalkInternalException("Cannot restore Group permissions on object ("
                                     + "type=" + Constants.typeText[dso.getType()] + ", "
                                     + "handle=" + dso.getHandle() + ", "
                                     + "ID=" + dso.getID()
-                                    + "). The Person with email/netid '" + personEmail + "' is missing from DSpace. "
-                                    + "Please restore this Person object using the SITE AIP, or recreate it.");
+                                    + "). The Group named '" + groupName + "' is missing from DSpace. "
+                                    + "Please restore this group using the SITE AIP, or recreate it.");
                         }
 
-                        //assign person to the policy
-                        rp.setEPerson(person);
-                    }//end if Person
-                    else {
-                        log.error("Unrecognized CONTEXTCLASS:  " + contextClass);
+                        //assign group to policy
+                        rp.setGroup(group);
                     }
-                    
-                    //set permissions on policy and add to object
-                    rp.setAction(parsePermissions(permsElement));
-                	policies.add(rp);
-                	assignPermissions(context, dso, policies);
-                } catch (NullPointerException ex) {
-                    java.util.logging.Logger.getLogger(METSRightsCrosswalk.class.getName()).log(Level.SEVERE, null, ex);
+                    catch(PackageException pe)
+                    {
+                        //A PackageException will only be thrown if translateDefaultGroupName() fails
+                        //We'll just wrap it as a CrosswalkException and throw it upwards
+                        throw new CrosswalkException(pe);
+                    }
+                }// else if this permission pertains to a DSpace person
+                else if(PERSON_CONTEXTCLASS.equals(contextClass))
+                {
+                    //we need to find the person it pertains to
+                    // Get the text within the <UserName> child element,
+                    // this is the person's email address
+                    String personEmail = element.getChildTextTrim("UserName", METSRights_NS);
+
+                    //Check if this person exists in DSpace already
+                    EPerson person = ePersonService.findByEmail(context, personEmail);
+
+                    //If cannot find by email, try by netID
+                    //(though METSRights should contain email if it was exported by DSpace)
+                    if(person==null)
+                    {
+                        person = ePersonService.findByNetid(context, personEmail);
+                    }
+
+                    //if not found, throw an error -- user should restore person from the SITE AIP
+                    if(person==null)
+                    {
+                        throw new CrosswalkInternalException("Cannot restore Person permissions on object ("
+                                + "type=" + Constants.typeText[dso.getType()] + ", "
+                                + "handle=" + dso.getHandle() + ", "
+                                + "ID=" + dso.getID()
+                                + "). The Person with email/netid '" + personEmail + "' is missing from DSpace. "
+                                + "Please restore this Person object using the SITE AIP, or recreate it.");
+                    }
+
+                    //assign person to the policy
+                    rp.setEPerson(person);
+                }//end if Person
+                else {
+                    log.error("Unrecognized CONTEXTCLASS:  " + contextClass);
                 }
+                
+                //set permissions on policy and add to object
+                rp.setAction(parsePermissions(permsElement));
+            	policies.add(rp);
+            	assignPermissions(context, dso, policies);
+                
             } //end if "Context" element
         }//end while loop
     }

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/METSRightsCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/METSRightsCrosswalk.java
@@ -476,7 +476,9 @@ public class METSRightsCrosswalk
                 	ResourcePolicy rp = resourcePolicyService.create(context);
             		SimpleDateFormat sdf = new SimpleDateFormat( "yyyy-MM-dd" );
             		
-            		//also get reference to the <Permissions> element
+            		// get reference to the <Permissions> element
+            		// Note: we are assuming here that there will only ever be ONE <Permissions>
+            		//  element. Currently there are no known use cases for multiple.
                     Element permsElement = element.getChild("Permissions", METSRights_NS);
                     
                     if (element.getAttributeValue("rpName") != null)


### PR DESCRIPTION
Consolidation/refactoring of the METSRightsCrosswalk ingest() method logic to address NPEs
and incorrect behavior when importing certain objects (e.g. a collection
with an rpName and association to a non-Admin/non-Anonymous group).

Ticket: https://jira.duraspace.org/browse/DS-3140
