### PR TITLE
[DS-3463] Fix IP authentication for anonymous users

### DIFF
--- a/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
@@ -185,6 +185,15 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
             //lookup eperson in normal groups and subgroups
             return epersonInGroup(context, groupName, currentUser);
         } else {
+            // Check also for anonymous users if IP authentication used
+            List<Group> specialGroups = context.getSpecialGroups();
+            if(CollectionUtils.isNotEmpty(specialGroups)) {
+                for(Group specialGroup : specialGroups){
+                    if (StringUtils.equals(specialGroup.getName(), groupName)) {
+                        return true;
+                    }
+                }
+            }
             return false;
         }
     }


### PR DESCRIPTION
Suggested fix for https://jira.duraspace.org/browse/DS-3463. Adds special groups membership check even if no eperson is in the context (as is the case with IP-based authentication). Reported in dspace-tech 23 Feb 2017, tested with Dspace 6.x.