### PR TITLE
DS-3017 Compliance with the OpenAIRE 3.0 guidelines for literature repositories

### DIFF
--- a/dspace/config/crosswalks/oai/xoai.xml
+++ b/dspace/config/crosswalks/oai/xoai.xml
@@ -16,7 +16,7 @@
     <Contexts>
         <Context baseurl="request" name="Default Context">
             <!-- Restrict access to hidden items by default -->
-            <Filter ref="defaultFilter" />
+            <Filter ref="defaultFilter"/>
 
             <Format ref="oaidc"/>
             <Format ref="mets"/>
@@ -60,9 +60,9 @@
         </Context>
 
         <!--
-            OpenAIRE Guidelines 1.1:
+            OpenAIRE Guidelines 3.0:
 
-            - https://guidelines.openaire.eu/en/latest/
+            - https://guidelines.openaire.eu/
 
             There is a limitation over the embargoedEndDate parameter:
 
@@ -79,7 +79,7 @@
             <Format ref="oaidc"/>
             <Format ref="mets"/>
             <Description>
-                This context complies with OpenAIRE rules.
+                This contexts complies with OpenAIRE Guidelines for Literature Repositories v3.0.
             </Description>
         </Context>
     </Contexts>
@@ -243,19 +243,23 @@
                     <LeftCondition>
                         <And>
                             <LeftCondition>
-                                <Custom ref="titleExistsCondition"/>
+                                <And>
+                                    <LeftCondition>
+                                        <Custom ref="titleExistsCondition"/>
+                                    </LeftCondition>
+                                    <RightCondition>
+                                        <Custom ref="authorExistsCondition"/>
+                                    </RightCondition>
+                                </And>
                             </LeftCondition>
                             <RightCondition>
-                                <Custom ref="authorExistsCondition"/>
+                                <Custom ref="driverDocumentTypeCondition"/>
                             </RightCondition>
                         </And>
                     </LeftCondition>
                     <RightCondition>
-                        <And>
+                        <Or>
                             <LeftCondition>
-                                <Custom ref="driverDocumentTypeCondition"/>
-                            </LeftCondition>
-                            <RightCondition>
                                 <And>
                                     <LeftCondition>
                                         <Or>
@@ -268,11 +272,14 @@
                                         </Or>
                                     </LeftCondition>
                                     <RightCondition>
-                                        <Custom ref="openaireRelationCondition"/>
+                                        <Custom ref="driverAccessCondition"/>
                                     </RightCondition>
                                 </And>
+                            </LeftCondition>
+                            <RightCondition>
+                                <Custom ref="openaireRelationCondition"/>
                             </RightCondition>
-                        </And>
+                        </Or>
                     </RightCondition>
                 </And>
             </Definition>
@@ -360,6 +367,7 @@
                     <string>annotation</string>
                     <string>contributionToPeriodical</string>
                     <string>patent</string>
+                    <string>dataset</string>
                     <string>other</string>
                 </list>
             </Configuration>
@@ -374,7 +382,6 @@
                 <string name="field">dc.rights</string>
                 <string name="operator">contains</string>
                 <list name="values">
-                    <string>open access</string>
                     <string>openAccess</string>
                 </list>
             </Configuration>
@@ -400,7 +407,7 @@
             <Configuration>
                 <string name="field">dc.relation</string>
                 <string name="operator">starts_with</string>
-                <string name="value">info:eu-repo/grantAgreement/EC</string>
+                <string name="value">info:eu-repo/grantAgreement/</string>
             </Configuration>
         </CustomCondition>
     </Filters>
@@ -412,8 +419,8 @@
             <!-- Just an alias -->
         </Set>
         <Set id="openaireSet">
-            <Spec>ec_fundedresources</Spec>
-            <Name>EC_fundedresources set</Name>
+            <Spec>openaire</Spec>
+            <Name>OpenAIRE</Name>
             <!-- Just an alias -->
         </Set>
     </Sets>


### PR DESCRIPTION
This pull request is to update the level of OpenAIRE compliance for 3.0 available in the XOAI. 
The OpenAIRE OAI set has been renamed from ec_fundedresources to openaire.
This renamed set exposes the open access content plus the funded related content ("openaireRelationCondition" and "driverAccessCondition"), as difened on the OpenAIRE literature guidelines, not only the EC funded content as the previous set.
