### PR TITLE
DS-3152 JSPUI -> Word breaking on long filenames/description

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemTag.java
@@ -926,7 +926,7 @@ public class ItemTag extends TagSupport
             			handle = "db-id/" + item.getID();
             		}
 
-            		out.print("<tr><td headers=\"t1\" class=\"standard\">");
+            		out.print("<tr><td headers=\"t1\" class=\"standard break-all\">");
                     out.print("<a target=\"_blank\" href=\"");
                     out.print(request.getContextPath());
                     out.print("/html/");
@@ -941,7 +941,7 @@ public class ItemTag extends TagSupport
                     
             		if (multiFile)
             		{
-            			out.print("</td><td headers=\"t2\" class=\"standard\">");
+            			out.print("</td><td headers=\"t2\" class=\"standard break-all\">");
 
             			String desc = primaryBitstream.getDescription();
             			out.print((desc != null) ? desc : "");
@@ -1016,7 +1016,7 @@ public class ItemTag extends TagSupport
                                             Constants.DEFAULT_ENCODING) + "\">";
 
             					out
-                                    .print("<tr><td headers=\"t1\" class=\"standard\">");
+                                    .print("<tr><td headers=\"t1\" class=\"standard break-all\">");
                                 out.print("<a ");
             					out.print(bsLink);
             					out.print(b.getName());
@@ -1098,7 +1098,7 @@ public class ItemTag extends TagSupport
             					if (multiFile)
             					{
             						out
-                                        .print("</td><td headers=\"t2\" class=\"standard\">");
+                                        .print("</td><td headers=\"t2\" class=\"standard break-all\">");
 
             						String desc = b.getDescription();
             						out.print((desc != null) ? desc : "");

--- a/dspace-jspui/src/main/webapp/static/css/bootstrap/dspace-theme.css
+++ b/dspace-jspui/src/main/webapp/static/css/bootstrap/dspace-theme.css
@@ -108,5 +108,7 @@ span.batchimport-error-caused {
 }
 
 .break-all{
-    word-break: break-all;
+	-ms-word-break:   break-all;
+	word-break:       break-word;
+	word-wrap:        break-word;
 }

--- a/dspace-jspui/src/main/webapp/static/css/bootstrap/dspace-theme.css
+++ b/dspace-jspui/src/main/webapp/static/css/bootstrap/dspace-theme.css
@@ -109,6 +109,6 @@ span.batchimport-error-caused {
 
 .break-all{
 	-ms-word-break:   break-all;
-	word-break:       break-word;
+	word-break:       break-all;
 	word-wrap:        break-word;
 }

--- a/dspace-jspui/src/main/webapp/static/css/bootstrap/dspace-theme.css
+++ b/dspace-jspui/src/main/webapp/static/css/bootstrap/dspace-theme.css
@@ -106,3 +106,7 @@ span.batchimport-error-tab {
 span.batchimport-error-caused {
 	font-weight:bold;
 }
+
+.break-all{
+    word-break: break-all;
+}

--- a/dspace-jspui/src/main/webapp/submit/review-upload.jsp
+++ b/dspace-jspui/src/main/webapp/submit/review-upload.jsp
@@ -68,7 +68,7 @@
 <div class="col-md-10">
                                     <div class="row">
                                         <span class="metadataFieldLabel col-md-4"><%= (subInfo.getSubmissionItem().hasMultipleFiles() ? LocaleSupport.getLocalizedMessage(pageContext, "jsp.submit.review.upload1") : LocaleSupport.getLocalizedMessage(pageContext, "jsp.submit.review.upload2")) %></span>
-                                        <span class="metadataFieldValue col-md-8">
+                                        <span class="metadataFieldValue col-md-8 break-all">
 <%
     List<Bitstream> bitstreams = ContentServiceFactory.getInstance().getItemService().getNonInternalBitstreams(context, item);
 

--- a/dspace-jspui/src/main/webapp/submit/upload-file-list.jsp
+++ b/dspace-jspui/src/main/webapp/submit/upload-file-list.jsp
@@ -176,7 +176,7 @@
 			   <%   }
 			      } %> />
 		</td>
-                <td headers="t2" class="<%= row %>RowOddCol">
+                <td headers="t2" class="<%= row %>RowOddCol break-all">
                 	<a href="<%= request.getContextPath() %>/retrieve/<%= bitstreams.get(i).getID() %>/<%= org.dspace.app.webui.util.UIUtil.encodeBitstreamName(bitstreams.get(i).getName()) %>" target="_blank"><%= bitstreams.get(i).getName() %></a>
             <%      // Don't display "remove" button in workflow mode
 			        if (allowFileEditing)
@@ -189,7 +189,7 @@
 			        } %>	
                 </td>
                 <td headers="t3" class="<%= row %>RowEvenCol"><%= bitstreams.get(i).getSize() %> bytes</td>
-                <td headers="t4" class="<%= row %>RowOddCol">
+                <td headers="t4" class="<%= row %>RowOddCol break-all">
                     <%= (bitstreams.get(i).getDescription() == null || bitstreams.get(i).getDescription().equals("")
                         ? LocaleSupport.getLocalizedMessage(pageContext, "jsp.submit.upload-file-list.empty1")
                         : bitstreams.get(i).getDescription()) %>


### PR DESCRIPTION
JIRA ticket -> https://jira.duraspace.org/browse/DS-3152

Word-break on long filenames and file descriptions during submission/reviewstep + item display.
Re-usable css class if more similar bugs are found.
