### PR TITLE
DS-3231 fixed by using cc.license.jurisdiction

### DIFF
--- a/dspace-jspui/src/main/webapp/submit/creative-commons.jsp
+++ b/dspace-jspui/src/main/webapp/submit/creative-commons.jsp
@@ -48,7 +48,7 @@
     Boolean lExists = (Boolean)request.getAttribute("cclicense.exists");
     boolean licenseExists = (lExists == null ? false : lExists.booleanValue());
 
-    String jurisdiction = ConfigurationManager.getProperty("webui.submit.cc-jurisdiction");
+    String jurisdiction = ConfigurationManager.getProperty("cc.license.jurisdiction");
     if ((jurisdiction != null) && (!"".equals(jurisdiction)))
     {
         jurisdiction = "&amp;jurisdiction=" + jurisdiction.trim();


### PR DESCRIPTION
Fixed [ DS-3231](https://jira.duraspace.org/projects/DS/issues/DS-3231) by changing webui.submit.cc-jurisdiction to cc.license.jurisdiction

Acording to the [docs](https://wiki.duraspace.org/display/DSDOC6x/Configuration+Reference#ConfigurationReference-ConfiguringCreativeCommonsLicense) cc.license.jurisdiction is a XMLUI property, but the current webui.submit.cc-jurisdiction does not exist. Instead of creating multiple properties for the same thing, i think cc.license.jurisdiction should be reused.
