### PR TITLE
[DS-3488] REST7: Create Item Converter

### DIFF
--- a/dspace-spring-rest/README.md
+++ b/dspace-spring-rest/README.md
@@ -12,6 +12,8 @@ We don't use Spring Data REST as we haven't a spring data layer and we want to p
 ## How to contribute
 Check the infomation available on the DSpace Official Wiki page for the [DSpace 7 Working Group](https://wiki.duraspace.org/display/DSPACE/DSpace+7+UI+Working+Group)
 
+[DSpace 7 REST: Coding DSpace Objects](https://wiki.duraspace.org/display/DSPACE/DSpace+7+REST%3A+Coding+DSpace+Objects)
+
 ## How to run
 The only tested way right now is to run this webapp inside your IDE (Eclipse). Just create a new Tomcat 8 server and deploy the dspace-spring-rest maven module to it.
 > The *dspace.dir* is configured in the *dspace-spring-rest/src/main/resources/application.properties* file

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -46,7 +46,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  */
 @RestController
-@RequestMapping("/api/core/{model}s")
+@RequestMapping("/api/core/{model}")
 @SuppressWarnings("rawtypes")
 public class RestResourceController {
 	@Autowired

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/BitstreamConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/BitstreamConverter.java
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class BitstreamConverter
 		extends DSpaceObjectConverter<org.dspace.content.Bitstream, org.dspace.app.rest.model.BitstreamRest> {
-	@Autowired
+	@Autowired(required = true)
 	BitstreamFormatConverter bfConverter;
 
 	@Override

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/CommunityConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/CommunityConverter.java
@@ -1,0 +1,37 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.converter;
+
+import org.dspace.app.rest.model.CommunityRest;
+import org.springframework.stereotype.Component;
+
+/**
+ * This is the converter from/to the community in the DSpace API data model and
+ * the REST data model
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+@Component
+public class CommunityConverter
+		extends DSpaceObjectConverter<org.dspace.content.Community, org.dspace.app.rest.model.CommunityRest> {
+	@Override
+	public org.dspace.content.Community toModel(org.dspace.app.rest.model.CommunityRest obj) {
+		return (org.dspace.content.Community) super.toModel(obj);
+	}
+
+	@Override
+	public CommunityRest fromModel(org.dspace.content.Community obj) {
+		return (CommunityRest) super.fromModel(obj);
+	}
+
+	@Override
+	protected CommunityRest newInstance() {
+		return new CommunityRest();
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
@@ -26,7 +26,12 @@ public class ItemConverter extends DSpaceObjectConverter<org.dspace.content.Item
 	@Override
 	public ItemRest fromModel(org.dspace.content.Item obj) {
 		ItemRest item = super.fromModel(obj);
-		// item.setOwningCollection(collectionConverter.fromModel(obj.getOwningCollection()));
+		item.setInArchive(obj.isArchived());
+		item.setDiscoverable(obj.isDiscoverable());
+		item.setWithdrawn(obj.isWithdrawn());
+		item.setLastModified(obj.getLastModified());
+		//item.setTemplateItemOf(collectionConverter.fromModel(obj.getTemplateItemOf()));
+		//item.setOwningCollection(collectionConverter.fromModel(obj.getOwningCollection()));
 		return item;
 	}
 
@@ -40,4 +45,5 @@ public class ItemConverter extends DSpaceObjectConverter<org.dspace.content.Item
 	protected ItemRest newInstance() {
 		return new ItemRest();
 	}
+
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/CommunityRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/CommunityRest.java
@@ -1,0 +1,24 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+/**
+ * The Community REST Resource
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+public class CommunityRest extends DSpaceObjectRest {
+	public static final String NAME = "community";
+
+	@Override
+	public String getType() {
+		return NAME;
+	}
+
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/ItemRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/ItemRest.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.app.rest.model;
 
+import java.util.Date;
+
 /**
  * The Item REST Resource
  * 
@@ -15,9 +17,54 @@ package org.dspace.app.rest.model;
  */
 public class ItemRest extends DSpaceObjectRest {
 	public static final String NAME = "item";
+	private boolean inArchive = false;
+	private boolean discoverable = false;
+	private boolean withdrawn = false;
+	private Date lastModified = new Date();
+	private CollectionRest owningCollection;
+	private CollectionRest templateItemOf;
+	//private EPerson submitter;
 
 	@Override
 	public String getType() {
 		return NAME;
 	}
+	
+	public boolean getInArchive() {
+		return inArchive;
+	}
+	public void setInArchive(boolean inArchive) {
+		this.inArchive = inArchive;
+	}
+	public boolean getDiscoverable() {
+		return discoverable;
+	}
+	public void setDiscoverable(boolean discoverable) {
+		this.discoverable = discoverable;
+	}
+	public boolean getWithdrawn() {
+		return withdrawn;
+	}
+	public void setWithdrawn(boolean withdrawn) {
+		this.withdrawn = withdrawn;
+	}
+	public Date getLastModified() {
+		return lastModified;
+	}
+	public void setLastModified(Date lastModified){
+		this.lastModified = lastModified;
+	}
+	public CollectionRest getOwningCollection() {
+		return owningCollection;
+	}
+	public void setOwningCollection(CollectionRest owningCollection){
+		this.owningCollection = owningCollection;
+	}
+	public CollectionRest getTemplateItemOf() {
+		return templateItemOf;
+	}
+	public void setTemplateItemOf(CollectionRest templateItemOf){
+		this.templateItemOf = templateItemOf;
+	}
+
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/ItemRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/ItemRest.java
@@ -10,6 +10,8 @@ package org.dspace.app.rest.model;
 import java.util.Date;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 /**
  * The Item REST Resource
  * 
@@ -22,7 +24,9 @@ public class ItemRest extends DSpaceObjectRest {
 	private boolean discoverable = false;
 	private boolean withdrawn = false;
 	private Date lastModified = new Date();
+	@JsonIgnore
 	private CollectionRest owningCollection;
+	@JsonIgnore
 	private CollectionRest templateItemOf;
 	//private EPerson submitter;
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/ItemRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/ItemRest.java
@@ -8,6 +8,7 @@
 package org.dspace.app.rest.model;
 
 import java.util.Date;
+import java.util.List;
 
 /**
  * The Item REST Resource
@@ -25,6 +26,8 @@ public class ItemRest extends DSpaceObjectRest {
 	private CollectionRest templateItemOf;
 	//private EPerson submitter;
 
+	List<BitstreamRest> bitstreams;
+	
 	@Override
 	public String getType() {
 		return NAME;
@@ -65,6 +68,13 @@ public class ItemRest extends DSpaceObjectRest {
 	}
 	public void setTemplateItemOf(CollectionRest templateItemOf){
 		this.templateItemOf = templateItemOf;
+	}
+	public List<BitstreamRest> getBitstreams() {
+		return bitstreams;
+	}
+
+	public void setBitstreams(List<BitstreamRest> bitstreams) {
+		this.bitstreams = bitstreams;
 	}
 
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/CollectionResource.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/CollectionResource.java
@@ -1,0 +1,25 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model.hateoas;
+
+import org.dspace.app.rest.model.CollectionRest;
+import org.dspace.app.rest.utils.Utils;
+
+/**
+ * Item Rest HAL Resource. The HAL Resource wraps the REST Resource
+ * adding support for the links and embedded resources
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+@RelNameDSpaceResource(CollectionRest.NAME)
+public class CollectionResource extends DSpaceResource<CollectionRest> {
+	public CollectionResource(CollectionRest collection, Utils utils, String... rels) {
+		super(collection, utils, rels);
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/CommunityResource.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/CommunityResource.java
@@ -1,0 +1,32 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model.hateoas;
+
+import org.dspace.app.rest.model.CommunityRest;
+import org.dspace.app.rest.utils.Utils;
+
+/**
+ * Item Rest HAL Resource. The HAL Resource wraps the REST Resource
+ * adding support for the links and embedded resources
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+@RelNameDSpaceResource(CommunityRest.NAME)
+public class CommunityResource extends DSpaceResource<CommunityRest> {
+	public CommunityResource(CommunityRest community, Utils utils, String... rels) {
+		super(community, utils, rels);
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
@@ -1,0 +1,88 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.repository;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.dspace.app.rest.converter.CollectionConverter;
+import org.dspace.app.rest.model.CollectionRest;
+import org.dspace.app.rest.model.hateoas.CollectionResource;
+import org.dspace.content.Collection;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.CollectionService;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+/**
+ * This is the repository responsible to manage Item Rest object
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+
+@Component(CollectionRest.NAME)
+public class CollectionRestRepository extends DSpaceRestRepository<CollectionRest, UUID> {
+	CollectionService cs = ContentServiceFactory.getInstance().getCollectionService();
+	@Autowired
+	CollectionConverter converter;
+	
+	
+	public CollectionRestRepository() {
+		System.out.println("Repository initialized by Spring");
+	}
+
+	@Override
+	public CollectionRest findOne(Context context, UUID id) {
+		Collection collection = null;
+		try {
+			collection = cs.find(context, id);
+		} catch (SQLException e) {
+			throw new RuntimeException(e.getMessage(), e);
+		}
+		if (collection == null) {
+			return null;
+		}
+		return converter.fromModel(collection);
+	}
+
+	@Override
+	public Page<CollectionRest> findAll(Context context, Pageable pageable) {
+		List<Collection> it = null;
+		List<Collection> collections = new ArrayList<Collection>();
+		int total = 0;
+		try {
+			total = cs.countTotal(context);
+			it = cs.findAll(context);
+			for (Collection c: it) {
+				collections.add(c);
+			}
+		} catch (SQLException e) {
+			throw new RuntimeException(e.getMessage(), e);
+		}
+		Page<CollectionRest> page = new PageImpl<Collection>(collections, pageable, total).map(converter);
+		return page;
+	}
+	
+	@Override
+	public Class<CollectionRest> getDomainClass() {
+		return CollectionRest.class;
+	}
+	
+	@Override
+	public CollectionResource wrapResource(CollectionRest collection, String... rels) {
+		return new CollectionResource(collection, utils, rels);
+	}
+
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
@@ -64,7 +64,7 @@ public class CollectionRestRepository extends DSpaceRestRepository<CollectionRes
 		int total = 0;
 		try {
 			total = cs.countTotal(context);
-			it = cs.findAll(context);
+			it = cs.findAll(context, pageable.getPageSize(), pageable.getOffset());
 			for (Collection c: it) {
 				collections.add(c);
 			}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
@@ -64,7 +64,7 @@ public class CommunityRestRepository extends DSpaceRestRepository<CommunityRest,
 		int total = 0;
 		try {
 			total = cs.countTotal(context);
-			it = cs.findAll(context);
+			it = cs.findAll(context, pageable.getPageSize(), pageable.getOffset());
 			for (Community c: it) {
 				communities.add(c);
 			}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
@@ -1,0 +1,88 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.repository;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.dspace.app.rest.converter.CommunityConverter;
+import org.dspace.app.rest.model.CommunityRest;
+import org.dspace.app.rest.model.hateoas.CommunityResource;
+import org.dspace.content.Community;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.CommunityService;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+/**
+ * This is the repository responsible to manage Item Rest object
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+
+@Component(CommunityRest.NAME)
+public class CommunityRestRepository extends DSpaceRestRepository<CommunityRest, UUID> {
+	CommunityService cs = ContentServiceFactory.getInstance().getCommunityService();
+	@Autowired
+	CommunityConverter converter;
+	
+	
+	public CommunityRestRepository() {
+		System.out.println("Repository initialized by Spring");
+	}
+
+	@Override
+	public CommunityRest findOne(Context context, UUID id) {
+		Community community = null;
+		try {
+			community = cs.find(context, id);
+		} catch (SQLException e) {
+			throw new RuntimeException(e.getMessage(), e);
+		}
+		if (community == null) {
+			return null;
+		}
+		return converter.fromModel(community);
+	}
+
+	@Override
+	public Page<CommunityRest> findAll(Context context, Pageable pageable) {
+		List<Community> it = null;
+		List<Community> communities = new ArrayList<Community>();
+		int total = 0;
+		try {
+			total = cs.countTotal(context);
+			it = cs.findAll(context);
+			for (Community c: it) {
+				communities.add(c);
+			}
+		} catch (SQLException e) {
+			throw new RuntimeException(e.getMessage(), e);
+		}
+		Page<CommunityRest> page = new PageImpl<Community>(communities, pageable, total).map(converter);
+		return page;
+	}
+	
+	@Override
+	public Class<CommunityRest> getDomainClass() {
+		return CommunityRest.class;
+	}
+	
+	@Override
+	public CommunityResource wrapResource(CommunityRest community, String... rels) {
+		return new CommunityResource(community, utils, rels);
+	}
+
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/Utils.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/Utils.java
@@ -11,8 +11,10 @@ import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 
 import java.util.List;
 
+import org.atteo.evo.inflector.English;
 import org.dspace.app.rest.exception.PaginationException;
 import org.dspace.app.rest.exception.RepositoryNotFoundException;
+import org.dspace.app.rest.model.CommunityRest;
 import org.dspace.app.rest.model.RestModel;
 import org.dspace.app.rest.model.hateoas.DSpaceResource;
 import org.dspace.app.rest.repository.DSpaceRestRepository;
@@ -64,11 +66,20 @@ public class Utils {
 		return linkTo(data.getController(), data.getType()).slash(data).slash(rel).withRel(rel);
 	}
 
-	public DSpaceRestRepository getResourceRepository(String model) {
+	public DSpaceRestRepository getResourceRepository(String modelPlural) {
+		String model = makeSingular(modelPlural);
 		try {
 			return applicationContext.getBean(model, DSpaceRestRepository.class);
 		} catch (NoSuchBeanDefinitionException e) {
 			throw new RepositoryNotFoundException(model);
 		}
+	}
+	
+	public static String makeSingular(String modelPlural) {
+		//The old dspace res package includes the evo inflection library which has a plural() function but no singular function
+		if (modelPlural.equals("communities")) {
+			return CommunityRest.NAME;
+		}
+		return modelPlural.replaceAll("s$", "");
 	}
 }


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3488?jql=component%20%3D%20new-REST

@abollini , here is a first attempt at an item converter.  

Questions:
1. Will we be exposing Bundle objects through the API or is bundle simple an attribute of a bitstream?
2. The approach in this PR creates bitstream objects when the item object is created.  What is the proper way to expose the link to the bitstream objects rather than automatically loading them?
3. With my latest commit, I have links appearing for collections, but the serialized JSON is displaying null.  Some guidance on how to properly annotate/code DSpace object links would be appreciated.