### PR TITLE
DS-3234 and DS-3268 : Upgrade to Flyway 4 and fix Ant migration issues

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -635,7 +635,7 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-            <version>3.2.1</version>
+            <version>4.0.3</version>
         </dependency>
 
         <!-- Google Analytics -->

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseRegistryUpdater.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseRegistryUpdater.java
@@ -141,16 +141,6 @@ public class DatabaseRegistryUpdater implements FlywayCallback
     }
 
     @Override
-    public void beforeInit(Connection connection) {
-
-    }
-
-    @Override
-    public void afterInit(Connection connection) {
-
-    }
-
-    @Override
     public void beforeBaseline(Connection connection) {
 
     }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -110,8 +110,13 @@ public class DatabaseUtils
                     printDBInfo(connection);
 
                     // Print any database warnings/errors found (if any)
-                    printDBWarnings(connection);
-                    System.exit(0);
+                    boolean issueFound = printDBIssues(connection);
+
+                    // If issues found, exit with an error status (even if connection succeeded).
+                    if(issueFound)
+                        System.exit(1);
+                    else
+                        System.exit(0);
                 }
                 catch (SQLException sqle)
                 {
@@ -149,8 +154,13 @@ public class DatabaseUtils
                     }
 
                     // Print any database warnings/errors found (if any)
-                    printDBWarnings(connection);
-                    System.exit(0);
+                    boolean issueFound = printDBIssues(connection);
+
+                    // If issues found, exit with an error status
+                    if(issueFound)
+                        System.exit(1);
+                    else
+                        System.exit(0);
                 }
                 catch (SQLException e)
                 {
@@ -360,10 +370,13 @@ public class DatabaseUtils
      * Print any warnings about current database setup to System.err (if any).
      * This is utilized by both the 'test' and 'info' commandline options.
      * @param connection current database connection
+     * @return boolean true if database issues found, false otherwise
      * @throws SQLException if database error occurs
      */
-    private static void printDBWarnings(Connection connection) throws SQLException
+    private static boolean printDBIssues(Connection connection) throws SQLException
     {
+        boolean issueFound = false;
+
         // Get the DB Type
         String dbType = getDbType(connection);
 
@@ -390,6 +403,7 @@ public class DatabaseUtils
                     System.out.println(requirementsMsg);
                     System.out.println("To update it, please connect to your DSpace database as a 'superuser' and manually run the following command: ");
                     System.out.println("\n  ALTER EXTENSION " + PostgresUtils.PGCRYPTO + " UPDATE TO '" + pgcryptoAvailable + "';\n");
+                    issueFound = true;
                 }
                 else if(pgcryptoInstalled==null) // If it's not installed in database
                 {
@@ -397,6 +411,7 @@ public class DatabaseUtils
                     System.out.println(requirementsMsg);
                     System.out.println("To install it, please connect to your DSpace database as a 'superuser' and manually run the following command: ");
                     System.out.println("\n  CREATE EXTENSION " + PostgresUtils.PGCRYPTO + ";\n");
+                    issueFound = true;
                 }
             }
             // Check if installed in Postgres, but an unsupported version
@@ -406,6 +421,7 @@ public class DatabaseUtils
                 System.out.println(requirementsMsg);
                 System.out.println("Make sure you are running a supported version of PostgreSQL, and then install " + PostgresUtils.PGCRYPTO + " version >= " + PostgresUtils.PGCRYPTO_VERSION);
                 System.out.println("The '" + PostgresUtils.PGCRYPTO + "' extension is often provided in the 'postgresql-contrib' package for your operating system.");
+                issueFound = true;
             }
             else if(pgcryptoAvailable==null) // If it's not installed in Postgres
             {
@@ -414,8 +430,10 @@ public class DatabaseUtils
                 System.out.println("The '" + PostgresUtils.PGCRYPTO + "' extension is often provided in the 'postgresql-contrib' package for your operating system.");
                 System.out.println("Once the extension is installed globally, please connect to your DSpace database as a 'superuser' and manually run the following command: ");
                 System.out.println("\n  CREATE EXTENSION " + PostgresUtils.PGCRYPTO + ";\n");
+                issueFound = true;
             }
         }
+        return issueFound;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -86,7 +86,7 @@ public class DatabaseUtils
         if (argv.length < 1)
         {
             System.out.println("\nDatabase action argument is missing.");
-            System.out.println("Valid actions: 'test', 'info', 'migrate', 'repair' or 'clean'");
+            System.out.println("Valid actions: 'test', 'info', 'migrate', 'repair', 'validate' or 'clean'");
             System.out.println("\nOr, type 'database help' for more information.\n");
             System.exit(1);
         }
