### PR TITLE
DS-3209 AIP Import: Extend accepted handles for supports()

### DIFF
--- a/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
@@ -67,14 +67,14 @@ public class HandleIdentifierProvider extends IdentifierProvider {
         {
             return true;
         }
-        // return true if base prefix matches in case of multi-instance deployment with derived prefixes demarcated by a dot "." 
-        if(prefix.contains(".")) {
-            String[] splitPrefix = prefix.split("\\.");
-            if(splitPrefix.length > 1 && identifier.startsWith(splitPrefix[0])) {
+        
+        //Check additional prefixes supported in the config file
+        String[] additionalPrefixes = DSpaceServicesFactory.getInstance().getConfigurationService().getArrayProperty("handle.additional.prefixes");
+        for(String additionalPrefix: additionalPrefixes) {
+            if (identifier.startsWith(additionalPrefix)) {
                 return true;
             }
         }
-        // otherwise, assume invalid handle
         return false;
     }
 

--- a/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
@@ -51,14 +51,14 @@ public class HandleIdentifierProvider extends IdentifierProvider {
     @Override
     public boolean supports(String identifier)
     {
-    	String prefix = handleService.getPrefix();
+        String prefix = handleService.getPrefix();
         String canonicalPrefix = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("handle.canonical.prefix");
         if (identifier == null)
         {
             return false;
         }
         // return true if handle has valid starting pattern
-        if (identifier.startsWith(prefix)
+        if (identifier.startsWith(prefix + "/")
                 || identifier.startsWith(canonicalPrefix)
                 || identifier.startsWith("hdl:")
                 || identifier.startsWith("info:hdl")
@@ -71,10 +71,11 @@ public class HandleIdentifierProvider extends IdentifierProvider {
         //Check additional prefixes supported in the config file
         String[] additionalPrefixes = DSpaceServicesFactory.getInstance().getConfigurationService().getArrayProperty("handle.additional.prefixes");
         for(String additionalPrefix: additionalPrefixes) {
-            if (identifier.startsWith(additionalPrefix)) {
+            if (identifier.startsWith(additionalPrefix + "/")) {
                 return true;
             }
         }
+
         return false;
     }
 

--- a/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
@@ -62,19 +62,20 @@ public class HandleIdentifierProvider extends IdentifierProvider {
                 || identifier.startsWith(canonicalPrefix)
                 || identifier.startsWith("hdl:")
                 || identifier.startsWith("info:hdl")
-                || identifier.matches("^https?://hdl.handle.net/")
-                || identifier.matches("^https?://.+/handle/"))
+                || identifier.matches("^https?://hdl\\.handle\\.net/.*")
+                || identifier.matches("^https?://.+/handle/.*"))
         {
             return true;
         }
-        // return false if identifier starts with DOI prefix
-        if(identifier.startsWith("10.") || identifier.matches("^https?://dx.doi.org") || identifier.startsWith("doi:"))
-        	return false;
-        // return false if identifier does not contain a '/' or is a URL that does not match above patterns 
-        if(! identifier.contains("/") || identifier.matches("^https?://.+"))
-        	return false;
-        // otherwise, assumed a valid handle
-        return true;
+        // return true if base prefix matches in case of multi-instance deployment with derived prefixes demarcated by a dot "." 
+        if(prefix.contains(".")) {
+            String[] splitPrefix = prefix.split("\\.");
+            if(splitPrefix.length > 1 && identifier.startsWith(splitPrefix[0])) {
+                return true;
+            }
+        }
+        // otherwise, assume invalid handle
+        return false;
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
@@ -78,7 +78,7 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
             return false;
         }
         // return true if handle has valid starting pattern
-        if (identifier.startsWith(prefix)
+        if (identifier.startsWith(prefix + "/")
                 || identifier.startsWith(canonicalPrefix)
                 || identifier.startsWith("hdl:")
                 || identifier.startsWith("info:hdl")
@@ -87,13 +87,15 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
         {
             return true;
         }
-        // return true if base prefix matches in case of multi-instance deployment with derived prefixes demarcated by a dot "." 
-        if(prefix.contains(".")) {
-            String[] splitPrefix = prefix.split("\\.");
-            if(splitPrefix.length > 1 && identifier.startsWith(splitPrefix[0])) {
+
+        //Check additional prefixes supported in the config file
+        String[] additionalPrefixes = DSpaceServicesFactory.getInstance().getConfigurationService().getArrayProperty("handle.additional.prefixes");
+        for(String additionalPrefix: additionalPrefixes) {
+            if (identifier.startsWith(additionalPrefix + "/")) {
                 return true;
             }
         }
+
         // otherwise, assume invalid handle
         return false;
     }

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
@@ -82,19 +82,20 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
                 || identifier.startsWith(canonicalPrefix)
                 || identifier.startsWith("hdl:")
                 || identifier.startsWith("info:hdl")
-                || identifier.matches("^https?://hdl.handle.net/")
-                || identifier.matches("^https?://.+/handle/"))
+                || identifier.matches("^https?://hdl\\.handle\\.net/.*")
+                || identifier.matches("^https?://.+/handle/.*"))
         {
             return true;
         }
-        // return false if identifier starts with DOI prefix
-        if(identifier.startsWith("10.") || identifier.matches("^https?://dx.doi.org") || identifier.startsWith("doi:"))
-        	return false;
-        // return false if identifier does not contain a '/' or is a URL that does not match above patterns 
-        if(! identifier.contains("/") || identifier.matches("^https?://.+"))
-        	return false;
-        // otherwise, assumed a valid handle
-        return true;
+        // return true if base prefix matches in case of multi-instance deployment with derived prefixes demarcated by a dot "." 
+        if(prefix.contains(".")) {
+            String[] splitPrefix = prefix.split("\\.");
+            if(splitPrefix.length > 1 && identifier.startsWith(splitPrefix[0])) {
+                return true;
+            }
+        }
+        // otherwise, assume invalid handle
+        return false;
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
@@ -85,6 +85,16 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
             return true;
         }
         
+        try {
+            String outOfUrl = retrieveHandleOutOfUrl(identifier);
+            if(outOfUrl != null)
+                {
+                    return true;
+                }
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
+        }
+        
         return false;
     }
 

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
@@ -16,6 +16,7 @@ import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.LogManager;
 import org.dspace.handle.service.HandleService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.versioning.*;
 import org.dspace.versioning.service.VersionHistoryService;
 import org.dspace.versioning.service.VersioningService;
@@ -70,32 +71,30 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
     @Override
     public boolean supports(String identifier)
     {
-        String prefix = handleService.getPrefix();
-        String handleResolver = ConfigurationManager.getProperty("handle.canonical.prefix");
+    	String prefix = handleService.getPrefix();
+        String canonicalPrefix = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("handle.canonical.prefix");
         if (identifier == null)
         {
             return false;
         }
+        // return true if handle has valid starting pattern
         if (identifier.startsWith(prefix)
-                || identifier.startsWith(handleResolver)
-                || identifier.startsWith("http://hdl.handle.net/")
+                || identifier.startsWith(canonicalPrefix)
                 || identifier.startsWith("hdl:")
-                || identifier.startsWith("info:hdl"))
+                || identifier.startsWith("info:hdl")
+                || identifier.matches("^https?://hdl.handle.net/")
+                || identifier.matches("^https?://.+/handle/"))
         {
             return true;
         }
-        
-        try {
-            String outOfUrl = retrieveHandleOutOfUrl(identifier);
-            if(outOfUrl != null)
-                {
-                    return true;
-                }
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-        }
-        
-        return false;
+        // return false if identifier starts with DOI prefix
+        if(identifier.startsWith("10.") || identifier.matches("^https?://dx.doi.org") || identifier.startsWith("doi:"))
+        	return false;
+        // return false if identifier does not contain a '/' or is a URL that does not match above patterns 
+        if(! identifier.contains("/") || identifier.matches("^https?://.+"))
+        	return false;
+        // otherwise, assumed a valid handle
+        return true;
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
@@ -16,6 +16,7 @@ import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.LogManager;
 import org.dspace.handle.service.HandleService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.versioning.*;
 import org.dspace.versioning.service.VersionHistoryService;
 import org.dspace.versioning.service.VersioningService;
@@ -66,22 +67,30 @@ public class VersionedHandleIdentifierProviderWithCanonicalHandles extends Ident
     @Override
     public boolean supports(String identifier)
     {
-        String prefix = handleService.getPrefix();
-        String handleResolver = ConfigurationManager.getProperty("handle.canonical.prefix");
+    	String prefix = handleService.getPrefix();
+        String canonicalPrefix = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("handle.canonical.prefix");
         if (identifier == null)
         {
             return false;
         }
+        // return true if handle has valid starting pattern
         if (identifier.startsWith(prefix)
-                || identifier.startsWith(handleResolver)
-                || identifier.startsWith("http://hdl.handle.net/")
+                || identifier.startsWith(canonicalPrefix)
                 || identifier.startsWith("hdl:")
-                || identifier.startsWith("info:hdl"))
+                || identifier.startsWith("info:hdl")
+                || identifier.matches("^https?://hdl.handle.net/")
+                || identifier.matches("^https?://.+/handle/"))
         {
             return true;
         }
-        
-        return false;
+        // return false if identifier starts with DOI prefix
+        if(identifier.startsWith("10.") || identifier.matches("^https?://dx.doi.org") || identifier.startsWith("doi:"))
+        	return false;
+        // return false if identifier does not contain a '/' or is a URL that does not match above patterns 
+        if(! identifier.contains("/") || identifier.matches("^https?://.+"))
+        	return false;
+        // otherwise, assumed a valid handle
+        return true;
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
@@ -74,7 +74,7 @@ public class VersionedHandleIdentifierProviderWithCanonicalHandles extends Ident
             return false;
         }
         // return true if handle has valid starting pattern
-        if (identifier.startsWith(prefix)
+        if (identifier.startsWith(prefix + "/")
                 || identifier.startsWith(canonicalPrefix)
                 || identifier.startsWith("hdl:")
                 || identifier.startsWith("info:hdl")
@@ -83,13 +83,15 @@ public class VersionedHandleIdentifierProviderWithCanonicalHandles extends Ident
         {
             return true;
         }
-        // return true if base prefix matches in case of multi-instance deployment with derived prefixes demarcated by a dot "." 
-        if(prefix.contains(".")) {
-            String[] splitPrefix = prefix.split("\\.");
-            if(splitPrefix.length > 1 && identifier.startsWith(splitPrefix[0])) {
+
+        //Check additional prefixes supported in the config file
+        String[] additionalPrefixes = DSpaceServicesFactory.getInstance().getConfigurationService().getArrayProperty("handle.additional.prefixes");
+        for(String additionalPrefix: additionalPrefixes) {
+            if (identifier.startsWith(additionalPrefix + "/")) {
                 return true;
             }
         }
+
         // otherwise, assume invalid handle
         return false;
     }

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
@@ -78,19 +78,20 @@ public class VersionedHandleIdentifierProviderWithCanonicalHandles extends Ident
                 || identifier.startsWith(canonicalPrefix)
                 || identifier.startsWith("hdl:")
                 || identifier.startsWith("info:hdl")
-                || identifier.matches("^https?://hdl.handle.net/")
-                || identifier.matches("^https?://.+/handle/"))
+                || identifier.matches("^https?://hdl\\.handle\\.net/.*")
+                || identifier.matches("^https?://.+/handle/.*"))
         {
             return true;
         }
-        // return false if identifier starts with DOI prefix
-        if(identifier.startsWith("10.") || identifier.matches("^https?://dx.doi.org") || identifier.startsWith("doi:"))
-        	return false;
-        // return false if identifier does not contain a '/' or is a URL that does not match above patterns 
-        if(! identifier.contains("/") || identifier.matches("^https?://.+"))
-        	return false;
-        // otherwise, assumed a valid handle
-        return true;
+        // return true if base prefix matches in case of multi-instance deployment with derived prefixes demarcated by a dot "." 
+        if(prefix.contains(".")) {
+            String[] splitPrefix = prefix.split("\\.");
+            if(splitPrefix.length > 1 && identifier.startsWith(splitPrefix[0])) {
+                return true;
+            }
+        }
+        // otherwise, assume invalid handle
+        return false;
     }
 
     @Override

--- a/dspace-api/src/test/java/org/dspace/identifier/HandleIdentifierProviderTest.java
+++ b/dspace-api/src/test/java/org/dspace/identifier/HandleIdentifierProviderTest.java
@@ -1,0 +1,348 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.identifier;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+import org.dspace.AbstractDSpaceTest;
+import org.dspace.kernel.ServiceManager;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.beans.factory.support.GenericBeanDefinition;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test the HandleIdentifierProvider.
+ *
+ * @author mwood
+ */
+public class HandleIdentifierProviderTest
+        extends AbstractDSpaceTest
+{
+    /** A name for our testing bean definition. */
+    private static final String BEAN_NAME = "test-HandleIdentifierProvider";
+
+    /** DSpace service manager. */
+    private static ServiceManager serviceManager;
+
+    /** Spring application context. */
+    private static GenericApplicationContext applicationContext;
+
+    public HandleIdentifierProviderTest()
+    {
+    }
+
+    @BeforeClass
+    public static void setUpClass()
+    {
+        serviceManager = kernelImpl.getServiceManager();
+
+        // We need to define a Bean for the System Under Test so that we can
+        // get Spring to do autowiring on it.  There are several conflicting
+        // definitions of Handle provider beans, so to test them all we'd have
+        // to reconfigure between tests.  Instead, create a new definition just
+        // for testing so that we know we have the one that we want.
+        applicationContext
+                = (GenericApplicationContext) serviceManager.getServiceByName(
+                        ApplicationContext.class.getName(),
+                        ApplicationContext.class);
+        GenericBeanDefinition bd = new GenericBeanDefinition();
+        bd.setBeanClass(HandleIdentifierProvider.class);
+        applicationContext.registerBeanDefinition(BEAN_NAME, bd); // Now our SUT is a Bean.
+    }
+
+    @AfterClass
+    public static void tearDownClass()
+    {
+        // Clean up dynamic bean definitions from setup.
+        applicationContext.removeBeanDefinition(BEAN_NAME);
+    }
+
+    @Before
+    public void setUp()
+    {
+    }
+
+    @After
+    public void tearDown()
+    {
+    }
+
+    /**
+     * Test of supports(Class) method, of class HandleIdentifierProvider.
+     */
+/*
+    @Test
+    public void testSupports_Class()
+    {
+        System.out.println("supports(Class)");
+        Class<? extends Identifier> identifier = null;
+        HandleIdentifierProvider instance = new HandleIdentifierProvider();
+        boolean expResult = false;
+        boolean result = instance.supports(identifier);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of supports(String) method, of class HandleIdentifierProvider.
+     * Read a property list of identifiers and ask an instance of the provider
+     * whether it supports them.  Properties are "identifier = true/false",
+     * where the value indicates whether the identifier should be supported.
+     * The list is a .properties on the class path.
+     */
+    @Test
+    public void testSupports_String()
+    {
+        System.out.println("supports(String)");
+
+        // We have to get Spring to instantiate the provider as a Bean, because
+        // the bean class has autowired fields.
+        HandleIdentifierProvider instance   // Make one to test.
+                = applicationContext.getBean(BEAN_NAME, HandleIdentifierProvider.class);
+
+        // Load the test cases
+        Properties forms = new Properties();
+        try {
+            forms.load(this.getClass().getResourceAsStream("handle-forms.properties"));
+        } catch (IOException e) {
+            System.err.format("Could not load handle-forms.properties:  %s%n", e.getMessage());
+            return;
+        }
+
+        // Test each case
+        for (Map.Entry<Object, Object> entry : forms.entrySet())
+        {
+            String identifier = (String)entry.getKey();
+            boolean expResult = Boolean.parseBoolean((String)entry.getValue());
+            boolean result = instance.supports(identifier);
+            String message = expResult ?
+                    "This provider should support " + identifier :
+                    "This provider should not support " + identifier;
+            assertEquals(message, expResult, result);
+        }
+    }
+
+    /**
+     * Test of register method, of class HandleIdentifierProvider.
+     */
+/*
+    @Test
+    public void testRegister_Context_DSpaceObject()
+    {
+        System.out.println("register");
+        Context context = null;
+        DSpaceObject dso = null;
+        HandleIdentifierProvider instance = new HandleIdentifierProvider();
+        String expResult = "";
+        String result = instance.register(context, dso);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of register method, of class HandleIdentifierProvider.
+     */
+/*
+    @Test
+    public void testRegister_3args()
+    {
+        System.out.println("register");
+        Context context = null;
+        DSpaceObject dso = null;
+        String identifier = "";
+        HandleIdentifierProvider instance = new HandleIdentifierProvider();
+        instance.register(context, dso, identifier);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of reserve method, of class HandleIdentifierProvider.
+     */
+/*
+    @Test
+    public void testReserve()
+    {
+        System.out.println("reserve");
+        Context context = null;
+        DSpaceObject dso = null;
+        String identifier = "";
+        HandleIdentifierProvider instance = new HandleIdentifierProvider();
+        instance.reserve(context, dso, identifier);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of mint method, of class HandleIdentifierProvider.
+     */
+/*
+    @Test
+    public void testMint()
+    {
+        System.out.println("mint");
+        Context context = null;
+        DSpaceObject dso = null;
+        HandleIdentifierProvider instance = new HandleIdentifierProvider();
+        String expResult = "";
+        String result = instance.mint(context, dso);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of resolve method, of class HandleIdentifierProvider.
+     */
+/*
+    @Test
+    public void testResolve()
+    {
+        System.out.println("resolve");
+        Context context = null;
+        String identifier = "";
+        String[] attributes = null;
+        HandleIdentifierProvider instance = new HandleIdentifierProvider();
+        DSpaceObject expResult = null;
+        DSpaceObject result = instance.resolve(context, identifier, attributes);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of lookup method, of class HandleIdentifierProvider.
+     * @throws java.lang.Exception passed through.
+     */
+/*
+    @Test
+    public void testLookup()
+            throws Exception
+    {
+        System.out.println("lookup");
+        Context context = null;
+        DSpaceObject dso = null;
+        HandleIdentifierProvider instance = new HandleIdentifierProvider();
+        String expResult = "";
+        String result = instance.lookup(context, dso);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of delete method, of class HandleIdentifierProvider.
+     * @throws java.lang.Exception passed through.
+     */
+/*
+    @Test
+    public void testDelete_3args()
+            throws Exception
+    {
+        System.out.println("delete");
+        Context context = null;
+        DSpaceObject dso = null;
+        String identifier = "";
+        HandleIdentifierProvider instance = new HandleIdentifierProvider();
+        instance.delete(context, dso, identifier);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of delete method, of class HandleIdentifierProvider.
+     * @throws java.lang.Exception passed through.
+     */
+/*
+    @Test
+    public void testDelete_Context_DSpaceObject()
+            throws Exception
+    {
+        System.out.println("delete");
+        Context context = null;
+        DSpaceObject dso = null;
+        HandleIdentifierProvider instance = new HandleIdentifierProvider();
+        instance.delete(context, dso);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of retrieveHandleOutOfUrl method, of class HandleIdentifierProvider.
+     * @throws java.lang.Exception passed through.
+     */
+/*
+    @Test
+    public void testRetrieveHandleOutOfUrl()
+            throws Exception
+    {
+        System.out.println("retrieveHandleOutOfUrl");
+        String url = "";
+        String expResult = "";
+        String result = HandleIdentifierProvider.retrieveHandleOutOfUrl(url);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of getPrefix method, of class HandleIdentifierProvider.
+     */
+/*
+    @Test
+    public void testGetPrefix()
+    {
+        System.out.println("getPrefix");
+        String expResult = "";
+        String result = HandleIdentifierProvider.getPrefix();
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+
+    /**
+     * Test of populateHandleMetadata method, of class HandleIdentifierProvider.
+     * @throws java.lang.Exception passed through.
+     */
+/*
+    @Test
+    public void testPopulateHandleMetadata()
+            throws Exception
+    {
+        System.out.println("populateHandleMetadata");
+        Context context = null;
+        Item item = null;
+        String handle = "";
+        HandleIdentifierProvider instance = new HandleIdentifierProvider();
+        instance.populateHandleMetadata(context, item, handle);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+*/
+}

--- a/dspace-api/src/test/java/org/dspace/identifier/HandleIdentifierProviderTest.java
+++ b/dspace-api/src/test/java/org/dspace/identifier/HandleIdentifierProviderTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Properties;
 import org.dspace.AbstractDSpaceTest;
 import org.dspace.kernel.ServiceManager;
+import org.dspace.services.factory.DSpaceServicesFactory;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -126,6 +127,9 @@ public class HandleIdentifierProviderTest
     {
         System.out.println("supports(String)");
 
+        DSpaceServicesFactory.getInstance().getConfigurationService().setProperty("handle.prefix", "123456789");
+        DSpaceServicesFactory.getInstance().getConfigurationService().setProperty("handle.additional.prefixes", "123456789.1,123456789.2");
+        
         // We have to get Spring to instantiate the provider as a Bean, because
         // the bean class has autowired fields.
         HandleIdentifierProvider instance = new HandleIdentifierProvider();

--- a/dspace-api/src/test/java/org/dspace/identifier/HandleIdentifierProviderTest.java
+++ b/dspace-api/src/test/java/org/dspace/identifier/HandleIdentifierProviderTest.java
@@ -25,6 +25,12 @@ import static org.junit.Assert.*;
 
 /**
  * Test the HandleIdentifierProvider.
+ * <p>
+ * We need to define a Bean for the System Under Test so that we can get Spring
+ * to do autowiring on it.  There are several conflicting definitions of Handle
+ * provider beans in the XML Spring configuration, so to test them all we'd have
+ * to reconfigure between tests.  Instead, create a new definition just for
+ * testing so that we know that we have the one that we want.
  *
  * @author mwood
  */
@@ -33,9 +39,6 @@ public class HandleIdentifierProviderTest
 {
     /** A name for our testing bean definition. */
     private static final String BEAN_NAME = "test-HandleIdentifierProvider";
-
-    /** DSpace service manager. */
-    private static ServiceManager serviceManager;
 
     /** Spring application context. */
     private static GenericApplicationContext applicationContext;
@@ -47,17 +50,14 @@ public class HandleIdentifierProviderTest
     @BeforeClass
     public static void setUpClass()
     {
-        serviceManager = kernelImpl.getServiceManager();
+        ServiceManager serviceManager = kernelImpl.getServiceManager();
 
-        // We need to define a Bean for the System Under Test so that we can
-        // get Spring to do autowiring on it.  There are several conflicting
-        // definitions of Handle provider beans, so to test them all we'd have
-        // to reconfigure between tests.  Instead, create a new definition just
-        // for testing so that we know we have the one that we want.
         applicationContext
                 = (GenericApplicationContext) serviceManager.getServiceByName(
                         ApplicationContext.class.getName(),
                         ApplicationContext.class);
+
+        // Define our special bean for testing the target class.
         GenericBeanDefinition bd = new GenericBeanDefinition();
         bd.setBeanClass(HandleIdentifierProvider.class);
         applicationContext.registerBeanDefinition(BEAN_NAME, bd); // Now our SUT is a Bean.
@@ -101,7 +101,7 @@ public class HandleIdentifierProviderTest
     /**
      * Test of supports(String) method, of class HandleIdentifierProvider.
      * Read a property list of identifiers and ask an instance of the provider
-     * whether it supports them.  Properties are "identifier = true/false",
+     * whether it supports each.  Properties are "identifier = true/false",
      * where the value indicates whether the identifier should be supported.
      * The list is a .properties on the class path.
      */

--- a/dspace-api/src/test/resources/org/dspace/identifier/handle-forms.properties
+++ b/dspace-api/src/test/resources/org/dspace/identifier/handle-forms.properties
@@ -2,4 +2,25 @@
 # identifier be supported by the provider under test?
 
 http://dx.doi.org/10.14279/depositonce-5383 = false
+
+# Note: This next one only succeeds because handle.prefix=123456789 in Test Framework
 123456789/1 = true
+
+# Note: This next one only succeeds because handle.additional.prefixes=123456789.1,123456789.2 in Test 
+123456789.1/1 = true
+123456789.2/1 = true
+123456789.3/1 = false
+
+# Other matches that should succeed
+hdl:123456789/1 = true
+hdl:123.456/1.2 = true
+info:hdl/12345/4000 = true
+http://hdl.handle.net/20.500.1/1.2 = true
+https://hdl.handle.net/987/1 = true
+http://my.dspace.edu/handle/123/456 = true
+https://my.dspace.edu/handle/1.23/45.6 = true
+
+# Other matches that should fail
+http://example.com/ = false
+987654321/1 = false
+12.3456789/1 = false

--- a/dspace-api/src/test/resources/org/dspace/identifier/handle-forms.properties
+++ b/dspace-api/src/test/resources/org/dspace/identifier/handle-forms.properties
@@ -1,5 +1,5 @@
 # Key is the identifier to be tested; value is "true" or "false":  should this
 # identifier be supported by the provider under test?
 
-"http://dx.doi.org/10.14279/depositonce-5383" = false
-"123456789/1" = true
+http://dx.doi.org/10.14279/depositonce-5383 = false
+123456789/1 = true

--- a/dspace-api/src/test/resources/org/dspace/identifier/handle-forms.properties
+++ b/dspace-api/src/test/resources/org/dspace/identifier/handle-forms.properties
@@ -1,0 +1,5 @@
+# Key is the identifier to be tested; value is "true" or "false":  should this
+# identifier be supported by the provider under test?
+
+"http://dx.doi.org/10.14279/depositonce-5383" = false
+"123456789/1" = true


### PR DESCRIPTION
Adds an additional supported handle format to the supports() method of
VersionedHandleIdentifierProvider to make behavior more in-line with the
DS 5.4 code.

https://jira.duraspace.org/browse/DS-3209
