### PR TITLE
DS-3191 CC license is not preserved when creating a version of an item

### DIFF
--- a/dspace-api/src/main/java/org/dspace/submit/step/CCLicenseStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/CCLicenseStep.java
@@ -10,7 +10,7 @@ package org.dspace.submit.step;
 import java.util.Enumeration;
 import java.util.Map;
 import java.util.HashMap;
-
+import org.apache.commons.lang3.*;
 import javax.servlet.http.HttpSession;
 
 import org.apache.log4j.Logger;
@@ -272,7 +272,7 @@ public class CCLicenseStep extends AbstractProcessingStep
     		}
     		return STATUS_COMPLETE;
     	}
-    	else if (licenseclass.equals("xmlui.Submission.submit.CCLicenseStep.select_change"))
+    	else if (StringUtils.isBlank(licenseclass) || licenseclass.equals("xmlui.Submission.submit.CCLicenseStep.select_change"))
     	{
     		removeRequiredAttributes(session);    
     		return STATUS_COMPLETE;


### PR DESCRIPTION
Updated class CCLicenseStep to not remove the license when the next button is clicked in JSPUI.

jira ticket:
https://jira.duraspace.org/browse/DS-3191?jql=labels%20%3D%20testathon
