### PR TITLE
Add exception message in log when a bean cannot be loaded

### DIFF
--- a/dspace-services/src/main/java/org/dspace/servicemanager/spring/SpringServiceManager.java
+++ b/dspace-services/src/main/java/org/dspace/servicemanager/spring/SpringServiceManager.java
@@ -103,7 +103,7 @@ public final class SpringServiceManager implements ServiceManagerSystem {
                     bean = (T) applicationContext.getBean(name, type);
                 } catch (BeansException e) {
                     // no luck, try the fall back option
-                    log.info("Unable to locate bean by name or id=" + name + ". Will try to look up bean by type next.");
+                    log.info("Unable to locate bean by name or id=" + name + ". Will try to look up bean by type next. BeansException: " + e.getMessage());
                     bean = null;
                 }
             } else {
@@ -112,7 +112,7 @@ public final class SpringServiceManager implements ServiceManagerSystem {
                     bean = (T) applicationContext.getBean(type.getName(), type);
                 } catch (BeansException e) {
                     // no luck, try the fall back option
-                    log.info("Unable to locate bean by name or id=" + type.getName() + ". Will try to look up bean by type next.");
+                    log.info("Unable to locate bean by name or id=" + type.getName() + ". Will try to look up bean by type next. BeansException: " + e.getMessage());
                     bean = null;
                 }
             }


### PR DESCRIPTION
Hi,

this is my first DSpace pull request, the beans exception was ignored whereas the root cause it contains is usually needed to fix the configuration issue (or head scratching ensues), so it's simply adding the exception message in existing log statements.

Cheers