### PR TITLE
[DS-3292] Delete the Item from EditItemServlet doesn't work well

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -203,14 +203,11 @@ public class MetadataImport
                             }
 
                             // Remove the item
-                            List<Collection> owners = item.getCollections();
-                            for (Collection owner : owners)
-                            {
-                                if (change)
-                                {
-                                    collectionService.removeItem(c, owner, item);
-                                }
-                            }
+
+							if (change) {
+								itemService.delete(c, item);
+							}
+                            
                             whatHasChanged.setDeleted();
                         }
                         else if ("withdraw".equals(action))

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EditItemServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EditItemServlet.java
@@ -228,18 +228,9 @@ public class EditItemServlet extends DSpaceServlet
         case CONFIRM_DELETE:
 
             // Delete the item - if "cancel" was pressed this would be
-            // picked up above
-            // FIXME: Don't know if this does all it should - remove Handle?
-            Iterator<Collection> collIter = item.getCollections().iterator();
+            // picked up above            
+            itemService.delete(context, item);
             
-            // Remove item from all the collections it's in
-            while(collIter.hasNext())
-            {
-                Collection c = collIter.next();
-                collIter.remove();
-                collectionService.removeItem(context, c, item);
-            }
-
             JSPManager.showJSP(request, response, "/tools/get-item-id.jsp");
             context.complete();
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3292

Bug fix for deletion of Item. Pratically if you want to delete an item from all owner collections you don't want to iterate all collections but rather delete it directly.

I searched all references in the code base and I found and fix a similar issue into MetadataImport (untested yet) .
