### PR TITLE
DS-3340 fix test

### DIFF
--- a/dspace-api/src/test/java/org/dspace/util/MultiFormatDateParserTest.java
+++ b/dspace-api/src/test/java/org/dspace/util/MultiFormatDateParserTest.java
@@ -12,7 +12,6 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
-import org.dspace.AbstractUnitTest;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -24,20 +23,26 @@ import org.junit.runners.Parameterized;
 import static org.junit.Assert.*;
 
 /**
+ * Drive the MultiFormatDateParser from a table of test formats and sample data
+ * using JUnit's Parameterized runner.
  *
  * @author mhwood
  */
 @RunWith(Parameterized.class)
 public class MultiFormatDateParserTest
-        extends AbstractUnitTest
 {
-    private String testMessage;
-    private String toParseDate;
-    private String expectedFormat;
-    private boolean expectedResult;
+	private static Locale vmLocale;
+    private final String testMessage;
+    private final String toParseDate;
+    private final String expectedFormat;
+    private final boolean expectedResult;
 
-
-    public MultiFormatDateParserTest(String testMessage, String toParseDate, String expectedFormat, boolean expectedResult)
+    /**
+     * Test a single date format.
+     * JUnit will instantiate this class repeatedly with data from {@link #dateFormatsToTest}.
+     */
+    public MultiFormatDateParserTest(String testMessage, String toParseDate,
+            String expectedFormat, boolean expectedResult)
     {
         this.testMessage = testMessage;
         this.toParseDate = toParseDate;
@@ -45,6 +50,7 @@ public class MultiFormatDateParserTest
         this.expectedResult = expectedResult;
     }
 
+    /** Date formats and samples to drive the parameterized test. */
     @Parameterized.Parameters
     public static Collection dateFormatsToTest() {
        return Arrays.asList(new Object[][]{
@@ -78,11 +84,49 @@ public class MultiFormatDateParserTest
     @BeforeClass
     public static void setUpClass()
     {
+    	// store default locale of the environment
+    	vmLocale = Locale.getDefault();
+    	// set default locale to English just for the test of this class
+    	Locale.setDefault(Locale.ENGLISH);
+        Map<String, String> formats = new HashMap<>(32);
+        formats.put("\\d{8}" ,"yyyyMMdd");
+        formats.put("\\d{1,2}-\\d{1,2}-\\d{4}", "dd-MM-yyyy");
+        formats.put("\\d{4}-\\d{1,2}-\\d{1,2}", "yyyy-MM-dd");
+        formats.put("\\d{4}-\\d{1,2}", "yyyy-MM");
+        formats.put("\\d{1,2}/\\d{1,2}/\\d{4}", "MM/dd/yyyy");
+        formats.put("\\d{4}/\\d{1,2}/\\d{1,2}", "yyyy/MM/dd");
+        formats.put("\\d{1,2}\\s[a-z]{3}\\s\\d{4}", "dd MMM yyyy");
+        formats.put("\\d{1,2}\\s[a-z]{4,}\\s\\d{4}", "dd MMMM yyyy");
+        formats.put("\\d{12}", "yyyyMMddHHmm");
+        formats.put("\\d{8}\\s\\d{4}", "yyyyMMdd HHmm");
+        formats.put("\\d{1,2}-\\d{1,2}-\\d{4}\\s\\d{1,2}:\\d{2}", "dd-MM-yyyy HH:mm");
+        formats.put("\\d{4}-\\d{1,2}-\\d{1,2}\\s\\d{1,2}:\\d{2}", "yyyy-MM-dd HH:mm");
+        formats.put("\\d{1,2}/\\d{1,2}/\\d{4}\\s\\d{1,2}:\\d{2}", "MM/dd/yyyy HH:mm");
+        formats.put("\\d{4}/\\d{1,2}/\\d{1,2}\\s\\d{1,2}:\\d{2}", "yyyy/MM/dd HH:mm");
+        formats.put("\\d{1,2}\\s[a-z]{3}\\s\\d{4}\\s\\d{1,2}:\\d{2}", "dd MMM yyyy HH:mm");
+        formats.put("\\d{1,2}\\s[a-z]{4,}\\s\\d{4}\\s\\d{1,2}:\\d{2}", "dd MMMM yyyy HH:mm");
+        formats.put("\\d{4}\\s[a-z]{3}\\s\\d{1,2}", "yyyy MMM dd");
+        formats.put("\\d{14}", "yyyyMMddHHmmss");
+        formats.put("\\d{6}", "yyyyMM");
+        formats.put("\\d{4}", "yyyy");
+        formats.put("\\d{8}\\s\\d{6}", "yyyyMMdd HHmmss");
+        formats.put("\\d{1,2}-\\d{1,2}-\\d{4}\\s\\d{1,2}:\\d{2}:\\d{2}", "dd-MM-yyyy HH:mm:ss");
+        formats.put("\\d{4}-\\d{1,2}-\\d{1,2}\\s\\d{1,2}:\\d{2}:\\d{2}", "yyyy-MM-dd HH:mm:ss");
+        formats.put("\\d{1,2}/\\d{1,2}/\\d{4}\\s\\d{1,2}:\\d{2}:\\d{2}", "MM/dd/yyyy HH:mm:ss");
+        formats.put("\\d{4}/\\d{1,2}/\\d{1,2}\\s\\d{1,2}:\\d{2}:\\d{2}", "yyyy/MM/dd HH:mm:ss");
+        formats.put("\\d{1,2}\\s[a-z]{3}\\s\\d{4}\\s\\d{1,2}:\\d{2}:\\d{2}", "dd MMM yyyy HH:mm:ss");
+        formats.put("\\d{1,2}\\s[a-z]{4,}\\s\\d{4}\\s\\d{1,2}:\\d{2}:\\d{2}", "dd MMMM yyyy HH:mm:ss");
+        formats.put("\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{2}:\\d{2}Z", "yyyy-MM-dd'T'HH:mm:ss'Z'");
+        formats.put("\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{2}:\\d{2}\\.\\d{3}Z", "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+
+        new MultiFormatDateParser().setPatterns(formats);
     }
 
     @AfterClass
     public static void tearDownClass()
     {
+    	// restore locale
+    	Locale.setDefault(vmLocale);
     }
 
     @Before
@@ -102,6 +146,7 @@ public class MultiFormatDateParserTest
     public void testParse() throws ParseException
     {
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat(expectedFormat);
+        simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
         Date result = MultiFormatDateParser.parse(toParseDate);
         assertEquals(testMessage, expectedResult, simpleDateFormat.parse(toParseDate).equals(result));
     }

--- a/dspace-rest/src/test/java/org/dspace/rest/common/TestJAXBSchema.java
+++ b/dspace-rest/src/test/java/org/dspace/rest/common/TestJAXBSchema.java
@@ -22,6 +22,8 @@ import javax.xml.transform.stream.StreamResult;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
+import com.google.common.base.CharMatcher;
+
 public class TestJAXBSchema {
 
     private static class TestSchemaOutputResolver extends SchemaOutputResolver {
@@ -61,10 +63,12 @@ public class TestJAXBSchema {
         String res = "org/dspace/rest/common/expected_xsd0.xsd";
         InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(res);
         String expected = IOUtils.toString(is, "UTF-8");
-
+        
+        String expectedRemoveAllSpaces = CharMatcher.BREAKING_WHITESPACE.removeFrom(expected);
+        String writerRemoveAllSpaces = CharMatcher.BREAKING_WHITESPACE.removeFrom(writer.toString());
         // System.err.println(writer.toString());
-
-        assertEquals("JAXB schema", expected, writer.toString());
+        
+        assertEquals("JAXB schema", expectedRemoveAllSpaces, writerRemoveAllSpaces);
     }
 
 }


### PR DESCRIPTION
During preparation of DSpace 5.6 release I encountered two test into failure.
- MultiFormatDateParserTest.java was fixed with the backport of the code from master;
- TestJAXBSchema.java was fixed comparing the two string without newline or space.
