### PR TITLE
[DS-3217] fix more than one test

### DIFF
--- a/dspace-api/src/test/java/org/dspace/content/DCDateTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/DCDateTest.java
@@ -398,7 +398,8 @@ public class DCDateTest
     public void testGetCurrent()
     {
      Calendar calendar = Calendar.getInstance();
-         calendar.setTimeInMillis(System.currentTimeMillis());      
+         calendar.setTimeInMillis(System.currentTimeMillis());
+         calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
          assertTrue("testGetCurrent 0", DateUtils.isSameDay(DCDate.getCurrent().toDate(), calendar.getTime())); 
     }
 

--- a/dspace-api/src/test/java/org/dspace/content/DCDateTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/DCDateTest.java
@@ -397,7 +397,9 @@ public class DCDateTest
     @Test
     public void testGetCurrent()
     {
-        assertTrue("testGetCurrent 0", DateUtils.isSameDay(DCDate.getCurrent().toDate(), new Date()));
+     Calendar calendar = Calendar.getInstance();
+         calendar.setTimeInMillis(System.currentTimeMillis());      
+         assertTrue("testGetCurrent 0", DateUtils.isSameDay(DCDate.getCurrent().toDate(), calendar.getTime())); 
     }
 
 

--- a/dspace-api/src/test/java/org/dspace/content/InstallItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/InstallItemTest.java
@@ -25,11 +25,13 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.sql.SQLException;
+import java.text.SimpleDateFormat;
 import java.util.List;
+import java.util.Calendar;
+import java.util.TimeZone;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.*;
-
 
 /**
  * Unit Tests for class InstallItem
@@ -246,10 +248,13 @@ public class InstallItemTest extends AbstractUnitTest
         itemService.addMetadata(context, is.getItem(), "dc", "date", "issued", Item.ANY, "2011-01-01");
 
         //get current date
-        DCDate now = DCDate.getCurrent();
-        String dayAndTime = now.toString();
-        //parse out just the date, remove the time (format: yyyy-mm-ddT00:00:00Z)
-        String date = dayAndTime.substring(0, dayAndTime.indexOf("T"));
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTimeInMillis(System.currentTimeMillis());
+        calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
+       
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+
+        String date = sdf.format(calendar.getTime());
 
         Item result = installItemService.installItem(context, is, handle);
         context.restoreAuthSystemState();
@@ -296,10 +301,11 @@ public class InstallItemTest extends AbstractUnitTest
         itemService.addMetadata(context, is.getItem(), "dc", "date", "issued", Item.ANY, "2011-01-01");
 
         //get current date
-        DCDate now = DCDate.getCurrent();
-        String dayAndTime = now.toString();
-        //parse out just the date, remove the time (format: yyyy-mm-ddT00:00:00Z)
-        String date = dayAndTime.substring(0, dayAndTime.indexOf("T"));
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTimeInMillis(System.currentTimeMillis());
+        calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        String date = sdf.format(calendar.getTime());
 
         Item result = installItemService.restoreItem(context, is, handle);
         context.restoreAuthSystemState();


### PR DESCRIPTION
Revised a few tests to make them work no matter the time of day (they were failing between 23UTC and 24UTC). Used Calendar instead of Date, thanks to a hint from LuizClaudioSantos, set the time zone on the Calendar object thanks to a hint from Helix84. Swapped out some old string hacking for a nice standard SimpleDateFormat object.
