### PR TITLE
[DS-3090] Discovery search results contain char-set-related errors from reading the fulltext bitstream

### DIFF
--- a/dspace/solr/search/conf/solrconfig.xml
+++ b/dspace/solr/search/conf/solrconfig.xml
@@ -1048,9 +1048,9 @@
       <str name="uprefix">ignored_</str>
 
       <!-- capture link hrefs but ignore div attributes -->
-      <str name="captureAttr">false</str>
-      <!--<str name="fmap.a">links</str>-->
-      <!--<str name="fmap.div">ignored_</str>-->
+      <str name="captureAttr">true</str>
+      <str name="fmap.a">ignored_</str>
+      <str name="fmap.div">ignored_</str>
     </lst>
   </requestHandler>
 


### PR DESCRIPTION
If you configure captureAttr to false, Tika puts the metadata about the processed file in the "content" field, which is certainly not the wanted behavior as the content is used as the fulltext field in DSpace.
Problem:
https://jira.duraspace.org/browse/DS-3090
Stack Overflow solution:
http://stackoverflow.com/questions/10888792/textual-content-without-metadata-from-tika-via-solrcell
