### PR TITLE
DS-3151 Update of non-existant log.dir retrieval property

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/statistics/CreateStatReport.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/CreateStatReport.java
@@ -95,7 +95,7 @@ public class CreateStatReport {
         context.setIgnoreAuthorization(true);
         
         //get paths to directories
-        outputLogDirectory = ConfigurationManager.getProperty("log.dir") + File.separator;
+        outputLogDirectory = ConfigurationManager.getProperty("log.report.dir") + File.separator;
         outputReportDirectory = ConfigurationManager.getProperty("report.dir") + File.separator;
         
         //read in command line variable to determine which statistic to run

--- a/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
@@ -184,8 +184,8 @@ public class LogAnalyser
    ////////////////////////
    
    /** the log directory to be analysed */
-   private static String logDir = ConfigurationManager.getProperty("log.dir");  
-        
+   private static String logDir = ConfigurationManager.getProperty("log.report.dir");
+
    /** the regex to describe the file name format */
    private static String fileTemplate = "dspace\\.log.*";
         
@@ -195,7 +195,7 @@ public class LogAnalyser
                             "dstat.cfg";
    
    /** the output file to which to write aggregation data */
-   private static String outFile = ConfigurationManager.getProperty("log.dir") + File.separator + "dstat.dat";
+   private static String outFile = ConfigurationManager.getProperty("log.report.dir") + File.separator + "dstat.dat";
    
    /** the starting date of the report */
    private static Date startDate = null;
@@ -561,7 +561,7 @@ public class LogAnalyser
         {
             logDir = myLogDir;
         }
-        
+
         if (myFileTemplate != null)
         {
             fileTemplate = myFileTemplate;

--- a/dspace-api/src/main/java/org/dspace/app/statistics/StatisticsLoader.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/StatisticsLoader.java
@@ -348,7 +348,7 @@ public class StatisticsLoader
      */
     private static File[] getAnalysisAndReportFileList()
     {
-        File reportDir = new File(ConfigurationManager.getProperty("log.dir"));
+        File reportDir = new File(ConfigurationManager.getProperty("log.report.dir"));
         if (reportDir != null)
         {
             return reportDir.listFiles(new AnalysisAndReportFilter());

--- a/dspace-api/src/main/java/org/dspace/checker/DailyReportEmailer.java
+++ b/dspace-api/src/main/java/org/dspace/checker/DailyReportEmailer.java
@@ -190,7 +190,7 @@ public class DailyReportEmailer
             int numBitstreams = 0;
 
             // create a temporary file in the log directory
-            String dirLocation = ConfigurationManager.getProperty("log.dir");
+            String dirLocation = ConfigurationManager.getProperty("log.report.dir");
             File directory = new File(dirLocation);
 
             if (directory.exists() && directory.isDirectory())

--- a/dspace-api/src/main/java/org/dspace/health/InfoCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/InfoCheck.java
@@ -7,16 +7,14 @@
  */
 package org.dspace.health;
 
-import java.text.SimpleDateFormat;
 import org.apache.commons.io.FileUtils;
 import org.dspace.core.ConfigurationManager;
-import org.dspace.storage.bitstore.BitstreamStorageServiceImpl;
+import org.dspace.services.ConfigurationService;
 import org.dspace.storage.bitstore.DSBitStoreService;
-import org.dspace.storage.bitstore.factory.StorageServiceFactory;
-import org.dspace.storage.bitstore.service.BitstreamStorageService;
 import org.dspace.utils.DSpace;
 
 import java.io.File;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
 /**
@@ -27,7 +25,8 @@ public class InfoCheck extends Check {
     @Override
     public String run( ReportInfo ri ) {
         StringBuilder sb = new StringBuilder();
-
+        ConfigurationService configurationService
+                = new DSpace().getConfigurationService();
         sb.append("Generated: ").append(
             new Date().toString()
         ).append("\n");
@@ -50,10 +49,10 @@ public class InfoCheck extends Check {
                 localStore.getBaseDir().toString(),
                 "Assetstore size", },
             new String[] {
-                ConfigurationManager.getProperty("search.dir"),
+                    configurationService.getProperty("search.dir"),
                 "Search dir size", },
             new String[] {
-                ConfigurationManager.getProperty("log.dir"),
+                    configurationService.getProperty("log.report.dir"),
                 "Log dir size", }, })
         {
             try {

--- a/dspace-api/src/main/java/org/dspace/usage/TabFileUsageEventListener.java
+++ b/dspace-api/src/main/java/org/dspace/usage/TabFileUsageEventListener.java
@@ -65,7 +65,7 @@ public class TabFileUsageEventListener
         String logDir = null;
         if (!new File(logPath).isAbsolute())
         {
-            logDir = configurationService.getProperty("log.dir");
+            logDir = configurationService.getProperty("log.report.dir");
         }
 
         File logFile = new File(logDir, logPath);

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1561,6 +1561,8 @@ report.public = false
 # directory where live reports are stored
 report.dir = ${dspace.dir}/reports/
 
+# directory where logs are stored
+log.report.dir = ${dspace.dir}/log
 
 
 ###### Web Interface Settings ######


### PR DESCRIPTION
JIRA Ticket
https://jira.duraspace.org/browse/DS-3151

Changed log.dir property in the (retrieval) of the directory to a more meaningful log.report.dir, this being more concise with the log.report property. These 2 being something to read from to see what is happening in the repository.
