### PR TITLE
[DS-3286] Remove clearCache() and allow uncacheEntity() on specific objects

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -693,6 +693,13 @@ public class Context
         return (E) dbConnection.reloadEntity(entity);
     }
 
+    /**
+     * Remove an entity from the cache. This is necessary when batch processing a large number of items.
+     *
+     * @param entity The entity to reload
+     * @param <E> The class of the enity. The entity must implement the {@link ReloadableEntity} interface.
+     * @throws SQLException When reloading the entity from the database fails.
+     */
     @SuppressWarnings("unchecked")
     public <E extends ReloadableEntity> void uncacheEntity(E entity) throws SQLException {
         dbConnection.uncacheEntity(entity);

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -714,6 +714,12 @@ public class Context
         return (E) dbConnection.reloadEntity(entity);
     }
 
+    @SuppressWarnings("unchecked")
+    public <E extends ReloadableEntity> void uncacheEntity(E entity) throws SQLException {
+        dbConnection.uncacheEntity(entity);
+    }
+
+    
     /**
      * Reload all entities related to this context.
      * @throws SQLException When reloading one of the entities fails.

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -643,27 +643,6 @@ public class Context
         dbConnection.shutdown();
     }
 
-    /**
-     * Clear the cache of all object that have been read from the database so far. This will also free up
-     * (heap space) memory. You should use this method when processing a large number of records.
-     *
-     * <b>WARNING: After calling this method all previously fetched entities are "detached" (pending
-     * changes are not tracked anymore). You have to reload all entities you still want to work with
-     * manually after this method call (see {@link Context#reloadEntity(ReloadableEntity)}).</b>
-     *
-     * This method will take care of reloading the current user.
-     *
-     * @throws SQLException When clearing the entity cache fails
-     */
-	public void clearCache() throws SQLException {
-        if(log.isDebugEnabled()) {
-            log.debug("Cache size before clear cache is " + getCacheSize());
-        }
-
-		this.getDBConnection().clearCache();
-
-        reloadContextBoundEntities();
-    }
 
     /**
      * Returns the size of the cache of all object that have been read from the database so far. A larger number

--- a/dspace-api/src/main/java/org/dspace/core/DBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/DBConnection.java
@@ -53,4 +53,6 @@ public interface DBConnection<T> {
      * @param entity The DSpace object to reload
      */
     public <E extends ReloadableEntity> E reloadEntity(E entity) throws SQLException;
+
+    public <E extends ReloadableEntity> void uncacheEntity(E entity) throws SQLException ;
 }

