### PR TITLE
DS-3311: Changing default configuration of healthcheck

### DIFF
--- a/dspace/config/modules/healthcheck.cfg
+++ b/dspace/config/modules/healthcheck.cfg
@@ -1,9 +1,11 @@
 ### Healthcheck module config
 
-# names must match plugin.named below
+# You can configure which module should be used during healthcheck.
+# Names must match plugin.named below.
+# If you use the Pre-DSpace-3.0 embargo feature, you might want to
+# add 'Embargo items (Pre-3.0),' to the following list.
 healthcheck.checks = General Information,\
     Checksum,\
-    Embargo items (Pre-3.0),\
     Item summary,\
     User summary,\
     Log Analyser Check


### PR DESCRIPTION
Healthcheck can check for passed Pre-3.0-embargos. These are disabled in DSpace out of the box in favor for Past-3.0-embargos. This PR just changes the configuration of the healthcheck to disable the pre-3.0-embargo check.
