### PR TITLE
DS-3194 Update port of baseURL for pagination-link creation

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/recentSubmissions/RecentSubmissionTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/recentSubmissions/RecentSubmissionTransformer.java
@@ -181,7 +181,7 @@ public class RecentSubmissionTransformer extends AbstractDSpaceTransformer {
 
     protected String getBaseUrl(DSpaceObject dso) throws SQLException {
         String url = contextPath;
-        if(dso != null && dso.equals(siteService.findSite(context)))
+        if(dso != null && !dso.equals(siteService.findSite(context)))
         {
             url += "/handle/" + dso.getHandle();
         }


### PR DESCRIPTION
Condition had been reversed during the initial refactoring due to the service api
https://github.com/DSpace/DSpace/blob/0292cee4c8a9eee519192b15aff770e291546523/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/recentSubmissions/RecentSubmissionTransformer.java#L182
Was the original check (excluding the addition of "handle/_/_*" for a site object)