--- a/dspace-api/src/main/java/org/dspace/core/DBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/DBConnection.java
@@ -40,8 +40,6 @@ public interface DBConnection<T> {
 
     public DatabaseConfigVO getDatabaseConfig() throws SQLException;
     
-    public void clearCache() throws SQLException;
-
     public void setOptimizedForBatchProcessing(boolean batchOptimized) throws SQLException;
 
     public boolean isOptimizedForBatchProcessing();

--- a/dspace-api/src/main/java/org/dspace/core/DBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/DBConnection.java
@@ -52,5 +52,9 @@ public interface DBConnection<T> {
      */
     public <E extends ReloadableEntity> E reloadEntity(E entity) throws SQLException;
 
+    /**
+     * Remove a DSpace object from the cache when batch processing a large number of objects.
+     * @param entity The DSpace object to reload
+     */
     public <E extends ReloadableEntity> void uncacheEntity(E entity) throws SQLException ;
 }

--- a/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
@@ -116,11 +116,6 @@ public class HibernateDBConnection implements DBConnection<Session> {
         return databaseConfigVO;
     }
 
-	@Override
-	public void clearCache() throws SQLException {
-        getSession().flush();
-		getSession().clear();
-	}
 
     @Override
     public long getCacheSize() throws SQLException {

--- a/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
@@ -157,4 +157,9 @@ public class HibernateDBConnection implements DBConnection<Session> {
             getSession().setFlushMode(FlushMode.AUTO);
         }
     }
+
+    @Override
+    public <E extends ReloadableEntity> void uncacheEntity(E entity) throws SQLException {
+        getSession().evict(entity);        
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
@@ -153,6 +153,13 @@ public class HibernateDBConnection implements DBConnection<Session> {
         }
     }
 
+    /**
+     * Evict an entity from the hibernate cache. This is necessary when batch processing a large number of items.
+     *
+     * @param entity The entity to reload
+     * @param <E> The class of the enity. The entity must implement the {@link ReloadableEntity} interface.
+     * @throws SQLException When reloading the entity from the database fails.
+     */
     @Override
     public <E extends ReloadableEntity> void uncacheEntity(E entity) throws SQLException {
         getSession().evict(entity);        

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
@@ -174,12 +174,14 @@ public class IndexClient {
             final String communityHandle = community.getHandle();
             for (final Community subcommunity : community.getSubcommunities()) {
                 count += indexAll(indexingService, itemService, context, subcommunity);
+                context.uncacheEntity(subcommunity);
             }
             final Community reloadedCommunity = (Community) HandleServiceFactory.getInstance().getHandleService().resolveToObject(context, communityHandle);
             for (final Collection collection : reloadedCommunity.getCollections()) {
                 count++;
                 indexingService.indexContent(context, collection, true, true);
                 count += indexItems(indexingService, itemService, context, collection);
+                context.uncacheEntity(collection);
             }
         } else if (dso.getType() == Constants.COLLECTION) {
             count += indexItems(indexingService, itemService, context, (Collection) dso);

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
@@ -9,11 +9,20 @@ package org.dspace.discovery;
 
 import org.apache.log4j.Logger;
 import org.apache.commons.cli.*;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Constants;
 import org.dspace.core.Context;
+import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.services.factory.DSpaceServicesFactory;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.Iterator;
 
 /**
  * Class used to reindex dspace communities/collections/items into discovery
@@ -41,19 +50,26 @@ public class IndexClient {
         Context context = new Context();
         context.setIgnoreAuthorization(true);
 
-        String usage = "org.dspace.discovery.IndexClient [-cbhf[r <item handle>]] or nothing to update/clean an existing index.";
+        String usage = "org.dspace.discovery.IndexClient [-cbhf] | [-r <handle>] | [-i <handle>] or nothing to update/clean an existing index.";
         Options options = new Options();
         HelpFormatter formatter = new HelpFormatter();
         CommandLine line = null;
 
         options
                 .addOption(OptionBuilder
-                        .withArgName("item handle")
+                        .withArgName("handle to remove")
                         .hasArg(true)
                         .withDescription(
                                 "remove an Item, Collection or Community from index based on its handle")
                         .create("r"));
 
+        options
+                .addOption(OptionBuilder
+                        .withArgName("handle to add or update")
+                        .hasArg(true)
+                        .withDescription(
+                                "add or update an Item, Collection or Community based on its handle")
+                        .create("i"));
 
         options
                 .addOption(OptionBuilder
@@ -119,6 +135,19 @@ public class IndexClient {
             indexer.optimize();
         } else if(line.hasOption('s')) {
             checkRebuildSpellCheck(line, indexer);
+        } else if(line.hasOption('i')) {
+            final String handle = line.getOptionValue('i');
+            final DSpaceObject dso = HandleServiceFactory.getInstance().getHandleService().resolveToObject(context, handle);
+            if (dso == null) {
+                throw new IllegalArgumentException("Cannot resolve " + handle + " to a DSpace object");
+            }
+            log.info("Forcibly Indexing " + handle);
+            // Enable batch mode; we may be indexing a large number of items
+            context.enableBatchMode(true);
+            final long startTimeMillis = System.currentTimeMillis();
+            final long count = indexAll(indexer,  ContentServiceFactory.getInstance().getItemService(), context, dso);
+            final long seconds = (System.currentTimeMillis() - startTimeMillis ) / 1000;
+            log.info("Indexed " + count + " DSpace object" + (count > 1 ? "s" : "") + " in " + seconds + " seconds");
         } else {
             log.info("Updating and Cleaning Index");
             indexer.cleanIndex(line.hasOption("f"));
@@ -128,6 +157,57 @@ public class IndexClient {
 
         log.info("Done with indexing");
 	}
+
+    /**
+     * Indexes the given object and all children, if applicable.
+     */
+    private static long indexAll(final IndexingService indexingService,
+                                 final ItemService itemService,
+                                 final Context context,
+                                 final DSpaceObject dso) throws IOException, SearchServiceException, SQLException {
+        long count = 0;
+
+        indexingService.indexContent(context, dso, true, true);
+        count++;
+        if (dso.getType() == Constants.COMMUNITY) {
+            final Community community = (Community) dso;
+            final String communityHandle = community.getHandle();
+            for (final Community subcommunity : community.getSubcommunities()) {
+                count += indexAll(indexingService, itemService, context, subcommunity);
+            }
+            final Community reloadedCommunity = (Community) HandleServiceFactory.getInstance().getHandleService().resolveToObject(context, communityHandle);
+            for (final Collection collection : reloadedCommunity.getCollections()) {
+                count++;
+                indexingService.indexContent(context, collection, true, true);
+                count += indexItems(indexingService, itemService, context, collection);
+            }
+        } else if (dso.getType() == Constants.COLLECTION) {
+            count += indexItems(indexingService, itemService, context, (Collection) dso);
+        }
+
+        return count;
+    }
+
+    /**
+     * Indexes all items in the given collection.
+     */
+    private static long indexItems(final IndexingService indexingService,
+                                   final ItemService itemService,
+                                   final Context context,
+                                   final Collection collection) throws IOException, SearchServiceException, SQLException {
+        long count = 0;
+
+        final Iterator<Item> itemIterator = itemService.findByCollection(context, collection);
+        while (itemIterator.hasNext()) {
+            Item item = itemIterator.next();
+            indexingService.indexContent(context, itemIterator.next(), true, false);
+            count++;
+            context.uncacheEntity(item);
+        }
+        indexingService.commit();
+
+        return count;
+    }
 
     /**
      * Check the command line options and rebuild the spell check if active.

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
@@ -174,6 +174,7 @@ public class IndexClient {
             final String communityHandle = community.getHandle();
             for (final Community subcommunity : community.getSubcommunities()) {
                 count += indexAll(indexingService, itemService, context, subcommunity);
+                //To prevent memory issues, discard an object from the cache after processing
                 context.uncacheEntity(subcommunity);
             }
             final Community reloadedCommunity = (Community) HandleServiceFactory.getInstance().getHandleService().resolveToObject(context, communityHandle);
@@ -181,6 +182,7 @@ public class IndexClient {
                 count++;
                 indexingService.indexContent(context, collection, true, true);
                 count += indexItems(indexingService, itemService, context, collection);
+                //To prevent memory issues, discard an object from the cache after processing
                 context.uncacheEntity(collection);
             }
         } else if (dso.getType() == Constants.COLLECTION) {
@@ -204,6 +206,7 @@ public class IndexClient {
             Item item = itemIterator.next();
             indexingService.indexContent(context, item, true, false);
             count++;
+            //To prevent memory issues, discard an object from the cache after processing
             context.uncacheEntity(item);
         }
         indexingService.commit();

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
@@ -200,7 +200,7 @@ public class IndexClient {
         final Iterator<Item> itemIterator = itemService.findByCollection(context, collection);
         while (itemIterator.hasNext()) {
             Item item = itemIterator.next();
-            indexingService.indexContent(context, itemIterator.next(), true, false);
+            indexingService.indexContent(context, item, true, false);
             count++;
             context.uncacheEntity(item);
         }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -392,7 +392,6 @@ public class SolrServiceImpl implements SearchService, IndexingService {
     {
         try {
             Iterator<Item> items = null;
-            int itemCount = 0;
             for (items = itemService.findAllUnfiltered(context); items.hasNext();)
             {
                 Item item = items.next();

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -397,10 +397,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
             {
                 Item item = items.next();
                 indexContent(context, item, force);
-                if (itemCount++ >= 1000) {
-                	context.clearCache();
-                	itemCount = 0;
-                }
+                context.uncacheEntity(item);
             }
 
             List<Collection> collections = collectionService.findAll(context);

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -396,6 +396,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
             {
                 Item item = items.next();
                 indexContent(context, item, force);
+                //To prevent memory issues, discard an object from the cache after processing
                 context.uncacheEntity(item);
             }
 


### PR DESCRIPTION
Rather than working around the risks of calling clearCache() allow the user to manage the presence of specific objects within the cache.

I want to get some feedback on this approach to the issue.

I have tested this with a small database instance.  I plan to test this with a very large instance.
