### PR TITLE
[DS-2789] 6x Display a "restricted image" for a thumbnail if the bitstream is restricted

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/item-list.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/item-list.xsl
@@ -185,12 +185,24 @@
             <a class="image-link" href="{$href}">
                 <xsl:choose>
                     <xsl:when test="mets:fileGrp[@USE='THUMBNAIL']">
-                        <img class="img-responsive img-thumbnail" alt="xmlui.mirage2.item-list.thumbnail" i18n:attr="alt">
-                            <xsl:attribute name="src">
-                                <xsl:value-of
-                                        select="mets:fileGrp[@USE='THUMBNAIL']/mets:file/mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
-                            </xsl:attribute>
-                        </img>
+                        <!-- Checking if Thumbnail is restricted and if so, show a restricted image --> 
+                        <xsl:variable name="src">
+                            <xsl:value-of select="mets:fileGrp[@USE='THUMBNAIL']/mets:file/mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
+                        </xsl:variable>
+                        <xsl:choose>
+                            <xsl:when test="contains($src,'isAllowed=n')">
+                                <div style="width: 100%; text-align: center">
+                                    <i aria-hidden="true" class="glyphicon  glyphicon-lock"></i>
+                                </div>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <img class="img-responsive img-thumbnail" alt="xmlui.mirage2.item-list.thumbnail" i18n:attr="alt">
+                                    <xsl:attribute name="src">
+                                        <xsl:value-of select="$src"/>
+                                    </xsl:attribute>
+                                </img>
+                            </xsl:otherwise>
+                        </xsl:choose>
                     </xsl:when>
                     <xsl:otherwise>
                         <img class="img-thumbnail" alt="xmlui.mirage2.item-list.thumbnail" i18n:attr="alt">

--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/item-view.xsl
@@ -181,11 +181,17 @@
                             </xsl:otherwise>
                         </xsl:choose>
                     </xsl:variable>
-                    <img class="img-thumbnail" alt="Thumbnail">
-                        <xsl:attribute name="src">
-                            <xsl:value-of select="$src"/>
-                        </xsl:attribute>
-                    </img>
+                    <!-- Checking if Thumbnail is restricted and if so, show a restricted image --> 
+                    <xsl:choose>
+                        <xsl:when test="contains($src,'isAllowed=n')"/>
+                        <xsl:otherwise>
+                            <img class="img-thumbnail" alt="Thumbnail">
+                                <xsl:attribute name="src">
+                                    <xsl:value-of select="$src"/>
+                                </xsl:attribute>
+                            </img>
+                        </xsl:otherwise>
+                    </xsl:choose>
                 </xsl:when>
                 <xsl:otherwise>
                     <img class="img-thumbnail" alt="Thumbnail">

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/aspect/artifactbrowser/item-list.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/aspect/artifactbrowser/item-list.xsl
@@ -248,12 +248,31 @@
                 <a class="image-link" href="{$href}">
                     <xsl:choose>
                         <xsl:when test="mets:fileGrp[@USE='THUMBNAIL']">
-                            <img alt="Thumbnail">
-                                <xsl:attribute name="src">
-                                    <xsl:value-of
-                                            select="mets:fileGrp[@USE='THUMBNAIL']/mets:file/mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
-                                </xsl:attribute>
-                            </img>
+                            <!-- Checking if Thumbnail is restricted and if so, show a restricted image --> 
+                            <xsl:variable name="src">
+                              <xsl:value-of select="mets:fileGrp[@USE='THUMBNAIL']/mets:file/mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
+                            </xsl:variable>
+                            <xsl:choose>
+                              <xsl:when test="contains($src,'isAllowed=n')">
+                                <div style="width: 100%; text-align: center">
+                                    <img>
+                                      <xsl:attribute name="src">
+                                        <xsl:value-of select="$context-path"/>
+                                        <xsl:text>/static/icons/lock24.png</xsl:text>
+                                      </xsl:attribute>
+                                      <xsl:attribute name="alt">xmlui.dri2xhtml.METS-1.0.blocked</xsl:attribute>
+                                      <xsl:attribute name="attr" namespace="http://apache.org/cocoon/i18n/2.1">alt</xsl:attribute>
+                                    </img>
+                                </div>
+                              </xsl:when>
+                              <xsl:otherwise>
+                                <img alt="Thumbnail">
+                                    <xsl:attribute name="src">
+                                        <xsl:value-of select="$src"/>
+                                    </xsl:attribute>
+                                </img>
+                              </xsl:otherwise>
+                            </xsl:choose>
                         </xsl:when>
                         <xsl:otherwise>
                             <img alt="Icon" src="{concat($theme-path, '/images/mime.png')}" style="height: {$thumbnail.maxheight}px;"/>

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -405,12 +405,19 @@
                     <xsl:choose>
                         <xsl:when test="$context/mets:fileSec/mets:fileGrp[@USE='THUMBNAIL']/
                         mets:file[@GROUPID=current()/@GROUPID]">
-                            <img alt="Thumbnail">
-                                <xsl:attribute name="src">
-                                    <xsl:value-of select="$context/mets:fileSec/mets:fileGrp[@USE='THUMBNAIL']/
-                                    mets:file[@GROUPID=current()/@GROUPID]/mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
-                                </xsl:attribute>
-                            </img>
+                            <xsl:variable name="src" 
+                              select="$context/mets:fileSec/mets:fileGrp[@USE='THUMBNAIL']/mets:file[@GROUPID=current()/@GROUPID]/mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
+                            <!-- Checking if Thumbnail is restricted and if so, show a restricted image --> 
+                            <xsl:choose>
+                              <xsl:when test="contains($src,'isAllowed=n')"/>
+                              <xsl:otherwise>
+                                <img class="img-thumbnail" alt="Thumbnail">
+                                    <xsl:attribute name="src">
+                                        <xsl:value-of select="$src"/>
+                                    </xsl:attribute>
+                                </img>
+                              </xsl:otherwise>
+                            </xsl:choose>
                         </xsl:when>
                         <xsl:otherwise>
                             <img alt="Icon" src="{concat($theme-path, '/images/mime.png')}" style="height: {$thumbnail.maxheight}px;"/>


### PR DESCRIPTION
George Kozak suggested this change in https://jira.duraspace.org/browse/DS-2789 to prevent the display of an unavailable image icon for restricted thumbnails.  

George's suggested code contained a reference to "restricted.png".  In the absence of that image, I am simply displaying the lock glyph.  An actual image may be preferred.

This change would also make sense to apply to the non-Mirage2 themes.  Which themes are actively supported?

# Before

## Mirage View

![image](https://cloud.githubusercontent.com/assets/1111057/23284562/028ea42a-f9e1-11e6-987c-de5d0e32243c.png)

## Mirage2 View

![image](https://cloud.githubusercontent.com/assets/1111057/23284639/6bb5ff70-f9e1-11e6-95d9-cbc15836ebf5.png)

# After

## Mirage View

![image](https://cloud.githubusercontent.com/assets/1111057/23283976/c5bb60c2-f9dd-11e6-90d2-960460fa6dd5.png)

## Mirage2 View

![image](https://cloud.githubusercontent.com/assets/1111057/23284062/3d7ba04a-f9de-11e6-94cb-0f4a131488c9.png)
