### PR TITLE
[DS-3535] Reduced error logging by interrupted download

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/DSpaceServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/DSpaceServlet.java
@@ -160,6 +160,15 @@ public class DSpaceServlet extends HttpServlet
             }
             abortContext(context);
         }
+        catch (IOException ioe)
+        {
+            /*
+             * If a an IOException occurs (e.g. if the client interrupted a download),
+             * just log a simple warning without stacktrace.
+             */
+            log.warn(LogManager.getHeader(context, "io_error", ioe.toString()));
+            abortContext(context);
+        }
         catch (Exception e)
         {
             log.warn(LogManager.getHeader(context, "general_jspui_error", e

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/util/JSPManager.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/util/JSPManager.java
@@ -57,7 +57,16 @@ public class JSPManager
         }
         try {
             // For the moment, a simple forward
-            request.getRequestDispatcher(jsp).forward(request, response);
+            // First test if the response is already committed (could happen by broken downloads),
+            // if that is the case, forward won't work.
+            if (!response.isCommitted())
+            {
+                request.getRequestDispatcher(jsp).forward(request, response);
+            }
+            else
+            {
+                log.warn("Couldn't show jsp, response is already commited.");
+            }
         } catch (Exception e) {
              throw new ServletException(e);
         }


### PR DESCRIPTION
Reducing stacktraces of errors caused by interrupted downloads in DSpace6 JSP-UI