### PR TITLE
README updates for SWORDv1 and a new README for SWORDv2

### DIFF
--- a/dspace-sword/README.md
+++ b/dspace-sword/README.md
@@ -1,13 +1,11 @@
-===================
-DSpace SWORD README
-===================
+# DSpace SWORD (v1) README
 
-Author: Richard Jones
-Last Updated: 18-02-2008
-SWORD Version: 1.3
-DSpace-SWORD Version: 1.3.1
+* Author: Richard Jones
+* Last Updated: 18-02-2008
+* SWORD Version: 1.3
+* DSpace-SWORD Version: 1.3.1
 
-This document describes the DSpace implementation of the SWORD deposit standard.  This is an extension to the ATOM
+This document describes the DSpace implementation of the SWORD (v1) deposit standard.  This is an extension to the ATOM
 Publishing Protocol (APP), which provides a framework to discover deposit targets, and to deposit packaged content into
 remote repositories.
 
@@ -15,11 +13,9 @@ For more information see:
 
 http://www.swordapp.org/
 
-Changes
-=======
+## Changes
 
-Version 1.3.1
--------------
+### Version 1.3.1
 
 Second major version to be compliant with the SWORD 1.3 standard.
 
@@ -32,21 +28,18 @@ Second major version to be compliant with the SWORD 1.3 standard.
   on items
 - Meet request/response requirements of 1.3 specification
 
-Version 1.2.1
--------------
+### Version 1.2.1
 
 Initial version to be compliant with the SWORD 1.2 standard.
 
 - Support for depositing METS DSpace SIP files into DSpace collections
 - Expose all DSpace Collections as ATOM Collections in SWORD Service Documents
 
-Configuration
-=============
+## Configuration
 
-The SWORD interface is configured within the main dspace.cfg file.
+The SWORD (v1) interface is configured within the `[dspace]/config/modules/sword-server.cfg` file.
 
-Testing
-=======
+## Testing
 
 Supplied along with the source code is a package which can be used for testing. This consists of a mets.xml file, which
 is a METS document containing a Dublin Core XML section of descriptive metadata which conforms to the SWAP standard.
@@ -55,47 +48,44 @@ There are additionally 3 example PDF files.
 These files are provided additionally inside a zip file which should form the  content of a deposit request
 (example.zip).
 
-These files are all available in the directory: [dspace-sword]/example
+These files are all available in the directory: `[dspace-sword]/example`
 
 Testing can be performed using the separately available SWORD Client, or by invoking the sword deposit web service via a
-command line tool such as curl:
+command line tool such as `curl`:
 
-Service Documents
------------------
+### Service Documents
 
 Authorised by dspace/dspace:
 
-curl -i http://dspace:dspace@localhost:8080/sword/servicedocument
+`curl -i http://dspace:dspace@localhost:8080/sword/servicedocument`
 
 Authorised by dspace/dspace on behalf of admin:
 
-curl -i -H "X-On-Behalf-Of: admin" http://dspace:dspace@localhost:8080/sword/servicedocument
+`curl -i -H "X-On-Behalf-Of: admin" http://dspace:dspace@localhost:8080/sword/servicedocument`
 
-Deposits
---------
+### Deposits
 
 Authorised by dspace/dspace on a Collection:
 
-curl -i --data-binary "@dspace-sword/example/example.zip" -H "Content-Disposition: filename=myDSpaceMETSItem.zip"
+`curl -i --data-binary "@dspace-sword/example/example.zip" -H "Content-Disposition: filename=myDSpaceMETSItem.zip"
      -H "Content-Type: application/zip" -H "X-Packaging: http://purl.org/net/sword-types/METSDSpaceSIP"
-     -H "X-No-Op: false" -H "X-Verbose: true" http://dspace:dspace@localhost:8080/sword/deposit/123456789/2
+     -H "X-No-Op: false" -H "X-Verbose: true" http://dspace:dspace@localhost:8080/sword/deposit/123456789/2`
 
 Authorised by dspace/dspace on behalf of admin on a Collection:
 
