### PR TITLE
[DS-3165] Cannot assign a group READ policy in XMLUI

### DIFF
--- a/dspace-xmlui/src/main/resources/aspects/Administrative/administrative.js
+++ b/dspace-xmlui/src/main/resources/aspects/Administrative/administrative.js
@@ -2380,7 +2380,7 @@ function doEditPolicy(objectType,objectID,policyID)
                 var name = names.nextElement();
                 var match = null;
 
-	        if ((match = name.match(/submit_group_id_(\d+)/)) != null)
+	        if ((match = name.match(/submit_group_id_([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/)) != null)
 			{
 	        	groupID = UUID.fromString(match[1]);
 			}


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3165

The regex to match a buttons name still assumed that integers were used as identifiers, fixed the regex.
