### PR TITLE
DS-3545 mirage2: custom sitemap.xmap is ignored

### DIFF
--- a/dspace/modules/xmlui-mirage2/pom.xml
+++ b/dspace/modules/xmlui-mirage2/pom.xml
@@ -66,57 +66,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <phase>process-resources</phase>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/themes</outputDirectory>
-                            <resources>
-                                <resource>
-                                    <directory>${basedir}/src/main/webapp/themes</directory>
-                                    <excludes>
-                                        <exclude>**/*.bmp</exclude>
-                                        <exclude>**/*.jpg</exclude>
-                                        <exclude>**/*.jpeg</exclude>
-                                        <exclude>**/*.gif</exclude>
-                                        <exclude>**/*.png</exclude>
-                                        <exclude>**/*.ico</exclude>
-                                        <exclude>**/*.svg</exclude>
-                                        <exclude>**/*.ttf</exclude>
-                                        <exclude>**/*.woff</exclude>
-                                        <exclude>**/*.eot</exclude>
-                                        <exclude>**/*.xsl</exclude>
-                                    </excludes>
-                                    <filtering>true</filtering>
-                                </resource>
-                                <resource>
-                                    <directory>${basedir}/src/main/webapp/themes</directory>
-                                    <includes>
-                                        <include>**/*.bmp</include>
-                                        <include>**/*.jpg</include>
-                                        <include>**/*.jpeg</include>
-                                        <include>**/*.gif</include>
-                                        <include>**/*.png</include>
-                                        <include>**/*.ico</include>
-                                        <include>**/*.svg</include>
-                                        <include>**/*.ttf</include>
-                                        <include>**/*.woff</include>
-                                        <include>**/*.eot</include>
-                                        <include>**/*.xsl</include>
-                                    </includes>
-                                    <filtering>false</filtering>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
@@ -227,7 +176,6 @@
                                             <goal>copy-resources</goal>
                                             <configuration>
                                                 <outputDirectory>${project.build.directory}/themes/@item@</outputDirectory>
-                                                <overwrite>false</overwrite>
                                                 <resources>
                                                     <resource>
                                                         <directory>${project.build.directory}/mirage2-source-extracted</directory>
@@ -235,6 +183,13 @@
                                                         <excludes>
                                                             <exclude>sitemap.xmap</exclude>
                                                         </excludes>
+                                                    </resource>
+                                                    <resource>
+                                                        <directory>${project.build.directory}/mirage2-source-extracted</directory>
+                                                        <filtering>true</filtering>
+                                                        <includes>
+                                                            <include>sitemap.xmap</include>
+                                                        </includes>
                                                     </resource>
                                                 </resources>
                                             </configuration>
@@ -247,10 +202,17 @@
                                             <goal>copy-resources</goal>
                                             <configuration>
                                                 <outputDirectory>${project.build.directory}/themes/@item@</outputDirectory>
-                                                <overwrite>false</overwrite>
+                                                <overwrite>true</overwrite>
                                                 <resources>
                                                     <resource>
-                                                        <directory>${project.build.directory}/mirage2-source-extracted</directory>
+                                                        <directory>${basedir}/src/main/webapp/themes/@item@</directory>
+                                                        <filtering>false</filtering>
+                                                        <excludes>
+                                                            <exclude>sitemap.xmap</exclude>
+                                                        </excludes>
+                                                    </resource>
+                                                    <resource>
+                                                        <directory>${basedir}/src/main/webapp/themes/@item@</directory>
                                                         <filtering>true</filtering>
                                                         <includes>
                                                             <include>sitemap.xmap</include>
@@ -389,7 +351,6 @@
                                             <goal>copy-resources</goal>
                                             <configuration>
                                                 <outputDirectory>${project.build.directory}/themes/@item@</outputDirectory>
-                                                <overwrite>false</overwrite>
                                                 <resources>
                                                     <resource>
                                                         <directory>${project.build.directory}/mirage2-source-extracted</directory>
@@ -397,6 +358,13 @@
                                                         <excludes>
                                                             <exclude>sitemap.xmap</exclude>
                                                         </excludes>
+                                                    </resource>
+                                                    <resource>
+                                                        <directory>${project.build.directory}/mirage2-source-extracted</directory>
+                                                        <filtering>true</filtering>
+                                                        <includes>
+                                                            <include>sitemap.xmap</include>
+                                                        </includes>
                                                     </resource>
                                                 </resources>
                                             </configuration>
@@ -409,10 +377,17 @@
                                             <goal>copy-resources</goal>
                                             <configuration>
                                                 <outputDirectory>${project.build.directory}/themes/@item@</outputDirectory>
-                                                <overwrite>false</overwrite>
+                                                <overwrite>true</overwrite>
                                                 <resources>
                                                     <resource>
-                                                        <directory>${project.build.directory}/mirage2-source-extracted</directory>
+                                                        <directory>${basedir}/src/main/webapp/themes/@item@</directory>
+                                                        <filtering>false</filtering>
+                                                        <excludes>
+                                                            <exclude>sitemap.xmap</exclude>
+                                                        </excludes>
+                                                    </resource>
+                                                    <resource>
+                                                        <directory>${basedir}/src/main/webapp/themes/@item@</directory>
                                                         <filtering>true</filtering>
                                                         <includes>
                                                             <include>sitemap.xmap</include>


### PR DESCRIPTION
https://jira.duraspace.org/projects/DS/issues/DS-3545?filter=allopenissues

There are two resources plugins:

* one for the local customizations (outside the maven-iterator-plugin)
* one for the dspace source files (inside the maven-iterator-plugin)

The first one is ran first, afterwards the other one runs.
The property 'overwrite=false' should avoid that local customizations would be overwritten by dspace source files.
But the property 'filtering=true' causes maven to ignore the overwrite property.
So the sitemap (the only file that will be filtered) will always be overwritten by the dspace original!

To fix this, I also moved the local customizations resources-plugin to inside the maven-iterator-plugin.
This is necessary anyway, because to filter a sitemap, the name of the theme directory is needed for the ${theme-path} and ${theme-name} variables.
I put it after the resources-plugin for the dspace source, and gave it 'overwrite=true'.
So the order is now reversed: first the source files are processed, and then overwritten by any local customizations.

I also made the split between files to filter and files not to filter consistent accross the two resources plugins: only filter the sitemap.
(instead of filtering everything, except a list of image extensions)