### PR TITLE
DS-3269: Disable Flyway out of order migrations. Also cleanup of XML Workflow enabling.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseRegistryUpdater.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseRegistryUpdater.java
@@ -15,6 +15,8 @@ import org.dspace.administer.RegistryLoader;
 import org.dspace.core.Context;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.workflow.factory.WorkflowServiceFactory;
+import org.dspace.xmlworkflow.service.XmlWorkflowService;
 import org.flywaydb.core.api.MigrationInfo;
 import org.flywaydb.core.api.callback.FlywayCallback;
 import org.slf4j.Logger;
@@ -74,8 +76,7 @@ public class DatabaseRegistryUpdater implements FlywayCallback
             MetadataImporter.loadRegistry(base + "sword-metadata.xml", true);
 
             // Check if XML Workflow is enabled in workflow.cfg
-            String framework = config.getProperty("workflow.framework");
-            if (framework!=null && framework.equals("xmlworkflow"))
+            if (WorkflowServiceFactory.getInstance().getWorkflowService() instanceof XmlWorkflowService)
             {
                 // If so, load in the workflow metadata types as well
                 MetadataImporter.loadRegistry(base + "workflow-types.xml", true);

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -191,13 +191,29 @@ public class DatabaseUtils
                         {
                             // Otherwise, we assume "argv[1]" is a valid migration version number
                             // This is only for testing! Never specify for Production!
-                            System.out.println("Migrating database ONLY to version " + argv[1] + " ... (Check logs for details)");
+                            String migrationVersion = argv[1];
+                            BufferedReader input = new BufferedReader(new InputStreamReader(System.in));
+
+                            System.out.println("You've specified to migrate your database ONLY to version " + migrationVersion + " ...");
                             System.out.println("\nWARNING: It is highly likely you will see errors in your logs when the Metadata");
                             System.out.println("or Bitstream Format Registry auto-update. This is because you are attempting to");
-                            System.out.println("use an OLD version " + argv[1] + " Database with a newer DSpace API. NEVER do this in a");
+                            System.out.println("use an OLD version " + migrationVersion + " Database with a newer DSpace API. NEVER do this in a");
                             System.out.println("PRODUCTION scenario. The resulting old DB is only useful for migration testing.\n");
-                            // Update the database, to the version specified.
-                            updateDatabase(dataSource, connection, argv[1], false);
+
+                            System.out.print("Are you SURE you only want to migrate your database to version " + migrationVersion + "? [y/n]: ");
+                            String choiceString = input.readLine();
+                            input.close();
+
+                            if (choiceString.equalsIgnoreCase("y"))
+                            {
+                                System.out.println("Migrating database ONLY to version " + migrationVersion + " ... (Check logs for details)");
+                                // Update the database, to the version specified.
+                                updateDatabase(dataSource, connection, migrationVersion, false);
+                            }
+                            else
+                            {
+                                System.out.println("No action performed.");
+                            }
                         }
                     }
                     else
@@ -306,6 +322,10 @@ public class DatabaseUtils
                         cleanDatabase(flyway, dataSource);
                         System.out.println("Done.");
                         System.exit(0);
+                    }
+                    else
+                    {
+                        System.out.println("No action performed.");
                     }
                 }
                 catch(SQLException e)

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/xmlworkflow/V6_0_2015_09_01__DS_2701_Enable_XMLWorkflow_Migration.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/xmlworkflow/V6_0_2015_09_01__DS_2701_Enable_XMLWorkflow_Migration.java
@@ -7,7 +7,6 @@
  */
 package org.dspace.storage.rdbms.xmlworkflow;
 
-import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Constants;
 import org.dspace.storage.rdbms.DatabaseUtils;
 import org.dspace.workflow.factory.WorkflowServiceFactory;
