### PR TITLE
DS-3199

### DIFF
--- a/dspace-xmlui/src/main/resources/aspects/Administrative/administrative.js
+++ b/dspace-xmlui/src/main/resources/aspects/Administrative/administrative.js
@@ -1849,7 +1849,7 @@ function doEditBitstream(itemID, bitstreamID)
             // Update the metadata
             var primary = cocoon.request.get("primary");
             var description = cocoon.request.get("description");
-            var formatID = UUID.fromString(cocoon.request.get("formatID"));
+            var formatID = cocoon.request.get("formatID");
             var userFormat = cocoon.request.get("user_format");
             var bitstreamName = cocoon.request.get("bitstreamName");
 


### PR DESCRIPTION
in administrative.js the Bitstream Format ID was being treated as a UUID.

jira ticket:
https://jira.duraspace.org/browse/DS-3199
