### PR TITLE
Ds 3406 sort communities and collections with Hibernate Sort annotation

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/Collection.java
+++ b/dspace-api/src/main/java/org/dspace/content/Collection.java
@@ -7,16 +7,18 @@
  */
 package org.dspace.content;
 
+import org.dspace.content.comparator.NameAscendingComparator;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.CollectionService;
 import org.dspace.core.*;
 import org.dspace.eperson.Group;
+import org.hibernate.annotations.Sort;
+import org.hibernate.annotations.SortType;
 import org.hibernate.proxy.HibernateProxyHelper;
 
 import javax.persistence.*;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 /**
  * Class representing a collection.
@@ -83,7 +85,8 @@ public class Collection extends DSpaceObject implements DSpaceObjectLegacySuppor
             joinColumns = {@JoinColumn(name = "collection_id") },
             inverseJoinColumns = {@JoinColumn(name = "community_id") }
     )
-    private final List<Community> communities = new ArrayList<>();
+    @Sort(type = SortType.COMPARATOR, comparator = NameAscendingComparator.class)
+    private Set<Community> communities = new TreeSet<>(new NameAscendingComparator());
 
     @Transient
     private transient CollectionService collectionService;
@@ -263,7 +266,8 @@ public class Collection extends DSpaceObject implements DSpaceObjectLegacySuppor
      */
     public List<Community> getCommunities() throws SQLException
     {
-        return communities;
+        // We return a copy because we do not want people to add elements to this collection directly.
+        return Arrays.asList(communities.toArray(new Community[]{}));
     }
 
     void addCommunity(Community community) {

--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -749,8 +749,8 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
         while (owningCommunities.hasNext())
         {
             Community owningCommunity = owningCommunities.next();
-            owningCommunities.remove();
-            owningCommunity.getCollections().remove(collection);
+            collection.removeCommunity(owningCommunity);
+            owningCommunity.removeCollection(collection);
         }
 
         collectionDAO.delete(context, collection);

--- a/dspace-api/src/main/java/org/dspace/content/Community.java
+++ b/dspace-api/src/main/java/org/dspace/content/Community.java
@@ -9,10 +9,13 @@ package org.dspace.content;
 
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.log4j.Logger;
+import org.dspace.content.comparator.NameAscendingComparator;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.CommunityService;
 import org.dspace.core.*;
 import org.dspace.eperson.Group;
+import org.hibernate.annotations.Sort;
+import org.hibernate.annotations.SortType;
 import org.hibernate.proxy.HibernateProxyHelper;
 
 import javax.persistence.*;
@@ -44,13 +47,16 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
             joinColumns = {@JoinColumn(name = "parent_comm_id") },
             inverseJoinColumns = {@JoinColumn(name = "child_comm_id") }
     )
-    private final List<Community> subCommunities = new ArrayList<>();
+    @Sort(type = SortType.COMPARATOR, comparator = NameAscendingComparator.class)
+    private Set<Community> subCommunities = new TreeSet<Community>(new NameAscendingComparator());
 
     @ManyToMany(fetch = FetchType.LAZY, mappedBy = "subCommunities")
-    private List<Community> parentCommunities = new ArrayList<>();
+    @Sort(type = SortType.COMPARATOR, comparator = NameAscendingComparator.class)
+    private Set<Community> parentCommunities = new TreeSet<Community>(new NameAscendingComparator());;
 
     @ManyToMany(fetch = FetchType.LAZY, mappedBy = "communities", cascade = {CascadeType.PERSIST})
-    private final List<Collection> collections = new ArrayList<>();
+    @Sort(type = SortType.COMPARATOR, comparator = NameAscendingComparator.class)
+    private Set<Collection> collections =new TreeSet<Collection>(new NameAscendingComparator());;
 
     @OneToOne
     @JoinColumn(name = "admin")
@@ -85,13 +91,13 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
 
     void addSubCommunity(Community subCommunity)
     {
-        getSubcommunities().add(subCommunity);
+        subCommunities.add(subCommunity);
         setModified();
     }
 
     void removeSubCommunity(Community subCommunity)
     {
-        getSubcommunities().remove(subCommunity);
+        subCommunities.remove(subCommunity);
         setModified();
     }
 
