### PR TITLE
DS-3415 - administrative.js doEditCommunity wrong parameter name

### DIFF
--- a/dspace-xmlui/src/main/resources/aspects/Administrative/administrative.js
+++ b/dspace-xmlui/src/main/resources/aspects/Administrative/administrative.js
@@ -2979,10 +2979,10 @@ function doCreateCommunity(parentCommunityID)
 /**
  * Edit a community.
  */
-function doEditCommunity(itemID)
+function doEditCommunity(communityID)
 {
 	// Always go to the status page first
-	doEditCommunityMetadata(itemID);
+	doEditCommunityMetadata(communityID);
 
 	do {
 	    if (cocoon.request.get("submit_return"))
@@ -2990,29 +2990,29 @@ function doEditCommunity(itemID)
 			return null;
 		}
                 else if (cocoon.request.get("submit_metadata")) {
-                    doEditCommunityMetadata(itemID);
+                    doEditCommunityMetadata(communityID);
                 }
 		else if (cocoon.request.get("submit_status"))
 		{
-			doEditItemStatus(itemID);
+			doEditItemStatus(communityID);
 		}
 		else if (cocoon.request.get("submit_bitstreams"))
 		{
-			doEditItemBitstreams(itemID);
+			doEditItemBitstreams(communityID);
 		}
 		else if (cocoon.request.get("submit_save") || cocoon.request.get("submit_delete") || cocoon.request.get("submit_delete_logo"))
 		{
-			doEditCommunityMetadata(itemID, -1);
+			doEditCommunityMetadata(communityID, -1);
 		}
                 else if (cocoon.request.get("submit_authorizations")) {
 			result = doAuthorizeCommunity(communityID);
 		}
 		else if (cocoon.request.get("submit_roles"))
 		{
-			doAssignCommunityRoles(itemID);
+			doAssignCommunityRoles(communityID);
 		}
 	        else if (cocoon.request.get("submit_curate"))  {
-                        doCurateCommunity(itemID, cocoon.request.get("curate_task"));
+                        doCurateCommunity(communityID, cocoon.request.get("curate_task"));
                 }
                 else
 		{


### PR DESCRIPTION
parameter name 'itemID' isn't a logical name, 'communityID' would be better
the parameter of doAuthorizeCommunity is named 'communityID', but this variable doesn't exist
https://jira.duraspace.org/browse/DS-3415

also committed on master (dspace 6)
#1582