### PR TITLE
DS-3291 DCSeriesNumber's toString() now filters empty, nonnull strings.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/DCSeriesNumber.java
+++ b/dspace-api/src/main/java/org/dspace/content/DCSeriesNumber.java
@@ -81,7 +81,7 @@ public class DCSeriesNumber
         {
             return (null);
         }
-        else if (number == null)
+        else if (number == null || number.replaceAll("\\s","").length() == 0)
         {
             return (series);
         }


### PR DESCRIPTION
 [Bugfix for DS-3291](https://jira.duraspace.org/browse/DS-3291)
