### PR TITLE
DS-3122 Set handle.canonical.prefix to the ${dspace.url}/handle.

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -225,22 +225,21 @@ identifier.doi.namespaceseparator = dspace/
 
 # Canonical Handle URL prefix
 #
-# By default, DSpace is configured to use http://hdl.handle.net/
-# as the canonical URL prefix when generating dc.identifier.uri
-# during submission, and in the 'identifier' displayed in JSPUI
-# item record pages.
-#
-# If you do not subscribe to CNRI's handle service, you can change this
-# to match the persistent URL service you use, or you can force DSpace
-# to use your site's URL, eg.
-#handle.canonical.prefix = ${dspace.url}/handle/
+# Items in DSpace receive a unique URL, stored in dc.identifier.uri
+# after it is generated during the submission process.
+handle.canonical.prefix = ${dspace.url}/handle/
+
+# If you register with CNRI's handle service at http://www.handle.net/,
+# these links can be generated as permalinks using http://hdl.handle.net/
+# as canonical prefix. Please make sure to change handle.canonical.prefix
+# after registering with handle.net by uncommenting one of the following
+# lines, depending if you prefer to use http or https:
+# handle.canonical.prefix = http://hdl.handle.net/
+# handle.canonical.prefix = https://hdl.handle.net/
 #
 # Note that this will not alter dc.identifer.uri metadata for existing
 # items (only for subsequent submissions), but it will alter the URL
 # in JSPUI's 'identifier' message on item record pages for existing items.
-#
-# If omitted, the canonical URL prefix will be http://hdl.handle.net/
-handle.canonical.prefix = http://hdl.handle.net/
 
 # CNRI Handle prefix
 # (Defaults to a dummy/fake prefix of 123456789)

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -138,25 +138,23 @@ db.schema = public
 ########################
 # HANDLE CONFIGURATION #
 ########################
-
+#
 # Canonical Handle URL prefix
 #
-# By default, DSpace is configured to use http://hdl.handle.net/
-# as the canonical URL prefix when generating dc.identifier.uri
-# during submission, and in the 'identifier' displayed in JSPUI
-# item record pages.
-#
-# If you do not subscribe to CNRI's handle service, you can change this
-# to match the persistent URL service you use, or you can force DSpace
-# to use your site's URL, eg.
-#handle.canonical.prefix = ${dspace.url}/handle/
+# Items in DSpace receive a unique URL, stored in dc.identifier.uri
+# after it is generated during the submission process.
+# 
+# If you register with CNRI's handle service at http://www.handle.net/,
+# these links can be generated as permalinks using http://hdl.handle.net/
+# as canonical prefix. Please make sure to change handle.canonical.prefix
+# after registering with handle.net by uncommenting one of the following
+# lines, depending if you prefer to use http or https:
+# handle.canonical.prefix = http://hdl.handle.net/
+# handle.canonical.prefix = https://hdl.handle.net/
 #
 # Note that this will not alter dc.identifer.uri metadata for existing
-# items (only for subsequent submissions), but it will alter the URL 
+# items (only for subsequent submissions), but it will alter the URL
 # in JSPUI's 'identifier' message on item record pages for existing items.
-#
-# If omitted, the canonical URL prefix will be http://hdl.handle.net/
-#handle.canonical.prefix = http://hdl.handle.net/
 
 # CNRI Handle prefix
 # (Defaults to a dummy/fake prefix of 123456789)


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3112

DS-3112 suggest to change our default handle configuration. @bram-atmire created #1344 to resolve it by changing handle.canonical.prefix and handle.prefix. In the PR discussion it became clear that changing handle.prefix has some bigger implications inside and outside of DSpace (we should search code that looks out for 123456789 as handle prefix). Nevertheless the idea of changing handle.canonical.prefix is a good one.
This PR changes handle.canonical.prefix but leaves handle.prefix as it was in previous versions of DSpace. With this configuration valid URLs will be added in dc.identifier.uri and following in the OAI-PMH interface. Beside that it has much less implications as it does not change handle.prefix. I think we should merge this PR before DSpace 6.0 and may discuss later whether we also want to change handle.prefix.
