### PR TITLE
Metadata hierarchy representation in the new REST

### DIFF
--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/MetadataFieldConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/MetadataFieldConverter.java
@@ -1,0 +1,36 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.converter;
+
+import org.dspace.app.rest.model.MetadataFieldRest;
+import org.springframework.stereotype.Component;
+
+/**
+ * This is the converter from/to the MetadataField in the DSpace API data model and
+ * the REST data model
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ */
+@Component
+public class MetadataFieldConverter extends DSpaceConverter<org.dspace.content.MetadataField, MetadataFieldRest> {
+	@Override
+	public MetadataFieldRest fromModel(org.dspace.content.MetadataField obj) {
+		MetadataFieldRest field = new MetadataFieldRest();
+		field.setId(obj.getID());
+		field.setElement(obj.getElement());
+		field.setQualifier(obj.getQualifier());
+		field.setScopeNote(obj.getScopeNote());
+		return field;
+	}
+
+	@Override
+	public org.dspace.content.MetadataField toModel(MetadataFieldRest obj) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/MetadataSchemaConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/MetadataSchemaConverter.java
@@ -1,0 +1,35 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.converter;
+
+import org.dspace.app.rest.model.MetadataSchemaRest;
+import org.springframework.stereotype.Component;
+
+/**
+ * This is the converter from/to the MetadataSchema in the DSpace API data model and
+ * the REST data model
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ */
+@Component
+public class MetadataSchemaConverter extends DSpaceConverter<org.dspace.content.MetadataSchema, MetadataSchemaRest> {
+	@Override
+	public MetadataSchemaRest fromModel(org.dspace.content.MetadataSchema obj) {
+		MetadataSchemaRest schema = new MetadataSchemaRest();
+		schema.setId(obj.getID());
+		schema.setNamespace(obj.getNamespace());
+		schema.setPrefix(obj.getName());
+		return schema;
+	}
+
+	@Override
+	public org.dspace.content.MetadataSchema toModel(MetadataSchemaRest obj) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/AuthorityListRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/AuthorityListRest.java
@@ -1,0 +1,66 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import java.util.List;
+
+import org.dspace.app.rest.RestResourceController;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * The AuthorityList REST Resource. It represents an authority list that can be
+ * used to control the values for specific metadata
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+public class AuthorityListRest extends BaseObjectRest<String> {
+	public static final String NAME = "authority";
+
+	private String name;
+
+	private boolean hasVariants;
+	
+	private List<MetadataFieldRest> linkedMetadata;
+	
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public boolean isHasVariants() {
+		return hasVariants;
+	}
+
+	public void setHasVariants(boolean hasVariants) {
+		this.hasVariants = hasVariants;
+	}
+
+	public List<MetadataFieldRest> getLinkedMetadata() {
+		return linkedMetadata;
+	}
+
+	public void setLinkedMetadata(List<MetadataFieldRest> linkedMetadata) {
+		this.linkedMetadata = linkedMetadata;
+	}
+
+	@Override
+	public String getType() {
+		return NAME;
+	}
+
+	@Override
+	@JsonIgnore
+	public Class getController() {
+		return RestResourceController.class;
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/AuthorityValueRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/AuthorityValueRest.java
@@ -1,0 +1,66 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import java.util.List;
+
+import org.dspace.app.rest.RestResourceController;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * The AuthorityValue REST Resource. It represents a single entry in an
+ * authority list used or not by a metadata
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+public class AuthorityValueRest extends BaseObjectRest<String> {
+	public static final String NAME = "authorityvalue";
+
+	private AuthorityListRest authorityList;
+
+	private String preferredLabel;
+
+	private List<String> variants;
+
+	public AuthorityListRest getAuthorityList() {
+		return authorityList;
+	}
+
+	public void setAuthorityList(AuthorityListRest authorityList) {
+		this.authorityList = authorityList;
+	}
+
+	public String getPreferredLabel() {
+		return preferredLabel;
+	}
+
+	public void setPreferredLabel(String preferredLabel) {
+		this.preferredLabel = preferredLabel;
+	}
+
+	public List<String> getVariants() {
+		return variants;
+	}
+
+	public void setVariants(List<String> variants) {
+		this.variants = variants;
+	}
+
+	@Override
+	public String getType() {
+		return NAME;
+	}
+
+	@Override
+	@JsonIgnore
+	public Class getController() {
+		return RestResourceController.class;
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/DSpaceObjectRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/DSpaceObjectRest.java
@@ -12,6 +12,8 @@ import java.util.List;
 import org.dspace.app.rest.RestResourceController;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
 
 /**
  * Base REST representation for all the DSpaceObjects
@@ -27,7 +29,10 @@ public abstract class DSpaceObjectRest extends BaseObjectRest<String> {
 	private String handle;
 	private String type;
 
-	List<MetadataEntryRest> metadata;
+//	List<MetadataEntryRest> metadata;
+	
+	@JsonProperty(access = Access.WRITE_ONLY)
+	MetadataEmbeddedRest metadata;
 
 	@Override
 	@JsonIgnore
@@ -59,14 +64,22 @@ public abstract class DSpaceObjectRest extends BaseObjectRest<String> {
 		this.handle = handle;
 	}
 
-	public List<MetadataEntryRest> getMetadata() {
+//	public List<MetadataEntryRest> getMetadata() {
+//		return metadata;
+//	}
+//
+//	public void setMetadata(List<MetadataEntryRest> metadata) {
+//		this.metadata = metadata;
+//	}
+
+	public MetadataEmbeddedRest getMetadata() {
 		return metadata;
 	}
-
-	public void setMetadata(List<MetadataEntryRest> metadata) {
-		this.metadata = metadata;
+	
+	public void setMetadata(MetadataEmbeddedRest meta) {
+		this.metadata = meta;
 	}
-
+	
 	@Override
 	@JsonIgnore
 	public Class getController() {

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/EmbeddedRestModel.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/EmbeddedRestModel.java
@@ -1,0 +1,17 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+/**
+ * Methods to implement to make an embedded resource linkable to other
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+public interface EmbeddedRestModel {
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataElementRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataElementRest.java
@@ -1,0 +1,47 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
+/**
+ * A Metadata Element to use to embedd metadata in a REST Resource
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+public class MetadataElementRest implements EmbeddedRestModel {
+	
+	@JsonIgnore
+	private Map<String, MetadataQualifierRest> qualifiers = new HashMap<String, MetadataQualifierRest>();
+	
+	@JsonUnwrapped
+	private MetadataQualifierRest nullQualifier;
+
+	@JsonAnyGetter
+	public Map<String, MetadataQualifierRest> getQualifiers() {
+		return qualifiers;
+	}
+
+	public void setQualifiers(Map<String, MetadataQualifierRest> qualifiers) {
+		this.qualifiers = qualifiers;
+	}
+
+	public MetadataQualifierRest getNullQualifier() {
+		return nullQualifier;
+	}
+
+	public void setNullQualifier(MetadataQualifierRest nullQualifier) {
+		this.nullQualifier = nullQualifier;
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataEmbeddedRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataEmbeddedRest.java
@@ -1,0 +1,34 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
+
+/**
+ * A class to embedd metadata in the object resource
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+public class MetadataEmbeddedRest implements EmbeddedRestModel {
+	@JsonProperty(access=Access.WRITE_ONLY)
+	private Map<String, MetadataSchemaEmbeddedRest> metadata = new HashMap<String, MetadataSchemaEmbeddedRest>();
+
+	public Map<String, MetadataSchemaEmbeddedRest> getMetadata() {
+		return metadata;
+	}
+
+	public void setMetadata(Map<String, MetadataSchemaEmbeddedRest> metadata) {
+		this.metadata = metadata;
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataFieldRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataFieldRest.java
@@ -1,0 +1,63 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import org.dspace.app.rest.RestResourceController;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * The MetadataField REST Resource
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+public class MetadataFieldRest extends BaseObjectRest<Integer> {
+	public static final String NAME = "metadatafield";
+
+	private String element;
+
+	private String qualifier;
+
+	private String scopeNote;
+
+	public String getElement() {
+		return element;
+	}
+
+	public void setElement(String element) {
+		this.element = element;
+	}
+
+	public String getQualifier() {
+		return qualifier;
+	}
+
+	public void setQualifier(String qualifier) {
+		this.qualifier = qualifier;
+	}
+
+	public String getScopeNote() {
+		return scopeNote;
+	}
+
+	public void setScopeNote(String scopeNote) {
+		this.scopeNote = scopeNote;
+	}
+
+	@Override
+	public String getType() {
+		return NAME;
+	}
+
+	@Override
+	@JsonIgnore
+	public Class getController() {
+		return RestResourceController.class;
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataQualifierRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataQualifierRest.java
@@ -1,0 +1,42 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * A Metadata Qualifier to use in the embedded Metadata REST Resource
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+public class MetadataQualifierRest implements EmbeddedRestModel {
+	@JsonIgnore
+	private MetadataFieldRest metadataField;
+	
+	private List<MetadataValueRest> values = new ArrayList<MetadataValueRest>();
+
+	public MetadataFieldRest getMetadataField() {
+		return metadataField;
+	}
+
+	public void setMetadataField(MetadataFieldRest metadataField) {
+		this.metadataField = metadataField;
+	}
+
+	public List<MetadataValueRest> getValues() {
+		return values;
+	}
+
+	public void setValues(List<MetadataValueRest> values) {
+		this.values = values;
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataSchemaEmbeddedRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataSchemaEmbeddedRest.java
@@ -1,0 +1,44 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * A Metadata Schema wrapper to use to embedd metadata in a REST Resource
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+public class MetadataSchemaEmbeddedRest implements EmbeddedRestModel {
+	@JsonIgnore
+	private MetadataSchemaRest metadataSchema;
+
+	private Map<String, MetadataElementRest> elements = new HashMap<String, MetadataElementRest>();
+
+	public MetadataSchemaRest getMetadataSchema() {
+		return metadataSchema;
+	}
+
+	public void setMetadataSchema(MetadataSchemaRest metadataSchema) {
+		this.metadataSchema = metadataSchema;
+	}
+
+	@JsonAnyGetter
+	public Map<String, MetadataElementRest> getElements() {
+		return elements;
+	}
+
+	public void setElements(Map<String, MetadataElementRest> elements) {
+		this.elements = elements;
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataSchemaRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataSchemaRest.java
@@ -1,0 +1,55 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import java.util.List;
+
+import org.dspace.app.rest.RestResourceController;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * The MetadataSchema REST Resource
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+public class MetadataSchemaRest extends BaseObjectRest<Integer> {
+	public static final String NAME = "metadataschema";
+
+	private String prefix;
+
+	private String namespace;
+
+	public String getPrefix() {
+		return prefix;
+	}
+	
+	public void setPrefix(String prefix) {
+		this.prefix = prefix;
+	}
+	
+	public String getNamespace() {
+		return namespace;
+	}
+	
+	public void setNamespace(String namespace) {
+		this.namespace = namespace;
+	}
+	
+	@Override
+	public String getType() {
+		return NAME;
+	}
+
+	@Override
+	@JsonIgnore
+	public Class getController() {
+		return RestResourceController.class;
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataValueRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataValueRest.java
@@ -1,0 +1,64 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import java.util.List;
+import java.util.Map;
+
+import org.dspace.app.rest.RestResourceController;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * A Metadata Value to embedd in a REST Resource
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+public class MetadataValueRest {
+	
+	private String value;
+	
+	private int confidence;
+	
+	private AuthorityValueRest authorityValue;
+	
+	private String lang;
+
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+	public int getConfidence() {
+		return confidence;
+	}
+
+	public void setConfidence(int confidence) {
+		this.confidence = confidence;
+	}
+
+	public AuthorityValueRest getAuthorityValue() {
+		return authorityValue;
+	}
+
+	public void setAuthorityValue(AuthorityValueRest authorityValue) {
+		this.authorityValue = authorityValue;
+	}
+	
+	public String getLang() {
+		return lang;
+	}
+	
+	public void setLang(String lang) {
+		this.lang = lang;
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/MetadataFieldResource.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/MetadataFieldResource.java
@@ -1,0 +1,26 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model.hateoas;
+
+import org.dspace.app.rest.model.MetadataFieldRest;
+import org.dspace.app.rest.model.MetadataSchemaRest;
+import org.dspace.app.rest.utils.Utils;
+
+/**
+ * MetadataField Rest HAL Resource. The HAL Resource wraps the REST Resource
+ * adding support for the links and embedded resources
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+@RelNameDSpaceResource(MetadataSchemaRest.NAME)
+public class MetadataFieldResource extends DSpaceResource<MetadataFieldRest> {
+	public MetadataFieldResource(MetadataFieldRest ms, Utils utils, String... rels) {
+		super(ms, utils, rels);
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/MetadataSchemaResource.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/MetadataSchemaResource.java
@@ -1,0 +1,25 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model.hateoas;
+
+import org.dspace.app.rest.model.MetadataSchemaRest;
+import org.dspace.app.rest.utils.Utils;
+
+/**
+ * MetadataSchema Rest HAL Resource. The HAL Resource wraps the REST Resource
+ * adding support for the links and embedded resources
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+@RelNameDSpaceResource(MetadataSchemaRest.NAME)
+public class MetadataSchemaResource extends DSpaceResource<MetadataSchemaRest> {
+	public MetadataSchemaResource(MetadataSchemaRest ms, Utils utils, String... rels) {
+		super(ms, utils, rels);
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
@@ -1,0 +1,75 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.repository;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.dspace.app.rest.converter.MetadataFieldConverter;
+import org.dspace.app.rest.model.MetadataFieldRest;
+import org.dspace.app.rest.model.hateoas.MetadataFieldResource;
+import org.dspace.content.MetadataField;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.MetadataFieldService;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+/**
+ * This is the repository responsible to manage MetadataField Rest object
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+@Component(MetadataFieldRest.NAME)
+public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFieldRest, Integer> {
+	MetadataFieldService metaFieldService = ContentServiceFactory.getInstance().getMetadataFieldService();
+	@Autowired
+	MetadataFieldConverter converter;
+
+	public MetadataFieldRestRepository() {
+	}
+
+	@Override
+	public MetadataFieldRest findOne(Context context, Integer id) {
+		MetadataField metadataField = null;
+		try {
+			metadataField = metaFieldService.find(context, id);
+		} catch (SQLException e) {
+			throw new RuntimeException(e.getMessage(), e);
+		}
+		if (metadataField == null) {
+			return null;
+		}
+		return converter.fromModel(metadataField);
+	}
+
+	@Override
+	public Page<MetadataFieldRest> findAll(Context context, Pageable pageable) {
+		List<MetadataField> metadataField = null;
+		try {
+			metadataField = metaFieldService.findAll(context);
+		} catch (SQLException e) {
+			throw new RuntimeException(e.getMessage(), e);
+		}
+		Page<MetadataFieldRest> page = utils.getPage(metadataField, pageable).map(converter);
+		return page;
+	}
+
+	@Override
+	public Class<MetadataFieldRest> getDomainClass() {
+		return MetadataFieldRest.class;
+	}
+
+	@Override
+	public MetadataFieldResource wrapResource(MetadataFieldRest bs, String... rels) {
+		return new MetadataFieldResource(bs, utils, rels);
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/MetadataSchemaRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/MetadataSchemaRestRepository.java
@@ -1,0 +1,75 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.repository;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.dspace.app.rest.converter.MetadataSchemaConverter;
+import org.dspace.app.rest.model.MetadataSchemaRest;
+import org.dspace.app.rest.model.hateoas.MetadataSchemaResource;
+import org.dspace.content.MetadataSchema;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.MetadataSchemaService;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+/**
+ * This is the repository responsible to manage MetadataSchema Rest object
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+@Component(MetadataSchemaRest.NAME)
+public class MetadataSchemaRestRepository extends DSpaceRestRepository<MetadataSchemaRest, Integer> {
+	MetadataSchemaService metaScemaService = ContentServiceFactory.getInstance().getMetadataSchemaService();
+	@Autowired
+	MetadataSchemaConverter converter;
+
+	public MetadataSchemaRestRepository() {
+	}
+
+	@Override
+	public MetadataSchemaRest findOne(Context context, Integer id) {
+		MetadataSchema metadataSchema = null;
+		try {
+			metadataSchema = metaScemaService.find(context, id);
+		} catch (SQLException e) {
+			throw new RuntimeException(e.getMessage(), e);
+		}
+		if (metadataSchema == null) {
+			return null;
+		}
+		return converter.fromModel(metadataSchema);
+	}
+
+	@Override
+	public Page<MetadataSchemaRest> findAll(Context context, Pageable pageable) {
+		List<MetadataSchema> metadataSchema = null;
+		try {
+			metadataSchema = metaScemaService.findAll(context);
+		} catch (SQLException e) {
+			throw new RuntimeException(e.getMessage(), e);
+		}
+		Page<MetadataSchemaRest> page = utils.getPage(metadataSchema, pageable).map(converter);
+		return page;
+	}
+
+	@Override
+	public Class<MetadataSchemaRest> getDomainClass() {
+		return MetadataSchemaRest.class;
+	}
+
+	@Override
+	public MetadataSchemaResource wrapResource(MetadataSchemaRest bs, String... rels) {
+		return new MetadataSchemaResource(bs, utils, rels);
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/Utils.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/Utils.java
@@ -11,7 +11,6 @@ import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 
 import java.util.List;
 
-import org.atteo.evo.inflector.English;
 import org.dspace.app.rest.exception.PaginationException;
 import org.dspace.app.rest.exception.RepositoryNotFoundException;
 import org.dspace.app.rest.model.CommunityRest;
@@ -37,7 +36,7 @@ import org.springframework.stereotype.Component;
 public class Utils {
 	@Autowired
 	ApplicationContext applicationContext;
-
+	
 	public <T> Page<T> getPage(List<T> fullContents, Pageable pageable) {
 		int total = fullContents.size();
 		List<T> pageContent = null;
@@ -81,5 +80,9 @@ public class Utils {
 			return CommunityRest.NAME;
 		}
 		return modelPlural.replaceAll("s$", "");
+	}
+
+	public Link linkToSubResource(String baseUrl, String name) {
+		return new Link(baseUrl + "/" + name).withRel(name);
 	}
 }


### PR DESCRIPTION
This PR changes the representation of the metadata as proposed in 
https://github.com/DSpace-Labs/Rest7Contract/issues/3

here you can see how a bitstream looks like
https://gist.github.com/abollini/990017419b26b53c1f67a8590c9cf851

Know issues:
- there is an extraneous data attributes in the metadata embedded resource
https://gist.github.com/abollini/990017419b26b53c1f67a8590c9cf851#file-bitstream-json-L25
it comes from the resource wrapper but I'm not able to figure how to avoid it serialization

- the endpoints to get specific metadata are not yet implemented, i.e. 
/{models}/{uuid}/metadata/dc/title return 404