### PR TITLE
[DS-3322] Prevent concurrent modification exception in Undo Bulk Ingest

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -561,10 +561,16 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
     {
         if (!isTest)
         {
+            ArrayList<Collection> removeList = new ArrayList<>();
             List<Collection> collections = myitem.getCollections();
 
-            // Remove item from all the collections it's in
+            // Save items to be removed to prevent concurrent modification exception DS-3322
             for (Collection collection : collections) {
+                removeList.add(collection);
+            }
+
+            // Remove item from all the collections it's in
+            for (Collection collection : removeList) {
                 collectionService.removeItem(c, collection, myitem);
             }
         }


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3322

This patch fixed the issue in my test instance.

Does DSpace have a preferred approach to avoid this issue?