-curl -i --data-binary "@dspace-sword/example/example.zip" -H "Content-Disposition: filename=myDSpaceMETSItem.zip"
+`curl -i --data-binary "@dspace-sword/example/example.zip" -H "Content-Disposition: filename=myDSpaceMETSItem.zip"
      -H "X-On-Behalf-Of: admin" -H "Content-Type: application/zip"
      -H "X-Packaging: http://purl.org/net/sword-types/METSDSpaceSIP" -H "X-No-Op: false" -H "X-Verbose: true"
-     http://dspace:dspace@localhost:8080/sword/deposit/123456789/2
+     http://dspace:dspace@localhost:8080/sword/deposit/123456789/2`
 
 Authorised by dspace/dspace on an Item:
 
-curl -i --data-binary "@dspace-sword/example/pdf1.pdf" -H "Content-Disposition: filename=somepdf.pdf"
+`curl -i --data-binary "@dspace-sword/example/pdf1.pdf" -H "Content-Disposition: filename=somepdf.pdf"
      -H "Content-Type: application/pdf" -H "X-No-Op: true" -H "X-Verbose: true"
-     http://dspace:dspace@localhost:8080/sword/deposit/123456789/21
+     http://dspace:dspace@localhost:8080/sword/deposit/123456789/21`
 
 
-Implementation Notes
-====================
+## Implementation Notes
 
 - The logic of onBehalfOf is as follows:  The list of collections which is supplied during a request which is done
   onBehalfOf another user is the intersection of the lists of collections that the authenticated user can submit to and
@@ -104,7 +94,7 @@ Implementation Notes
 - When items are deposited and pass into the DSpace workflow system, they cannot be assigned external identifiers
   immediately.  Therefore the returned id on "Accepted" items will be the front page of the repository on which the
   deposit happened.  Alternatives to this mechanism are being sought, but may require core DSpace modifications.
-  
+
 - If a request is made with an onBehalfOf user supplied, the authentication process requires that the username/password
   pair successfully  authenticate a user, and that the onBehalfOf user simply exists in the user database.  If any of
   these conditions fail, authentication fails.

--- a/dspace-swordv2/README.md
+++ b/dspace-swordv2/README.md
@@ -45,8 +45,7 @@ While we've provided a few example deposits below. These examples do not make us
 This is an example of depositing one of the `example.zip` packages (or a similarly structured package). In this example, the `example.zip` file is assumed to be located in the current directory. We are depositing it into a Collection with handle `10673/2` as the Demo Administrator account.
 
 ```
-curl -i http://demo.dspace.org/swordv2/collection/10673/2 --data-binary "@example.zip" -H "Content-Disposition: file
-name=example.zip" -H "Content-Type: application/zip" -H "Packaging: http://purl.org/net/sword/package/METSDSpaceSIP" --user "dspacedemo+admin@gmail.com"
+curl -i http://demo.dspace.org/swordv2/collection/10673/2 --data-binary "@example.zip" -H "Content-Disposition: filename=example.zip" -H "Content-Type: application/zip" -H "Packaging: http://purl.org/net/sword/package/METSDSpaceSIP" --user "dspacedemo+admin@gmail.com"
 ```
 
 #### Depositing via an Atom entry

