### PR TITLE
DS-3419

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/package.json
+++ b/dspace-xmlui-mirage2/src/main/webapp/package.json
@@ -10,7 +10,7 @@
     "grunt-contrib-compass": "^1.1.1",
     "grunt-contrib-concat": "~1.0.1",
     "grunt-contrib-copy": "~1.0.0",
-    "grunt-contrib-handlebars": "1.0.0",
+    "grunt-contrib-handlebars": "0.9.3",
     "grunt-contrib-uglify": "~2.0.0",
     "grunt-usemin": "~3.1.1",
     "load-grunt-tasks": "~3.5.2",


### PR DESCRIPTION
lowered the version of grunt-contrib-handlebars to 0.9.3 to resolve conflicts on the handlebars version in Mirage2.

https://jira.duraspace.org/browse/DS-3419