### PR TITLE
DS-3240: comm/coll admins misses some functions and a propper navbar.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
@@ -418,6 +418,44 @@ public class AuthorizeServiceImpl implements AuthorizeService
             return groupService.isMember(c, Group.ADMIN);
         }
     }
+    
+    public boolean isCommunityAdmin(Context c) throws SQLException 
+    {
+        EPerson e = c.getCurrentUser();
+        
+        if (e != null) 
+        {
+            List<ResourcePolicy> policies = resourcePolicyService.find(c, e,
+                    groupService.allMemberGroups(c, e),
+                    Constants.ADMIN, Constants.COMMUNITY);
+
+            if (CollectionUtils.isNotEmpty(policies)) 
+            {
+                return true;
+            }
+        }
+        
+        return false;
+    }
+    
+    public boolean isCollectionAdmin(Context c) throws SQLException 
+    {
+        EPerson e = c.getCurrentUser();
+        
+        if (e != null) 
+        {
+            List<ResourcePolicy> policies = resourcePolicyService.find(c, e,
+                    groupService.allMemberGroups(c, e),
+                    Constants.ADMIN, Constants.COLLECTION);
+
+            if (CollectionUtils.isNotEmpty(policies)) 
+            {
+                return true;
+            }
+        }
+        
+        return false;
+    }
 
     ///////////////////////////////////////////////
     // policy manipulation methods

--- a/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
@@ -107,6 +107,10 @@ public class ResourcePolicyServiceImpl implements ResourcePolicyService
     public List<ResourcePolicy> find(Context c, DSpaceObject dso, Group group, int action, int notPolicyID) throws SQLException {
         return resourcePolicyDAO.findByTypeIdGroupAction(c, dso, group, action, notPolicyID);
     }
+    
+    public List<ResourcePolicy> find(Context c, EPerson e, List<Group> groups, int action, int type_id) throws SQLException{
+        return resourcePolicyDAO.findByEPersonGroupTypeIdAction(c, e, groups, action, type_id);
+    }
 
     /**
      * Delete an ResourcePolicy

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
@@ -35,6 +35,8 @@ public interface ResourcePolicyDAO extends GenericDAO<ResourcePolicy> {
     public List<ResourcePolicy> findByDSoAndAction(Context context, DSpaceObject dso, int actionId) throws SQLException;
 
     public List<ResourcePolicy> findByTypeIdGroupAction(Context context, DSpaceObject dso, Group group, int action, int notPolicyID) throws SQLException;
+    
+    public List<ResourcePolicy> findByEPersonGroupTypeIdAction(Context context, EPerson e, List<Group> groups, int action, int type_id) throws SQLException;
 
     public void deleteByDso(Context context, DSpaceObject dso) throws SQLException;
 

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
@@ -92,6 +92,19 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
 
         return list(criteria);
     }
+     public List<ResourcePolicy> findByEPersonGroupTypeIdAction(Context context, EPerson e, List<Group> groups, int action, int type_id) throws SQLException
+     {
+         Criteria criteria = createCriteria(context, ResourcePolicy.class);
+         criteria.add(Restrictions.and(
+                  Restrictions.eq("resourceTypeId", type_id),
+                  Restrictions.eq("actionId", action),
+                  (Restrictions.or(
+                    Restrictions.eq("eperson", e),
+                    Restrictions.in("epersonGroup", groups)
+                    ))
+                 ));
+         return list(criteria);
+     }
 
     @Override
     public void deleteByDso(Context context, DSpaceObject dso) throws SQLException

--- a/dspace-api/src/main/java/org/dspace/authorize/service/AuthorizeService.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/service/AuthorizeService.java
@@ -179,6 +179,10 @@ public interface AuthorizeService {
      * @throws SQLException if database error
      */
     public boolean isAdmin(Context c) throws SQLException;
+    
+    public boolean isCommunityAdmin(Context c) throws SQLException;
+    
+    public boolean isCollectionAdmin(Context c) throws SQLException; 
 
     ///////////////////////////////////////////////
     // policy manipulation methods

--- a/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
@@ -36,6 +36,8 @@ public interface ResourcePolicyService extends DSpaceCRUDService<ResourcePolicy>
     public List<ResourcePolicy> find(Context c, DSpaceObject dso, Group group, int action, int notPolicyID) throws SQLException;
 
     public List<ResourcePolicy> find(Context context, Group group) throws SQLException;
+    
+    public List<ResourcePolicy> find(Context c, EPerson e, List<Group> groups, int action, int type_id) throws SQLException;
 
     public String getActionText(ResourcePolicy resourcePolicy);
 

--- a/dspace-api/src/main/java/org/dspace/browse/SolrBrowseDAO.java
+++ b/dspace-api/src/main/java/org/dspace/browse/SolrBrowseDAO.java
@@ -8,9 +8,12 @@
 package org.dspace.browse;
 
 import java.io.Serializable;
+import java.sql.SQLException;
 import java.util.*;
 
 import org.apache.log4j.Logger;
+import org.dspace.authorize.factory.AuthorizeServiceFactory;
+import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.Constants;
@@ -124,7 +127,9 @@ public class SolrBrowseDAO implements BrowseDAO
     private boolean distinct = false;
 
     private String facetField;
-
+    
+    protected AuthorizeService authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();
+    
     // administrative attributes for this class
 
 
