### PR TITLE
DS-3275 Fix erroneous duplicate policy error on edit

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
@@ -87,7 +87,7 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
         List<ResourcePolicy> results;
         if (notPolicyID != -1)
         {
-            criteria.add(Restrictions.and(Restrictions.not(Restrictions.eq("id", action))));
+            criteria.add(Restrictions.and(Restrictions.not(Restrictions.eq("id", notPolicyID))));
         }
 
         return list(criteria);


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3275

This causes policy editing to work again. The restriction was comparing the wrong field.
