### PR TITLE
DS-3345 Add sql script from dspace 5.6

### DIFF
--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V5.6_2016.08.23__DS-3097.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V5.6_2016.08.23__DS-3097.sql
@@ -1,0 +1,24 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+------------------------------------------------------
+-- DS-3097 introduced new action id for WITHDRAWN_READ 
+------------------------------------------------------
+
+UPDATE resourcepolicy SET action_id = 12 where action_id = 0 and resource_type_id = 0 and resource_id in (
+	SELECT bundle2bitstream.bitstream_id FROM bundle2bitstream
+		LEFT JOIN item2bundle ON bundle2bitstream.bundle_id = item2bundle.bundle_id
+		LEFT JOIN item ON item2bundle.item_id = item.item_id
+		WHERE item.withdrawn = 1
+);
+
+UPDATE resourcepolicy SET action_id = 12 where action_id = 0 and resource_type_id = 1 and resource_id in (
+	SELECT item2bundle.bundle_id FROM item2bundle
+		LEFT JOIN item ON item2bundle.item_id = item.item_id
+		WHERE item.withdrawn = 1
+);

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V5.6_2016.08.23__DS-3097.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V5.6_2016.08.23__DS-3097.sql
@@ -1,0 +1,24 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+------------------------------------------------------
+-- DS-3097 introduced new action id for WITHDRAWN_READ 
+------------------------------------------------------
+
+UPDATE resourcepolicy SET action_id = 12 where action_id = 0 and resource_type_id = 0 and resource_id in (
+	SELECT bundle2bitstream.bitstream_id FROM bundle2bitstream
+		LEFT JOIN item2bundle ON bundle2bitstream.bundle_id = item2bundle.bundle_id
+		LEFT JOIN item ON item2bundle.item_id = item.item_id
+		WHERE item.withdrawn = 1
+);
+
+UPDATE resourcepolicy SET action_id = 12 where action_id = 0 and resource_type_id = 1 and resource_id in (
+	SELECT item2bundle.bundle_id FROM item2bundle
+		LEFT JOIN item ON item2bundle.item_id = item.item_id
+		WHERE item.withdrawn = 1
+);

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V5.6_2016.08.23__DS-3097.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V5.6_2016.08.23__DS-3097.sql
@@ -1,0 +1,24 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+------------------------------------------------------
+-- DS-3097 introduced new action id for WITHDRAWN_READ 
+------------------------------------------------------
+
+UPDATE resourcepolicy SET action_id = 12 where action_id = 0 and resource_type_id = 0 and resource_id in (
+	SELECT bundle2bitstream.bitstream_id FROM bundle2bitstream
+		LEFT JOIN item2bundle ON bundle2bitstream.bundle_id = item2bundle.bundle_id
+		LEFT JOIN item ON item2bundle.item_id = item.item_id
+		WHERE item.withdrawn = true
+);
+
+UPDATE resourcepolicy SET action_id = 12 where action_id = 0 and resource_type_id = 1 and resource_id in (
+	SELECT item2bundle.bundle_id FROM item2bundle
+		LEFT JOIN item ON item2bundle.item_id = item.item_id
+		WHERE item.withdrawn = true
+);


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3345

I don't remove the V6.0_2016.08.23__DS-3097.sql because
- it doesn't create any trouble to user that move from <= dspace 5 to DSpace 6 (it is a noop)
- it allows user that are using DSpace 6RC to easy migrate to the official DSpace 6 release (the 6.0 release has take so long that I guess many are using in their working progress project the RC version)

Please note that I have decided to not include the 4.7 sql script as
- it is unknown by flyway (not in DSpace 5.x)
- rerun the DSpace 5.6 and DSpace 6.0 sql script will cause no trouble (noop) to user that come from DSpace 4.7
- user that have installed a 4.7 could have missed to run (manually) the fix sql file so this give more guarantee

I have succesful tested the migration from 4.6, 4.7 and 5.6 previous installations