@@ -19,6 +18,18 @@ import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
 import java.sql.Connection;
 
 /**
+ * This class automatically migrates your DSpace Database to use the
+ * XML-based Configurable Workflow system whenever it is enabled.
+ * <P>
+ * Because XML-based Configurable Workflow existed prior to our migration, this
+ * class first checks for the existence of the "cwf_workflowitem" table before
+ * running any migrations.
+ * <P>
+ * This class represents a Flyway DB Java Migration
+ * http://flywaydb.org/documentation/migration/java.html
+ * <P>
+ * It can upgrade a 6.0 version of DSpace to use the XMLWorkflow.
+ * 
  * User: kevin (kevin at atmire.com)
  * Date: 1/09/15
  * Time: 11:34

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/xmlworkflow/oracle/v6.0__DS-2701_data_workflow_migration.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/xmlworkflow/oracle/v6.0__DS-2701_data_workflow_migration.sql
@@ -17,7 +17,7 @@
 --
 -- This script is called automatically by the following
 -- Flyway Java migration class:
--- org.dspace.storage.rdbms.migration.V5_0_2014_01_01__XMLWorkflow_Migration
+-- org.dspace.storage.rdbms.xmlworkflow.V6_0_2015_09_01__DS_2701_Enable_XMLWorkflow_Migration
 ----------------------------------------------------
 
 -- Convert workflow groups:

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/xmlworkflow/oracle/v6.0__DS-2701_xml_workflow_migration.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/xmlworkflow/oracle/v6.0__DS-2701_xml_workflow_migration.sql
@@ -7,7 +7,7 @@
 --
 
 ----------------------------------------------------
--- Database Schema Update for XML/Configurable Workflow
+-- Database Schema Update for XML/Configurable Workflow (for DSpace 6.0)
 --
 -- This file will automatically create/update your
 -- DSpace Database tables to support XML/Configurable workflows.
@@ -17,7 +17,7 @@
 --
 -- This script is called automatically by the following
 -- Flyway Java migration class:
--- org.dspace.storage.rdbms.migration.V5_0_2014_01_01__XMLWorkflow_Migration
+-- org.dspace.storage.rdbms.xmlworkflow.V6_0_2015_09_01__DS_2701_Enable_XMLWorkflow_Migration
 ----------------------------------------------------
 
 CREATE SEQUENCE cwf_workflowitem_seq;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/xmlworkflow/postgres/v6.0__DS-2701_data_workflow_migration.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/xmlworkflow/postgres/v6.0__DS-2701_data_workflow_migration.sql
@@ -17,7 +17,7 @@
 --
 -- This script is called automatically by the following
 -- Flyway Java migration class:
--- org.dspace.storage.rdbms.migration.V5_0_2014_01_01__XMLWorkflow_Migration
+-- org.dspace.storage.rdbms.xmlworkflow.V6_0_2015_09_01__DS_2701_Enable_XMLWorkflow_Migration
 ----------------------------------------------------
 
 -- Convert workflow groups:

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/xmlworkflow/postgres/v6.0__DS-2701_xml_workflow_migration.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/xmlworkflow/postgres/v6.0__DS-2701_xml_workflow_migration.sql
@@ -17,7 +17,7 @@
 --
 -- This script is called automatically by the following
 -- Flyway Java migration class:
--- org.dspace.storage.rdbms.migration.V5_0_2014_01_01__XMLWorkflow_Migration
+-- org.dspace.storage.rdbms.xmlworkflow.V6_0_2015_09_01__DS_2701_Enable_XMLWorkflow_Migration
 ----------------------------------------------------
 
 CREATE SEQUENCE cwf_workflowitem_seq;

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowContainerUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowContainerUtils.java
@@ -9,7 +9,6 @@ package org.dspace.app.xmlui.aspect.administrative;
 
 import org.apache.cocoon.environment.Request;
 import org.apache.cocoon.servlet.multipart.Part;
-import org.apache.commons.lang.StringUtils;
 import org.dspace.app.xmlui.utils.UIException;
 import org.dspace.app.xmlui.wing.Message;
 import org.dspace.authorize.AuthorizeException;
@@ -43,6 +42,7 @@ import org.dspace.workflow.WorkflowService;
 import org.dspace.workflow.factory.WorkflowServiceFactory;
 import org.dspace.xmlworkflow.WorkflowConfigurationException;
 import org.dspace.xmlworkflow.WorkflowUtils;
+import org.dspace.xmlworkflow.service.XmlWorkflowService;
 import org.jdom.JDOMException;
 import org.jdom.input.SAXBuilder;
 import org.xml.sax.SAXException;
@@ -58,6 +58,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
+
 
 /**
  * Utility methods to processes actions on Communities and Collections.
@@ -540,7 +541,7 @@ public class FlowContainerUtils
 			collectionService.removeSubmitters(context, collection);
 		}
         else{
-            if(StringUtils.equals(DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("workflow.framework"), "xmlworkflow"))
+            if(WorkflowServiceFactory.getInstance().getWorkflowService() instanceof XmlWorkflowService)
             {
                 WorkflowUtils.deleteRoleGroup(context, collection, roleName);
             }else{

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/collection/AssignCollectionRoles.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/collection/AssignCollectionRoles.java
@@ -25,10 +25,11 @@ import org.dspace.core.LogManager;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.GroupService;
-import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.workflow.factory.WorkflowServiceFactory;
 import org.dspace.xmlworkflow.Role;
 import org.dspace.xmlworkflow.WorkflowConfigurationException;
 import org.dspace.xmlworkflow.WorkflowUtils;
+import org.dspace.xmlworkflow.service.XmlWorkflowService;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -247,7 +248,7 @@ public class AssignCollectionRoles extends AbstractDSpaceTransformer
         tableRow.addCell(1,2).addHighlight("fade offset").addContent(T_help_default_read);
 
 
-		if(StringUtils.equals(DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("workflow.framework"), "xmlworkflow")) {
+		if(WorkflowServiceFactory.getInstance().getWorkflowService() instanceof XmlWorkflowService) {
              try{
                  HashMap<String, Role> roles = WorkflowUtils.getAllExternalRoles(thisCollection);
                  addXMLWorkflowRoles(thisCollection, baseURL, roles, rolesTable);

--- a/dspace-xmlui/src/main/resources/aspects/Administrative/administrative.js
+++ b/dspace-xmlui/src/main/resources/aspects/Administrative/administrative.js
@@ -29,7 +29,10 @@ importClass(Packages.org.dspace.eperson.EPerson);
 importClass(Packages.org.dspace.eperson.Group);
 importClass(Packages.org.dspace.app.util.Util);
 
+importClass(Packages.org.dspace.workflow.factory.WorkflowServiceFactory);
 importClass(Packages.org.dspace.xmlworkflow.factory.XmlWorkflowServiceFactory);
+importClass(Packages.org.dspace.xmlworkflow.service.XmlWorkflowService);
+
 importClass(Packages.java.util.Set);
 
 importClass(Packages.org.dspace.app.xmlui.utils.FlowscriptUtils);
@@ -45,7 +48,6 @@ importClass(Packages.org.dspace.app.xmlui.aspect.administrative.FlowCurationUtil
 importClass(Packages.org.dspace.app.xmlui.aspect.administrative.FlowMetadataImportUtils);
 importClass(Packages.org.dspace.app.xmlui.aspect.administrative.FlowBatchImportUtils);
 importClass(Packages.java.lang.System);
-importClass(Packages.org.dspace.core.ConfigurationManager);
 
 /**
  * Simple access method to access the current cocoon object model.
@@ -2698,7 +2700,7 @@ function doAssignCollectionRoles(collectionID)
 		{
 			result = doDeleteCollectionRole(collectionID, "DEFAULT_READ");
 		}else{
-            if(StringUtils.equals(ConfigurationManager.getProperty("workflow.framework"), "xmlworkflow")){
+            if(WorkflowServiceFactory.getInstance().getWorkflowService() instanceof XmlWorkflowService){
                 if(workflow == null){
                     var collection = getCollectionService().find(getDSContext(),collectionID);
                     workflow = getXmlWorkflowFactory().getWorkflow(collection);

--- a/dspace/config/hibernate.cfg.xml
+++ b/dspace/config/hibernate.cfg.xml
@@ -64,17 +64,19 @@
         <mapping class="org.dspace.versioning.Version"/>
         <mapping class="org.dspace.versioning.VersionHistory"/>
 
+        <mapping class="org.dspace.app.requestitem.RequestItem"/>
+
+        <!--Basic workflow services, comment or remove when switching to the configurable workflow -->
         <mapping class="org.dspace.workflowbasic.BasicWorkflowItem"/>
         <mapping class="org.dspace.workflowbasic.TaskListItem"/>
 
-        <mapping class="org.dspace.app.requestitem.RequestItem"/>
-
-        <!--<mapping class="org.dspace.xmlworkflow.storedcomponents.ClaimedTask"/>-->
-        <!--<mapping class="org.dspace.xmlworkflow.storedcomponents.CollectionRole"/>-->
-        <!--<mapping class="org.dspace.xmlworkflow.storedcomponents.InProgressUser"/>-->
-        <!--<mapping class="org.dspace.xmlworkflow.storedcomponents.PoolTask"/>-->
-        <!--<mapping class="org.dspace.xmlworkflow.storedcomponents.WorkflowItemRole"/>-->
-        <!--<mapping class="org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem"/>-->
+        <!--Configurable workflow services, uncomment the xml workflow classes below to enable the configurable workflow-->
+        <!--<mapping class="org.dspace.xmlworkflow.storedcomponents.ClaimedTask"/>
+        <mapping class="org.dspace.xmlworkflow.storedcomponents.CollectionRole"/>
+        <mapping class="org.dspace.xmlworkflow.storedcomponents.InProgressUser"/>
+        <mapping class="org.dspace.xmlworkflow.storedcomponents.PoolTask"/>
+        <mapping class="org.dspace.xmlworkflow.storedcomponents.WorkflowItemRole"/>
+        <mapping class="org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem"/>-->
 
     </session-factory>
 </hibernate-configuration>

--- a/dspace/config/modules/workflow.cfg
+++ b/dspace/config/modules/workflow.cfg
@@ -4,12 +4,12 @@
 # Configuration properties used solely by the Configurable      #
 # Reviewer Workflow (XMLUI only)                                #
 #---------------------------------------------------------------#
-#Selection of workflow framework that will be used in DSpace
-# Possible values:
-#   originalworkflow = Traditional DSpace Workflow
-#   xmlworkflow = New (as of 1.8.0) Configurable Reviewer Workflow
-workflow.framework=originalworkflow
-#workflow.framework=xmlworkflow
+#
+# Workflow framework used by DSpace is now determined by the configured
+# WorkflowService implementation in [dspace.dir]/config/spring/api/core-services.xml
+# One of two WorkflowServices should be enabled in that file:
+#   org.dspace.workflowbasic.BasicWorkflowServiceImpl = Traditional DSpace Workflow
+#   org.dspace.xmlworkflow.XmlWorkflowServiceImpl = Configurable (XML) Workflow
 
 #Allow the reviewers to add/edit/remove files from the submission
 #When changing this property you might want to alert submitters in the license that reviewers can alter their files

--- a/dspace/config/spring/api/core-services.xml
+++ b/dspace/config/spring/api/core-services.xml
@@ -103,19 +103,15 @@
     <bean class="org.dspace.workflowbasic.BasicWorkflowItemServiceImpl"/>
     <bean class="org.dspace.workflowbasic.BasicWorkflowServiceImpl"/>
 
-
-
-    <!--<bean class="org.dspace.xmlworkflow.storedcomponents.ClaimedTaskServiceImpl"/>-->
-    <!--<bean class="org.dspace.xmlworkflow.storedcomponents.CollectionRoleServiceImpl"/>-->
-    <!--<bean class="org.dspace.xmlworkflow.storedcomponents.InProgressUserServiceImpl"/>-->
-    <!--<bean class="org.dspace.xmlworkflow.storedcomponents.PoolTaskServiceImpl"/>-->
-    <!--<bean class="org.dspace.xmlworkflow.storedcomponents.WorkflowItemRoleServiceImpl"/>-->
-    <!--<bean class="org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItemServiceImpl"/>-->
-
-
     <!--Configurable workflow services, uncomment the xml workflow beans below to enable the configurable workflow-->
-    <!--<bean class="org.dspace.xmlworkflow.XmlWorkflowServiceImpl"/>-->
-    <!--<bean class="org.dspace.xmlworkflow.WorkflowRequirementsServiceImpl"/>-->
-    <!--<bean class="org.dspace.xmlworkflow.XmlWorkflowFactoryImpl"/>-->
+    <!--<bean class="org.dspace.xmlworkflow.storedcomponents.ClaimedTaskServiceImpl"/>
+    <bean class="org.dspace.xmlworkflow.storedcomponents.CollectionRoleServiceImpl"/>
+    <bean class="org.dspace.xmlworkflow.storedcomponents.InProgressUserServiceImpl"/>
+    <bean class="org.dspace.xmlworkflow.storedcomponents.PoolTaskServiceImpl"/>
+    <bean class="org.dspace.xmlworkflow.storedcomponents.WorkflowItemRoleServiceImpl"/>
+    <bean class="org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItemServiceImpl"/>
+    <bean class="org.dspace.xmlworkflow.XmlWorkflowServiceImpl"/>
+    <bean class="org.dspace.xmlworkflow.WorkflowRequirementsServiceImpl"/>
+    <bean class="org.dspace.xmlworkflow.XmlWorkflowFactoryImpl"/>-->
 
 </beans>


### PR DESCRIPTION
_NOTE:_ this PR is based off of #1468 (same branch) since it also needs to touch Flyway (and it therefore needs to be tested alongside the changes in #1468).  **UPDATE: #1468 is already merged, and this PR was rebased**

In reality, this PR has only two extra commits:
- Turning off out-of-order migrations in Flyway & a small SQL fix. See https://github.com/DSpace/DSpace/commit/db46dc527ce802ff0a226014352ad30fc2dad863
- Cleanup of enabling XML Workflow Migrations (begun in DS-2713 but never finished). Specifically, the "workflow.framework" config is no longer needed (so it's been fully stripped out at this point, completing work that began in DS-2713).  Instead XML Workflow is enabled/disabled based on which WorkflowService is enabled in Spring configs. See https://github.com/DSpace/DSpace/commit/307d3c6aa4bc2c4a7e6ddb89f1df423988f66861

https://jira.duraspace.org/browse/DS-3269
https://jira.duraspace.org/browse/DS-2713

With these changes in place, the XML Workflow documentation needs updating to note that **enabling XML Workflow migrations now requires doing the following (in this order):**
1. Swapping out Spring configs as noted at https://wiki.duraspace.org/display/DSDOC6x/Configurable+Workflow
2. Running all "ignored" migrations (as XML Workflow migrations will be ignored by default):
   `[dspace]/bin/dspace database migrate ignored`

Needs testing in the following scenarios (I've checked the scenarios I've tested myself so far):
- [x] Upgrading 5.x (with XML Workflow already enabled) to 6.x and ensuring XML Workflow still works
- [x] Upgrading to 6.x, THEN enabling XML Workflow (based on instructions above)
- [x] Installing 6.x, THEN enabling XML Workflow (based on instructions above)
- [x] Installing 6.x with XML Workflow pre-enabled
