### PR TITLE
DS-1929 Permit bitstream embargo edit only via Edit Policy

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowItemUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowItemUtils.java
@@ -709,8 +709,6 @@ public class FlowItemUtils
 		// Save our changes
 		bitstreamService.update(context, bitstream);
 
-        processAccessFields(context, request, ((Item)bitstreamService.getParentObject(context,bitstream)).getOwningCollection(), bitstream);
-
         result.setContinue(true);
         result.setOutcome(true);
         result.setMessage(T_bitstream_updated);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/EditBitstreamForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/EditBitstreamForm.java
@@ -149,8 +149,7 @@ public class EditBitstreamForm extends AbstractDSpaceTransformer
         if(!isAdvancedFormEnabled){
             AccessStepUtil asu = new AccessStepUtil(context);
             // if the item is embargoed default value will be displayed.
-            asu.addEmbargoDateSimpleForm(bitstream, edit, -1);
-            asu.addReason(null, edit, -1);
+            asu.addEmbargoDateDisplayOnly(bitstream, edit);
         }
 
 		edit.addItem(T_para1);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/AccessStepUtil.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/AccessStepUtil.java
@@ -15,6 +15,7 @@ import org.dspace.authorize.factory.AuthorizeServiceFactory;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.authorize.service.ResourcePolicyService;
 import org.dspace.content.*;
+import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.app.xmlui.wing.WingException;
 import org.dspace.app.xmlui.wing.element.*;
@@ -199,13 +200,11 @@ public class AccessStepUtil extends AbstractDSpaceTransformer {
     }
 
     private void populateEmbargoDetail(final DSpaceObject dso, final Text text) throws SQLException, WingException {
-        final java.util.List<ResourcePolicy> policies = authorizeService.findPoliciesByDSOAndType(context, dso, ResourcePolicy.TYPE_CUSTOM);
-        if (policies.size() > 0) {
-            final ResourcePolicy firstCustomPolicy = policies.get(0);
-            if (firstCustomPolicy.getStartDate() != null) {
-                final String dateString = DateFormatUtils.format(firstCustomPolicy.getStartDate(), "yyyy-MM-dd");
+        for (final ResourcePolicy readPolicy : authorizeService.getPoliciesActionFilter(context, dso, Constants.READ)) {
+            if (Group.ANONYMOUS.equals(readPolicy.getGroup().getName()) && readPolicy.getStartDate() != null) {
+                final String dateString = DateFormatUtils.format(readPolicy.getStartDate(), "yyyy-MM-dd");
                 text.setValue(dateString);
-                globalReason = firstCustomPolicy.getRpDescription();
+                globalReason = readPolicy.getRpDescription();
             }
         }
     }

--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -785,7 +785,8 @@
     <message key="xmlui.Submission.submit.AccessStep.column4">End Date</message>
     <message key="xmlui.Submission.submit.AccessStep.table_edit_button">Edit</message>
     <message key="xmlui.Submission.submit.AccessStep.table_delete_button">Remove</message>
-    <message key="xmlui.administrative.authorization.AccessStep.label_date_help">The first day from which access is allowed. Accepted format: yyyy, yyyy-mm, yyyy-mm-dd</message>
+	<message key="xmlui.administrative.authorization.AccessStep.label_date_help">The first day from which access is allowed. Accepted format: yyyy, yyyy-mm, yyyy-mm-dd</message>
+    <message key="xmlui.administrative.authorization.AccessStep.label_date_displayonly_help">The first day from which access is allowed. <b>This date cannot be modified on this form.</b> To set an embargo date for a bitstream, go to the <i>Item Status</i> tab, click <i>Authorizations...</i>, create or edit the bitstream's <i>READ</i> policy, and set the <i>Start Date</i> as desired.</message>
     <message key="xmlui.Submission.submit.AccessStep.review_policy_line">Name: {0}; action: {1}, group: {2}, start date: {3}, end date: {4}</message>
     <message key="xmlui.Submission.submit.AccessStep.review_public_item">The item will be searchable</message>
     <message key="xmlui.Submission.submit.AccessStep.review_private_item">The item will not be searchable</message>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-1929

This addresses the problem where custom bitstream policies are wiped out upon editing any attribute of a bitstream on the Edit Bitstream page. The solution implemented here is to only permit bitstream embargo changes on the Edit Policy page, where it is known to work correctly. 

Rationale: This bug has been outstanding for quite a while, and it's fairly serious in that it can destroy policies people have created for bitstreams without their noticing. Rather than wait for someone to implement a solution that retains the ability to edit bitstream embargo dates right on the Edit Bitstream page, I think it makes sense to just avoid the problematic code path for now...a couple extra clicks is a better user experience than data loss :)
