### PR TITLE
annotate unit tests so they can be run directly from a Junit runner

### DIFF
--- a/dspace-api/src/test/java/org/dspace/AbstractDSpaceTest.java
+++ b/dspace-api/src/test/java/org/dspace/AbstractDSpaceTest.java
@@ -19,6 +19,10 @@ import org.dspace.servicemanager.DSpaceKernelInit;
 import org.junit.AfterClass;
 import static org.junit.Assert.fail;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+
+import mockit.integration.junit4.JMockit;
 
 /**
  * DSpace Unit Tests need to initialize the DSpace Kernel / Service Mgr
@@ -33,6 +37,8 @@ import org.junit.BeforeClass;
  * @see AbstractIntegrationTest
  * @author Tim
  */
+@Ignore
+@RunWith(JMockit.class)
 public class AbstractDSpaceTest
 {
     /** log4j category */

--- a/dspace-api/src/test/java/org/dspace/AbstractIntegrationTest.java
+++ b/dspace-api/src/test/java/org/dspace/AbstractIntegrationTest.java
@@ -8,6 +8,7 @@
 package org.dspace;
 
 import org.databene.contiperf.junit.ContiPerfRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 
 /**
@@ -20,6 +21,7 @@ import org.junit.Rule;
  *
  * @author pvillega
  */
+@Ignore
 public class AbstractIntegrationTest extends AbstractUnitTest
 {
 

--- a/dspace-api/src/test/java/org/dspace/AbstractUnitTest.java
+++ b/dspace-api/src/test/java/org/dspace/AbstractUnitTest.java
@@ -21,6 +21,7 @@ import org.dspace.storage.rdbms.DatabaseUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 
 import java.sql.SQLException;
 
@@ -38,6 +39,7 @@ import static org.junit.Assert.fail;
  * @see AbstractDSpaceTest
  * @author pvillega
  */
+@Ignore
 public class AbstractUnitTest extends AbstractDSpaceTest
 {
     /** log4j category */


### PR DESCRIPTION
When running unit tests directly from eclipse junit4 runner, abstract (base classes) tests are also run as unit tests and rightfully failing.
To prevent that, one solution is to @Ignore tests base classes (implemented here). Another one would be to rename base class names so they don't match any of maven-surefire-plugin patterns (here *Test).