### PR TITLE
DS-3267 Add alt getCollectionDefaultRead method w/UUIDs

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowContainerUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowContainerUtils.java
@@ -621,7 +621,14 @@ public class FlowContainerUtils
 
 		return itemGroup;
 	}
-	
+
+	/**
+	 * @see #getCollectionDefaultRead(Context, Collection)
+     */
+	public static UUID getCollectionDefaultRead(final Context context, final UUID collectionID) throws SQLException, AuthorizeException {
+		return getCollectionDefaultRead(context, collectionService.find(context,collectionID)).getID();
+	}
+
 	/**
 	 * Change default privileges from the anonymous group to a new group that will be created and
 	 * appropriate privileges assigned. The id of this new group will be returned.


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3267

This fixes the issue with editing collection default read policies by adding an alternative signature for getCollectionDefaultRead, which accepts and returns a UUID.
