### PR TITLE
DS-3360 Anonymize policy groups on collection DEFAULT_READ deletion

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
@@ -598,6 +598,13 @@ public class AuthorizeServiceImpl implements AuthorizeService
     }
 
     @Override
+    public void anonymizeGroupPolicies(Context c, Group group)
+            throws SQLException
+    {
+        resourcePolicyService.anonymizeGroupPolicies(c, group);
+    }
+
+    @Override
     public void removeGroupPolicies(Context c, Group group)
             throws SQLException
     {

--- a/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
@@ -241,6 +241,11 @@ public class ResourcePolicyServiceImpl implements ResourcePolicyService
     }
 
     @Override
+    public void anonymizeGroupPolicies(Context c, Group group) throws SQLException {
+        resourcePolicyDAO.anonymizeByGroup(c, group);
+    }
+
+    @Override
     public void removeGroupPolicies(Context c, Group group) throws SQLException {
         resourcePolicyDAO.deleteByGroup(c, group);
     }

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
@@ -38,6 +38,8 @@ public interface ResourcePolicyDAO extends GenericDAO<ResourcePolicy> {
     
     public List<ResourcePolicy> findByEPersonGroupTypeIdAction(Context context, EPerson e, List<Group> groups, int action, int type_id) throws SQLException;
 
+    public void anonymizeByGroup(Context context, Group group) throws SQLException;
+
     public void deleteByDso(Context context, DSpaceObject dso) throws SQLException;
 
     public void deleteByDsoAndAction(Context context, DSpaceObject dso, int actionId) throws SQLException;

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
@@ -107,6 +107,14 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
      }
 
     @Override
