### PR TITLE
DS-3288: Fix CSV export to use valueSeparator between values instead of fieldSeparator

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSV.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSV.java
@@ -631,7 +631,7 @@ public class DSpaceCSV implements Serializable
         int c = 1;
         while (i.hasNext())
         {
-            csvLines[c++] = i.next().toCSV(headingsCopy, fieldSeparator);
+            csvLines[c++] = i.next().toCSV(headingsCopy, fieldSeparator, valueSeparator);
         }
 
         return csvLines;

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSVLine.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSVLine.java
@@ -150,16 +150,17 @@ public class DSpaceCSVLine implements Serializable
      * Write this line out as a CSV formatted string, in the order given by the headings provided
      *
      * @param headings The headings which define the order the elements must be presented in
-     * @param fieldSeparator field separator
+     * @param fieldSeparator separator between metadata fields
+     * @param valueSeparator separator between metadata values (within a field)
      * @return The CSV formatted String
      */
-    protected String toCSV(List<String> headings, String fieldSeparator)
+    protected String toCSV(List<String> headings, String fieldSeparator, String valueSeparator)
     {
         StringBuilder bits = new StringBuilder();
 
         // Add the id
         bits.append("\"").append(id).append("\"").append(fieldSeparator);
-        bits.append(valueToCSV(items.get("collection"), fieldSeparator));
+        bits.append(valueToCSV(items.get("collection"),valueSeparator));
 
         // Add the rest of the elements
         for (String heading : headings)
@@ -168,7 +169,7 @@ public class DSpaceCSVLine implements Serializable
             List<String> values = items.get(heading);
             if (values != null && !"collection".equals(heading))
             {
-                bits.append(valueToCSV(values, fieldSeparator));
+                bits.append(valueToCSV(values, valueSeparator));
             }
         }
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3288

During the Service API refactor, the CSV export code was accidentally refactored to use the configured `bulkedit.fieldSeparator` between _values_ (resulting in commas between values), when obviously it should use the `bulkedit.valueSeparator` (which defaults to a double pipe, ||, between values).

This PR corrects that bug.  I've tested this locally, and it fixes the problem described in DS-3288.
