### PR TITLE
[DS-3348] Drop date check in EmbargoService

### DIFF
--- a/dspace-api/src/main/java/org/dspace/embargo/EmbargoServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/embargo/EmbargoServiceImpl.java
@@ -138,13 +138,11 @@ public class EmbargoServiceImpl implements EmbargoService
                             + result.toString());
         }
 
-        // sanity check: do not allow an embargo lift date in the past.
-        if (liftDate.before(new Date()))
-        {
-            throw new IllegalArgumentException(
-                    "Embargo lift date must be in the future, but this is in the past: "
-                            + result.toString());
-        }
+        /*
+         *  DS-3348 In DSpace 5x and prior, this method returned an IllegalArgumentException if the lift date was in the past.
+         *  This exception was being triggered when performing an AIP restored which is not desirable.
+         *  In XMLUI, the date check (if needed) should be performed in the EmbargoSetter
+         */
         return result;
     }
 

--- a/dspace-api/src/main/java/org/dspace/embargo/EmbargoServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/embargo/EmbargoServiceImpl.java
@@ -139,9 +139,8 @@ public class EmbargoServiceImpl implements EmbargoService
         }
 
         /*
-         *  DS-3348 In DSpace 5x and prior, this method returned an IllegalArgumentException if the lift date was in the past.
-         *  This exception was being triggered when performing an AIP restored which is not desirable.
-         *  In XMLUI, the date check (if needed) should be performed in the EmbargoSetter
+         * NOTE: We do not check here for past dates as it can result in errors during AIP restoration. 
+         * Therefore, UIs should perform any such date validation on input. See DS-3348
          */
         return result;
     }


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3348
### Impacts of this Change

With this change in place, an AIP restore will succeed with a lift date in the past.

In XMLUI, with this change, an item will be created with a lift date in the past.  Bitstreams will be added with an effective READ date in the past.
### XMLUI Behavior without this change

Without this patch and the DefaultEmbargoSetter, the item submission fails at the end of item submission.  The user must use the back button to recover from this error.

Embargo lift date must be in the future, but this is in the past: 2011-04-04
Go to DSpace home

Please contact the site administrator if you wish to report this error. If possible, please provide details about what you were doing at the time this error occurred.

Contact site administrator || Show underlying error stack

Java stacktrace: 
java.lang.IllegalArgumentException: Embargo lift date must be in the future, but this is in the past: 2011-04-04
    at org.dspace.embargo.EmbargoServiceImpl.getEmbargoTermsAsDate(EmbargoServiceImpl.java:144)
    at org.dspace.content.InstallItemServiceImpl.populateMetadata(InstallItemServiceImpl.java:157)
    at org.dspace.content.InstallItemServiceImpl.installItem(InstallItemServiceImpl.java:77)
    at org.dspace.content.InstallItemServiceImpl.installItem(InstallItemServiceImpl.java:56)
    at org.dspace.workflowbasic.BasicWorkflowServiceImpl.archive(BasicWorkflowServiceImpl.java:656)
