### PR TITLE
DS-3357 rethrow AuthorizationException in the SubmissionControl

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SubmissionController.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SubmissionController.java
@@ -526,6 +526,10 @@ public class SubmissionController extends DSpaceServlet
                 context.complete();
             }
         }
+        catch (AuthorizeException ae)
+        {
+        	throw ae;
+        }
         catch (Exception e)
         {
             log.error("Error loading step class'" + currentStepConfig.getProcessingClassName() + "':", e);


### PR DESCRIPTION
Small fix to allow the SubmissionController to rethrow authorization excpetion throws performing  by submission steps

https://jira.duraspace.org/browse/DS-3357