@@ -285,6 +285,23 @@ public class DatabaseUtils
                     System.exit(1);
                 }
             }
+            // "validate" = Run Flyway validation to check for database errors/issues
+            else if(argv[0].equalsIgnoreCase("validate"))
+            {
+                try (Connection connection = dataSource.getConnection();)
+                {
+                    System.out.println("\nDatabase URL: " + connection.getMetaData().getURL());
+                    System.out.println("Attempting to validate database status (and migration checksums) via FlywayDB... (Check dspace logs for more details)");
+                    flyway.validate();
+                    System.out.println("Done.");
+                }
+                catch(SQLException|FlywayException e)
+                {
+                    System.err.println("Validation exception:");
+                    e.printStackTrace();
+                    System.exit(1);
+                }
+            }
             // "clean" = Run Flyway clean script
             else if(argv[0].equalsIgnoreCase("clean"))
             {
@@ -348,6 +365,7 @@ public class DatabaseUtils
                 System.out.println(" - info / status = Describe basic info/status about database, including validating the compatibility of this database");
                 System.out.println(" - migrate       = Migrate the database to the latest version");
                 System.out.println(" - repair        = Attempt to repair any previously failed database migrations or checksum mismatches (via Flyway repair)");
+                System.out.println(" - validate      = Validate current database's migration status (via Flyway validate), validating all migration checksums.");
                 System.out.println(" - clean         = DESTROY all data and tables in database (WARNING there is no going back!)");
                 System.out.println("");
             }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -386,34 +386,34 @@ public class DatabaseUtils
                 // Check if installed in database, but outdated version
                 if(pgcryptoInstalled!=null && pgcryptoInstalled.compareTo(PostgresUtils.PGCRYPTO_VERSION)<0)
                 {
-                    System.err.println("\nWARNING: Required PostgreSQL '" + PostgresUtils.PGCRYPTO + "' extension is OUTDATED (installed version=" + pgcryptoInstalled + ", available version = " + pgcryptoAvailable + ").");
-                    System.err.println(requirementsMsg);
-                    System.err.println("To update it, please connect to your DSpace database as a 'superuser' and manually run the following command: ");
-                    System.err.println("\n  ALTER EXTENSION " + PostgresUtils.PGCRYPTO + " UPDATE TO '" + pgcryptoAvailable + "';\n");
+                    System.out.println("\nWARNING: Required PostgreSQL '" + PostgresUtils.PGCRYPTO + "' extension is OUTDATED (installed version=" + pgcryptoInstalled + ", available version = " + pgcryptoAvailable + ").");
+                    System.out.println(requirementsMsg);
+                    System.out.println("To update it, please connect to your DSpace database as a 'superuser' and manually run the following command: ");
+                    System.out.println("\n  ALTER EXTENSION " + PostgresUtils.PGCRYPTO + " UPDATE TO '" + pgcryptoAvailable + "';\n");
                 }
                 else if(pgcryptoInstalled==null) // If it's not installed in database
                 {
-                    System.err.println("\nWARNING: Required PostgreSQL '" + PostgresUtils.PGCRYPTO + "' extension is NOT INSTALLED on this database.");
-                    System.err.println(requirementsMsg);
-                    System.err.println("To install it, please connect to your DSpace database as a 'superuser' and manually run the following command: ");
-                    System.err.println("\n  CREATE EXTENSION " + PostgresUtils.PGCRYPTO + ";\n");
+                    System.out.println("\nWARNING: Required PostgreSQL '" + PostgresUtils.PGCRYPTO + "' extension is NOT INSTALLED on this database.");
+                    System.out.println(requirementsMsg);
+                    System.out.println("To install it, please connect to your DSpace database as a 'superuser' and manually run the following command: ");
+                    System.out.println("\n  CREATE EXTENSION " + PostgresUtils.PGCRYPTO + ";\n");
                 }
             }
             // Check if installed in Postgres, but an unsupported version
             else if(pgcryptoAvailable!=null && pgcryptoAvailable.compareTo(PostgresUtils.PGCRYPTO_VERSION)<0)
             {
-                System.err.println("\nWARNING: UNSUPPORTED version of PostgreSQL '" + PostgresUtils.PGCRYPTO + "' extension found (version=" + pgcryptoAvailable + ").");
-                System.err.println(requirementsMsg);
-                System.err.println("Make sure you are running a supported version of PostgreSQL, and then install " + PostgresUtils.PGCRYPTO + " version >= " + PostgresUtils.PGCRYPTO_VERSION);
-                System.err.println("The '" + PostgresUtils.PGCRYPTO + "' extension is often provided in the 'postgresql-contrib' package for your operating system.");
+                System.out.println("\nWARNING: UNSUPPORTED version of PostgreSQL '" + PostgresUtils.PGCRYPTO + "' extension found (version=" + pgcryptoAvailable + ").");
+                System.out.println(requirementsMsg);
+                System.out.println("Make sure you are running a supported version of PostgreSQL, and then install " + PostgresUtils.PGCRYPTO + " version >= " + PostgresUtils.PGCRYPTO_VERSION);
+                System.out.println("The '" + PostgresUtils.PGCRYPTO + "' extension is often provided in the 'postgresql-contrib' package for your operating system.");
             }
             else if(pgcryptoAvailable==null) // If it's not installed in Postgres
             {
-                System.err.println("\nWARNING: PostgreSQL '" + PostgresUtils.PGCRYPTO + "' extension is NOT AVAILABLE. Please install it into this PostgreSQL instance.");
-                System.err.println(requirementsMsg);
-                System.err.println("The '" + PostgresUtils.PGCRYPTO + "' extension is often provided in the 'postgresql-contrib' package for your operating system.");
-                System.err.println("Once the extension is installed globally, please connect to your DSpace database as a 'superuser' and manually run the following command: ");
-                System.err.println("\n  CREATE EXTENSION " + PostgresUtils.PGCRYPTO + ";\n");
+                System.out.println("\nWARNING: PostgreSQL '" + PostgresUtils.PGCRYPTO + "' extension is NOT AVAILABLE. Please install it into this PostgreSQL instance.");
+                System.out.println(requirementsMsg);
+                System.out.println("The '" + PostgresUtils.PGCRYPTO + "' extension is often provided in the 'postgresql-contrib' package for your operating system.");
+                System.out.println("Once the extension is installed globally, please connect to your DSpace database as a 'superuser' and manually run the following command: ");
+                System.out.println("\n  CREATE EXTENSION " + PostgresUtils.PGCRYPTO + ";\n");
             }
         }
     }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -257,8 +257,8 @@ public class DatabaseUtils
                 // If clean is disabled, return immediately
                 if(flyway.isCleanDisabled())
                 {
-                    System.out.println("WARNING: 'clean' command is currently disabled, as it is dangerous to run in Production scenarios!");
-                    System.out.println("\n In order to run a 'clean' you first must enable it in your DSpace config by specifying 'db.cleanDisabled=false'.");
+                    System.out.println("\nWARNING: 'clean' command is currently disabled, as it is dangerous to run in Production scenarios!");
+                    System.out.println("\nIn order to run a 'clean' you first must enable it in your DSpace config by specifying 'db.cleanDisabled=false'.\n");
                     System.exit(1);
                 }
 
