### PR TITLE
DS-3108 support non email based authentication in rest api

### DIFF
--- a/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
@@ -55,8 +55,10 @@ public class RestIndex {
                         "<ul>" +
                             "<li>GET / - Return this page.</li>" +
                             "<li>GET /test - Return the string \"REST api is running\" for testing purposes.</li>" +
-                            "<li>POST /login - Method for logging into the DSpace RESTful API. You must post User class. Example: {\"email\":\"test@dspace\",\"password\":\"pass\"}. Returns a token which must be included in future requests in the \"rest-dspace-token\" header.</li>" +
-                            "<li>POST /logout - Method for logging out of the DSpace RESTful API. The request must include the \"rest-dspace-token\" token</li> header." +
+                            "<li>GET /login - Method for logging into the DSpace RESTful API. You must provide the user and password, e.g. /login?user=john@doe.com&password=secretpassword. This will return you a JSESSIONID cookie which must be included in future requests.</li>" +
+                            "<li>GET /shibboleth-login - Method for logging into the DSpace RESTful API with Shibboleth. You must configure Shibboleth to pass the Shibboleth session to this endpoint. This will return you a JSESSIONID cookie which must be included in future requests.</li>" +
+                            "<li>GET /status - Method for retrieving information on the current authenticated user. The request must include the JSESSIONID cookie.</li>" +
+                            "<li>GET /logout - Method for logging out of the DSpace RESTful API. The request must include the JSESSIONID cookie.</li>" +
                         "</ul>" +
                     "<h2>Communities</h2>" +
                         "<ul>" +

--- a/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
@@ -7,28 +7,20 @@
  */
 package org.dspace.rest;
 
-import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.sql.SQLException;
-import java.util.Iterator;
 
 import javax.servlet.ServletContext;
 import javax.ws.rs.*;
 import javax.ws.rs.core.*;
 import javax.ws.rs.core.Context;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
-import org.dspace.authenticate.AuthenticationMethod;
-import org.dspace.authenticate.ShibAuthentication;
-import org.dspace.authenticate.factory.AuthenticateServiceFactory;
-import org.dspace.authenticate.service.AuthenticationService;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
 import org.dspace.rest.common.Status;
 import org.dspace.rest.exceptions.ContextException;
-import org.dspace.utils.DSpace;
 
 /**
  * Root of RESTful api. It provides login and logout. Also have method for

--- a/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
@@ -168,10 +168,36 @@ public class RestIndex {
     @POST
     @Path("/login")
     @Consumes({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
-    public Response login(@QueryParam("user") String email, @QueryParam("password") String password) {
-
+    public Response login(@QueryParam("user") String user, @QueryParam("password") String password)
+    {
         //If you can get here, you should be authenticated, the actual login is handled by spring security.
         //If not, the provided credentials are invalid.
+
+        return getLoginResponse("Authentication failed for user " + user + ": The credentials you provided are not valid.");
+    }
+
+    @GET
+    @Path("/shibboleth-login")
+    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    public Response shibbolethLogin()
+    {
+        //If you can get here, you should be authenticated, the actual login is handled by spring security.
+        //If not, no valid Shibboleth session is present or Shibboleth config is missing.
+
+        /* Make sure to apply
+           - AuthType shibboleth
+           - ShibRequireSession On
+           - ShibUseHeaders On
+           - require valid-user
+           to this endpoint. The Shibboleth daemon will then take care of redirecting you to the login page if
+           necessary.
+         */
+
+        return getLoginResponse("Shibboleth authentication failed: No valid Shibboleth session could be found.");
+    }
+
+    protected Response getLoginResponse(String failedMessage) {
+        //Get the context and check if we have an authenticated eperson
 
         org.dspace.core.Context context = null;
         try {
@@ -183,70 +209,18 @@ public class RestIndex {
             log.error("Unable to load user information from the database: " + e.getMessage(), e);
             return Response.serverError().entity(e.getMessage()).build();
         } catch (WebApplicationException e) {
-            log.warn("REST API authentication for user " + email + " failed.");
+            log.warn("REST API authentication failed.");
             context = null;
         }
 
         if(context == null || context.getCurrentUser() == null) {
             return Response.status(Response.Status.FORBIDDEN)
-                    .entity("Authentication failed. The credentials you provided are not valid.")
+                    .entity(failedMessage)
                     .build();
         } else {
             //We have a user, so the login was successful.
             return Response.ok().build();
         }
-    }
-
-
-    @GET
-    @Path("/shibboleth-login")
-    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-    public Response shibbolethLogin()
-    {
-        //If you can get here, you are authenticated, the actual login is handled by spring security
-        return Response.ok().build();
-    }
-
-    @GET
-    @Path("/login-shibboleth")
-    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-    public Response shibbolethLoginEndPoint()
-    {
-        org.dspace.core.Context context = null;
-        try
-        {
-            context = Resource.createContext();
-            AuthenticationService authenticationService = AuthenticateServiceFactory.getInstance().getAuthenticationService();
-            Iterator<AuthenticationMethod> authenticationMethodIterator = authenticationService.authenticationMethodIterator();
-            while (authenticationMethodIterator.hasNext())
-            {
-                AuthenticationMethod authenticationMethod = authenticationMethodIterator.next();
-                if (authenticationMethod instanceof ShibAuthentication)
-                {
-                    //TODO: Perhaps look for a better way of handling this ?
-                    org.dspace.services.model.Request currentRequest = new DSpace().getRequestService().getCurrentRequest();
-                    String loginPageURL = authenticationMethod.loginPageURL(context, currentRequest.getHttpServletRequest(), currentRequest.getHttpServletResponse());
-                    if (StringUtils.isNotBlank(loginPageURL))
-                    {
-                        currentRequest.getHttpServletResponse().sendRedirect(loginPageURL);
-                    }
-                }
-            }
-            context.abort();
-        }
-        catch (ContextException | SQLException | IOException e)
-        {
-            Resource.processException("Shibboleth endpoint error:  " + e.getMessage(), context);
-        }
-        finally
-        {
-            if (context != null && context.isValid())
-            {
-                context.abort();
-            }
-
-        }
-        return Response.ok().build();
     }
 
     /**

--- a/dspace-rest/src/main/java/org/dspace/rest/authentication/DSpaceAuthenticationProvider.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/authentication/DSpaceAuthenticationProvider.java
@@ -75,7 +75,7 @@ public class DSpaceAuthenticationProvider implements AuthenticationProvider {
                     return createAuthenticationToken(password, context, grantedAuthorities);
 
                 } else {
-                    log.info(LogManager.getHeader(context, "failed_login", "email="
+                    log.info(LogManager.getHeader(context, "failed_login", "user="
                             + name + ", result="
                             + authenticateResult));
                     throw new BadCredentialsException("Login failed");

--- a/dspace-rest/src/main/java/org/dspace/rest/authentication/DSpaceAuthenticationProvider.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/authentication/DSpaceAuthenticationProvider.java
@@ -7,12 +7,14 @@
  */
 package org.dspace.rest.authentication;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.dspace.authenticate.AuthenticationMethod;
 import org.dspace.authenticate.factory.AuthenticateServiceFactory;
 import org.dspace.authenticate.service.AuthenticationService;
 import org.dspace.core.Context;
 import org.dspace.core.LogManager;
+import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.utils.DSpace;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -60,7 +62,8 @@ public class DSpaceAuthenticationProvider implements AuthenticationProvider {
             if (implicitStatus == AuthenticationMethod.SUCCESS) {
                 log.info(LogManager.getHeader(context, "login", "type=implicit"));
                 addSpecialGroupsToGrantedAuthorityList(context, httpServletRequest, grantedAuthorities);
-                return new UsernamePasswordAuthenticationToken(name, password, grantedAuthorities);
+                return createAuthenticationToken(password, context, grantedAuthorities);
+
             } else {
                 int authenticateResult = authenticationService.authenticate(context, name, password, null, httpServletRequest);
                 if (AuthenticationMethod.SUCCESS == authenticateResult) {
@@ -69,7 +72,8 @@ public class DSpaceAuthenticationProvider implements AuthenticationProvider {
                     log.info(LogManager
                             .getHeader(context, "login", "type=explicit"));
 
-                    return new UsernamePasswordAuthenticationToken(name, password, grantedAuthorities);
+                    return createAuthenticationToken(password, context, grantedAuthorities);
+
                 } else {
                     log.info(LogManager.getHeader(context, "failed_login", "email="
                             + name + ", result="
@@ -99,6 +103,17 @@ public class DSpaceAuthenticationProvider implements AuthenticationProvider {
         List<Group> groups = authenticationService.getSpecialGroups(context, httpServletRequest);
         for (Group group : groups) {
             grantedAuthorities.add(new SimpleGrantedAuthority(group.getName()));
+        }
+    }
+
+    private Authentication createAuthenticationToken(final String password, final Context context, final List<SimpleGrantedAuthority> grantedAuthorities) {
+        EPerson ePerson = context.getCurrentUser();
+        if(ePerson != null && StringUtils.isNotBlank(ePerson.getEmail())) {
+            return new UsernamePasswordAuthenticationToken(ePerson.getEmail(), password, grantedAuthorities);
+
+        } else {
+            log.info(LogManager.getHeader(context, "failed_login", "No eperson with an non-blank e-mail address found"));
+            throw new BadCredentialsException("Login failed");
         }
     }
 

--- a/dspace-rest/src/main/java/org/dspace/rest/authentication/DSpaceAuthenticationProvider.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/authentication/DSpaceAuthenticationProvider.java
@@ -35,10 +35,9 @@ import java.util.List;
  * @author Roeland Dillen (roeland at atmire dot com)
  * @author kevinvandevelde at atmire.com
  *
- * @deprecated This provider handles both the authorization as well as the authentication,
+ * FIXME This provider handles both the authorization as well as the authentication,
  * due to the way that the DSpace authentication is implemented there is currently no other way to do this.
  */
-@Deprecated
 public class DSpaceAuthenticationProvider implements AuthenticationProvider {
 
     private static Logger log = Logger.getLogger(DSpaceAuthenticationProvider.class);

--- a/dspace-rest/src/main/webapp/WEB-INF/security-applicationContext.xml
+++ b/dspace-rest/src/main/webapp/WEB-INF/security-applicationContext.xml
@@ -38,7 +38,7 @@
         <property name="authenticationManager" ref="dspaceAuthenticationManager"/>
         <!-- Ensures that after login no redirect is made to the home page, the rest will return a 200 status code -->
         <property name="authenticationSuccessHandler" ref="org.dspace.rest.authentication.NoRedirectAuthenticationLoginSuccessHandler"/>
-        <property name="usernameParameter" value="email"/>
+        <property name="usernameParameter" value="user"/>
         <property name="passwordParameter" value="password"/>
         <property name="postOnly" value="false"/>
         <!--Match on any request-->


### PR DESCRIPTION
This pull request addresses the following:
- A fix for when you authenticate in the REST API using a mechanism in which the user does not enter an e-mail address (as discussed here: https://groups.google.com/forum/#!topic/dspace-tech/jUhneGwgSeU)
- Renamed the "email" parameter to "user" since it will not always contain an e-mail address
- Removed the /login-shibboleth which contained a manual implementation of the Shibboleth redirection. Shibboleth redirection should not be a concern of the client application but should only be handled by the Shibboleth daemon.
- Changed a depreciation warning to a FIXME warning since no alternative is ready yet
- Updated the REST API home page to provide details on how to authenticate.