### PR TITLE
[DS-3217] removed testGetCurrent

### DIFF
--- a/dspace-api/src/test/java/org/dspace/content/DCDateTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/DCDateTest.java
@@ -391,16 +391,6 @@ public class DCDateTest
                 equalTo("14-Apr-2010"));
     }
 
-    /**
-     * Test of getCurrent method, of class DCDate.
-     */
-    @Test
-    public void testGetCurrent()
-    {
-        assertTrue("testGetCurrent 0", DateUtils.isSameDay(DCDate.getCurrent().toDate(), new Date()));
-    }
-
-
 
     /**
      * Test of getMonthName method, of class DCDate.


### PR DESCRIPTION
not worth the trouble, as written it will fail between 23UTC and 24 UTC, possibly through 1 UTC
