### PR TITLE
DS-2766 /rest/collections/xxx?expand=parentCommunityList only returns 1 parent community

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/Collection.java
+++ b/dspace-api/src/main/java/org/dspace/content/Collection.java
@@ -259,7 +259,7 @@ public class Collection extends DSpaceObject implements DSpaceObjectLegacySuppor
      * Get the communities this collection appears in
      * 
      * See DS-2766 for some documented assumptions about collection parents.
-     * In DSpace6x, the assumption is that a collection exists in only one community/subcommunity.
+     * In DSpace6x, the assumption is that a collection exists in only one community/subcommunity. 
      *
      * @return array of <code>Community</code> objects
      * @throws SQLException if database error

--- a/dspace-api/src/main/java/org/dspace/content/Collection.java
+++ b/dspace-api/src/main/java/org/dspace/content/Collection.java
@@ -257,6 +257,9 @@ public class Collection extends DSpaceObject implements DSpaceObjectLegacySuppor
 
     /**
      * Get the communities this collection appears in
+     * 
+     * See DS-2766 for some documented assumptions about collection parents.
+     * In DSpace6x, the assumption is that a collection exists in only one community/subcommunity.
      *
      * @return array of <code>Community</code> objects
      * @throws SQLException if database error

--- a/dspace-rest/src/main/java/org/dspace/rest/common/Collection.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/common/Collection.java
@@ -72,8 +72,8 @@ public class Collection extends DSpaceObject {
             List<org.dspace.content.Community> parentCommunities = collection.getCommunities();
             for(org.dspace.content.Community parentCommunity : parentCommunities) {
                 this.addParentCommunityList(new Community(parentCommunity, servletContext, null, context));
-                //See DS-2766 for an interpretation of this field.  This code assumes a collection lives in only one community.  
-                //This method will return the community ancestor chain for this collection.
+                //The parentCommunityList is the list of community/subcommunity ancestors for a collection  
+                //Retrieve the set of ancestors for the parentCommunity and append each one to the list
                 for(org.dspace.content.Community ancestor: parentCommunity.getParentCommunities()) {
                     this.addParentCommunityList(new Community(ancestor, servletContext, null, context));                    
                 }

--- a/dspace-rest/src/main/java/org/dspace/rest/common/Collection.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/common/Collection.java
@@ -75,12 +75,10 @@ public class Collection extends DSpaceObject {
                 //The parentCommunityList is the list of community/subcommunity ancestors for a collection  
                 //Retrieve the set of ancestors for the parentCommunity and append each one to the list
                 
-                if (parentCommunity.getParentCommunities().size() > 0) {
-                  for(org.dspace.content.Community ancestor = parentCommunity.getParentCommunities().get(0); 
-                          ancestor.getParentCommunities().size() > 0; 
-                          ancestor = ancestor.getParentCommunities().get(0)) {
+                for(org.dspace.content.Community ancestor = parentCommunity.getParentCommunities().isEmpty() ? null : parentCommunity.getParentCommunities().get(0); 
+                          ancestor != null; 
+                          ancestor = ancestor.getParentCommunities().isEmpty() ? null : ancestor.getParentCommunities().get(0)) {
                     this.addParentCommunityList(new Community(ancestor, servletContext, null, context));                    
-                  }                    
                 }
             }
         } else {

--- a/dspace-rest/src/main/java/org/dspace/rest/common/Collection.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/common/Collection.java
@@ -72,6 +72,9 @@ public class Collection extends DSpaceObject {
             List<org.dspace.content.Community> parentCommunities = collection.getCommunities();
             for(org.dspace.content.Community parentCommunity : parentCommunities) {
                 this.addParentCommunityList(new Community(parentCommunity, servletContext, null, context));
+                for(org.dspace.content.Community ancestor: parentCommunity.getParentCommunities()) {
+                    this.addParentCommunityList(new Community(ancestor, servletContext, null, context));                    
+                }
             }
         } else {
             this.addExpand("parentCommunityList");

--- a/dspace-rest/src/main/java/org/dspace/rest/common/Collection.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/common/Collection.java
@@ -72,6 +72,8 @@ public class Collection extends DSpaceObject {
             List<org.dspace.content.Community> parentCommunities = collection.getCommunities();
             for(org.dspace.content.Community parentCommunity : parentCommunities) {
                 this.addParentCommunityList(new Community(parentCommunity, servletContext, null, context));
+                //See DS-2766 for an interpretation of this field.  This code assumes a collection lives in only one community.  
+                //This method will return the community ancestor chain for this collection.
                 for(org.dspace.content.Community ancestor: parentCommunity.getParentCommunities()) {
                     this.addParentCommunityList(new Community(ancestor, servletContext, null, context));                    
                 }

--- a/dspace-rest/src/main/java/org/dspace/rest/common/Collection.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/common/Collection.java
@@ -74,8 +74,13 @@ public class Collection extends DSpaceObject {
                 this.addParentCommunityList(new Community(parentCommunity, servletContext, null, context));
                 //The parentCommunityList is the list of community/subcommunity ancestors for a collection  
                 //Retrieve the set of ancestors for the parentCommunity and append each one to the list
-                for(org.dspace.content.Community ancestor: parentCommunity.getParentCommunities()) {
+                
+                if (parentCommunity.getParentCommunities().size() > 0) {
+                  for(org.dspace.content.Community ancestor = parentCommunity.getParentCommunities().get(0); 
+                          ancestor.getParentCommunities().size() > 0; 
+                          ancestor = ancestor.getParentCommunities().get(0)) {
                     this.addParentCommunityList(new Community(ancestor, servletContext, null, context));                    
+                  }                    
                 }
             }
         } else {


### PR DESCRIPTION
See https://jira.duraspace.org/browse/DS-2766 for the assumptions surrounding this change.
