### PR TITLE
DS-3146 NPE when starting a new JSPUI submission with BTE metadata import enabled

### DIFF
--- a/dspace-api/src/main/java/org/dspace/submit/step/StartSubmissionLookupStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/StartSubmissionLookupStep.java
@@ -120,7 +120,7 @@ public class StartSubmissionLookupStep extends AbstractProcessingStep
             AuthorizeException
     {
         // First we find the collection which was selected
-        UUID id = Util.getUUIDParameter(request, "collection");
+        UUID id = Util.getUUIDParameter(request, "collectionid");
         String titolo = request.getParameter("search_title");
         String date = request.getParameter("search_year");
         String autori = request.getParameter("search_authors");

--- a/dspace-api/src/main/java/org/dspace/submit/step/StartSubmissionLookupStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/StartSubmissionLookupStep.java
@@ -120,7 +120,7 @@ public class StartSubmissionLookupStep extends AbstractProcessingStep
             AuthorizeException
     {
         // First we find the collection which was selected
-        UUID id = Util.getUUIDParameter(request, "collectionid");
+        UUID id = Util.getUUIDParameter(request, "collection");
         String titolo = request.getParameter("search_title");
         String date = request.getParameter("search_year");
         String autori = request.getParameter("search_authors");

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/submit/step/JSPStartSubmissionLookupStep.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/submit/step/JSPStartSubmissionLookupStep.java
@@ -131,15 +131,14 @@ public class JSPStartSubmissionLookupStep extends JSPStep
         collection_id = UIUtil.getUUIDParameter(request, "collection");
     }
 
-        UUID collectionID = null;
-        if(!DEFAULT_COLLECTION_ID.equals(request.getParameter("collectionid"))) {
-            collectionID = UIUtil.getUUIDParameter(request, "collectionid");
+        if(collection_id == null && !DEFAULT_COLLECTION_ID.equals(request.getParameter("collectionid"))) {
+            collection_id = UIUtil.getUUIDParameter(request, "collectionid");
         }
         Collection col = null;
 
-        if (collectionID != null)
+        if (collection_id != null)
         {
-            col = collectionService.find(context, collectionID);
+            col = collectionService.find(context, collection_id);
         }
 
         // if we already have a valid collection, then we can forward directly
@@ -147,7 +146,7 @@ public class JSPStartSubmissionLookupStep extends JSPStep
         if (col != null)
         {
             log.debug("Select Collection page skipped, since a Collection ID was already found.  Collection ID="
-                    + collectionID);
+                    + collection_id);
         }
         else
         {
@@ -178,7 +177,7 @@ public class JSPStartSubmissionLookupStep extends JSPStep
             else {
                 request.setAttribute("collection_id", DEFAULT_COLLECTION_ID);
             }
-            request.setAttribute("collectionID", collectionID);
+            request.setAttribute("collectionID", collection_id);
 
             Map<String, List<String>> identifiers2providers = slService
                     .getProvidersIdentifiersMap();

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/submit/step/JSPStartSubmissionLookupStep.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/submit/step/JSPStartSubmissionLookupStep.java
@@ -79,6 +79,8 @@ public class JSPStartSubmissionLookupStep extends JSPStep
     
 	private CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
 
+    private final String DEFAULT_COLLECTION_ID = "-1";
+
     /**
      * Do any pre-processing to determine which JSP (if any) is used to generate
      * the UI for this step. This method should include the gathering and
@@ -124,8 +126,15 @@ public class JSPStartSubmissionLookupStep extends JSPStep
          * With no parameters, this servlet prepares for display of the Select
          * Collection JSP.
          */
-        UUID collection_id = UIUtil.getUUIDParameter(request, "collection");
-        UUID collectionID = UIUtil.getUUIDParameter(request, "collectionid");
+        UUID collection_id = null;
+        if(!DEFAULT_COLLECTION_ID.equals(request.getParameter("collection"))) {
+        collection_id = UIUtil.getUUIDParameter(request, "collection");
+    }
+
+        UUID collectionID = null;
+        if(!DEFAULT_COLLECTION_ID.equals(request.getParameter("collectionid"))) {
+            collectionID = UIUtil.getUUIDParameter(request, "collectionid");
+        }
         Collection col = null;
 
         if (collectionID != null)
@@ -162,7 +171,13 @@ public class JSPStartSubmissionLookupStep extends JSPStep
 
             // save collections to request for JSP
             request.setAttribute("collections", collections);
-            request.setAttribute("collection_id", collection_id);
+
+            if(collection_id!=null) {
+                request.setAttribute("collection_id", collection_id);
+            }
+            else {
+                request.setAttribute("collection_id", DEFAULT_COLLECTION_ID);
+            }
             request.setAttribute("collectionID", collectionID);
 
             Map<String, List<String>> identifiers2providers = slService

--- a/dspace-jspui/src/main/webapp/submit/start-lookup-submission.jsp
+++ b/dspace-jspui/src/main/webapp/submit/start-lookup-submission.jsp
@@ -23,8 +23,7 @@
 
 <%@ page import="org.dspace.content.Collection" %>
 <%@ page import="java.lang.Boolean" %>
-<%@ page import="java.util.List" %>
-<%@ page import="java.util.Map" %>
+<%@ page import="java.util.*" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core"
     prefix="c" %>
@@ -42,8 +41,18 @@
         (List<Collection>) request.getAttribute("collections");
 
     //get collection id from the collection home
-    String collection_id = (String) request.getAttribute("collection_id");
-    
+	Object collection_id_object = request.getAttribute("collection_id");
+
+	String collection_id;
+
+	if(collection_id_object instanceof UUID){
+		UUID uuid = (UUID) collection_id_object;
+		collection_id = uuid.toString();
+	}
+	else {
+		collection_id = (String) collection_id_object;
+	}
+
     //check if we need to display the "no collection selected" error
     Boolean noCollection = (Boolean) request.getAttribute("no.collection");
     Boolean nosuuid = (Boolean) request.getAttribute("nouuid");


### PR DESCRIPTION
The error occurred because the collection id was null when no collection was selected. Updated class JSPStartSubmissionLookupStep to set the collection id to "-1" instead of null, so that the default value in the collection list is selected. 

jira ticket:
https://jira.duraspace.org/browse/DS-3146
