### PR TITLE
DS-3226: Avoid NPEs for wrong search URIs.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -1524,8 +1524,12 @@ public class SolrServiceImpl implements SearchService, IndexingService {
     public String locationToName(Context context, String field, String value) throws SQLException {
         if("location.comm".equals(field) || "location.coll".equals(field))
         {
-            int type = field.equals("location.comm") ? Constants.COMMUNITY : Constants.COLLECTION;
-            DSpaceObject commColl = contentServiceFactory.getDSpaceObjectService(type).find(context, UUID.fromString(value));
+            int type = ("location.comm").equals(field) ? Constants.COMMUNITY : Constants.COLLECTION;
+            DSpaceObject commColl = null;
+            if (StringUtils.isNotBlank(value))
+            {
+                commColl = contentServiceFactory.getDSpaceObjectService(type).find(context, UUID.fromString(value));
+            }
             if(commColl != null)
             {
                 return commColl.getName();
@@ -2017,7 +2021,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         DiscoverFilterQuery result = new DiscoverFilterQuery();
 
         StringBuilder filterQuery = new StringBuilder();
-        if(StringUtils.isNotBlank(field))
+        if(StringUtils.isNotBlank(field) && StringUtils.isNotBlank(value))
         {
             filterQuery.append(field);
             if("equals".equals(operator))
@@ -2069,10 +2073,9 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                 }
             }
 
-
+            result.setDisplayedValue(transformDisplayedValue(context, field, value));
         }
 
-        result.setDisplayedValue(transformDisplayedValue(context, field, value));
         result.setFilterQuery(filterQuery.toString());
         return result;
     }

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/discovery/DiscoverUtility.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/discovery/DiscoverUtility.java
@@ -247,9 +247,13 @@ public class DiscoverUtility
         {
             try
             {
-            String newFilterQuery = SearchUtils.getSearchService()
-                    .toFilterQuery(context, f[0], f[1], f[2])
-                    .getFilterQuery();
+            String newFilterQuery = null;
+            if (StringUtils.isNotBlank(f[0]) && StringUtils.isNotBlank(f[2]))
+            {
+                newFilterQuery = SearchUtils.getSearchService()
+                        .toFilterQuery(context, f[0], f[1], f[2])
+                        .getFilterQuery();
+            }
             if (newFilterQuery != null)
             {
                 queryArgs.addFilterQueries(newFilterQuery);

--- a/dspace-jspui/src/main/webapp/search/discovery.jsp
+++ b/dspace-jspui/src/main/webapp/search/discovery.jsp
@@ -67,7 +67,7 @@
 <%
     // Get the attributes
     DSpaceObject scope = (DSpaceObject) request.getAttribute("scope" );
-    String searchScope = scope!=null?scope.getHandle():"";
+    String searchScope = scope!=null ? scope.getHandle() : "";
     List<DSpaceObject> scopes = (List<DSpaceObject>) request.getAttribute("scopes");
     List<String> sortOptions = (List<String>) request.getAttribute("sortOptions");
 
@@ -77,7 +77,7 @@
 	    query = "";
 	}
     Boolean error_b = (Boolean)request.getAttribute("search.error");
-    boolean error = (error_b == null ? false : error_b.booleanValue());
+    boolean error = error_b==null ? false : error_b.booleanValue();
     
     DiscoverQuery qArgs = (DiscoverQuery) request.getAttribute("queryArgs");
     String sortedBy = qArgs.getSortField();
@@ -94,6 +94,13 @@
 	    int idx = 1;
 	    for (String[] filter : appliedFilters)
 	    {
+                if (filter == null
+                        || filter[0] == null || filter[0].trim().equals("")
+                        || filter[2] == null || filter[2].trim().equals(""))
+                {
+                    idx++;
+                    continue;
+                }
 	        httpFilters += "&amp;filter_field_"+idx+"="+URLEncoder.encode(filter[0],"UTF-8");
 	        httpFilters += "&amp;filter_type_"+idx+"="+URLEncoder.encode(filter[1],"UTF-8");
 	        httpFilters += "&amp;filter_value_"+idx+"="+URLEncoder.encode(filter[2],"UTF-8");
@@ -217,7 +224,7 @@
 					{
 					    String fkey = "jsp.search.filter." + Escape.uriParam(searchFilter.getIndexFieldName());
 					    %><option value="<%= Utils.addEntities(searchFilter.getIndexFieldName()) %>"<% 
-					            if (filter[0].equals(searchFilter.getIndexFieldName()))
+					            if (searchFilter.getIndexFieldName().equals(filter[0]))
 					            {
 					                %> selected="selected"<%
 					                found = true;


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3226

To test this open a community or collection in JSPUI and add `/simple-search?location=123456789%2F2&query=&rpp=10&sort_by=score&order=desc&filter_field_1=dateIssued&filter_type_1=equals&filter_value_2=2016` to the URL. Without this patch this results in an Null Pointer exception. With this patch this results in a search without any filter.
