### PR TITLE
Improvements to ORCID lookup

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authority/orcid/model/Bio.java
+++ b/dspace-api/src/main/java/org/dspace/authority/orcid/model/Bio.java
@@ -34,6 +34,8 @@ public class Bio {
 
     protected String biography;
 
+    protected String email;
+
     public Bio() {
         this.name = new BioName();
         keywords = new LinkedHashSet<String>();
@@ -97,6 +99,14 @@ public class Bio {
         this.biography = biography;
     }
 
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
     @Override
     public String toString() {
         return "Bio{" +
@@ -107,6 +117,7 @@ public class Bio {
                 ", bioExternalIdentifiers=" + bioExternalIdentifiers +
                 ", researcherUrls=" + researcherUrls +
                 ", biography='" + biography + '\'' +
+                ", email='" + email + '\'' +
                 '}';
     }
 }

--- a/dspace-api/src/main/java/org/dspace/authority/orcid/model/Profile.java
+++ b/dspace-api/src/main/java/org/dspace/authority/orcid/model/Profile.java
@@ -1,0 +1,38 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+package org.dspace.authority.orcid.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Profile extends Bio
+{
+    protected List<String> affiliations;
+
+    public Profile() {
+        super();
+
+        this.affiliations = new ArrayList<String>();
+    }
+
+    public List<String> getAffiliations() {
+        return this.affiliations;
+    }
+
+    public void addAffiliation(String affiliation) {
+        this.affiliations.add(affiliation);
+    }
+
+    @Override
+    public String toString() {
+        return "Profile{" + super.toString() +
+               ", affiliations='" + affiliations + "'" +
+               "}";
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/authority/orcid/xml/XMLtoBio.java
+++ b/dspace-api/src/main/java/org/dspace/authority/orcid/xml/XMLtoBio.java
@@ -54,6 +54,7 @@ public class XMLtoBio extends Converter {
 
     protected String CONTACT_DETAILS = "contact-details";
     protected String COUNTRY = CONTACT_DETAILS + "/address/country";
+    protected String EMAIL = CONTACT_DETAILS + "/email[@primary='true']";
 
     protected String KEYWORDS = "keywords";
     protected String KEYWORD = KEYWORDS + "/keyword";
@@ -70,9 +71,7 @@ public class XMLtoBio extends Converter {
     protected String URL_NAME = "url-name";
     protected String URL = "url";
 
-    protected String BIOGRAPHY = ORCID_BIO + "/biography";
-
-    protected String AFFILIATIONS = ORCID_BIO + "/affiliation";
+    protected String BIOGRAPHY = "biography";
 
     /**
      * Regex
@@ -130,7 +129,7 @@ public class XMLtoBio extends Converter {
     }
 
 
-    private void setOrcid(Node node, Bio bio) {
+    protected void setOrcid(Node node, Bio bio) {
         try {
             String orcid = XMLUtils.getTextContent(node, ORCID);
             bio.setOrcid(orcid);
@@ -209,6 +208,13 @@ public class XMLtoBio extends Converter {
             bio.setCountry(country);
         } catch (XPathExpressionException e) {
             log.error("Error in finding the country in bio xml.", e);
+        }
+
+        try {
+            String email = XMLUtils.getTextContent(xml, EMAIL);
+            bio.setEmail(email);
+        } catch (XPathExpressionException e) {
+            log.error("Error in finding the email in bio xml.", e);
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/authority/orcid/xml/XMLtoProfile.java
+++ b/dspace-api/src/main/java/org/dspace/authority/orcid/xml/XMLtoProfile.java
@@ -1,0 +1,85 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.authority.orcid.xml;
+
+import org.dspace.authority.orcid.model.Profile;
+import org.dspace.authority.util.XMLUtils;
+import org.apache.log4j.Logger;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.xpath.XPathExpressionException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class XMLtoProfile extends XMLtoBio
+{
+    private static Logger log = Logger.getLogger(XMLtoProfile.class);
+
+    protected String ORCID_PROFILE = "//orcid-profile";
+    protected String ORCID_BIO = "orcid-bio";
+    protected String ORCID_ACTIVITIES = "orcid-activities";
+    protected String AFFILIATION = ORCID_ACTIVITIES + "/affiliations/affiliation[type='employment']/organization/name";
+
+    public List<Profile> convertProfile(Document xml) {
+        List<Profile> result = new ArrayList<Profile>();
+
+        if (XMLErrors.check(xml)) {
+
+            try {
+                Iterator<Node> iterator = XMLUtils.getNodeListIterator(xml, ORCID_PROFILE);
+                while (iterator.hasNext()) {
+                    Profile profile = convertProfile(iterator.next());
+                    result.add(profile);
+                }
+            } catch (XPathExpressionException e) {
+                log.error("Error in xpath syntax", e);
+            }
+        } else {
+            processError(xml);
+        }
+
+        return result;
+    }
+
+    private Profile convertProfile(Node node) {
+        Profile profile = new Profile();
+
+        try {
+            Node bioNode = XMLUtils.getNode(node, ORCID_BIO);
+
+            setOrcid(bioNode, profile);
+            setPersonalDetails(bioNode, profile);
+            setContactDetails(bioNode, profile);
+            setKeywords(bioNode, profile);
+            setExternalIdentifiers(bioNode, profile);
+            setResearcherUrls(bioNode, profile);
+            setBiography(bioNode, profile);
+        } catch (XPathExpressionException e) {
+            log.error("Error in finding the bio in profile xml.", e);
+        }
+
+        setAffiliations(node, profile);
+
+        return profile;
+    }
+
+    protected void setAffiliations(Node xml, Profile profile) {
+        try {
+            Iterator<Node> iterator = XMLUtils.getNodeListIterator(xml, AFFILIATION);
+            while (iterator.hasNext()) {
+                String affiliation = iterator.next().getTextContent();
+                profile.addAffiliation(affiliation);
+            }
+        } catch (XPathExpressionException e) {
+            log.error("Error in finding the affiliations in profile xml.", e);
+        }
+    }
+}


### PR DESCRIPTION
This makes some changes to the query string in the ORCID search to allow the first names and surname to be in any order and can search for a specific ORCID id. It also adds the persons' email and affiliations to the lookup. The downside is that a separate API call is required for each person in order to get their affiliations.

This implements most of [DS-2957](https://jira.duraspace.org/browse/DS-2957), but doesn't allow filtering by affiliation.