### PR TITLE
DS-3445 Only add "ResultCode" if not default

### DIFF
--- a/dspace-api/src/main/java/org/dspace/checker/ResultsPruner.java
+++ b/dspace-api/src/main/java/org/dspace/checker/ResultsPruner.java
@@ -145,17 +145,14 @@ public final class ResultsPruner
                 throw new IllegalStateException("Problem parsing duration: "
                         + e.getMessage(), e);
             }
-            ChecksumResultCode code = ChecksumResultCode.valueOf(resultCode);
-            if(code == null)
-            {
-                throw new IllegalStateException("Checksum result code not found: " + resultCode);
-            }
-            if ("default".equals(resultCode))
-            {
+            if ("default".equals(resultCode)) {
                 rp.setDefaultDuration(duration);
-            }
-            else
-            {
+            } else {
+                ChecksumResultCode code = ChecksumResultCode.valueOf(resultCode);
+                if (code == null) {
+                    throw new IllegalStateException("Checksum result code not found: " + resultCode);
+                }
+
                 rp.addInterested(code, duration);
             }
         }


### PR DESCRIPTION
JIRA ticket
https://jira.duraspace.org/projects/DS/issues/DS-3445
Only try to search for the "ChecksumResultCode" enum if the resultCode string is not default.
Avoiding breaking enum search