### PR TITLE
[DS-3248] REST api: expand parameter not working on find-by-metadata-field

### DIFF
--- a/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
@@ -931,7 +931,7 @@ public class ItemsResource extends Resource
             while (itemIterator.hasNext())
             {
                 org.dspace.content.Item dspaceItem = itemIterator.next();
-                Item item = new Item(dspaceItem, servletContext, "", context);
+                Item item = new Item(dspaceItem, servletContext, expand, context);
                 writeStats(dspaceItem, UsageEvent.Action.VIEW, user_ip, user_agent, xforwardedfor, headers,
                         request, context);
                 items.add(item);


### PR DESCRIPTION
expand parameter was not passed during new item creation when accessing find-by-metadata-field
