### PR TITLE
DS-3381 workspace item not saved when using versioning

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/versioning/VersionManager.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/versioning/VersionManager.java
@@ -73,6 +73,9 @@ public class VersionManager {
                 Version version = versioningService.createNewVersion(context, item, summary);
                 WorkspaceItem wsi = workspaceItemService.findByItem(context, version.getItem());
 
+                //Force data to be written to the database
+                context.commit();
+
                 result.setParameter("wsid", wsi.getID());
                 result.setOutcome(true);
                 result.setContinue(true);


### PR DESCRIPTION
This PR fixes the versioning in XMLUI.

In DSpace 6, the context.commit() call was removed. However this call is required so that the item is saved to the database before the call to cocoon.redirectTo() in versioning.js (function startCreateNewVersionItem).
