### PR TITLE
Fix for DS-3479 preventing the import of empty metadata

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -712,6 +712,10 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
         {
             value = "";
         }
+        else
+        {
+        	value = value.trim();
+        }
         // //getElementData(n, "element");
         String element = getAttributeValue(n, "element");
         String qualifier = getAttributeValue(n, "qualifier"); //NodeValue();
@@ -733,8 +737,8 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
         {
             qualifier = null;
         }
-
-        if (!isTest)
+        // only add metadata if it is no test and there is a real value
+        if (!isTest && !value.equals(""))
         {
             itemService.addMetadata(c, i, schema, element, qualifier, language, value);
         }


### PR DESCRIPTION
Simple fix for DS-3479 checking for empty metadata values during SAF import