### PR TITLE
DS-3256 Configuration of metadata fields to show in JSPUI itemdisplay is broken

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemTag.java
@@ -25,6 +25,7 @@ import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.JspWriter;
 import javax.servlet.jsp.jstl.fmt.LocaleSupport;
 import javax.servlet.jsp.tagext.TagSupport;
+import org.apache.commons.lang.ArrayUtils;
 
 import org.apache.commons.lang.time.DateFormatUtils;
 import org.apache.log4j.Logger;
@@ -430,11 +431,11 @@ public class ItemTag extends TagSupport
         HttpServletRequest request = (HttpServletRequest)pageContext.getRequest();
         Context context = UIUtil.obtainContext(request);
         Locale sessionLocale = UIUtil.getSessionLocale(request);
-        String configLine = styleSelection.getConfigurationForStyle(style);
+        String[] metadataFields = styleSelection.getConfigurationForStyle(style);
 
-        if (configLine == null)
+        if (ArrayUtils.isEmpty(metadataFields))
         {
-            configLine = defaultFields;
+            metadataFields = defaultFields.split(",");
         }
 
         out.println("<table class=\"table itemDisplayTable\">");
@@ -446,11 +447,9 @@ public class ItemTag extends TagSupport
          * to a more efficient intermediate class, but then it would become more
          * difficult to reload the configuration "on the fly".
          */
-        StringTokenizer st = new StringTokenizer(configLine, ",");
-
-        while (st.hasMoreTokens())
+        for (String field : metadataFields)
         {
-        	String field = st.nextToken().trim();
+            field = field.trim();
             boolean isDate = false;
             boolean isLink = false;
             boolean isResolver = false;

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/util/AKeyBasedStyleSelection.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/util/AKeyBasedStyleSelection.java
@@ -7,7 +7,8 @@
  */
 package org.dspace.app.webui.util;
 
-import org.dspace.core.ConfigurationManager;
+import org.dspace.services.factory.DSpaceServicesFactory;
+
 /**
  * Simple abstract class that provide utility method for get/check style configuration from dspace.cfg file 
  * @author Andrea Bollini
@@ -16,13 +17,15 @@ import org.dspace.core.ConfigurationManager;
  */
 public abstract class AKeyBasedStyleSelection implements StyleSelection
 {   
-    public String getConfigurationForStyle(String style)
+    public String[] getConfigurationForStyle(String style)
     {
-        return ConfigurationManager.getProperty("webui.itemdisplay." + style);
+        return DSpaceServicesFactory.getInstance().getConfigurationService()
+                .getArrayProperty("webui.itemdisplay." + style);
     }
     
     protected boolean isConfigurationDefinedForStyle(String style)
     {
-        return ConfigurationManager.getProperty("webui.itemdisplay." + style) == null;
+        return DSpaceServicesFactory.getInstance().getConfigurationService()
+                .getProperty("webui.itemdisplay." + style) != null;
     }
 }

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/util/CollectionStyleSelection.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/util/CollectionStyleSelection.java
@@ -106,7 +106,7 @@ public class CollectionStyleSelection extends AKeyBasedStyleSelection
         }
 
         // Specific style specified. Check style exists
-        if (isConfigurationDefinedForStyle(styleName))
+        if (!isConfigurationDefinedForStyle(styleName))
         {
             log.warn("dspace.cfg specifies undefined item display style '"
                     + styleName + "' for collection handle " + handle + ".  Using default");

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/util/MetadataStyleSelection.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/util/MetadataStyleSelection.java
@@ -59,7 +59,7 @@ public class MetadataStyleSelection extends AKeyBasedStyleSelection
         
        
         // Specific style specified. Check style exists
-        if (isConfigurationDefinedForStyle(styleName))
+        if (!isConfigurationDefinedForStyle(styleName))
         {
             log.warn("metadata '" + metadata + "' specify undefined item display style '"
                     + styleName + "'.  Using default");

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/util/StyleSelection.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/util/StyleSelection.java
@@ -32,6 +32,7 @@ public interface StyleSelection
      * The configuration has the following syntax: <code>schema.element[.qualifier|.*][(display-option)]</code> 
      * 
      * @param style
+     * @return An array of Strings each containing a metadata field and if given a display option.
      */
-    public String getConfigurationForStyle(String style);
+    public String[] getConfigurationForStyle(String style);
 }


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3256
### How to test:

Add a local configuration for `webui.itemdisplay.default` containing more than one field. Publish an item containing at least two of those fields and open it in JSPUI. Without this patch only the first field mentioned in the property will be displayed, with this patch all configured fields should be shown (as long as they are not configured to be hidden by `metadata.hide.<schema>.<element>[.<qualifier>] = true`).
