### PR TITLE
DS-3167: empty list of metadataformats in JSPUI

### DIFF
--- a/dspace-jspui/src/main/webapp/tools/edit-collection.jsp
+++ b/dspace-jspui/src/main/webapp/tools/edit-collection.jsp
@@ -411,7 +411,7 @@
                 	<select class="form-control" name="metadata_format" >
 	                	<%
 		                // Add an entry for each instance of ingestion crosswalks configured for harvesting 
-			            String metaString = "harvester.oai.metadataformats.";
+			            String metaString = "harvester.metadataformats.";
 			            Enumeration pe = ConfigurationManager.propertyNames("oai");
 			            while (pe.hasMoreElements())
 			            {


### PR DESCRIPTION
After merging #1326 this is the only thing left from #1385. I haven't tested it (yet?).
