### PR TITLE
DS-3284 disableFileEditing not working as intended during workflow-fileupload

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/UploadStep.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/UploadStep.java
@@ -261,7 +261,8 @@ public class UploadStep extends AbstractSubmissionStep
         //  If the user has already uploaded files provide a list for the user.
         if (bitstreams.size() > 0 || disableFileEditing)
         {
-            Table summary = div.addTable("submit-upload-summary",(bitstreams.size() * 2) + 2,7);
+            int cols = disableFileEditing?6:7;
+            Table summary = div.addTable("submit-upload-summary",(bitstreams.size() * 2) + 2, cols);
             summary.setHead(T_head2);
 
             Row header = summary.addRow(Row.ROLE_HEADER);
@@ -271,8 +272,9 @@ public class UploadStep extends AbstractSubmissionStep
             header.addCellContent(T_column3); // size
             header.addCellContent(T_column4); // description
             header.addCellContent(T_column5); // format
-            header.addCellContent(T_column6); // edit button
-
+            if(!disableFileEditing){
+                header.addCellContent(T_column6); // edit button
+            }
             for (Bitstream bitstream : bitstreams)
             {
                 UUID id = bitstream.getID();
@@ -344,8 +346,10 @@ public class UploadStep extends AbstractSubmissionStep
                     }
                 }
 
-                Button edit = row.addCell().addButton("submit_edit_"+id);
-                edit.setValue(T_submit_edit);
+                if(!disableFileEditing){
+                    Button edit = row.addCell().addButton("submit_edit_"+id);
+                    edit.setValue(T_submit_edit);
+                }
 
                 Row checksumRow = summary.addRow();
                 checksumRow.addCell();

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/UploadWithEmbargoStep.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/UploadWithEmbargoStep.java
@@ -262,7 +262,8 @@ public class UploadWithEmbargoStep extends UploadStep
         //  If the user has already uploaded files provide a list for the user.
         if (bitstreams.size() > 0 || disableFileEditing)
 		{
-	        Table summary = div.addTable("submit-upload-summary",(bitstreams.size() * 2) + 2,7);
+            int cols= disableFileEditing?6:7;
+	        Table summary = div.addTable("submit-upload-summary",(bitstreams.size() * 2) + 2,cols);
 	        summary.setHead(T_head2);
 	        
 	        Row header = summary.addRow(Row.ROLE_HEADER);
@@ -272,8 +273,10 @@ public class UploadWithEmbargoStep extends UploadStep
 	        header.addCellContent(T_column3); // size
 	        header.addCellContent(T_column4); // description
 	        header.addCellContent(T_column5); // format
-	        header.addCellContent(T_column6); // edit button
-	        
+            if(!disableFileEditing){
+	            header.addCellContent(T_column6); // edit button
+            }
+
 	        for (Bitstream bitstream : bitstreams)
 	        {
                 UUID id = bitstream.getID();
@@ -344,9 +347,11 @@ public class UploadWithEmbargoStep extends UploadStep
 	            		break;
 	            	}
 	            }
-	            
-	            Button edit = row.addCell().addButton("submit_edit_"+id);
-	            edit.setValue(T_submit_edit);
+
+                if(!disableFileEditing){
+                    Button edit = row.addCell().addButton("submit_edit_"+id);
+	                edit.setValue(T_submit_edit);
+                }
 
                 if(isAdvancedFormEnabled){
                     Button policy = row.addCell().addButton("submit_editPolicy_"+id);
@@ -355,7 +360,7 @@ public class UploadWithEmbargoStep extends UploadStep
 
                 Row checksumRow = summary.addRow();
 	            checksumRow.addCell();
-	            Cell checksumCell = checksumRow.addCell(null, null, 0, 6, null);
+	            Cell checksumCell = checksumRow.addCell(null, null, 0, cols, null);
 	            checksumCell.addHighlight("bold").addContent(T_checksum);
 	            checksumCell.addContent(" ");
 	            checksumCell.addContent(algorithm + ":" + checksum);
@@ -366,7 +371,7 @@ public class UploadWithEmbargoStep extends UploadStep
 	        	// Workflow users can not remove files.
 		        Row actionRow = summary.addRow();
 		        actionRow.addCell();
-		        Button removeSeleceted = actionRow.addCell(null, null, 0, 6, null).addButton("submit_remove_selected");
+		        Button removeSeleceted = actionRow.addCell(null, null, 0, cols, null).addButton("submit_remove_selected");
 		        removeSeleceted.setValue(T_submit_remove);
 	        }
 	        


### PR DESCRIPTION
PR for following Jira ticket
https://jira.duraspace.org/browse/DS-3284

Actual hiding of the "edit" button if "disableFileEditing" is true during uploadstep in workflow review
