### PR TITLE
DS-3075 : Replace parsing config by commas with getArrayProperty()

### DIFF
--- a/dspace-api/src/main/java/org/dspace/browse/ItemListConfig.java
+++ b/dspace-api/src/main/java/org/dspace/browse/ItemListConfig.java
@@ -11,8 +11,10 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.StringTokenizer;
+import org.apache.commons.lang.ArrayUtils;
 
-import org.dspace.core.ConfigurationManager;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
  * Class to mediate with the item list configuration
@@ -33,6 +35,9 @@ public class ItemListConfig
 	
 	/** constant for a TEXT column */
 	private static final int TEXT = 2;
+
+        private final transient ConfigurationService configurationService
+             = DSpaceServicesFactory.getInstance().getConfigurationService();
 	
 	/**
 	 * Create a new instance of the Item list configuration.  This loads
@@ -45,21 +50,19 @@ public class ItemListConfig
 	{
 		try
 		{
-			String configLine = ConfigurationManager.getProperty("webui.itemlist.columns");
+			String[] browseFields  = configurationService.getArrayProperty("webui.itemlist.columns");
 			
-			if (configLine == null || "".equals(configLine))
+			if (ArrayUtils.isEmpty(browseFields))
 			{
 				throw new BrowseException("There is no configuration for webui.itemlist.columns");
 			}
 			
 			// parse the config
-			StringTokenizer st = new StringTokenizer(configLine, ",");
 			int i = 1;
-			while (st.hasMoreTokens())
+			for(String token : browseFields)
 			{
 				Integer key = Integer.valueOf(i);
-				String token = st.nextToken();
-				
+
 				// find out if the field is a date
 				if (token.indexOf("(date)") > 0)
 				{


### PR DESCRIPTION
Found another example of DS-3075 :
https://jira.duraspace.org/browse/DS-3075

This example is in `ItemListConfig`, and `StringTokenizer` was being used to parse a multi-valued configuration. This PR fixes the code to use `configurationService.getArrayProperty()`

NOTE: There seems to be no direct way to trigger this code, as `ItemListConfig` is only used by `BrowseInfo.toString()` to print out a String representation of Browse configs _for debugging purposes_.  See https://github.com/DSpace/DSpace/blob/master/dspace-api/src/main/java/org/dspace/browse/BrowseInfo.java#L686

However, rather than removing this class altogether, I've decided to simply fix the obvious bug in how it is accessing this multi-valued configuration. 

Sidenote: I also did search our code for _other_ examples of using `StringTokenizer` to split configs on commas, but didn't find any other examples.

This PR simply needs code review, then I think it can be merged. As mentioned, it only changes code that was created for debugging purposes.
