### PR TITLE
DS-3425 outputstream gets closed in JSONDiscoverySearcher

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/json/JSONDiscoverySearcher.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/json/JSONDiscoverySearcher.java
@@ -134,7 +134,6 @@ public class JSONDiscoverySearcher extends AbstractReader implements Recyclable 
             }
         }
         out.flush();
-        out.close();
     }
 
     /**


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3425

When doing a call to {dspace}/JSON/discovery/search, no output is returned.
The cause for this is the output stream being closed in JSONDiscoverySearcher.

This was committed for DS-3246:

https://jira.duraspace.org/browse/DS-3246
https://github.com/DSpace/DSpace/pull/1437

Not sure why the out.close() was added, but removing it restores normal output for a JSON/discovery/search call.