### PR TITLE
DS-3435 possible nullpointerexception at AccessStepUtil$populateEmbar…

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicy.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicy.java
@@ -218,9 +218,9 @@ public class ResourcePolicy implements ReloadableEntity<Integer> {
     }
 
     /**
-     * gets ID for Group referred to by this policy
+     * gets the Group referred to by this policy
      *
-     * @return groupID, or null if no group set
+     * @return group, or null if no group set
      */
     public Group getGroup()
     {
@@ -228,7 +228,7 @@ public class ResourcePolicy implements ReloadableEntity<Integer> {
     }
 
     /**
-     * sets ID for Group referred to by this policy
+     * sets the Group referred to by this policy
      * @param epersonGroup Group
      */
     public void setGroup(Group epersonGroup)

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/AccessStepUtil.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/AccessStepUtil.java
@@ -247,7 +247,7 @@ public class AccessStepUtil extends AbstractDSpaceTransformer {
     private void populateEmbargoDetail(final DSpaceObject dso, final Text text) throws SQLException, WingException {
         for (final ResourcePolicy readPolicy : authorizeService.getPoliciesActionFilter(context, dso, Constants.READ))
         {
-            if (Group.ANONYMOUS.equals(readPolicy.getGroup().getName()) && readPolicy.getStartDate() != null)
+            if (readPolicy.getGroup() != null && Group.ANONYMOUS.equals(readPolicy.getGroup().getName()) && readPolicy.getStartDate() != null)
             {
                 final String dateString = DateFormatUtils.format(readPolicy.getStartDate(), "yyyy-MM-dd");
                 text.setValue(dateString);


### PR DESCRIPTION
DS-3435: possible nullpointerexception at AccessStepUtil$populateEmbargoDetail (line 250)

The ResourcePolicy$getGroup method documentation states the policy group can be null (which is correct, since the policy can also be defined for a specific eperson), but AccessStepUtil seems to assume it won't be null.

Also, the documentation for ResourcePolicy$getGroup needs to be updated, it mentions group id but the group object is returned instead. Same for setGroup.