### PR TITLE
don't close the out stream

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/json/JSONDiscoverySearcher.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/json/JSONDiscoverySearcher.java
@@ -134,7 +134,6 @@ public class JSONDiscoverySearcher extends AbstractReader implements Recyclable 
             }
         }
         out.flush();
-        out.close();
     }
 
     /**


### PR DESCRIPTION
fixes aucomplete for search filters...Not sure if DSpace is still using the `/xmlui/JSON/discovery/search...` endpoint for autocomplete of advanced search filters; we do use it and closing of the out stream breaks that functionality. My understanding is that, since the OutputStream out is passed to AbstractReader, some other object holds the reference and actually tries to do something with the stream but fails, because the stream is closed.