### PR TITLE
DS-3553: when creating a new version, do context complete before redirecting to the submission page

### DIFF
--- a/dspace-xmlui/src/main/resources/aspects/Versioning/versioning.js
+++ b/dspace-xmlui/src/main/resources/aspects/Versioning/versioning.js
@@ -127,6 +127,7 @@ function doCreateNewVersion(itemID, result){
             result = VersionManager.processCreateNewVersion(getDSContext(),itemID, summary);
 
             var wsid = result.getParameter("wsid");
+            getDSContext().complete();
             cocoon.redirectTo(cocoon.request.getContextPath()+"/submit?workspaceID=" + wsid,true);
 	        cocoon.exit();
         }


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3553

when creating a new item version, I get the following error:
TypeError: Cannot call method "getSubmitter" of null (resource://aspects/Submission/submission.js#229)
this is because in submission.js:
getWorkspaceItemService().find(getDSContext(), workspaceID);
returns null.

this is because VersionManager.processCreateNewVersion() creates a new work space item, and passes the workspace item id to the request, but doesn't commit these changes.