### PR TITLE
[DS-3210] NPE viewing Administrative/Statistics on demo.dspace.org

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/statistics/CreateStatReport.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/CreateStatReport.java
@@ -20,7 +20,8 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.PosixParser;
 
 import org.dspace.core.Context;
-import org.dspace.core.ConfigurationManager;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
  * This class allows the running of the DSpace statistic tools
@@ -35,7 +36,11 @@ import org.dspace.core.ConfigurationManager;
 
 public class CreateStatReport {
 
-	/**Current date and time*/
+    /**DSpace configuration*/
+    private static final ConfigurationService configuration
+            = DSpaceServicesFactory.getInstance().getConfigurationService();
+
+    /**Current date and time*/
 	private static Calendar calendar = null;
 	
 	/**Reporting start date and time*/
@@ -53,8 +58,9 @@ public class CreateStatReport {
 	/**User context*/
 	private static Context context;
 
-    /** the config file from which to configure the analyser */
-    private static String configFile = ConfigurationManager.getProperty("dspace.dir") +
+    /** the configuration file from which to configure the analyser */
+    private static final String configFile
+            = configuration.getProperty("dspace.dir") +
                             File.separator + "config" + File.separator +
                             "dstat.cfg";
 
@@ -95,9 +101,10 @@ public class CreateStatReport {
         context.setIgnoreAuthorization(true);
         
         //get paths to directories
-        outputLogDirectory = ConfigurationManager.getProperty("log.dir") + File.separator;
-        outputReportDirectory = ConfigurationManager.getProperty("report.dir") + File.separator;
-        
+        outputLogDirectory = configuration.getProperty("dspace.dir")
+                + File.separator + "log" + File.separator; // FIXME assumption!
+        outputReportDirectory = configuration.getProperty("report.dir") + File.separator;
+
         //read in command line variable to determine which statistic to run
 		CommandLineParser parser = new PosixParser();
 		Options options = new Options();

--- a/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
@@ -8,7 +8,6 @@
 package org.dspace.app.statistics;
 
 import org.apache.commons.lang3.StringUtils;
-import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 import org.dspace.core.LogManager;
 import org.dspace.discovery.DiscoverQuery;
@@ -30,6 +29,8 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
  * This class performs all the actual analysis of a given set of DSpace log
@@ -178,25 +179,32 @@ public class LogAnalyser
    
    /** process timing clock */
    private static Calendar startTime = null;
-   
+
+   /////////////////////////
+   // Needful services
+   /////////////////////////
+   private static final ConfigurationService configuration
+           = DSpaceServicesFactory.getInstance().getConfigurationService();
+
    /////////////////////////
    // command line options
    ////////////////////////
    
    /** the log directory to be analysed */
-   private static String logDir = ConfigurationManager.getProperty("log.dir");  
-        
+   private static String logDir = configuration.getProperty("dspace.dir")
+           + File.separator + "log"; // FIXME assumption!
+
    /** the regex to describe the file name format */
    private static String fileTemplate = "dspace\\.log.*";
         
    /** the config file from which to configure the analyser */
-   private static String configFile = ConfigurationManager.getProperty("dspace.dir") + 
+   private static String configFile = configuration.getProperty("dspace.dir") +
                             File.separator + "config" + File.separator +
                             "dstat.cfg";
    
    /** the output file to which to write aggregation data */
-   private static String outFile = ConfigurationManager.getProperty("log.dir") + File.separator + "dstat.dat";
-   
+   private static String outFile = logDir + File.separator + "dstat.dat";
+
    /** the starting date of the report */
    private static Date startDate = null;
         
@@ -514,9 +522,9 @@ public class LogAnalyser
         }
         
         // now do the host name and url lookup
-        hostName = ConfigurationManager.getProperty("dspace.hostname").trim();
-        name = ConfigurationManager.getProperty("dspace.name").trim();
-        url = ConfigurationManager.getProperty("dspace.url").trim();
+        hostName = configuration.getProperty("dspace.hostname").trim();
+        name = configuration.getProperty("dspace.name").trim();
+        url = configuration.getProperty("dspace.url").trim();
         if ((url != null) && (!url.endsWith("/")))
         {
                 url = url + "/";

--- a/dspace-api/src/main/java/org/dspace/app/statistics/StatisticsLoader.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/StatisticsLoader.java
@@ -7,9 +7,6 @@
  */
 package org.dspace.app.statistics;
 
-import org.apache.commons.lang.time.DateUtils;
-import org.dspace.core.ConfigurationManager;
-
 import java.text.DateFormat;
 import java.util.*;
 import java.util.regex.Pattern;
@@ -18,6 +15,9 @@ import java.io.File;
 import java.io.FilenameFilter;
 import java.text.SimpleDateFormat;
 import java.text.ParseException;
+import org.apache.commons.lang.time.DateUtils;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
  * Helper class for loading the analysis / report files from the reports directory
@@ -231,8 +231,8 @@ public class StatisticsLoader
         }
 
         // Create new maps for the monthly analysis / reports
-        Map<String, StatsFile> newMonthlyAnalysis = new HashMap<String, StatsFile>();
-        Map<String, StatsFile> newMonthlyReports  = new HashMap<String, StatsFile>();
+        Map<String, StatsFile> newMonthlyAnalysis = new HashMap<>();
+        Map<String, StatsFile> newMonthlyReports  = new HashMap<>();
 
         StatsFile newGeneralAnalysis = null;
         StatsFile newGeneralReport = null;
@@ -348,13 +348,12 @@ public class StatisticsLoader
      */
     private static File[] getAnalysisAndReportFileList()
     {
-        File reportDir = new File(ConfigurationManager.getProperty("log.dir"));
-        if (reportDir != null)
-        {
-            return reportDir.listFiles(new AnalysisAndReportFilter());
-        }
-
-        return null;
+        ConfigurationService cfg = DSpaceServicesFactory
+                .getInstance()
+                .getConfigurationService();
+        File dspaceDir = new File(cfg.getProperty("dspace.dir"));
+        File reportDir = new File(dspaceDir, "log"); // FIXME assumption!
+        return reportDir.listFiles(new AnalysisAndReportFilter());
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/checker/DailyReportEmailer.java
+++ b/dspace-api/src/main/java/org/dspace/checker/DailyReportEmailer.java
@@ -190,7 +190,8 @@ public class DailyReportEmailer
             int numBitstreams = 0;
 
             // create a temporary file in the log directory
-            String dirLocation = ConfigurationManager.getProperty("log.dir");
+            String dirLocation = ConfigurationManager.getProperty("dspace.dir")
+                    + File.separator + "log"; // FIXME assumption!
             File directory = new File(dirLocation);
 
             if (directory.exists() && directory.isDirectory())

--- a/dspace-api/src/main/java/org/dspace/health/InfoCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/InfoCheck.java
@@ -10,10 +10,7 @@ package org.dspace.health;
 import java.text.SimpleDateFormat;
 import org.apache.commons.io.FileUtils;
 import org.dspace.core.ConfigurationManager;
-import org.dspace.storage.bitstore.BitstreamStorageServiceImpl;
 import org.dspace.storage.bitstore.DSBitStoreService;
-import org.dspace.storage.bitstore.factory.StorageServiceFactory;
-import org.dspace.storage.bitstore.service.BitstreamStorageService;
 import org.dspace.utils.DSpace;
 
 import java.io.File;
@@ -53,7 +50,7 @@ public class InfoCheck extends Check {
                 ConfigurationManager.getProperty("search.dir"),
                 "Search dir size", },
             new String[] {
-                ConfigurationManager.getProperty("log.dir"),
+                ConfigurationManager.getProperty("dspace.dir") + File.separator + "log", // FIXME assumption!
                 "Log dir size", }, })
         {
             try {

--- a/dspace-api/src/main/java/org/dspace/usage/TabFileUsageEventListener.java
+++ b/dspace-api/src/main/java/org/dspace/usage/TabFileUsageEventListener.java
@@ -23,10 +23,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Serialize {@link UsageEvent} data to a file as Tab delimited. In dspace.cfg
- * specify the path to the file as the value of
+ * Serialize {@link UsageEvent} data to a file as Tab delimited. In
+ * {@code dspace.cfg} specify the path to the file as the value of
  * {@code usageEvent.tabFileLogger.file}.  If that path is not absolute, it
- * will be interpreted as relative to the directory named in {@code log.dir}.
+ * will be interpreted as relative to the directory {@code ${dspace.dir}/log}.
  * If no name is configured, it defaults to "usage-events.tsv".  If the file is
  * new or empty, a column heading record will be written when the file is opened.
  * 
@@ -65,7 +65,8 @@ public class TabFileUsageEventListener
         String logDir = null;
         if (!new File(logPath).isAbsolute())
         {
-            logDir = configurationService.getProperty("log.dir");
+            logDir = configurationService.getProperty("dspace.dir")
+                    + File.separator + "log"; // FIXME assumption!
         }
 
         File logFile = new File(logDir, logPath);


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3210

This removes the last active vestiges of log.dir outside of log4j.
Not yet tested.
