### PR TITLE
DS-2302 license headers cleanup

### DIFF
--- a/dspace/config/crosswalks/DIM2DataCite.xsl
+++ b/dspace/config/crosswalks/DIM2DataCite.xsl
@@ -5,7 +5,7 @@
     Created on : January 23, 2013, 1:26 PM
     Updated on : November 26, 2015, 3:00 PM
     Author     : pbecker, ffuerste
-    Description: Converts metadata from DSpace Intermediat Format (DIM) into
+    Description: Converts metadata from DSpace Intermediate Format (DIM) into
                  metadata following the DataCite Schema for the Publication and
                  Citation of Research Data, Version 3.1
 -->

--- a/dspace/config/crosswalks/DIM2EZID.xsl
+++ b/dspace/config/crosswalks/DIM2EZID.xsl
@@ -5,7 +5,7 @@
     Created on : January 23, 2013, 1:26 PM
     Updated on : November 26, 2015, 3:00 PM
     Author     : pbecker, ffuerste
-    Description: Converts metadata from DSpace Intermediat Format (DIM) into
+    Description: Converts metadata from DSpace Intermediate Format (DIM) into
                  metadata following the DataCite Schema for the Publication and
                  Citation of Research Data, Version 3.1, for use with EZID.
                  Copied from DIM2DataCite.xsl, with small changes.

--- a/dspace/config/crosswalks/mods.properties
+++ b/dspace/config/crosswalks/mods.properties
@@ -1,10 +1,6 @@
 # Default MODS crosswalk configuration file.  See class
 #  org.dspace.content.crosswalk.MODSDisseminationCrosswalk for details.
 #
-# Revision: $Revision$
-#
-# Date:     $Date$
-#
 dc.contributor = <mods:name><mods:namePart>%s</mods:namePart></mods:name> | mods:namePart/text()
 dc.contributor.advisor = <mods:name><mods:role><mods:roleTerm type="text">advisor</mods:roleTerm></mods:role><mods:namePart>%s</mods:namePart></mods:name> | mods:namePart/text()
 dc.contributor.author = <mods:name><mods:role><mods:roleTerm type="text">author</mods:roleTerm></mods:role><mods:namePart>%s</mods:namePart></mods:name> | mods:namePart/text()

--- a/dspace/config/crosswalks/oai/metadataFormats/didl.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/didl.xsl
@@ -1,18 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- 
-
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-	Developed by DSpace @ Lyncode (dspace at lyncode dot com)
-	
-	> http://www.openarchives.org/OAI/2.0/oai_dc.xsd
-
- -->
-<xsl:stylesheet 
+<!-- http://www.openarchives.org/OAI/2.0/oai_dc.xsd -->
+<xsl:stylesheet
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	xmlns:doc="http://www.lyncode.com/xoai"
 	version="1.0">

--- a/dspace/config/crosswalks/oai/metadataFormats/dim.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/dim.xsl
@@ -1,13 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- 
-
-	The contents of this file are subject to the license and copyright detailed 
-	in the LICENSE and NOTICE files at the root of the source tree and available 
-	online at http://www.dspace.org/license/ 
-	
-	Developed by DSpace @ Lyncode (dspace at lyncode dot com) 
-	
--->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:doc="http://www.lyncode.com/xoai"
                 xmlns:dim="http://www.dspace.org/xmlns/dspace/dim" version="1.0">

--- a/dspace/config/crosswalks/oai/metadataFormats/etdms.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/etdms.xsl
@@ -1,15 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- 
-
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-	Developed by DSpace @ Lyncode (dspace at lyncode dot com)
-
- -->
 <xsl:stylesheet 
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	xmlns:doc="http://www.lyncode.com/xoai"

--- a/dspace/config/crosswalks/oai/metadataFormats/junii2.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/junii2.xsl
@@ -1,14 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!--
-
-  The contents of this file are subject to the license and copyright
-  detailed in the LICENSE and NOTICE files at the root of the source
-  tree and available online at
-
-  http://www.dspace.org/license/
-  Developed by Keiji Suzuki
-
- -->
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:doc="http://www.lyncode.com/xoai"

--- a/dspace/config/crosswalks/oai/metadataFormats/marc.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/marc.xsl
@@ -1,17 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- 
-
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-	Developed by DSpace @ Lyncode (dspace at lyncode dot com)
-	
-	> http://www.loc.gov/marc/bibliographic/ecbdlist.html
-
- -->
+<!-- http://www.loc.gov/marc/bibliographic/ecbdlist.html -->
 <xsl:stylesheet 
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	xmlns:doc="http://www.lyncode.com/xoai"

