### PR TITLE
DS-3315: update node dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,12 @@ env:
 
 # Install prerequisites for building Mirage2 more rapidly
 before_install:
-  # Install latest Node.js 0.10.x & print version info
-  - nvm install 0.10
+  # Install Node.js 6.5.0 & print version info
+  - nvm install 6.5.0
   - node --version
+  # Install npm 3.10.8 & print version info
+  - npm install -g npm@3.10.8
+  - npm --version
   # Install Bower
   - npm install -g bower
   # Install Grunt & print version info

--- a/dspace-xmlui-mirage2/readme.md
+++ b/dspace-xmlui-mirage2/readme.md
@@ -38,19 +38,19 @@ We recommend using [nvm](https://github.com/creationix/nvm) (Node Version Manage
 First download and install nvm:
 
 ```bash
-    curl https://raw.githubusercontent.com/creationix/nvm/v0.5.1/install.sh | sh 
+    curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.7/install.sh | bash 
 ```
 
-Then, close and reopen your terminal, and install a node version. We’ve been using v0.10.31 during the development of the theme, but it may very well work on other versions
+Then, close and reopen your terminal, and install a node version. We’ve been using v6.5.0 during the development of the theme, but it may very well work on other versions
 
 ```bash
-    nvm install 0.10.31 
+    nvm install 6.5.0 
 ```
 
 Set the node version you installed as the default version.
 
 ```bash
-    nvm alias default 0.10.31
+    nvm alias default 6.5.0
 ```
 
 

--- a/dspace-xmlui-mirage2/src/main/webapp/bower.json
+++ b/dspace-xmlui-mirage2/src/main/webapp/bower.json
@@ -1,6 +1,6 @@
 {
-    "name": "Mirage2",
-    "version": "0.1.1",
+    "name": "mirage2",
+    "version": "0.1.2",
     "dependencies": {
         "bootstrap-sass-official": "3.3.0",
         "modernizr": "2.8.3",

--- a/dspace-xmlui-mirage2/src/main/webapp/package.json
+++ b/dspace-xmlui-mirage2/src/main/webapp/package.json
@@ -1,25 +1,25 @@
 {
   "name": "Mirage2",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "dependencies": {},
   "devDependencies": {
-    "bower": "1.3.12",
-    "grunt": "~0.4.4",
-    "grunt-cli": "0.1.13",
-    "grunt-contrib-compass": "~0.6.0",
-    "load-grunt-tasks": "~0.1.0",
-    "time-grunt": "~0.1.1",
-    "grunt-contrib-coffee": "~0.7.0",
-    "grunt-contrib-handlebars": "0.9.0",
-    "grunt-usemin": "~2.1.0",
-    "grunt-contrib-uglify": "~0.4.0",
-    "grunt-contrib-concat": "~0.3.0",
-    "grunt-contrib-copy": "~0.5.0"
+    "bower": "1.7.9",
+    "grunt": "~1.0.1",
+    "grunt-cli": "1.2.0",
+    "grunt-contrib-coffee": "~1.0.0",
+    "grunt-contrib-compass": "^1.1.1",
+    "grunt-contrib-concat": "~1.0.1",
+    "grunt-contrib-copy": "~1.0.0",
+    "grunt-contrib-handlebars": "1.0.0",
+    "grunt-contrib-uglify": "~2.0.0",
+    "grunt-usemin": "~3.1.1",
+    "load-grunt-tasks": "~3.5.2",
+    "time-grunt": "~1.4.0"
   },
   "scripts": {
     "postinstall": "bower install"
   },
   "engines": {
-    "node": ">=0.10.17 <0.11"
+    "node": ">=6.0.0 <7.0.0"
   }
 }

--- a/dspace/modules/xmlui-mirage2/pom.xml
+++ b/dspace/modules/xmlui-mirage2/pom.xml
@@ -350,7 +350,7 @@
                         <plugin>
                             <groupId>com.github.eirslett</groupId>
                             <artifactId>frontend-maven-plugin</artifactId>
-                            <version>0.0.23</version>
+                            <version>1.0</version>
                         </plugin>
                     </plugins>
                 </pluginManagement>

--- a/dspace/modules/xmlui-mirage2/pom.xml
+++ b/dspace/modules/xmlui-mirage2/pom.xml
@@ -25,8 +25,8 @@
         <!-- Versions of build dependencies to be auto-installed when "mirage2.deps.included=true" -->
         <sass.version>3.3.14</sass.version>
         <compass.version>1.0.1</compass.version>
-        <node.version>0.10.31</node.version>
-        <npm.version>1.4.23</npm.version>
+        <node.version>6.5.0</node.version>
+        <npm.version>3.10.8</npm.version>
     </properties>
 
     <build>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3315

A few remarks:
- This only updates the dependencies described in the issue as producing warnings: the node dependencies. These are the build tools, not the libraries used in the theme (jquery, handlebars, etc.). They are specified in bower.json. Updating those to the latest versions has more consequences as it will most likely require us to rewrite parts of the javascript code due to breaking changes. It will likely also affect the list of supported browsers, as the newer versions of those libs are likely to drop support for older Internet Explorer versions for example. Doing so may be worth considering, but it warrants a separate issue in my opinion.
- Using these newer node tools, also requires a node version >= 6. That means people that have installed the dependencies locally will likely need to upgrade their node version when upgrading to DSpace 6. If they used nvm, as we suggested in the docs, it won't be hard, but it is still something to keep in mind.
- I've tested this PR on node 6.5.0, npm 3.10.8 on OS X El Capitan, both dev and prod builds, and builds with and without preinstalled dependencies work using that combination of tools/platform. It is recommended that this is tested on a few more platforms before it is merged. _Especially on windows_!
