### PR TITLE
[DS-2775] Drop unused database SEQUENCEs and do not try to update them

### DIFF
--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V6.0_2016.07.21__DS-2775.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V6.0_2016.07.21__DS-2775.sql
@@ -1,0 +1,30 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+------------------------------------------------------
+-- DS-2775 Drop unused sequences
+------------------------------------------------------
+
+DROP SEQUENCE bitstream_seq;
+DROP SEQUENCE bundle2bitstream_seq;
+DROP SEQUENCE bundle_seq;
+DROP SEQUENCE collection2item_seq;
+DROP SEQUENCE collection_seq;
+DROP SEQUENCE community2collection_seq;
+DROP SEQUENCE community2community_seq;
+DROP SEQUENCE community_seq;
+DROP SEQUENCE dcvalue_seq;
+DROP SEQUENCE eperson_seq;
+DROP SEQUENCE epersongroup2eperson_seq;
+DROP SEQUENCE epersongroup2workspaceitem_seq;
+DROP SEQUENCE epersongroup_seq;
+DROP SEQUENCE group2group_seq;
+DROP SEQUENCE group2groupcache_seq;
+DROP SEQUENCE historystate_seq;
+DROP SEQUENCE item2bundle_seq;
+DROP SEQUENCE item_seq;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V6.0_2016.07.21__DS-2775.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V6.0_2016.07.21__DS-2775.sql
@@ -1,0 +1,30 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+------------------------------------------------------
+-- DS-2775 Drop unused sequences
+------------------------------------------------------
+
+DROP SEQUENCE bitstream_seq;
+DROP SEQUENCE bundle2bitstream_seq;
+DROP SEQUENCE bundle_seq;
+DROP SEQUENCE collection2item_seq;
+DROP SEQUENCE collection_seq;
+DROP SEQUENCE community2collection_seq;
+DROP SEQUENCE community2community_seq;
+DROP SEQUENCE community_seq;
+DROP SEQUENCE dcvalue_seq;
+DROP SEQUENCE eperson_seq;
+DROP SEQUENCE epersongroup2eperson_seq;
+DROP SEQUENCE epersongroup2workspaceitem_seq;
+DROP SEQUENCE epersongroup_seq;
+DROP SEQUENCE group2group_seq;
+DROP SEQUENCE group2groupcache_seq;
+DROP SEQUENCE historystate_seq;
+DROP SEQUENCE item2bundle_seq;
+DROP SEQUENCE item_seq;

--- a/dspace/etc/oracle/update-sequences.sql
+++ b/dspace/etc/oracle/update-sequences.sql
@@ -1,11 +1,7 @@
 --
 -- update-sequences.sql
 --
--- Version: $Revision$
---
--- Date:    $Date$
---
--- Copyright (c) 2002-2009, The DSpace Foundation.  All rights reserved.
+-- Copyright (c) 2002-2016, The DSpace Foundation.  All rights reserved.
 -- 
 -- Redistribution and use in source and binary forms, with or without
 -- modification, are permitted provided that the following conditions are
@@ -47,7 +43,7 @@
 -- org.dspace.content API which is safe to use concurrently and in multiple
 -- JVMs.  The SQL code below will typically only be required after a direct
 -- SQL data dump from a backup or somesuch.
- 
+
 
 -- There should be one of these calls for every ID sequence defined in
 -- database_schema.sql.
@@ -57,30 +53,13 @@
 
 @updateseq.sql bitstreamformatregistry_seq bitstreamformatregistry bitstream_format_id ""
 @updateseq.sql fileextension_seq fileextension file_extension_id ""
-@updateseq.sql bitstream_seq bitstream bitstream_id ""
-@updateseq.sql eperson_seq eperson eperson_id ""
-@updateseq.sql epersongroup_seq epersongroup eperson_group_id ""
-@updateseq.sql group2group_seq group2group id ""
-@updateseq.sql group2groupcache_seq group2groupcache id ""
-@updateseq.sql item_seq item item_id ""
-@updateseq.sql bundle_seq bundle bundle_id ""
-@updateseq.sql item2bundle_seq item2bundle id ""
-@updateseq.sql bundle2bitstream_seq bundle2bitstream id ""
-@updateseq.sql dcvalue_seq dcvalue dc_value_id ""
-@updateseq.sql community_seq community community_id ""
-@updateseq.sql community2community_seq community2community id ""
-@updateseq.sql collection_seq collection collection_id ""
-@updateseq.sql community2collection_seq community2collection id ""
-@updateseq.sql collection2item_seq collection2item id ""
 @updateseq.sql resourcepolicy_seq resourcepolicy policy_id ""
