### PR TITLE
[DS-2789] Display a "restricted image" for a thumbnail if the bitstream is restricted

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/item-list.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/item-list.xsl
@@ -192,9 +192,7 @@
                             <xsl:attribute name="src">
                                 <!-- Checking if Thumbnail is restricted and if so, show a restricted image --> 
                                 <xsl:choose>
-                                    <xsl:when test="contains($src,'isAllowed=n')">
-                                        <xsl:value-of select="concat($theme-path,'/images/restricted.png')"/>
-                                    </xsl:when>
+                                    <xsl:when test="contains($src,'isAllowed=n')"/>
                                     <xsl:otherwise>
                                         <xsl:value-of select="$src"/>
                                     </xsl:otherwise>

--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/item-list.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/item-list.xsl
@@ -185,20 +185,20 @@
             <a class="image-link" href="{$href}">
                 <xsl:choose>
                     <xsl:when test="mets:fileGrp[@USE='THUMBNAIL']">
-                        <img class="img-responsive img-thumbnail" alt="xmlui.mirage2.item-list.thumbnail" i18n:attr="alt">
-                            <xsl:variable name="src">
-                                <xsl:value-of select="mets:fileGrp[@USE='THUMBNAIL']/mets:file/mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
-                            </xsl:variable>
-                            <xsl:attribute name="src">
-                                <!-- Checking if Thumbnail is restricted and if so, show a restricted image --> 
-                                <xsl:choose>
-                                    <xsl:when test="contains($src,'isAllowed=n')"/>
-                                    <xsl:otherwise>
+                        <!-- Checking if Thumbnail is restricted and if so, show a restricted image --> 
+                        <xsl:variable name="src">
+                            <xsl:value-of select="mets:fileGrp[@USE='THUMBNAIL']/mets:file/mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
+                        </xsl:variable>
+                        <xsl:choose>
+                            <xsl:when test="contains($src,'isAllowed=n')"/>
+                            <xsl:otherwise>
+                                <img class="img-responsive img-thumbnail" alt="xmlui.mirage2.item-list.thumbnail" i18n:attr="alt">
+                                    <xsl:attribute name="src">
                                         <xsl:value-of select="$src"/>
-                                    </xsl:otherwise>
-                                </xsl:choose>
-                            </xsl:attribute>
-                        </img>
+                                    </xsl:attribute>
+                                </img>
+                            </xsl:otherwise>
+                        </xsl:choose>
                     </xsl:when>
                     <xsl:otherwise>
                         <img class="img-thumbnail" alt="xmlui.mirage2.item-list.thumbnail" i18n:attr="alt">

--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/item-list.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/item-list.xsl
@@ -190,7 +190,11 @@
                             <xsl:value-of select="mets:fileGrp[@USE='THUMBNAIL']/mets:file/mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
                         </xsl:variable>
                         <xsl:choose>
-                            <xsl:when test="contains($src,'isAllowed=n')"/>
+                            <xsl:when test="contains($src,'isAllowed=n')">
+                                <div style="width: 100%; text-align: center">
+                                    <i aria-hidden="true" class="glyphicon  glyphicon-lock"></i>
+                                </div>
+                            </xsl:when>
                             <xsl:otherwise>
                                 <img class="img-responsive img-thumbnail" alt="xmlui.mirage2.item-list.thumbnail" i18n:attr="alt">
                                     <xsl:attribute name="src">

--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/item-list.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/item-list.xsl
@@ -186,9 +186,19 @@
                 <xsl:choose>
                     <xsl:when test="mets:fileGrp[@USE='THUMBNAIL']">
                         <img class="img-responsive img-thumbnail" alt="xmlui.mirage2.item-list.thumbnail" i18n:attr="alt">
+                            <xsl:variable name="src">
+                                <xsl:value-of select="mets:fileGrp[@USE='THUMBNAIL']/mets:file/mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
+                            </xsl:variable>
                             <xsl:attribute name="src">
-                                <xsl:value-of
-                                        select="mets:fileGrp[@USE='THUMBNAIL']/mets:file/mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
+                                <!-- Checking if Thumbnail is restricted and if so, show a restricted image --> 
+                                <xsl:choose>
+                                    <xsl:when test="contains($src,'isAllowed=n')">
+                                        <xsl:value-of select="concat($theme-path,'/images/restricted.png')"/>
+                                    </xsl:when>
+                                    <xsl:otherwise>
+                                        <xsl:value-of select="$src"/>
+                                    </xsl:otherwise>
+                                </xsl:choose>
                             </xsl:attribute>
                         </img>
                     </xsl:when>

--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/item-view.xsl
@@ -185,9 +185,7 @@
                         <xsl:attribute name="src">
                             <!-- Checking if Thumbnail is restricted and if so, show a restricted image --> 
                             <xsl:choose>
-                                <xsl:when test="contains($src,'isAllowed=n')">
-                                    <xsl:value-of select="concat($theme-path,'/images/restricted.png')"/>
-                                </xsl:when>
+                                <xsl:when test="contains($src,'isAllowed=n')"/>
                                 <xsl:otherwise>
                                     <xsl:value-of select="$src"/>
                                 </xsl:otherwise>

--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/item-view.xsl
@@ -183,7 +183,15 @@
                     </xsl:variable>
                     <img class="img-thumbnail" alt="Thumbnail">
                         <xsl:attribute name="src">
-                            <xsl:value-of select="$src"/>
+                            <!-- Checking if Thumbnail is restricted and if so, show a restricted image --> 
+                            <xsl:choose>
+                                <xsl:when test="contains($src,'isAllowed=n')">
+                                    <xsl:value-of select="concat($theme-path,'/images/restricted.png')"/>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:value-of select="$src"/>
+                                </xsl:otherwise>
+                            </xsl:choose>
                         </xsl:attribute>
                     </img>
                 </xsl:when>

--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/item-view.xsl
@@ -181,17 +181,17 @@
                             </xsl:otherwise>
                         </xsl:choose>
                     </xsl:variable>
-                    <img class="img-thumbnail" alt="Thumbnail">
-                        <xsl:attribute name="src">
-                            <!-- Checking if Thumbnail is restricted and if so, show a restricted image --> 
-                            <xsl:choose>
-                                <xsl:when test="contains($src,'isAllowed=n')"/>
-                                <xsl:otherwise>
+                    <!-- Checking if Thumbnail is restricted and if so, show a restricted image --> 
+                    <xsl:choose>
+                        <xsl:when test="contains($src,'isAllowed=n')"/>
+                        <xsl:otherwise>
+                            <img class="img-thumbnail" alt="Thumbnail">
+                                <xsl:attribute name="src">
                                     <xsl:value-of select="$src"/>
-                                </xsl:otherwise>
-                            </xsl:choose>
-                        </xsl:attribute>
-                    </img>
+                                </xsl:attribute>
+                            </img>
+                        </xsl:otherwise>
+                    </xsl:choose>
                 </xsl:when>
                 <xsl:otherwise>
                     <img class="img-thumbnail" alt="Thumbnail">


### PR DESCRIPTION
George Kozak suggested this change in https://jira.duraspace.org/browse/DS-2789 to prevent the display of an unavailable image icon for restricted thumbnails.  

George's suggested code contained a reference to "restricted.png".  In the absence of that image, I am simply displaying the lock glyph.  An actual image may be preferred.

This change would also make sense to apply to the non-Mirage2 themes.  Which themes are actively supported?

If another 5x release takes place, this would be a worthwhile change to port to 5x.