### PR TITLE
[DS-3312] Prevent mvn error on xsl override

### DIFF
--- a/dspace/modules/xmlui-mirage2/pom.xml
+++ b/dspace/modules/xmlui-mirage2/pom.xml
@@ -89,6 +89,7 @@
                                         <include>**/*.ttf</include>
                                         <include>**/*.woff</include>
                                         <include>**/*.eot</include>
+                                        <include>**/*.xsl</include>
                                     </excludes>
                                     <filtering>true</filtering>
                                 </resource>
@@ -105,6 +106,7 @@
                                         <include>**/*.ttf</include>
                                         <include>**/*.woff</include>
                                         <include>**/*.eot</include>
+                                        <include>**/*.xsl</include>
                                     </includes>
                                     <filtering>false</filtering>
                                 </resource>

--- a/dspace/modules/xmlui-mirage2/pom.xml
+++ b/dspace/modules/xmlui-mirage2/pom.xml
@@ -86,10 +86,10 @@
                                         <exclude>**/*.png</exclude>
                                         <exclude>**/*.ico</exclude>
                                         <exclude>**/*.svg</exclude>
-                                        <include>**/*.ttf</include>
-                                        <include>**/*.woff</include>
-                                        <include>**/*.eot</include>
-                                        <include>**/*.xsl</include>
+                                        <exclude>**/*.ttf</exclude>
+                                        <exclude>**/*.woff</exclude>
+                                        <exclude>**/*.eot</exclude>
+                                        <exclude>**/*.xsl</exclude>
                                     </excludes>
                                     <filtering>true</filtering>
                                 </resource>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3312

The mirage2 build process was failing for me with overrides to xsl files in my additions/xmlui-mirage2 folder

This patch seems to allow the build to run to completion.