--- a/dspace-swordv2/README.md
+++ b/dspace-swordv2/README.md
@@ -1,0 +1,75 @@
+# DSpace SWORD (v2) README
+
+* Author: Richard Jones
+* SWORDv2 Version: 1.0
+* Based on: https://github.com/swordapp/JavaServer2.0/
+
+This document describes the DSpace implementation of the SWORD (v2) deposit standard.  This is an extension to the ATOM
+Publishing Protocol (APP), which provides a framework to discover deposit targets, and to deposit packaged content into
+remote repositories.
+
+For more information see:
+
+http://swordapp.org/sword-v2/sword-v2-specifications/
+
+## Configuration
+
+The SWORD (v2) interface is configured within the `[dspace]/config/modules/swordv2-server.cfg` file.
+
+## Testing
+
+Test example ZIP packages for SWORDv2 are available within the swordapp GitHub repository at: https://github.com/swordapp/JavaClient2.0/tree/master/src/test/resources
+
+These ZIP packages consist of a `mets.xml` file (providing metadata) along with example PDF files.
+
+Testing can be performed using a separately available SWORDv2 Client, or by invoking the sword deposit web service via a
+command line tool such as `curl`.  Below are some examples of using `curl` against our demo server (http://demo.dspace.org) SWORDv2 interface.
+
+### Service Documents
+
+An example request to obtain the `servicedocument`:
+
+```
+curl -i  http://demo.dspace.org/swordv2/servicedocument --user "dspacedemo+admin@gmail.com"
+```
+
+In the above example, we are attempting to login as the Demo Administrator account (dspacedemo+admin@gmail.com)
+and will be prompted for the password.
+
+### Deposits
+
+While we've provided a few example deposits below. These examples do not make use of all the available options within the SWORDv2 protocol. For all the nitty gritty details, see the SWORDv2 Profile documentation on "Creating a Resource": http://swordapp.github.io/SWORDv2-Profile/SWORDProfile.html#protocoloperations_creatingresource
+
+#### Depositing a zip package
+
+This is an example of depositing one of the `example.zip` packages (or a similarly structured package). In this example, the `example.zip` file is assumed to be located in the current directory. We are depositing it into a Collection with handle `10673/2` as the Demo Administrator account.
+
+```
+curl -i http://demo.dspace.org/swordv2/collection/10673/2 --data-binary "@example.zip" -H "Content-Disposition: file
+name=example.zip" -H "Content-Type: application/zip" -H "Packaging: http://purl.org/net/sword/package/METSDSpaceSIP" --user "dspacedemo+admin@gmail.com"
+```
+
+#### Depositing via an Atom entry
+
+You can also perform a deposit via an Atom entry. This will create a *metadata-only* Item initially, but you can POST files to it after creating the item.
+
+To perform this type of deposit, first you must create file to represent your Atom entry, with the metadata provided in `dcterms`. You can name it whatever you want, but in this example we've named it `entry.xml`. Here's an example:
+
+```
+<?xml version='1.0' encoding='UTF-8'?>
+<entry xmlns:dcterms="http://purl.org/dc/terms/" xmlns="http://www.w3.org/2005/Atom">
+  <dcterms:title>This is a sample book chapter</dcterms:title>
+  <dcterms:type>book-chapter</dcterms:type>
+  <dcterms:contributor>Jane Doe</dcterms:contributor>
+  <dcterms:contributor>John Smith</dcterms:contributor>
+  <dcterms:identifier>http://example.com/my-book-chapter</dcterms:identifier>
+</entry>
+```
+
+Once your `entry.xml` is created, you can deposit it via `curl` similar to below. In this example, the `entry.xml` file is assumed to be located in the current directory. We are depositing it into a Collection with handle `10673/2` as the Demo Administrator account.
+
+```
+curl -i http://demo.dspace.org/swordv2/collection/10673/2 --data-binary "@entry.xml" -H "Content-Type: application/atom+xml" --user "dspacedemo+admin@gmail.com"
+```
+
+The result will be a new metadata-only Item in DSpace.


### PR DESCRIPTION
Based on discussions around how to test/verify DS-3310:
https://jira.duraspace.org/browse/DS-3310

This PR simply makes README updates:
- Updates SWORDv1 README to use markdown, and minor tweaks for obviously incorrect statements
- Creates a new SWORDv2 README.md which provides basic examples of testing SWORDv2 via `curl`.  These were used in DS-3310 (see comments in that ticket).

This involves no code changes, just README updates. Still, would be worth one other person doing a quick review here.