-@updateseq.sql epersongroup2eperson_seq epersongroup2eperson id ""
 @updateseq.sql workspaceitem_seq workspaceitem workspace_item_id ""
 @updateseq.sql workflowitem_seq workflowitem workflow_id ""
 @updateseq.sql tasklistitem_seq tasklistitem tasklist_id ""
 @updateseq.sql registrationdata_seq registrationdata registrationdata_id ""
 @updateseq.sql subscription_seq subscription subscription_id ""
 @updateseq.sql communities2item_seq communities2item id ""
-@updateseq.sql epersongroup2workspaceitem_seq epersongroup2workspaceitem id ""
 @updateseq.sql metadatafieldregistry_seq metadatafieldregistry metadata_field_id ""
 @updateseq.sql metadatavalue_seq metadatavalue metadata_value_id ""
 @updateseq.sql metadataschemaregistry_seq metadataschemaregistry metadata_schema_id ""

--- a/dspace/etc/oracle/update-sequences.sql
+++ b/dspace/etc/oracle/update-sequences.sql
@@ -45,7 +45,7 @@
 -- SQL data dump from a backup or somesuch.
 
 -- Depends on being run from sqlplus with incseq.sql in the current path
--- you can find incseq.sql at: http://akadia.com/services/scripts/incseq.sql
+-- you can find incseq.sql at: http://www.akadia.com/services/scripts/incseq.sql
 -- Here that script was renamed to updateseq.sql.
 
 @updateseq.sql bitstreamformatregistry_seq bitstreamformatregistry bitstream_format_id ""

--- a/dspace/etc/oracle/update-sequences.sql
+++ b/dspace/etc/oracle/update-sequences.sql
@@ -44,12 +44,9 @@
 -- JVMs.  The SQL code below will typically only be required after a direct
 -- SQL data dump from a backup or somesuch.
 
-
--- There should be one of these calls for every ID sequence defined in
--- database_schema.sql.
-
--- depends on being run from sqlplus with incseq.sql in the current path
+-- Depends on being run from sqlplus with incseq.sql in the current path
 -- you can find incseq.sql at: http://akadia.com/services/scripts/incseq.sql
+-- Here that script was renamed to updateseq.sql.
 
 @updateseq.sql bitstreamformatregistry_seq bitstreamformatregistry bitstream_format_id ""
 @updateseq.sql fileextension_seq fileextension file_extension_id ""
@@ -59,7 +56,6 @@
 @updateseq.sql tasklistitem_seq tasklistitem tasklist_id ""
 @updateseq.sql registrationdata_seq registrationdata registrationdata_id ""
 @updateseq.sql subscription_seq subscription subscription_id ""
-@updateseq.sql communities2item_seq communities2item id ""
 @updateseq.sql metadatafieldregistry_seq metadatafieldregistry metadata_field_id ""
 @updateseq.sql metadatavalue_seq metadatavalue metadata_value_id ""
 @updateseq.sql metadataschemaregistry_seq metadataschemaregistry metadata_schema_id ""

--- a/dspace/etc/postgres/update-sequences.sql
+++ b/dspace/etc/postgres/update-sequences.sql
@@ -1,11 +1,7 @@
 --
 -- update-sequences.sql
 --
--- Version: $Revision$
---
--- Date:    $Date$
---
--- Copyright (c) 2002-2009, The DSpace Foundation.  All rights reserved.
+-- Copyright (c) 2002-2016, The DSpace Foundation.  All rights reserved.
 -- 
 -- Redistribution and use in source and binary forms, with or without
 -- modification, are permitted provided that the following conditions are
@@ -47,7 +43,7 @@
 -- org.dspace.content API which is safe to use concurrently and in multiple
 -- JVMs.  The SQL code below will typically only be required after a direct
 -- SQL data dump from a backup or somesuch.
- 
+
 
 -- There should be one of these calls for every ID sequence defined in
 -- database_schema.sql.
@@ -55,30 +51,13 @@
 
 SELECT setval('bitstreamformatregistry_seq', max(bitstream_format_id)) FROM bitstreamformatregistry;
 SELECT setval('fileextension_seq', max(file_extension_id)) FROM fileextension;
