### PR TITLE
DS-3406: Sort communities and collections in-memory using a comparator

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/Collection.java
+++ b/dspace-api/src/main/java/org/dspace/content/Collection.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.content;
 
+import org.dspace.content.comparator.NameAscendingComparator;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.CollectionService;
 import org.dspace.core.*;
@@ -16,6 +17,7 @@ import org.hibernate.proxy.HibernateProxyHelper;
 import javax.persistence.*;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -263,6 +265,7 @@ public class Collection extends DSpaceObject implements DSpaceObjectLegacySuppor
      */
     public List<Community> getCommunities() throws SQLException
     {
+        Collections.sort(communities, new NameAscendingComparator());
         return communities;
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/Community.java
+++ b/dspace-api/src/main/java/org/dspace/content/Community.java
@@ -9,6 +9,7 @@ package org.dspace.content;
 
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.log4j.Logger;
+import org.dspace.content.comparator.NameAscendingComparator;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.CommunityService;
 import org.dspace.core.*;
@@ -140,6 +141,7 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
      */
     public List<Collection> getCollections()
     {
+        Collections.sort(collections, new NameAscendingComparator());
         return collections;
     }
 
@@ -162,6 +164,7 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
      */
     public List<Community> getSubcommunities()
     {
+        Collections.sort(subCommunities, new NameAscendingComparator());
         return subCommunities;
     }
 
@@ -173,6 +176,7 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
      */
     public List<Community> getParentCommunities()
     {
+        Collections.sort(parentCommunities, new NameAscendingComparator());
         return parentCommunities;
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/Item.java
+++ b/dspace-api/src/main/java/org/dspace/content/Item.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.content;
 
+import org.dspace.content.comparator.NameAscendingComparator;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Constants;
@@ -16,6 +17,7 @@ import org.hibernate.proxy.HibernateProxyHelper;
 
 import javax.persistence.*;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -230,6 +232,7 @@ public class Item extends DSpaceObject implements DSpaceObjectLegacySupport
      */
     public List<Collection> getCollections()
     {
+        Collections.sort(collections, new NameAscendingComparator());
         return collections;
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/Item.java
+++ b/dspace-api/src/main/java/org/dspace/content/Item.java
@@ -226,7 +226,7 @@ public class Item extends DSpaceObject implements DSpaceObjectLegacySupport
     }
 
     /**
-     * Get the collections this item is in. The order is indeterminate.
+     * Get the collections this item is in. The order is sorted ascending by collection name.
      *
      * @return the collections this item is in, if any.
      */

--- a/dspace-api/src/main/java/org/dspace/content/comparator/NameAscendingComparator.java
+++ b/dspace-api/src/main/java/org/dspace/content/comparator/NameAscendingComparator.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.content.comparator;
 
-import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang.StringUtils;
 import org.dspace.content.DSpaceObject;
 
 import java.util.Comparator;
@@ -23,7 +23,9 @@ public class NameAscendingComparator implements Comparator<DSpaceObject>{
         }else if (dso2 == null){
             return 1;
         }else {
-            return ObjectUtils.compare(dso1.getName(),dso2.getName());
+            String name1 = StringUtils.trimToEmpty(dso1.getName());
+            String name2 = StringUtils.trimToEmpty(dso2.getName());
+            return name1.compareToIgnoreCase(name2);
         }
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/comparator/NameAscendingComparator.java
+++ b/dspace-api/src/main/java/org/dspace/content/comparator/NameAscendingComparator.java
@@ -1,0 +1,29 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.comparator;
+
+import org.apache.commons.lang3.ObjectUtils;
+import org.dspace.content.DSpaceObject;
+
+import java.util.Comparator;
+
+public class NameAscendingComparator implements Comparator<DSpaceObject>{
+
+    @Override
+    public int compare(DSpaceObject dso1, DSpaceObject dso2) {
+        if (dso1 == dso2){
+            return 0;
+        }else if (dso1 == null){
+            return -1;
+        }else if (dso2 == null){
+            return 1;
+        }else {
+            return ObjectUtils.compare(dso1.getName(),dso2.getName());
+        }
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/content/comparator/NameAscendingComparatorTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/comparator/NameAscendingComparatorTest.java
@@ -61,7 +61,7 @@ public class NameAscendingComparatorTest {
 
     @Test
     public void testCompareSecondNull() throws Exception {
-        when(dso2.getName()).thenReturn("b");
+        when(dso1.getName()).thenReturn("a");
 
         assertTrue(comparator.compare(dso1, null) > 0);
     }
@@ -75,6 +75,22 @@ public class NameAscendingComparatorTest {
     public void testCompareNameNull() throws Exception {
         when(dso1.getName()).thenReturn(null);
         when(dso2.getName()).thenReturn("b");
+
+        assertTrue(comparator.compare(dso1, dso2) < 0);
+    }
+
+    @Test
+    public void testCompareCaseInsensitive() throws Exception {
+        when(dso1.getName()).thenReturn("a");
+        when(dso2.getName()).thenReturn("B");
+
+        assertTrue(comparator.compare(dso1, dso2) < 0);
+    }
+
+    @Test
+    public void testCompareCaseTrimmed() throws Exception {
+        when(dso1.getName()).thenReturn("a");
+        when(dso2.getName()).thenReturn(" b ");
 
         assertTrue(comparator.compare(dso1, dso2) < 0);
     }

--- a/dspace-api/src/test/java/org/dspace/content/comparator/NameAscendingComparatorTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/comparator/NameAscendingComparatorTest.java
@@ -1,0 +1,81 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.comparator;
+
+import org.dspace.content.DSpaceObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NameAscendingComparatorTest {
+
+    private NameAscendingComparator comparator = new NameAscendingComparator();
+
+    @Mock
+    private DSpaceObject dso1;
+
+    @Mock
+    private DSpaceObject dso2;
+
+
+    @Test
+    public void testCompareLessThan() throws Exception {
+        when(dso1.getName()).thenReturn("a");
+        when(dso2.getName()).thenReturn("b");
+
+        assertTrue(comparator.compare(dso1, dso2) < 0);
+    }
+
+    @Test
+    public void testCompareGreaterThan() throws Exception {
+        when(dso1.getName()).thenReturn("b");
+        when(dso2.getName()).thenReturn("a");
+
+        assertTrue(comparator.compare(dso1, dso2) > 0);
+    }
+
+    @Test
+    public void testCompareEqual() throws Exception {
+        when(dso1.getName()).thenReturn("b");
+        when(dso2.getName()).thenReturn("b");
+
+        assertTrue(comparator.compare(dso1, dso2) == 0);
+    }
+
+    @Test
+    public void testCompareFirstNull() throws Exception {
+        when(dso2.getName()).thenReturn("b");
+
+        assertTrue(comparator.compare(null, dso2) < 0);
+    }
+
+    @Test
+    public void testCompareSecondNull() throws Exception {
+        when(dso2.getName()).thenReturn("b");
+
+        assertTrue(comparator.compare(dso1, null) > 0);
+    }
+
+    @Test
+    public void testCompareBothNull() throws Exception {
+        assertTrue(comparator.compare(null, null) == 0);
+    }
+
+    @Test
+    public void testCompareNameNull() throws Exception {
+        when(dso1.getName()).thenReturn(null);
+        when(dso2.getName()).thenReturn("b");
+
+        assertTrue(comparator.compare(dso1, dso2) < 0);
+    }
+}


### PR DESCRIPTION
Fix for https://jira.duraspace.org/browse/DS-3406 where the sorting of communities and collections happens in-memory and not by Hibernate.