### PR TITLE
DS-3290: Revert yuicompressor back to v 2.3.6

### DIFF
--- a/dspace-xmlui/pom.xml
+++ b/dspace-xmlui/pom.xml
@@ -219,7 +219,7 @@
         <dependency>
             <groupId>com.yahoo.platform.yui</groupId>
             <artifactId>yuicompressor</artifactId>
-            <version>2.4.8</version>
+            <version>2.3.6</version>
             <exclusions>
                 <exclusion>
                     <groupId>rhino</groupId>


### PR DESCRIPTION
Fix for DS-3290 and DS-444:
https://jira.duraspace.org/browse/DS-3290
https://jira.duraspace.org/browse/DS-444

Based on the comments to the above tickets, the upgrade of `yuicompressor` XMLUI dependency in #1264 has been causing strange errors on some versions of Tomcat and/or Jetty.

This PR simply reverts `yuicompressor` to version 2.3.6 (which was the version used in DSpace 5.x), which is reported to resolve the issues. 

NOTE: I've personally been unable to replicate the reported issues. But, we've had two users report this same issue, and both reported that downgrading `yuicompressor` resolves the issue.  There seems to have been no definitive reason to upgrade `yuicompressor` (other than to be on the latest version), so we may as well stick with the version that is less problematic.