-SELECT setval('bitstream_seq', max(bitstream_id)) FROM bitstream;
-SELECT setval('eperson_seq', max(eperson_id)) FROM eperson;
-SELECT setval('epersongroup_seq', max(eperson_group_id)) FROM epersongroup;
-SELECT setval('group2group_seq', max(id)) FROM group2group;
-SELECT setval('group2groupcache_seq', max(id)) FROM group2groupcache;
-SELECT setval('item_seq', max(item_id)) FROM item;
-SELECT setval('bundle_seq', max(bundle_id)) FROM bundle;
-SELECT setval('item2bundle_seq', max(id)) FROM item2bundle;
-SELECT setval('bundle2bitstream_seq', max(id)) FROM bundle2bitstream;
-SELECT setval('dcvalue_seq', max(dc_value_id)) FROM dcvalue;
-SELECT setval('community_seq', max(community_id)) FROM community;
-SELECT setval('community2community_seq', max(id)) FROM community2community;
-SELECT setval('collection_seq', max(collection_id)) FROM collection;
-SELECT setval('community2collection_seq', max(id)) FROM community2collection;
-SELECT setval('collection2item_seq', max(id)) FROM collection2item;
 SELECT setval('resourcepolicy_seq', max(policy_id)) FROM resourcepolicy;
-SELECT setval('epersongroup2eperson_seq', max(id)) FROM epersongroup2eperson;
 SELECT setval('workspaceitem_seq', max(workspace_item_id)) FROM workspaceitem;
 SELECT setval('workflowitem_seq', max(workflow_id)) FROM workflowitem;
 SELECT setval('tasklistitem_seq', max(tasklist_id)) FROM tasklistitem;
 SELECT setval('registrationdata_seq', max(registrationdata_id)) FROM registrationdata;
 SELECT setval('subscription_seq', max(subscription_id)) FROM subscription;
 SELECT setval('communities2item_seq', max(id)) FROM communities2item;
-SELECT setval('epersongroup2workspaceitem_seq', max(id)) FROM epersongroup2workspaceitem;
 SELECT setval('metadatafieldregistry_seq', max(metadata_field_id)) FROM metadatafieldregistry;
 SELECT setval('metadatavalue_seq', max(metadata_value_id)) FROM metadatavalue;
 SELECT setval('metadataschemaregistry_seq', max(metadata_schema_id)) FROM metadataschemaregistry;

--- a/dspace/etc/postgres/update-sequences.sql
+++ b/dspace/etc/postgres/update-sequences.sql
@@ -45,10 +45,6 @@
 -- SQL data dump from a backup or somesuch.
 
 
--- There should be one of these calls for every ID sequence defined in
--- database_schema.sql.
-
-
 SELECT setval('bitstreamformatregistry_seq', max(bitstream_format_id)) FROM bitstreamformatregistry;
 SELECT setval('fileextension_seq', max(file_extension_id)) FROM fileextension;
 SELECT setval('resourcepolicy_seq', max(policy_id)) FROM resourcepolicy;
@@ -57,7 +53,6 @@ SELECT setval('workflowitem_seq', max(workflow_id)) FROM workflowitem;
 SELECT setval('tasklistitem_seq', max(tasklist_id)) FROM tasklistitem;
 SELECT setval('registrationdata_seq', max(registrationdata_id)) FROM registrationdata;
 SELECT setval('subscription_seq', max(subscription_id)) FROM subscription;
-SELECT setval('communities2item_seq', max(id)) FROM communities2item;
 SELECT setval('metadatafieldregistry_seq', max(metadata_field_id)) FROM metadatafieldregistry;
 SELECT setval('metadatavalue_seq', max(metadata_value_id)) FROM metadatavalue;
 SELECT setval('metadataschemaregistry_seq', max(metadata_schema_id)) FROM metadataschemaregistry;


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2775 "Correct "update-sequences" documentation / notes"

It turns out that quite a few of our SEQUENCEs are no longer used.  This patch removes any sequence for which I could find no use as a default column value or in a @SequenceGenerator or @GeneratedValue annotation.  That should be all of the DSO tables and all of their junction tables.  It also includes a few strays:  dcvalue_seq and historystate_seq.

Not tested as I write this.
