### PR TITLE
DS-3233: Update HandlePlugin to start/stop its own DSpaceKernel 

### DIFF
--- a/dspace/bin/buildpath.bat
+++ b/dspace/bin/buildpath.bat
@@ -1,43 +1,13 @@
-@REM
-@REM buildpath.bat
-@REM
-@REM Version: $Revision$
-@REM
-@REM Date: $Date$
-@REM
-@REM Copyright (c) 2002-2009, The DSpace Foundation.  All rights reserved.
-@REM
-@REM Redistribution and use in source and binary forms, with or without
-@REM modification, are permitted provided that the following conditions are
-@REM met:
-@REM
-@REM - Redistributions of source code must retain the above copyright
-@REM notice, this list of conditions and the following disclaimer.
-@REM
-@REM - Redistributions in binary form must reproduce the above copyright
-@REM notice, this list of conditions and the following disclaimer in the
-@REM documentation and/or other materials provided with the distribution.
-@REM
-@REM - Neither the name of the DSpace Foundation nor the names of its
-@REM contributors may be used to endorse or promote products derived from
-@REM this software without specific prior written permission.
-@REM
-@REM THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-@REM ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-@REM LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-@REM A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-@REM HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-@REM INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-@REM BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-@REM OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-@REM ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
-@REM TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-@REM USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-@REM DAMAGE.
-@REM
-
-@REM A simple script to facilitate building a CLASSPATH dynamically
-@REM in dsrun.bat
+@REM ###########################################################################
+@REM # The contents of this file are subject to the license and copyright
+@REM # detailed in the LICENSE and NOTICE files at the root of the source
+@REM # tree and available online at
+@REM # 
+@REM # http://www.dspace.org/license/
+@REM ###########################################################################
+@REM # 'buildpath.bat' script
+@REM # A simple Windows batch script to facilitate building a CLASSPATH dynamically
+@REM # in 'dspace.bat' (and similar Windows batch scripts)
 
 @echo off
 

--- a/dspace/bin/dspace
+++ b/dspace/bin/dspace
@@ -1,47 +1,13 @@
 #!/bin/sh
-
 ###########################################################################
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
 #
-# dspace
-#
-# Version: $Revision$
-#
-# Date: $Date$
-#
-# Copyright (c) 2002-2009, Duraspace.  All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are
-# met:
-#
-# - Redistributions of source code must retain the above copyright
-# notice, this list of conditions and the following disclaimer.
-#
-# - Redistributions in binary form must reproduce the above copyright
-# notice, this list of conditions and the following disclaimer in the
-# documentation and/or other materials provided with the distribution.
-#
-# - Neither the name of the Duraspace nor the names of its
-# contributors may be used to endorse or promote products derived from
-# this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-# HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
-# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-# DAMAGE.
-#
+# http://www.dspace.org/license/
 ###########################################################################
-
-#
-# This is a simple shell script for running a command-line DSpace tool.
+# 'dspace' script
+# This is a Unix shell script for running a command-line DSpace tool.
 # It sets the CLASSPATH appropriately before invoking Java.
 
 BINDIR=`dirname $0`

--- a/dspace/bin/dspace.bat
+++ b/dspace/bin/dspace.bat
@@ -1,43 +1,13 @@
 @REM ###########################################################################
-@REM #
-@REM # dspace.bat
-@REM #
-@REM # Version: $Revision$
-@REM #
-@REM # Date: $Date$
-@REM #
-@REM # Copyright (c) 2002-2009, Duraspace.  All rights reserved.
-@REM #
-@REM # Redistribution and use in source and binary forms, with or without
-@REM # modification, are permitted provided that the following conditions are
-@REM # met:
-@REM #
-@REM # - Redistributions of source code must retain the above copyright
-@REM # notice, this list of conditions and the following disclaimer.
-@REM #
-@REM # - Redistributions in binary form must reproduce the above copyright
-@REM # notice, this list of conditions and the following disclaimer in the
-@REM # documentation and/or other materials provided with the distribution.
-@REM #
-@REM # - Neither the name of the Duraspace nor the names of its
-@REM # contributors may be used to endorse or promote products derived from
-@REM # this software without specific prior written permission.
-@REM #
-@REM # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-@REM # ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-@REM # LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-@REM # A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-@REM # HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-@REM # INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-@REM # BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-@REM # OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-@REM # ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
-@REM # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-@REM # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-@REM # DAMAGE.
-@REM #
+@REM # The contents of this file are subject to the license and copyright
+@REM # detailed in the LICENSE and NOTICE files at the root of the source
+@REM # tree and available online at
+@REM # 
+@REM # http://www.dspace.org/license/
 @REM ###########################################################################
