### PR TITLE
Ds 3552 read only context and hibernate improvements

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
@@ -304,6 +304,7 @@ public class AuthorizeServiceImpl implements AuthorizeService
             if (ignoreCustomPolicies
                     && ResourcePolicy.TYPE_CUSTOM.equals(rp.getRpType()))
             {
+                c.uncacheEntity(rp);
                 continue;
             }
 
@@ -313,6 +314,7 @@ public class AuthorizeServiceImpl implements AuthorizeService
                 if (rp.getEPerson() != null && rp.getEPerson().equals(userToCheck))
                 {
                     c.cacheAuthorizedAction(o, action, e, true);
+                    c.uncacheEntity(rp);
                     return true; // match
                 }
 
@@ -322,9 +324,11 @@ public class AuthorizeServiceImpl implements AuthorizeService
                     // group was set, and eperson is a member
                     // of that group
                     c.cacheAuthorizedAction(o, action, e, true);
+                    c.uncacheEntity(rp);
                     return true;
                 }
             }
+            c.uncacheEntity(rp);
         }
 
         // default authorization is denial
@@ -389,6 +393,7 @@ public class AuthorizeServiceImpl implements AuthorizeService
                 if (rp.getEPerson() != null && rp.getEPerson().equals(c.getCurrentUser()))
                 {
                     c.cacheAuthorizedAction(o, Constants.ADMIN, c.getCurrentUser(), true);
+                    c.uncacheEntity(rp);
                     return true; // match
                 }
 
@@ -398,9 +403,11 @@ public class AuthorizeServiceImpl implements AuthorizeService
                     // group was set, and eperson is a member
                     // of that group
                     c.cacheAuthorizedAction(o, Constants.ADMIN, c.getCurrentUser(), true);
+                    c.uncacheEntity(rp);
                     return true;
                 }
             }
+            c.uncacheEntity(rp);
         }
 
         // If user doesn't have specific Admin permissions on this object,

--- a/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
@@ -244,6 +244,12 @@ public class AuthorizeServiceImpl implements AuthorizeService
             return true;
         }
 
+        // If authorization was given before and cached
+        Boolean cachedResult = c.getCachedAuthorizationResult(o, action, e);
+        if (cachedResult != null) {
+            return cachedResult.booleanValue();
+        }
+
         // is eperson set? if not, userToCheck = null (anonymous)
         EPerson userToCheck = null;
         if (e != null)
@@ -256,6 +262,7 @@ public class AuthorizeServiceImpl implements AuthorizeService
 
             if (isAdmin(c, adminObject))
             {
+                c.cacheAuthorizedAction(o, action, e, true);
                 return true;
             }
         }
@@ -305,6 +312,7 @@ public class AuthorizeServiceImpl implements AuthorizeService
             {
                 if (rp.getEPerson() != null && rp.getEPerson().equals(userToCheck))
                 {
+                    c.cacheAuthorizedAction(o, action, e, true);
                     return true; // match
                 }
 
@@ -313,12 +321,14 @@ public class AuthorizeServiceImpl implements AuthorizeService
                 {
                     // group was set, and eperson is a member
                     // of that group
+                    c.cacheAuthorizedAction(o, action, e, true);
                     return true;
                 }
             }
         }
 
         // default authorization is denial
+        c.cacheAuthorizedAction(o, action, e, false);
         return false;
     }
 

--- a/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
@@ -371,6 +371,11 @@ public class AuthorizeServiceImpl implements AuthorizeService
             return false;
         }
 
+        Boolean cachedResult = c.getCachedAuthorizationResult(o, Constants.ADMIN, c.getCurrentUser());
+        if (cachedResult != null) {
+            return cachedResult.booleanValue();
+        }
+
         //
         // First, check all Resource Policies directly on this object
         //
@@ -383,6 +388,7 @@ public class AuthorizeServiceImpl implements AuthorizeService
             {
                 if (rp.getEPerson() != null && rp.getEPerson().equals(c.getCurrentUser()))
                 {
+                    c.cacheAuthorizedAction(o, Constants.ADMIN, c.getCurrentUser(), true);
                     return true; // match
                 }
 
@@ -391,6 +397,7 @@ public class AuthorizeServiceImpl implements AuthorizeService
                 {
                     // group was set, and eperson is a member
                     // of that group
+                    c.cacheAuthorizedAction(o, Constants.ADMIN, c.getCurrentUser(), true);
                     return true;
                 }
             }
@@ -403,9 +410,12 @@ public class AuthorizeServiceImpl implements AuthorizeService
         DSpaceObject parent = serviceFactory.getDSpaceObjectService(o).getParentObject(c, o);
         if (parent != null)
         {
-            return isAdmin(c, parent);
+            boolean admin = isAdmin(c, parent);
+            c.cacheAuthorizedAction(o, Constants.ADMIN, c.getCurrentUser(), admin);
+            return admin;
         }
 
+        c.cacheAuthorizedAction(o, Constants.ADMIN, c.getCurrentUser(), false);
         return false;
     }
 

--- a/dspace-api/src/main/java/org/dspace/checker/ChecksumHistory.java
+++ b/dspace-api/src/main/java/org/dspace/checker/ChecksumHistory.java
@@ -55,7 +55,7 @@ public class ChecksumHistory implements ReloadableEntity<Long>
     private String checksumCalculated;
 
     @ManyToOne
-    @JoinColumn(name = "result")
+    @JoinColumn(name = "result", referencedColumnName = "result_code")
     private ChecksumResult checksumResult;
 
 

--- a/dspace-api/src/main/java/org/dspace/checker/MostRecentChecksum.java
+++ b/dspace-api/src/main/java/org/dspace/checker/MostRecentChecksum.java
@@ -59,7 +59,7 @@ public class MostRecentChecksum implements Serializable
     private boolean bitstreamFound;
 
     @OneToOne
-    @JoinColumn(name= "result")
+    @JoinColumn(name= "result", referencedColumnName = "result_code")
     private ChecksumResult checksumResult;
 
     /**

--- a/dspace-api/src/main/java/org/dspace/checker/MostRecentChecksum.java
+++ b/dspace-api/src/main/java/org/dspace/checker/MostRecentChecksum.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.checker;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.dspace.content.Bitstream;
 
 import javax.persistence.*;
@@ -154,5 +156,45 @@ public class MostRecentChecksum implements Serializable
 
     public void setBitstreamFound(boolean bitstreamFound) {
         this.bitstreamFound = bitstreamFound;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass()) return false;
+
+        MostRecentChecksum that = (MostRecentChecksum) o;
+
+        return new EqualsBuilder()
+                .append(toBeProcessed, that.toBeProcessed)
+                .append(matchedPrevChecksum, that.matchedPrevChecksum)
+                .append(infoFound, that.infoFound)
+                .append(bitstreamFound, that.bitstreamFound)
+                .append(bitstream, that.bitstream)
+                .append(expectedChecksum, that.expectedChecksum)
+                .append(currentChecksum, that.currentChecksum)
+                .append(processStartDate, that.processStartDate)
+                .append(processEndDate, that.processEndDate)
+                .append(checksumAlgorithm, that.checksumAlgorithm)
+                .append(checksumResult, that.checksumResult)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(bitstream)
+                .append(toBeProcessed)
+                .append(expectedChecksum)
+                .append(currentChecksum)
+                .append(processStartDate)
+                .append(processEndDate)
+                .append(checksumAlgorithm)
+                .append(matchedPrevChecksum)
+                .append(infoFound)
+                .append(bitstreamFound)
+                .append(checksumResult)
+                .toHashCode();
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/Collection.java
+++ b/dspace-api/src/main/java/org/dspace/content/Collection.java
@@ -11,6 +11,7 @@ import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.CollectionService;
 import org.dspace.core.*;
 import org.dspace.eperson.Group;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.proxy.HibernateProxyHelper;
 
 import javax.persistence.*;
@@ -34,6 +35,8 @@ import java.util.List;
  */
 @Entity
 @Table(name="collection")
+@Cacheable
+@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, include = "non-lazy")
 public class Collection extends DSpaceObject implements DSpaceObjectLegacySupport
 {
 

--- a/dspace-api/src/main/java/org/dspace/content/Community.java
+++ b/dspace-api/src/main/java/org/dspace/content/Community.java
@@ -13,6 +13,7 @@ import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.CommunityService;
 import org.dspace.core.*;
 import org.dspace.eperson.Group;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.proxy.HibernateProxyHelper;
 
 import javax.persistence.*;
@@ -30,6 +31,8 @@ import java.util.*;
  */
 @Entity
 @Table(name="community")
+@Cacheable
+@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, include = "non-lazy")
 public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
 {
     /** log4j category */

--- a/dspace-api/src/main/java/org/dspace/content/Site.java
+++ b/dspace-api/src/main/java/org/dspace/content/Site.java
@@ -12,7 +12,9 @@ import org.dspace.content.service.SiteService;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 
+import javax.persistence.Cacheable;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 import javax.persistence.Transient;
@@ -22,6 +24,8 @@ import javax.persistence.Transient;
  * By default, the handle suffix "0" represents the Site, e.g. "1721.1/0"
  */
 @Entity
+@Cacheable
+@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @Table(name = "site")
 public class Site extends DSpaceObject
 {

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/CollectionDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/CollectionDAOImpl.java
@@ -121,6 +121,8 @@ public class CollectionDAOImpl extends AbstractHibernateDSODAO<Collection> imple
                 Restrictions.eq("resourcePolicy.eperson", ePerson),
                 actionQuery
         ));
+        criteria.setCacheable(true);
+
         return list(criteria);
     }
 
@@ -160,6 +162,8 @@ public class CollectionDAOImpl extends AbstractHibernateDSODAO<Collection> imple
         query.append(" AND rp.epersonGroup.id IN (select g.id from Group g where (from EPerson e where e.id = :eperson_id) in elements(epeople))");
         Query hibernateQuery = createQuery(context, query.toString());
         hibernateQuery.setParameter("eperson_id", ePerson.getID());
+        hibernateQuery.setCacheable(true);
+
         return list(hibernateQuery);
 
 

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/CommunityDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/CommunityDAOImpl.java
@@ -91,6 +91,7 @@ public class CommunityDAOImpl extends AbstractHibernateDSODAO<Community> impleme
 
         Query query = createQuery(context, queryBuilder.toString());
         query.setParameter(sortField.toString(), sortField.getID());
+        query.setCacheable(true);
 
         return findMany(context, query);
     }
@@ -129,6 +130,8 @@ public class CommunityDAOImpl extends AbstractHibernateDSODAO<Community> impleme
                 Restrictions.eq("resourcePolicy.eperson", ePerson),
                 actionQuery
         ));
+        criteria.setCacheable(true);
+
         return list(criteria);
     }
 
@@ -164,6 +167,8 @@ public class CommunityDAOImpl extends AbstractHibernateDSODAO<Community> impleme
         query.append(" AND rp.epersonGroup.id IN (select g.id from Group g where (from EPerson e where e.id = :eperson_id) in elements(epeople))");
         Query hibernateQuery = createQuery(context, query.toString());
         hibernateQuery.setParameter("eperson_id", ePerson.getID());