--- a/dspace/config/crosswalks/oai/metadataFormats/mets.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/mets.xsl
@@ -1,17 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- 
-
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-    
-	Developed by DSpace @ Lyncode (dspace at lyncode dot com)
-	
-	>  http://www.loc.gov/standards/mets/mets.xsd
--->
+<!-- http://www.loc.gov/standards/mets/mets.xsd -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	xmlns:doc="http://www.lyncode.com/xoai" 
     xmlns:date="http://exslt.org/dates-and-times" 

--- a/dspace/config/crosswalks/oai/metadataFormats/mods.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/mods.xsl
@@ -1,15 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- 
-
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-	Developed by DSpace @ Lyncode (dspace at lyncode dot com)
-
- -->
 <xsl:stylesheet 
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	xmlns:doc="http://www.lyncode.com/xoai"

--- a/dspace/config/crosswalks/oai/metadataFormats/oai_dc.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/oai_dc.xsl
@@ -1,17 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- 
-
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-	Developed by DSpace @ Lyncode (dspace at lyncode dot com)
-	
-	> http://www.openarchives.org/OAI/2.0/oai_dc.xsd
-
- -->
+<!--  http://www.openarchives.org/OAI/2.0/oai_dc.xsl-->
 <xsl:stylesheet 
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	xmlns:doc="http://www.lyncode.com/xoai"

--- a/dspace/config/crosswalks/oai/metadataFormats/ore.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/ore.xsl
@@ -1,15 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- 
-
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-	Developed by DSpace @ Lyncode (dspace at lyncode dot com)
-
- -->
 <xsl:stylesheet 
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	xmlns:doc="http://www.lyncode.com/xoai"

--- a/dspace/config/crosswalks/oai/metadataFormats/qdc.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/qdc.xsl
@@ -1,17 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- 
-
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-	Developed by DSpace @ Lyncode <jmelo@lyncode.com>
-	
-	> http://www.openarchives.org/OAI/2.0/oai_dc.xsd
-
- -->
+<!-- http://www.openarchives.org/OAI/2.0/oai_dc.xsd -->
 <xsl:stylesheet 
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	xmlns:doc="http://www.lyncode.com/xoai"

--- a/dspace/config/crosswalks/oai/metadataFormats/rdf.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/rdf.xsl
@@ -1,15 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- 
-
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-	Developed by DSpace @ Lyncode (dspace at lyncode dot com)
-
- -->
 <xsl:stylesheet 
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	xmlns:doc="http://www.lyncode.com/xoai"

--- a/dspace/config/crosswalks/oai/metadataFormats/uketd_dc.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/uketd_dc.xsl
@@ -1,15 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!--
-
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-    Developed by DSpace @ Lyncode (dspace at lyncode dot com)
-
- -->
 <xsl:stylesheet
         xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
         xmlns:doc="http://www.lyncode.com/xoai"

--- a/dspace/config/crosswalks/oai/metadataFormats/xoai.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/xoai.xsl
@@ -1,16 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- 
-
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-
-	Developed by DSpace @ Lyncode (dspace at lyncode dot com) 
-
- -->
 <xsl:stylesheet 
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	xmlns:doc="http://www.lyncode.com/xoai"

--- a/dspace/config/crosswalks/oai/transformers/driver.xsl
+++ b/dspace/config/crosswalks/oai/transformers/driver.xsl
@@ -1,18 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
-
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-    
-	Developed by DSpace @ Lyncode (dspace at lyncode dot com) 
-	Following Driver Guidelines 2.0:
-		- http://www.driver-support.eu/managers.html#guidelines
-
- -->
+<!-- Following Driver Guidelines 2.0: http://www.driver-support.eu/managers.html#guidelines -->
 <xsl:stylesheet version="1.0"
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:doc="http://www.lyncode.com/xoai">
 	<xsl:output indent="yes" method="xml" omit-xml-declaration="yes" />

--- a/dspace/config/crosswalks/oai/transformers/openaire.xsl
+++ b/dspace/config/crosswalks/oai/transformers/openaire.xsl
@@ -1,17 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-
-	Developed by DSpace @ Lyncode (dspace at lyncode dot com) 
-	Following OpenAIRE Guidelines 1.1:
-		- http://www.openaire.eu/component/content/article/207
-
- -->
+<!-- Following OpenAIRE Guidelines 1.1: http://www.openaire.eu/component/content/article/207 -->
 <xsl:stylesheet version="1.0"
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:doc="http://www.lyncode.com/xoai">
 	<xsl:output indent="yes" method="xml" omit-xml-declaration="yes" />

