### PR TITLE
DS-3277 : Create new 'handle_id_seq' for handle_id column. Use 'handle_seq' to mint new handles.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/handle/Handle.java
+++ b/dspace-api/src/main/java/org/dspace/handle/Handle.java
@@ -26,8 +26,8 @@ public class Handle implements ReloadableEntity<Integer> {
 
     @Id
     @Column(name="handle_id")
-    @GeneratedValue(strategy = GenerationType.SEQUENCE ,generator="handle_seq")
-    @SequenceGenerator(name="handle_seq", sequenceName="handle_seq", allocationSize = 1)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator="handle_id_seq")
+    @SequenceGenerator(name="handle_id_seq", sequenceName="handle_id_seq", allocationSize = 1)
     private Integer id;
 
     @Column(name = "handle", unique = true)
@@ -54,6 +54,7 @@ public class Handle implements ReloadableEntity<Integer> {
 
     }
 
+    @Override
     public Integer getID() {
         return id;
     }
@@ -82,6 +83,7 @@ public class Handle implements ReloadableEntity<Integer> {
         return resourceTypeId;
     }
 
+    @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
 
@@ -96,6 +98,7 @@ public class Handle implements ReloadableEntity<Integer> {
                 .isEquals();
     }
 
+    @Override
     public int hashCode() {
         return new HashCodeBuilder(17, 37)
                 .append(id)

--- a/dspace-api/src/main/java/org/dspace/handle/dao/HandleDAO.java
+++ b/dspace-api/src/main/java/org/dspace/handle/dao/HandleDAO.java
@@ -24,6 +24,8 @@ import java.util.List;
  */
 public interface HandleDAO extends GenericDAO<Handle> {
 
+    public Long getNextHandleSuffix(Context context) throws SQLException;
+
     public List<Handle> getHandlesByDSpaceObject(Context context, DSpaceObject dso) throws SQLException;
 
     public Handle findByHandle(Context context, String handle)throws SQLException;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V6.0_2016.07.21__DS-2775.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V6.0_2016.07.21__DS-2775.sql
@@ -1,0 +1,30 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+------------------------------------------------------
+-- DS-2775 Drop unused sequences
+------------------------------------------------------
+
+DROP SEQUENCE bitstream_seq;
+DROP SEQUENCE bundle2bitstream_seq;
+DROP SEQUENCE bundle_seq;
+DROP SEQUENCE collection2item_seq;
+DROP SEQUENCE collection_seq;
+DROP SEQUENCE community2collection_seq;
+DROP SEQUENCE community2community_seq;
+DROP SEQUENCE community_seq;
+DROP SEQUENCE dcvalue_seq;
+DROP SEQUENCE eperson_seq;
+DROP SEQUENCE epersongroup2eperson_seq;
+DROP SEQUENCE epersongroup2workspaceitem_seq;
+DROP SEQUENCE epersongroup_seq;
+DROP SEQUENCE group2group_seq;
+DROP SEQUENCE group2groupcache_seq;
+DROP SEQUENCE historystate_seq;
+DROP SEQUENCE item2bundle_seq;
+DROP SEQUENCE item_seq;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V6.0_2016.07.26__DS-3277_fix_handle_assignment.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V6.0_2016.07.26__DS-3277_fix_handle_assignment.sql
@@ -1,0 +1,15 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+----------------------------------------------------------------------------------
+-- DS-3277 : 'handle_id' column needs its own separate sequence, so that Handles 
+-- can be minted from 'handle_seq'
+----------------------------------------------------------------------------------
+-- Create a new sequence for 'handle_id' column.
+-- The role of this sequence is to simply provide a unique internal ID to the database.
+CREATE SEQUENCE handle_id_seq;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V6.0_2016.07.26__DS-3277_fix_handle_assignment.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V6.0_2016.07.26__DS-3277_fix_handle_assignment.sql
@@ -1,0 +1,44 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+----------------------------------------------------------------------------------
+-- DS-3277 : 'handle_id' column needs its own separate sequence, so that Handles 
+-- can be minted from 'handle_seq'
+----------------------------------------------------------------------------------
+-- Create a new sequence for 'handle_id' column.
+-- The role of this sequence is to simply provide a unique internal ID to the database.
+CREATE SEQUENCE handle_id_seq;
+-- Initialize new 'handle_id_seq' to the maximum value of 'handle_id'
+DECLARE
+  curr  NUMBER := 0;
+BEGIN
+  SELECT max(handle_id) INTO curr FROM handle;
+
+  curr := curr + 1;
+
+  EXECUTE IMMEDIATE 'DROP SEQUENCE handle_id_seq';
+
+  EXECUTE IMMEDIATE 'CREATE SEQUENCE handle_id_seq START WITH ' || NVL(curr,1);
+END;
+/
+
+-- Ensure the 'handle_seq' is updated to the maximum *suffix* in 'handle' column,
+-- as this sequence is used to mint new Handles.
+-- Code borrowed from update-sequences.sql and updateseq.sql
+DECLARE
+  curr  NUMBER := 0;
+BEGIN
+  SELECT max(to_number(regexp_replace(handle, '.*/', ''), '999999999999')) INTO curr FROM handle WHERE REGEXP_LIKE(handle, '^.*/[0123456789]*$');
+
+  curr := curr + 1;
+
+  EXECUTE IMMEDIATE 'DROP SEQUENCE handle_seq';
+
+  EXECUTE IMMEDIATE 'CREATE SEQUENCE handle_seq START WITH ' || NVL(curr,1);
+END;
+/

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V6.0_2016.07.26__DS-3277_fix_handle_assignment.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V6.0_2016.07.26__DS-3277_fix_handle_assignment.sql
@@ -1,0 +1,30 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+----------------------------------------------------------------------------------
+-- DS-3277 : 'handle_id' column needs its own separate sequence, so that Handles 
+-- can be minted from 'handle_seq'
+----------------------------------------------------------------------------------
+-- Create a new sequence for 'handle_id' column.
+-- The role of this sequence is to simply provide a unique internal ID to the database.
+CREATE SEQUENCE handle_id_seq;
+-- Initialize new 'handle_id_seq' to the maximum value of 'handle_id'
+SELECT setval('handle_id_seq', max(handle_id)) FROM handle;
+
+-- Ensure the 'handle_seq' is updated to the maximum *suffix* in 'handle' column,
+-- as this sequence is used to mint new Handles.
+-- Code borrowed from update-sequences.sql
+SELECT setval('handle_seq',
+              CAST (
+                    max(
+                        to_number(regexp_replace(handle, '.*/', ''), '999999999999')
+                       )
+                    AS BIGINT)
+             )
+    FROM handle
+    WHERE handle SIMILAR TO '%/[0123456789]*';

--- a/dspace/etc/oracle/update-sequences.sql
+++ b/dspace/etc/oracle/update-sequences.sql
@@ -63,6 +63,7 @@
 @updateseq.sql harvested_item_seq harvested_item id ""
 @updateseq.sql webapp_seq webapp webapp_id ""
 @updateseq.sql requestitem_seq requestitem requestitem_id ""
+@updateseq.sql handle_id_seq handle handle_id ""
 
 -- Handle Sequence is a special case.  Since Handles minted by DSpace use the 'handle_seq',
 -- we need to ensure the next assigned handle will *always* be unique.  So, 'handle_seq'

--- a/dspace/etc/oracle/update-sequences.sql
+++ b/dspace/etc/oracle/update-sequences.sql
@@ -61,7 +61,8 @@
 @updateseq.sql metadataschemaregistry_seq metadataschemaregistry metadata_schema_id ""
 @updateseq.sql harvested_collection_seq harvested_collection id ""
 @updateseq.sql harvested_item_seq harvested_item id ""
-@updateseq.sql webapp_seq webapp id ""
+@updateseq.sql webapp_seq webapp webapp_id ""
+@updateseq.sql requestitem_seq requestitem requestitem_id ""
 
 -- Handle Sequence is a special case.  Since Handles minted by DSpace use the 'handle_seq',
 -- we need to ensure the next assigned handle will *always* be unique.  So, 'handle_seq'

--- a/dspace/etc/postgres/update-sequences.sql
+++ b/dspace/etc/postgres/update-sequences.sql
@@ -60,6 +60,7 @@ SELECT setval('harvested_collection_seq', max(id)) FROM harvested_collection;
 SELECT setval('harvested_item_seq', max(id)) FROM harvested_item;
 SELECT setval('webapp_seq', max(webapp_id)) FROM webapp;
 SELECT setval('requestitem_seq', max(requestitem_id)) FROM requestitem;
+SELECT setval('handle_id_seq', max(handle_id)) FROM handle;
 
 -- Handle Sequence is a special case.  Since Handles minted by DSpace use the 'handle_seq',
 -- we need to ensure the next assigned handle will *always* be unique.  So, 'handle_seq'


### PR DESCRIPTION
Fixes DS-3277: https://jira.duraspace.org/browse/DS-3277

Also includes one commit (https://github.com/DSpace/DSpace/commit/99ec435a5caf951fc528f6fbc2c07193275d457f) which adds to fixes for DS-2775 (See #1472). That previous PR accidentally left out H2 migrations.

To fix DS-3277 the following was implemented:
- A new `handle_id_seq` was created. This sequence is used by `handle_id` to simply generate a new internal database ID (which has no direct relationship with the Handle suffix itself). The `handle_id` column is only used by Hibernate to initialize a new row in the table (see DS-3277 comments).
- A new `HandleDAO.getNextHandleSuffix()` method was created to query the next available value of the existing `handle_seq`. This method is now used to mint _new_ Handles from `HandleService`.
- Minor cleanup in `HandleServiceImpl` to update it to use ConfigurationService, etc.

Needs further testing / validation from others, but this passes all existing Unit & Integration Tests (and obviously Handles are used / minted throughout our Tests).
