### PR TITLE
DS-3358 corrects display of author name in browsing while working with authority

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/BrowseListTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/BrowseListTag.java
@@ -532,24 +532,26 @@ public class BrowseListTag extends TagSupport
                             	{
                                     String argument;
                                     String value;
+                                    String authorityArgument = null;
+                                    String authorityValue = null;
                                     if (metadataArray[j].authority != null &&
                                             metadataArray[j].confidence >= MetadataAuthorityManager.getManager()
                                                 .getMinConfidence(metadataArray[j].schema, metadataArray[j].element, metadataArray[j].qualifier))
                                     {
-                                        argument = "authority";
-                                        value = metadataArray[j].authority;
+                                        authorityArgument = "authority";
+                                        authorityValue = metadataArray[j].authority;
                                     }
-                                    else
-                                    {
                                         argument = "value";
                                         value = metadataArray[j].value;
-                                    }
                             		if (viewFull[colIdx])
                             		{
                             			argument = "vfocus";
                             		}
                             		startLink = "<a href=\"" + hrq.getContextPath() + "/browse?type=" + browseType[colIdx] + "&amp;" +
                                         argument + "=" + URLEncoder.encode(value,"UTF-8");
+                                        if (authorityArgument != null && authorityValue != null) {
+                                            startLink += "&amp;" + authorityArgument + "=" + URLEncoder.encode(authorityValue,"UTF-8");
+                                        }
 
                                     if (metadataArray[j].language != null)
                                     {

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemListTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemListTag.java
@@ -497,24 +497,26 @@ public class ItemListTag extends TagSupport
                                 {
                                     String argument;
                                     String value;
+                                    String authorityArgument = null;
+                                    String authorityValue = null;
                                     if (metadataArray[j].authority != null &&
                                             metadataArray[j].confidence >= MetadataAuthorityManager.getManager()
                                                 .getMinConfidence(metadataArray[j].schema, metadataArray[j].element, metadataArray[j].qualifier))
                                     {
-                                        argument = "authority";
-                                        value = metadataArray[j].authority;
+                                        authorityArgument = "authority";
+                                        authorityValue = metadataArray[j].authority;
                                     }
-                                    else
-                                    {
-                                        argument = "value";
-                                        value = metadataArray[j].value;
-                                    }
+                                    argument = "value";
+                                    value = metadataArray[j].value;
                                     if (viewFull[colIdx])
                                     {
                                         argument = "vfocus";
                                     }
                                     startLink = "<a href=\"" + hrq.getContextPath() + "/browse?type=" + browseType[colIdx] + "&amp;" +
                                         argument + "=" + URLEncoder.encode(value,"UTF-8");
+                                    if (authorityArgument != null && authorityValue != null) {
+                                        startLink += "&amp;" + authorityArgument + "=" + URLEncoder.encode(authorityValue,"UTF-8");
+                                    }
 
                                     if (metadataArray[j].language != null)
                                     {

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemTag.java
@@ -594,22 +594,26 @@ public class ItemTag extends TagSupport
                         else if (browseIndex != null)
                         {
 	                        String argument, value;
+                                String authorityArgument = null;
+                                String authorityValue = null;
 	                        if ( values[j].authority != null &&
 	                                            values[j].confidence >= MetadataAuthorityManager.getManager()
 	                                                .getMinConfidence( values[j].schema,  values[j].element,  values[j].qualifier))
 	                        {
-	                            argument = "authority";
-	                            value = values[j].authority;
+                                    authorityArgument = "authority";
+	                            authorityValue = values[j].authority;
 	                        }
-	                        else
-	                        {
-	                            argument = "value";
-	                            value = values[j].value;
-	                        }
-	                    	out.print("<a class=\"" + ("authority".equals(argument)?"authority ":"") + browseIndex + "\""
+                                argument = "value";
+                                value = values[j].value;
+	                        String linkString = "<a class=\"" + ("authority".equals(argument)?"authority ":"") + browseIndex + "\""
 	                                                + "href=\"" + request.getContextPath() + "/browse?type=" + browseIndex + "&amp;" + argument + "="
-	                    				+ URLEncoder.encode(value, "UTF-8") + "\">" + Utils.addEntities(values[j].value)
-	                    				+ "</a>");
+	                    				+ URLEncoder.encode(value, "UTF-8");
+                                if (authorityArgument != null && authorityValue != null) {
+                                    linkString += "&amp;" + authorityArgument + "=" + URLEncoder.encode(authorityValue,"UTF-8");
+                                }
+                                linkString += "\">" + Utils.addEntities(values[j].value)
+	                    				+ "</a>";
+                                out.print(linkString);
 	                    }
                         else
                         {

--- a/dspace-jspui/src/main/webapp/browse/full.jsp
+++ b/dspace-jspui/src/main/webapp/browse/full.jsp
@@ -96,6 +96,7 @@
 	String direction = (bi.isAscending() ? "ASC" : "DESC");
 	
 	String argument = null;
+        String displayValue = bi.getValue();
 	if (bi.hasAuthority())
     {
         value = bi.getAuthority();
@@ -177,7 +178,7 @@
 
 	<%-- Build the header (careful use of spacing) --%>
 	<h2>
-		<fmt:message key="browse.full.header"><fmt:param value="<%= scope %>"/></fmt:message> <fmt:message key="<%= typeKey %>"/> <%= value %>
+		<fmt:message key="browse.full.header"><fmt:param value="<%= scope %>"/></fmt:message> <fmt:message key="<%= typeKey %>"/> <%= displayValue %>
 	</h2>
 
 	<%-- Include the main navigation for all the browse pages --%>

--- a/dspace-jspui/src/main/webapp/browse/single.jsp
+++ b/dspace-jspui/src/main/webapp/browse/single.jsp
@@ -275,7 +275,7 @@
     {
 %>
                 <li class="list-group-item">
-                    <a href="<%= sharedLink %><% if (results[i][1] != null) { %>&amp;authority=<%= URLEncoder.encode(results[i][1], "UTF-8") %>" class="authority <%= bix.getName() %>"><%= Utils.addEntities(results[i][0]) %></a> <% } else { %>&amp;value=<%= URLEncoder.encode(results[i][0], "UTF-8") %>"><%= Utils.addEntities(results[i][0]) %></a> <% } %>
+                    <a href="<%= sharedLink %><% if (results[i][1] != null) { %>&amp;authority=<%= URLEncoder.encode(results[i][1], "UTF-8") %>&amp;value=<%= URLEncoder.encode(results[i][0], "UTF-8") %>" class="authority <%= bix.getName() %>"><%= Utils.addEntities(results[i][0]) %></a> <% } else { %>&amp;value=<%= URLEncoder.encode(results[i][0], "UTF-8") %>"><%= Utils.addEntities(results[i][0]) %></a> <% } %>
 					<%= StringUtils.isNotBlank(results[i][2])?" <span class=\"badge\">"+results[i][2]+"</span>":""%>
                 </li>
 <%


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3358

In DSpace browsing authors shows the authority key instead of a human readable name, if this person has an authority key. This PR fixes this issue in JSPUI. 
