### PR TITLE
Fix for DS-3479 avoid adding empty metadata values during import

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -1108,6 +1108,10 @@ public class ItemImport
         {
             value = "";
         }
+        else
+        {
+        	value = value.trim();
+        }
         // //getElementData(n, "element");
         String element = getAttributeValue(n, "element");
         String qualifier = getAttributeValue(n, "qualifier"); //NodeValue();
@@ -1129,8 +1133,8 @@ public class ItemImport
         {
             qualifier = null;
         }
-
-        if (!isTest)
+        // only add metadata if it is no test and there is an real value
+        if (!isTest && !value.equals(""))
         {
             i.addMetadata(schema, element, qualifier, language, value);
         }


### PR DESCRIPTION
Simple fix for DS-3479 checking for empty metadata values during SAF import.
