### PR TITLE
bump up to latest minor pdfbox version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -855,17 +855,17 @@
          <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
-            <version>1.6.0</version>
+            <version>1.8.12</version>
          </dependency>
          <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>fontbox</artifactId>
-            <version>1.6.0</version>
+            <version>1.8.12</version>
          </dependency>
          <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>jempbox</artifactId>
-            <version>1.6.0</version>
+            <version>1.8.12</version>
          </dependency>
          <dependency>
 	        <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
Also in this branch the version of pdfbox 1.8.12 running well.

Scenario:
- cherry pick from dspace-5_x for the correct version of pdfbox (follow the suggestion of the reporter the 1.8.7 works well in other context)
- build and deploy from scratch a copy of dspace-4_x (pdfbox version 1.8.12 into lib checked)
- submit an item with a sample pdf
- launch mediafilter

The result: no errors and txt extracted from pdf is available. Ok it works.
