### PR TITLE
[DS-3477] fix altmetrics config lookups in item-view.xsl (6.x)

### DIFF
--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -40,10 +40,10 @@
 
     <xsl:template name="itemSummaryView-DIM">
         <!-- optional: Altmeric.com badge and PlumX widget -->
-        <xsl:if test='confman:getProperty("altmetrics", "altmetric.enabled") and ($identifier_doi or $identifier_handle)'>
+        <xsl:if test='confman:getProperty("altmetric.enabled") and ($identifier_doi or $identifier_handle)'>
             <xsl:call-template name='impact-altmetric'/>
         </xsl:if>
-        <xsl:if test='confman:getProperty("altmetrics", "plumx.enabled") and $identifier_doi'>
+        <xsl:if test='confman:getProperty("plumx.enabled") and $identifier_doi'>
             <xsl:call-template name='impact-plumx'/>
         </xsl:if>
 
@@ -569,31 +569,31 @@
             </script>
             <div id='altmetric'
                  class='altmetric-embed'>
-                <xsl:variable name='badge_type' select='confman:getProperty("altmetrics", "altmetric.badgeType")'/>
+                <xsl:variable name='badge_type' select='confman:getProperty("altmetric.badgeType")'/>
                 <xsl:if test='boolean($badge_type)'>
                     <xsl:attribute name='data-badge-type'><xsl:value-of select='$badge_type'/></xsl:attribute>
                 </xsl:if>
 
-                <xsl:variable name='badge_popover' select='confman:getProperty("altmetrics", "altmetric.popover")'/>
+                <xsl:variable name='badge_popover' select='confman:getProperty("altmetric.popover")'/>
                 <xsl:if test='$badge_popover'>
                     <xsl:attribute name='data-badge-popover'><xsl:value-of select='$badge_popover'/></xsl:attribute>
                 </xsl:if>
 
-                <xsl:variable name='badge_details' select='confman:getProperty("altmetrics", "altmetric.details")'/>
+                <xsl:variable name='badge_details' select='confman:getProperty("altmetric.details")'/>
                 <xsl:if test='$badge_details'>
                     <xsl:attribute name='data-badge-details'><xsl:value-of select='$badge_details'/></xsl:attribute>
                 </xsl:if>
 
-                <xsl:variable name='no_score' select='confman:getProperty("altmetrics", "altmetric.noScore")'/>
+                <xsl:variable name='no_score' select='confman:getProperty("altmetric.noScore")'/>
                 <xsl:if test='$no_score'>
                     <xsl:attribute name='data-no-score'><xsl:value-of select='$no_score'/></xsl:attribute>
                 </xsl:if>
 
-                <xsl:if test='confman:getProperty("altmetrics", "altmetric.hideNoMentions")'>
+                <xsl:if test='confman:getProperty("altmetric.hideNoMentions")'>
                     <xsl:attribute name='data-hide-no-mentions'>true</xsl:attribute>
                 </xsl:if>
 
-                <xsl:variable name='link_target' select='confman:getProperty("altmetrics", "altmetric.linkTarget")'/>
+                <xsl:variable name='link_target' select='confman:getProperty("altmetric.linkTarget")'/>
                 <xsl:if test='$link_target'>
                     <xsl:attribute name='data-link-target'><xsl:value-of select='$link_target'/></xsl:attribute>
                 </xsl:if>
@@ -614,7 +614,7 @@
     <xsl:template name="impact-plumx">
         <div id="impact-plumx" style="clear:right">
             <!-- PlumX <http://plu.mx> -->
-            <xsl:variable name="plumx_type" select="confman:getProperty('altmetrics', 'plumx.widget-type')"/>
+            <xsl:variable name="plumx_type" select="confman:getProperty('plumx.widget-type')"/>
             <xsl:variable name="plumx-script-url">
                 <xsl:choose>
                     <xsl:when test="boolean($plumx_type)">
@@ -643,30 +643,30 @@
                 <xsl:attribute name="class"><xsl:value-of select="$plumx-class"/></xsl:attribute>
                 <xsl:attribute name="href">https://plu.mx/pitt/a/?doi=<xsl:value-of select="$identifier_doi"/></xsl:attribute>
 
-                <xsl:variable name="plumx_data-popup" select="confman:getProperty('altmetrics', 'plumx.data-popup')"/>
+                <xsl:variable name="plumx_data-popup" select="confman:getProperty('plumx.data-popup')"/>
                 <xsl:if test="$plumx_data-popup">
                     <xsl:attribute name="data-popup"><xsl:value-of select="$plumx_data-popup"/></xsl:attribute>
                 </xsl:if>
 
-                <xsl:if test="confman:getProperty('altmetrics', 'plumx.data-hide-when-empty')">
+                <xsl:if test="confman:getProperty('plumx.data-hide-when-empty')">
                     <xsl:attribute name="data-hide-when-empty">true</xsl:attribute>
                 </xsl:if>
 
-                <xsl:if test="confman:getProperty('altmetrics', 'plumx.data-hide-print')">
+                <xsl:if test="confman:getProperty('plumx.data-hide-print')">
                     <xsl:attribute name="data-hide-print">true</xsl:attribute>
                 </xsl:if>
 
-                <xsl:variable name="plumx_data-orientation" select="confman:getProperty('altmetrics', 'plumx.data-orientation')"/>
+                <xsl:variable name="plumx_data-orientation" select="confman:getProperty('plumx.data-orientation')"/>
                 <xsl:if test="$plumx_data-orientation">
                     <xsl:attribute name="data-orientation"><xsl:value-of select="$plumx_data-orientation"/></xsl:attribute>
                 </xsl:if>
 
-                <xsl:variable name="plumx_data-width" select="confman:getProperty('altmetrics', 'plumx.data-width')"/>
+                <xsl:variable name="plumx_data-width" select="confman:getProperty('plumx.data-width')"/>
                 <xsl:if test="$plumx_data-width">
                     <xsl:attribute name="data-width"><xsl:value-of select="$plumx_data-width"/></xsl:attribute>
                 </xsl:if>
 
-                <xsl:if test="confman:getProperty('altmetrics', 'plumx.data-border')">
+                <xsl:if test="confman:getProperty('plumx.data-border')">
                     <xsl:attribute name="data-border">true</xsl:attribute>
                 </xsl:if>
                 &#xFEFF;


### PR DESCRIPTION
Fixes issues noted in [DS-3477](https://jira.duraspace.org/browse/DS-3477) (Mirage item-view.xsl altmetrics config is not read due to deprecated scope reference)

To test, enable altmetrics by enabling it in `[dspace]/config/modules/altmetrics.cfg`:
`altmetric.enabled = true`

To test altmetric badges where URI is a handle set a test item's dc.identifier.uri to http://hdl.handle.net/2022/14471

To test altmetric badges where URI is a DOI, set a test item's dc.identifier.uri to http://doi.org/10.1038/nature.2012.9872 (or set dc.identifier.doi to this value and change identifier in the config like `altmetrics.field = dc.identifier.doi`)

