### PR TITLE
DS-3272: Result count for XMLUI's usage stats is now a configurable option

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/statistics/StatisticsTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/statistics/StatisticsTransformer.java
@@ -17,9 +17,10 @@ import org.dspace.app.xmlui.wing.WingException;
 import org.dspace.app.xmlui.wing.element.*;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.DSpaceObject;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.ItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.core.ConfigurationManager;
 import org.dspace.statistics.Dataset;
 import org.dspace.statistics.content.*;
 import org.xml.sax.SAXException;
@@ -49,24 +50,18 @@ public class StatisticsTransformer extends AbstractDSpaceTransformer {
 
     private SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
 
+	protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();
+
     public StatisticsTransformer(Date dateStart, Date dateEnd) {
         this.dateStart = dateStart;
         this.dateEnd = dateEnd;
 
-        try {
-            this.context = new Context();
-        } catch (SQLException e) {
-            log.error("Error getting context in StatisticsTransformer:" + e.getMessage());
-        }
-    }
+		this.context = new Context();
+	}
 
     public StatisticsTransformer() {
-        try {
-            this.context = new Context();
-        } catch (SQLException e) {
-            log.error("Error getting context in StatisticsTransformer:" + e.getMessage());
-        }
-    }
+		this.context = new Context();
+	}
 
     /**
      * Add a page title and trail links
@@ -79,7 +74,7 @@ public class StatisticsTransformer extends AbstractDSpaceTransformer {
 
         if(dso != null)
         {
-            HandleUtil.buildHandleTrail(dso, pageMeta, contextPath, true);
+            HandleUtil.buildHandleTrail(context, dso, pageMeta, contextPath, true);
         }
         pageMeta.addTrailLink(contextPath + "/handle" + (dso != null && dso.getHandle() != null ? "/" + dso.getHandle() : "/statistics"), T_statistics_trail);
 
@@ -141,16 +136,16 @@ public class StatisticsTransformer extends AbstractDSpaceTransformer {
 		}
 		*/
 		try {
-            /** List of the top n items for the entire repository **/
+            /** List of the top 10 items for the entire repository **/
 			StatisticsListing statListing = new StatisticsListing(
 					new StatisticsDataVisits());
 
 			statListing.setTitle(T_head_visits_total);
 			statListing.setId("list1");
 
-            //Adding a new generator for our top n items without a name length delimiter
+            //Adding a new generator for our top 10 items without a name length delimiter
             DatasetDSpaceObjectGenerator dsoAxis = new DatasetDSpaceObjectGenerator();
-            dsoAxis.addDsoChild(Constants.ITEM, chooseResultCount(), false, -1);
+            dsoAxis.addDsoChild(Constants.ITEM, 10, false, -1);
             statListing.addDatasetGenerator(dsoAxis);
 
             //Render the list as a table
@@ -181,7 +176,7 @@ public class StatisticsTransformer extends AbstractDSpaceTransformer {
 			statListing.setId("list1");
 
 			DatasetDSpaceObjectGenerator dsoAxis = new DatasetDSpaceObjectGenerator();
-			dsoAxis.addDsoChild(dso.getType(), chooseResultCount(), false, -1);
+			dsoAxis.addDsoChild(dso.getType(), 10, false, -1);
 			statListing.addDatasetGenerator(dsoAxis);
 
 			addDisplayListing(division, statListing);
@@ -207,7 +202,7 @@ public class StatisticsTransformer extends AbstractDSpaceTransformer {
 			statisticsTable.addDatasetGenerator(timeAxis);
 
 			DatasetDSpaceObjectGenerator dsoAxis = new DatasetDSpaceObjectGenerator();
-			dsoAxis.addDsoChild(dso.getType(), chooseResultCount(), false, -1);
+			dsoAxis.addDsoChild(dso.getType(), 10, false, -1);
 			statisticsTable.addDatasetGenerator(dsoAxis);
 
 			addDisplayTable(division, statisticsTable);
@@ -223,14 +218,14 @@ public class StatisticsTransformer extends AbstractDSpaceTransformer {
              //Make sure our item has at least one bitstream
              org.dspace.content.Item item = (org.dspace.content.Item) dso;
             try {
-                if(item.hasUploadedFiles()){
+                if(itemService.hasUploadedFiles(item)){
                     StatisticsListing statsList = new StatisticsListing(new StatisticsDataVisits(dso));
 
                     statsList.setTitle(T_head_visits_bitstream);
                     statsList.setId("list-bit");
 
                     DatasetDSpaceObjectGenerator dsoAxis = new DatasetDSpaceObjectGenerator();
-                    dsoAxis.addDsoChild(Constants.BITSTREAM, chooseResultCount(), false, -1);
+                    dsoAxis.addDsoChild(Constants.BITSTREAM, 10, false, -1);
                     statsList.addDatasetGenerator(dsoAxis);
 
                     addDisplayListing(division, statsList);
@@ -255,7 +250,7 @@ public class StatisticsTransformer extends AbstractDSpaceTransformer {
 
             DatasetTypeGenerator typeAxis = new DatasetTypeGenerator();
             typeAxis.setType("countryCode");
-            typeAxis.setMax(chooseResultCount());
+            typeAxis.setMax(10);
             statListing.addDatasetGenerator(typeAxis);
 
             addDisplayListing(division, statListing);
@@ -278,7 +273,7 @@ public class StatisticsTransformer extends AbstractDSpaceTransformer {
 
             DatasetTypeGenerator typeAxis = new DatasetTypeGenerator();
             typeAxis.setType("city");
-            typeAxis.setMax(chooseResultCount());
+            typeAxis.setMax(10);
             statListing.addDatasetGenerator(typeAxis);
 
             addDisplayListing(division, statListing);
@@ -415,19 +410,5 @@ public class StatisticsTransformer extends AbstractDSpaceTransformer {
 		}
 
 	}
-    
-    /**
-     * Gets the number of results to display from usage-statistics.cfg
-     * Returns 10 if there is no such entry in usage-statistics.cfg
-     * */
-    private int chooseResultCount() {
-        Integer numItems = ConfigurationManager.getIntProperty("usage-statistics", "itemcount.usage");
-        if(numItems == null ){
-            numItems = 10;
-        }
-        return numItems;
-        
-    }
-    
 
 }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/statistics/StatisticsTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/statistics/StatisticsTransformer.java
@@ -21,6 +21,7 @@ import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
+import org.dspace.core.ConfigurationManager;
 import org.dspace.statistics.Dataset;
 import org.dspace.statistics.content.*;
 import org.xml.sax.SAXException;
@@ -136,16 +137,16 @@ public class StatisticsTransformer extends AbstractDSpaceTransformer {
 		}
 		*/
 		try {
-            /** List of the top 10 items for the entire repository **/
+            /** List of the top n items for the entire repository **/
 			StatisticsListing statListing = new StatisticsListing(
 					new StatisticsDataVisits());
 
 			statListing.setTitle(T_head_visits_total);
 			statListing.setId("list1");
 
-            //Adding a new generator for our top 10 items without a name length delimiter
+            //Adding a new generator for our top n items without a name length delimiter
             DatasetDSpaceObjectGenerator dsoAxis = new DatasetDSpaceObjectGenerator();
-            dsoAxis.addDsoChild(Constants.ITEM, 10, false, -1);
+            dsoAxis.addDsoChild(Constants.ITEM, chooseResultCount(), false, -1);
             statListing.addDatasetGenerator(dsoAxis);
 
             //Render the list as a table
@@ -176,7 +177,7 @@ public class StatisticsTransformer extends AbstractDSpaceTransformer {
 			statListing.setId("list1");
 
 			DatasetDSpaceObjectGenerator dsoAxis = new DatasetDSpaceObjectGenerator();
-			dsoAxis.addDsoChild(dso.getType(), 10, false, -1);
+			dsoAxis.addDsoChild(dso.getType(), chooseResultCount(), false, -1);
 			statListing.addDatasetGenerator(dsoAxis);
 
 			addDisplayListing(division, statListing);
@@ -202,7 +203,7 @@ public class StatisticsTransformer extends AbstractDSpaceTransformer {
 			statisticsTable.addDatasetGenerator(timeAxis);
 
 			DatasetDSpaceObjectGenerator dsoAxis = new DatasetDSpaceObjectGenerator();
-			dsoAxis.addDsoChild(dso.getType(), 10, false, -1);
+			dsoAxis.addDsoChild(dso.getType(), chooseResultCount(), false, -1);
 			statisticsTable.addDatasetGenerator(dsoAxis);
 
 			addDisplayTable(division, statisticsTable);
@@ -225,7 +226,7 @@ public class StatisticsTransformer extends AbstractDSpaceTransformer {
                     statsList.setId("list-bit");
 
                     DatasetDSpaceObjectGenerator dsoAxis = new DatasetDSpaceObjectGenerator();
-                    dsoAxis.addDsoChild(Constants.BITSTREAM, 10, false, -1);
+                    dsoAxis.addDsoChild(Constants.BITSTREAM, chooseResultCount(), false, -1);
                     statsList.addDatasetGenerator(dsoAxis);
 
                     addDisplayListing(division, statsList);
@@ -250,7 +251,7 @@ public class StatisticsTransformer extends AbstractDSpaceTransformer {
 
             DatasetTypeGenerator typeAxis = new DatasetTypeGenerator();
             typeAxis.setType("countryCode");
-            typeAxis.setMax(10);
+            typeAxis.setMax(chooseResultCount());
             statListing.addDatasetGenerator(typeAxis);
 
             addDisplayListing(division, statListing);
@@ -273,7 +274,7 @@ public class StatisticsTransformer extends AbstractDSpaceTransformer {
 
             DatasetTypeGenerator typeAxis = new DatasetTypeGenerator();
             typeAxis.setType("city");
-            typeAxis.setMax(10);
+            typeAxis.setMax(chooseResultCount());
             statListing.addDatasetGenerator(typeAxis);
 
             addDisplayListing(division, statListing);
@@ -410,5 +411,18 @@ public class StatisticsTransformer extends AbstractDSpaceTransformer {
 		}
 
 	}
+    
+    /**
+    * Gets the number of results to display from usage-statistics.cfg
+    * Returns 10 if there is no such entry in usage-statistics.cfg
+    * @return number of results to display
+    */
+    private int chooseResultCount() {
+        Integer numItems = ConfigurationManager.getIntProperty("usage-statistics", "itemcount.usage");
+        if(numItems == null ){
+            numItems = 10;
+        }
+        return numItems;
+    }
 
 }

--- a/dspace/config/modules/usage-statistics.cfg
+++ b/dspace/config/modules/usage-statistics.cfg
@@ -28,6 +28,8 @@ usage-statistics.authorization.admin.usage=true
 usage-statistics.authorization.admin.search=true
 #Workflow result statistics
 usage-statistics.authorization.admin.workflow=true
+#Number of results to show in statistics-home for usage stats
+itemcount.usage = 10
 
 # Enable/disable logging of spiders in solr statistics.
 # If false, and IP matches an address in spiderips.urls, event is not logged.

--- a/dspace/config/modules/usage-statistics.cfg
+++ b/dspace/config/modules/usage-statistics.cfg
@@ -29,6 +29,9 @@ usage-statistics.authorization.admin.search=true
 #Workflow result statistics
 usage-statistics.authorization.admin.workflow=true
 
+#Number of results to show in statistics-home for usage stats
+itemcount.usage = 10
+
 # Enable/disable logging of spiders in solr statistics.
 # If false, and IP matches an address in spiderips.urls, event is not logged.
 # If true, event will be logged with the 'isBot' field set to true

--- a/dspace/config/modules/usage-statistics.cfg
+++ b/dspace/config/modules/usage-statistics.cfg
@@ -29,9 +29,6 @@ usage-statistics.authorization.admin.search=true
 #Workflow result statistics
 usage-statistics.authorization.admin.workflow=true
 
-#Number of results to show in statistics-home for usage stats
-itemcount.usage = 10
-
 # Enable/disable logging of spiders in solr statistics.
 # If false, and IP matches an address in spiderips.urls, event is not logged.
 # If true, event will be logged with the 'isBot' field set to true


### PR DESCRIPTION
Number of results displayed for XMLUI usage stats is now a configurable option in `[dspace]/config/modules/usage-statistics.cfg`. This was previously hardcoded in the Java source.

If no such option is specified, result count defaults to 10. 