-
+@REM # 'dspace.bat' script
+@REM # This is a Windows batch script for running a command-line DSpace tool.
+@REM # It sets the CLASSPATH appropriately before invoking Java.
 @echo off
 
 set CURRENT_DIR=%cd%

--- a/dspace/bin/log-reporter
+++ b/dspace/bin/log-reporter
@@ -1,45 +1,12 @@
 #!/usr/bin/env perl
-
 ###########################################################################
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
 #
-# log-reporter
-#
-# Version: $Revision$
-#
-# Date: $Date$
-#
-# Copyright (c) 2002-2009, The DSpace Foundation.  All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are
-# met:
-#
-# - Redistributions of source code must retain the above copyright
-# notice, this list of conditions and the following disclaimer.
-#
-# - Redistributions in binary form must reproduce the above copyright
-# notice, this list of conditions and the following disclaimer in the
-# documentation and/or other materials provided with the distribution.
-#
-# - Neither the name of the DSpace Foundation nor the names of its
-# contributors may be used to endorse or promote products derived from
-# this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-# HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
-# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-# DAMAGE.
-#
+# http://www.dspace.org/license/
 ###########################################################################
-
+# 'log-reporter' Perl script
 # Does a useful, if simple, summary of the DSpace log for a given
 # time period.  Uses ParseDate to allow flexible specification of 
 # date ranges.

--- a/dspace/bin/make-handle-config
+++ b/dspace/bin/make-handle-config
@@ -1,46 +1,13 @@
 #!/bin/sh
-
 ###########################################################################
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
 #
-# make-handle-config
-#
-# Version: $Revision$
-#
-# Date: $Date$
-#
-# Copyright (c) 2002-2009, The DSpace Foundation.  All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are
-# met:
-#
-# - Redistributions of source code must retain the above copyright
-# notice, this list of conditions and the following disclaimer.
-#
-# - Redistributions in binary form must reproduce the above copyright
-# notice, this list of conditions and the following disclaimer in the
-# documentation and/or other materials provided with the distribution.
-#
-# - Neither the name of the DSpace Foundation nor the names of its
-# contributors may be used to endorse or promote products derived from
-# this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-# HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
-# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-# DAMAGE.
-#
+# http://www.dspace.org/license/
 ###########################################################################
-
-# Shell script for writing a simple barebones configuration file for the
+# 'make-handle-config' script
+# Unix shell script for writing a simple barebones configuration file for the
 # Handle server, with default options, unencrypted keys and connected
 # to the DSpace Handle plugin code.
 

--- a/dspace/bin/start-handle-server
+++ b/dspace/bin/start-handle-server
@@ -1,47 +1,14 @@
 #!/bin/sh
-
 ###########################################################################
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
 #
-# start-handle-server
-#
-# Version: $Revision$
-#
-# Date: $Date$
-#
-# Copyright (c) 2002-2010, Duraspace.  All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are
-# met:
-#
-# - Redistributions of source code must retain the above copyright
-# notice, this list of conditions and the following disclaimer.
-#
-# - Redistributions in binary form must reproduce the above copyright
-# notice, this list of conditions and the following disclaimer in the
-# documentation and/or other materials provided with the distribution.
-#
-# - Neither the name of Duraspacen nor the names of its
-# contributors may be used to endorse or promote products derived from
-# this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-# HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
-# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-# DAMAGE.
-#
+# http://www.dspace.org/license/
 ###########################################################################
-
-# Shell script for starting Handle server.  WARNING this assumes the old
-# one has been terminated.
+# 'start-handle-server' script
+# Unix shell script for starting Handle server.  WARNING this assumes any
+# previously running Handle servers have been terminated.
 
 # Assume we're in the bin subdirectory of the DSpace installation directory
 BINDIR=`dirname $0`

