### PR TITLE
[DS-3270] NoClassDefFoundError error when launching the instance OAI

### DIFF
--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -166,16 +166,6 @@
         <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>dspace-api</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.ow2.asm</groupId>
-                    <artifactId>asm</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-lang3</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- Solr (Datasource) -->

--- a/dspace/modules/oai/pom.xml
+++ b/dspace/modules/oai/pom.xml
@@ -99,16 +99,8 @@
             <artifactId>additions</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>org.ow2.asm</groupId>
-                    <artifactId>asm</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>com.lyncode</groupId>
                     <artifactId>builder-commons</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-lang3</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -165,4 +157,3 @@
         </developer>
     </developers>
 </project>
-


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3270

Restore the transitive dependency on asm and commons-lang3 through dspace-api, erroneously excluded in a prior edit.

As noted in Jira, this is WIP due to uncovering another dependency mess.
