### PR TITLE
DS-3367: Fix authorization error on claim by non-admin user

### DIFF
--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/WorkflowRequirementsServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/WorkflowRequirementsServiceImpl.java
@@ -72,12 +72,17 @@ public class WorkflowRequirementsServiceImpl implements WorkflowRequirementsServ
         ipu.setUser(user);
         ipu.setFinished(false);
         inProgressUserService.update(context, ipu);
+
+        //Make sure the user has the necessary rights to update the item after the tasks is removed from the pool
+        xmlWorkflowService.grantUserAllItemPolicies(context, wfi.getItem(), user);
+
         int totalUsers = inProgressUserService.getNumberOfInProgressUsers(context, wfi) + inProgressUserService.getNumberOfFinishedUsers(context, wfi);
 
         if(totalUsers == step.getRequiredUsers()){
             //If enough users have claimed/finished this step then remove the tasks
             xmlWorkflowService.deleteAllPooledTasks(context, wfi);
         }
+
         xmlWorkflowItemService.update(context, wfi);
     }
 
@@ -89,6 +94,8 @@ public class WorkflowRequirementsServiceImpl implements WorkflowRequirementsServ
         //Then remove the current user from the inProgressUsers
         inProgressUserService.delete(context, inProgressUserService.findByWorkflowItemAndEPerson(context, wfi, user));
 
+        //Make sure the removed user has his custom rights removed
+        xmlWorkflowService.removeUserItemPolicies(context, wfi.getItem(), user);
 
         Workflow workflow = workflowFactory.getWorkflow(wfi.getCollection());
         Step step = workflow.getStep(stepID);

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
@@ -661,7 +661,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
         grantUserAllItemPolicies(context, wi.getItem(), e);
     }
 
-    protected void grantUserAllItemPolicies(Context context, Item item, EPerson epa) throws AuthorizeException, SQLException {
+    public void grantUserAllItemPolicies(Context context, Item item, EPerson epa) throws AuthorizeException, SQLException {
         if (epa != null){
             //A list of policies the user has for this item
             List<Integer>  userHasPolicies = new ArrayList<Integer>();
@@ -739,7 +739,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
         }
     }
 
-    protected void removeUserItemPolicies(Context context, Item item, EPerson e) throws SQLException, AuthorizeException {
+    public void removeUserItemPolicies(Context context, Item item, EPerson e) throws SQLException, AuthorizeException {
         if (e != null){
             //Also remove any lingering authorizations from this user
             authorizeService.removeEPersonPolicies(context, item, e);

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/service/XmlWorkflowService.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/service/XmlWorkflowService.java
@@ -8,6 +8,7 @@
 package org.dspace.xmlworkflow.service;
 
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.Item;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.dspace.workflow.WorkflowService;
@@ -58,6 +59,10 @@ public interface XmlWorkflowService extends WorkflowService<XmlWorkflowItem> {
             throws SQLException, AuthorizeException;
 
     public void createOwnedTask(Context context, XmlWorkflowItem wi, Step step, WorkflowActionConfig action, EPerson e) throws SQLException, AuthorizeException;
+
+    public void grantUserAllItemPolicies(Context context, Item item, EPerson epa) throws AuthorizeException, SQLException;
+
+    public void removeUserItemPolicies(Context context, Item item, EPerson e) throws SQLException, AuthorizeException;
 
     public String getEPersonName(EPerson ePerson);
 }


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3367

When a workflow task is removed from the pool in the configurable workflow, WRITE rights corresponding to the workflow group are also removed.

However the exception to this should be the user that claimed the task so that he can still update the item and change its state (archive or put back into workflow).