### PR TITLE
DS-3229: JSPUI: Submission verify step ignores type binding

### DIFF
--- a/dspace-jspui/src/main/webapp/submit/review-metadata.jsp
+++ b/dspace-jspui/src/main/webapp/submit/review-metadata.jsp
@@ -43,17 +43,17 @@
     // Obtain DSpace context
     Context context = UIUtil.obtainContext(request);
 
-        //get submission information object
+    //get submission information object
     SubmissionInfo subInfo = SubmissionController.getSubmissionInfo(context, request);
 
-        //get the step number (for jump-to link and to determine page)
-        String stepJump = (String) request.getParameter("submission.jump");
+    //get the step number (for jump-to link and to determine page)
+    String stepJump = (String) request.getParameter("submission.jump");
 
-        //extract out the step & page numbers from the stepJump (format: stepNum.pageNum)
-        //(since there are multiple pages, we need to know which page we are reviewing!)
+    //extract out the step & page numbers from the stepJump (format: stepNum.pageNum)
+    //(since there are multiple pages, we need to know which page we are reviewing!)
     String[] fields = stepJump.split("\\.");  //split on period
     int stepNum = Integer.parseInt(fields[0]);
-        int pageNum = Integer.parseInt(fields[1]);
+    int pageNum = Integer.parseInt(fields[1]);
 
     Item item = subInfo.getSubmissionItem().getItem();
     