+    public void anonymizeByGroup(Context context, Group group) throws SQLException {
+        String queryString = "update ResourcePolicy set epersonGroup= (select id from Group where name='Anonymous') where epersonGroup= :epersonGroup";
+        Query query = createQuery(context, queryString);
+        query.setParameter("epersonGroup", group);
+        query.executeUpdate();
+    }
+
+    @Override
     public void deleteByDso(Context context, DSpaceObject dso) throws SQLException
     {
         String queryString = "delete from ResourcePolicy where dSpaceObject= :dSpaceObject";

--- a/dspace-api/src/main/java/org/dspace/authorize/service/AuthorizeService.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/service/AuthorizeService.java
@@ -349,6 +349,16 @@ public interface AuthorizeService {
     public void removePoliciesActionFilter(Context context, DSpaceObject dso, int actionID) throws SQLException, AuthorizeException;
 
     /**
+     * Anonymizes all policies relating to a particular group. FIXME doesn't check
+     * authorization
+     *
+     * @param c current context
+     * @param group the group
+     * @throws SQLException if there's a database problem
+     */
+    public void anonymizeGroupPolicies(Context c, Group group) throws SQLException;
+
+    /**
      * Removes all policies relating to a particular group. FIXME doesn't check
      * authorization
      *

--- a/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
@@ -55,6 +55,8 @@ public interface ResourcePolicyService extends DSpaceCRUDService<ResourcePolicy>
 
     public void removeDsoEPersonPolicies(Context context, DSpaceObject dso, EPerson ePerson) throws SQLException, AuthorizeException;
 
+    public void anonymizeGroupPolicies(Context c, Group group) throws SQLException;
+
     public void removeGroupPolicies(Context c, Group group) throws SQLException;
 
     public void removeDsoAndTypeNotEqualsToPolicies(Context c, DSpaceObject o, String type) throws SQLException, AuthorizeException;

--- a/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
@@ -335,6 +335,11 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
 
     @Override
     public void delete(Context context, Group group) throws SQLException {
+        delete(context, group, false);
+    }
+
+    @Override
+    public void delete(Context context, Group group, boolean anonymizePolicies) throws SQLException {
         if (group.isPermanent())
         {
             log.error("Attempt to delete permanent Group $", group.getName());
@@ -348,7 +353,11 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
         group.getSupervisedItems().clear();
 
         // Remove any ResourcePolicies that reference this group
-        authorizeService.removeGroupPolicies(context, group);
+        if (anonymizePolicies) {
+            authorizeService.anonymizeGroupPolicies(context, group);
+        } else {
+            authorizeService.removeGroupPolicies(context, group);
+        }
 
         group.getMemberGroups().clear();
         group.getParentGroups().clear();

--- a/dspace-api/src/main/java/org/dspace/eperson/service/GroupService.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/service/GroupService.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.eperson.service;
 
+import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
 
@@ -290,4 +291,6 @@ public interface GroupService extends DSpaceObjectService<Group>, DSpaceObjectLe
      * @throws SQLException database exception
      */
     List<Group> findByMetadataField(Context context, String searchValue, MetadataField metadataField) throws SQLException;
+
+    public void delete(Context context, Group group, boolean anonymizePolicies) throws SQLException, AuthorizeException, IOException;
 }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowContainerUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowContainerUtils.java
@@ -697,7 +697,8 @@ public class FlowContainerUtils
 		Group anonymous = groupService.findByName(context, Group.ANONYMOUS);
 		
 		// Delete the old role, this will remove the default privileges.
-		groupService.delete(context, defaultRead);
+		authorizeService.removeGroupPolicies(context, collection, defaultRead);
+		groupService.delete(context, defaultRead, true);
 		
 		// Set anonymous as the default read group.
 		authorizeService.addPolicy(context, collection, Constants.DEFAULT_ITEM_READ, anonymous);


### PR DESCRIPTION
Fix for bug [DS-3360](https://jira.duraspace.org/browse/DS-3360?filter=-2).
### Description

A bug has been present in DSpace since at least 4.0 where the deletion of a Collection's DEFAULT_READ policy Group results in Items, Bundles, and Bitstreams contained within the Collection which now have no policies (instead of Anonymous policies).

The cause of this issue has been `FlowContainerUtils.changeCollectionDefaultReadToAnonymous`. The method calls for the Collection's DEFAULT_READ Group to be deleted, but this has the negative effect of also deleting _ALL_ policies pertaining to this Group. As stated, the end result is a set of Items, Bundles, and Bitstreams (which had previously inherited this Collection's policy Group) which now have no policies. This can cause major issues with DSpace, which usually assumes the presence of an Anonymous policy at the very least.
### Solution

Rather than remove all policies, the policies pertaining to this Group should be replaced with Anonymous policies, instead. The process of removing all policies and then re-adding Anonymous policies to all objects within the Collection could be very costly. So, it is better to simply [replace](https://github.com/DSpace/DSpace/pull/1558/commits/d18532b259bcfc98d706d968457cdfe1b2fd8d2e#diff-3cfb715ac300b2a8cf012d3745ca305dR111) the policy Group of existing policies with the Anonymous Group.

I found the best place to hook this capability into was within `GroupService.delete`. A new service method was [added](https://github.com/DSpace/DSpace/pull/1558/commits/d18532b259bcfc98d706d968457cdfe1b2fd8d2e#diff-e2954cc0ab5dfabee6ae6d382b1fce82R342) which is the same as the previous `delete` method, but accepts an additional boolean parameter which designates if policies should be anonymized (or deleted). The [old](https://github.com/DSpace/DSpace/pull/1558/commits/d18532b259bcfc98d706d968457cdfe1b2fd8d2e#diff-e2954cc0ab5dfabee6ae6d382b1fce82R338) `delete` method simple calls this new method with false, resulting in the usual policy deletion. `FlowContainerUtils.changeCollectionDefaultReadToAnonymous` now [calls](https://github.com/DSpace/DSpace/pull/1558/commits/d18532b259bcfc98d706d968457cdfe1b2fd8d2e#diff-cdd2fa81c3604f94b46109a11d2c3995R701) this method with true, resulting in anonymous policies instead of empty ones. 

While testing, I noticed that the group was being deleted, but was still showing up when the page reloaded. This was resolved by [removing](https://github.com/DSpace/DSpace/pull/1558/commits/d18532b259bcfc98d706d968457cdfe1b2fd8d2e#diff-cdd2fa81c3604f94b46109a11d2c3995R700) the Collection's policy rather than anonymizing it.