--- a/dspace/config/crosswalks/oai/xoai.xml
+++ b/dspace/config/crosswalks/oai/xoai.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-
-	Developed by DSpace @ Lyncode (dspace at lyncode dot com)
- -->
 <Configuration indented="false" maxListIdentifiersSize="100" maxListRecordsSize="100"
                maxListSetsSize="100" stylesheet="static/style.xsl"
                xmlns="http://www.lyncode.com/XOAIConfiguration">

--- a/dspace/config/crosswalks/sample-crosswalk-DIM2DC.xsl
+++ b/dspace/config/crosswalks/sample-crosswalk-DIM2DC.xsl
@@ -12,10 +12,6 @@
 
         This is only fit for a simple smoke test of the XSLT-based
         crosswalk plugin, do not use it for anthing more serious.
-
- Revision: $Revision$
- Date:     $Date$
-
  -->
 
         <xsl:template match="@* | node()">

--- a/dspace/config/crosswalks/sword-swap-ingest.xsl
+++ b/dspace/config/crosswalks/sword-swap-ingest.xsl
@@ -1,42 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- sord-swap-ingest.xsl
- * 
- * Copyright (c) 2007, Aberystwyth University
- *
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- *  - Redistributions of source code must retain the above
- *    copyright notice, this list of conditions and the
- *    following disclaimer.
- *
- *  - Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- *
- *  - Neither the name of the Centre for Advanced Software and
- *    Intelligent Systems (CASIS) nor the names of its
- *    contributors may be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
- * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
- -->
-
 <xsl:stylesheet
         xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
         xmlns:dim="http://www.dspace.org/xmlns/dspace/dim"

--- a/dspace/config/registries/bitstream-formats.xml
+++ b/dspace/config/registries/bitstream-formats.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0"?>
 
 <!--
-  - bitstream-formats.xml
-  -
-  - Version:  $Revision$
-  -
-  - Date:     $Date$
-  -
   - Initial contents for bitstream format registry.  Once the registry has
   - been loaded, this file becomes obsolete; the current version of the
   - registry must be read from the database.  Use

--- a/dspace/config/registries/dcterms-types.xml
+++ b/dspace/config/registries/dcterms-types.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0"?>
 
 <!--
-  - dcterms-types.xml
-  -
-  - Version:  $Revision$
-  -
-  - Date:     $Date$
-  -
   - DCTerms registry contributed to eventually replace dublin-core-types.xml
   - 
   - <dc-type>
@@ -16,8 +10,6 @@
   -   <scope_note></scope_note>
   - </dc-type>
   -->
-
-<!-- start of XML -->
 
 <dspace-dc-types>
 

--- a/dspace/config/registries/dublin-core-types.xml
+++ b/dspace/config/registries/dublin-core-types.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0"?>
 
 <!--
-  - dublin-core-types.xml
-  -
-  - Version:  $Revision$
-  -
-  - Date:     $Date$
-  -
   - Initial contents for Dublin Core type registry.  Once the registry has
   - been loaded, this file becomes obsolete; the current version of the
   - registry must be read from the database.
@@ -20,8 +14,6 @@
   -   <scope_note></scope_note>
   - </dc-type>
   -->
-
-<!-- start of XML -->
 
 <dspace-dc-types>
 

--- a/dspace/config/registries/sword-metadata.xml
+++ b/dspace/config/registries/sword-metadata.xml
@@ -1,42 +1,4 @@
 <?xml version="1.0"?>
-<!-- sword-metadata.xsl
- *
- * Copyright (c) 2007, Aberystwyth University
- *
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- *  - Redistributions of source code must retain the above
- *    copyright notice, this list of conditions and the
- *    following disclaimer.
- *
- *  - Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- *
- *  - Neither the name of the Centre for Advanced Software and
- *    Intelligent Systems (CASIS) nor the names of its
- *    contributors may be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
- * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
- -->
-
 <dspace-dc-types>
 
   <dspace-header>

--- a/dspace/config/spring/api/bte.xml
+++ b/dspace/config/spring/api/bte.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<!-- TEST-SPRING.XML -->
-
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans

--- a/dspace/config/spring/api/discovery-solr.xml
+++ b/dspace/config/spring/api/discovery-solr.xml
@@ -1,13 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-
--->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -1,13 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-
--->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"

--- a/dspace/config/spring/api/identifier-service.xml
+++ b/dspace/config/spring/api/identifier-service.xml
@@ -1,13 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-
-    Copyright (c) 2002-2010, DuraSpace.  All rights reserved
-    Licensed under the DuraSpace License.
-
-    A copy of the DuraSpace License has been included in this
-    distribution and is available at: http://www.dspace.org/license
-
--->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans

