### PR TITLE
DS-3266 : Fix AIP restore logic for restricted items and add Integration Tests

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/InstallItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/InstallItemServiceImpl.java
@@ -75,7 +75,15 @@ public class InstallItemServiceImpl implements InstallItemService
 
         populateMetadata(c, item);
 
-        return finishItem(c, item, is);
+        // Finish up / archive the item
+        item = finishItem(c, item, is);
+
+        // As this is a BRAND NEW item, as a final step we need to remove the
+        // submitter item policies created during deposit and replace them with
+        // the default policies from the collection.
+        itemService.inheritCollectionDefaultPolicies(c, item, is.getCollection());
+
+        return item;
     }
 
     @Override
@@ -102,7 +110,7 @@ public class InstallItemServiceImpl implements InstallItemService
         
         // If the item doesn't have a date.accessioned, set it to today
         List<MetadataValue> dateAccessioned = itemService.getMetadata(item, MetadataSchema.DC_SCHEMA, "date", "accessioned", Item.ANY);
-        if (dateAccessioned.size() == 0)
+        if (dateAccessioned.isEmpty())
         {
 	        itemService.addMetadata(c, item, MetadataSchema.DC_SCHEMA, "date", "accessioned", null, now.toString());
         }
@@ -174,7 +182,7 @@ public class InstallItemServiceImpl implements InstallItemService
 
         // If an issue date was passed in and it wasn't set to "today" (literal string)
         // then note this previous issue date in provenance message
-        if (currentDateIssued.size() != 0)
+        if (currentDateIssued.isEmpty())
         {
             String previousDateIssued = currentDateIssued.get(0).getValue();
             if(previousDateIssued!=null && !previousDateIssued.equalsIgnoreCase("today"))
@@ -189,8 +197,18 @@ public class InstallItemServiceImpl implements InstallItemService
         itemService.addMetadata(c, item, MetadataSchema.DC_SCHEMA, "description", "provenance", "en", provDescription);
     }
 
