### PR TITLE
[DS-3283] Mirage2: Edit Collection Source - No Field Label for Set Id

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/collection/SetupCollectionHarvestingForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/collection/SetupCollectionHarvestingForm.java
@@ -191,12 +191,12 @@ public class SetupCollectionHarvestingForm extends AbstractDSpaceTransformer
         }
 
         settings.addLabel(T_label_setid);
-        Composite oaiSetComp = settings.addItem().addComposite("oai-set-comp");
-        Radio oaiSetSettingRadio = oaiSetComp.addRadio("oai-set-setting");
+        //Composite oaiSetComp = settings.addItem().addComposite("oai-set-comp");
+        Radio oaiSetSettingRadio = settings.addItem().addRadio("oai-set-setting");
         oaiSetSettingRadio.addOption("all".equals(oaiSetIdValue) || oaiSetIdValue == null, "all", "All sets");
         oaiSetSettingRadio.addOption(!"all".equals(oaiSetIdValue) && oaiSetIdValue != null, "specific", "Specific sets");
 
-        Text oaiSetId = oaiSetComp.addText("oai_setid");
+        Text oaiSetId = settings.addItem().addText("oai_setid");
         oaiSetId.setSize(40);
         if (!"all".equals(oaiSetIdValue) && oaiSetIdValue != null)
         {


### PR DESCRIPTION
Tested locally for Mirage and Mirage2 themes.

https://jira.duraspace.org/browse/DS-3283

![image](https://cloud.githubusercontent.com/assets/1111057/18975871/3bba24c4-8662-11e6-88d3-c596c58ece77.png)

This replaces https://github.com/DSpace/DSpace/pull/1544