### PR TITLE
DS-3441 READ permssion on the Collection object not respected by the JSPUI

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/HandleServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/HandleServlet.java
@@ -565,11 +565,15 @@ public class HandleServlet extends DSpaceServlet
      *            the HTTP response
      * @param community
      *            the community
+     * @throws AuthorizeException 
      */
     private void communityHome(Context context, HttpServletRequest request,
             HttpServletResponse response, Community community)
-            throws ServletException, IOException, SQLException
+            throws ServletException, IOException, SQLException, AuthorizeException
     {
+        // Ensure the user has authorisation
+        authorizeService.authorizeAction(context, community, Constants.READ);
+
         // Handle click on a browse or search button
         if (!handleButton(request, response, community.getHandle()))
         {
@@ -664,6 +668,9 @@ public class HandleServlet extends DSpaceServlet
             Collection collection) throws ServletException, IOException,
             SQLException, AuthorizeException
     {
+    	// Ensure the user has authorisation
+        authorizeService.authorizeAction(context, collection, Constants.READ);
+        
         // Handle click on a browse or search button
         if (!handleButton(request, response, collection.getHandle()))
         {


### PR DESCRIPTION
Add check for READ permission on collection and community home page visualization
see
https://jira.duraspace.org/browse/DS-3441

Reserved community and collection are still listed in the community-list, removing from here could have performance implication