--- a/dspace/config/spring/api/item-marking.xml
+++ b/dspace/config/spring/api/item-marking.xml
@@ -1,13 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-
--->
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:context="http://www.springframework.org/schema/context"

--- a/dspace/config/spring/api/orcid-authority-services.xml
+++ b/dspace/config/spring/api/orcid-authority-services.xml
@@ -1,13 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-
-    Copyright (c) 2002-2010, DuraSpace.  All rights reserved
-    Licensed under the DuraSpace License.
-
-    A copy of the DuraSpace License has been included in this
-    distribution and is available at: http://www.dspace.org/license
-
--->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"

--- a/dspace/config/spring/api/requestitem.xml
+++ b/dspace/config/spring/api/requestitem.xml
@@ -1,13 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-
--->
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:context="http://www.springframework.org/schema/context"

--- a/dspace/config/spring/api/sherpa.xml
+++ b/dspace/config/spring/api/sherpa.xml
@@ -1,13 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-
--->
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:context="http://www.springframework.org/schema/context"

--- a/dspace/config/spring/api/versioning-service.xml
+++ b/dspace/config/spring/api/versioning-service.xml
@@ -1,13 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-
-    Copyright (c) 2002-2010, DuraSpace.  All rights reserved
-    Licensed under the DuraSpace License.
-
-    A copy of the DuraSpace License has been included in this
-    distribution and is available at: http://www.dspace.org/license
-
--->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans

--- a/dspace/config/xmlui.xconf
+++ b/dspace/config/xmlui.xconf
@@ -1,51 +1,9 @@
 <?xml version="1.0"?>
 <!DOCTYPE xmlui SYSTEM "xmlui.dtd">
-
-<!--
-    - xmlui.xconf
-    -
-    - Copyright (c) 2002-2009, The DSpace Foundation.  All rights reserved.
-    - 
-    - Redistribution and use in source and binary forms, with or without
-    - modification, are permitted provided that the following conditions are
-    - met:
-    - 
-    - - Redistributions of source code must retain the above copyright
-    - notice, this list of conditions and the following disclaimer.
-    - 
-    - - Redistributions in binary form must reproduce the above copyright
-    - notice, this list of conditions and the following disclaimer in the
-    - documentation and/or other materials provided with the distribution.
-    - 
-    - Neither the name of the DSpace Foundation nor the names of its
-    - contributors may be used to endorse or promote products derived from
-    - this software without specific prior written permission.
-    - 
-    - THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-    - ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-    - LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-    - A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-    - HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-    - INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-    - BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-    - OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    - ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
-    - TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-    - USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-    - DAMAGE.
--->
-
-
-<!--
-    - The XMLUI (Manakin Release) configuration file
-    -
-    - Authors: Scott Phillips
-    - Version: $Revision$
-    - Date:    $Date$
--->
-
 <xmlui>
     <!--
+        Aspects are the chainable pipeline of features of that can be enabled for XMLUI
+
         This section configures the Aspect "chain". An Aspect provides a set 
         of coupled features for the system. All Aspects are chained together
         such that together they form the complete DSpace website. This is where
@@ -61,19 +19,14 @@
     <aspects>
         <!-- =====================
              Item Level Versioning
+             Disabled by default due to DS-1382 and DS-1349
              ===================== -->
-        <!--
-             To enable Item Level Versioning features, uncomment this aspect.
-             This is currently disabled by default because of one known issue:
-             DS-1382. Please, review them to see whether they apply
-             to you before enabling versioning.
-        -->
         <!--<aspect name="Versioning Aspect" path="resource://aspects/Versioning/" />-->
         
         <!-- =====================
              Base Features/Aspects
+             Providing Display, Browse, Search, Admin, Login, and Submission
              ===================== -->
-        <!-- Base DSpace XMLUI Aspects for Display, Browse, Search, Admin, Login and Submission -->
         <aspect name="Displaying Artifacts" path="resource://aspects/ViewArtifacts/" />
         <aspect name="Browsing Artifacts" path="resource://aspects/BrowseArtifacts/" />
         <aspect name="Discovery" path="resource://aspects/Discovery/" />
@@ -83,18 +36,10 @@
 
         <!-- ========================
              Usage Statistics Engines
+             Available options: Statistics (Solr based, default), StatisticsGoogleAnalytics
+             It is perhaps best to only use one Usage Statistics provider, since they cause UI overlap
              ======================== -->