@@ -278,7 +278,7 @@ public class DatabaseUtils
                             System.out.println("\nERROR: The database user '" + username + "' does not have sufficient privileges to run a 'database clean' (via Flyway).");
                             System.out.println("\nIn order to run a 'clean', the database user MUST have 'superuser' privileges");
                             System.out.println("OR the '" + PostgresUtils.PGCRYPTO + "' extension must be installed in a separate schema (see documentation).");
-                            System.out.println("\nOptionally, you could also manually remove the '" + PostgresUtils.PGCRYPTO + "' extension first (DROP EXTENSION " + PostgresUtils.PGCRYPTO + " CASCADE), then rerun the 'clean'");
+                            System.out.println("\nOptionally, you could also manually remove the '" + PostgresUtils.PGCRYPTO + "' extension first (DROP EXTENSION " + PostgresUtils.PGCRYPTO + " CASCADE;), then rerun the 'clean'");
                             System.exit(1);
                         }
                     }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/GroupServiceInitializer.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/GroupServiceInitializer.java
@@ -98,16 +98,6 @@ public class GroupServiceInitializer implements FlywayCallback {
     }
 
     @Override
-    public void beforeInit(Connection connection) {
-
-    }
-
-    @Override
-    public void afterInit(Connection connection) {
-
-    }
-
-    @Override
     public void beforeBaseline(Connection connection) {
 
     }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/PostgreSQLCryptoChecker.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/PostgreSQLCryptoChecker.java
@@ -147,16 +147,6 @@ public class PostgreSQLCryptoChecker implements FlywayCallback
     }
 
     @Override
