### PR TITLE
DS-1518 : Initialize LDAP context object for anonymous searching

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
@@ -481,15 +481,17 @@ public class LDAPAuthentication
                         env.put(javax.naming.Context.SECURITY_AUTHENTICATION, "simple");
                         env.put(javax.naming.Context.SECURITY_PRINCIPAL, adminUser);
                         env.put(javax.naming.Context.SECURITY_CREDENTIALS, adminPassword);
-                        
-                        // Create initial context
-                        ctx = new InitialLdapContext(env, null);
                     }
                 }
                 else
                 {
                     // Use anonymous authentication
                     env.put(javax.naming.Context.SECURITY_AUTHENTICATION, "none");
+                }
+                        
+                if (ctx == null) {
+                    // Create initial context
+                    ctx = new InitialLdapContext(env, null);
                 }
 
                 Attributes matchAttrs = new BasicAttributes(true);


### PR DESCRIPTION
In commit 7cf90d3db2a806 we added support for StartTLS in LDAP, but
opened up a path for a NullPointerException when anonymous searching of
the LDAP directory is in use.

Signed-off-by: Dan Scott dscott@laurentian.ca

Update: this is a minor bug fix to https://jira.duraspace.org/browse/DS-1518