-        <!-- By default, DSpace uses a Statistics engine based on SOLR -->
-        <aspect name="Statistics" path="resource://aspects/Statistics/" />
-
-        <!--
-             If you prefer to use "Elastic Search" Statistics, you can uncomment the below
-             aspect and COMMENT OUT the default "Statistics" aspect above.
-             You must also enable the ElasticSearchLoggerEventListener.
-        -->
-        <!-- <aspect name="Statistics - Elastic Search" path="resource://aspects/StatisticsElasticSearch/" /> -->
-
-        <!-- Additionally you may choose to expose your Google Analytics statistics in DSpace -->
+        <aspect name="Statistics - Solr" path="resource://aspects/Statistics/" />
         <!-- <aspect name="StatisticsGoogleAnalytics" path="resource://aspects/StatisticsGoogleAnalytics/" /> -->
 
         <!-- =========================
@@ -112,7 +57,7 @@
         <!-- ==============
              SWORDv1 Client
              ============== -->
-        <!-- DSpace also comes with an option SWORD Client aspect, which allows
+        <!-- DSpace also comes with an optional SWORD Client aspect, which allows
              you to submit content FROM your DSpace TO another SWORD-enabled repository.
              To enable this feature, uncomment the aspect below. -->
         <!-- <aspect name="SwordClient" path="resource://aspects/SwordClient/" /> -->
@@ -126,51 +71,36 @@
     </aspects>
 
     <!--
-        This section configures which Theme should apply to a particular URL. 
-        Themes stylize an abstract DRI document (generated by the Aspect
-        chain from above) and produce XHTML (or possibly another format) for 
-        display to the user. Each theme rule is processed in the order that it 
-        is listed below, the first rule that matches is the theme that is applied.
-        
-        The <theme> element has several attributes including: name, id, regex, 
-        handle, and path. The name attribute is used to identify the theme, while
-        the path determines the directory. The path attribute should be listed 
-        exactly as it is found in the /xmlui/cocoon/themes/ directory. Both the
-        regex and handle attributes determine if the theme rule matches the URL.
-        If either the pattern or handle attribute is left off then the only the 
+        Themes are the skin (html+css+js) that presents/renders the site differently
+        The first theme rule that matches, will be used for a given URL.
+
+        PATH
+            - Is folder name of the theme in the themes directory, must end in /
+        HANDLE
+            - Will match down the hierarchy, a collection will match when its parent community is entered as the handle
+        REGEX
+            - matches text in the url. regex and handle in the same rule would AND together
+
+        If either the regex or handle attribute is left off then the only the 
         other component is used to determine matching. 
-        
+ 
         Keep in mind that the order of <theme> elements matters in the case of 
         overlapping matching rules. For example, a theme rule with a very broad
         matching rule (like regex=".*") will override a more specific theme 
         declaration (like handle="1234/23") if placed before it. 
-        
-        Finally, theme application also "cascades" down to pages derived from the
-        one that the theme directly applies to. Thus, a theme applied to a 
-        specific community will also apply to that community's collections and 
-        their respective items.    
-    -->
+     -->
     <themes>
-        <!-- Example configuration -->
-
         <!-- <theme name="Test Theme 1" handle="123456789/1" path="theme1/"/>    -->
         <!-- <theme name="Test Theme 2" regex="community-list" path="theme2/"/> -->
 
         <!-- Mirage theme, @mire contributed theme, default since DSpace 3.0 -->
         <theme name="Atmire Mirage Theme" regex=".*" path="Mirage/" />
 
-        <!-- Reference theme, the default Manakin XMLUI layout up to DSpace 1.8 -->
+        <!-- <theme name="Atmire Mirage2 Theme" regex=".*" path="Mirage2/" /> -->
         <!-- <theme name="Default Reference Theme" regex=".*" path="Reference/" /> -->
-
-        <!-- Classic theme, inspired by the JSP UI -->
         <!-- <theme name="Classic" regex=".*" path="Classic/" /> -->
-
-        <!-- The Kubrick theme -->
         <!-- <theme name="Kubrick" regex=".*" path="Kubrick/" /> -->
 
-        <!--
-             For information on configuring the mobile theme, see:
-             dspace-xmlui/src/main/webapp/themes/mobile/readme.txt
-        -->
+        <!-- Mobile theme information at: dspace-xmlui/src/main/webapp/themes/mobile/readme.txt -->
     </themes>
 </xmlui>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2302

Replaces #753 which had a merge conflict.

Files such as xmlui.xconf have a tremendous amount of comments, which is a giant license header, and then very verbose usage instructions. Just like there aren't instructions on a light switch (switch can be up or down, but not both up and down), some of this verbosity is too much. So, I've made a sweep through dspace/config, and removed license headers. The actual DSpace code needs license headers, but not these configs.