+        hibernateQuery.setCacheable(true);
+
         return list(hibernateQuery);
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/SiteDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/SiteDAOImpl.java
@@ -32,6 +32,7 @@ public class SiteDAOImpl extends AbstractHibernateDAO<Site> implements SiteDAO
     @Override
     public Site findSite(Context context) throws SQLException {
         Criteria criteria = createCriteria(context, Site.class);
+        criteria.setCacheable(true);
         return uniqueResult(criteria);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -47,9 +47,6 @@ public class Context
 {
     private static final Logger log = Logger.getLogger(Context.class);
 
-    /** option flags */
-    public static final short READ_ONLY = 0x01;
-
     /** Current user - null means anonymous access */
     private EPerson currentUser;
 
@@ -723,15 +720,15 @@ public class Context
     }
 
     public Boolean getCachedAuthorizationResult(DSpaceObject dspaceObject, int action, EPerson eperson) {
-        if(mode == Mode.READ_ONLY) {
+        if(isReadOnly()) {
             return authorizedActionsCache.get(buildAuthorizedActionKey(dspaceObject, action, eperson));
         } else {
-            return false;
+            return null;
         }
     }
 
     public void cacheAuthorizedAction(DSpaceObject dspaceObject, int action, EPerson eperson, Boolean result) {
-        if(mode == Mode.READ_ONLY) {
+        if(isReadOnly()) {
             authorizedActionsCache.put(buildAuthorizedActionKey(dspaceObject, action, eperson), result);
         }
     }

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -690,8 +690,11 @@ public class Context
             log.warn("Unable to set database connection mode", ex);
         }
 
-        //clear our read-only cache to prevent any inconsistencies
-        readOnlyCache.clear();
+        //Always clear the cache, except when going from READ_ONLY to READ_ONLY
+        if(mode != Mode.READ_ONLY || newMode != Mode.READ_ONLY) {
+            //clear our read-only cache to prevent any inconsistencies
+            readOnlyCache.clear();
+        }
 
         //save the new mode
         mode = newMode;

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -529,7 +529,7 @@ public class Context
         try
         {
             // Rollback if we have a database connection, and it is NOT Read Only
-            if (isValid() && !isReadOnly())
+            if (isValid())
             {
                 dbConnection.rollback();
             }

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -665,28 +665,28 @@ public class Context
      * READ_WRITE: This is the default mode and enables the normal database behaviour. This behaviour is optimal for querying and updating a
      * small number of records.
      *
-     * @param mode The mode to put this context in
+     * @param newMode The mode to put this context in
      * @throws SQLException When configuring the database connection fails.
      */
-    public void setMode(Mode mode) throws SQLException {
-        
-        switch (mode) {
+    public void setMode(Mode newMode) throws SQLException {
+        //update the database settings
+        switch (newMode) {
             case BATCH_EDIT:
-                dbConnection.setOptimizedForBatchProcessing(true);
-                dbConnection.setReadOnly(false);
+                dbConnection.setConnectionMode(true, false);
                 break;
             case READ_ONLY:
-                dbConnection.setReadOnly(true);
-                dbConnection.setOptimizedForBatchProcessing(false);
+                dbConnection.setConnectionMode(false, true);
                 break;
             case READ_WRITE:
-                dbConnection.setOptimizedForBatchProcessing(false);
-                dbConnection.setReadOnly(false);
+                dbConnection.setConnectionMode(false, false);
                 break;
             default:
                 log.warn("New context mode detected that has nog been configured.");
                 break;
         }
+
+        //save the new mode
+        this.mode = newMode;
     }
 
     /**
@@ -695,6 +695,36 @@ public class Context
      */
     public Mode getCurrentMode() {
         return mode;
+    }
+
+    /**
+     * Enable or disable "batch processing mode" for this context.
+     *
+     * Enabling batch processing mode means that the database connection is configured so that it is optimized to
+     * process a large number of records.
+     *
+     * Disabling batch processing mode restores the normal behaviour that is optimal for querying and updating a
+     * small number of records.
+     *
+     * @param batchModeEnabled When true, batch processing mode will be enabled. If false, it will be disabled.
+     * @throws SQLException When configuring the database connection fails.
+     */
+    @Deprecated
+    public void enableBatchMode(boolean batchModeEnabled) throws SQLException {
+        if(batchModeEnabled) {
+            setMode(Mode.BATCH_EDIT);
+        } else {
+            setMode(Mode.READ_WRITE);
+        }
+    }
+
+    /**
+     * Check if "batch processing mode" is enabled for this context.
+     * @return True if batch processing mode is enabled, false otherwise.
+     */
+    @Deprecated
+    public boolean isBatchModeEnabled() {
+        return mode != null && mode == Mode.BATCH_EDIT;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -768,9 +768,14 @@ public class Context
         }
     }
 
-    public void cacheAuthorizedAction(DSpaceObject dspaceObject, int action, EPerson eperson, Boolean result) {
+    public void cacheAuthorizedAction(DSpaceObject dspaceObject, int action, EPerson eperson, Boolean result, ResourcePolicy rp) {
         if(isReadOnly()) {
             readOnlyCache.cacheAuthorizedAction(dspaceObject, action, eperson, result);
+            try {
+                uncacheEntity(rp);
+            } catch (SQLException e) {
+                log.warn("Unable to uncache a resource policy when in read-only mode", e);
+            }
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -7,11 +7,6 @@
  */
 package org.dspace.core;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.ImmutableTriple;
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.commons.lang3.tuple.Triple;
 import org.apache.log4j.Logger;
 import org.dspace.content.DSpaceObject;
 import org.dspace.eperson.EPerson;
@@ -112,6 +107,7 @@ public class Context
     }
 
     protected Context(EventService eventService, DBConnection dbConnection)  {
+        this.mode = Mode.READ_WRITE;
         this.eventService = eventService;
         this.dbConnection = dbConnection;
         init();
@@ -124,6 +120,7 @@ public class Context
      */
     public Context()
     {
+        this.mode = Mode.READ_WRITE;
         init();
     }
 
@@ -685,6 +682,7 @@ public class Context
             case READ_WRITE:
                 dbConnection.setOptimizedForBatchProcessing(false);
                 dbConnection.setReadOnly(false);
+                break;
             default:
                 log.warn("New context mode detected that has nog been configured.");
                 break;

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -9,8 +9,7 @@ package org.dspace.core;
 
 import org.apache.log4j.Logger;
 import org.dspace.authorize.ResourcePolicy;
-import org.dspace.content.*;
-import org.dspace.content.Collection;
+import org.dspace.content.DSpaceObject;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.factory.EPersonServiceFactory;
@@ -18,7 +17,6 @@ import org.dspace.event.Dispatcher;
 import org.dspace.event.Event;
 import org.dspace.event.factory.EventServiceFactory;
 import org.dspace.event.service.EventService;
-import org.dspace.handle.Handle;
 import org.dspace.storage.rdbms.DatabaseConfigVO;
 import org.dspace.storage.rdbms.DatabaseUtils;
 import org.dspace.utils.DSpace;
@@ -692,8 +690,11 @@ public class Context
             log.warn("Unable to set database connection mode", ex);
         }
 
+        //clear our read-only cache to prevent any inconsistencies
+        readOnlyCache.clear();
+
         //save the new mode
-        this.mode = newMode;
+        mode = newMode;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -750,7 +750,9 @@ public class Context
      */
     @SuppressWarnings("unchecked")
     public <E extends ReloadableEntity> void uncacheEntity(E entity) throws SQLException {
-        dbConnection.uncacheEntity(entity);
+        if(entity != null) {
+            dbConnection.uncacheEntity(entity);
+        }
     }
 
     public Boolean getCachedAuthorizationResult(DSpaceObject dspaceObject, int action, EPerson eperson) {

--- a/dspace-api/src/main/java/org/dspace/core/ContextReadOnlyCache.java
+++ b/dspace-api/src/main/java/org/dspace/core/ContextReadOnlyCache.java
@@ -79,6 +79,12 @@ public class ContextReadOnlyCache {
         return allMemberGroupsCache.get(buildAllMembersGroupKey(ePerson));
     }
 
+    public void clear() {
+        authorizedActionsCache.clear();
+        groupMembershipCache.clear();
+        allMemberGroupsCache.clear();
+    }
+
     private String buildAllMembersGroupKey(EPerson ePerson) {
         return ePerson == null ? "" : ePerson.getID().toString();
     }
@@ -93,4 +99,5 @@ public class ContextReadOnlyCache {
         return new ImmutablePair<>(group == null ? "" : group.getName(),
                 eperson == null ? "" : eperson.getID().toString());
     }
+
 }

--- a/dspace-api/src/main/java/org/dspace/core/ContextReadOnlyCache.java
+++ b/dspace-api/src/main/java/org/dspace/core/ContextReadOnlyCache.java
@@ -1,0 +1,93 @@
+package org.dspace.core;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
+import org.dspace.content.DSpaceObject;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
+import org.springframework.util.CollectionUtils;
+
+import java.util.HashMap;
+import java.util.Set;
+
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+public class ContextReadOnlyCache {
+
+    /**
+     * Authorized actions cache that is used when the context is in READ_ONLY mode.
+     * The key of the cache is: DSpace Object ID, action ID, Eperson ID.
+     */
+    private final HashMap<Triple<String, Integer, String>, Boolean> authorizedActionsCache = new HashMap<>();
+
+    /**
+     * Group membership cache that is used when the context is in READ_ONLY mode.
+     * The key of the cache is: Group Name, Eperson ID.
+     */
+    private final HashMap<Pair<String, String>, Boolean> groupMembershipCache = new HashMap<>();
+
+    /**
+     * Cache for all the groups the current ePerson is a member of when the context is in READ_ONLY mode.
+     */
+    private final HashMap<String, Set<Group>> allMemberGroupsCache = new HashMap<>();
+
+    public Boolean getCachedAuthorizationResult(DSpaceObject dspaceObject, int action, EPerson eperson) {
+        return authorizedActionsCache.get(buildAuthorizedActionKey(dspaceObject, action, eperson));
+    }
+
+    public void cacheAuthorizedAction(DSpaceObject dspaceObject, int action, EPerson eperson, Boolean result) {
+        authorizedActionsCache.put(buildAuthorizedActionKey(dspaceObject, action, eperson), result);
+    }
+
+    public Boolean getCachedGroupMembership(Group group, EPerson eperson) {
+        String allMembersGroupKey = buildAllMembersGroupKey(eperson);
+
+        if (CollectionUtils.isEmpty(allMemberGroupsCache.get(allMembersGroupKey))) {
+            return groupMembershipCache.get(buildGroupMembershipKey(group, eperson));
+
+        } else {
+            return allMemberGroupsCache.get(allMembersGroupKey).contains(group);
+        }
+
+    }
+
+    public void cacheGroupMembership(Group group, EPerson eperson, Boolean isMember) {
+        if (CollectionUtils.isEmpty(allMemberGroupsCache.get(buildAllMembersGroupKey(eperson)))) {
+            groupMembershipCache.put(buildGroupMembershipKey(group, eperson), isMember);
+        }
+    }
+
+    public void cacheAllMemberGroupsSet(EPerson ePerson, Set<Group> groups) {
+        allMemberGroupsCache.put(buildAllMembersGroupKey(ePerson),
+                groups);
+
+        //clear the individual groupMembershipCache as we have all memberships now.
+        groupMembershipCache.clear();
+    }
+
+    public Set<Group> getCachedAllMemberGroupsSet(EPerson ePerson) {
+        return allMemberGroupsCache.get(buildAllMembersGroupKey(ePerson));
+    }
+
+    private String buildAllMembersGroupKey(EPerson ePerson) {
+        return ePerson == null ? "" : ePerson.getID().toString();
+    }
+
+    private ImmutableTriple<String, Integer, String> buildAuthorizedActionKey(DSpaceObject dspaceObject, int action, EPerson eperson) {
+        return new ImmutableTriple<>(dspaceObject == null ? "" : dspaceObject.getID().toString(),
+                Integer.valueOf(action),
+                eperson == null ? "" : eperson.getID().toString());
+    }
+
+    private Pair<String, String> buildGroupMembershipKey(Group group, EPerson eperson) {
+        return new ImmutablePair<>(group == null ? "" : group.getName(),
+                eperson == null ? "" : eperson.getID().toString());
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/core/ContextReadOnlyCache.java
+++ b/dspace-api/src/main/java/org/dspace/core/ContextReadOnlyCache.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.core;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -13,11 +20,7 @@ import java.util.HashMap;
 import java.util.Set;
 
 /**
- * The contents of this file are subject to the license and copyright
- * detailed in the LICENSE and NOTICE files at the root of the source
- * tree and available online at
- *
- * http://www.dspace.org/license/
+ * Object that manages the read-only caches for the Context class
  */
 public class ContextReadOnlyCache {
 

--- a/dspace-api/src/main/java/org/dspace/core/DBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/DBConnection.java
@@ -40,11 +40,9 @@ public interface DBConnection<T> {
 
     public DatabaseConfigVO getDatabaseConfig() throws SQLException;
     
-    public void setOptimizedForBatchProcessing(boolean batchOptimized) throws SQLException;
+    public void setConnectionMode(boolean batchOptimized, boolean readOnlyOptimized) throws SQLException;
 
     public boolean isOptimizedForBatchProcessing();
-
-    public void setReadOnly(boolean readOnlyOptimized) throws SQLException;
 
     public long getCacheSize() throws SQLException;
 

--- a/dspace-api/src/main/java/org/dspace/core/DBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/DBConnection.java
@@ -44,6 +44,8 @@ public interface DBConnection<T> {
 
     public boolean isOptimizedForBatchProcessing();
 
+    public void setReadOnly(boolean readOnlyOptimized) throws SQLException;
+
     public long getCacheSize() throws SQLException;
 
     /**

--- a/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
@@ -134,20 +134,15 @@ public class HibernateDBConnection implements DBConnection<Session> {
     }
 
     @Override
-    public void setOptimizedForBatchProcessing(final boolean batchOptimized) throws SQLException {
+    public void setConnectionMode(final boolean batchOptimized, final boolean readOnlyOptimized) throws SQLException {
         this.batchModeEnabled = batchOptimized;
+        this.readOnlyEnabled = readOnlyOptimized;
         configureDatabaseMode();
     }
 
     @Override
     public boolean isOptimizedForBatchProcessing() {
         return batchModeEnabled;
-    }
-
-    @Override
-    public void setReadOnly(boolean readOnlyOptimized) throws SQLException {
-        this.readOnlyEnabled = readOnlyOptimized;
-        configureDatabaseMode();
     }
 
     private void configureDatabaseMode() throws SQLException {

--- a/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
@@ -7,11 +7,11 @@
  */
 package org.dspace.core;
 
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.content.*;
+import org.dspace.handle.Handle;
 import org.dspace.storage.rdbms.DatabaseConfigVO;
-import org.hibernate.FlushMode;
-import org.hibernate.Session;
-import org.hibernate.SessionFactory;
-import org.hibernate.Transaction;
+import org.hibernate.*;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.proxy.HibernateProxyHelper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -164,6 +164,83 @@ public class HibernateDBConnection implements DBConnection<Session> {
      */
     @Override
     public <E extends ReloadableEntity> void uncacheEntity(E entity) throws SQLException {
-        getSession().evict(entity);        
+        if(entity != null) {
+            if (entity instanceof DSpaceObject) {
+                DSpaceObject dso = (DSpaceObject) entity;
+
+                // The metadatavalue relation has CascadeType.ALL, so they are evicted automatically
+                // and we don' need to uncache the values explicitly.
+
+                if(Hibernate.isInitialized(dso.getHandles())) {
+                    for (Handle handle : Utils.emptyIfNull(dso.getHandles())) {
+                        uncacheEntity(handle);
+                    }
+                }
+
+                //We always need to explicitly check Resource Policies because they could have been fetched by
+                // a direct query and thus not through an initialized collection.
+                for (ResourcePolicy policy : Utils.emptyIfNull(dso.getResourcePolicies())) {
+                    uncacheEntity(policy);
+                }
+            }
+
+            if (entity instanceof Item) {
+                Item item = (Item) entity;
+
+                if(Hibernate.isInitialized(item.getSubmitter())) {
+                    uncacheEntity(item.getSubmitter());
+                }
+                if(Hibernate.isInitialized(item.getBundles())) {
+                    for (Bundle bundle : Utils.emptyIfNull(item.getBundles())) {
+                        uncacheEntity(bundle);
+                    }
+                }
+            } else if (entity instanceof Bundle) {
+                Bundle bundle = (Bundle) entity;
+
+                if(Hibernate.isInitialized(bundle.getBitstreams())) {
+                    for (Bitstream bitstream : Utils.emptyIfNull(bundle.getBitstreams())) {
+                        uncacheEntity(bitstream);
+                    }
+                }
+            //} else if(entity instanceof Bitstream) {
+            //    Bitstream bitstream = (Bitstream) entity;
+            //    No specific child entities to decache
+            } else if (entity instanceof Community) {
+                Community community = (Community) entity;
+                if(Hibernate.isInitialized(community.getAdministrators())) {
+                    uncacheEntity(community.getAdministrators());
+                }
+
+                if(Hibernate.isInitialized(community.getLogo())) {
+                    uncacheEntity(community.getLogo());
+                }
+            } else if (entity instanceof Collection) {
+                Collection collection = (Collection) entity;
+                if(Hibernate.isInitialized(collection.getLogo())) {
+                    uncacheEntity(collection.getLogo());
+                }
+                if(Hibernate.isInitialized(collection.getAdministrators())) {
+                    uncacheEntity(collection.getAdministrators());
+                }
+                if(Hibernate.isInitialized(collection.getSubmitters())) {
+                    uncacheEntity(collection.getSubmitters());
+                }
+                if(Hibernate.isInitialized(collection.getTemplateItem())) {
+                    uncacheEntity(collection.getTemplateItem());
+                }
+                if(Hibernate.isInitialized(collection.getWorkflowStep1())) {
+                    uncacheEntity(collection.getWorkflowStep1());
+                }
+                if(Hibernate.isInitialized(collection.getWorkflowStep2())) {
+                    uncacheEntity(collection.getWorkflowStep2());
+                }
+                if(Hibernate.isInitialized(collection.getWorkflowStep3())) {
+                    uncacheEntity(collection.getWorkflowStep3());
+                }
+            }
+
+            getSession().evict(entity);
+        }
     }
 }

--- a/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
@@ -177,10 +177,10 @@ public class HibernateDBConnection implements DBConnection<Session> {
                     }
                 }
 
-                //We always need to explicitly check Resource Policies because they could have been fetched by
-                // a direct query and thus not through an initialized collection.
-                for (ResourcePolicy policy : Utils.emptyIfNull(dso.getResourcePolicies())) {
-                    uncacheEntity(policy);
+                if(Hibernate.isInitialized(dso.getResourcePolicies())) {
+                    for (ResourcePolicy policy : Utils.emptyIfNull(dso.getResourcePolicies())) {
+                        uncacheEntity(policy);
+                    }
                 }
             }
 

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
@@ -47,7 +47,7 @@ public class IndexClient {
      */
     public static void main(String[] args) throws SQLException, IOException, SearchServiceException {
 
-        Context context = new Context();
+        Context context = new Context(Context.Mode.READ_ONLY);
         context.turnOffAuthorisationSystem();
 
         String usage = "org.dspace.discovery.IndexClient [-cbhf] | [-r <handle>] | [-i <handle>] or nothing to update/clean an existing index.";
@@ -142,8 +142,6 @@ public class IndexClient {
                 throw new IllegalArgumentException("Cannot resolve " + handle + " to a DSpace object");
             }
             log.info("Forcibly Indexing " + handle);
-            // Enable batch mode; we may be indexing a large number of items
-            context.setMode(Context.Mode.BATCH_EDIT);
             final long startTimeMillis = System.currentTimeMillis();
             final long count = indexAll(indexer,  ContentServiceFactory.getInstance().getItemService(), context, dso);
             final long seconds = (System.currentTimeMillis() - startTimeMillis ) / 1000;

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
@@ -143,7 +143,7 @@ public class IndexClient {
             }
             log.info("Forcibly Indexing " + handle);
             // Enable batch mode; we may be indexing a large number of items
-            context.enableBatchMode(true);
+            context.setMode(Context.Mode.BATCH_EDIT);
             final long startTimeMillis = System.currentTimeMillis();
             final long count = indexAll(indexer,  ContentServiceFactory.getInstance().getItemService(), context, dso);
             final long seconds = (System.currentTimeMillis() - startTimeMillis ) / 1000;

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceResourceRestrictionPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceResourceRestrictionPlugin.java
@@ -29,10 +29,8 @@ import org.dspace.eperson.service.GroupService;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
+
 import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
@@ -98,7 +96,7 @@ public class SolrServiceResourceRestrictionPlugin implements SolrServiceIndexPlu
                 }
 
                 //Retrieve all the groups the current user is a member of !
-                List<Group> groups = groupService.allMemberGroups(context, currentUser);
+                Set<Group> groups = groupService.allMemberGroupsSet(context, currentUser);
                 for (Group group : groups) {
                     resourceQuery.append(" OR g").append(group.getID());
                 }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceResourceRestrictionPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceResourceRestrictionPlugin.java
@@ -8,30 +8,27 @@
 package org.dspace.discovery;
 
 
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.log4j.Logger;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.common.SolrInputDocument;
 import org.dspace.authorize.ResourcePolicy;
 import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.authorize.service.ResourcePolicyService;
+import org.dspace.content.DSpaceObject;
 import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.CommunityService;
-import org.dspace.authorize.service.ResourcePolicyService;
-import org.dspace.content.Collection;
-import org.dspace.content.Community;
-import org.dspace.content.DSpaceObject;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.LogManager;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.service.GroupService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.sql.SQLException;
-import java.util.*;
-
-import org.dspace.services.factory.DSpaceServicesFactory;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Restriction plugin that ensures that indexes all the resource policies.
@@ -72,6 +69,9 @@ public class SolrServiceResourceRestrictionPlugin implements SolrServiceIndexPlu
                 }
 
                 document.addField("read", fieldValue);
+
+                //remove the policy from the cache to save memory
+                context.uncacheEntity(resourcePolicy);
             }
         } catch (SQLException e) {
             log.error(LogManager.getHeader(context, "Error while indexing resource policies", "DSpace object: (id " + dso.getID() + " type " + dso.getType() + ")"));

--- a/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
@@ -16,6 +16,7 @@ import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.proxy.HibernateProxyHelper;
 
 import javax.persistence.*;
@@ -31,6 +32,8 @@ import java.util.List;
  * @version $Revision$
  */
 @Entity
+@Cacheable
+@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, include = "non-lazy")
 @Table(name = "eperson")
 public class EPerson extends DSpaceObject implements DSpaceObjectLegacySupport
 {

--- a/dspace-api/src/main/java/org/dspace/eperson/Group.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/Group.java
@@ -16,6 +16,7 @@ import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.GroupService;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.proxy.HibernateProxyHelper;
 
 import javax.persistence.*;
@@ -29,6 +30,8 @@ import java.util.List;
  * @author David Stuve
  */
 @Entity
+@Cacheable
+@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, include = "non-lazy")
 @Table(name = "epersongroup" )
 public class Group extends DSpaceObject implements DSpaceObjectLegacySupport
 {

--- a/dspace-api/src/main/java/org/dspace/eperson/Group2GroupCache.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/Group2GroupCache.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.eperson;
 
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.hibernate.proxy.HibernateProxyHelper;
 
 import javax.persistence.*;
@@ -78,5 +79,13 @@ public class Group2GroupCache implements Serializable {
             return false;
         }
         return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return new org.apache.commons.lang.builder.HashCodeBuilder()
+                .append(parent == null ? "" : parent.getID())
+                .append(child == null ? "" : child.getID())
+                .toHashCode();
     }
 }

--- a/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
@@ -158,39 +158,55 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
 
     @Override
     public boolean isMember(Context context, Group group) throws SQLException {
-        return isMember(context, group.getName());
-    }
+        EPerson currentUser = context.getCurrentUser();
 
-    @Override
-    public boolean isMember(final Context context, final String groupName) throws SQLException {
-        // special, everyone is member of group 0 (anonymous)
-        if (StringUtils.equals(groupName, Group.ANONYMOUS))
-        {
+        if(group == null) {
+            return false;
+
+            // special, everyone is member of group 0 (anonymous)
+        } else if (StringUtils.equals(group.getName(), Group.ANONYMOUS)) {
             return true;
-        } else if(context.getCurrentUser() != null) {
-            EPerson currentUser = context.getCurrentUser();
 
-            //First check the special groups
-            List<Group> specialGroups = context.getSpecialGroups();
-            if(CollectionUtils.isNotEmpty(specialGroups)) {
-                for (Group specialGroup : specialGroups)
-                {
-                    //Check if the current special group is the one we are looking for OR retrieve all groups & make a check here.
-                    if(StringUtils.equals(specialGroup.getName(), groupName) || allMemberGroups(context, currentUser).contains(findByName(context, groupName)))
-                    {
-                        return true;
-                    }
-                }
+        } else if(currentUser != null) {
+
+            Boolean cachedGroupMembership = context.getCachedGroupMembership(group, currentUser);
+            if(cachedGroupMembership != null) {
+                return cachedGroupMembership.booleanValue();
+
+            } else if(CollectionUtils.isNotEmpty(context.getSpecialGroups())) {
+                Set<Group> allMemberGroups = allMemberGroupsSet(context, currentUser);
+                boolean result = allMemberGroups.contains(group);
+
+                context.cacheGroupMembership(group, currentUser, result);
+                return result;
+            } else {
+                //lookup eperson in normal groups and subgroups
+                boolean result = epersonInGroup(context, group.getName(), currentUser);
+                context.cacheGroupMembership(group, currentUser, result);
+                return result;
             }
-            //lookup eperson in normal groups and subgroups
-            return epersonInGroup(context, groupName, currentUser);
         } else {
             return false;
         }
     }
 
     @Override
+    public boolean isMember(final Context context, final String groupName) throws SQLException {
+        return isMember(context, findByName(context, groupName));
+    }
+
+    @Override
     public List<Group> allMemberGroups(Context context, EPerson ePerson) throws SQLException {
+        return new ArrayList<>(allMemberGroupsSet(context, ePerson));
+    }
+
+    @Override
+    public Set<Group> allMemberGroupsSet(Context context, EPerson ePerson) throws SQLException {
+        Set<Group> cachedGroupMembership = context.getCachedAllMemberGroupsSet(ePerson);
+        if(cachedGroupMembership != null) {
+            return cachedGroupMembership;
+        }
+
         Set<Group> groups = new HashSet<>();
 
         if (ePerson != null)
@@ -216,7 +232,6 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
         // all the users are members of the anonymous group
         groups.add(findByName(context, Group.ANONYMOUS));
 
-
         List<Group2GroupCache> groupCache = group2GroupCacheDAO.findByChildren(context, groups);
         // now we have all owning groups, also grab all parents of owning groups
         // yes, I know this could have been done as one big query and a union,
@@ -225,7 +240,8 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
             groups.add(group2GroupCache.getParent());
         }
 
-        return new ArrayList<>(groups);
+        context.cacheAllMemberGroupsSet(ePerson, groups);
+        return groups;
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/eperson/dao/impl/EPersonDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/dao/impl/EPersonDAOImpl.java
@@ -43,6 +43,8 @@ public class EPersonDAOImpl extends AbstractHibernateDSODAO<EPerson> implements 
         // All email addresses are stored as lowercase, so ensure that the email address is lowercased for the lookup
         Criteria criteria = createCriteria(context, EPerson.class);
         criteria.add(Restrictions.eq("email", email.toLowerCase()));
+
+        criteria.setCacheable(true);
         return uniqueResult(criteria);
     }
 
@@ -52,6 +54,8 @@ public class EPersonDAOImpl extends AbstractHibernateDSODAO<EPerson> implements 
     {
         Criteria criteria = createCriteria(context, EPerson.class);
         criteria.add(Restrictions.eq("netid", netid));
+
+        criteria.setCacheable(true);
         return uniqueResult(criteria);
     }
 

--- a/dspace-api/src/main/java/org/dspace/eperson/service/GroupService.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/service/GroupService.java
@@ -9,6 +9,7 @@ package org.dspace.eperson.service;
 
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Set;
 
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.MetadataField;
@@ -153,6 +154,8 @@ public interface GroupService extends DSpaceObjectService<Group>, DSpaceObjectLe
      * @throws SQLException if database error
      */
     public List<Group> allMemberGroups(Context context, EPerson ePerson) throws SQLException;
+
+    Set<Group> allMemberGroupsSet(Context context, EPerson ePerson) throws SQLException;
 
     /**
      * Get all of the epeople who are a member of the

--- a/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
@@ -215,8 +215,8 @@ public class OAIHarvester {
      */
 	public void runHarvest() throws SQLException, IOException, AuthorizeException
 	{
-		boolean originalMode = ourContext.isBatchModeEnabled();
-		ourContext.enableBatchMode(true);
+		Context.Mode originalMode = ourContext.getCurrentMode();
+		ourContext.setMode(Context.Mode.BATCH_EDIT);
 
 		// figure out the relevant parameters
 		String oaiSource = harvestRow.getOaiSource();
@@ -432,7 +432,7 @@ public class OAIHarvester {
 		log.info("Harvest from " + oaiSource + " successful. The process took " + timeTaken + " milliseconds. Harvested " + currentRecord + " items.");
 		harvestedCollection.update(ourContext, harvestRow);
 
-		ourContext.enableBatchMode(originalMode);
+		ourContext.setMode(originalMode);
 	}
 
 	private void intermediateCommit() throws SQLException {

--- a/dspace-api/src/main/java/org/dspace/rdf/RDFConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/rdf/RDFConsumer.java
@@ -320,7 +320,7 @@ public class RDFConsumer implements Consumer
         // create a new context, to be sure to work as anonymous user
         // we don't want to store private data in a triplestore with public
         // SPARQL endpoint.
-        ctx = new Context(Context.READ_ONLY);
+        ctx = new Context(Context.Mode.READ_ONLY);
         if (toDelete == null) 
         {
             log.debug("Deletion queue does not exists, creating empty queue.");

--- a/dspace-api/src/main/java/org/dspace/rdf/RDFizer.java
+++ b/dspace-api/src/main/java/org/dspace/rdf/RDFizer.java
@@ -84,7 +84,7 @@ public class RDFizer {
         this.dryrun = false;
         this.lang = "TURTLE";
         this.processed = new CopyOnWriteArraySet<UUID>();
-        this.context = new Context(Context.READ_ONLY);
+        this.context = new Context(Context.Mode.READ_ONLY);
         
         this.configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
         this.contentServiceFactory = ContentServiceFactory.getInstance();
@@ -796,7 +796,7 @@ public class RDFizer {
         // data into a triple store that provides a public sparql endpoint.
         // all exported rdf data can be read by anonymous users.
         // We won't change the database => read_only context will assure this.
-        Context context = new Context(Context.READ_ONLY);
+        Context context = new Context(Context.Mode.READ_ONLY);
 
         RDFizer myself = null;
         myself = new RDFizer();        

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/PoolTaskServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/PoolTaskServiceImpl.java
@@ -20,10 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 /**
  * Service implementation for the PoolTask object.
@@ -92,7 +89,7 @@ public class PoolTaskServiceImpl implements PoolTaskService {
             else{
                 //If the user does not have a claimedtask yet, see whether one of the groups of the user has pooltasks
                 //for this workflow item
-                List<Group> groups = groupService.allMemberGroups(context, ePerson);
+                Set<Group> groups = groupService.allMemberGroupsSet(context, ePerson);
                 for (Group group : groups) {
                     poolTask = poolTaskDAO.findByWorkflowItemAndGroup(context, group, workflowItem);
                     if(poolTask != null)

--- a/dspace-api/src/test/java/org/dspace/core/ContextReadOnlyCacheTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/ContextReadOnlyCacheTest.java
@@ -1,0 +1,121 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.core;
+
+import org.dspace.content.Item;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+/**
+ * Class to test the read-only Context cache
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ContextReadOnlyCacheTest {
+
+    private ContextReadOnlyCache readOnlyCache;
+
+    @Mock
+    private EPerson ePerson;
+
+    @Before
+    public void init() {
+        readOnlyCache = new ContextReadOnlyCache();
+        when(ePerson.getID()).thenReturn(UUID.randomUUID());
+    }
+
+    @Test
+    public void cacheAuthorizedAction() throws Exception {
+        Item item = Mockito.mock(Item.class);
+        when(item.getID()).thenReturn(UUID.randomUUID());
+
+        readOnlyCache.cacheAuthorizedAction(item, Constants.READ, ePerson, true);
+        readOnlyCache.cacheAuthorizedAction(item, Constants.WRITE, ePerson, false);
+
+        assertTrue(readOnlyCache.getCachedAuthorizationResult(item, Constants.READ, ePerson));
+        assertFalse(readOnlyCache.getCachedAuthorizationResult(item, Constants.WRITE, ePerson));
+
+        assertNull(readOnlyCache.getCachedAuthorizationResult(item, Constants.ADMIN, ePerson));
+        assertNull(readOnlyCache.getCachedAuthorizationResult(item, Constants.READ, null));
+        assertNull(readOnlyCache.getCachedAuthorizationResult(null, Constants.READ, ePerson));
+    }
+
+    @Test
+    public void cacheGroupMembership() throws Exception {
+        Group group1 = buildGroupMock("Test Group 1");
+        Group group2 = buildGroupMock("Test Group 2");
+        Group group3 = buildGroupMock("Test Group 3");
+
+        readOnlyCache.cacheGroupMembership(group1, ePerson, true);
+        readOnlyCache.cacheGroupMembership(group2, ePerson, false);
+
+        assertTrue(readOnlyCache.getCachedGroupMembership(group1, ePerson));
+        assertFalse(readOnlyCache.getCachedGroupMembership(group2, ePerson));
+
+        assertNull(readOnlyCache.getCachedGroupMembership(group3, ePerson));
+        assertNull(readOnlyCache.getCachedGroupMembership(null, ePerson));
+        assertNull(readOnlyCache.getCachedGroupMembership(group2, null));
+    }
+
+    @Test
+    public void cacheAllMemberGroupsSet() throws Exception {
+        Group group1 = buildGroupMock("Test Group 1");
+        Group group2 = buildGroupMock("Test Group 2");
+        Group group3 = buildGroupMock("Test Group 3");
+
+        readOnlyCache.cacheAllMemberGroupsSet(ePerson, new HashSet<>(Arrays.asList(group1, group2)));
+
+        assertTrue(readOnlyCache.getCachedGroupMembership(group1, ePerson));
+        assertTrue(readOnlyCache.getCachedGroupMembership(group2, ePerson));
+        assertFalse(readOnlyCache.getCachedGroupMembership(group3, ePerson));
+        assertFalse(readOnlyCache.getCachedGroupMembership(null, ePerson));
+
+        assertNull(readOnlyCache.getCachedGroupMembership(group2, null));
+    }
+
+    @Test
+    public void clear() throws Exception {
+        Item item = Mockito.mock(Item.class);
+        when(item.getID()).thenReturn(UUID.randomUUID());
+        Group group1 = buildGroupMock("Test Group 1");
+
+        //load data into the cache
+        readOnlyCache.cacheAuthorizedAction(item, Constants.READ, ePerson, true);
+        readOnlyCache.cacheGroupMembership(group1, ePerson, true);
+
+        //double check the data is there
+        assertTrue(readOnlyCache.getCachedAuthorizationResult(item, Constants.READ, ePerson));
+        assertTrue(readOnlyCache.getCachedGroupMembership(group1, ePerson));
+
+        //clear the cache
+        readOnlyCache.clear();
+
+        //check that the data is not present anymore
+        assertNull(readOnlyCache.getCachedAuthorizationResult(item, Constants.READ, ePerson));
+        assertNull(readOnlyCache.getCachedGroupMembership(group1, ePerson));
+    }
+
+    private Group buildGroupMock(final String name) {
+        Group group = Mockito.mock(Group.class);
+        when(group.getName()).thenReturn(name);
+        return group;
+    }
+
+}

--- a/dspace-api/src/test/java/org/dspace/core/ContextTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/ContextTest.java
@@ -310,6 +310,9 @@ public class ContextTest extends AbstractUnitTest
         Context instance = new Context(Context.Mode.READ_ONLY);
         assertThat("testIsReadOnly 1", instance.isReadOnly(), equalTo(true));
 
+        //When in read-only, we only support abort().
+        instance.abort();
+
         // Cleanup our context
         cleanupContext(instance);
     }

--- a/dspace-api/src/test/java/org/dspace/core/ContextTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/ContextTest.java
@@ -307,7 +307,7 @@ public class ContextTest extends AbstractUnitTest
         assertThat("testIsReadOnly 0", context.isReadOnly(), equalTo(false));
         
         // Create a new read-only context
-        Context instance = new Context(Context.READ_ONLY);
+        Context instance = new Context(Context.Mode.READ_ONLY);
         assertThat("testIsReadOnly 1", instance.isReadOnly(), equalTo(true));
 
         // Cleanup our context

--- a/dspace-api/src/test/java/org/dspace/core/ContextTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/ContextTest.java
@@ -318,6 +318,30 @@ public class ContextTest extends AbstractUnitTest
     }
 
     /**
+     * Test that commit cannot be called when the context is in read-only mode
+     */
+    @Test
+    public void testIsReadOnlyCommit() throws SQLException
+    {
+        // Create a new read-only context
+        Context instance = new Context(Context.Mode.READ_ONLY);
+        assertThat("testIsReadOnly 1", instance.isReadOnly(), equalTo(true));
+
+        try {
+            //When in read-only, calling commit() should result in an error
+            instance.commit();
+            fail();
+        } catch (Exception ex) {
+            assertTrue(ex instanceof UnsupportedOperationException);
+        }
+
+        instance.abort();
+
+        // Cleanup our context
+        cleanupContext(instance);
+    }
+
+    /**
      * Test of getCacheSize method, of class Context.
      */
     /*@Test

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/MyDSpaceServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/MyDSpaceServlet.java
@@ -7,21 +7,6 @@
  */
 package org.dspace.app.webui.servlet;
 
-import java.io.DataInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.sql.SQLException;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.UUID;
-
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.log4j.Logger;
 import org.dspace.app.itemexport.ItemExportException;
 import org.dspace.app.itemexport.factory.ItemExportServiceFactory;
@@ -40,11 +25,7 @@ import org.dspace.content.Community;
 import org.dspace.content.Item;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.content.factory.ContentServiceFactory;
-import org.dspace.content.service.CollectionService;
-import org.dspace.content.service.CommunityService;
-import org.dspace.content.service.ItemService;
-import org.dspace.content.service.SupervisedItemService;
-import org.dspace.content.service.WorkspaceItemService;
+import org.dspace.content.service.*;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 import org.dspace.core.LogManager;
@@ -60,6 +41,20 @@ import org.dspace.workflowbasic.BasicWorkflowItem;
 import org.dspace.workflowbasic.factory.BasicWorkflowServiceFactory;
 import org.dspace.workflowbasic.service.BasicWorkflowItemService;
 import org.dspace.workflowbasic.service.BasicWorkflowService;
+
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
 
 /**
  * Servlet for constructing the components of the "My DSpace" page
@@ -134,8 +129,13 @@ public class MyDSpaceServlet extends DSpaceServlet
             HttpServletResponse response) throws ServletException, IOException,
             SQLException, AuthorizeException
     {
+        Context.Mode originalMode = context.getCurrentMode();
+        context.setMode(Context.Mode.READ_ONLY);
+
         // GET displays the main page - everthing else is a POST
         showMainPage(context, request, response);
+
+        context.setMode(originalMode);
      }
     
     @Override

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/submit/step/JSPSelectCollectionStep.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/submit/step/JSPSelectCollectionStep.java
@@ -7,15 +7,6 @@
  */
 package org.dspace.app.webui.submit.step;
 
-import java.io.IOException;
-import java.sql.SQLException;
-import java.util.List;
-import java.util.UUID;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.log4j.Logger;
 import org.dspace.app.util.SubmissionInfo;
 import org.dspace.app.util.Util;
@@ -31,6 +22,14 @@ import org.dspace.content.service.CollectionService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.submit.step.SelectCollectionStep;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
 
 /**
  * Step which controls selecting a Collection for the Item Submission process
@@ -101,6 +100,9 @@ public class JSPSelectCollectionStep extends JSPStep
             throws ServletException, IOException, SQLException,
             AuthorizeException
     {
+        Context.Mode originalMode = context.getCurrentMode();
+        context.setMode(Context.Mode.READ_ONLY);
+
         /*
          * Possible parameters from JSP:
          * 
@@ -161,6 +163,8 @@ public class JSPSelectCollectionStep extends JSPStep
             // we need to load the select collection JSP
             JSPStepManager.showJSP(request, response, subInfo, SELECT_COLLECTION_JSP);
         }
+
+        context.setMode(originalMode);
     }
 
     /**

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -11,19 +11,6 @@ import com.lyncode.xoai.dataprovider.exceptions.ConfigurationException;
 import com.lyncode.xoai.dataprovider.exceptions.MetadataBindException;
 import com.lyncode.xoai.dataprovider.exceptions.WritingXmlException;
 import com.lyncode.xoai.dataprovider.xml.XmlOutputContext;
-
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.net.ConnectException;
-import java.sql.SQLException;
-import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-import javax.xml.stream.XMLStreamException;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.Options;
@@ -36,34 +23,36 @@ import org.apache.solr.client.solrj.SolrServer;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrInputDocument;
-
 import org.dspace.authorize.factory.AuthorizeServiceFactory;
 import org.dspace.authorize.service.AuthorizeService;
-import org.dspace.content.Bitstream;
-import org.dspace.content.Bundle;
+import org.dspace.content.*;
 import org.dspace.content.Collection;
-import org.dspace.content.Community;
-import org.dspace.content.Item;
-import org.dspace.content.MetadataValue;
-import org.dspace.content.MetadataField;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
+import org.dspace.core.Utils;
 import org.dspace.xoai.exceptions.CompilingException;
+import org.dspace.xoai.services.api.CollectionsService;
 import org.dspace.xoai.services.api.cache.XOAICacheService;
 import org.dspace.xoai.services.api.cache.XOAIItemCacheService;
 import org.dspace.xoai.services.api.cache.XOAILastCompilationCacheService;
 import org.dspace.xoai.services.api.config.ConfigurationService;
-import org.dspace.xoai.services.api.CollectionsService;
 import org.dspace.xoai.services.api.solr.SolrServerResolver;
 import org.dspace.xoai.solr.DSpaceSolrSearch;
 import org.dspace.xoai.solr.exceptions.DSpaceSolrException;
 import org.dspace.xoai.solr.exceptions.DSpaceSolrIndexerException;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import javax.xml.stream.XMLStreamException;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.sql.SQLException;
+import java.text.ParseException;
+import java.util.*;
 
 import static com.lyncode.xoai.dataprovider.core.Granularity.Second;
 import static org.dspace.xoai.util.ItemUtils.retrieveMetadata;
@@ -206,7 +195,12 @@ public class XOAI {
             SolrServer server = solrServerResolver.getServer();
             while (iterator.hasNext()) {
                 try {
-                    server.add(this.index(iterator.next()));
+                    Item item = iterator.next();
+                    server.add(this.index(item));
+
+                    uncacheItem(item);
+                    System.out.println("Indexed item " + i + ". Cache size is " + context.getCacheSize());
+
                 } catch (SQLException | MetadataBindException | ParseException
                         | XMLStreamException | WritingXmlException ex) {
                     log.error(ex.getMessage(), ex);
@@ -220,6 +214,22 @@ public class XOAI {
         } catch (SolrServerException | IOException ex) {
             throw new DSpaceSolrIndexerException(ex.getMessage(), ex);
         }
+    }
+
+    private void uncacheItem(final Item item) throws SQLException {
+        context.uncacheEntity(item.getOwningCollection());
+        context.uncacheEntity(item.getSubmitter());
+        context.uncacheEntity(item.getTemplateItemOf());
+
+        for (Bundle bundle : Utils.emptyIfNull(item.getBundles())) {
+            context.uncacheEntity(bundle);
+        }
+
+        for (Collection collection : Utils.emptyIfNull(item.getCollections())) {
+            context.uncacheEntity(collection);
+        }
+
+        context.uncacheEntity(item);
     }
 
     private SolrInputDocument index(Item item) throws SQLException, MetadataBindException, ParseException, XMLStreamException, WritingXmlException {
@@ -272,7 +282,6 @@ public class XOAI {
         if (verbose) {
             println("Item with handle " + handle + " indexed");
         }
-
 
         return doc;
     }
@@ -382,7 +391,7 @@ public class XOAI {
                 String command = line.getArgs()[0];
 
                 if (COMMAND_IMPORT.equals(command)) {
-                    ctx = new Context();
+                    ctx = new Context(Context.Mode.READ_ONLY);
                     XOAI indexer = new XOAI(ctx,
                             line.hasOption('o'),
                             line.hasOption('c'),

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -33,6 +33,7 @@ import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.Utils;
+import org.dspace.handle.Handle;
 import org.dspace.xoai.exceptions.CompilingException;
 import org.dspace.xoai.services.api.CollectionsService;
 import org.dspace.xoai.services.api.cache.XOAICacheService;
@@ -198,8 +199,8 @@ public class XOAI {
                     Item item = iterator.next();
                     server.add(this.index(item));
 
-                    uncacheItem(item);
-                    System.out.println("Indexed item " + i + ". Cache size is " + context.getCacheSize());
+                    //Uncache the item to keep memory consumption low
+                    context.uncacheEntity(item);
 
                 } catch (SQLException | MetadataBindException | ParseException
                         | XMLStreamException | WritingXmlException ex) {
@@ -214,22 +215,6 @@ public class XOAI {
         } catch (SolrServerException | IOException ex) {
             throw new DSpaceSolrIndexerException(ex.getMessage(), ex);
         }
-    }
-
-    private void uncacheItem(final Item item) throws SQLException {
-        context.uncacheEntity(item.getOwningCollection());
-        context.uncacheEntity(item.getSubmitter());
-        context.uncacheEntity(item.getTemplateItemOf());
-
-        for (Bundle bundle : Utils.emptyIfNull(item.getBundles())) {
-            context.uncacheEntity(bundle);
-        }
-
-        for (Collection collection : Utils.emptyIfNull(item.getCollections())) {
-            context.uncacheEntity(collection);
-        }
-
-        context.uncacheEntity(item);
     }
 
     private SolrInputDocument index(Item item) throws SQLException, MetadataBindException, ParseException, XMLStreamException, WritingXmlException {

--- a/dspace-rdf/src/main/java/org/dspace/rdf/providing/DataProviderServlet.java
+++ b/dspace-rdf/src/main/java/org/dspace/rdf/providing/DataProviderServlet.java
@@ -87,7 +87,7 @@ public class DataProviderServlet extends HttpServlet {
         DSpaceObject dso = null;
         try
         {
-            context = new Context(Context.READ_ONLY);
+            context = new Context(Context.Mode.READ_ONLY);
             dso = handleService.resolveToObject(context, handle);
         }
         catch (SQLException ex)

--- a/dspace-rdf/src/main/java/org/dspace/rdf/providing/LocalURIRedirectionServlet.java
+++ b/dspace-rdf/src/main/java/org/dspace/rdf/providing/LocalURIRedirectionServlet.java
@@ -69,7 +69,7 @@ public class LocalURIRedirectionServlet extends HttpServlet
         DSpaceObject dso = null;
         try
         {
-            context = new Context(Context.READ_ONLY);
+            context = new Context(Context.Mode.READ_ONLY);
             dso = handleService.resolveToObject(context, handle);
         }
         catch (SQLException ex)

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowContainerUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowContainerUtils.java
@@ -339,8 +339,8 @@ public class FlowContainerUtils
 	 */
 	public static FlowResult processReimportCollection(Context context, UUID collectionID, Request request) throws SQLException, IOException, AuthorizeException, CrosswalkException, ParserConfigurationException, SAXException, TransformerException, BrowseException
 	{
-		boolean originalMode = context.isBatchModeEnabled();
-		context.enableBatchMode(true);
+		Context.Mode originalMode = context.getCurrentMode();
+		context.setMode(Context.Mode.BATCH_EDIT);
 
 		Collection collection = collectionService.find(context, collectionID);
 		HarvestedCollection hc = harvestedCollectionService.find(context, collection);
@@ -362,7 +362,7 @@ public class FlowContainerUtils
         // update the context?
 		//context.dispatchEvent() // not sure if this is required yet.ts();
 
-		context.enableBatchMode(originalMode);
+		context.setMode(originalMode);
 
 		return processRunCollectionHarvest(context, collectionID, request);
 	}

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/ItemExport.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/ItemExport.java
@@ -246,7 +246,7 @@ public class ItemExport extends AbstractDSpaceTransformer implements
 
 					validity.add(context, eperson);
 
-					java.util.List<Group> groups = groupService.allMemberGroups(context, eperson);
+					java.util.Set<Group> groups = groupService.allMemberGroupsSet(context, eperson);
 					for (Group group : groups) {
 						validity.add(context, group);
 					}

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/Navigation.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/Navigation.java
@@ -165,7 +165,7 @@ public class Navigation extends AbstractDSpaceTransformer implements CacheablePr
 		            
 		            validity.add(context, eperson);
 		            
-		            java.util.List<Group> groups = groupService.allMemberGroups(context, eperson);
+		            java.util.Set<Group> groups = groupService.allMemberGroupsSet(context, eperson);
 		            for (Group group : groups)
 		            {
 		            	validity.add(context, group);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/eperson/EditEPersonForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/eperson/EditEPersonForm.java
@@ -381,7 +381,7 @@ public class EditEPersonForm extends AbstractDSpaceTransformer
 	        List member = edit.addList("eperson-member-of");
 	        member.setHead(T_member_head);
 
-	        java.util.List<Group> groups = groupService.allMemberGroups(context, eperson);
+	        java.util.Set<Group> groups = groupService.allMemberGroupsSet(context, eperson);
 	        for (Group group : groups)
 	        {
 	        	String url = contextPath + "/admin/groups?administrative-continue="+knot.getId()+"&submit_edit_group&groupID="+group.getID();
@@ -433,7 +433,7 @@ public class EditEPersonForm extends AbstractDSpaceTransformer
 		// Otherwise check what group this eperson is a member through
 		java.util.List<Group> targets = group.getMemberGroups();
 		
-		java.util.List<Group> groups = groupService.allMemberGroups(context, eperson);
+		java.util.Set<Group> groups = groupService.allMemberGroupsSet(context, eperson);
 		for (Group member : groups)
 		{
 			for (Group target : targets)

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/CommunityBrowser.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/CommunityBrowser.java
@@ -40,6 +40,7 @@ import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.CommunityService;
+import org.dspace.core.Context;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.core.Constants;
 import org.dspace.core.LogManager;
@@ -146,7 +147,10 @@ public class CommunityBrowser extends AbstractDSpaceTransformer implements Cache
     	if (validity == null)
     	{
 	        try {
-	            DSpaceValidity theValidity = new DSpaceValidity();
+                Context.Mode originalMode = context.getCurrentMode();
+                context.setMode(Context.Mode.READ_ONLY);
+
+                DSpaceValidity theValidity = new DSpaceValidity();
 	            
 	            TreeNode treeRoot = buildTree(communityService.findAllTop(context));
 	            
@@ -187,6 +191,8 @@ public class CommunityBrowser extends AbstractDSpaceTransformer implements Cache
                 }
 	            
 	            this.validity = theValidity.complete();
+
+                context.setMode(originalMode);
 	        } 
 	        catch (SQLException sqle) 
 	        {
@@ -236,6 +242,9 @@ public class CommunityBrowser extends AbstractDSpaceTransformer implements Cache
         division.setHead(T_head);
         division.addPara(T_select);
 
+        Context.Mode originalMode = context.getCurrentMode();
+        context.setMode(Context.Mode.READ_ONLY);
+
         TreeNode treeRoot = buildTree(communityService.findAllTop(context));
 
         boolean full = DSpaceServicesFactory.getInstance().getConfigurationService().getBooleanProperty("xmlui.community-list.render.full", true);
@@ -264,6 +273,8 @@ public class CommunityBrowser extends AbstractDSpaceTransformer implements Cache
  	        }
         	
         }
+
+        context.setMode(originalMode);
     } 
     
     /**

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ConfigurableBrowse.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ConfigurableBrowse.java
@@ -7,11 +7,6 @@
  */
 package org.dspace.app.xmlui.aspect.artifactbrowser;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.sql.SQLException;
-import java.util.*;
-
 import org.apache.avalon.framework.parameters.Parameters;
 import org.apache.cocoon.ProcessingException;
 import org.apache.cocoon.ResourceNotFoundException;
@@ -28,34 +23,28 @@ import org.dspace.app.xmlui.cocoon.AbstractDSpaceTransformer;
 import org.dspace.app.xmlui.utils.*;
 import org.dspace.app.xmlui.wing.Message;
 import org.dspace.app.xmlui.wing.WingException;
-import org.dspace.app.xmlui.wing.element.Body;
-import org.dspace.app.xmlui.wing.element.Cell;
-import org.dspace.app.xmlui.wing.element.Division;
-import org.dspace.app.xmlui.wing.element.List;
-import org.dspace.app.xmlui.wing.element.PageMeta;
-import org.dspace.app.xmlui.wing.element.Para;
-import org.dspace.app.xmlui.wing.element.ReferenceSet;
-import org.dspace.app.xmlui.wing.element.Row;
-import org.dspace.app.xmlui.wing.element.Select;
-import org.dspace.app.xmlui.wing.element.Table;
+import org.dspace.app.xmlui.wing.element.*;
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.browse.BrowseEngine;
-import org.dspace.browse.BrowseException;
-import org.dspace.browse.BrowseIndex;
-import org.dspace.browse.BrowseInfo;
-import org.dspace.browse.BrowserScope;
+import org.dspace.browse.*;
 import org.dspace.content.*;
-import org.dspace.content.Collection;
+import org.dspace.content.Item;
 import org.dspace.content.authority.factory.ContentAuthorityServiceFactory;
 import org.dspace.content.authority.service.ChoiceAuthorityService;
-import org.dspace.sort.SortOption;
-import org.dspace.sort.SortException;
-import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.core.Context;
 import org.dspace.core.LogManager;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.sort.SortException;
+import org.dspace.sort.SortOption;
 import org.xml.sax.SAXException;
 
 import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.Serializable;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Implements all the browse functionality (browse by title, subject, authors,
@@ -187,6 +176,9 @@ public class ConfigurableBrowse extends AbstractDSpaceTransformer implements
         {
             try
             {
+                Context.Mode originalMode = context.getCurrentMode();
+                context.setMode(Context.Mode.READ_ONLY);
+
                 DSpaceValidity validity = new DSpaceValidity();
                 DSpaceObject dso = HandleUtil.obtainHandle(objectModel);
 
@@ -218,6 +210,8 @@ public class ConfigurableBrowse extends AbstractDSpaceTransformer implements
                 }
 
                 this.validity =  validity.complete();
+
+                context.setMode(originalMode);
             }
             catch (RuntimeException re)
             {
@@ -243,6 +237,9 @@ public class ConfigurableBrowse extends AbstractDSpaceTransformer implements
     public void addPageMeta(PageMeta pageMeta) throws SAXException, WingException, UIException,
             SQLException, IOException, AuthorizeException
     {
+        Context.Mode originalMode = context.getCurrentMode();
+        context.setMode(Context.Mode.READ_ONLY);
+
         BrowseInfo info = getBrowseInfo();
 
         pageMeta.addMetadata("title").addContent(getTitleMessage(info));
@@ -256,6 +253,8 @@ public class ConfigurableBrowse extends AbstractDSpaceTransformer implements
         }
 
         pageMeta.addTrail().addContent(getTrailMessage(info));
+
+        context.setMode(originalMode);
     }
 
     /**
@@ -264,6 +263,9 @@ public class ConfigurableBrowse extends AbstractDSpaceTransformer implements
     public void addBody(Body body) throws SAXException, WingException, UIException, SQLException,
             IOException, AuthorizeException
     {
+        Context.Mode originalMode = context.getCurrentMode();
+        context.setMode(Context.Mode.READ_ONLY);
+
         BrowseParams params = null;
 
         try {
@@ -365,6 +367,8 @@ public class ConfigurableBrowse extends AbstractDSpaceTransformer implements
         {
             results.addPara(T_no_results);
         }
+
+        context.setMode(originalMode);
     }
 
     /**

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SidebarFacetsTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SidebarFacetsTransformer.java
@@ -115,6 +115,9 @@ public class SidebarFacetsTransformer extends AbstractDSpaceTransformer implemen
         if (this.validity == null) {
 
             try {
+                Context.Mode originalMode = context.getCurrentMode();
+                context.setMode(Context.Mode.READ_ONLY);
+
                 DSpaceObject dso = HandleUtil.obtainHandle(objectModel);
                 DSpaceValidity val = new DSpaceValidity();
 
@@ -143,6 +146,7 @@ public class SidebarFacetsTransformer extends AbstractDSpaceTransformer implemen
                 }
 
                 this.validity = val.complete();
+                context.setMode(originalMode);
             }
             catch (Exception e) {
                 log.error(e.getMessage(),e);
@@ -172,6 +176,9 @@ public class SidebarFacetsTransformer extends AbstractDSpaceTransformer implemen
 
     @Override
     public void addOptions(Options options) throws SAXException, WingException, SQLException, IOException, AuthorizeException {
+
+        Context.Mode originalMode = context.getCurrentMode();
+        context.setMode(Context.Mode.READ_ONLY);
 
         Request request = ObjectModelHelper.getRequest(objectModel);
 
@@ -263,6 +270,8 @@ public class SidebarFacetsTransformer extends AbstractDSpaceTransformer implemen
                 }
             }
         }
+
+        context.setMode(originalMode);
     }
 
     /**

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SimpleSearch.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SimpleSearch.java
@@ -25,6 +25,7 @@ import org.dspace.app.xmlui.wing.element.Item;
 import org.dspace.app.xmlui.wing.element.List;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.*;
+import org.dspace.core.Context;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.discovery.*;
 import org.dspace.discovery.configuration.DiscoveryConfiguration;
@@ -111,6 +112,9 @@ public class SimpleSearch extends AbstractSearch implements CacheableProcessingC
     @Override
     public void addBody(Body body) throws SAXException, WingException,
             SQLException, IOException, AuthorizeException {
+
+        Context.Mode originalMode = context.getCurrentMode();
+        context.setMode(Context.Mode.READ_ONLY);
 
         Request request = ObjectModelHelper.getRequest(objectModel);
         String queryString = getQuery();
@@ -231,6 +235,7 @@ public class SimpleSearch extends AbstractSearch implements CacheableProcessingC
             throw new UIException(e.getMessage(), e);
         }
 
+        context.setMode(originalMode);
     }
 
     protected void addFilterRow(java.util.List<DiscoverySearchFilter> filterFields, int index, Row row, String selectedFilterType, String relationalOperator, String value) throws WingException {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/EditProfile.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/EditProfile.java
@@ -452,7 +452,7 @@ public class EditProfile extends AbstractDSpaceTransformer
        if (!registering)
        {
                 // Add a list of groups that this user is apart of.
-                        java.util.List<Group> memberships = groupService.allMemberGroups(context, context.getCurrentUser());
+                        java.util.Set<Group> memberships = groupService.allMemberGroupsSet(context, context.getCurrentUser());
                 
                 
                         // Not a member of any groups then don't do anything.

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/Navigation.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/Navigation.java
@@ -145,7 +145,7 @@ public class Navigation extends AbstractDSpaceTransformer implements CacheablePr
 		            
 		            validity.add(context, eperson);
 		            
-		            java.util.List<Group> groups = groupService.allMemberGroups(context, eperson);
+		            java.util.Set<Group> groups = groupService.allMemberGroupsSet(context, eperson);
 		            for (Group group : groups)
 		            {
 		            	validity.add(context, group);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/CollectionViewer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/CollectionViewer.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.cocoon.caching.CacheableProcessingComponent;
 import org.apache.cocoon.util.HashUtil;
@@ -118,7 +119,7 @@ public class CollectionViewer extends AbstractDSpaceTransformer implements Cache
 	            validity.add(context, eperson);
 	            
 	            // Include any groups they are a member of
-	            List<Group> groups = groupService.allMemberGroups(context, eperson);
+	            Set<Group> groups = groupService.allMemberGroupsSet(context, eperson);
 	            for (Group group : groups)
 	            {
 	            	validity.add(context, group);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/Submissions.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/Submissions.java
@@ -26,6 +26,7 @@ import org.dspace.content.service.ItemService;
 import org.dspace.content.service.SupervisedItemService;
 import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Constants;
+import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.xml.sax.SAXException;
 
@@ -125,6 +126,9 @@ public class Submissions extends AbstractDSpaceTransformer
     public void addBody(Body body) throws SAXException, WingException,
             UIException, SQLException, IOException, AuthorizeException
     {
+        Context.Mode originalMode = context.getCurrentMode();
+        context.setMode(Context.Mode.READ_ONLY);
+
         Request request = ObjectModelHelper.getRequest(objectModel);
         boolean displayAll = false;
         //This param decides whether we display all of the user's previous
@@ -141,6 +145,8 @@ public class Submissions extends AbstractDSpaceTransformer
         this.addUnfinishedSubmissions(div);
 //        this.addSubmissionsInWorkflowDiv(div);
         this.addPreviousSubmissions(div, displayAll);
+
+        context.setMode(originalMode);
     }
 
     /**

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/SelectCollectionStep.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/SelectCollectionStep.java
@@ -27,6 +27,7 @@ import org.dspace.content.DSpaceObject;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.CollectionService;
 import org.dspace.core.Constants;
+import org.dspace.core.Context;
 import org.dspace.handle.HandleServiceImpl;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
@@ -78,7 +79,10 @@ public class SelectCollectionStep extends AbstractSubmissionStep
   
     public void addBody(Body body) throws SAXException, WingException,
             UIException, SQLException, IOException, AuthorizeException
-    {     
+    {
+        Context.Mode originalMode = context.getCurrentMode();
+        context.setMode(Context.Mode.READ_ONLY);
+
         java.util.List<Collection> collections; // List of possible collections.
         String actionURL = contextPath + "/submit/" + knot.getId() + ".continue";
         DSpaceObject dso = handleService.resolveToObject(context, handle);
@@ -113,6 +117,8 @@ public class SelectCollectionStep extends AbstractSubmissionStep
         
         Button submit = list.addItem().addButton("submit");
         submit.setValue(T_submit_next);
+
+        context.setMode(originalMode);
     }
     
     /** 

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/versioning/Navigation.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/versioning/Navigation.java
@@ -117,7 +117,7 @@ public class Navigation extends AbstractDSpaceTransformer implements CacheablePr
 
 		            validity.add(context, eperson);
 
-		            java.util.List<Group> groups = groupService.allMemberGroups(context, eperson);
+		            java.util.Set<Group> groups = groupService.allMemberGroupsSet(context, eperson);
 		            for (Group group : groups)
 		            {
 		            	validity.add(context, group);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/xmlworkflow/Navigation.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/xmlworkflow/Navigation.java
@@ -98,7 +98,7 @@ public class Navigation extends AbstractDSpaceTransformer implements CacheablePr
 
 		            validity.add(context, eperson);
 
-		            java.util.List<Group> groups = groupService.allMemberGroups(context, eperson);
+		            java.util.Set<Group> groups = groupService.allMemberGroupsSet(context, eperson);
 		            for (Group group : groups)
 		            {
 		            	validity.add(context, group);

--- a/dspace/config/ehcache.xsd
+++ b/dspace/config/ehcache.xsd
@@ -1,0 +1,265 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" version="1.7">
+
+    <xs:element name="ehcache">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element maxOccurs="1" minOccurs="0" ref="diskStore"/>
+                <xs:element maxOccurs="1" minOccurs="0" ref="transactionManagerLookup"/>
+                <xs:element maxOccurs="1" minOccurs="0" ref="cacheManagerEventListenerFactory"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" ref="cacheManagerPeerProviderFactory"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" ref="cacheManagerPeerListenerFactory"/>
+                <xs:element maxOccurs="1" minOccurs="0" ref="terracottaConfig"/>
+                <xs:element ref="defaultCache"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" ref="cache"/>
+            </xs:sequence>
+            <xs:attribute name="name" use="optional"/>
+            <xs:attribute default="true" name="updateCheck" type="xs:boolean" use="optional"/>
+            <xs:attribute default="autodetect" name="monitoring" type="monitoringType" use="optional"/>
+            <xs:attribute default="true" name="dynamicConfig" type="xs:boolean" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="diskStore">
+        <xs:complexType>
+            <xs:attribute name="path" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+     <xs:element name="transactionManagerLookup">
+        <xs:complexType>
+            <xs:attribute name="class" use="required"/>
+            <xs:attribute name="properties" use="optional"/>
+            <xs:attribute name="propertySeparator" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="cacheManagerEventListenerFactory">
+        <xs:complexType>
+            <xs:attribute name="class" use="required"/>
+            <xs:attribute name="properties" use="optional"/>
+            <xs:attribute name="propertySeparator" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="cacheManagerPeerProviderFactory">
+        <xs:complexType>
+            <xs:attribute name="class" use="required"/>
+            <xs:attribute name="properties" use="optional"/>
+            <xs:attribute name="propertySeparator" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="cacheManagerPeerListenerFactory">
+        <xs:complexType>
+            <xs:attribute name="class" use="required"/>
+            <xs:attribute name="properties" use="optional"/>
+            <xs:attribute name="propertySeparator" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="terracottaConfig">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element maxOccurs="1" minOccurs="0" name="tc-config">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:any maxOccurs="unbounded" minOccurs="0" processContents="skip"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+            <xs:attribute default="localhost:9510" name="url" use="optional"/>
+            <xs:attribute name="registerStatsMBean" type="xs:boolean" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+    <!-- add clone support for addition of cacheExceptionHandler. Important! -->
+    <xs:element name="defaultCache">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="cacheEventListenerFactory"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="cacheExtensionFactory"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="cacheLoaderFactory"/>
+                <xs:element minOccurs="0" maxOccurs="1" ref="bootstrapCacheLoaderFactory"/>
+                <xs:element minOccurs="0" maxOccurs="1" ref="cacheExceptionHandlerFactory"/>
+                <xs:element minOccurs="0" maxOccurs="1" ref="terracotta"/>
+                <xs:element minOccurs="0" maxOccurs="1" ref="cacheWriter"/>
+                <xs:element minOccurs="0" maxOccurs="1" ref="copyStrategy"/>
+            </xs:sequence>
+            <xs:attribute name="diskExpiryThreadIntervalSeconds" type="xs:integer" use="optional"/>
+            <xs:attribute name="diskSpoolBufferSizeMB" type="xs:integer" use="optional"/>
+            <xs:attribute name="diskPersistent" type="xs:boolean" use="optional"/>
+            <xs:attribute name="diskAccessStripes" type="xs:integer" use="optional" default="1"/>
+            <xs:attribute name="eternal" type="xs:boolean" use="required"/>
+            <xs:attribute name="maxElementsInMemory" type="xs:integer" use="required"/>
+            <xs:attribute name="clearOnFlush" type="xs:boolean" use="optional"/>
+            <xs:attribute name="memoryStoreEvictionPolicy" type="xs:string" use="optional"/>
+            <xs:attribute name="overflowToDisk" type="xs:boolean" use="required"/>
+            <xs:attribute name="timeToIdleSeconds" type="xs:integer" use="optional"/>
+            <xs:attribute name="timeToLiveSeconds" type="xs:integer" use="optional"/>
+            <xs:attribute name="maxElementsOnDisk" type="xs:integer" use="optional"/>
+            <xs:attribute name="transactionalMode" type="transactionalMode" use="optional" default="off"/>
+            <xs:attribute name="statistics" type="xs:boolean" use="optional" default="false"/>
+            <xs:attribute name="copyOnRead" type="xs:boolean" use="optional" default="false"/>
+            <xs:attribute name="copyOnWrite" type="xs:boolean" use="optional" default="false"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="cache">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="cacheEventListenerFactory"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="cacheExtensionFactory"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="cacheLoaderFactory"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="cacheDecoratorFactory"/>
+                <xs:element minOccurs="0" maxOccurs="1" ref="bootstrapCacheLoaderFactory"/>
+                <xs:element minOccurs="0" maxOccurs="1" ref="cacheExceptionHandlerFactory"/>
+                <xs:element minOccurs="0" maxOccurs="1" ref="terracotta"/>
+                <xs:element minOccurs="0" maxOccurs="1" ref="cacheWriter"/>
+                <xs:element minOccurs="0" maxOccurs="1" ref="copyStrategy"/>
+            </xs:sequence>
+            <xs:attribute name="diskExpiryThreadIntervalSeconds" type="xs:integer" use="optional"/>
+            <xs:attribute name="diskSpoolBufferSizeMB" type="xs:integer" use="optional"/>
+            <xs:attribute name="diskPersistent" type="xs:boolean" use="optional"/>
+            <xs:attribute name="diskAccessStripes" type="xs:integer" use="optional" default="1"/>
+            <xs:attribute name="eternal" type="xs:boolean" use="required"/>
+            <xs:attribute name="maxElementsInMemory" type="xs:integer" use="required"/>
+            <xs:attribute name="memoryStoreEvictionPolicy" type="xs:string" use="optional"/>
+            <xs:attribute name="clearOnFlush" type="xs:boolean" use="optional"/>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="overflowToDisk" type="xs:boolean" use="required"/>
+            <xs:attribute name="timeToIdleSeconds" type="xs:integer" use="optional"/>
+            <xs:attribute name="timeToLiveSeconds" type="xs:integer" use="optional"/>
+            <xs:attribute name="maxElementsOnDisk" type="xs:integer" use="optional"/>
+            <xs:attribute name="transactionalMode" type="transactionalMode" use="optional" default="off" />
+            <xs:attribute name="statistics" type="xs:boolean" use="optional" default="false"/>
+            <xs:attribute name="copyOnRead" type="xs:boolean" use="optional" default="false"/>
+            <xs:attribute name="copyOnWrite" type="xs:boolean" use="optional" default="false"/>
+            <xs:attribute name="logging" type="xs:boolean" use="optional" default="false"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="cacheEventListenerFactory">
+        <xs:complexType>
+            <xs:attribute name="class" use="required"/>
+            <xs:attribute name="properties" use="optional"/>
+            <xs:attribute name="propertySeparator" use="optional"/>
+            <xs:attribute name="listenFor" use="optional" type="notificationScope" default="all"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="bootstrapCacheLoaderFactory">
+        <xs:complexType>
+            <xs:attribute name="class" use="required"/>
+            <xs:attribute name="properties" use="optional"/>
+            <xs:attribute name="propertySeparator" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="cacheExtensionFactory">
+        <xs:complexType>
+            <xs:attribute name="class" use="required"/>
+            <xs:attribute name="properties" use="optional"/>
+            <xs:attribute name="propertySeparator" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="cacheExceptionHandlerFactory">
+        <xs:complexType>
+            <xs:attribute name="class" use="required"/>
+            <xs:attribute name="properties" use="optional"/>
+            <xs:attribute name="propertySeparator" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="cacheLoaderFactory">
+        <xs:complexType>
+            <xs:attribute name="class" use="required"/>
+            <xs:attribute name="properties" use="optional"/>
+            <xs:attribute name="propertySeparator" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="cacheDecoratorFactory">
+        <xs:complexType>
+            <xs:attribute name="class" use="required"/>
+            <xs:attribute name="properties" use="optional"/>
+            <xs:attribute name="propertySeparator" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="terracotta">
+        <xs:complexType>
+            <xs:attribute name="clustered" use="optional" type="xs:boolean" default="true"/>
+            <xs:attribute name="valueMode" use="optional" type="terracottaCacheValueType" default="serialization"/>
+            <xs:attribute name="coherentReads" use="optional" type="xs:boolean" default="true"/>
+            <xs:attribute name="localKeyCache" use="optional" type="xs:boolean" default="false"/>
+            <xs:attribute name="localKeyCacheSize" use="optional" type="xs:positiveInteger" default="300000"/>
+            <xs:attribute name="orphanEviction" use="optional" type="xs:boolean" default="true"/>
+            <xs:attribute name="orphanEvictionPeriod" use="optional" type="xs:positiveInteger" default="4"/>
+            <xs:attribute name="copyOnRead" use="optional" type="xs:boolean" default="false"/>
+            <xs:attribute name="coherent" use="optional" type="xs:boolean" default="true"/>
+            <xs:attribute name="synchronousWrites" use="optional" type="xs:boolean" default="false"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:simpleType name="monitoringType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="autodetect"/>
+            <xs:enumeration value="on"/>
+            <xs:enumeration value="off"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="terracottaCacheValueType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="serialization" />
+            <xs:enumeration value="identity" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="transactionalMode">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="off"/>
+            <xs:enumeration value="xa"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:element name="cacheWriter">
+        <xs:complexType>
+            <xs:sequence >
+                <xs:element minOccurs="0" maxOccurs="1" ref="cacheWriterFactory"/>
+            </xs:sequence>
+            <xs:attribute name="writeMode" use="optional" type="writeModeType" default="write-through"/>
+            <xs:attribute name="notifyListenersOnException" use="optional" type="xs:boolean" default="false"/>
+            <xs:attribute name="minWriteDelay" use="optional" type="xs:nonNegativeInteger" default="1"/>
+            <xs:attribute name="maxWriteDelay" use="optional" type="xs:nonNegativeInteger" default="1"/>
+            <xs:attribute name="rateLimitPerSecond" use="optional" type="xs:nonNegativeInteger" default="0"/>
+            <xs:attribute name="writeCoalescing" use="optional" type="xs:boolean" default="false"/>
+            <xs:attribute name="writeBatching" use="optional" type="xs:boolean" default="false"/>
+            <xs:attribute name="writeBatchSize" use="optional" type="xs:positiveInteger" default="1"/>
+            <xs:attribute name="retryAttempts" use="optional" type="xs:nonNegativeInteger" default="0"/>
+            <xs:attribute name="retryAttemptDelaySeconds" use="optional" type="xs:nonNegativeInteger" default="1"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:simpleType name="writeModeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="write-through" />
+            <xs:enumeration value="write-behind" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:element name="cacheWriterFactory">
+        <xs:complexType>
+            <xs:attribute name="class" use="required"/>
+            <xs:attribute name="properties" use="optional"/>
+            <xs:attribute name="propertySeparator" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="copyStrategy">
+        <xs:complexType>
+            <xs:attribute name="class" use="required" type="xs:string" />
+        </xs:complexType>
+    </xs:element>
+
+    <xs:simpleType name="notificationScope">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="local"/>
+            <xs:enumeration value="remote"/>
+            <xs:enumeration value="all"/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>

--- a/dspace/config/hibernate-ehcache-config.xml
+++ b/dspace/config/hibernate-ehcache-config.xml
@@ -330,7 +330,7 @@
     <!-- The number of groups in a repository can be very big, but only a small percentage of them is used
          very frequently. So it makes sense to cache Group records because the cache hit rate is likely to be high -->
     <cache name="org.dspace.eperson.Group"
-           maxElementsInMemory="3000" eternal="false" timeToIdleSeconds="1800"
+           maxElementsInMemory="5000" eternal="false" timeToIdleSeconds="1800"
            timeToLiveSeconds="3600" overflowToDisk="false"
            memoryStoreEvictionPolicy="LRU"/>
 

--- a/dspace/config/hibernate-ehcache-config.xml
+++ b/dspace/config/hibernate-ehcache-config.xml
@@ -325,7 +325,7 @@
          so the cache would have to be updated frequently. In addition there are many processes that
          touch a lot of different items (discovery search, filter media, curation tasks...) which also makes
          the cache less efficient. The probably of having a cache hit is thus very low and that is why Items
-         should not be cached. The same reasoning applies to Metadata values, Bundles and Bitstreams. -->
+         should not be cached. The same reasoning applies to Metadata values, Bundles, Bitstreams and Handles. -->
 
     <!-- The number of groups in a repository can be very big, but only a small percentage of them is used
          very frequently. So it makes sense to cache Group records because the cache hit rate is likely to be high -->

--- a/dspace/config/hibernate-ehcache-config.xml
+++ b/dspace/config/hibernate-ehcache-config.xml
@@ -300,6 +300,11 @@
 
     <!-- DSpace classes in the second level cache -->
 
+    <cache name="org.dspace.content.Site"
+           maxElementsInMemory="1" eternal="false" timeToIdleSeconds="86400"
+           timeToLiveSeconds="86400" overflowToDisk="false" diskExpiryThreadIntervalSeconds="60"
+           memoryStoreEvictionPolicy="LRU"/>
+
     <cache name="org.dspace.content.MetadataSchema"
            maxElementsInMemory="1000" eternal="false" timeToIdleSeconds="3600"
            timeToLiveSeconds="3600" overflowToDisk="true" diskExpiryThreadIntervalSeconds="60"
@@ -313,6 +318,11 @@
     <cache name="org.dspace.eperson.Group"
            maxElementsInMemory="3000" eternal="false" timeToIdleSeconds="1800"
            timeToLiveSeconds="3600" overflowToDisk="false" diskExpiryThreadIntervalSeconds="60"
+           memoryStoreEvictionPolicy="LRU"/>
+
+    <cache name="org.dspace.eperson.EPerson"
+           maxElementsInMemory="1000" eternal="false" timeToIdleSeconds="1800"
+           timeToLiveSeconds="1800" overflowToDisk="false" diskExpiryThreadIntervalSeconds="60"
            memoryStoreEvictionPolicy="LRU"/>
 
 <!-- DISTRIBUTED CACHING

--- a/dspace/config/hibernate-ehcache-config.xml
+++ b/dspace/config/hibernate-ehcache-config.xml
@@ -1,0 +1,541 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+-->
+<ehcache xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="ehcache.xsd">
+
+    <!-- Sets the path to the directory where cache .data files are created.
+
+         If the path is a Java System Property it is replaced by
+         its value in the running VM.
+
+         The following properties are translated:
+         user.home - User's home directory
+         user.dir - User's current working directory
+         java.io.tmpdir - Default temp file path -->
+
+    <diskStore path="java.io.tmpdir/DSpaceHibernateCache"/>
+
+
+    <!--
+    Cache configuration
+    ===================
+
+    The following attributes are required.
+
+    name:
+    Sets the name of the cache. This is used to identify the cache. It must be unique.
+
+    maxElementsInMemory:
+    Sets the maximum number of objects that will be created in memory
+
+        maxElementsOnDisk:
+    Sets the maximum number of objects that will be maintained in the DiskStore
+        The default value is zero, meaning unlimited.
+
+    eternal:
+    Sets whether elements are eternal. If eternal,  timeouts are ignored and the
+    element is never expired.
+
+    overflowToDisk:
+    Sets whether elements can overflow to disk when the memory store
+    has reached the maxInMemory limit.
+
+    The following attributes and elements are optional.
+
+    timeToIdleSeconds:
+    Sets the time to idle for an element before it expires.
+    i.e. The maximum amount of time between accesses before an element expires
+    Is only used if the element is not eternal.
+    Optional attribute. A value of 0 means that an Element can idle for infinity.
+    The default value is 0.
+
+    timeToLiveSeconds:
+    Sets the time to live for an element before it expires.
+    i.e. The maximum time between creation time and when an element expires.
+    Is only used if the element is not eternal.
+    Optional attribute. A value of 0 means that and Element can live for infinity.
+    The default value is 0.
+
+    diskPersistent:
+    Whether the disk store persists between restarts of the Virtual Machine.
+    The default value is false.
+
+    diskExpiryThreadIntervalSeconds:
+    The number of seconds between runs of the disk expiry thread. The default value
+    is 120 seconds.
+
+    diskSpoolBufferSizeMB:
+    This is the size to allocate the DiskStore for a spool buffer. Writes are made
+    to this area and then asynchronously written to disk. The default size is 30MB.
+    Each spool buffer is used only by its cache. If you get OutOfMemory errors consider
+    lowering this value. To improve DiskStore performance consider increasing it. Trace level
+    logging in the DiskStore will show if put back ups are occurring.
+
+    memoryStoreEvictionPolicy:
+    Policy would be enforced upon reaching the maxElementsInMemory limit. Default
+    policy is Least Recently Used (specified as LRU). Other policies available -
+    First In First Out (specified as FIFO) and Less Frequently Used
+    (specified as LFU)
+    *NOTE: LFU seems to have some possible issues -AZ
+
+    Cache elements can also contain sub elements which take the same format of a factory class
+    and properties. Defined sub-elements are:
+
+    * cacheEventListenerFactory - Enables registration of listeners for cache events, such as
+      put, remove, update, and expire.
+
+    * bootstrapCacheLoaderFactory - Specifies a BootstrapCacheLoader, which is called by a
+      cache on initialisation to prepopulate itself.
+
+    * cacheExtensionFactory - Specifies a CacheExtension, a generic mechansim to tie a class
+      which holds a reference to a cache to the cache lifecycle.
+
+    RMI Cache Replication
+
+    Each cache that will be distributed needs to set a cache event listener which replicates
+    messages to the other CacheManager peers. For the built-in RMI implementation this is done
+    by adding a cacheEventListenerFactory element of type RMICacheReplicatorFactory to each
+    distributed cache's configuration as per the following example:
+
+    <cacheEventListenerFactory class="net.sf.ehcache.distribution.RMICacheReplicatorFactory"
+         properties="replicateAsynchronously=true,
+         replicatePuts=true,
+         replicateUpdates=true,
+         replicateUpdatesViaCopy=true,
+         replicateRemovals=true
+         asynchronousReplicationIntervalMillis=<number of milliseconds"
+         propertySeparator="," />
+
+    The RMICacheReplicatorFactory recognises the following properties:
+
+    * replicatePuts=true|false - whether new elements placed in a cache are
+      replicated to others. Defaults to true.
+
+    * replicateUpdates=true|false - whether new elements which override an
+      element already existing with the same key are replicated. Defaults to true.
+
+    * replicateRemovals=true - whether element removals are replicated. Defaults to true.
+
+    * replicateAsynchronously=true | false - whether replications are
+      asynchronous (true) or synchronous (false). Defaults to true.
+
+    * replicateUpdatesViaCopy=true | false - whether the new elements are
+      copied to other caches (true), or whether a remove message is sent. Defaults to true.
+
+    * asynchronousReplicationIntervalMillis=<number of milliseconds> - The asynchronous
+      replicator runs at a set interval of milliseconds. The default is 1000. The minimum
+      is 10. This property is only applicable if replicateAsynchronously=true
+
+
+    Cluster Bootstrapping
+
+    The RMIBootstrapCacheLoader bootstraps caches in clusters where RMICacheReplicators are
+    used. It is configured as per the following example:
+
+    <bootstrapCacheLoaderFactory
+        class="net.sf.ehcache.distribution.RMIBootstrapCacheLoaderFactory"
+        properties="bootstrapAsynchronously=true, maximumChunkSizeBytes=5000000"
+        propertySeparator="," />
+
+    The RMIBootstrapCacheLoaderFactory recognises the following optional properties:
+
+    * bootstrapAsynchronously=true|false - whether the bootstrap happens in the background
+      after the cache has started. If false, bootstrapping must complete before the cache is
+      made available. The default value is true.
+
+    * maximumChunkSizeBytes=<integer> - Caches can potentially be very large, larger than the
+      memory limits of the VM. This property allows the bootstraper to fetched elements in
+      chunks. The default chunk size is 5000000 (5MB).
+
+
+    Cache Exception Handling
+
+    By default, most cache operations will propagate a runtime CacheException on failure. An interceptor,
+      using a dynamic proxy, may be configured so that a CacheExceptionHandler can be configured to
+      intercept Exceptions. Errors are not intercepted. It is configured as per the following example:
+
+      <cacheExceptionHandlerFactory class="net.sf.ehcache.exceptionhandler.CountingExceptionHandlerFactory"
+                                      properties="logLevel=FINE"/>
+
+    Caches with ExceptionHandling configured are not of type Cache, but are of type Ehcache only, and are not available
+    using CacheManager.getCache(), but using CacheManager.getEhcache().
+
+
+    CacheLoader
+
+    A CacheLoader may be configured against a cache.
+
+        <cacheLoaderFactory class="net.sf.ehcache.loader.CountingCacheLoaderFactory"
+                                      properties="type=int,startCounter=10"/>
+
+    -->
+
+    <!--
+    Mandatory Default Cache configuration. These settings will be applied to caches
+    created programmtically using CacheManager.add(String cacheName).
+
+    The defaultCache has an implicit name "default" which is a reserved cache name.
+    -->
+    <defaultCache
+         maxElementsInMemory="3000"
+         eternal="false"
+         timeToIdleSeconds="1"
+         timeToLiveSeconds="1200"
+         overflowToDisk="true"
+         diskSpoolBufferSizeMB="30"
+         maxElementsOnDisk="10000"
+         diskPersistent="false"
+         diskExpiryThreadIntervalSeconds="120"
+         memoryStoreEvictionPolicy="LRU">
+     </defaultCache>
+
+
+    <!--Predefined caches.  Add your cache configuration settings here.
+        If you do not have a configuration for your cache a WARNING will be issued when the
+        CacheManager starts
+
+        The following attributes are required for defaultCache:
+
+        name              - Sets the name of the cache. This is used to identify the cache. It must be unique.
+        maxInMemory       - Sets the maximum number of objects that will be created in memory
+        eternal           - Sets whether elements are eternal. If eternal,  timeouts are ignored and the element
+                            is never expired.
+        timeToIdleSeconds - Sets the time to idle for an element before it expires.
+                            i.e. The maximum amount of time between accesses before an element expires
+                            Is only used if the element is not eternal.
+                            Optional attribute. A value of 0 means that an Element can idle for infinity
+        timeToLiveSeconds - Sets the time to live for an element before it expires.
+                            i.e. The maximum time between creation time and when an element expires.
+                            Is only used if the element is not eternal.
+                            Optional attribute. A value of 0 means that an Element can live for infinity
+        overflowToDisk    - Sets whether elements can overflow to disk when the in-memory cache
+                            has reached the maxInMemory limit.
+
+        -->
+
+    <!-- CACHES FOR TESTING -->
+<!-- 
+    <cache name="org.dspace.caching.MemOnly"
+         maxElementsInMemory="10000"
+         eternal="false"
+         timeToIdleSeconds="600"
+         timeToLiveSeconds="1200"
+         overflowToDisk="false"
+         diskSpoolBufferSizeMB="0"
+         maxElementsOnDisk="0"
+         diskPersistent="false"
+         diskExpiryThreadIntervalSeconds="120"
+         memoryStoreEvictionPolicy="LRU">
+     </cache>
+
+    <cache name="org.dspace.caching.DiskOnly"
+         maxElementsInMemory="1"
+         eternal="false"
+         timeToIdleSeconds="600"
+         timeToLiveSeconds="1200"
+         overflowToDisk="true"
+         diskSpoolBufferSizeMB="30"
+         maxElementsOnDisk="10000"
+         diskPersistent="false"
+         diskExpiryThreadIntervalSeconds="120"
+         memoryStoreEvictionPolicy="LRU">
+     </cache>
+
+    <cache name="org.dspace.caching.Distributed"
+         maxElementsInMemory="10"
+         eternal="false"
+         timeToIdleSeconds="10"
+         timeToLiveSeconds="30"
+         overflowToDisk="false"
+         memoryStoreEvictionPolicy="LRU">
+         <cacheEventListenerFactory class="net.sf.ehcache.distribution.RMICacheReplicatorFactory" 
+            properties="replicateAsynchronously=true, 
+               replicatePuts=true, 
+               replicateUpdates=true, 
+               replicateUpdatesViaCopy=false, 
+               replicateRemovals=true "/>
+     </cache>
+
+    <cache name="org.dspace.caching.DistributedDisk"
+         maxElementsInMemory="5"
+         eternal="false"
+         timeToIdleSeconds="10"
+         timeToLiveSeconds="30"
+         overflowToDisk="true"
+         diskSpoolBufferSizeMB="30"
+         maxElementsOnDisk="10"
+         diskPersistent="false"
+         diskExpiryThreadIntervalSeconds="120"
+         memoryStoreEvictionPolicy="LRU">
+         <cacheEventListenerFactory class="net.sf.ehcache.distribution.RMICacheReplicatorFactory" 
+            properties="replicateAsynchronously=true, 
+               replicatePuts=true, 
+               replicateUpdates=true, 
+               replicateUpdatesViaCopy=false, 
+               replicateRemovals=true "/>
+     </cache>
+-->
+
+   <!-- Place configuration for your caches following -->
+
+   <!-- this cache tracks the timestamps of the most recent updates to particular tables. 
+     It is important that the cache timeout of the underlying cache implementation be set to a 
+     higher value than the timeouts of any of the query caches. In fact, it is recommended that 
+     the the underlying cache not be configured for expiry at all. -->
+    <cache name="org.hibernate.cache.spi.UpdateTimestampsCache"
+           maxElementsInMemory="6000" eternal="true" overflowToDisk="false" />
+
+    <!-- this cache stores the actual objects pulled out of the DB by hibernate -->
+    <cache name="org.hibernate.cache.internal.StandardQueryCache"
+           maxElementsInMemory="2000" eternal="false" timeToIdleSeconds="1800"
+           timeToLiveSeconds="600" overflowToDisk="false" diskExpiryThreadIntervalSeconds="60"
+           memoryStoreEvictionPolicy="LRU"/>
+
+    <!-- DSpace classes in the second level cache -->
+
+    <cache name="org.dspace.content.MetadataSchema"
+           maxElementsInMemory="1000" eternal="false" timeToIdleSeconds="3600"
+           timeToLiveSeconds="3600" overflowToDisk="true" diskExpiryThreadIntervalSeconds="60"
+           memoryStoreEvictionPolicy="LRU"/>
+
+    <cache name="org.dspace.content.MetadataField"
+           maxElementsInMemory="1000" eternal="false"  timeToIdleSeconds="3600"
+           timeToLiveSeconds="3600" overflowToDisk="true" diskExpiryThreadIntervalSeconds="60"
+           memoryStoreEvictionPolicy="LRU"/>
+
+    <cache name="org.dspace.eperson.Group"
+           maxElementsInMemory="3000" eternal="false" timeToIdleSeconds="1800"
+           timeToLiveSeconds="3600" overflowToDisk="false" diskExpiryThreadIntervalSeconds="60"
+           memoryStoreEvictionPolicy="LRU"/>
+
+<!-- DISTRIBUTED CACHING
+
+    Add cacheEventListenerFactory to the cache
+    ==========================================
+         <cacheEventListenerFactory class="net.sf.ehcache.distribution.RMICacheReplicatorFactory" 
+            properties="replicateAsynchronously=true, 
+               replicatePuts=true, 
+               replicateUpdates=true, 
+               replicateUpdatesViaCopy=false, 
+               replicateRemovals=true "/>
+    
+    For Example:
+    ============
+    <cache name="org.dspace.authz.api.SecurityService.cache"
+         maxElementsInMemory="20000"
+         eternal="false"
+         timeToIdleSeconds="1800"
+         timeToLiveSeconds="2400"
+         overflowToDisk="true"
+         diskSpoolBufferSizeMB="30"
+         maxElementsOnDisk="100000"
+         diskPersistent="true"
+         diskExpiryThreadIntervalSeconds="120">
+         <cacheEventListenerFactory class="net.sf.ehcache.distribution.RMICacheReplicatorFactory" 
+            properties="replicateAsynchronously=true, 
+               replicatePuts=true, 
+               replicateUpdates=true, 
+               replicateUpdatesViaCopy=false, 
+               replicateRemovals=true "/>
+   </cache>
+
+
+    CacheManagerPeerProvider
+    ========================
+    (Enable for distributed operation)
+
+    Specifies a CacheManagerPeerProviderFactory which will be used to create a
+    CacheManagerPeerProvider, which discovers other CacheManagers in the cluster.
+
+    The attributes of cacheManagerPeerProviderFactory are:
+    * class - a fully qualified factory class name
+    * properties - comma separated properties having meaning only to the factory.
+
+    Ehcache comes with a built-in RMI-based distribution system with two means of discovery of
+    CacheManager peers participating in the cluster:
+    * automatic, using a multicast group. This one automatically discovers peers and detects
+      changes such as peers entering and leaving the group
+    * manual, using manual rmiURL configuration. A hardcoded list of peers is provided at
+      configuration time.
+
+    Configuring Automatic Discovery:
+    Automatic discovery is configured as per the following example:
+    <cacheManagerPeerProviderFactory
+                        class="net.sf.ehcache.distribution.RMICacheManagerPeerProviderFactory"
+                        properties="peerDiscovery=automatic, multicastGroupAddress=230.0.0.1,
+                                    multicastGroupPort=4446, timeToLive=32"/>
+
+    Valid properties are:
+    * peerDiscovery (mandatory) - specify "automatic"
+    * multicastGroupAddress (mandatory) - specify a valid multicast group address
+    * multicastGroupPort (mandatory) - specify a dedicated port for the multicast heartbeat
+      traffic
+    * timeToLive - specify a value between 0 and 255 which determines how far the packets will propagate.
+      By convention, the restrictions are:
+      0   - the same host
+      1   - the same subnet
+      32  - the same site
+      64  - the same region
+      128 - the same continent
+      255 - unrestricted
+
+    Configuring Manual Discovery:
+    Manual discovery is configured as per the following example:
+    <cacheManagerPeerProviderFactory class=
+                          "net.sf.ehcache.distribution.RMICacheManagerPeerProviderFactory"
+                          properties="peerDiscovery=manual,
+                          rmiUrls=//server1:40000/sampleCache1|//server2:40000/sampleCache1
+                          | //server1:40000/sampleCache2|//server2:40000/sampleCache2"
+                          propertySeparator="," />
+
+    Valid properties are:
+    * peerDiscovery (mandatory) - specify "manual"
+    * rmiUrls (mandatory) - specify a pipe separated list of rmiUrls, in the form
+                            //hostname:port
+
+    The hostname is the hostname of the remote CacheManager peer. The port is the listening
+    port of the RMICacheManagerPeerListener of the remote CacheManager peer.
+
+    <cacheManagerPeerProviderFactory
+            class="net.sf.ehcache.distribution.RMICacheManagerPeerProviderFactory"
+            properties="peerDiscovery=automatic,
+                        multicastGroupAddress=230.0.0.1,
+                        multicastGroupPort=4446, timeToLive=1"
+            propertySeparator=","
+            />
+    -->
+
+    <!--
+    CacheManagerPeerListener
+    ========================
+    (Enable for distributed operation)
+
+    Specifies a CacheManagerPeerListenerFactory which will be used to create a
+    CacheManagerPeerListener, which
+    listens for messages from cache replicators participating in the cluster.
+
+    The attributes of cacheManagerPeerListenerFactory are:
+    class - a fully qualified factory class name
+    properties - comma separated properties having meaning only to the factory.
+
+    Ehcache comes with a built-in RMI-based distribution system. The listener component is
+    RMICacheManagerPeerListener which is configured using
+    RMICacheManagerPeerListenerFactory. It is configured as per the following example:
+
+    <cacheManagerPeerListenerFactory
+        class="net.sf.ehcache.distribution.RMICacheManagerPeerListenerFactory"
+        properties="hostName=fully_qualified_hostname_or_ip,
+                    port=40001,
+                    socketTimeoutMillis=120000"
+                    propertySeparator="," />
+
+    All properties are optional. They are:
+    * hostName - the hostName of the host the listener is running on. Specify
+      where the host is multihomed and you want to control the interface over which cluster
+      messages are received. Defaults to the host name of the default interface if not
+      specified.
+    * port - the port the listener listens on. This defaults to a free port if not specified.
+    * socketTimeoutMillis - the number of ms client sockets will stay open when sending
+      messages to the listener. This should be long enough for the slowest message.
+      If not specified it defaults 120000ms.
+    * timeToLive - You can control how far the multicast packets propagate by setting the 
+    badly misnamed time to live. Using the multicast IP protocol, the timeToLive value 
+    indicates the scope or range in which a packet may be forwarded. By convention:
+        0 is restricted to the same host
+        1 is restricted to the same subnet
+        32 is restricted to the same site
+        64 is restricted to the same region
+        128 is restricted to the same continent
+        255 is unrestricted
+
+    <cacheManagerPeerListenerFactory
+            class="net.sf.ehcache.distribution.RMICacheManagerPeerListenerFactory"/>
+    -->
+
+   <!-- Sample Distributed cache settings -->
+
+
+   <!-- Option A: automatic discovery using tcp multicast
+        For the multicast version, the IP address is no longer that of the server. 
+        Rather, you need to choose the address and port in a designated range that has been reserved for multicasting. 
+        It is as if the server and all potential clients are agreeing that messages will be left in a particular location. 
+        The available addresses for multicasting are in the range 224.0.0.0 through 239.255.255.255. 
+        You can check for the assigned addresses in this range (http://www.iana.org/assignments/multicast-addresses). 
+        Recommended default is to use the IP address 230.0.0.1 and the port 4446.
+
+   <cacheManagerPeerProviderFactory
+      class="net.sf.ehcache.distribution.RMICacheManagerPeerProviderFactory"
+      properties="peerDiscovery=automatic, 
+         multicastGroupAddress=230.0.0.1,
+         multicastGroupPort=4446, 
+         timeToLive=1" />
+    -->
+
+
+
+   <!-- Option B: manual discovery (you must customize this to include every node in the cluster) -->
+<!--
+   <cacheManagerPeerProviderFactory
+      class="net.sf.ehcache.distribution.RMICacheManagerPeerProviderFactory"
+      properties="peerDiscovery=manual,
+      rmiUrls=//server2:40001/sampleCache11|//server2:40001/sampleCache12" />
+-->
+
+
+    <!-- 
+        A CacheManagerPeerListener listens for messages from peers to the current CacheManager.
+        
+        You configure the CacheManagerPeerListener by specifiying a CacheManagerPeerListenerFactory which is used to create 
+        the CacheManagerPeerListener using the plugin mechanism.
+        
+        The attributes of cacheManagerPeerListenerFactory are:
+        * class - a fully qualified factory class name 
+        * properties - comma separated properties having meaning only to the factory.
+        
+        Ehcache comes with a built-in RMI-based distribution system. The listener component is RMICacheManagerPeerListener 
+        which is configured using RMICacheManagerPeerListenerFactory. It is configured as per the following example:
+        
+        <cacheManagerPeerListenerFactory
+            class="net.sf.ehcache.distribution.RMICacheManagerPeerListenerFactory"
+            properties="hostName=localhost, port=40001, socketTimeoutMillis=2000" />
+        
+        Valid properties are:
+        * hostName (optional) - the hostName of the host the listener is running on. Specify where the host is 
+            multihomed and you want to control the interface over which cluster messages are received.
+            
+            The hostname is checked for reachability during CacheManager initialisation.
+            
+            If the hostName is unreachable, the CacheManager will refuse to start and an CacheException will be thrown 
+            indicating connection was refused.
+            
+            If unspecified, the hostname will use InetAddress.getLocalHost().getHostAddress(), which corresponds to the 
+            default host network interface.
+            
+            Warning: Explicitly setting this to localhost refers to the local loopback of 127.0.0.1, which is not network 
+            visible and will cause no replications to be received from remote hosts. You should only use this setting when 
+            multiple CacheManagers are on the same machine.
+
+            NOTE: this is not obvious, but if you run a netstat -an | grep LISTEN you will see that the configuration shown below:
+            properties="hostName=127.0.0.1, port=40001"
+            will actually cause a bind to happen to *:40001 which is what we want and will allow the servers to start
+            even if there is no netowkr connection. On the other hand, if you use localhost there will be a resolution
+            failure on startup. This is probably what you should use regardless of the setup of the peer provider factory. -AZ
+        * port (mandatory) - the port the listener listens on.
+        * socketTimeoutMillis (optional) - the number of seconds client sockets will wait when sending messages to this 
+            listener until they give up. By default this is 2000ms.
+    -->
+
+    <!-- For Distributed Caching in a cluster, this will listen for the messages from peers
+    <cacheManagerPeerListenerFactory
+      class="net.sf.ehcache.distribution.RMICacheManagerPeerListenerFactory"
+      properties="hostName=127.0.0.1, port=40001" />
+    -->
+
+</ehcache>

--- a/dspace/config/hibernate-ehcache-config.xml
+++ b/dspace/config/hibernate-ehcache-config.xml
@@ -20,8 +20,9 @@
          user.dir - User's current working directory
          java.io.tmpdir - Default temp file path -->
 
+    <!-- WARNING: If you are running multiple DSpace instances on the same server, make sure to start
+         each DSpace instance with another value for java.io.tmpdir !!! -->
     <diskStore path="java.io.tmpdir/DSpaceHibernateCache"/>
-
 
     <!--
     Cache configuration
@@ -300,30 +301,64 @@
 
     <!-- DSpace classes in the second level cache -->
 
+    <!-- We only have 1 site object, so it is best to cache it -->
     <cache name="org.dspace.content.Site"
            maxElementsInMemory="1" eternal="false" timeToIdleSeconds="86400"
-           timeToLiveSeconds="86400" overflowToDisk="false" diskExpiryThreadIntervalSeconds="60"
+           timeToLiveSeconds="86400" overflowToDisk="false"
            memoryStoreEvictionPolicy="LRU"/>
 
+    <!-- The number of metadata schemas is limited and not updated frequently, so if we cache them
+         the likelihood of a cache hit is very high -->
     <cache name="org.dspace.content.MetadataSchema"
-           maxElementsInMemory="1000" eternal="false" timeToIdleSeconds="3600"
+           maxElementsInMemory="100" eternal="false" timeToIdleSeconds="3600"
            timeToLiveSeconds="3600" overflowToDisk="true" diskExpiryThreadIntervalSeconds="60"
            memoryStoreEvictionPolicy="LRU"/>
 
+    <!-- The number of metadata fields is limited and not updated frequently, so if we cache them
+         the likelihood of a cache hit is very high -->
     <cache name="org.dspace.content.MetadataField"
-           maxElementsInMemory="1000" eternal="false"  timeToIdleSeconds="3600"
+           maxElementsInMemory="2000" eternal="false"  timeToIdleSeconds="3600"
            timeToLiveSeconds="3600" overflowToDisk="true" diskExpiryThreadIntervalSeconds="60"
            memoryStoreEvictionPolicy="LRU"/>
 
+    <!-- It is not a good idea to cache Item records. Most repositories have a large number of items
+         so the cache would have to be updated frequently. In addition there are many processes that
+         touch a lot of different items (discovery search, filter media, curation tasks...) which also makes
+         the cache less efficient. The probably of having a cache hit is thus very low and that is why Items
+         should not be cached. The same reasoning applies to Metadata values, Bundles and Bitstreams. -->
+
+    <!-- The number of groups in a repository can be very big, but only a small percentage of them is used
+         very frequently. So it makes sense to cache Group records because the cache hit rate is likely to be high -->
     <cache name="org.dspace.eperson.Group"
            maxElementsInMemory="3000" eternal="false" timeToIdleSeconds="1800"
-           timeToLiveSeconds="3600" overflowToDisk="false" diskExpiryThreadIntervalSeconds="60"
+           timeToLiveSeconds="3600" overflowToDisk="false"
            memoryStoreEvictionPolicy="LRU"/>
 
+    <!-- Like items, there are too many different Resource policy records for the cache to work efficiently.
+         In addition, resource policies are the core security mechanism in DSpace so want need to be 100% we
+         do not receive a stale policy when querying them. -->
+
+    <!-- The total number of epersons in DSpace can be very large, but the number of concurrent authenticated users is mostly
+         limited. Therefor having the authenticated users data cached will increase performance as the cache hit rate will
+         be high. -->
     <cache name="org.dspace.eperson.EPerson"
            maxElementsInMemory="1000" eternal="false" timeToIdleSeconds="1800"
-           timeToLiveSeconds="1800" overflowToDisk="false" diskExpiryThreadIntervalSeconds="60"
+           timeToLiveSeconds="1800" overflowToDisk="false"
            memoryStoreEvictionPolicy="LRU"/>
+
+    <!-- The number of collections is mostly a fixed set in a repository which is not updated frequently. This means that
+         most queries for a collection will be able to use the cached version. So adding caching here makes sense. -->
+    <cache name="org.dspace.content.Collection"
+           maxElementsInMemory="4000" eternal="false" timeToIdleSeconds="1800"
+           timeToLiveSeconds="1800" overflowToDisk="true" diskExpiryThreadIntervalSeconds="60"
+           memoryStoreEvictionPolicy="LRU"/>
+
+    <!-- Like collections, the same applies to communities. So we also setup a cache for communities. -->
+    <cache name="org.dspace.content.Community"
+           maxElementsInMemory="2000" eternal="false" timeToIdleSeconds="1800"
+           timeToLiveSeconds="1800" overflowToDisk="true" diskExpiryThreadIntervalSeconds="60"
+           memoryStoreEvictionPolicy="LRU"/>
+
 
 <!-- DISTRIBUTED CACHING
 

--- a/dspace/config/hibernate.cfg.xml
+++ b/dspace/config/hibernate.cfg.xml
@@ -18,12 +18,14 @@
         <!--Debug property that can be used to display the sql-->
         <property name="show_sql">false</property>
 
-
         <!--Second level cache configuration-->
-        <property name="hibernate.cache.use_second_level_cache">true</property>
         <property name="hibernate.cache.use_query_cache">true</property>
+        <property name="hibernate.cache.use_second_level_cache">true</property>
         <property name="hibernate.cache.region.factory_class">org.hibernate.cache.ehcache.EhCacheRegionFactory</property>
+        <property name="hibernate.cache.use_structured_entries">true</property>
         <property name="javax.persistence.sharedCache.mode">ENABLE_SELECTIVE</property>
+        <!-- Set in config/spring/api/core-hibernate.xml -->
+        <!--<property name="net.sf.ehcache.configurationResourceName">file:${dspace.dir}/config/hibernate-ehcache-config.xml</property>-->
 
 
         <!-- Entities to be loaded by hibernate -->

--- a/dspace/config/spring/api/core-hibernate.xml
+++ b/dspace/config/spring/api/core-hibernate.xml
@@ -21,6 +21,17 @@
         </property>
     </bean>
 
+    <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+        <property name="targetClass" value="java.lang.System" />
+        <property name="targetMethod" value="setProperty" />
+        <property name="arguments">
+            <list>
+                <value>net.sf.ehcache.configurationResourceName</value>
+                <value>file:${dspace.dir}/config/hibernate-ehcache-config.xml</value>
+            </list>
+        </property>
+    </bean>
+
     <bean id='dataSource'
           class='org.springframework.jndi.JndiObjectFactoryBean'>
         <description>


### PR DESCRIPTION
This is a fix for https://jira.duraspace.org/browse/DS-3552

In short this PR:
* Fixes some recursion issues in GroupServiceImpl.isMember() and AuthorizeServiceImpl.isAdmin()
* Adds a "READ-ONLY" mode to the Context object which tells Hibernate to skip some checks when only doing read operations
* Adds additional caching for authorized actions and group membership when the Context is in READ-ONLY mode
* Fixes and improves the Hibernate 2nd Level Ehcache configuration
