### PR TITLE
DS-3317: Don't autoRelease artifacts to Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -776,7 +776,8 @@
                                  MUST be specified for server 'ossrh' -->
                             <serverId>ossrh</serverId>
                             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <!-- Require manual verification / release to Maven Central -->
+                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
                         </configuration>
                     </plugin>
                     <!-- For new releases, generate Source JAR files -->
@@ -1506,9 +1507,7 @@
     </contributors>
 
     <!--
-      The SCM repository location is used by Continuum to update against
-      when changes have occurred.  This spawns a new build cycle and releases
-      snapshots into the snapshot repository below.
+      Information about the SCM repository where source code exists.
     -->
     <scm>
         <connection>scm:git:git@github.com:DSpace/DSpace.git</connection>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3317

Fix bug accidentally introduced into our 6.x Maven Release process. Ensure we must still manually verify a release before it gets sent out to Maven Central.

These code changes were verified in https://github.com/DSpace/dspace-api-lang/pull/19 , and were used during the `dspace-api-lang` and `dspace-xmlui-lang` 6.0.2 releases.  Just copying them over to our main Parent POM so that we use them in 6.0 final.

@pnbecker and/or @mwoodiupui , could you verify this PR since you were involved in the discussion regarding dspace-api-lang?