-    // final housekeeping when adding new Item to archive
-    // common between installing and "restoring" items.
+    /**
+     * Final housekeeping when adding a new Item into the archive.
+     * This method is used by *both* installItem() and restoreItem(),
+     * so all actions here will be run for a newly added item or a restored item.
+     *
+     * @param c DSpace Context
+     * @param item Item in question
+     * @param is InProgressSubmission object
+     * @return final "archived" Item
+     * @throws SQLException if database error
+     * @throws AuthorizeException if authorization error
+     */
     protected Item finishItem(Context c, Item item, InProgressSubmission is)
         throws SQLException, AuthorizeException
     {
@@ -212,10 +230,6 @@ public class InstallItemServiceImpl implements InstallItemService
 
         // remove in-progress submission
         contentServiceFactory.getInProgressSubmissionService(is).deleteWrapper(c, is);
-
-        // remove the item's policies and replace them with
-        // the defaults from the collection
-        itemService.inheritCollectionDefaultPolicies(c, item, is.getCollection());
 
         // set embargo lift date and take away read access if indicated.
         embargoService.setEmbargo(c, item);

--- a/dspace-api/src/main/java/org/dspace/content/InstallItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/InstallItemServiceImpl.java
@@ -62,6 +62,7 @@ public class InstallItemServiceImpl implements InstallItemService
             AuthorizeException
     {
         Item item = is.getItem();
+        Collection collection = is.getCollection();
         try {
             if(suppliedHandle == null)
             {
@@ -81,7 +82,7 @@ public class InstallItemServiceImpl implements InstallItemService
         // As this is a BRAND NEW item, as a final step we need to remove the
         // submitter item policies created during deposit and replace them with
         // the default policies from the collection.
-        itemService.inheritCollectionDefaultPolicies(c, item, is.getCollection());
+        itemService.inheritCollectionDefaultPolicies(c, item, collection);
 
         return item;
     }
@@ -182,7 +183,7 @@ public class InstallItemServiceImpl implements InstallItemService
 
         // If an issue date was passed in and it wasn't set to "today" (literal string)
         // then note this previous issue date in provenance message
-        if (currentDateIssued.isEmpty())
+        if (!currentDateIssued.isEmpty())
         {
             String previousDateIssued = currentDateIssued.get(0).getValue();
             if(previousDateIssued!=null && !previousDateIssued.equalsIgnoreCase("today"))

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/METSRightsCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/METSRightsCrosswalk.java
@@ -17,7 +17,6 @@ import java.util.Map;
 import java.util.Date;
 
 import java.text.SimpleDateFormat;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
@@ -448,171 +447,167 @@ public class METSRightsCrosswalk
     public void ingest(Context context, DSpaceObject dso, List<Element> ml, boolean createMissingMetadataFields)
         throws CrosswalkException, IOException, SQLException, AuthorizeException
     {
-        // we cannot crosswalk METSRights to a SITE object
+        // SITE objects are not supported by the METSRightsCrosswalk
         if (dso.getType() == Constants.SITE)
         {
             throw new CrosswalkObjectNotSupported("Wrong target object type, METSRightsCrosswalk cannot crosswalk a SITE object.");
         }
 
-        if(!ml.isEmpty())
+        // If we're fed the top-level <RightsDeclarationMD> wrapper element, recurse into its guts.
+        // What we need to analyze are the <Context> elements underneath it.
+        if(!ml.isEmpty() && ml.get(0).getName().equals("RightsDeclarationMD"))
         {
-            Element topElement = ml.get(0);
-            // If we're fed a <RightsDeclarationMD> wrapper object, recurse on its guts
-            if(topElement.getName().equals("RightsDeclarationMD"))
-            {
-                ingest(context, dso, topElement.getChildren(), createMissingMetadataFields);
-            }
+            ingest(context, dso, ml.get(0).getChildren(), createMissingMetadataFields);
         }
-
-        // Loop through each Element in the passed in List, creating a ResourcePolicy for each
-        List<ResourcePolicy> policies = new ArrayList<>();
-        for (Element element : ml)
+        else
         {
-            // Must be a "Context" section (where permissions are stored)
-            if (element.getName().equals("Context"))
+            // Loop through each <Context> Element in the passed in List, creating a ResourcePolicy for each
+            List<ResourcePolicy> policies = new ArrayList<>();
+            for (Element element : ml)
             {
-                //get what class of context this is
-                String contextClass = element.getAttributeValue("CONTEXTCLASS");
-                
-                ResourcePolicy rp = resourcePolicyService.create(context);
-                SimpleDateFormat sdf = new SimpleDateFormat( "yyyy-MM-dd" );
-        		
-                // get reference to the <Permissions> element
-                // Note: we are assuming here that there will only ever be ONE <Permissions>
-                //  element. Currently there are no known use cases for multiple.
-                Element permsElement = element.getChild("Permissions", METSRights_NS);
-                if(permsElement == null) {
-                	log.error("No <Permissions> element was found. Skipping this <Context> element.");
-                	continue;
-                }
-                
-                if (element.getAttributeValue("rpName") != null)
+                // Must be a "Context" section (where permissions are stored)
+                if (element.getName().equals("Context"))
                 {
-                    rp.setRpName(element.getAttributeValue("rpName"));
-                }
-                try {
-                    if (element.getAttributeValue("start-date") != null)
-                    {
-                        rp.setStartDate(sdf.parse(element.getAttributeValue("start-date")));
-                    }
-                    if (element.getAttributeValue("end-date") != null)
-                    {
-                    	rp.setEndDate(sdf.parse(element.getAttributeValue("end-date")));
-                    }
-                }catch (ParseException ex) {
-                    log.error("Failed to parse embargo date. The date needs to be in the format 'yyyy-MM-dd'.", ex);
-                }
-                
-                //Check if this permission pertains to Anonymous users
-                if(ANONYMOUS_CONTEXTCLASS.equals(contextClass))
-                {
-                    //get DSpace Anonymous group, ID=0
-                    Group anonGroup = groupService.findByName(context, Group.ANONYMOUS);
-                    if(anonGroup==null)
-                    {
-                        throw new CrosswalkInternalException("The DSpace database has not been properly initialized.  The Anonymous Group is missing from the database.");
+                    //get what class of context this is
+                    String contextClass = element.getAttributeValue("CONTEXTCLASS");
+
+                    ResourcePolicy rp = resourcePolicyService.create(context);
+                    SimpleDateFormat sdf = new SimpleDateFormat( "yyyy-MM-dd" );
+
+                    // get reference to the <Permissions> element
+                    // Note: we are assuming here that there will only ever be ONE <Permissions>
+                    //  element. Currently there are no known use cases for multiple.
+                    Element permsElement = element.getChild("Permissions", METSRights_NS);
+                    if(permsElement == null) {
+                            log.error("No <Permissions> element was found. Skipping this <Context> element.");
+                            continue;
                     }
 
-                    rp.setGroup(anonGroup);
-                } // else if this permission declaration pertains to Administrators
-                else if(ADMIN_CONTEXTCLASS.equals(contextClass))
-                {
-                    //get DSpace Administrator group, ID=1
-                    Group adminGroup = groupService.findByName(context, Group.ADMIN);
-                    if(adminGroup==null)
+                    if (element.getAttributeValue("rpName") != null)
                     {
-                        throw new CrosswalkInternalException("The DSpace database has not been properly initialized.  The Administrator Group is missing from the database.");
+                        rp.setRpName(element.getAttributeValue("rpName"));
                     }
-
-                    rp.setGroup(adminGroup);
-                } // else if this permission pertains to another DSpace group
-                else if(GROUP_CONTEXTCLASS.equals(contextClass))
-                {
-                    try
-                    {
-                        //we need to find the name of DSpace group it pertains to
-                        //Get the text within the <UserName> child element,
-                        // this is the group's name
-                        String groupName = element.getChildTextTrim("UserName", METSRights_NS);
-
-                        //Translate Group name back to internal ID format (e.g. COLLECTION_<ID>_ADMIN)
-                        // from its external format (e.g. COLLECTION_<handle>_ADMIN)
-                        groupName = PackageUtils.translateGroupNameForImport(context, groupName);
-
-                        //Check if this group exists in DSpace already
-                        Group group = groupService.findByName(context, groupName);
-
-                        //if not found, throw an error -- user should restore group from the SITE AIP
-                        if(group==null)
+                    try {
+                        if (element.getAttributeValue("start-date") != null)
                         {
-                            throw new CrosswalkInternalException("Cannot restore Group permissions on object ("
+                            rp.setStartDate(sdf.parse(element.getAttributeValue("start-date")));
+                        }
+                        if (element.getAttributeValue("end-date") != null)
+                        {
+                            rp.setEndDate(sdf.parse(element.getAttributeValue("end-date")));
+                        }
+                    }catch (ParseException ex) {
+                        log.error("Failed to parse embargo date. The date needs to be in the format 'yyyy-MM-dd'.", ex);
+                    }
+
+                    //Check if this permission pertains to Anonymous users
+                    if(ANONYMOUS_CONTEXTCLASS.equals(contextClass))
+                    {
+                        //get DSpace Anonymous group, ID=0
+                        Group anonGroup = groupService.findByName(context, Group.ANONYMOUS);
+                        if(anonGroup==null)
+                        {
+                            throw new CrosswalkInternalException("The DSpace database has not been properly initialized.  The Anonymous Group is missing from the database.");
+                        }
+
+                        rp.setGroup(anonGroup);
+                    } // else if this permission declaration pertains to Administrators
+                    else if(ADMIN_CONTEXTCLASS.equals(contextClass))
+                    {
+                        //get DSpace Administrator group, ID=1
+                        Group adminGroup = groupService.findByName(context, Group.ADMIN);
+                        if(adminGroup==null)
+                        {
+                            throw new CrosswalkInternalException("The DSpace database has not been properly initialized.  The Administrator Group is missing from the database.");
+                        }
+
+                        rp.setGroup(adminGroup);
+                    } // else if this permission pertains to another DSpace group
+                    else if(GROUP_CONTEXTCLASS.equals(contextClass))
+                    {
+                        try
+                        {
+                            //we need to find the name of DSpace group it pertains to
+                            //Get the text within the <UserName> child element,
+                            // this is the group's name
+                            String groupName = element.getChildTextTrim("UserName", METSRights_NS);
+
+                            //Translate Group name back to internal ID format (e.g. COLLECTION_<ID>_ADMIN)
+                            // from its external format (e.g. COLLECTION_<handle>_ADMIN)
+                            groupName = PackageUtils.translateGroupNameForImport(context, groupName);
+
+                            //Check if this group exists in DSpace already
+                            Group group = groupService.findByName(context, groupName);
+
+                            //if not found, throw an error -- user should restore group from the SITE AIP
+                            if(group==null)
+                            {
+                                throw new CrosswalkInternalException("Cannot restore Group permissions on object ("
+                                        + "type=" + Constants.typeText[dso.getType()] + ", "
+                                        + "handle=" + dso.getHandle() + ", "
+                                        + "ID=" + dso.getID()
+                                        + "). The Group named '" + groupName + "' is missing from DSpace. "
+                                        + "Please restore this group using the SITE AIP, or recreate it.");
+                            }
+
+                            //assign group to policy
+                            rp.setGroup(group);
+                        }
+                        catch(PackageException pe)
+                        {
+                            //A PackageException will only be thrown if translateDefaultGroupName() fails
+                            //We'll just wrap it as a CrosswalkException and throw it upwards
+                            throw new CrosswalkException(pe);
+                        }
+                    }// else if this permission pertains to a DSpace person
+                    else if(PERSON_CONTEXTCLASS.equals(contextClass))
+                    {
+                        //we need to find the person it pertains to
+                        // Get the text within the <UserName> child element,
+                        // this is the person's email address
+                        String personEmail = element.getChildTextTrim("UserName", METSRights_NS);
+
+                        //Check if this person exists in DSpace already
+                        EPerson person = ePersonService.findByEmail(context, personEmail);
+
+                        //If cannot find by email, try by netID
+                        //(though METSRights should contain email if it was exported by DSpace)
+                        if(person==null)
+                        {
+                            person = ePersonService.findByNetid(context, personEmail);
+                        }
+
+                        //if not found, throw an error -- user should restore person from the SITE AIP
+                        if(person==null)
+                        {
+                            throw new CrosswalkInternalException("Cannot restore Person permissions on object ("
                                     + "type=" + Constants.typeText[dso.getType()] + ", "
                                     + "handle=" + dso.getHandle() + ", "
                                     + "ID=" + dso.getID()
-                                    + "). The Group named '" + groupName + "' is missing from DSpace. "
-                                    + "Please restore this group using the SITE AIP, or recreate it.");
+                                    + "). The Person with email/netid '" + personEmail + "' is missing from DSpace. "
+                                    + "Please restore this Person object using the SITE AIP, or recreate it.");
                         }
 
-                        //assign group to policy
-                        rp.setGroup(group);
-                    }
-                    catch(PackageException pe)
-                    {
-                        //A PackageException will only be thrown if translateDefaultGroupName() fails
-                        //We'll just wrap it as a CrosswalkException and throw it upwards
-                        throw new CrosswalkException(pe);
-                    }
-                }// else if this permission pertains to a DSpace person
-                else if(PERSON_CONTEXTCLASS.equals(contextClass))
-                {
-                    //we need to find the person it pertains to
-                    // Get the text within the <UserName> child element,
-                    // this is the person's email address
-                    String personEmail = element.getChildTextTrim("UserName", METSRights_NS);
-
-                    //Check if this person exists in DSpace already
-                    EPerson person = ePersonService.findByEmail(context, personEmail);
-
-                    //If cannot find by email, try by netID
-                    //(though METSRights should contain email if it was exported by DSpace)
-                    if(person==null)
-                    {
-                        person = ePersonService.findByNetid(context, personEmail);
+                        //assign person to the policy
+                        rp.setEPerson(person);
+                    }//end if Person
+                    else {
+                        log.error("Unrecognized CONTEXTCLASS:  " + contextClass);
                     }
 
-                    //if not found, throw an error -- user should restore person from the SITE AIP
-                    if(person==null)
-                    {
-                        throw new CrosswalkInternalException("Cannot restore Person permissions on object ("
-                                + "type=" + Constants.typeText[dso.getType()] + ", "
-                                + "handle=" + dso.getHandle() + ", "
-                                + "ID=" + dso.getID()
-                                + "). The Person with email/netid '" + personEmail + "' is missing from DSpace. "
-                                + "Please restore this Person object using the SITE AIP, or recreate it.");
-                    }
+                    //set permissions on policy add to list of policies
+                    rp.setAction(parsePermissions(permsElement));
+                    policies.add(rp);
+                } //end if "Context" element
+            }//end for loop
 
-                    //assign person to the policy
-                    rp.setEPerson(person);
-                }//end if Person
-                else {
-                    log.error("Unrecognized CONTEXTCLASS:  " + contextClass);
-                }
-                
-                //set permissions on policy add to list of policies
-                rp.setAction(parsePermissions(permsElement));
-                policies.add(rp);
-            } //end if "Context" element
-        }//end for loop
-
-        // Finally, as long as the compiled list of policies is not empty,
-        // replace existing object policies with the new ones
-        if(!CollectionUtils.isEmpty(policies))
-        {
-            // Remove all existing policies
+            // Finally, we need to remove any existing policies from the current object,
+            // and replace them with the policies provided via METSRights. NOTE:
+            // if the list of policies provided by METSRights is an empty list, then
+            // the final object will have no policies attached.
             authorizeService.removeAllPolicies(context, dso);
-            // Update with new list of policies
             authorizeService.addPolicies(context, policies, dso);
-        }
+        } // end else
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSIngester.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSIngester.java
@@ -333,18 +333,18 @@ public abstract class AbstractMETSIngester extends AbstractPackageIngester
         }
         else
         {
-            ZipFile zip = new ZipFile(pkgFile);
+            try(ZipFile zip = new ZipFile(pkgFile))
+            {
+                // Retrieve the manifest file entry (named mets.xml)
+                ZipEntry manifestEntry = zip.getEntry(METSManifest.MANIFEST_FILE);
 
-            // Retrieve the manifest file entry (named mets.xml)
-            ZipEntry manifestEntry = zip.getEntry(METSManifest.MANIFEST_FILE);
-
-            // parse the manifest and sanity-check it.
-            manifest = METSManifest.create(zip.getInputStream(manifestEntry),
-                    validate, getConfigurationName());
-
-            // close the Zip file for now
-            // (we'll extract the other files from zip when we need them)
-            zip.close();
+                if(manifestEntry!=null)
+                {
+                    // parse the manifest and sanity-check it.
+                    manifest = METSManifest.create(zip.getInputStream(manifestEntry),
+                        validate, getConfigurationName());
+                }
+            }
         }
 
         // return our parsed out METS manifest

--- a/dspace-api/src/test/java/org/dspace/content/packager/ITDSpaceAIP.java
+++ b/dspace-api/src/test/java/org/dspace/content/packager/ITDSpaceAIP.java
@@ -68,6 +68,7 @@ public class ITDSpaceAIP extends AbstractUnitTest
     protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
     protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();
     protected BundleService bundleService = ContentServiceFactory.getInstance().getBundleService();
+    protected BitstreamService bitstreamService = ContentServiceFactory.getInstance().getBitstreamService();
     protected WorkspaceItemService workspaceItemService = ContentServiceFactory.getInstance().getWorkspaceItemService();
     protected InstallItemService installItemService = ContentServiceFactory.getInstance().getInstallItemService();
     protected HandleService handleService = HandleServiceFactory.getInstance().getHandleService();
@@ -278,30 +279,6 @@ public class ITDSpaceAIP extends AbstractUnitTest
         {
             context = new Context();
             context.setCurrentUser(EPersonServiceFactory.getInstance().getEPersonService().findByEmail(context, submitterEmail));
-            // Locate the top level community (from our test data)
-            Community topCommunity = (Community) handleService.resolveToObject(context, topCommunityHandle);
-
-            log.info("init() - CREATE TEST AIPS");
-            // NOTE: This will not overwrite the AIPs if they already exist.
-            // But, it does ensure they are created PRIOR to running any of the below tests.
-            // (So, essentially, this runs ONCE...after that, it'll be ignored since AIPs already exist)
-            // While ideally, you don't want to share data between tests, generating AIPs is VERY timeconsuming.
-            createAIP(topCommunity, null, true, false);
-        }
-        catch(PackageException|CrosswalkException ex)
-        {
-            log.error("Packaging Error in init()", ex);
-            fail("Packaging Error in init(): " + ex.getMessage());
-        }
-        catch (AuthorizeException ex)
-        {
-            log.error("Authorization Error in init()", ex);
-            fail("Authorization Error in init(): " + ex.getMessage());
-        }
-        catch (IOException ex)
-        {
-            log.error("IO Error in init()", ex);
-            fail("IO Error in init(): " + ex.getMessage());
         }
         catch (SQLException ex)
         {
@@ -342,9 +319,9 @@ public class ITDSpaceAIP extends AbstractUnitTest
         HashMap<String,String> infoMap = new HashMap<String,String>();
         saveObjectInfo(topCommunity, infoMap);
 
-        // Ensure community & child AIPs are exported (but don't overwrite)
+        // Export community & child AIPs
         log.info("testRestoreCommunityHierarchy() - CREATE AIPs");
-        File aipFile = createAIP(topCommunity, null, true, false);
+        File aipFile = createAIP(topCommunity, null, true);
 
         // Delete everything from parent community on down
         log.info("testRestoreCommunityHierarchy() - DELETE Community Hierarchy");
@@ -414,9 +391,9 @@ public class ITDSpaceAIP extends AbstractUnitTest
         authorizeService.removeAllPolicies(context, community);
         authorizeService.addPolicies(context, policies, community);
 
-        // Ensure collection AIP is exported (overwrite it, as we just updated policies)
-        log.info("testRestoreRestrictedCommunity() - CREATE Community AIP (overwrite)");
-        File aipFile = createAIP(community, null, false, true);
+        // Export collection AIP
+        log.info("testRestoreRestrictedCommunity() - CREATE Community AIP");
+        File aipFile = createAIP(community, null, false);
 
         // Now, delete that Collection
         log.info("testRestoreRestrictedCommunity() - DELETE Community");
@@ -468,9 +445,9 @@ public class ITDSpaceAIP extends AbstractUnitTest
         // Get the count of collections under our Community or any Sub-Communities
         int numberOfCollections = communityService.getAllCollections(context, topCommunity).size();
         
-        // Ensure community & child AIPs are exported (but don't overwrite)
+        // Export community & child AIPs
         log.info("testReplaceCommunityHierarchy() - CREATE AIPs");
-        File aipFile = createAIP(topCommunity, null, true, false);
+        File aipFile = createAIP(topCommunity, null, true);
         
         // Get some basic info about Collection to be deleted
         // In this scenario, we'll delete the test "Grandchild Collection" 
@@ -542,9 +519,9 @@ public class ITDSpaceAIP extends AbstractUnitTest
         // Get its current name / title
         String oldName = topCommunity.getName();
         
-        // Ensure only community AIP is exported (but don't overwrite)
+        // Export only community AIP
         log.info("testReplaceCommunityOnly() - CREATE Community AIP");
-        File aipFile = createAIP(topCommunity, null, false, false);
+        File aipFile = createAIP(topCommunity, null, false);
         
         // Change the Community name
         String newName = "This is NOT my Community name!";
@@ -586,9 +563,9 @@ public class ITDSpaceAIP extends AbstractUnitTest
         HashMap<String,String> infoMap = new HashMap<String,String>();
         saveObjectInfo(testCollection, infoMap);
 
-        // Ensure collection & child AIPs are exported (but don't overwrite)
+        // Export collection & child AIPs
         log.info("testRestoreCollectionHierarchy() - CREATE AIPs");
-        File aipFile = createAIP(testCollection, null, true, false);
+        File aipFile = createAIP(testCollection, null, true);
 
         // Delete everything from collection on down
         log.info("testRestoreCollectionHierarchy() - DELETE Collection Hierarchy");
@@ -648,9 +625,9 @@ public class ITDSpaceAIP extends AbstractUnitTest
         authorizeService.removeAllPolicies(context, collection);
         authorizeService.addPolicies(context, policies, collection);
 
-        // Ensure collection AIP is exported (overwrite it, as we just updated policies)
-        log.info("testRestoreRestrictedCollection() - CREATE Collection AIP (overwrite)");
-        File aipFile = createAIP(collection, null, false, true);
+        // Export collection AIP
+        log.info("testRestoreRestrictedCollection() - CREATE Collection AIP");
+        File aipFile = createAIP(collection, null, false);
 
         // Now, delete that Collection
         log.info("testRestoreRestrictedCollection() - DELETE Collection");
@@ -702,9 +679,9 @@ public class ITDSpaceAIP extends AbstractUnitTest
         // How many items are in this Collection?
         int numberOfItems = itemService.countItems(context, testCollection);
         
-        // Ensure collection & child AIPs are exported (but don't overwrite)
+        // Export collection & child AIPs
         log.info("testReplaceCollectionHierarchy() - CREATE AIPs");
-        File aipFile = createAIP(testCollection, null, true, false);
+        File aipFile = createAIP(testCollection, null, true);
         
         // Get some basic info about Item to be deleted
         // In this scenario, we'll delete the test "Grandchild Collection Item #1" 
@@ -760,9 +737,9 @@ public class ITDSpaceAIP extends AbstractUnitTest
         // Get its current name / title
         String oldName = testCollection.getName();
         
-        // Ensure only collection AIP is exported (but don't overwrite)
+        // Export only collection AIP
         log.info("testReplaceCollectionOnly() - CREATE Collection AIP");
-        File aipFile = createAIP(testCollection, null, false, false);
+        File aipFile = createAIP(testCollection, null, false);
         
         // Change the Collection name
         String newName = "This is NOT my Collection name!";
@@ -819,9 +796,9 @@ public class ITDSpaceAIP extends AbstractUnitTest
         if(bitstreamCount<=0)
             fail("No test bitstream found for Item in testRestoreItem()!");
 
-        // Ensure item AIP is exported (but don't overwrite)
+        // Export item AIP
         log.info("testRestoreItem() - CREATE Item AIP");
-        File aipFile = createAIP(testItem, null, false, false);
+        File aipFile = createAIP(testItem, null, false);
         
         // Get parent, so we can restore under the same parent
         Collection parent = (Collection) itemService.getParentObject(context, testItem);
@@ -866,8 +843,19 @@ public class ITDSpaceAIP extends AbstractUnitTest
 
         log.info("testRestoreRestrictedItem() - BEGIN");
 
-        // Locate the item (from our test data)
-        Item testItem = (Item) handleService.resolveToObject(context, testItemHandle);
+        // Locate the test Collection (as a parent)
+        Collection parent = (Collection) handleService.resolveToObject(context, testCollectionHandle);
+
+        // Create a brand new Item to test with (since we will be changing policies)
+        WorkspaceItem wsItem = workspaceItemService.create(context, parent, false);
+        Item item = installItemService.installItem(context, wsItem);
+        itemService.addMetadata(context, item, "dc", "title", null, null, "Test Restricted Item");
+        // Create a test Bitstream in the ORIGINAL bundle
+        File f = new File(testProps.get("test.bitstream").toString());
+        Bitstream b = itemService.createSingleBitstream(context, new FileInputStream(f), item);
+        b.setName(context, "Test Bitstream");
+        bitstreamService.update(context, b);
+        itemService.update(context, item);
 
         // Create a custom resource policy for this Item
         List<ResourcePolicy> policies = new ArrayList<>();
@@ -877,30 +865,30 @@ public class ITDSpaceAIP extends AbstractUnitTest
         admin_policy.setGroup(adminGroup);
         admin_policy.setAction(Constants.READ);
         policies.add(admin_policy);
-        itemService.replaceAllItemPolicies(context, testItem, policies);
+        itemService.replaceAllItemPolicies(context, item, policies);
 
-        // Ensure item AIP is exported (overwrite it, as we just updated policies)
-        log.info("testRestoreRestrictedItem() - CREATE Item AIP (overwrite)");
-        File aipFile = createAIP(testItem, null, false, true);
+        // Export item AIP
+        log.info("testRestoreRestrictedItem() - CREATE Item AIP");
+        File aipFile = createAIP(item, null, false);
 
-        // Get parent, so we can restore under the same parent
-        Collection parent = (Collection) itemService.getParentObject(context, testItem);
+        // Get item handle, so we can check that it is later restored properly
+        String itemHandle = item.getHandle();
 
         // Now, delete that item
         log.info("testRestoreRestrictedItem() - DELETE Item");
-        collectionService.removeItem(context, parent, testItem);
+        collectionService.removeItem(context, parent, item);
 
         // Assert the deleted item no longer exists
-        DSpaceObject obj = handleService.resolveToObject(context, testItemHandle);
-        assertThat("testRestoreRestrictedItem() item " + testItemHandle + " doesn't exist", obj, nullValue());
+        DSpaceObject obj = handleService.resolveToObject(context, itemHandle);
+        assertThat("testRestoreRestrictedItem() item " + itemHandle + " doesn't exist", obj, nullValue());
 
         // Restore Item from AIP (non-recursive)
         log.info("testRestoreRestrictedItem() - RESTORE Item");
         restoreFromAIP(parent, aipFile, null, false);
 
         // Assert the deleted item is RESTORED
-        DSpaceObject objRestored = handleService.resolveToObject(context, testItemHandle);
-        assertThat("testRestoreRestrictedItem() item " + testItemHandle + " exists", objRestored, notNullValue());
+        DSpaceObject objRestored = handleService.resolveToObject(context, itemHandle);
+        assertThat("testRestoreRestrictedItem() item " + itemHandle + " exists", objRestored, notNullValue());
 
         // Assert the number of restored policies is equal
         List<ResourcePolicy> policiesRestored = authorizeService.getPolicies(context, objRestored);
@@ -930,34 +918,45 @@ public class ITDSpaceAIP extends AbstractUnitTest
 
         log.info("testRestoreItemNoPolicies() - BEGIN");
 
-        // Locate the item (from our test data)
-        Item testItem = (Item) handleService.resolveToObject(context, testItemHandle);
+        // Locate the test Collection (as a parent)
+        Collection parent = (Collection) handleService.resolveToObject(context, testCollectionHandle);
+
+        // Create a brand new Item to test with (since we will be changing policies)
+        WorkspaceItem wsItem = workspaceItemService.create(context, parent, false);
+        Item item = installItemService.installItem(context, wsItem);
+        itemService.addMetadata(context, item, "dc", "title", null, null, "Test No Policies Item");
+        // Create a test Bitstream in the ORIGINAL bundle
+        File f = new File(testProps.get("test.bitstream").toString());
+        Bitstream b = itemService.createSingleBitstream(context, new FileInputStream(f), item);
+        b.setName(context, "Test Bitstream");
+        bitstreamService.update(context, b);
+        itemService.update(context, item);
 
         // Remove all existing policies from the Item
-        authorizeService.removeAllPolicies(context, testItem);
+        authorizeService.removeAllPolicies(context, item);
 
-        // Ensure item AIP is exported (overwrite it, as we just updated policies)
-        log.info("testRestoreItemNoPolicies() - CREATE Item AIP (overwrite)");
-        File aipFile = createAIP(testItem, null, false, true);
+        // Export item AIP
+        log.info("testRestoreItemNoPolicies() - CREATE Item AIP");
+        File aipFile = createAIP(item, null, false);
 
-        // Get parent, so we can restore under the same parent
-        Collection parent = (Collection) itemService.getParentObject(context, testItem);
+        // Get item handle, so we can check that it is later restored properly
+        String itemHandle = item.getHandle();
 
         // Now, delete that item
         log.info("testRestoreItemNoPolicies() - DELETE Item");
-        collectionService.removeItem(context, parent, testItem);
+        collectionService.removeItem(context, parent, item);
 
         // Assert the deleted item no longer exists
-        DSpaceObject obj = handleService.resolveToObject(context, testItemHandle);
-        assertThat("testRestoreItemNoPolicies() item " + testItemHandle + " doesn't exist", obj, nullValue());
+        DSpaceObject obj = handleService.resolveToObject(context, itemHandle);
+        assertThat("testRestoreItemNoPolicies() item " + itemHandle + " doesn't exist", obj, nullValue());
 
         // Restore Item from AIP (non-recursive)
         log.info("testRestoreItemNoPolicies() - RESTORE Item");
         restoreFromAIP(parent, aipFile, null, false);
 
         // Assert the deleted item is RESTORED
-        DSpaceObject objRestored = handleService.resolveToObject(context, testItemHandle);
-        assertThat("testRestoreItemNoPolicies() item " + testItemHandle + " exists", objRestored, notNullValue());
+        DSpaceObject objRestored = handleService.resolveToObject(context, itemHandle);
+        assertThat("testRestoreItemNoPolicies() item " + itemHandle + " exists", objRestored, notNullValue());
 
         // Assert the restored item also has ZERO policies
         List<ResourcePolicy> policiesRestored = authorizeService.getPolicies(context, objRestored);
@@ -987,9 +986,9 @@ public class ITDSpaceAIP extends AbstractUnitTest
         // Get its current name / title
         String oldName = testItem.getName();
         
-        // Ensure item AIP is exported (but don't overwrite)
+        // Export item AIP
         log.info("testReplaceItem() - CREATE Item AIP");
-        File aipFile = createAIP(testItem, null, false, false);
+        File aipFile = createAIP(testItem, null, false);
         
         // Change the Item name
         String newName = "This is NOT my Item name!";
@@ -1033,9 +1032,9 @@ public class ITDSpaceAIP extends AbstractUnitTest
         List<Collection> mappedCollections = item.getCollections();
         assertEquals("testRestoreMappedItem() item " + testMappedItemHandle + " is mapped to multiple collections", 2, mappedCollections.size());
         
-        // Ensure mapped item AIP is exported (but don't overwrite)
+        // Export mapped item AIP
         log.info("testRestoreMappedItem() - CREATE Mapped Item AIP");
-        File aipFile = createAIP(item, null, false, false);
+        File aipFile = createAIP(item, null, false);
         
         // Now, delete that item (must be removed from BOTH collections to delete it)
         log.info("testRestoreMappedItem() - DELETE Item");
@@ -1067,10 +1066,9 @@ public class ITDSpaceAIP extends AbstractUnitTest
      * @param dso DSpaceObject to create AIP(s) for
      * @param pkParams any special PackageParameters to pass (if any)
      * @param recursive whether to recursively create AIPs or just a single AIP
-     * @param overwrite whether to overwrite the local AIP file if it is found
      * @return exported root AIP file
      */
-    private File createAIP(DSpaceObject dso, PackageParameters pkgParams, boolean recursive, boolean overwrite)
+    private File createAIP(DSpaceObject dso, PackageParameters pkgParams, boolean recursive)
             throws PackageException, CrosswalkException, AuthorizeException, SQLException, IOException
     {
         // Get a reference to the configured "AIP" package disseminator
@@ -1079,14 +1077,13 @@ public class ITDSpaceAIP extends AbstractUnitTest
         if (dip == null)
         {
             fail("Could not find a disseminator for type 'AIP'");
+            return null;
         }
-        
-        // Export file (this is placed in JUnit's temporary folder, so that it can be cleaned up after tests complete)
-        File exportAIPFile = new File(testFolder.getRoot().getAbsolutePath() + File.separator + PackageUtils.getPackageName(dso, "zip"));
-        
-        // To save time, we'll skip re-exporting AIPs, unless overwrite == true
-        if(!exportAIPFile.exists() || overwrite)
+        else
         {
+            // Export file (this is placed in JUnit's temporary folder, so that it can be cleaned up after tests complete)
+            File exportAIPFile = new File(testFolder.getRoot().getAbsolutePath() + File.separator + PackageUtils.getPackageName(dso, "zip"));
+
             // If unspecified, set default PackageParameters
             if (pkgParams==null)
                 pkgParams = new PackageParameters();
@@ -1096,9 +1093,9 @@ public class ITDSpaceAIP extends AbstractUnitTest
                 dip.disseminateAll(context, dso, pkgParams, exportAIPFile);
             else
                 dip.disseminate(context, dso, pkgParams, exportAIPFile);
+
+            return exportAIPFile;
         }
-        
-        return exportAIPFile;
     }
     
     /**
@@ -1118,24 +1115,29 @@ public class ITDSpaceAIP extends AbstractUnitTest
         {
             fail("Could not find a ingestor for type 'AIP'");
         }
-        
-        if(!aipFile.exists())
-        {
-            fail("AIP Package File does NOT exist: " + aipFile.getAbsolutePath());
-        }
-        
-        // If unspecified, set default PackageParameters
-        if(pkgParams==null)
-            pkgParams = new PackageParameters();
-        
-        // Ensure restore mode is enabled
-        pkgParams.setRestoreModeEnabled(true);
-        
-        // Actually ingest the object(s) from AIPs
-        if(recursive)
-            sip.ingestAll(context, parent, aipFile, pkgParams, null);
         else
-            sip.ingest(context, parent, aipFile, pkgParams, null);
+        {
+            if(!aipFile.exists())
+            {
+                fail("AIP Package File does NOT exist: " + aipFile.getAbsolutePath());
+            }
+
+            // If unspecified, set default PackageParameters
+            if(pkgParams==null)
+                pkgParams = new PackageParameters();
+
+            // Ensure restore mode is enabled
+            pkgParams.setRestoreModeEnabled(true);
+
+            // Actually ingest the object(s) from AIPs
+            if(recursive)
+                sip.ingestAll(context, parent, aipFile, pkgParams, null);
+            else
+                sip.ingest(context, parent, aipFile, pkgParams, null);
+
+            // Delete the AIP file as we are done with it
+            aipFile.delete();
+        }
     }
     
     /**
@@ -1155,24 +1157,29 @@ public class ITDSpaceAIP extends AbstractUnitTest
         {
             fail("Could not find a ingestor for type 'AIP'");
         }
-        
-        if(!aipFile.exists())
-        {
-            fail("AIP Package File does NOT exist: " + aipFile.getAbsolutePath());
-        }
-        
-        // If unspecified, set default PackageParameters
-        if (pkgParams==null)
-            pkgParams = new PackageParameters();
-        
-        // Ensure restore mode is enabled
-        pkgParams.setRestoreModeEnabled(true);
-        
-        // Actually replace the object(s) from AIPs
-        if(recursive)
-            sip.replaceAll(context, dso, aipFile, pkgParams);
         else
-            sip.replace(context, dso, aipFile, pkgParams);
+        {
+            if(!aipFile.exists())
+            {
+                fail("AIP Package File does NOT exist: " + aipFile.getAbsolutePath());
+            }
+
+            // If unspecified, set default PackageParameters
+            if (pkgParams==null)
+                pkgParams = new PackageParameters();
+
+            // Ensure restore mode is enabled
+            pkgParams.setRestoreModeEnabled(true);
+
+            // Actually replace the object(s) from AIPs
+            if(recursive)
+                sip.replaceAll(context, dso, aipFile, pkgParams);
+            else
+                sip.replace(context, dso, aipFile, pkgParams);
+
+            // Delete the AIP file as we are done with it
+            aipFile.delete();
+        }
     }
     
     /**

--- a/dspace-api/src/test/java/org/dspace/content/packager/ITDSpaceAIP.java
+++ b/dspace-api/src/test/java/org/dspace/content/packager/ITDSpaceAIP.java
@@ -89,11 +89,15 @@ public class ITDSpaceAIP extends AbstractUnitTest
     private static String submitterEmail = "aip-test@dspace.org";
     private Context context;
     
-    /** Create a temporary folder which will be cleaned up automatically by JUnit.
-        NOTE: As a ClassRule, this temp folder is shared by ALL tests below.
-        Its AIP contents are initialized in init() below. **/
+    /** Create a global temporary upload folder which will be cleaned up automatically by JUnit.
+        NOTE: As a ClassRule, this temp folder is shared by ALL tests below. **/
     @ClassRule
-    public static final TemporaryFolder testFolder = new TemporaryFolder();
+    public static final TemporaryFolder uploadTempFolder = new TemporaryFolder();
+
+    /** Create another temporary folder for AIPs. As a Rule, this one is *recreated* for each
+        test, in order to ensure each test is standalone with respect to AIPs. **/
+    @Rule
+    public final TemporaryFolder aipTempFolder = new TemporaryFolder();
     
     /**
      * This method will be run during class initialization. It will initialize
@@ -272,7 +276,7 @@ public class ITDSpaceAIP extends AbstractUnitTest
         // JUnit TemporaryFolder. This ensures Crosswalk classes like RoleCrosswalk
         // store their temp files in a place where JUnit can clean them up automatically.
         new NonStrictExpectations(configService.getClass()) {{
-            configService.getProperty("upload.temp.dir"); result = testFolder.getRoot().getAbsolutePath();
+            configService.getProperty("upload.temp.dir"); result = uploadTempFolder.getRoot().getAbsolutePath();
         }};
         
         try
@@ -1082,7 +1086,7 @@ public class ITDSpaceAIP extends AbstractUnitTest
         else
         {
             // Export file (this is placed in JUnit's temporary folder, so that it can be cleaned up after tests complete)
-            File exportAIPFile = new File(testFolder.getRoot().getAbsolutePath() + File.separator + PackageUtils.getPackageName(dso, "zip"));
+            File exportAIPFile = new File(aipTempFolder.getRoot().getAbsolutePath() + File.separator + PackageUtils.getPackageName(dso, "zip"));
 
             // If unspecified, set default PackageParameters
             if (pkgParams==null)
@@ -1134,9 +1138,6 @@ public class ITDSpaceAIP extends AbstractUnitTest
                 sip.ingestAll(context, parent, aipFile, pkgParams, null);
             else
                 sip.ingest(context, parent, aipFile, pkgParams, null);
-
-            // Delete the AIP file as we are done with it
-            aipFile.delete();
         }
     }
     
@@ -1176,9 +1177,6 @@ public class ITDSpaceAIP extends AbstractUnitTest
                 sip.replaceAll(context, dso, aipFile, pkgParams);
             else
                 sip.replace(context, dso, aipFile, pkgParams);
-
-            // Delete the AIP file as we are done with it
-            aipFile.delete();
         }
     }
     


### PR DESCRIPTION
This PR fixes https://jira.duraspace.org/browse/DS-3266

Does the following:
-  Adds new Integration Tests to `ITDSpaceAIP` to test that restoring restricted objects via AIPs is working as expected. See https://github.com/DSpace/DSpace/commit/127fd92481ae6da98fa67f4d00ddc1cadb04a7a2  (Initially these tests were failing for Items)
- Refactor `METSRightsCrosswalk` to cleanup the `for loop` logic in that class. It was not working exactly as expected. Also removed unused methods. See https://github.com/DSpace/DSpace/commit/a3854f54a8f851a0d2212ae047e2f43553fc69d4
- Fixed/refactored the logic in `InstallItemServiceImpl.finishItem()` to no longer replace/add policies of parent Collection in the case of a _restored_ items.  I just moved this logic to `installItem()` which is only run for new items. See https://github.com/DSpace/DSpace/commit/a2704fe1f653ddcee9378bbb12b57b9cc22b2466

The Integration Tests now all succeed and restrictions on Items are now restored properly.