--- a/dspace/bin/start-handle-server.bat
+++ b/dspace/bin/start-handle-server.bat
@@ -1,0 +1,61 @@
+@REM ###########################################################################
+@REM # The contents of this file are subject to the license and copyright
+@REM # detailed in the LICENSE and NOTICE files at the root of the source
+@REM # tree and available online at
+@REM # 
+@REM # http://www.dspace.org/license/
+@REM ###########################################################################
+@REM # 'start-handle-server.bat' script
+@REM # Windows bash script for starting Handle server.  WARNING this assumes any
+@REM # previously running Handle servers have been terminated.
+@echo off
+
+set CURRENT_DIR=%cd%
+
+REM Determine DSpace 'bin' directory. CD to directory script is in
+chdir /D "%~p0"
+set BINDIR=%cd%
+
+REM Read 'dspace.dir' parameter from DSpace config (using dspace.bat script)
+REM (Note: see http://stackoverflow.com/a/12069559/3750035 for this 'for' syntax)
+set DSPACEDIR=
+for /f "delims=" %%a in ('%BINDIR%\dspace dsprop --property dspace.dir') do @set DSPACEDIR=%%a
+echo Using DSpace installation in: %DSPACEDIR%
+
+REM Read 'handle.dir' parameter from DSpace config (using dspace.bat script)
+set HANDLEDIR=
+for /f "delims=" %%a in ('%BINDIR%\dspace dsprop --property handle.dir') do @set HANDLEDIR=%%a
+echo Using Handle server directory: %HANDLEDIR%
+
+REM Assume log directory is a subdirectory of DSPACEDIR.
+REM If you want your handle server logs stored elsewhere, change this value
+set LOGDIR=%DSPACEDIR%/log
+
+REM Build a CLASSPATH including all classes in oai webapp, all libraries in [dspace]/lib and the config folder.
+set DSPACE_CLASSPATH=%CLASSPATH%;%DSPACEDIR%\config;%DSPACEDIR%\webapps\oai\WEB-INF\classes\
+for %%f in (%DSPACEDIR%\lib\*.jar) DO CALL %BINDIR%\buildpath.bat %%f
+
+REM If JAVA_OPTS specified, use those options
+REM Otherwise, default Java to using 256MB of memory
+if "%JAVA_OPTS%"=="" set "JAVA_OPTS=-Xmx256m -Dfile.encoding=UTF-8"
+
+REM Remove (forcibly) lock file, in case the old Handle server did not shut down properly
+if exist "%HANDLEDIR%\txns\lock" del /F "%HANDLEDIR%\txns\lock"
+
+REM Execute Java
+REM Start the Handle server, with a special log4j properties file.
+REM We cannot simply write to the same logs, since log4j
+REM does not support more than one JVM writing to the same rolling log.
+echo.
+echo Starting Handle Server (check logs for details)...
+echo.
+echo NOTE: If you want to run the Handle Server as a backend process, re-execute this script
+echo using the Windows "start" command. For example, "start /B start-handle-server.bat"
+echo.
+java %JAVA_OPTS% -cp "%DSPACE_CLASSPATH%" -Ddspace.log.init.disable=true -Dlog4j.configuration=log4j-handle-plugin.properties net.handle.server.Main %HANDLEDIR%  >> "%LOGDIR%/handle-server.log"
+
+REM Clean up DSPACE_CLASSPATH variable
+set DSPACE_CLASSPATH=
+
+REM Back to original dir
+chdir /D %CURRENT_DIR%


### PR DESCRIPTION
As noted in the discussion of DS-3233, the `HandlePlugin` now needs its own DSpace Kernel for access to the `HandleService` and other services.

https://jira.duraspace.org/browse/DS-3233

This PR updates the `HandlePlugin` to start its own Kernel in its `init()` method, and destroy it in its `shutdown()` method.  That ensures the Kernel remains alive as long as the Handle Server is running (and using `HandlePlugin`).

I've tested this PR locally, and the `start-handle-server` script works again.  Before this PR, running `start-handle-server` threw errors and the Handle Server failed to startup.

UPDATE: This PR also now includes a _Windows Version_ of the 'start-handle-script'.  See https://github.com/DSpace/DSpace/pull/1489/commits/8da4fb5bf72add113e84f47b37148a3ffd04972d