@@ -207,6 +212,21 @@ public class SolrBrowseDAO implements BrowseDAO
         else if (!itemsDiscoverable)
         {
             query.addFilterQueries("discoverable:false");
+            // TODO
+
+            try 
+            {
+                if (!authorizeService.isAdmin(context)
+                        && (authorizeService.isCommunityAdmin(context)
+                        || authorizeService.isCollectionAdmin(context))) 
+                {
+                        query.addFilterQueries(searcher.createLocationQueryForAdministrableItems(context));
+                }
+            } 
+            catch (SQLException ex) 
+            {
+                log.error(ex);
+            }
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/discovery/SearchService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SearchService.java
@@ -105,7 +105,23 @@ public interface SearchService {
      */
     DiscoverFilterQuery toFilterQuery(Context context, String field, String operator, String value) throws SQLException;
 
-	List<Item> getRelatedItems(Context context, Item item, DiscoveryMoreLikeThisConfiguration moreLikeThisConfiguration);
+    List<Item> getRelatedItems(Context context, Item item, DiscoveryMoreLikeThisConfiguration moreLikeThisConfiguration);
+    
+    /**
+     * Method to create a  Query that includes all 
+     * communities and collections a user may administrate.
+     * If a user has the appropriate rights to administrate communities and/or
+     * collections we want to look up all contents of those communities and/or
+     * collections, ignoring the read policies of the items (e.g. to list all
+     * private items of communities/collections the user administrate). This
+     * method returns a query to filter for items that belongs to those
+     * communities/collections only.
+     *
+     * @param context
+     * @return
+     * @throws SQLException
+     */
+    String createLocationQueryForAdministrableItems(Context context) throws SQLException;
 
     /**
      * Transforms the metadata field of the given sort configuration into the indexed field which we can then use in our solr queries

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -63,6 +63,10 @@ import java.sql.SQLException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.authorize.factory.AuthorizeServiceFactory;
+import org.dspace.eperson.Group;
+import org.dspace.eperson.factory.EPersonServiceFactory;
 
 /**
  * SolrIndexer contains the methods that index Items and their metadata,
@@ -689,6 +693,72 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         }
 
         return locations;
+    }
+    
+    @Override
+    public String createLocationQueryForAdministrableItems(Context context)
+            throws SQLException
+    {
+        StringBuilder locationQuery = new StringBuilder();
+        
+        if (context.getCurrentUser() != null) 
+        {
+            List<Group> groupList = EPersonServiceFactory.getInstance().getGroupService()
+                    .allMemberGroups(context, context.getCurrentUser());
+            
+            List<ResourcePolicy> communitiesPolicies = AuthorizeServiceFactory.getInstance().getResourcePolicyService()
+                    .find(context, context.getCurrentUser(), groupList, Constants.ADMIN, Constants.COMMUNITY);
+
+            List<ResourcePolicy> collectionsPolicies = AuthorizeServiceFactory.getInstance().getResourcePolicyService()
+                    .find(context, context.getCurrentUser(), groupList, Constants.ADMIN, Constants.COLLECTION);
+
+            List<Collection> allCollections = new ArrayList<>();
+            
+            for( ResourcePolicy rp: collectionsPolicies){
+                Collection collection = ContentServiceFactory.getInstance().getCollectionService()
+                        .find(context, rp.getdSpaceObject().getID());
+                allCollections.add(collection);
+            }
+
+            if (CollectionUtils.isNotEmpty(communitiesPolicies) || CollectionUtils.isNotEmpty(allCollections)) 
+            {
+                locationQuery.append("location:( ");
+
+                for (int i = 0; i< communitiesPolicies.size(); i++) 
+                {
+                    ResourcePolicy rp = communitiesPolicies.get(i);
+                    Community community = ContentServiceFactory.getInstance().getCommunityService()
+                            .find(context, rp.getdSpaceObject().getID());
+                
+                    locationQuery.append("m").append(community.getID());
+
+                    if (i != (communitiesPolicies.size() - 1)) {
+                        locationQuery.append(" OR ");
+                    }
+                    allCollections.addAll(ContentServiceFactory.getInstance().getCommunityService()
+                            .getAllCollections(context, community));
+                }
+
+                Iterator<Collection> collIter = allCollections.iterator();
+
+                if (communitiesPolicies.size() > 0 && allCollections.size() > 0) {
+                    locationQuery.append(" OR ");
+                }
+
+                while (collIter.hasNext()) {
+                    locationQuery.append("l").append(collIter.next().getID());
+
+                    if (collIter.hasNext()) {
+                        locationQuery.append(" OR ");
+                    }
+                }
+                locationQuery.append(")");
+            } else {
+                log.warn("We have a collection or community admin with ID: " + context.getCurrentUser().getID()
+                        + " without any administrable collection or community!");
+            }
+        }
+        return locationQuery.toString();
     }
 
     /**

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/util/Authenticate.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/util/Authenticate.java
@@ -304,10 +304,14 @@ public class Authenticate
         context.setCurrentUser(eperson);
         
         boolean isAdmin = false;
+        boolean isCommunityAdmin = false;
+        boolean isCollectionAdmin = false;
         
         try
         {
             isAdmin = authorizeService.isAdmin(context);
+            isCommunityAdmin = authorizeService.isCommunityAdmin(context);
+            isCollectionAdmin = authorizeService.isCollectionAdmin(context);
         }
         catch (SQLException se)
         {
@@ -316,6 +320,8 @@ public class Authenticate
         finally 
         {
             request.setAttribute("is.admin", Boolean.valueOf(isAdmin));
+            request.setAttribute("is.communityAdmin", Boolean.valueOf(isCommunityAdmin));
+            request.setAttribute("is.collectionAdmin", Boolean.valueOf(isCollectionAdmin));
         }
 
         // We store the current user in the request as an EPerson object...

--- a/dspace-jspui/src/main/webapp/WEB-INF/web.xml
+++ b/dspace-jspui/src/main/webapp/WEB-INF/web.xml
@@ -506,15 +506,20 @@
     <url-pattern>/exportdownload/*</url-pattern>
   </servlet-mapping>
 
-        <servlet-mapping>
-                <servlet-name>browse</servlet-name>
-                <url-pattern>/browse</url-pattern>
-        </servlet-mapping>
+  <servlet-mapping>
+    <servlet-name>browse</servlet-name>
+    <url-pattern>/browse</url-pattern>
+  </servlet-mapping>
 
-        <servlet-mapping>
-                <servlet-name>browsewithdrawn</servlet-name>
-                <url-pattern>/dspace-admin/withdrawn</url-pattern>
-        </servlet-mapping>
+  <servlet-mapping>
+    <servlet-name>browsewithdrawn</servlet-name>
+    <url-pattern>/dspace-admin/withdrawn</url-pattern>
+  </servlet-mapping>
+  
+  <servlet-mapping>
+    <servlet-name>browsewithdrawn</servlet-name>
+    <url-pattern>/tools/withdrawn</url-pattern>
+  </servlet-mapping>
 
   <servlet-mapping>
     <servlet-name>community-list</servlet-name>
@@ -789,6 +794,11 @@
   <servlet-mapping>
     <servlet-name>privateitems</servlet-name>
     <url-pattern>/dspace-admin/privateitems</url-pattern>
+  </servlet-mapping>
+  
+  <servlet-mapping>
+    <servlet-name>privateitems</servlet-name>
+    <url-pattern>/tools/privateitems</url-pattern>
   </servlet-mapping>
 
   <servlet-mapping>

--- a/dspace-jspui/src/main/webapp/browse/full.jsp
+++ b/dspace-jspui/src/main/webapp/browse/full.jsp
@@ -34,84 +34,105 @@
     String layoutNavbar = "default";
     boolean withdrawn = false;
     boolean privateitems = false;
-	if (request.getAttribute("browseWithdrawn") != null)
-	{
-	    layoutNavbar = "admin";
+
+    // Is the logged in user an admin or community admin or cllection admin
+    Boolean admin = (Boolean)request.getAttribute("is.admin");
+    boolean isAdmin = (admin == null ? false : admin.booleanValue());
+
+    Boolean communityAdmin = (Boolean)request.getAttribute("is.communityAdmin");
+    boolean isCommunityAdmin = (communityAdmin == null ? false : communityAdmin.booleanValue());
+
+    Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
+    boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
+
+    if (request.getAttribute("browseWithdrawn") != null)
+    {
+        layoutNavbar = "admin";
         urlFragment = "dspace-admin/withdrawn";
         withdrawn = true;
+
+        if(!isAdmin && (isCommunityAdmin || isCollectionAdmin))
+        {
+            layoutNavbar = "community-or-collection-admin";
+        }
     }
-	else if (request.getAttribute("browsePrivate") != null)
-	{
-	    layoutNavbar = "admin";
+    else if (request.getAttribute("browsePrivate") != null)	
+    {
+        layoutNavbar = "admin";
         urlFragment = "dspace-admin/privateitems";
         privateitems = true;
+
+        if(!isAdmin && (isCommunityAdmin || isCollectionAdmin))
+        {
+            layoutNavbar = "community-or-collection-admin";
+        }
     }
 
-	// First, get the browse info object
-	BrowseInfo bi = (BrowseInfo) request.getAttribute("browse.info");
-	BrowseIndex bix = bi.getBrowseIndex();
-	SortOption so = bi.getSortOption();
+        // First, get the browse info object
+        BrowseInfo bi = (BrowseInfo) request.getAttribute("browse.info");
+        BrowseIndex bix = bi.getBrowseIndex();
+        SortOption so = bi.getSortOption();
 
-	// values used by the header
-	String scope = "";
-	String type = "";
-	String value = "";
+        // values used by the header
+        String scope = "";
+        String type = "";
+        String value = "";
 	
-	Community community = null;
-	Collection collection = null;
-	if (bi.inCommunity())
-	{
-		community = (Community) bi.getBrowseContainer();
-	}
-	if (bi.inCollection())
-	{
-		collection = (Collection) bi.getBrowseContainer();
-	}
+        Community community = null;
+        Collection collection = null;
+        if (bi.inCommunity())
+        {
+                community = (Community) bi.getBrowseContainer();
+        }
+        if (bi.inCollection())
+        {
+                collection = (Collection) bi.getBrowseContainer();
+        }
 	
-	if (community != null)
-	{
-		scope = "\"" + community.getName() + "\"";
-	}
-	if (collection != null)
-	{
-		scope = "\"" + collection.getName() + "\"";
-	}
+        if (community != null)
+        {
+                scope = "\"" + community.getName() + "\"";
+        }
+        if (collection != null)
+        {
+                scope = "\"" + collection.getName() + "\"";
+        }
 	
-	type = bix.getName();
+        type = bix.getName();
 	
-	// next and previous links are of the form:
-	// [handle/<prefix>/<suffix>/]browse?type=<type>&sort_by=<sort_by>&order=<order>[&value=<value>][&rpp=<rpp>][&[focus=<focus>|vfocus=<vfocus>]
+        // next and previous links are of the form:
+        // [handle/<prefix>/<suffix>/]browse?type=<type>&sort_by=<sort_by>&order=<order>[&value=<value>][&rpp=<rpp>][&[focus=<focus>|vfocus=<vfocus>]
 	
-	// prepare the next and previous links
-	String linkBase = request.getContextPath() + "/";
-	if (collection != null)
-	{
-		linkBase = linkBase + "handle/" + collection.getHandle() + "/";
-	}
-	if (community != null)
-	{
-		linkBase = linkBase + "handle/" + community.getHandle() + "/";
-	}
+        // prepare the next and previous links
+        String linkBase = request.getContextPath() + "/";
+        if (collection != null)
+        {
+                linkBase = linkBase + "handle/" + collection.getHandle() + "/";
+        }
+        if (community != null)
+        {
+                linkBase = linkBase + "handle/" + community.getHandle() + "/";
+        }
 	
-	String direction = (bi.isAscending() ? "ASC" : "DESC");
+        String direction = (bi.isAscending() ? "ASC" : "DESC");
 	
-	String argument = null;
-	if (bi.hasAuthority())
+        String argument = null;
+        if (bi.hasAuthority())
     {
         value = bi.getAuthority();
         argument = "authority";
     }
-	else if (bi.hasValue())
-	{
-		value = bi.getValue();
-	    argument = "value";
-	}
+        else if (bi.hasValue())
+        {
+                value = bi.getValue();
+            argument = "value";
+        }
 
-	String valueString = "";
-	if (value!=null)
-	{
-		valueString = "&amp;" + argument + "=" + URLEncoder.encode(value, "UTF-8");
-	}
+        String valueString = "";
+        if (value!=null)
+        {
+                valueString = "&amp;" + argument + "=" + URLEncoder.encode(value, "UTF-8");
+        }
 	
     String sharedLink = linkBase + urlFragment + "?";
 
@@ -119,51 +140,51 @@
         sharedLink += "type=" + URLEncoder.encode(bix.getName(), "UTF-8");
 
     sharedLink += "&amp;sort_by=" + URLEncoder.encode(Integer.toString(so.getNumber()), "UTF-8") +
-				  "&amp;order=" + URLEncoder.encode(direction, "UTF-8") +
-				  "&amp;rpp=" + URLEncoder.encode(Integer.toString(bi.getResultsPerPage()), "UTF-8") +
-				  "&amp;etal=" + URLEncoder.encode(Integer.toString(bi.getEtAl()), "UTF-8") +
-				  valueString;
+                                  "&amp;order=" + URLEncoder.encode(direction, "UTF-8") +
+                                  "&amp;rpp=" + URLEncoder.encode(Integer.toString(bi.getResultsPerPage()), "UTF-8") +
+                                  "&amp;etal=" + URLEncoder.encode(Integer.toString(bi.getEtAl()), "UTF-8") +
+                                  valueString;
 	
-	String next = sharedLink;
-	String prev = sharedLink;
+        String next = sharedLink;
+        String prev = sharedLink;
 	
-	if (bi.hasNextPage())
+        if (bi.hasNextPage())
     {
         next = next + "&amp;offset=" + bi.getNextOffset();
     }
 	
-	if (bi.hasPrevPage())
+        if (bi.hasPrevPage())
     {
         prev = prev + "&amp;offset=" + bi.getPrevOffset();
     }
 	
-	// prepare a url for use by form actions
-	String formaction = request.getContextPath() + "/";
-	if (collection != null)
-	{
-		formaction = formaction + "handle/" + collection.getHandle() + "/";
-	}
-	if (community != null)
-	{
-		formaction = formaction + "handle/" + community.getHandle() + "/";
-	}
-	formaction = formaction + urlFragment;
+        // prepare a url for use by form actions
+        String formaction = request.getContextPath() + "/";
+        if (collection != null)
+        {
+                formaction = formaction + "handle/" + collection.getHandle() + "/";
+        }
+        if (community != null)
+        {
+                formaction = formaction + "handle/" + community.getHandle() + "/";
+        }
+        formaction = formaction + urlFragment;
 	
-	// prepare the known information about sorting, ordering and results per page
-	String sortedBy = so.getName();
-	String ascSelected = (bi.isAscending() ? "selected=\"selected\"" : "");
-	String descSelected = (bi.isAscending() ? "" : "selected=\"selected\"");
-	int rpp = bi.getResultsPerPage();
+        // prepare the known information about sorting, ordering and results per page
+        String sortedBy = so.getName();
+        String ascSelected = (bi.isAscending() ? "selected=\"selected\"" : "");
+        String descSelected = (bi.isAscending() ? "" : "selected=\"selected\"");
+        int rpp = bi.getResultsPerPage();
 	
-	// the message key for the type
-	String typeKey;
+        // the message key for the type
+        String typeKey;
 
-	if (bix.isMetadataIndex())
-		typeKey = "browse.type.metadata." + bix.getName();
-	else if (bi.getSortOption() != null)
-		typeKey = "browse.type.item." + bi.getSortOption().getName();
-	else
-		typeKey = "browse.type.item." + bix.getSortOption().getName();
+        if (bix.isMetadataIndex())
+                typeKey = "browse.type.metadata." + bix.getName();
+        else if (bi.getSortOption() != null)
+                typeKey = "browse.type.item." + bi.getSortOption().getName();
+        else
+                typeKey = "browse.type.item." + bix.getSortOption().getName();
 
     // Admin user or not
     Boolean admin_b = (Boolean)request.getAttribute("admin_button");

--- a/dspace-jspui/src/main/webapp/browse/no-results.jsp
+++ b/dspace-jspui/src/main/webapp/browse/no-results.jsp
@@ -34,6 +34,20 @@
 	if (request.getAttribute("browseWithdrawn") != null || request.getAttribute("browsePrivate") != null)
 	{
 	    layoutNavbar = "admin";
+            
+            // Is the logged in user an admin or community admin or cllection admin
+            Boolean admin = (Boolean)request.getAttribute("is.admin");
+            boolean isAdmin = (admin == null ? false : admin.booleanValue());
+    
+            Boolean communityAdmin = (Boolean)request.getAttribute("is.communityAdmin");
+            boolean isCommunityAdmin = (communityAdmin == null ? false : communityAdmin.booleanValue());
+
+            Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
+            boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
+            
+            if(!isAdmin && (isCommunityAdmin || isCollectionAdmin)){
+                layoutNavbar = "community-or-collection-admin";
+            }
 	}
 
 	// get the BrowseInfo object

--- a/dspace-jspui/src/main/webapp/dspace-admin/authorize-advanced.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/authorize-advanced.jsp
@@ -45,12 +45,31 @@
     List<Group>      groups     = (List<Group>)      request.getAttribute("groups"     );
     List<Collection> collections= (List<Collection>) request.getAttribute("collections");
     request.setAttribute("LanguageSwitch", "hide");
+    
+    // Is the logged in user an admin or community admin or cllection admin
+    Boolean admin = (Boolean)request.getAttribute("is.admin");
+    boolean isAdmin = (admin == null ? false : admin.booleanValue());
+    
+    Boolean communityAdmin = (Boolean)request.getAttribute("is.communityAdmin");
+    boolean isCommunityAdmin = (communityAdmin == null ? false : communityAdmin.booleanValue());
+    
+    Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
+    boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
+    
+    String naviAdmin = "admin";
+    String link = "/dspace-admin";
+    
+    if(!isAdmin && (isCommunityAdmin || isCollectionAdmin))
+    {
+        naviAdmin = "community-or-collection-admin";
+        link = "/tools";
+    }
 %>
 
 <dspace:layout style="submission" titlekey="jsp.dspace-admin.authorize-advanced.advanced"
-               navbar="admin"
+               navbar="<%= naviAdmin %>"
                locbar="link"
-               parentlink="/dspace-admin"
+               parentlink="<%= link %>"
                parenttitlekey="jsp.administer">
 
 <h1><fmt:message key="jsp.dspace-admin.authorize-advanced.advanced"/>

--- a/dspace-jspui/src/main/webapp/dspace-admin/authorize-collection-edit.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/authorize-collection-edit.jsp
@@ -50,13 +50,32 @@
     Collection collection = (Collection) request.getAttribute("collection");
     List<ResourcePolicy> policies =
         (List<ResourcePolicy>) request.getAttribute("policies");
+    
+    // Is the logged in user an admin or community admin or cllection admin
+    Boolean admin = (Boolean)request.getAttribute("is.admin");
+    boolean isAdmin = (admin == null ? false : admin.booleanValue());
+    
+    Boolean communityAdmin = (Boolean)request.getAttribute("is.communityAdmin");
+    boolean isCommunityAdmin = (communityAdmin == null ? false : communityAdmin.booleanValue());
+    
+    Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
+    boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
+    
+    String naviAdmin = "admin";
+    String link = "/dspace-admin";
+    
+    if(!isAdmin && (isCommunityAdmin || isCollectionAdmin))
+    {
+        naviAdmin = "community-or-collection-admin";
+        link = "/tools";
+    }
 %>
 
 <dspace:layout style="submission" titlekey="jsp.dspace-admin.authorize-collection-edit.title"
-               navbar="admin"
+               navbar="<%= naviAdmin %>"
                locbar="link"
                parenttitlekey="jsp.administer"
-               parentlink="/dspace-admin"
+               parentlink="<%= link %>"
                nocache="true">
 
 		<h1><fmt:message key="jsp.dspace-admin.authorize-collection-edit.policies">

--- a/dspace-jspui/src/main/webapp/dspace-admin/authorize-community-edit.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/authorize-community-edit.jsp
@@ -50,13 +50,32 @@
     Community community = (Community) request.getAttribute("community");
     List<ResourcePolicy> policies =
         (List<ResourcePolicy>) request.getAttribute("policies");
+    
+    // Is the logged in user an admin or community admin or cllection admin
+    Boolean admin = (Boolean)request.getAttribute("is.admin");
+    boolean isAdmin = (admin == null ? false : admin.booleanValue());
+    
+    Boolean communityAdmin = (Boolean)request.getAttribute("is.communityAdmin");
+    boolean isCommunityAdmin = (communityAdmin == null ? false : communityAdmin.booleanValue());
+    
+    Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
+    boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
+    
+    String naviAdmin = "admin";
+    String link = "/dspace-admin";
+    
+    if(!isAdmin && (isCommunityAdmin || isCollectionAdmin))
+    {
+        naviAdmin = "community-or-collection-admin";
+        link = "/tools";
+    }
 %>
 
 <dspace:layout style="submission" titlekey="jsp.dspace-admin.authorize-community-edit.title"
-               navbar="admin"
+               navbar="<%= naviAdmin %>"
                locbar="link"
                parenttitlekey="jsp.administer"
-               parentlink="/dspace-admin"
+               parentlink="<%= link %>"
                nocache="true">
   
 	<h1><fmt:message key="jsp.dspace-admin.authorize-community-edit.policies">

--- a/dspace-jspui/src/main/webapp/dspace-admin/authorize-item-edit.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/authorize-item-edit.jsp
@@ -69,13 +69,32 @@
     List<Bundle> bundles      = (List<Bundle>)request.getAttribute("bundles");
     Map bundle_policies    = (Map)request.getAttribute("bundle_policies"   );
     Map bitstream_policies = (Map)request.getAttribute("bitstream_policies");
+    
+   // Is the logged in user an admin or community admin or cllection admin
+    Boolean admin = (Boolean)request.getAttribute("is.admin");
+    boolean isAdmin = (admin == null ? false : admin.booleanValue());
+    
+    Boolean communityAdmin = (Boolean)request.getAttribute("is.communityAdmin");
+    boolean isCommunityAdmin = (communityAdmin == null ? false : communityAdmin.booleanValue());
+    
+    Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
+    boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
+    
+    String naviAdmin = "admin";
+    String link = "/dspace-admin";
+    
+    if(!isAdmin && (isCommunityAdmin || isCollectionAdmin))
+    {
+        naviAdmin = "community-or-collection-admin";
+        link = "/tools";
+    }
 %>
 
 <dspace:layout style="submission" titlekey="jsp.dspace-admin.authorize-item-edit.title"
-               navbar="admin"
+               navbar="<%= naviAdmin %>"
                locbar="link"
                parenttitlekey="jsp.administer"
-               parentlink="/dspace-admin"
+               parentlink="<%= link %>"
                nocache="true">
 
 

--- a/dspace-jspui/src/main/webapp/dspace-admin/authorize-main.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/authorize-main.jsp
@@ -38,14 +38,31 @@
 <% request.setAttribute("LanguageSwitch", "hide"); %>
 
 <%
-// this space intentionally left blank
+    // Is the logged in user an admin or community admin or cllection admin
+    Boolean admin = (Boolean)request.getAttribute("is.admin");
+    boolean isAdmin = (admin == null ? false : admin.booleanValue());
+    
+    Boolean communityAdmin = (Boolean)request.getAttribute("is.communityAdmin");
+    boolean isCommunityAdmin = (communityAdmin == null ? false : communityAdmin.booleanValue());
+    
+    Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
+    boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
+    
+    String naviAdmin = "admin";
+    String link = "/dspace-admin";
+    
+    if(!isAdmin && (isCommunityAdmin || isCollectionAdmin))
+    {
+        naviAdmin = "community-or-collection-admin";
+        link = "/tools";
+    }
 %>
 
 <dspace:layout style="submission" titlekey="jsp.dspace-admin.authorize-main.title"
-               navbar="admin"
+               navbar="<%= naviAdmin %>"
                locbar="link"
                parenttitlekey="jsp.administer"
-               parentlink="/dspace-admin">
+               parentlink="<%= link %>">
 
     <%-- <h1>Administer Authorization Policies</h1> --%>
     <h1><fmt:message key="jsp.dspace-admin.authorize-main.adm"/>
@@ -62,10 +79,12 @@
     <form method="post" action="">    
 
 				<div class="btn-group col-md-offset-5">
+                    <% if(isAdmin){ %>
 					<div class="row">
                     <%-- <input type="submit" name="submit_community" value="Manage a Community's Policies"> --%>
                     	<input class="btn btn-default col-md-12" type="submit" name="submit_community" value="<fmt:message key="jsp.dspace-admin.authorize-main.manage1"/>" />
 					</div>
+                    <% } %>
 					<div class="row">
                     <%-- <input type="submit" name="submit_collection" value="Manage Collection's Policies"> --%>
                     	<input class="btn btn-default col-md-12" type="submit" name="submit_collection" value="<fmt:message key="jsp.dspace-admin.authorize-main.manage2"/>" />
@@ -74,10 +93,12 @@
                     <%-- <input type="submit" name="submit_item" value="Manage An Item's Policies"> --%>
                     	<input class="btn btn-default col-md-12" type="submit" name="submit_item" value="<fmt:message key="jsp.dspace-admin.authorize-main.manage3"/>" />
 					</div>
+                    <% if(isAdmin){ %>
 					<div class="row">
                     <%-- <input type="submit" name="submit_advanced" value="Advanced/Item Wildcard Policy Admin Tool"> --%>
                     	<input class="btn btn-default col-md-12" type="submit" name="submit_advanced" value="<fmt:message key="jsp.dspace-admin.authorize-main.advanced"/>" />
                     </div>
+                    <% } %>
      			</div>
 
     </form>

--- a/dspace-jspui/src/main/webapp/dspace-admin/authorize-policy-edit.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/authorize-policy-edit.jsp
@@ -65,13 +65,32 @@
     int resourceRelevance = 1 << resourceType;
     
     request.setAttribute("LanguageSwitch", "hide");  
+    
+   // Is the logged in user an admin or community admin or cllection admin
+    Boolean admin = (Boolean)request.getAttribute("is.admin");
+    boolean isAdmin = (admin == null ? false : admin.booleanValue());
+    
+    Boolean communityAdmin = (Boolean)request.getAttribute("is.communityAdmin");
+    boolean isCommunityAdmin = (communityAdmin == null ? false : communityAdmin.booleanValue());
+    
+    Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
+    boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
+    
+    String naviAdmin = "admin";
+    String link = "/dspace-admin";
+    
+    if(!isAdmin && (isCommunityAdmin || isCollectionAdmin))
+    {
+        naviAdmin = "community-or-collection-admin";
+        link = "/tools";
+    }
 %>
 
 <dspace:layout style="submission" titlekey="jsp.dspace-admin.authorize-policy-edit.title"
-               navbar="admin"
+               navbar="<%= naviAdmin %>"
                locbar="link"
                parenttitlekey="jsp.administer"
-               parentlink="/dspace-admin"
+               parentlink="<%= link %>"
                nocache="true">
 
         <%-- <h1>Edit Policy for <%= edit_title %>:</h1> --%>

--- a/dspace-jspui/src/main/webapp/dspace-admin/collection-select.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/collection-select.jsp
@@ -37,13 +37,32 @@
         (List<Collection>) request.getAttribute("collections");
        
     request.setAttribute("LanguageSwitch", "hide");
+       
+   // Is the logged in user an admin or community admin or cllection admin
+    Boolean admin = (Boolean)request.getAttribute("is.admin");
+    boolean isAdmin = (admin == null ? false : admin.booleanValue());
+    
+    Boolean communityAdmin = (Boolean)request.getAttribute("is.communityAdmin");
+    boolean isCommunityAdmin = (communityAdmin == null ? false : communityAdmin.booleanValue());
+    
+    Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
+    boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
+    
+    String naviAdmin = "admin";
+    String link = "/dspace-admin";
+    
+    if(!isAdmin && (isCommunityAdmin || isCollectionAdmin))
+    {
+        naviAdmin = "community-or-collection-admin";
+        link = "/tools";
+    }
 %>
 
 <dspace:layout style="submission" titlekey="jsp.dspace-admin.collection-select.title"
-               navbar="admin"
+               navbar="<%= naviAdmin %>"
                locbar="link"
                parenttitlekey="jsp.administer"
-               parentlink="/dspace-admin">
+               parentlink="<%= link %>" >
 
     <%-- <h1>Collections:</h1> --%>
     <h1><fmt:message key="jsp.dspace-admin.collection-select.col"/></h1>

--- a/dspace-jspui/src/main/webapp/dspace-admin/community-select.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/community-select.jsp
@@ -37,13 +37,32 @@
         (List<Community>) request.getAttribute("communities");
         
     request.setAttribute("LanguageSwitch", "hide");
+    
+    // Is the logged in user an admin or community admin or cllection admin
+    Boolean admin = (Boolean)request.getAttribute("is.admin");
+    boolean isAdmin = (admin == null ? false : admin.booleanValue());
+    
+    Boolean communityAdmin = (Boolean)request.getAttribute("is.communityAdmin");
+    boolean isCommunityAdmin = (communityAdmin == null ? false : communityAdmin.booleanValue());
+    
+    Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
+    boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
+    
+    String naviAdmin = "admin";
+    String link = "/dspace-admin";
+    
+    if(!isAdmin && (isCommunityAdmin || isCollectionAdmin))
+    {
+        naviAdmin = "community-or-collection-admin";
+        link = "/tools";
+    }
 %>
 
 <dspace:layout style="submission" titlekey="jsp.dspace-admin.community-select.title"
-               navbar="admin"
+               navbar="<%= naviAdmin %>"
                locbar="link"
                parenttitlekey="jsp.administer"
-               parentlink="/dspace-admin">
+               parentlink="<%= link %>">
 
     <%-- <h1>communities:</h1> --%>
     <h1><fmt:message key="jsp.dspace-admin.community-select.com"/></h1>

--- a/dspace-jspui/src/main/webapp/dspace-admin/item-select.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/item-select.jsp
@@ -26,12 +26,31 @@
 
 <%@ page import="org.dspace.core.ConfigurationManager" %>
 
-
+<% 
+    // Is the logged in user an admin or community admin or cllection admin
+    Boolean admin = (Boolean)request.getAttribute("is.admin");
+    boolean isAdmin = (admin == null ? false : admin.booleanValue());
+    
+    Boolean communityAdmin = (Boolean)request.getAttribute("is.communityAdmin");
+    boolean isCommunityAdmin = (communityAdmin == null ? false : communityAdmin.booleanValue());
+    
+    Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
+    boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
+    
+    String naviAdmin = "admin";
+    String link = "/dspace-admin";
+    
+    if(!isAdmin && (isCommunityAdmin || isCollectionAdmin))
+    {
+        naviAdmin = "community-or-collection-admin";
+        link = "/tools";
+    }
+%>
 <dspace:layout style="submission" titlekey="jsp.dspace-admin.item-select.title"
-               navbar="admin"
+               navbar="<%= naviAdmin %>"
                locbar="link"
                parenttitlekey="jsp.administer"
-               parentlink="/dspace-admin">
+               parentlink="<%= link %>">
   
     <%-- <h1>Select an Item</h1> --%>  
 

--- a/dspace-jspui/src/main/webapp/dspace-admin/upload-logo.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/upload-logo.jsp
@@ -30,14 +30,32 @@
 <%
     Collection collection = (Collection) request.getAttribute("collection");
     Community community = (Community) request.getAttribute("community");
+        
+     // Is the logged in user an admin or community admin or cllection admin
+    Boolean admin = (Boolean)request.getAttribute("is.admin");
+    boolean isAdmin = (admin == null ? false : admin.booleanValue());
     
+    Boolean communityAdmin = (Boolean)request.getAttribute("is.communityAdmin");
+    boolean isCommunityAdmin = (communityAdmin == null ? false : communityAdmin.booleanValue());
+    
+    Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
+    boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
+    
+    String naviAdmin = "admin";
+    String link = "/dspace-admin";
+    
+    if(!isAdmin && (isCommunityAdmin || isCollectionAdmin))
+    {
+        naviAdmin = "community-or-collection-admin";
+        link = "/tools";
+    }
 %>
 
 <dspace:layout titlekey="jsp.dspace-admin.upload-logo.title"
-               navbar="admin"
+               navbar="<%= naviAdmin %>"
                locbar="link"
                parenttitlekey="jsp.administer"
-               parentlink="/dspace-admin" 
+               parentlink="<%= link %>" 
                nocache="true">
 
     <%-- <h1>Upload Logo</h1> --%>

--- a/dspace-jspui/src/main/webapp/layout/navbar-community-or-collection-admin.jsp
+++ b/dspace-jspui/src/main/webapp/layout/navbar-community-or-collection-admin.jsp
@@ -1,0 +1,103 @@
+<%--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+--%>
+<%--
+  - Navigation bar for admin pages
+  --%>
+
+<%@ page contentType="text/html;charset=UTF-8" %>
+
+<%@ page import="java.util.LinkedList" %>
+<%@ page import="java.util.List" %>
+
+<%@ page import="javax.servlet.jsp.jstl.fmt.LocaleSupport" %>
+
+<%@ page import="org.dspace.browse.BrowseInfo" %>
+<%@ page import="org.dspace.sort.SortOption" %>
+<%@ page import="org.dspace.app.webui.util.UIUtil" %>
+<%@ page import="org.dspace.eperson.EPerson" %>
+<%@page import="org.apache.commons.lang.StringUtils"%>
+
+<%@ taglib uri="http://www.dspace.org/dspace-tags.tld" prefix="dspace" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+
+<%
+	// Is anyone logged in?
+	EPerson user = (EPerson) request.getAttribute("dspace.current.user");
+
+    // Get the current page, minus query string
+    String currentPage = UIUtil.getOriginalURL(request);    
+    int c = currentPage.indexOf( '?' );
+    if( c > -1 )
+    {
+        currentPage = currentPage.substring(0, c);
+    }
+    
+    // E-mail may have to be truncated
+    String navbarEmail = null;
+    if (user != null)
+    {
+        navbarEmail = user.getEmail();
+    }
+
+%>
+
+       <div class="navbar-header">
+         <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+           <span class="icon-bar"></span>
+           <span class="icon-bar"></span>
+           <span class="icon-bar"></span>
+         </button>
+         <a class="navbar-brand" href="<%= request.getContextPath() %>/"><img height="25px" src="<%= request.getContextPath() %>/image/dspace-logo-only.png" /></a>
+       </div>
+       <nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
+         <ul class="nav navbar-nav">
+           <li><a href="<%= request.getContextPath() %>/"><span class="glyphicon glyphicon-home"></span> <fmt:message key="jsp.layout.navbar-default.home"/></a></li>
+           
+          <li class="dropdown">
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown"><fmt:message key="jsp.layout.navbar-admin.contents"/> <b class="caret"></b></a>
+             <ul class="dropdown-menu">
+               <li><a href="<%= request.getContextPath() %>/tools/edit-communities"><fmt:message key="jsp.layout.navbar-admin.communities-collections"/></a></li>
+               <li class="divider"></li>
+               <li><a href="<%= request.getContextPath() %>/tools/edit-item"><fmt:message key="jsp.layout.navbar-admin.items"/></a></li>
+               <li><a href="<%= request.getContextPath() %>/tools/withdrawn"><fmt:message key="jsp.layout.navbar-admin.withdrawn"/></a></li>
+               <li><a href="<%= request.getContextPath() %>/tools/privateitems"><fmt:message key="jsp.layout.navbar-admin.privateitems"/></a></li>
+            </ul>
+          </li>
+                          
+           <li class="dropdown">
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown"><fmt:message key="jsp.layout.navbar-admin.accesscontrol"/> <b class="caret"></b></a>
+             <ul class="dropdown-menu">
+               <li><a href="<%= request.getContextPath() %>/tools/group-edit"><fmt:message key="jsp.layout.navbar-admin.groups"/></a></li>
+               <li><a href="<%= request.getContextPath() %>/tools/authorize"><fmt:message key="jsp.layout.navbar-admin.authorization"/></a></li>
+            </ul>
+          </li>
+          <li class="<%= ( currentPage.endsWith( "/help" ) ? "active" : "" ) %>"><dspace:popup page="<%= LocaleSupport.getLocalizedMessage(pageContext, \"help.site-admin\") %>"><fmt:message key="jsp.layout.navbar-admin.help"/></dspace:popup></li>
+       </ul>
+       <div class="nav navbar-nav navbar-right">
+		<ul class="nav navbar-nav navbar-right">
+         <li class="dropdown">
+
+		<a href="#" class="dropdown-toggle" data-toggle="dropdown"><span class="glyphicon glyphicon-user"></span> <fmt:message key="jsp.layout.navbar-default.loggedin">
+		      <fmt:param><%= StringUtils.abbreviate(navbarEmail, 20) %></fmt:param>
+		  </fmt:message> <b class="caret"></b></a>
+		<ul class="dropdown-menu">
+               <li><a href="<%= request.getContextPath() %>/subscribe"><fmt:message key="jsp.layout.navbar-default.receive"/></a></li>
+               <li><a href="<%= request.getContextPath() %>/mydspace"><fmt:message key="jsp.layout.navbar-default.users"/></a></li>
+               <li><a href="<%= request.getContextPath() %>/profile"><fmt:message key="jsp.layout.navbar-default.edit"/></a></li>
+
+		
+		<li><a href="<%= request.getContextPath() %>/logout"><span class="glyphicon glyphicon-log-out"></span> <fmt:message key="jsp.layout.navbar-default.logout"/></a></li>
+		
+        </ul>
+       </li>
+    </ul>
+          
+	</div>
+</nav>

--- a/dspace-jspui/src/main/webapp/layout/navbar-default.jsp
+++ b/dspace-jspui/src/main/webapp/layout/navbar-default.jsp
@@ -39,6 +39,12 @@
     Boolean admin = (Boolean)request.getAttribute("is.admin");
     boolean isAdmin = (admin == null ? false : admin.booleanValue());
 
+    Boolean communityAdmin = (Boolean)request.getAttribute("is.communityAdmin");
+    boolean isCommunityAdmin = (communityAdmin == null ? false : communityAdmin.booleanValue());
+    
+    Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
+    boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
+
     // Get the current page, minus query string
     String currentPage = UIUtil.getOriginalURL(request);
     int c = currentPage.indexOf( '?' );
@@ -165,13 +171,19 @@
                <li><a href="<%= request.getContextPath() %>/profile"><fmt:message key="jsp.layout.navbar-default.edit"/></a></li>
 
 		<%
-		  if (isAdmin)
-		  {
-		%>
-			   <li class="divider"></li>  
-               <li><a href="<%= request.getContextPath() %>/dspace-admin"><fmt:message key="jsp.administer"/></a></li>
-		<%
-		  }
+                if (isAdmin || isCommunityAdmin || isCollectionAdmin) {
+                %>
+			   <li class="divider"></li>
+                           <% if (isAdmin) {%>
+                    
+                                <li><a href="<%= request.getContextPath()%>/dspace-admin">
+                           <% } else if (isCommunityAdmin || isCollectionAdmin) {%>
+                        
+                                <li><a href="<%= request.getContextPath()%>/tools">
+                <% } %>
+                <fmt:message key="jsp.administer"/></a></li>
+                <%
+                    }
 		  if (user != null) {
 		%>
 		<li><a href="<%= request.getContextPath() %>/logout"><span class="glyphicon glyphicon-log-out"></span> <fmt:message key="jsp.layout.navbar-default.logout"/></a></li>

--- a/dspace-jspui/src/main/webapp/tools/confirm-delete-item.jsp
+++ b/dspace-jspui/src/main/webapp/tools/confirm-delete-item.jsp
@@ -28,13 +28,32 @@
     String handle = (String) request.getAttribute("handle");
     Item item = (Item) request.getAttribute("item");
     request.setAttribute("LanguageSwitch", "hide");
+    
+    // Is the logged in user an admin or community admin or cllection admin
+    Boolean admin = (Boolean)request.getAttribute("is.admin");
+    boolean isAdmin = (admin == null ? false : admin.booleanValue());
+    
+    Boolean communityAdmin = (Boolean)request.getAttribute("is.communityAdmin");
+    boolean isCommunityAdmin = (communityAdmin == null ? false : communityAdmin.booleanValue());
+    
+    Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
+    boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
+    
+    String naviAdmin = "admin";
+    String link = "/dspace-admin";
+    
+    if(!isAdmin && (isCommunityAdmin || isCollectionAdmin))
+    {
+        naviAdmin = "community-or-collection-admin";
+        link = "/tools";
+    }
 %>
 
 <dspace:layout titlekey="jsp.tools.confirm-delete-item.title"
-               navbar="admin"
+               navbar="<%= naviAdmin %>"
                locbar="link"
                parenttitlekey="jsp.administer"
-               parentlink="/dspace-admin"
+               parentlink="<%= link %>"
                nocache="true">
 
     <%-- <h1>Delete Item: <%= (handle == null ? String.valueOf(item.getID()) : handle) %></h1> --%>

--- a/dspace-jspui/src/main/webapp/tools/confirm-privating-item.jsp
+++ b/dspace-jspui/src/main/webapp/tools/confirm-privating-item.jsp
@@ -28,13 +28,32 @@
     String handle = (String) request.getAttribute("handle");
     Item item = (Item) request.getAttribute("item");
     request.setAttribute("LanguageSwitch", "hide");
+
+   // Is the logged in user an admin or community admin or cllection admin
+    Boolean admin = (Boolean)request.getAttribute("is.admin");
+    boolean isAdmin = (admin == null ? false : admin.booleanValue());
+    
+    Boolean communityAdmin = (Boolean)request.getAttribute("is.communityAdmin");
+    boolean isCommunityAdmin = (communityAdmin == null ? false : communityAdmin.booleanValue());
+    
+    Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
+    boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
+    
+    String naviAdmin = "admin";
+    String link = "/dspace-admin";
+    
+    if(!isAdmin && (isCommunityAdmin || isCollectionAdmin))
+    {
+        naviAdmin = "community-or-collection-admin";
+        link = "/tools";
+    }
 %>
 
 <dspace:layout titlekey="jsp.tools.confirm-privating-item.title"
-               navbar="admin"
+               navbar="<%= naviAdmin %>"
                locbar="link"
                parenttitlekey="jsp.administer"
-               parentlink="/dspace-admin"
+               parentlink="<%= link %>"
                nocache="true">
 
     <h1><fmt:message key="jsp.tools.confirm-privating-item.title"/>: <%= (handle == null ? String.valueOf(item.getID()) : handle) %></h1>

--- a/dspace-jspui/src/main/webapp/tools/confirm-withdraw-item.jsp
+++ b/dspace-jspui/src/main/webapp/tools/confirm-withdraw-item.jsp
@@ -28,13 +28,32 @@
     String handle = (String) request.getAttribute("handle");
     Item item = (Item) request.getAttribute("item");
     request.setAttribute("LanguageSwitch", "hide");
+
+    // Is the logged in user an admin or community admin or cllection admin
+    Boolean admin = (Boolean)request.getAttribute("is.admin");
+    boolean isAdmin = (admin == null ? false : admin.booleanValue());
+    
+    Boolean communityAdmin = (Boolean)request.getAttribute("is.communityAdmin");
+    boolean isCommunityAdmin = (communityAdmin == null ? false : communityAdmin.booleanValue());
+    
+    Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
+    boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
+    
+    String naviAdmin = "admin";
+    String link = "/dspace-admin";
+    
+    if(!isAdmin && (isCommunityAdmin || isCollectionAdmin))
+    {
+        naviAdmin = "community-or-collection-admin";
+        link = "/tools";
+    }
 %>
 
 <dspace:layout titlekey="jsp.tools.confirm-withdraw-item.title"
-               navbar="admin"
+               navbar="<%= naviAdmin %>"
                locbar="link"
                parenttitlekey="jsp.administer"
-               parentlink="/dspace-admin"
+               parentlink="<%= link %>"
                nocache="true">
 
     <%-- <h1>Withdraw Item: <%= (handle == null ? String.valueOf(item.getID()) : handle) %></h1> --%>

--- a/dspace-jspui/src/main/webapp/tools/curate-collection.jsp
+++ b/dspace-jspui/src/main/webapp/tools/curate-collection.jsp
@@ -47,13 +47,31 @@
     String title = (collection != null ? collection.getName() : "Unknown Collection");
     String groupOptions = (String)request.getAttribute("curate_group_options");
     String taskOptions = (String)request.getAttribute("curate_task_options");
+    // Is the logged in user an admin or community admin or cllection admin
+    Boolean admin = (Boolean)request.getAttribute("is.admin");
+    boolean isAdmin = (admin == null ? false : admin.booleanValue());
+    
+    Boolean communityAdmin = (Boolean)request.getAttribute("is.communityAdmin");
+    boolean isCommunityAdmin = (communityAdmin == null ? false : communityAdmin.booleanValue());
+    
+    Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
+    boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
+    
+    String naviAdmin = "admin";
+    String link = "/dspace-admin";
+    
+    if(!isAdmin && (isCommunityAdmin || isCollectionAdmin))
+    {
+        naviAdmin = "community-or-collection-admin";
+        link = "/tools";
+    }
 %>
 
 <dspace:layout style="submission" titlekey="jsp.tools.curate.collection.title"
-               navbar="admin"
+               navbar="<%= naviAdmin %>"
                locbar="link"
                parenttitlekey="jsp.administer"
-               parentlink="/dspace-admin">
+               parentlink="<%= link %>">
 
 <%@ include file="/tools/curate-message.jsp" %>
 

--- a/dspace-jspui/src/main/webapp/tools/curate-community.jsp
+++ b/dspace-jspui/src/main/webapp/tools/curate-community.jsp
@@ -39,14 +39,33 @@
     UUID communityID = (community != null ? community.getID() : null);
     String title = (community != null ? community.getName() : "Unknown Community");
     String groupOptions = (String)request.getAttribute("curate_group_options");
-    String taskOptions = (String)request.getAttribute("curate_task_options");
+    String taskOptions = (String)request.getAttribute("curate_task_options"); 
+
+   // Is the logged in user an admin or community admin or cllection admin
+    Boolean admin = (Boolean)request.getAttribute("is.admin");
+    boolean isAdmin = (admin == null ? false : admin.booleanValue());
+    
+    Boolean communityAdmin = (Boolean)request.getAttribute("is.communityAdmin");
+    boolean isCommunityAdmin = (communityAdmin == null ? false : communityAdmin.booleanValue());
+    
+    Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
+    boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
+    
+    String naviAdmin = "admin";
+    String link = "/dspace-admin";
+    
+    if(!isAdmin && (isCommunityAdmin || isCollectionAdmin))
+    {
+        naviAdmin = "community-or-collection-admin";
+        link = "/tools";
+    }
 %>
 
 <dspace:layout style="submission" titlekey="jsp.tools.curate.community.title"
-               navbar="admin"
+               navbar="<%= naviAdmin %>"
                locbar="link"
                parenttitlekey="jsp.administer"
-               parentlink="/dspace-admin">
+               parentlink="<%= link %>">
 
 <%@ include file="/tools/curate-message.jsp" %>
 

--- a/dspace-jspui/src/main/webapp/tools/curate-item.jsp
+++ b/dspace-jspui/src/main/webapp/tools/curate-item.jsp
@@ -41,13 +41,32 @@
     }
     String groupOptions = (String)request.getAttribute("curate_group_options");
     String taskOptions = (String)request.getAttribute("curate_task_options");
+
+    // Is the logged in user an admin or community admin or cllection admin
+    Boolean admin = (Boolean)request.getAttribute("is.admin");
+    boolean isAdmin = (admin == null ? false : admin.booleanValue());
+    
+    Boolean communityAdmin = (Boolean)request.getAttribute("is.communityAdmin");
+    boolean isCommunityAdmin = (communityAdmin == null ? false : communityAdmin.booleanValue());
+    
+    Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
+    boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
+    
+    String naviAdmin = "admin";
+    String link = "/dspace-admin";
+    
+    if(!isAdmin && (isCommunityAdmin || isCollectionAdmin))
+    {
+        naviAdmin = "community-or-collection-admin";
+        link = "/tools";
+    }
 %>
 
 <dspace:layout style="submission" titlekey="jsp.tools.curate.item.title"
-               navbar="admin"
+               navbar="<%= naviAdmin %>"
                locbar="link"
                parenttitlekey="jsp.administer"
-               parentlink="/dspace-admin">
+               parentlink="<%= link %>">
 
 <%@ include file="/tools/curate-message.jsp" %>
 

--- a/dspace-jspui/src/main/webapp/tools/edit-collection.jsp
+++ b/dspace-jspui/src/main/webapp/tools/edit-collection.jsp
@@ -63,9 +63,24 @@
     Boolean deleteButton = (Boolean)request.getAttribute("delete_button");
     boolean bDeleteButton = (deleteButton == null ? false : deleteButton.booleanValue());
     
-    // Is the logged in user a sys admin
+   // Is the logged in user an admin or community admin or cllection admin
     Boolean admin = (Boolean)request.getAttribute("is.admin");
     boolean isAdmin = (admin == null ? false : admin.booleanValue());
+    
+    Boolean communityAdmin = (Boolean)request.getAttribute("is.communityAdmin");
+    boolean isCommunityAdmin = (communityAdmin == null ? false : communityAdmin.booleanValue());
+    
+    Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
+    boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
+    
+    String naviAdmin = "admin";
+    String link = "/dspace-admin";
+    
+    if(!isAdmin && (isCommunityAdmin || isCollectionAdmin))
+    {
+        naviAdmin = "community-or-collection-admin";
+        link = "/tools";
+    }
     
     HarvestedCollection hc = (HarvestedCollection) request.getAttribute("harvestInstance");
     
@@ -136,9 +151,9 @@
 %>
 
 <dspace:layout style="submission" titlekey="jsp.tools.edit-collection.title"
-               navbar="admin"
+               navbar="<%= naviAdmin %>"
                locbar="link"
-               parentlink="/dspace-admin"
+               parentlink="<%= link %>"
                parenttitlekey="jsp.administer"
                nocache="true">
 <div class="row">

--- a/dspace-jspui/src/main/webapp/tools/edit-community.jsp
+++ b/dspace-jspui/src/main/webapp/tools/edit-community.jsp
@@ -37,9 +37,25 @@
     Community community = (Community) request.getAttribute("community");
 	Community parentCommunity = (Community) request.getAttribute("parent");
     UUID parentID = (parentCommunity != null ? parentCommunity.getID() : null);
-    // Is the logged in user a sys admin
+    
+    // Is the logged in user an admin or community admin or cllection admin
     Boolean admin = (Boolean)request.getAttribute("is.admin");
     boolean isAdmin = (admin == null ? false : admin.booleanValue());
+    
+    Boolean communityAdmin = (Boolean)request.getAttribute("is.communityAdmin");
+    boolean isCommunityAdmin = (communityAdmin == null ? false : communityAdmin.booleanValue());
+    
+    Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
+    boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
+    
+    String naviAdmin = "admin";
+    String link = "/dspace-admin";
+    
+    if(!isAdmin && (isCommunityAdmin || isCollectionAdmin))
+    {
+        naviAdmin = "community-or-collection-admin";
+        link = "/tools";
+    }
     
     Boolean adminCreateGroup = (Boolean)request.getAttribute("admin_create_button");
     boolean bAdminCreateGroup = (adminCreateGroup == null ? false : adminCreateGroup.booleanValue());
@@ -77,9 +93,9 @@
 %>
 
 <dspace:layout style="submission" titlekey="jsp.tools.edit-community.title"
-		       navbar="admin"
+		       navbar="<%= naviAdmin %>"
 		       locbar="link"
-		       parentlink="/dspace-admin"
+		       parentlink="<%= link %>"
 		       parenttitlekey="jsp.administer" nocache="true">
 
 <div class="row">

--- a/dspace-jspui/src/main/webapp/tools/edit-item-form.jsp
+++ b/dspace-jspui/src/main/webapp/tools/edit-item-form.jsp
@@ -60,6 +60,25 @@
     // Is the logged in user an admin of the item
     Boolean itemAdmin = (Boolean)request.getAttribute("admin_button");
     boolean isItemAdmin = (itemAdmin == null ? false : itemAdmin.booleanValue());
+
+    // Is the logged in user an admin or community admin or cllection admin
+    Boolean admin = (Boolean)request.getAttribute("is.admin");
+    boolean isAdmin = (admin == null ? false : admin.booleanValue());
+    
+    Boolean communityAdmin = (Boolean)request.getAttribute("is.communityAdmin");
+    boolean isCommunityAdmin = (communityAdmin == null ? false : communityAdmin.booleanValue());
+    
+    Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
+    boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
+    
+    String naviAdmin = "admin";
+    String link = "/dspace-admin";
+    
+    if(!isAdmin && (isCommunityAdmin || isCollectionAdmin))
+    {
+        naviAdmin = "community-or-collection-admin";
+        link = "/tools";
+    }
     
     Boolean policy = (Boolean)request.getAttribute("policy_button");
     boolean bPolicy = (policy == null ? false : policy.booleanValue());
@@ -195,10 +214,10 @@
 </c:set>
 
 <dspace:layout style="submission" titlekey="jsp.tools.edit-item-form.title"
-               navbar="admin"
+               navbar="<%= naviAdmin %>"
                locbar="link"
                parenttitlekey="jsp.administer"
-               parentlink="/dspace-admin"
+               parentlink="<%= link %>"
                nocache="true">
 
 

--- a/dspace-jspui/src/main/webapp/tools/get-item-id.jsp
+++ b/dspace-jspui/src/main/webapp/tools/get-item-id.jsp
@@ -26,11 +26,31 @@
 
 <%@ page import="org.dspace.core.ConfigurationManager" %>
 
+<% 
+    // Is the logged in user an admin or community admin or cllection admin
+    Boolean admin = (Boolean)request.getAttribute("is.admin");
+    boolean isAdmin = (admin == null ? false : admin.booleanValue());
+    
+    Boolean communityAdmin = (Boolean)request.getAttribute("is.communityAdmin");
+    boolean isCommunityAdmin = (communityAdmin == null ? false : communityAdmin.booleanValue());
+    
+    Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
+    boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
+    
+    String naviAdmin = "admin";
+    String link = "/dspace-admin";
+    
+    if(!isAdmin && (isCommunityAdmin || isCollectionAdmin))
+    {
+        naviAdmin = "community-or-collection-admin";
+        link = "/tools";
+    }
+%>
 <dspace:layout style="submission" titlekey="jsp.tools.get-item-id.title"
-               navbar="admin"
+               navbar="<%= naviAdmin %>"
                locbar="link"
                parenttitlekey="jsp.administer"
-               parentlink="/dspace-admin">
+               parentlink="<%= link %>">
 
 	<%-- <h1>Edit or Delete Item</h1> --%>
 	<h1><fmt:message key="jsp.tools.get-item-id.heading"/>

--- a/dspace-jspui/src/main/webapp/tools/group-edit.jsp
+++ b/dspace-jspui/src/main/webapp/tools/group-edit.jsp
@@ -41,13 +41,32 @@
     
 	List<Group>   groups  = (List<Group>) request.getAttribute("membergroups");
 	request.setAttribute("LanguageSwitch", "hide");
+        
+    // Is the logged in user an admin or community admin or cllection admin
+    Boolean admin = (Boolean)request.getAttribute("is.admin");
+    boolean isAdmin = (admin == null ? false : admin.booleanValue());
+    
+    Boolean communityAdmin = (Boolean)request.getAttribute("is.communityAdmin");
+    boolean isCommunityAdmin = (communityAdmin == null ? false : communityAdmin.booleanValue());
+    
+    Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
+    boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
+    
+    String naviAdmin = "admin";
+    String link = "/dspace-admin";
+    
+    if(!isAdmin && (isCommunityAdmin || isCollectionAdmin))
+    {
+        naviAdmin = "community-or-collection-admin";
+        link = "/tools";
+    }
 %>
 
 <dspace:layout style="submission" titlekey="jsp.tools.group-edit.title"
-               navbar="admin"
+               navbar="<%= naviAdmin %>"
                locbar="link"
                parenttitlekey="jsp.administer"
-               parentlink="/dspace-admin"
+               parentlink="<%= link %>"
                nocache="true">
 
 	<h1><fmt:message key="jsp.tools.group-edit.title"/> : <%=group.getName()%> (id: <%=group.getID()%>)

--- a/dspace-jspui/src/main/webapp/tools/group-list.jsp
+++ b/dspace-jspui/src/main/webapp/tools/group-list.jsp
@@ -32,13 +32,32 @@
 <%
     List<Group> groups =
         (List<Group>) request.getAttribute("groups");
+        
+    // Is the logged in user an admin or community admin or cllection admin
+    Boolean admin = (Boolean)request.getAttribute("is.admin");
+    boolean isAdmin = (admin == null ? false : admin.booleanValue());
+    
+    Boolean communityAdmin = (Boolean)request.getAttribute("is.communityAdmin");
+    boolean isCommunityAdmin = (communityAdmin == null ? false : communityAdmin.booleanValue());
+    
+    Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
+    boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
+    
+    String naviAdmin = "admin";
+    String link = "/dspace-admin";
+    
+    if(!isAdmin && (isCommunityAdmin || isCollectionAdmin))
+    {
+        naviAdmin = "community-or-collection-admin";
+        link = "/tools";
+    }
 %>
 
 <dspace:layout style="submission" titlekey="jsp.tools.group-list.title"
-               navbar="admin"
+               navbar="<%= naviAdmin %>"
                locbar="link"
                parenttitlekey="jsp.administer"
-               parentlink="/dspace-admin"
+               parentlink="<%= link %>"
                nocache="true">
 
     <%--  <h1>Group Editor</h1> --%>
@@ -52,9 +71,11 @@
 	<p class="alert alert-warning"><fmt:message key="jsp.tools.group-list.note2"/></p>
    	
     <form method="post" action="">
-        <div class="row col-md-offset-5">
-	    	<input class="btn btn-success" type="submit" name="submit_add" value="<fmt:message key="jsp.tools.group-list.create.button"/>" />
-        </div>
+        <% if(isAdmin){ %>
+            <div class="row col-md-offset-5">
+                    <input class="btn btn-success" type="submit" name="submit_add" value="<fmt:message key="jsp.tools.group-list.create.button"/>" />
+            </div>
+        <% } %>
     </form>
 	<br/>
 	

--- a/dspace-jspui/src/main/webapp/tools/index.jsp
+++ b/dspace-jspui/src/main/webapp/tools/index.jsp
@@ -46,7 +46,7 @@
  
     Boolean collectionAdmin = (Boolean)request.getAttribute("is.collectionAdmin");
     boolean isCollectionAdmin = (collectionAdmin == null ? false : collectionAdmin.booleanValue());
-
+    
     try
     {
         context = UIUtil.obtainContext(request);
@@ -56,7 +56,7 @@
         }
 %>
 <dspace:layout style="submission" locbar="link" navbar="<%= naviAdmin %>" titlekey="jsp.administer">
-
+    
     <%-- <h1>Administration Tools</h1> --%>
     <h1><fmt:message key="jsp.dspace-admin.index.heading"/></h1>
     
@@ -77,6 +77,9 @@
         UIUtil.sendAlert(request, se);
 
         JSPManager.showInternalError(request, response);
+    }
+    finally {
+      context.abort();
     }
 %>
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3240

To test this: 
1. Create a community/collection and a community/collection admin. 
2. Create and publish/archive an item.
3. Login as community/collection admin, open the item and edit it. The admin navbar should appear and contain fields like "General Settings", that are protected from being used by community/collection admins.
4. Make the item private or withdraw it.
5. Choose from the admin navbar (still as community/collection admin) the button "content/withdrawn items" or "content/private items". You won't see the Item you just made private.

With this PR you should get a admin navbar containing only functions community/collection admins should be able to use. Also you should be able to see private/withdrawn item as community/collection admin.
