### PR TITLE
[DS-3406] add collection and subcommunity sorting by name comparator to Community getters

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/CollectionNameComparator.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionNameComparator.java
@@ -18,6 +18,9 @@ public class CollectionNameComparator
 {
     @Override
     public int compare(Collection collection1, Collection collection2) {
+        if(collection1 == collection2) { return 0; }
+        if(collection1 == null) { return -1; }
+        if(collection2 == null) { return -1; }
         return collection1.getName().compareTo(collection2.getName());
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/Community.java
+++ b/dspace-api/src/main/java/org/dspace/content/Community.java
@@ -142,7 +142,7 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
     {
         List<Collection> sortedCollections = new ArrayList<Collection>(collections);
         Collections.sort(sortedCollections, new CollectionNameComparator());
-        return collections;
+        return sortedCollections;
     }
 
     void addCollection(Collection collection)

--- a/dspace-api/src/main/java/org/dspace/content/Community.java
+++ b/dspace-api/src/main/java/org/dspace/content/Community.java
@@ -140,6 +140,8 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
      */
     public List<Collection> getCollections()
     {
+        List<Collection> sortedCollections = new ArrayList<Collection>(collections);
+        Collections.sort(sortedCollections, new CollectionNameComparator());
         return collections;
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/Community.java
+++ b/dspace-api/src/main/java/org/dspace/content/Community.java
@@ -164,7 +164,9 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
      */
     public List<Community> getSubcommunities()
     {
-        return subCommunities;
+        List<Community> sortedSubCommunities = new ArrayList<Community>(subCommunities);
+        Collections.sort(sortedSubCommunities, new CommunityNameComparator());
+        return sortedSubCommunities;
     }
 
     /**
@@ -175,7 +177,9 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
      */
     public List<Community> getParentCommunities()
     {
-        return parentCommunities;
+        List<Community> sortedParentCommunities = new ArrayList<Community>(parentCommunities);
+        Collections.sort(sortedParentCommunities, new CommunityNameComparator());
+        return sortedParentCommunities;
     }
 
     void addParentCommunity(Community parentCommunity) {

--- a/dspace-api/src/main/java/org/dspace/content/CommunityNameComparator.java
+++ b/dspace-api/src/main/java/org/dspace/content/CommunityNameComparator.java
@@ -1,0 +1,23 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content;
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+/**
+ * Compares the names of two {@link Community} objects.
+ */
+public class CommunityNameComparator
+        implements Comparator<Community>, Serializable
+{
+    @Override
+    public int compare(Community community1, Community community2) {
+        return community1.getName().compareTo(community2.getName());
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/content/CommunityNameComparator.java
+++ b/dspace-api/src/main/java/org/dspace/content/CommunityNameComparator.java
@@ -18,6 +18,9 @@ public class CommunityNameComparator
 {
     @Override
     public int compare(Community community1, Community community2) {
+        if(community1 == community2) { return 0; }
+        if(community1 == null) { return -1; }
+        if(community1 == null) { return -1; }
         return community1.getName().compareTo(community2.getName());
     }
 }


### PR DESCRIPTION
This PR resolves the collection/sub-community sorting issue described in [DS-3406](https://jira.duraspace.org/browse/DS-3406) for XMLUI and JSPUI, forcing a sort by getName() for collections, sub-communities and parent communities of a community.

It might be considered too expensive / adding unnecessary complexity to these otherwise simple getters? Another way could be to wire in some @OrderBy SQL sort for the entities in question? (but that makes an assumption on field usage unlike the comparators which use getName() to get title from wherever/whatever the collection metadata is)

To test, rebuild discovery indexes after rebuild and restart.