### PR TITLE
DS-2431 Mark spiders by user agent

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/service/SolrLoggerService.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/service/SolrLoggerService.java
@@ -98,6 +98,8 @@ public interface SolrLoggerService {
 
     public void markRobotsByIP();
 
+    public void markRobotsByUserAgent();
+    
     public void markRobotByUserAgent(String agent);
 
     public void deleteRobotsByIsBotFlag();

--- a/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetector.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetector.java
@@ -144,6 +144,42 @@ public class SpiderDetector {
         }
 
     }
+    
+    /**
+     * Return the patterns specified into agent files
+     * 
+     * @return
+     */
+    public static Set<String> getSpiderAgents() {
+    	Set<String> agentList = new HashSet<String>();
+    	
+        String filePath = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("dspace.dir");
+
+        try 
+        {
+            File agentsDir = new File(filePath, "config/spiders/agents");
+            
+            if (agentsDir.exists() && agentsDir.isDirectory()) {
+                for (File file : agentsDir.listFiles()) {
+                    if (file.isFile())
+                    {
+                        for (String agent : readPatterns(file)) 
+                        {
+                            agentList.add(agent);
+                        }
+                    }
+                }
+            } else {
+                log.info("No spider file loaded");
+            }
+        }
+        catch (IOException e)
+        {
+        	log.error("Error Loading Spiders:" + e.getMessage(), e);
+        }
+
+    	return agentList;
+    }
 
     /**
      * Load agent name patterns from all files in a single subdirectory of config/spiders.

--- a/dspace-api/src/main/java/org/dspace/statistics/util/StatisticsClient.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/StatisticsClient.java
@@ -57,6 +57,7 @@ public class StatisticsClient
                         DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("dspace.dir") + "/config/spiders");
 
         options.addOption("m", "mark-spiders", false, "Update isBot Flag in Solr");
+        options.addOption("a", "mark-spiders by user agent", false, "Update isBot Flag in Solr");
         options.addOption("f", "delete-spiders-by-flag", false, "Delete Spiders in Solr By isBot Flag");
         options.addOption("i", "delete-spiders-by-ip", false, "Delete Spiders in Solr By IP Address");
         options.addOption("o", "optimize", false, "Run maintenance on the SOLR index");
@@ -106,6 +107,10 @@ public class StatisticsClient
         else if(line.hasOption('s'))
         {
             solrLoggerService.shardSolrIndex();
+        }
+        else if(line.hasOption('a'))
+        {
+            solrLoggerService.markRobotsByUserAgent();
         }
         else
         {


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2431

Now stats-util has the -a option to mark spiders as bots using
the lists of user agents defined in config/spiders/agents