-    public void beforeInit(Connection connection) {
-
-    }
-
-    @Override
-    public void afterInit(Connection connection) {
-
-    }
-
-    @Override
     public void beforeBaseline(Connection connection) {
         // Before initializing database, check for pgcrypto
         checkPgCrypto(connection);

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/SiteServiceInitializer.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/SiteServiceInitializer.java
@@ -101,16 +101,6 @@ public class SiteServiceInitializer implements FlywayCallback {
     }
 
     @Override
-    public void beforeInit(Connection connection) {
-
-    }
-
-    @Override
-    public void afterInit(Connection connection) {
-
-    }
-
-    @Override
     public void beforeBaseline(Connection connection) {
 
     }

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -102,6 +102,13 @@ db.maxidle = -1
 # pool.
 #db.jndi = jdbc/dspace
 
+# Whether or not to allow for an entire 'clean' of the DSpace database.
+# Enabling it would allow your database owner to destroy all DSpace data, tables, etc
+# by simply running 'dspace database clean' from commandline.
+# WARNING: NEVER ENABLE IN PRODUCTION. This tool is for development/testing only.
+# (Defaults to 'true', i.e. disabled)
+# db.cleanDisabled = true
+
 ##### Email settings ######
 
 # SMTP mail server (allows DSpace to send email notifications)

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -103,10 +103,11 @@ db.maxidle = -1
 #db.jndi = jdbc/dspace
 
 # Whether or not to allow for an entire 'clean' of the DSpace database.
-# Enabling it would allow your database owner to destroy all DSpace data, tables, etc
-# by simply running 'dspace database clean' from commandline.
-# WARNING: NEVER ENABLE IN PRODUCTION. This tool is for development/testing only.
-# (Defaults to 'true', i.e. disabled)
+# By default, this setting is 'true', which ensures that the 'dspace database clean' command
+# does nothing (except return an error message saying clean is disabled)
+# Setting this config to 'false' allows your database owner to destroy all DSpace data, tables, etc
+# by running 'dspace database clean' from commandline. This is only useful for development/testing.
+# WARNING: NEVER SET TO 'false' IN PRODUCTION.
 # db.cleanDisabled = true
 
 ##### Email settings ######

--- a/dspace/config/log4j-console.properties
+++ b/dspace/config/log4j-console.properties
@@ -6,8 +6,10 @@
 # Its goal is to simply output logs to the commandline / console.
 #############################################################
 
-# Set root category priority to INFO and its only appender to A1.
-log4j.rootCategory=INFO, A1
+# Set root category priority to WARN and its only appender to A1.
+# For commandline / ant scripts, we are only concerned about significant warnings/errors
+# For the full detail, change this to INFO and re-run Ant.
+log4j.rootCategory=WARN, A1
 
 # A1 is set to be a ConsoleAppender.
 log4j.appender.A1=org.apache.log4j.ConsoleAppender

--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -135,7 +135,6 @@ Common usage:
         <echo message="fresh_install   --> Perform a fresh installation of the software. " />
         <echo message="" />
         <echo message="clean_backups   --> Remove .bak directories under install directory" />
-        <echo message="migrate_database   --> Migrate the DSpace database to the latest version." />
         <echo message="" />
         <echo message="" />
         <echo message="Available parameters are:" />
@@ -176,7 +175,7 @@ Common usage:
     <!-- Update an installation                                        -->
     <!-- ============================================================= -->
 
-    <target name="update" depends="update_configs,update_code,migrate_database,update_webapps,update_solr_indexes" description="Update installed code and web applications (without clobbering data/config)">
+    <target name="update" depends="update_configs,update_code,update_webapps,update_solr_indexes" description="Update installed code and web applications (without clobbering data/config)">
     </target>
 
     <!-- ============================================================= -->
@@ -797,16 +796,6 @@ Common usage:
             <arg value="test" />
         </java>
     </target>
-    <!-- Migrate the database -->
-    <target name="migrate_database">
-        <java classname="org.dspace.app.launcher.ScriptLauncher" classpathref="class.path" fork="yes" failonerror="yes">
-            <sysproperty key="log4j.configuration" value="file:config/log4j-console.properties" />
-            <sysproperty key="dspace.log.init.disable" value="true" />
-            <sysproperty key="dspace.dir" value="${dspace.dir}" />
-            <arg value="database" />
-            <arg value="migrate" />
-        </java>
-    </target>
 
     <!-- ============================================================= -->
     <!-- Install fresh code but do not touch the database              -->
@@ -864,7 +853,7 @@ Common usage:
     <!-- ============================================================= -->
 
     <target name="fresh_install"
-            depends="init_installation,init_configs,test_database,install_code,migrate_database"
+            depends="init_installation,init_configs,test_database,install_code"
             description="Do a fresh install of the system, overwriting any data">
 
         <delete failonerror="no">

--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -176,7 +176,7 @@ Common usage:
     <!-- Update an installation                                        -->
     <!-- ============================================================= -->
 
-    <target name="update" depends="update_configs,update_code,update_webapps,update_solr_indexes,test_database" description="Update installed code and web applications (without clobbering data/config)">
+    <target name="update" depends="update_configs,update_code,test_database,update_webapps,update_solr_indexes" description="Update installed code and web applications (without clobbering data/config)">
     </target>
 
     <!-- ============================================================= -->

--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -135,6 +135,7 @@ Common usage:
         <echo message="fresh_install   --> Perform a fresh installation of the software. " />
         <echo message="" />
         <echo message="clean_backups   --> Remove .bak directories under install directory" />
+        <echo message="test_database   --> Attempt to connect to the DSpace database in order to verify that configuration is correct" />
         <echo message="" />
         <echo message="" />
         <echo message="Available parameters are:" />
@@ -175,7 +176,7 @@ Common usage:
     <!-- Update an installation                                        -->
     <!-- ============================================================= -->
 
-    <target name="update" depends="update_configs,update_code,update_webapps,update_solr_indexes" description="Update installed code and web applications (without clobbering data/config)">
+    <target name="update" depends="update_configs,update_code,update_webapps,update_solr_indexes,test_database" description="Update installed code and web applications (without clobbering data/config)">
     </target>
 
     <!-- ============================================================= -->


### PR DESCRIPTION
This definitely needs more eyes / review / testing.  But, I wanted to get a PR posted as soon as possible for feedback from others.

https://jira.duraspace.org/browse/DS-3234
https://jira.duraspace.org/browse/DS-3268

There's several changes in this PR to fix DS-3234 and ensure DSpace 6.x behaves more like 5.x. Included in this was the fact that migrations were no longer being triggered when DSpace loads/reloads in Tomcat (which was the behavior in 5.x).
1. Upgrade us to Flyway 4.0.3 (latest version). Most of the fixes are in https://github.com/DSpace/DSpace/commit/5a61d621008e426d0f9f3b4fe7ca40bd42ee4757
2. Add a new `./dspace database validate` command to more easily test validation issues (like the one in DS-3234). See https://github.com/DSpace/DSpace/commit/aa582848a49a31f20d91adc79e1688783f01f9ec
3. Add support for new Flyway 4 capability to disable "clean" by default.  Now, running `./dspace database clean` requires first setting `db.cleanDisabled=false` in your configuration (default is true).  See https://github.com/DSpace/DSpace/commit/fe25840b6429e95f52d45c4eca8247eb331ccb66
4. Refactor `./dspace database test` to report database errors/warnings (like if "pgcrypto" is missing), and share that logic with existing `database info` command. This will allow Ant to check for common database issues _without_ having to run all migrations. See https://github.com/DSpace/DSpace/commit/fe25840b6429e95f52d45c4eca8247eb331ccb66
5. As part of the previous fix (# 4), Ant now returns an error if `ant test_database` (which runs `dspace database test`) finds any issues with your current database setup during either upgrade or fresh install.
6. Change Ant settings to no longer perform database migrations. Instead, migrations will be kicked off either by running `./dspace database migrate` or by starting up Tomcat  (this is the same behavior as in 5.x). See https://github.com/DSpace/DSpace/commit/24e7a5a5ec5f23063ac39dbd8a6a0d8b6e6ecaf8
7. Finally, update `Context` class to kick off database migrations via a static block _PRIOR_ to initializing Hibernate. This ensures migrations run automatically if you startup Tomcat. See https://github.com/DSpace/DSpace/pull/1468/commits/d1695521c56141579ee2626ebe82c6123b9dcda9

Requires testing the following scenarios (I've checked which ones I've tested so far):
- [x] Upgrade from 5.x (or below), upgrade database by just starting up Tomcat
- [x] Upgrade from 5.x (or below), upgrade database by running `./dspace database migrate`
- [x] Fresh Install, initialize database by just starting up Tomcat
- [x] Fresh Install, initialize database by running `./dspace database migrate` BEFORE starting Tomcat
- [x] Fresh install, running `./dspace create-administrator` BEFORE starting Tomcat (should initialize DB as well)
