### PR TITLE
Fix Travis CI Maven download timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ env:
 
 # Install prerequisites for building Mirage2 more rapidly
 before_install:
+  # Remove outdated settings.xml from Travis builds. Workaround for https://github.com/travis-ci/travis-ci/issues/4629
+  - rm ~/.m2/settings.xml
   # Install Node.js 6.5.0 & print version info
   - nvm install 6.5.0
   - node --version


### PR DESCRIPTION
While this PR is being submitted for `dspace-6_x`, it should be applied to other active branches.

This works around issues with Travis CI's default Maven `settings.xml` by simply removing the file (in favor of using Maven defaults).  

This fix is necessary until travis-ci/travis-ci#4629 is resolved.  (NOTE: This issue is no longer seemingly specific to the abandoned Codehaus repos, but also now seems to affect "repository.apache.org" repos, at least temporarily)