### PR TITLE
Fix failing test from changes in PR#1495

### DIFF
--- a/dspace-api/src/test/java/org/dspace/content/WorkspaceItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/WorkspaceItemTest.java
@@ -304,7 +304,7 @@ public class WorkspaceItemTest extends AbstractUnitTest
         workspaceItemService.update(context, wi);
         context.commit();
         // force to read the data from the database
-        context.clearCache();
+        context.uncacheEntity(wi);
         // read all our test attributes objects from the fresh session 
         // to avoid duplicate object in session issue
         wi = workspaceItemService.find(context, wi.getID());


### PR DESCRIPTION
We had a unit test that still used `context.clearCache()`, but this was removed in #1495.  This PR fixes that issue
