### PR TITLE
DS-3387 ORCID/SolrAuthority Lookup button doesn't work in Mirage2

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/bower.json
+++ b/dspace-xmlui-mirage2/src/main/webapp/bower.json
@@ -7,7 +7,7 @@
         "jquery": "~1.10.2",
         "jquery-ui": "1.10.3",
         "jqueryuibootstrap": "4f3772cd37b898f456c0126c4b44178ce8d4aad7",
-        "handlebars": "2.0.0",
+        "handlebars": "4.0.0",
         "respond": "1.4.2",
         "html5shiv": "3.7.2",
         "holderjs": "2.4.1",


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3387

updating handlebars reportedly resolves the problem