### PR TITLE
DS-3559 Allow creation of OAI index for large repositories (V2)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -640,6 +640,18 @@ public class Context
     public long getCacheSize() throws SQLException {
         return this.getDBConnection().getCacheSize();
     }
+    
+    /**
+     * Completely clear the database Session. Evict all loaded instances and cancel all pending saves, updates and deletions. 
+     * Does not close open iterators or instances of ScrollableResults.
+     * 
+     * Note: You will lose all pending saves, updates and deletions.
+     * 
+     * @throws SQLException 
+     */
+    public void clear() throws SQLException{
+            dbConnection.clear();
+    }
 
     /**
      * Enable or disable "batch processing mode" for this context.

--- a/dspace-api/src/main/java/org/dspace/core/DBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/DBConnection.java
@@ -45,6 +45,12 @@ public interface DBConnection<T> {
     public boolean isOptimizedForBatchProcessing();
 
     public long getCacheSize() throws SQLException;
+    
+    /**
+     * Completely clear the session. Evict all loaded instances and cancel all pending saves, updates and deletions. Do not close open iterators or instances of ScrollableResults.
+     * @throws SQLException 
+     */
+    public void clear() throws SQLException;
 
     /**
      * Reload a DSpace object from the database. This will make sure the object is valid and stored in the cache.

--- a/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
@@ -165,4 +165,10 @@ public class HibernateDBConnection implements DBConnection<Session> {
     public <E extends ReloadableEntity> void uncacheEntity(E entity) throws SQLException {
         getSession().evict(entity);        
     }
+
+    @Override
+    public void clear() throws SQLException
+    {
+        getSession().clear();
+    }
 }

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -211,13 +211,15 @@ public class XOAI {
                         | XMLStreamException | WritingXmlException ex) {
                     log.error(ex.getMessage(), ex);
                 }
+                // clear cache to avoid memory and performance problems.
+                context.clear();
                 i++;
                 if (i % 100 == 0) System.out.println(i + " items imported so far...");
             }
             System.out.println("Total: " + i + " items");
             server.commit();
             return i;
-        } catch (SolrServerException | IOException ex) {
+        } catch (SolrServerException | IOException | SQLException ex) {
             throw new DSpaceSolrIndexerException(ex.getMessage(), ex);
         }
     }


### PR DESCRIPTION
This pull request fixes a problem with a fast growing hibernate cache during OAI indexing.
It also add's the method clear() to the context object which clears the hibernate session