### PR TITLE
DS-3446: On bitstream delete, remove policies only after the bitstream has been updated

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -254,12 +254,12 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
             bundle.getBitstreams().remove(bitstream);
         }
 
-        // Remove policies
-        authorizeService.removeAllPolicies(context, bitstream);
-
         // Remove bitstream itself
         bitstream.setDeleted(true);
         update(context, bitstream);
+
+        // Remove policies only after the bitstream has been updated (otherwise the current user has not WRITE rights)
+        authorizeService.removeAllPolicies(context, bitstream);
 
         //Remove all bundles from the bitstream object, clearing the connection in 2 ways
         bundles.clear();


### PR DESCRIPTION
Otherwise the current user who is removing the bitstream doesn't have the necessary WRITE rights

https://jira.duraspace.org/browse/DS-3446
