### PR TITLE
[DS-3523] Bugfix for search with embargoed thumbnails

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemListTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemListTag.java
@@ -29,6 +29,8 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.dspace.app.webui.util.UIUtil;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.factory.AuthorizeServiceFactory;
+import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.browse.BrowseException;
 import org.dspace.browse.BrowseIndex;
 import org.dspace.browse.CrossLinks;
@@ -116,6 +118,9 @@ public class ItemListTag extends TagSupport
     
     private final transient ConfigurationService configurationService
              = DSpaceServicesFactory.getInstance().getConfigurationService();
+
+    private final transient AuthorizeService authorizeService
+            = AuthorizeServiceFactory.getInstance().getAuthorizeService();
 
     static
     {
@@ -817,7 +822,7 @@ public class ItemListTag extends TagSupport
             Context c = UIUtil.obtainContext(hrq);
             Thumbnail thumbnail = itemService.getThumbnail(c, item, linkToBitstream);
 
-            if (thumbnail == null)
+            if (thumbnail == null || !authorizeService.authorizeActionBoolean(c, thumbnail.getThumb(), Constants.READ))
             {
                 return "";
             }


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3523

If webui.browse.thumbnail.show is set true but a user lacks read permission to a bitstream shown in the JSPUI search page, an exception is thrown and the whole request results in an internal server error.