@@ -88,133 +88,131 @@
 %>
 
 <%!void layoutSection(HttpServletRequest request,
-                       javax.servlet.jsp.JspWriter out,
-                       DCInputSet inputSet,
-                       SubmissionInfo subInfo,
-                       Item item,
-                       String documentType,
-                       int pageNum,
-                       PageContext pageContext)
+        javax.servlet.jsp.JspWriter out,
+        DCInputSet inputSet,
+        SubmissionInfo subInfo,
+        Item item,
+        String documentType,
+        int pageNum,
+        PageContext pageContext)
         throws ServletException, IOException
     {
-       ItemService itemService = ContentServiceFactory.getInstance().getItemService();
-       InProgressSubmission ip = subInfo.getSubmissionItem();
-
-           //need to actually get the rows for pageNum-1 (since first page is index 0)
-           DCInput[] inputs = inputSet.getPageRows(pageNum-1,
-                                                   ip.hasMultipleTitles(),
-                                                   ip.isPublishedBefore());
-
+        ItemService itemService = ContentServiceFactory.getInstance().getItemService();
+        InProgressSubmission ip = subInfo.getSubmissionItem();
+ 
+        //need to actually get the rows for pageNum-1 (since first page is index 0)
+        DCInput[] inputs = inputSet.getPageRows(pageNum-1,
+                ip.hasMultipleTitles(),
+                ip.isPublishedBefore());
+            
         MetadataAuthorityService mam = ContentAuthorityServiceFactory.getInstance().getMetadataAuthorityService();
 
-
-       for (int z = 0; z < inputs.length; z++)
-       {
-          // Omit fields not allowed for this document type
-          if(!inputs[z].isAllowedFor(documentType))
-          {
-              continue;
-          }
-          String scope = subInfo.isInWorkflow() ? DCInput.WORKFLOW_SCOPE : DCInput.SUBMISSION_SCOPE;
-          if (!inputs[z].isVisible(scope) && !inputs[z].isReadOnly(scope))
-          {
-              continue;
-          }
-          String inputType = inputs[z].getInputType();
-          String pairsName = inputs[z].getPairsType();
-          String value;
-          List<MetadataValue> values;
-          StringBuffer row = new StringBuffer();
-          
-          row.append("<div class=\"row\">");
-          row.append("<span class=\"metadataFieldLabel col-md-4 \">");
-          row.append(inputs[z].getLabel());
-          row.append("</span>");
-          row.append("<span class=\"metadataFieldValue col-md-8\">");
-
-          if (inputType.equals("qualdrop_value"))
-          {
-             values = itemService.getMetadata(item, inputs[z].getSchema(), inputs[z].getElement(), Item.ANY, Item.ANY);
-          }
-          else
-          {
-             values = itemService.getMetadata(item, inputs[z].getSchema(), inputs[z].getElement(), inputs[z].getQualifier(), Item.ANY);
-          }
-          if (values.size() == 0)
-          {
-             row.append(LocaleSupport.getLocalizedMessage(pageContext, "jsp.submit.review.no_md"));
-          }
-          else
-          {
-             boolean isAuthorityControlled = mam.isAuthorityControlled(inputs[z].getSchema()+ "." +
-                                                    inputs[z].getElement() + "." + inputs[z].getQualifier());
-
-             for (int i = 0; i < values.size(); i++)
-             {
-                boolean newline = true;
-                if (inputType.equals("date"))
+        for (int z = 0; z < inputs.length; z++)
+        {
+            // Omit fields not allowed for this document type
+            if(!inputs[z].isAllowedFor(documentType))
+            {
+                continue;
+            }
+            String scope = subInfo.isInWorkflow() ? DCInput.WORKFLOW_SCOPE : DCInput.SUBMISSION_SCOPE;
+            if (!inputs[z].isVisible(scope) && !inputs[z].isReadOnly(scope))
+            {
+                continue;
+            }
+            String inputType = inputs[z].getInputType();
+            String pairsName = inputs[z].getPairsType();
+            String value;
+            List<MetadataValue> values;
+            StringBuffer row = new StringBuffer();
+            
+            row.append("<div class=\"row\">");
+            row.append("<span class=\"metadataFieldLabel col-md-4 \">");
+            row.append(inputs[z].getLabel());
+            row.append("</span>");
+            row.append("<span class=\"metadataFieldValue col-md-8\">");
+  
+            if (inputType.equals("qualdrop_value"))
+            {
+                values = itemService.getMetadata(item, inputs[z].getSchema(), inputs[z].getElement(), Item.ANY, Item.ANY);
+            }
+            else
+            {
+                values = itemService.getMetadata(item, inputs[z].getSchema(), inputs[z].getElement(), inputs[z].getQualifier(), Item.ANY);
+            }
+            if (values.size() == 0)
+            {
+                row.append(LocaleSupport.getLocalizedMessage(pageContext, "jsp.submit.review.no_md"));
+            }
+            else
+            {
+                boolean isAuthorityControlled = mam.isAuthorityControlled(inputs[z].getSchema()+ "." +
+                        inputs[z].getElement() + "." + inputs[z].getQualifier());
+  
+                for (int i = 0; i < values.size(); i++)
                 {
-                   DCDate date = new DCDate(values.get(i).getValue());
-                   row.append(UIUtil.displayDate(date, false, true, request));
-                }
-                else if (inputType.equals("dropdown") || inputType.equals("list"))
-                {
-                   String storedVal = values.get(i).getValue();
-                   String displayVal = inputs[z].getDisplayString(pairsName,
-                                                                storedVal);
-                   if (displayVal != null && !displayVal.equals(""))
-                   {
-                       row.append(Utils.addEntities(displayVal));
-                   }
-                   else if (storedVal != null && !storedVal.equals(""))
-                   {
-                       // use the stored value as label rather than null
-                       row.append(Utils.addEntities(storedVal));
-                   }
-                }
-                else if (inputType.equals("qualdrop_value"))
-                {
-                   String qual = values.get(i).getMetadataField().getQualifier();
-                   if(qual==null)
-                   {
-                       qual = "";
-                       newline = false;
-                   }
-                   else
-                   {
-                        String displayQual = inputs[z].getDisplayString(pairsName,qual);
-                        String displayValue = Utils.addEntities(values.get(i).getValue());
-                        if (displayQual != null)
+                    boolean newline = true;
+                    if (inputType.equals("date"))
+                    {
+                        DCDate date = new DCDate(values.get(i).getValue());
+                        row.append(UIUtil.displayDate(date, false, true, request));
+                    }
+                    else if (inputType.equals("dropdown") || inputType.equals("list"))
+                    {
+                        String storedVal = values.get(i).getValue();
+                        String displayVal = inputs[z].getDisplayString(pairsName, storedVal);
+                        if (displayVal != null && !displayVal.equals(""))
                         {
-                            row.append(displayQual + ":" + displayValue);
+                            row.append(Utils.addEntities(displayVal));
+                        }
+                        else if (storedVal != null && !storedVal.equals(""))
+                        {
+                            // use the stored value as label rather than null
+                            row.append(Utils.addEntities(storedVal));
+                        }
+                    }
+                    else if (inputType.equals("qualdrop_value"))
+                    {
+                        String qual = values.get(i).getMetadataField().getQualifier();
+                        if(qual==null)
+                        {
+                            qual = "";
+                            newline = false;
                         }
                         else
                         {
-                            newline = false;
+                            String displayQual = inputs[z].getDisplayString(pairsName,qual);
+                            String displayValue = Utils.addEntities(values.get(i).getValue());
+                            if (displayQual != null)
+                            {
+                                row.append(displayQual + ":" + displayValue);
+                            }
+                            else
+                            {
+                                newline = false;
+                            }
                         }
-                   }
+                    }
+                    else
+                    {
+                        row.append(Utils.addEntities(values.get(i).getValue()));
+                    }
+                    if (isAuthorityControlled)
+                    {
+                        row.append("<span class=\"ds-authority-confidence cf-")
+                            .append(values.get(i).getConfidence()).append("\">")
+                            .append(" </span>");
+                    }
+                    if (newline)
+                    {
+                        row.append("<br />");
+                    }
                 }
-                else
-                {
-                   row.append(Utils.addEntities(values.get(i).getValue()));
-                }
-                                if (isAuthorityControlled)
-                {
-                    row.append("<span class=\"ds-authority-confidence cf-")
-                       .append(values.get(i).getConfidence()).append("\">")
-                       .append(" </span>");
-                }
-                if (newline)
-                {
-                    row.append("<br />");
-                }
-             }
-          }
-          row.append("</span>");
-          row.append("</div>");
-   
-          out.write(row.toString());
-       }
+            }
+            row.append("</span>");
+            row.append("</div>");
+     
+            out.write(row.toString());
+        }
     }%>
 
 
