### PR TITLE
DS-3179 integration tests for Community/Collection Admin inherited delete permissions

### DIFF
--- a/dspace-api/src/test/java/org/dspace/content/BitstreamTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/BitstreamTest.java
@@ -415,7 +415,7 @@ public class BitstreamTest extends AbstractDSpaceObjectTest
      * Test of delete method, of class Bitstream.
      */
     @Test
-    public void testDelete() throws IOException, SQLException, AuthorizeException
+    public void testDeleteAndExpunge() throws IOException, SQLException, AuthorizeException
     {
         new NonStrictExpectations(authorizeService.getClass())
         {{
@@ -430,10 +430,16 @@ public class BitstreamTest extends AbstractDSpaceObjectTest
         // tests is unpredictable we don't want to delete the global bitstream
         File f = new File(testProps.get("test.bitstream").toString());
         Bitstream delBS = bitstreamService.create(context, new FileInputStream(f));
-        
+        UUID bitstreamId = delBS.getID();
+
+        // Test that delete will flag the bitstream as deleted
         assertFalse("testIsDeleted 0", delBS.isDeleted());
         bitstreamService.delete(context, delBS);
         assertTrue("testDelete 0", delBS.isDeleted());
+
+        // Now test expunge actually removes the bitstream
+        bitstreamService.expunge(context, delBS);
+        assertThat("testExpunge 0", bitstreamService.find(context, bitstreamId), nullValue());
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/content/ITCommunityCollection.java
+++ b/dspace-api/src/test/java/org/dspace/content/ITCommunityCollection.java
@@ -10,13 +10,21 @@ package org.dspace.content;
 import org.databene.contiperf.Required;
 import org.databene.contiperf.PerfTest;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.UUID;
 import org.apache.log4j.Logger;
 import org.dspace.AbstractIntegrationTest;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.*;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
+import org.dspace.eperson.factory.EPersonServiceFactory;
+import org.dspace.eperson.service.EPersonService;
+import org.dspace.eperson.service.GroupService;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,7 +32,7 @@ import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.*;
 
 /**
- * This is an integration test to ensure collections and communities interact properly
+ * This is an integration test to ensure collections and communities interact properly.
  *
  * The code below is attached as an example. Performance checks by ContiPerf
  * can be applied at method level or at class level. This shows the syntax
@@ -33,6 +41,7 @@ import static org.hamcrest.CoreMatchers.*;
  * @Required(max = 1200, average = 250)
  *
  * @author pvillega
+ * @author tdonohue
  */
 public class ITCommunityCollection extends AbstractIntegrationTest
 {
@@ -44,6 +53,10 @@ public class ITCommunityCollection extends AbstractIntegrationTest
     protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();
     protected InstallItemService installItemService = ContentServiceFactory.getInstance().getInstallItemService();
     protected WorkspaceItemService workspaceItemService = ContentServiceFactory.getInstance().getWorkspaceItemService();
+    protected EPersonService ePersonService = EPersonServiceFactory.getInstance().getEPersonService();
+    protected GroupService groupService = EPersonServiceFactory.getInstance().getGroupService();
+    protected BundleService bundleService = ContentServiceFactory.getInstance().getBundleService();
+    protected BitstreamService bitstreamService = ContentServiceFactory.getInstance().getBitstreamService();
 
     /**
      * This method will be run before every test as per @Before. It will
@@ -166,5 +179,151 @@ public class ITCommunityCollection extends AbstractIntegrationTest
         assertThat("testCountItems 1", itemService.countItems(context, col2), equalTo(collTotalItems));
         assertThat("testCountItems 2", itemService.countItems(context, childCom), equalTo(totalitems));
         assertThat("testCountItems 3", itemService.countItems(context, parentCom), equalTo(totalitems));
+    }
+
+     /**
+      * Tests that ensure Community Admin deletion permissions are being properly
+      * inherited to all objects in the Community hierarchy.
+      */
+    @Test
+    public void testCommunityAdminDeletions() throws SQLException, AuthorizeException, IOException
+    {
+        //Turn off auth while we create the EPerson and structure
+        context.turnOffAuthorisationSystem();
+
+        // Create our Community Admin
+        EPerson commAdmin = ePersonService.create(context);
+        commAdmin.setEmail("comm-admin@dspace.org");
+        ePersonService.update(context, commAdmin);
+
+        // Create our Top-Level Community and add the user as an Administrator of that community
+        Community parentCom = communityService.create(null, context);
+
+        Group adminGroup = communityService.createAdministrators(context, parentCom);
+        groupService.addMember(context, adminGroup, commAdmin);
+        groupService.update(context, adminGroup);
+
+        // Create a hierachy of sub-Communities and Collections and Items.
+        Community child = communityService.createSubcommunity(context, parentCom);
+        Community child2 = communityService.createSubcommunity(context, parentCom);
+        Community grandchild = communityService.createSubcommunity(context, child);
+        Collection childCol = collectionService.create(context, child);
+        Collection grandchildCol = collectionService.create(context, grandchild);
+        // Create two separate items
+        WorkspaceItem wsItem = workspaceItemService.create(context, childCol, false);
+        Item item = installItemService.installItem(context, wsItem);
+        wsItem = workspaceItemService.create(context, childCol, false);
+        Item item2 = installItemService.installItem(context, wsItem);
+        // Create a bitstream for one item
+        File f = new File(testProps.get("test.bitstream").toString());
+        Bitstream bitstream = itemService.createSingleBitstream(context, new FileInputStream(f), item);
+
+        // Done creating the objects. Turn auth system back on
+        context.restoreAuthSystemState();
+
+        // Set the Community Admin as our current user
+        context.setCurrentUser(commAdmin);
+
+        // Test deletion of single Bitstream as a Community Admin (delete just flags as deleted)
+        UUID bitstreamId = bitstream.getID();
+        bitstreamService.delete(context, bitstream);
+        assertTrue("Community Admin unable to flag Bitstream as deleted",
+                bitstream.isDeleted());
+        // NOTE: A Community Admin CANNOT "expunge" a Bitstream, as delete() removes all their permissions
+
+        // Test deletion of single Item as a Community Admin
+        UUID itemId = item2.getID();
+        itemService.delete(context, item2);
+        assertThat("Community Admin unable to delete sub-Item",
+                itemService.find(context, itemId), nullValue());
+
+        // Test deletion of single Collection as a Community Admin
+        UUID collId = grandchildCol.getID();
+        collectionService.delete(context, grandchildCol);
+        assertThat("Community Admin unable to delete sub-Collection",
+                collectionService.find(context, collId), nullValue());
+
+        // Test deletion of single Sub-Community as a Community Admin
+        UUID commId = child2.getID();
+        communityService.delete(context, child2);
+        assertThat("Community Admin unable to delete sub-Community",
+                communityService.find(context, commId), nullValue());
+
+        // Test deletion of Sub-Community Hierarchy as a Community Admin
+        commId = child.getID();
+        collId = childCol.getID();
+        itemId = item.getID();
+        communityService.delete(context, child);
+        assertThat("Community Admin unable to delete sub-Community in hierarchy",
+                communityService.find(context, commId), nullValue());
+        assertThat("Community Admin unable to delete sub-Collection in hierarchy",
+                collectionService.find(context, collId), nullValue());
+        assertThat("Community Admin unable to delete sub-Item in hierarchy",
+                itemService.find(context, itemId), nullValue());
+    }
+
+    /**
+     * Tests that ensure Collection Admin deletion permissions are being properly
+     * inherited to all objects in the Collection hierarchy.
+     */
+    @Test
+    public void testCollectionAdminDeletions() throws SQLException, AuthorizeException, IOException
+    {
+        //Turn off auth while we create the EPerson and structure
+        context.turnOffAuthorisationSystem();
+
+        // Create our Collection Admin
+        EPerson collAdmin = ePersonService.create(context);
+        collAdmin.setEmail("coll-admin@dspace.org");
+        ePersonService.update(context, collAdmin);
+
+        // Create our Collection and add the user as an Administrator of that collection
+        Community parentCom = communityService.create(null, context);
+        Collection collection = collectionService.create(context, parentCom);
+
+        Group adminGroup = collectionService.createAdministrators(context, collection);
+        groupService.addMember(context, adminGroup, collAdmin);
+        groupService.update(context, adminGroup);
+
+        // Create an item in this Collection
+        WorkspaceItem wsItem = workspaceItemService.create(context, collection, false);
+        Item item = installItemService.installItem(context, wsItem);
+        // Create two bundles in this item
+        Bundle bundle = bundleService.create(context, item, "Bundle1");
+        Bundle bundle2 = bundleService.create(context, item, "Bundle2");
+        // Create two bitstreams, one in each bundle
+        File f = new File(testProps.get("test.bitstream").toString());
+        Bitstream bitstream = itemService.createSingleBitstream(context, new FileInputStream(f), item, "Bundle1");
+        Bitstream bitstream2 = itemService.createSingleBitstream(context, new FileInputStream(f), item, "Bundle2");
+        // Done creating the objects. Turn auth system back on
+        context.restoreAuthSystemState();
+
+        // Set the Collection Admin as our current user
+        context.setCurrentUser(collAdmin);
+
+        // Test deletion of single Bitstream as a Collection Admin (delete just flags as deleted)
+        UUID bitstreamId = bitstream2.getID();
+        bitstreamService.delete(context, bitstream2);
+        assertTrue("Collection Admin unable to flag Bitstream as deleted",
+                bitstream2.isDeleted());
+        // NOTE: A Collection Admin CANNOT "expunge" a Bitstream, as delete() removes all their permissions
+
+        // Test deletion of single Bundle as a Collection Admin
+        UUID bundleId = bundle2.getID();
+        bundleService.delete(context, bundle2);
+        assertThat("Collection Admin unable to delete Bundle",
+                bundleService.find(context, bundleId), nullValue());
+
+        // Test deletion of single Item as a Collection Admin
+        UUID itemId = item.getID();
+        bundleId = bundle.getID();
+        bitstreamId = bitstream.getID();
+        itemService.delete(context, item);
+        assertThat("Collection Admin unable to delete sub-Item",
+                itemService.find(context, itemId), nullValue());
+        assertThat("Collection Admin unable to delete sub-Bundle",
+                bundleService.find(context, bundleId), nullValue());
+        assertTrue("Collection Admin unable to flag sub-Bitstream as deleted",
+                bitstream.isDeleted());
     }
 }


### PR DESCRIPTION
Companion to #1443.  This adds/updates Unit and Integration tests that validate Community / Collection Admin inherited deletion permissions.

NOTE: These tests will currently FAIL on master, because of the bug described in
https://jira.duraspace.org/browse/DS-3179

However, if you run these tests using the code in #1443, then they all SUCCEED.  This should prove that the fixes in #1443 are correct, and should be merged immediately (followed by or preceded by merger of this PR).
