### PR TITLE
[DS-1588] Update 1.7.x branch to build properly with Maven 3

### DIFF
--- a/dspace/modules/jspui/pom.xml
+++ b/dspace/modules/jspui/pom.xml
@@ -34,6 +34,7 @@
 			the configuration.
 		-->
 		<profile>
+         <id>dspace-config</id>
 			<activation>
 				<property>
 					<name>dspace.config</name>

--- a/dspace/modules/pom.xml
+++ b/dspace/modules/pom.xml
@@ -11,7 +11,7 @@
 		<groupId>org.dspace</groupId>
 		<artifactId>dspace-parent</artifactId>
 		<version>1.7.4-SNAPSHOT</version>
-		<relativePath>../..</relativePath>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
     <properties>

--- a/dspace/src/assemble/assembly.xml
+++ b/dspace/src/assemble/assembly.xml
@@ -41,8 +41,16 @@
 			<excludes>
 				<exclude>src</exclude>
 				<exclude>config/dspace.cfg</exclude>
-			</excludes>
+				<exclude>config/modules/**</exclude>
+        </excludes>
 		</fileSet>
+        <fileSet>
+            <outputDirectory>.</outputDirectory>
+            <includes>
+                <include>config/modules/**</include>
+            </includes>
+            <filtered>true</filtered>
+        </fileSet>
 	</fileSets>
 
 	<files>
@@ -70,12 +78,11 @@
 			
 			<binaries>
 				<includeDependencies>false</includeDependencies>
-				<outputDirectory>webapps/</outputDirectory>
-			   <outputFileNameMapping>${artifactId}/</outputFileNameMapping>
+				<outputDirectory>webapps/${module.artifactId}</outputDirectory>
             <unpack>true</unpack>
          </binaries>
-         
 		</moduleSet>
 	</moduleSets>
+
 
 </assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -1055,7 +1055,7 @@ Individual Maven projects may choose to override these defaults. -->
       <repository>
          <id>sonatype-releases</id>
          <name>Sonatype Releases Repository</name>
-         <url>http://oss.sonatype.org/content/repositories/releases/</url>
+         <url>https://oss.sonatype.org/content/repositories/releases/</url>
       </repository>
    </repositories>
 </project>


### PR DESCRIPTION
Dspace release 1.7.3 does not properly compile with Maven 2.2.1 (likely as side effect of upgrading the process to Maven 3, https://jira.duraspace.org/browse/DS-1588), resulting in incorrect directory structure under webapps (referred to in https://jira.duraspace.org/browse/DS-1587). This patch fixes the compilation, used in 1.7 (xmlui) -based production environment. 