@@ -140,17 +146,18 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
      */
     public List<Collection> getCollections()
     {
-        return collections;
+        // We return a copy because we do not want people to add elements to this collection directly.
+        return Arrays.asList(collections.toArray(new Collection[]{}));
     }
 
     void addCollection(Collection collection)
     {
-        getCollections().add(collection);
+        collections.add(collection);
     }
 
     void removeCollection(Collection collection)
     {
-        getCollections().remove(collection);
+        collections.remove(collection);
     }
 
     /**
@@ -162,7 +169,8 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
      */
     public List<Community> getSubcommunities()
     {
-        return subCommunities;
+        // We return a copy because we do not want people to add elements to this collection directly.
+        return Arrays.asList(subCommunities.toArray(new Community[]{}));
     }
 
     /**
@@ -173,16 +181,22 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
      */
     public List<Community> getParentCommunities()
     {
-        return parentCommunities;
+        // We return a copy because we do not want people to add elements to this collection directly.
+        return Arrays.asList(parentCommunities.toArray(new Community[]{}));
     }
 
     void addParentCommunity(Community parentCommunity) {
-        getParentCommunities().add(parentCommunity);
+        parentCommunities.add(parentCommunity);
     }
 
     void clearParentCommunities(){
         this.parentCommunities.clear();
         this.parentCommunities = null;
+    }
+
+    public void removeParentCommunity(Community parentCommunity)
+    {
+        this.parentCommunities.remove(parentCommunity);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
@@ -455,7 +455,7 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
 
         rawDelete(context, childCommunity);
 
-        childCommunity.getParentCommunities().remove(parentCommunity);
+        childCommunity.removeParentCommunity(parentCommunity);
         parentCommunity.removeSubCommunity(childCommunity);
 
         log.info(LogManager.getHeader(context, "remove_subcommunity",
@@ -492,7 +492,7 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
             Iterator<Community> subcommunities = community.getSubcommunities().iterator();
             while (subcommunities.hasNext()) {
                 Community subCommunity = subcommunities.next();
-                subcommunities.remove();
+                community.removeSubCommunity(subCommunity);
                 delete(context, subCommunity);
             }
             // now let the parent remove the community
@@ -535,7 +535,7 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
         while (collections.hasNext())
         {
             Collection collection = collections.next();
-            collections.remove();
+            community.removeCollection(collection);
             removeCollection(context, community, collection);
         }
         // delete subcommunities
@@ -544,7 +544,7 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
         while (subCommunities.hasNext())
         {
             Community subComm = subCommunities.next();
-            subCommunities.remove();
+            community.removeSubCommunity(subComm);
             delete(context, subComm);
         }
 

--- a/dspace-api/src/main/java/org/dspace/content/Item.java
+++ b/dspace-api/src/main/java/org/dspace/content/Item.java
@@ -7,17 +7,18 @@
  */
 package org.dspace.content;
 
+import org.dspace.content.comparator.NameAscendingComparator;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
+import org.hibernate.annotations.Sort;
+import org.hibernate.annotations.SortType;
 import org.hibernate.proxy.HibernateProxyHelper;
 
 import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 
 /**
  * Class representing an item in DSpace.
@@ -78,7 +79,8 @@ public class Item extends DSpaceObject implements DSpaceObjectLegacySupport
             joinColumns = {@JoinColumn(name = "item_id") },
             inverseJoinColumns = {@JoinColumn(name = "collection_id") }
     )
-    private final List<Collection> collections = new ArrayList<>();
+    @Sort(type = SortType.COMPARATOR, comparator = NameAscendingComparator.class)
+    private final Set<Collection> collections = new TreeSet<>(new NameAscendingComparator());
 
     @ManyToMany(fetch = FetchType.LAZY, mappedBy = "items")
     private final List<Bundle> bundles = new ArrayList<>();
@@ -230,17 +232,22 @@ public class Item extends DSpaceObject implements DSpaceObjectLegacySupport
      */
     public List<Collection> getCollections()
     {
-        return collections;
+        // We return a copy because we do not want people to add elements to this collection directly.
+        return Arrays.asList(collections.toArray(new Collection[]{}));
     }
 
     void addCollection(Collection collection)
     {
-        getCollections().add(collection);
+        collections.add(collection);
     }
 
     void removeCollection(Collection collection)
     {
-        getCollections().remove(collection);
+        collections.remove(collection);
+    }
+
+    public void clearCollections(){
+        collections.clear();
     }
 
     public Collection getTemplateItemOf() {

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -651,7 +651,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         }
 
         //Only clear collections after we have removed everything else from the item
-        item.getCollections().clear();
+        item.clearCollections();
         item.setOwningCollection(null);
 
         // Finally remove item row

--- a/dspace-api/src/main/java/org/dspace/content/comparator/NameAscendingComparator.java
+++ b/dspace-api/src/main/java/org/dspace/content/comparator/NameAscendingComparator.java
@@ -1,0 +1,27 @@
+package org.dspace.content.comparator;
+
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.dspace.content.DSpaceObject;
+
+import java.util.Comparator;
+
+/**
+ * Created by yana on 09/01/17.
+ */
+public class NameAscendingComparator implements Comparator<DSpaceObject>{
+
+
+    @Override
+    public int compare(DSpaceObject dso1, DSpaceObject dso2) {
+        if (dso1 == dso2){
+            return 0;
+        }else if (dso1 == null){
+            return -1;
+        }else if (dso2 == null){
+            return 1;
+        }else {
+            return ObjectUtils.compare(dso1.getName(),dso2.getName());
+        }
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/content/CollectionTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/CollectionTest.java
@@ -103,6 +103,7 @@ public class CollectionTest extends AbstractDSpaceObjectTest
                 if(collection != null)
                 {
                     collectionService.delete(context, collection);
+                    context.commit();
                     communityService.delete(context, communityService.find(context, owningCommunity.getID()));
                 }
                 context.restoreAuthSystemState();

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -1478,6 +1478,7 @@ public class ItemTest  extends AbstractDSpaceObjectTest
         context.turnOffAuthorisationSystem();
         Collection from = createCollection();
         Collection to = createCollection();
+        it.addCollection(from);
         it.setOwningCollection(from);
 
         itemService.move(context, it, from, to);


### PR DESCRIPTION
Fix for https://jira.duraspace.org/browse/DS-3406 where the sorting of communities and collections is done by Hibernate but still happens in-memory (and not by the database).