@@ -233,9 +231,9 @@
 <div class="col-md-10">
 
 <%
-            layoutSection(request, out, inputSet, subInfo, item, documentType, pageNum, pageContext);
+    layoutSection(request, out, inputSet, subInfo, item, documentType, pageNum, pageContext);
 %>
 </div>
 <div class="col-md-2">
-     <input class="btn btn-default" type="submit" name="submit_jump_<%=stepJump%>" value="<fmt:message key="jsp.submit.review.button.correct"/>" />
+    <input class="btn btn-default" type="submit" name="submit_jump_<%=stepJump%>" value="<fmt:message key="jsp.submit.review.button.correct"/>" />
 </div>

--- a/dspace-jspui/src/main/webapp/submit/review-metadata.jsp
+++ b/dspace-jspui/src/main/webapp/submit/review-metadata.jsp
@@ -59,6 +59,17 @@
     
     // determine collection
     Collection c = subInfo.getSubmissionItem().getCollection();
+    
+    // Fetch the document type (dc.type)
+    String documentType = "";
+    if( (ContentServiceFactory.getInstance().getItemService()
+            .getMetadataByMetadataString(item, "dc.type") != null)
+            && (ContentServiceFactory.getInstance().getItemService()
+                    .getMetadataByMetadataString(item, "dc.type").size() >0) )
+    {
+        documentType = ContentServiceFactory.getInstance().getItemService()
+                .getMetadataByMetadataString(item, "dc.type").get(0).getValue();
+    }
 
     DCInputSet inputSet = null;
 
@@ -81,6 +92,7 @@
                        DCInputSet inputSet,
                        SubmissionInfo subInfo,
                        Item item,
+                       String documentType,
                        int pageNum,
                        PageContext pageContext)
         throws ServletException, IOException
@@ -98,6 +110,11 @@
 
        for (int z = 0; z < inputs.length; z++)
        {
+          // Omit fields not allowed for this document type
+          if(!inputs[z].isAllowedFor(documentType))
+          {
+              continue;
+          }
           String scope = subInfo.isInWorkflow() ? DCInput.WORKFLOW_SCOPE : DCInput.SUBMISSION_SCOPE;
           if (!inputs[z].isVisible(scope) && !inputs[z].isReadOnly(scope))
           {
@@ -216,7 +233,7 @@
 <div class="col-md-10">
 
 <%
-            layoutSection(request, out, inputSet, subInfo, item, pageNum, pageContext);
+            layoutSection(request, out, inputSet, subInfo, item, documentType, pageNum, pageContext);
 %>
 </div>
 <div class="col-md-2">


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3229

I created two commits on purpose: one containing the bug fix, one changes indentation of the jsp. Reviewing this should be much simpler by reviewing one commit at a time.

Two test this you duplicate any arbitrary field that is part of the second page (!) within the input-forms.xml, add type bindings for two different document types (e.g. Book and Book chapter) to both fields (the original and the duplicated one) and create a submission in JSPUI. Without this fix the field shows up two time in the verify step for any document type independently if it was shown in the edit metadata step or not. With this fix the field show up only once and only if the document type matches the type binding.
