### PR TITLE
[DS-3521] Bugfix browsing embargoed thumbnail

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/BrowseListTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/BrowseListTag.java
@@ -29,6 +29,8 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.dspace.app.webui.util.UIUtil;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.factory.AuthorizeServiceFactory;
+import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.browse.BrowseException;
 import org.dspace.browse.BrowseIndex;
 import org.dspace.browse.BrowseInfo;
@@ -118,6 +120,9 @@ public class BrowseListTag extends TagSupport
     
     transient private final ConfigurationService configurationService
              = DSpaceServicesFactory.getInstance().getConfigurationService();
+
+    transient private final AuthorizeService authorizeService
+            = AuthorizeServiceFactory.getInstance().getAuthorizeService();
 
     static
     {
@@ -853,7 +858,7 @@ public class BrowseListTag extends TagSupport
             Context c = UIUtil.obtainContext(hrq);
             Thumbnail thumbnail = itemService.getThumbnail(c, item, linkToBitstream);
 
-            if (thumbnail == null)
+            if (thumbnail == null || !authorizeService.authorizeActionBoolean(c, thumbnail.getThumb(), Constants.READ))
     		{
     			return "";
     		}


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3521

If `webui.browse.thumbnail.show` is set `true` but a user misses read permission to a bitstream in JSPUI an exception is thrown and the whole browse request results in an internal server error.