### PR TITLE
DS-3154 : Disable 'doclint' checks by default when building with Java 8 or above

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/group/EditGroupForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/group/EditGroupForm.java
@@ -37,7 +37,7 @@ import java.util.List;
  * 
  * @author Alexey Maslov
  * @author Scott Phillips
- * @author Oriol Olivé - DS-3205
+ * @author Oriol OlivÃ© - DS-3205
  */
 public class EditGroupForm extends AbstractDSpaceTransformer   
 {

--- a/pom.xml
+++ b/pom.xml
@@ -494,6 +494,25 @@
         </profile>
 
         <!--
+            If building with Java 8 (JDK 1.8), then disable the default 'doclint' validation.
+            'doclint' validates all Javadoc comments (see http://openjdk.java.net/jeps/172).
+            Unfortunately though, it also causes our release process to fail with Java 8,
+            as DSpace still has several modules with invalid Javadoc comments.
+            While we hope to clean this up in the future, for now we are forced to disable it.
+            See DS-3154 for more info.
+        -->
+        <profile>
+            <id>doclint-java8-disable</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <!-- Note: ${javadoc.opts} is passed to maven-javadoc-plugin below -->
+                <javadoc.opts>-Xdoclint:none</javadoc.opts>
+            </properties>
+        </profile>
+
+        <!--
            These profiles activate the inclusion of various modules into
            the DSpace Build process. They activate automatically if the
            source module is in the local file system, correctly located
@@ -746,6 +765,9 @@
                                 <goals>
                                     <goal>aggregate-jar</goal>
                                 </goals>
+                                <configuration>
+                                    <additionalparam>${javadoc.opts}</additionalparam>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
See https://jira.duraspace.org/browse/DS-3154

Because of the number of javadocs errors in DSpace code, we've decided to disable the doclint checks by default. This PR adds a Profile which disables doclint if you are running Java 8 or above.
