### PR TITLE
DS-3517 Allow improved handling of CMYK PDFs

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
@@ -23,6 +23,7 @@ import org.dspace.content.Bundle;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 import org.im4java.core.ConvertCmd;
+import org.im4java.core.Info;
 import org.im4java.core.IM4JavaException;
 import org.im4java.core.IMOperation;
 import org.im4java.process.ProcessStarter;
@@ -42,6 +43,8 @@ public abstract class ImageMagickThumbnailFilter extends MediaFilter implements 
 	static String bitstreamDescription = "IM Thumbnail";
 	static final String defaultPattern = "Generated Thumbnail";
 	static Pattern replaceRegex = Pattern.compile(defaultPattern);
+	static String cmyk_profile;
+	static String srgb_profile;
 	
 	static {
 		String pre = ImageMagickThumbnailFilter.class.getName();
@@ -51,6 +54,8 @@ public abstract class ImageMagickThumbnailFilter extends MediaFilter implements 
 		height = ConfigurationManager.getIntProperty("thumbnail.maxheight", height);
                 flatten = ConfigurationManager.getBooleanProperty(pre + ".flatten", flatten);
 		String description = ConfigurationManager.getProperty(pre + ".bitstreamDescription");
+		cmyk_profile = ConfigurationManager.getProperty(pre + ".cmyk_profile");
+		srgb_profile = ConfigurationManager.getProperty(pre + ".srgb_profile");
 		if (description != null) {
 			bitstreamDescription = description;
 		}
@@ -132,12 +137,19 @@ public abstract class ImageMagickThumbnailFilter extends MediaFilter implements 
     	f2.deleteOnExit();
     	ConvertCmd cmd = new ConvertCmd();
 		IMOperation op = new IMOperation();
+		Info imageInfo = new Info(f.getAbsolutePath(),true);
 		String s = "[" + page + "]";
 		op.addImage(f.getAbsolutePath()+s);
                 if (flatten)
                 {
                     op.flatten();
                 }
+		String imageClass = imageInfo.getImageClass();
+		// PDFs using the CMYK color system can be handled specially if profiles are defined
+		if (imageClass.contains("CMYK") && cmyk_profile != null && srgb_profile != null) {
+			op.profile(cmyk_profile);
+			op.profile(srgb_profile);
+		}
 		op.addImage(f2.getAbsolutePath());
         if (MediaFilterManager.isVerbose) {
 		    System.out.println("IM Image Param: "+op);

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -505,6 +505,13 @@ filter.org.dspace.app.mediafilter.ImageMagickPdfThumbnailFilter.inputFormats = A
 # next property false, if necessary for any reasons.
 # org.dspace.app.mediafilter.ImageMagickThumbnailFilter.flatten = true
 
+# Optional: full paths to CMYK and sRGB color profiles. If present, will allow
+# ImageMagick to produce much more color accurate thumbnails for PDFs that are
+# using the CMYK color system. The default_cmyk.icc and default_rgb.icc profiles
+# provided by the system's Ghostscript (version 9.x) package are good choices.
+# org.dspace.app.mediafilter.ImageMagickThumbnailFilter.cmyk_profile = /usr/share/ghostscript/9.18/iccprofiles/default_cmyk.icc
+# org.dspace.app.mediafilter.ImageMagickThumbnailFilter.srgb_profile = /usr/share/ghostscript/9.18/iccprofiles/default_rgb.icc
+
 #### Crosswalk and Packager Plugin Settings ####
 # Crosswalks are used to translate external metadata formats into DSpace's internal format (DIM)
 # Packagers are used to ingest/export 'packages' (both content files and metadata)


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3517
https://jira.duraspace.org/browse/DS-2834

The ImageMagick-based thumbnailing in DSpace 5+ should explicitly generate JPGs in the sRGB color space, which is the default color space for the web. In the case where an input file is in another color space, like CMYK, ImageMagick happily generates a CMYK JPG, which leads to distorted colors.

It should be noted that this is a merely a regression in the DSpace 5+ thumbnail code, as the XPDF-based thumbnailing in DSpace 3 and 4 was correctly producing sRGB images.