### PR TITLE
[DS-3282] Fix js error for filters with dashes

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/discovery/discovery.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/discovery/discovery.xsl
@@ -443,9 +443,14 @@
                     }
                 </xsl:text>
                 <xsl:for-each select="dri:option">
-                    <xsl:text>window.DSpace.i18n.discovery.</xsl:text><xsl:value-of select="$filter_name"/>
-                    <xsl:text>.</xsl:text><xsl:value-of select="@returnValue"/><xsl:text>='</xsl:text><xsl:copy-of select="./*"/><xsl:text>';</xsl:text>
-                </xsl:for-each>
+                    <xsl:text>window.DSpace.i18n.discovery.</xsl:text>
+                    <xsl:value-of select="$filter_name"/>
+                    <xsl:text>['</xsl:text>
+                    <xsl:value-of select="@returnValue"/>
+                    <xsl:text>']='</xsl:text>
+                    <xsl:copy-of select="./*"/>
+                    <xsl:text>';</xsl:text>
+                 </xsl:for-each>
             </xsl:for-each>
         </script>
     </xsl:template>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3282
### To reproduce the error
1. In discovery.xml, change the indexFieldName to contain a dash
   `<property name="indexFieldName" value="my-title"/>`
2. Update the relevant entries in messages.xml for that search filter (optional)
3. Re-index your site
4. Perform a search in XMLUI
5. Display advanced search
6. Note that no filters are present
### The fix

Deploy this XSL change and repeat the search above, the search filters should be visible
