### PR TITLE
DS 3558 Case-insensitive bot matching option

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/factory/StatisticsServiceFactory.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/factory/StatisticsServiceFactory.java
@@ -10,6 +10,8 @@ package org.dspace.statistics.factory;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.statistics.service.ElasticSearchLoggerService;
 import org.dspace.statistics.service.SolrLoggerService;
+import org.dspace.statistics.util.SpiderDetector;
+import org.dspace.statistics.util.SpiderDetectorService;
 
 /**
  * Abstract factory to get services for the statistics package, use StatisticsServiceFactory.getInstance() to retrieve an implementation
@@ -21,6 +23,8 @@ public abstract class StatisticsServiceFactory {
     public abstract SolrLoggerService getSolrLoggerService();
 
     public abstract ElasticSearchLoggerService getElasticSearchLoggerService();
+
+    public abstract SpiderDetectorService getSpiderDetectorService();
 
     public static StatisticsServiceFactory getInstance()
     {

--- a/dspace-api/src/main/java/org/dspace/statistics/factory/StatisticsServiceFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/factory/StatisticsServiceFactoryImpl.java
@@ -10,6 +10,8 @@ package org.dspace.statistics.factory;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.statistics.service.ElasticSearchLoggerService;
 import org.dspace.statistics.service.SolrLoggerService;
+import org.dspace.statistics.util.SpiderDetector;
+import org.dspace.statistics.util.SpiderDetectorService;
 
 /**
  * Factory implementation to get services for the statistics package, use StatisticsServiceFactory.getInstance() to retrieve an implementation
@@ -28,5 +30,10 @@ public class StatisticsServiceFactoryImpl extends StatisticsServiceFactory {
     public ElasticSearchLoggerService getElasticSearchLoggerService() {
         // In order to lazy load, we cannot autowire it and instead load it by name
         return DSpaceServicesFactory.getInstance().getServiceManager().getServiceByName("elasticSearchLoggerService", ElasticSearchLoggerService.class);
+    }
+
+    @Override
+    public SpiderDetectorService getSpiderDetectorService() {
+        return DSpaceServicesFactory.getInstance().getServiceManager().getServiceByName("spiderDetectorService", SpiderDetectorService.class);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetector.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetector.java
@@ -7,62 +7,41 @@
  */
 package org.dspace.statistics.util;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-import java.util.Collections;
-import java.util.regex.Pattern;
 import javax.servlet.http.HttpServletRequest;
 
-import org.apache.commons.configuration.ConversionException;
-import org.apache.commons.lang.StringUtils;
-import org.dspace.services.ConfigurationService;
-import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.statistics.factory.StatisticsServiceFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * SpiderDetector is used to find IP's that are spiders...
- * In future someone may add Host Domains
- * to the detection criteria here.
+ * SpiderDetector delegates static methods to SpiderDetectorService, which is used to find IP's that are spiders...
  *
  * @author kevinvandevelde at atmire.com
  * @author ben at atmire.com
  * @author Mark Diggory (mdiggory at atmire.com)
+ * @author frederic at atmire.com
  */
 public class SpiderDetector {
 
     private static final Logger log = LoggerFactory.getLogger(SpiderDetector.class);
 
-    private Boolean useProxies;
-
-    private Boolean useCaseInsensitiveMatching;
+    //Service where all methods get delegated to, this is instantiated by a spring-bean defined in core-services.xml
+    private static SpiderDetectorService spiderDetectorService = StatisticsServiceFactory.getInstance().getSpiderDetectorService();
 
     /**
-     * Sparse HashTable structure to hold IP address ranges.
+     * Get an immutable Set representing all the Spider Addresses here
+     *
+     * @return a set of IP addresses as strings
      */
-    private IPTable table = null;
+    public static Set<String> getSpiderIpAddresses() {
 
-    /** Collection of regular expressions to match known spiders' agents. */
-    private final List<Pattern> agents
-            = Collections.synchronizedList(new ArrayList<Pattern>());
-
-    /** Collection of regular expressions to match known spiders' domain names. */
-    private final List<Pattern> domains
-            = Collections.synchronizedList(new ArrayList<Pattern>());
-
-    private ConfigurationService configurationService;
-
-    private static SpiderDetector spiderDetector = new SpiderDetector(DSpaceServicesFactory.getInstance().getConfigurationService());
-
-    public SpiderDetector(ConfigurationService configurationService) {
-        this.configurationService = configurationService;
+        spiderDetectorService.loadSpiderIpAddresses();
+        return spiderDetectorService.getTable().toSet();
     }
+
     /**
      * Utility method which reads lines from a file & returns them in a Set.
      *
@@ -73,134 +52,7 @@ public class SpiderDetector {
     public static Set<String> readPatterns(File patternFile)
             throws IOException
     {
-        Set<String> patterns = new HashSet<>();
-
-        if (!patternFile.exists() || !patternFile.isFile())
-        {
-            return patterns;
-        }
-
-        //Read our file & get all them patterns.
-        try (BufferedReader in = new BufferedReader(new FileReader(patternFile)))
-        {
-            String line;
-            while ((line = in.readLine()) != null) {
-                if (!line.startsWith("#")) {
-                    line = line.trim();
-
-                    if (!line.equals("")) {
-                        patterns.add(line);
-                    }
-                } else {
-                    //   ua.add(line.replaceFirst("#","").replaceFirst("UA","").trim());
-                    // ... add this functionality later
-                }
-            }
-        }
-        return patterns;
-    }
-
-    /**
-     * Get an immutable Set representing all the Spider Addresses here
-     *
-     * @return a set of IP addresses as strings
-     */
-    public static Set<String> getSpiderIpAddresses() {
-
-        spiderDetector.loadSpiderIpAddresses();
-        return spiderDetector.table.toSet();
-    }
-
-    /*
-     *  private loader to populate the table from files.
-     */
-    private synchronized void loadSpiderIpAddresses() {
-
-        if (table == null) {
-            table = new IPTable();
-
-            String filePath = configurationService.getProperty("dspace.dir");
-
-            try {
-                File spidersDir = new File(filePath, "config/spiders");
-
-                if (spidersDir.exists() && spidersDir.isDirectory()) {
-                    for (File file : spidersDir.listFiles()) {
-                        if (file.isFile())
-                        {
-                            for (String ip : readPatterns(file)) {
-                                log.debug("Loading {}", ip);
-                                if (!Character.isDigit(ip.charAt(0)))
-                                {
-                                    try {
-                                        ip = DnsLookup.forward(ip);
-                                        log.debug("Resolved to {}", ip);
-                                    } catch (IOException e) {
-                                        log.warn("Not loading {}:  {}", ip, e.getMessage());
-                                        continue;
-                                    }
-                                }
-                                table.add(ip);
-                            }
-                            log.info("Loaded Spider IP file: " + file);
-                        }
-                    }
-                } else {
-                    log.info("No spider file loaded");
-                }
-            }
-            catch (IOException | IPTable.IPFormatException e) {
-                log.error("Error Loading Spiders:" + e.getMessage(), e);
-            }
-
-        }
-
-    }
-
-    /**
-     * Load agent name patterns from all files in a single subdirectory of config/spiders.
-     *
-     * @param directory simple directory name (e.g. "agents").
-     *      "${dspace.dir}/config/spiders" will be prepended to yield the path to
-     *      the directory of pattern files.
-     * @param patternList patterns read from the files in {@code directory} will
-     *      be added to this List.
-     */
-    private void loadPatterns(String directory, List<Pattern> patternList)
-    {
-        String dspaceHome = configurationService.getProperty("dspace.dir");
-        File spidersDir = new File(dspaceHome, "config/spiders");
-        File patternsDir = new File(spidersDir, directory);
-        if (patternsDir.exists() && patternsDir.isDirectory())
-        {
-            for (File file : patternsDir.listFiles())
-            {
-                Set<String> patterns;
-                try
-                {
-                    patterns = readPatterns(file);
-                } catch (IOException ex)
-                {
-                    log.error("Patterns not read from {}:  {}",
-                            file.getPath(), ex.getMessage());
-                    continue;
-                }
-                //If case insensitive matching is enabled, lowercase the patterns so they can be lowercase matched
-                for (String pattern : patterns) {
-                    if(isUseCaseInsensitiveMatching()) {
-                        pattern = StringUtils.lowerCase(pattern);
-                    }
-                    patternList.add(Pattern.compile(pattern));
-                }
-
-
-                log.info("Loaded pattern file:  {}", file.getPath());
-            }
-        }
-        else
-        {
-            log.info("No patterns loaded from {}", patternsDir.getPath());
-        }
+        return spiderDetectorService.readPatterns(patternFile);
     }
 
     /**
@@ -215,84 +67,11 @@ public class SpiderDetector {
      * @param agent User-Agent header value, or null.
      * @return true if the client matches any spider characteristics list.
      */
-    public boolean isSpiderAgent(String clientIP, String proxyIPs,
-                                   String hostname, String agent)
-    {
-        // See if any agent patterns match
-        if (null != agent)
-        {
-            synchronized(agents)
-            {
-                if (agents.isEmpty())
-                    loadPatterns("agents", agents);
-            }
-
-            if(isUseCaseInsensitiveMatching()) {
-                agent = StringUtils.lowerCase(agent);
-                hostname = StringUtils.lowerCase(hostname);
-            }
-
-            for (Pattern candidate : agents) {
-
-                // prevent matcher() invocation from a null Pattern object
-                if (null != candidate && candidate.matcher(agent).find()) {
-                    return true;
-                }
-
-
-            }
-        }
-
-        // No.  See if any IP addresses match
-        if (isUseProxies() && proxyIPs != null) {
-            /* This header is a comma delimited list */
-            for (String xfip : proxyIPs.split(",")) {
-                if (isSpiderAgent(xfip))
-                {
-                    return true;
-                }
-            }
-        }
-
-        if (isSpiderAgent(clientIP))
-            return true;
-
-        // No.  See if any DNS names match
-        if (null != hostname)
-        {
-            synchronized(domains)
-            {
-                if (domains.isEmpty())
-                    loadPatterns("domains", domains);
-            }
-            for (Pattern candidate : domains)
-            {
-                // prevent matcher() invocation from a null Pattern object
-                if (null != candidate && candidate.matcher(hostname).find())
-                {
-                    return true;
-                }
-            }
-        }
-
-        // Not a known spider.
-        return false;
-    }
-
     public static boolean isSpider(String clientIP, String proxyIPs,
                                    String hostname, String agent)
     {
-        return spiderDetector.isSpiderAgent(clientIP, proxyIPs, hostname, agent);
+        return spiderDetectorService.isSpider(clientIP, proxyIPs, hostname, agent);
     }
-
-    public boolean isSpiderAgent(HttpServletRequest request)
-    {
-        return isSpiderAgent(request.getRemoteAddr(),
-                request.getHeader("X-Forwarded-For"),
-                request.getRemoteHost(),
-                request.getHeader("User-Agent"));
-    }
-
 
     /**
      * Static Service Method for testing spiders against existing spider files.
@@ -302,26 +81,7 @@ public class SpiderDetector {
      */
     public static boolean isSpider(HttpServletRequest request)
     {
-        return spiderDetector.isSpiderAgent(request);
-    }
-
-    public boolean isSpiderAgent(String ip) {
-
-        if (table == null) {
-            loadSpiderIpAddresses();
-        }
-
-        try {
-            if (table.contains(ip)) {
-                return true;
-            }
-        } catch (Exception e) {
-            return false;
-        }
-
-        return false;
-
-
+        return spiderDetectorService.isSpider(request);
     }
 
     /**
@@ -331,31 +91,7 @@ public class SpiderDetector {
      * @return if is spider IP
      */
     public static boolean isSpider(String ip) {
-
-        return spiderDetector.isSpiderAgent(ip);
-
-
-    }
-
-    private boolean isUseCaseInsensitiveMatching() {
-        if (useCaseInsensitiveMatching == null) {
-            try {
-                useCaseInsensitiveMatching = configurationService.getBooleanProperty("usage-statistics.bots.case-insensitive");
-            } catch (ConversionException e) {
-                useCaseInsensitiveMatching = false;
-                log.warn("Please use a boolean value for usage-statistics.bots.case-insensitive");
-            }
-        }
-
-        return useCaseInsensitiveMatching;
-    }
-
-    private boolean isUseProxies() {
-        if(useProxies == null) {
-            useProxies = configurationService.getBooleanProperty("useProxies");
-        }
-
-        return useProxies;
+        return spiderDetectorService.isSpider(ip);
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetector.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetector.java
@@ -175,6 +175,7 @@ public class SpiderDetector {
                             file.getPath(), ex.getMessage());
                     continue;
                 }
+                //If case insensitive matching is enabled, lowercase the patterns so they can be lowercase matched
                 if(isUseCaseInsensitiveMatching()) {
                     for (String pattern : patterns) {
                         patternList.add(Pattern.compile(pattern.toLowerCase()));

--- a/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetector.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetector.java
@@ -18,6 +18,8 @@ import java.util.Set;
 import java.util.Collections;
 import java.util.regex.Pattern;
 import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.lang.StringUtils;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -176,16 +178,14 @@ public class SpiderDetector {
                     continue;
                 }
                 //If case insensitive matching is enabled, lowercase the patterns so they can be lowercase matched
-                if(isUseCaseInsensitiveMatching()) {
-                    for (String pattern : patterns) {
-                        patternList.add(Pattern.compile(pattern.toLowerCase()));
+                for (String pattern : patterns) {
+                    if(isUseCaseInsensitiveMatching()) {
+                        pattern = StringUtils.lowerCase(pattern);
                     }
+                    patternList.add(Pattern.compile(pattern));
                 }
-                else {
-                    for (String pattern : patterns) {
-                        patternList.add(Pattern.compile(pattern));
-                    }
-                }
+
+
                 log.info("Loaded pattern file:  {}", file.getPath());
             }
         }
@@ -208,7 +208,7 @@ public class SpiderDetector {
      * @return true if the client matches any spider characteristics list.
      */
     public static boolean isSpider(String clientIP, String proxyIPs,
-            String hostname, String agent)
+                                   String hostname, String agent)
     {
         // See if any agent patterns match
         if (null != agent)
@@ -218,21 +218,20 @@ public class SpiderDetector {
                 if (agents.isEmpty())
                     loadPatterns("agents", agents);
             }
-            if(useCaseInsensitiveMatching) {
-                for (Pattern candidate : agents) {
-                    // prevent matcher() invocation from a null Pattern object
-                    if (null != candidate && candidate.matcher(agent.toLowerCase()).find()) {
-                        return true;
-                    }
-                }
+
+            if(isUseCaseInsensitiveMatching()) {
+                agent = StringUtils.lowerCase(agent);
+                hostname = StringUtils.lowerCase(hostname);
             }
-            else {
-                for (Pattern candidate : agents) {
-                    // prevent matcher() invocation from a null Pattern object
-                    if (null != candidate && candidate.matcher(agent).find()) {
-                        return true;
-                    }
+
+            for (Pattern candidate : agents) {
+
+                // prevent matcher() invocation from a null Pattern object
+                if (null != candidate && candidate.matcher(agent).find()) {
+                    return true;
                 }
+
+
             }
         }
 
@@ -260,8 +259,8 @@ public class SpiderDetector {
             }
             for (Pattern candidate : domains)
             {
-		// prevent matcher() invocation from a null Pattern object
-		if (null != candidate && candidate.matcher(hostname).find())
+                // prevent matcher() invocation from a null Pattern object
+                if (null != candidate && candidate.matcher(hostname).find())
                 {
                     return true;
                 }

--- a/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetector.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetector.java
@@ -37,6 +37,8 @@ public class SpiderDetector {
 
     private static Boolean useProxies;
 
+    private static Boolean useCaseInsensitiveMatching;
+
     /**
      * Sparse HashTable structure to hold IP address ranges.
      */
@@ -173,9 +175,15 @@ public class SpiderDetector {
                             file.getPath(), ex.getMessage());
                     continue;
                 }
-                for (String pattern : patterns)
-                {
-                    patternList.add(Pattern.compile(pattern,Pattern.CASE_INSENSITIVE));
+                if(isUseCaseInsensitiveMatching()) {
+                    for (String pattern : patterns) {
+                        patternList.add(Pattern.compile(pattern.toLowerCase()));
+                    }
+                }
+                else {
+                    for (String pattern : patterns) {
+                        patternList.add(Pattern.compile(pattern));
+                    }
                 }
                 log.info("Loaded pattern file:  {}", file.getPath());
             }
@@ -209,12 +217,20 @@ public class SpiderDetector {
                 if (agents.isEmpty())
                     loadPatterns("agents", agents);
             }
-            for (Pattern candidate : agents)
-            {
-		// prevent matcher() invocation from a null Pattern object
-                if (null != candidate && candidate.matcher(agent).find())
-                {
-                    return true;
+            if(useCaseInsensitiveMatching) {
+                for (Pattern candidate : agents) {
+                    // prevent matcher() invocation from a null Pattern object
+                    if (null != candidate && candidate.matcher(agent.toLowerCase()).find()) {
+                        return true;
+                    }
+                }
+            }
+            else {
+                for (Pattern candidate : agents) {
+                    // prevent matcher() invocation from a null Pattern object
+                    if (null != candidate && candidate.matcher(agent).find()) {
+                        return true;
+                    }
                 }
             }
         }
@@ -292,6 +308,14 @@ public class SpiderDetector {
         return false;
 
 
+    }
+
+    private static boolean isUseCaseInsensitiveMatching() {
+        if (useCaseInsensitiveMatching == null) {
+            useCaseInsensitiveMatching = DSpaceServicesFactory.getInstance().getConfigurationService().getBooleanProperty("usage-statistics.bots.case-insensitive");
+        }
+
+        return useCaseInsensitiveMatching;
     }
 
     private static boolean isUseProxies() {

--- a/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetectorService.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetectorService.java
@@ -1,0 +1,34 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.statistics.util;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.File;
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * Interface to implement a SpiderDetectorService
+ * @author frederic at atmire.com
+ */
+public interface SpiderDetectorService {
+
+    public boolean isSpider(String clientIP, String proxyIPs, String hostname, String agent);
+
+    public boolean isSpider(HttpServletRequest request);
+
+    public boolean isSpider(String ip);
+
+    public void loadSpiderIpAddresses();
+
+    public Set<String> readPatterns(File patternFile)
+            throws IOException;
+
+    public IPTable getTable();
+
+}

--- a/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetectorServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetectorServiceImpl.java
@@ -1,0 +1,329 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.statistics.util;
+
+import org.apache.commons.configuration.ConversionException;
+import org.apache.commons.lang.StringUtils;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.*;
+import java.util.regex.Pattern;
+
+/**
+ * SpiderDetectorServiceImpl is used to find IP's that are spiders...
+ * In future someone may add Host Domains
+ * to the detection criteria here.
+ *
+ * @author kevinvandevelde at atmire.com
+ * @author ben at atmire.com
+ * @author Mark Diggory (mdiggory at atmire.com)
+ * @author frederic at atmire.com
+ */
+public class SpiderDetectorServiceImpl implements SpiderDetectorService {
+
+    private static final Logger log = LoggerFactory.getLogger(SpiderDetectorServiceImpl.class);
+
+    private Boolean useProxies;
+
+    private Boolean useCaseInsensitiveMatching;
+
+    private final List<Pattern> agents
+            = Collections.synchronizedList(new ArrayList<Pattern>());
+
+    private final List<Pattern> domains
+            = Collections.synchronizedList(new ArrayList<Pattern>());
+
+    private ConfigurationService configurationService;
+
+    /**
+     * Sparse HashTable structure to hold IP address ranges.
+     */
+    private IPTable table = null;
+
+    @Autowired(required = true)
+    public SpiderDetectorServiceImpl(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+    }
+
+    public IPTable getTable() {
+        return table;
+    }
+
+    /**
+     * Service Method for testing spiders against existing spider files.
+     * <p>
+     * In future spiders HashSet may be optimized as byte offset array to
+     * improve performance and memory footprint further.
+     *
+     * @param clientIP address of the client.
+     * @param proxyIPs comma-list of X-Forwarded-For addresses, or null.
+     * @param hostname domain name of host, or null.
+     * @param agent User-Agent header value, or null.
+     * @return true if the client matches any spider characteristics list.
+     */
+    public boolean isSpider(String clientIP, String proxyIPs, String hostname, String agent) {
+        // See if any agent patterns match
+        if (null != agent)
+        {
+            synchronized(agents)
+            {
+                if (agents.isEmpty())
+                    loadPatterns("agents", agents);
+            }
+
+            if(isUseCaseInsensitiveMatching()) {
+                agent = StringUtils.lowerCase(agent);
+                hostname = StringUtils.lowerCase(hostname);
+            }
+
+            for (Pattern candidate : agents) {
+
+                // prevent matcher() invocation from a null Pattern object
+                if (null != candidate && candidate.matcher(agent).find()) {
+                    return true;
+                }
+
+
+            }
+        }
+
+        // No.  See if any IP addresses match
+        if (isUseProxies() && proxyIPs != null) {
+            /* This header is a comma delimited list */
+            for (String xfip : proxyIPs.split(",")) {
+                if (isSpider(xfip))
+                {
+                    return true;
+                }
+            }
+        }
+
+        if (isSpider(clientIP))
+            return true;
+
+        // No.  See if any DNS names match
+        if (null != hostname)
+        {
+            synchronized(domains)
+            {
+                if (domains.isEmpty())
+                    loadPatterns("domains", domains);
+            }
+            for (Pattern candidate : domains)
+            {
+                // prevent matcher() invocation from a null Pattern object
+                if (null != candidate && candidate.matcher(hostname).find())
+                {
+                    return true;
+                }
+            }
+        }
+
+        // Not a known spider.
+        return false;
+    }
+
+    /**
+     * Utility method which reads lines from a file & returns them in a Set.
+     *
+     * @param patternFile the location of our spider file
+     * @return a vector full of patterns
+     * @throws IOException could not happen since we check the file be4 we use it
+     */
+    public Set<String> readPatterns(File patternFile)
+            throws IOException
+    {
+        Set<String> patterns = new HashSet<>();
+
+        if (!patternFile.exists() || !patternFile.isFile())
+        {
+            return patterns;
+        }
+
+        //Read our file & get all them patterns.
+        try (BufferedReader in = new BufferedReader(new FileReader(patternFile)))
+        {
+            String line;
+            while ((line = in.readLine()) != null) {
+                if (!line.startsWith("#")) {
+                    line = line.trim();
+
+                    if (!line.equals("")) {
+                        patterns.add(line);
+                    }
+                } else {
+                    //   ua.add(line.replaceFirst("#","").replaceFirst("UA","").trim());
+                    // ... add this functionality later
+                }
+            }
+        }
+        return patterns;
+    }
+
+    /**
+     * Load agent name patterns from all files in a single subdirectory of config/spiders.
+     *
+     * @param directory simple directory name (e.g. "agents").
+     *      "${dspace.dir}/config/spiders" will be prepended to yield the path to
+     *      the directory of pattern files.
+     * @param patternList patterns read from the files in {@code directory} will
+     *      be added to this List.
+     */
+    private void loadPatterns(String directory, List<Pattern> patternList)
+    {
+        String dspaceHome = configurationService.getProperty("dspace.dir");
+        File spidersDir = new File(dspaceHome, "config/spiders");
+        File patternsDir = new File(spidersDir, directory);
+        if (patternsDir.exists() && patternsDir.isDirectory())
+        {
+            for (File file : patternsDir.listFiles())
+            {
+                Set<String> patterns;
+                try
+                {
+                    patterns = readPatterns(file);
+                } catch (IOException ex)
+                {
+                    log.error("Patterns not read from {}:  {}",
+                            file.getPath(), ex.getMessage());
+                    continue;
+                }
+                //If case insensitive matching is enabled, lowercase the patterns so they can be lowercase matched
+                for (String pattern : patterns) {
+                    if(isUseCaseInsensitiveMatching()) {
+                        pattern = StringUtils.lowerCase(pattern);
+                    }
+                    patternList.add(Pattern.compile(pattern));
+                }
+
+
+                log.info("Loaded pattern file:  {}", file.getPath());
+            }
+        }
+        else
+        {
+            log.info("No patterns loaded from {}", patternsDir.getPath());
+        }
+    }
+
+    /**
+     * Service Method for testing spiders against existing spider files.
+     *
+     * @param request
+     * @return true|false if the request was detected to be from a spider.
+     */
+    public boolean isSpider(HttpServletRequest request) {
+        return isSpider(request.getRemoteAddr(),
+                request.getHeader("X-Forwarded-For"),
+                request.getRemoteHost(),
+                request.getHeader("User-Agent"));
+    }
+
+    /**
+     * Check individual IP is a spider.
+     *
+     * @param ip
+     * @return if is spider IP
+     */
+    public boolean isSpider(String ip) {
+        if (table == null) {
+            loadSpiderIpAddresses();
+        }
+
+        try {
+            if (table.contains(ip)) {
+                return true;
+            }
+        } catch (Exception e) {
+            return false;
+        }
+
+        return false;
+    }
+
+    /*
+     *  loader to populate the table from files.
+     */
+    public synchronized void loadSpiderIpAddresses() {
+
+        if (table == null) {
+            table = new IPTable();
+
+            String filePath = configurationService.getProperty("dspace.dir");
+
+            try {
+                File spidersDir = new File(filePath, "config/spiders");
+
+                if (spidersDir.exists() && spidersDir.isDirectory()) {
+                    for (File file : spidersDir.listFiles()) {
+                        if (file.isFile())
+                        {
+                            for (String ip : readPatterns(file)) {
+                                log.debug("Loading {}", ip);
+                                if (!Character.isDigit(ip.charAt(0)))
+                                {
+                                    try {
+                                        ip = DnsLookup.forward(ip);
+                                        log.debug("Resolved to {}", ip);
+                                    } catch (IOException e) {
+                                        log.warn("Not loading {}:  {}", ip, e.getMessage());
+                                        continue;
+                                    }
+                                }
+                                table.add(ip);
+                            }
+                            log.info("Loaded Spider IP file: " + file);
+                        }
+                    }
+                } else {
+                    log.info("No spider file loaded");
+                }
+            }
+            catch (IOException | IPTable.IPFormatException e) {
+                log.error("Error Loading Spiders:" + e.getMessage(), e);
+            }
+
+        }
+
+    }
+
+    /**
+     * checks if case insensitive matching is enabled
+     * @return true if it's enabled, false if not
+     */
+    private boolean isUseCaseInsensitiveMatching() {
+        if (useCaseInsensitiveMatching == null) {
+            try {
+                useCaseInsensitiveMatching = configurationService.getBooleanProperty("usage-statistics.bots.case-insensitive");
+            } catch (ConversionException e) {
+                useCaseInsensitiveMatching = false;
+                log.warn("Please use a boolean value for usage-statistics.bots.case-insensitive");
+            }
+        }
+
+        return useCaseInsensitiveMatching;
+    }
+
+    private boolean isUseProxies() {
+        if(useProxies == null) {
+            useProxies = configurationService.getBooleanProperty("useProxies");
+        }
+
+        return useProxies;
+    }
+
+}

--- a/dspace-api/src/test/java/org/dspace/statistics/util/SpiderDetectorServiceImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/util/SpiderDetectorServiceImplTest.java
@@ -7,10 +7,10 @@
  */
 package org.dspace.statistics.util;
 
+
 import mockit.Mock;
 import mockit.MockUp;
 import org.dspace.AbstractDSpaceTest;
-import org.dspace.servicemanager.config.DSpaceConfigurationService;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.statistics.SolrLoggerServiceImpl;
@@ -18,37 +18,32 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 
-import java.lang.reflect.Field;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * @author mwood
+ * @author frederic at atmire.com
  */
 @RunWith(MockitoJUnitRunner.class)
-public class SpiderDetectorTest extends AbstractDSpaceTest
+public class SpiderDetectorServiceImplTest extends AbstractDSpaceTest
 {
     private static final String NOT_A_BOT_ADDRESS = "192.168.0.1";
 
-    @org.mockito.Mock
     private ConfigurationService configurationService;
-    /**
-     * Test method for {@link org.dspace.statistics.util.SpiderDetector#readPatterns(java.io.File)}.
-     */
 
-    private SpiderDetector spiderDetector;
+
+    private SpiderDetectorService spiderDetectorService;
 
     @Before
     public void init() {
         configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
-        spiderDetector = new SpiderDetector(configurationService);
+        spiderDetectorService = new SpiderDetectorServiceImpl(configurationService);
 
     }
 
@@ -58,20 +53,21 @@ public class SpiderDetectorTest extends AbstractDSpaceTest
 // FIXME        fail("Not yet implemented");
     }
 
-    /**
-     * Test method for {@link org.dspace.statistics.util.SpiderDetector#getSpiderIpAddresses()}.
-     */
     @Test
     public void testGetSpiderIpAddresses()
     {
 // FIXME        fail("Not yet implemented");
     }
 
+    /**
+     * Test if Case Insitive matching option works
+     * @throws Exception
+     */
     @Test
     public void testCaseInsensitiveMatching() throws Exception
     {
         configurationService.setProperty("usage-statistics.bots.case-insensitive", true);
-        spiderDetector = new SpiderDetector(configurationService);
+        spiderDetectorService = new SpiderDetectorServiceImpl(configurationService);
 
         DummyHttpServletRequest req = new DummyHttpServletRequest();
         req.setAddress(NOT_A_BOT_ADDRESS); // avoid surprises
@@ -82,32 +78,32 @@ public class SpiderDetectorTest extends AbstractDSpaceTest
 
         // Test agent patterns
         req.setAgent("msnboT Is WaTching you");
-        assertTrue("'msnbot' didn't match pattern", spiderDetector.isSpiderAgent(req));
+        assertTrue("'msnbot' didn't match pattern", spiderDetectorService.isSpider(req));
 
         req.setAgent("FirefOx");
-        assertFalse("'Firefox' matched a pattern", spiderDetector.isSpiderAgent(req));
+        assertFalse("'Firefox' matched a pattern", spiderDetectorService.isSpider(req));
 
         // Test IP patterns
         candidate = "192.168.2.1";
         req.setAddress(candidate);
-        assertTrue(candidate + " did not match IP patterns", spiderDetector.isSpiderAgent(req));
+        assertTrue(candidate + " did not match IP patterns", spiderDetectorService.isSpider(req));
 
         req.setAddress(NOT_A_BOT_ADDRESS);
-        assertFalse(NOT_A_BOT_ADDRESS + " matched IP patterns", spiderDetector.isSpiderAgent(req));
+        assertFalse(NOT_A_BOT_ADDRESS + " matched IP patterns", spiderDetectorService.isSpider(req));
 
         // Test DNS patterns
         candidate = "baiduspiDer-dSPace-test.crawl.baIDu.com";
         req.setRemoteHost(candidate);
-        assertTrue(candidate + " did match DNS patterns", spiderDetector.isSpiderAgent(req));
+        assertTrue(candidate + " did match DNS patterns", spiderDetectorService.isSpider(req));
 
         candidate = "wIki.dsPace.oRg";
         req.setRemoteHost(candidate);
-        assertFalse(candidate + " matched DNS patterns", spiderDetector.isSpiderAgent(req));
+        assertFalse(candidate + " matched DNS patterns", spiderDetectorService.isSpider(req));
 
     }
 
     /**
-     * Test method for {@link org.dspace.statistics.util.SpiderDetector#isSpider(javax.servlet.http.HttpServletRequest)}.
+     * Test method for {@link org.dspace.statistics.util.SpiderDetectorService#isSpider(javax.servlet.http.HttpServletRequest)}.
      */
     @Test
     public void testIsSpiderHttpServletRequest()
@@ -121,31 +117,31 @@ public class SpiderDetectorTest extends AbstractDSpaceTest
 
         // Test agent patterns
         req.setAgent("msnbot is watching you");
-        assertTrue("'msnbot' did not match any pattern", spiderDetector.isSpiderAgent(req));
+        assertTrue("'msnbot' did not match any pattern", spiderDetectorService.isSpider(req));
 
         req.setAgent("Firefox");
-        assertFalse("'Firefox' matched a pattern", spiderDetector.isSpiderAgent(req));
+        assertFalse("'Firefox' matched a pattern", spiderDetectorService.isSpider(req));
 
         // Test IP patterns
         candidate = "192.168.2.1";
         req.setAddress(candidate);
-        assertTrue(candidate + " did not match IP patterns", spiderDetector.isSpiderAgent(req));
+        assertTrue(candidate + " did not match IP patterns", spiderDetectorService.isSpider(req));
 
         req.setAddress(NOT_A_BOT_ADDRESS);
-        assertFalse(NOT_A_BOT_ADDRESS + " matched IP patterns", spiderDetector.isSpiderAgent(req));
+        assertFalse(NOT_A_BOT_ADDRESS + " matched IP patterns", spiderDetectorService.isSpider(req));
 
         // Test DNS patterns
         candidate = "baiduspider-dspace-test.crawl.baidu.com";
         req.setRemoteHost(candidate);
-        assertTrue(candidate + " did not match DNS patterns", spiderDetector.isSpiderAgent(req));
+        assertTrue(candidate + " did not match DNS patterns", spiderDetectorService.isSpider(req));
 
         candidate = "wiki.dspace.org";
         req.setRemoteHost(candidate);
-        assertFalse(candidate + " matched DNS patterns", spiderDetector.isSpiderAgent(req));
+        assertFalse(candidate + " matched DNS patterns", spiderDetectorService.isSpider(req));
     }
 
     /**
-     * Test method for {@link org.dspace.statistics.util.SpiderDetector#isSpider(java.lang.String, java.lang.String, java.lang.String, java.lang.String)}.
+     * Test method for {@link org.dspace.statistics.util.SpiderDetectorService#isSpider(java.lang.String, java.lang.String, java.lang.String, java.lang.String)}.
      */
     @Test
     public void testIsSpiderStringStringStringString()
@@ -155,33 +151,33 @@ public class SpiderDetectorTest extends AbstractDSpaceTest
         // Test IP patterns
         candidate = "192.168.2.1";
         assertTrue(candidate + " did not match IP patterns",
-                spiderDetector.isSpiderAgent(candidate, null, null, null));
+                spiderDetectorService.isSpider(candidate, null, null, null));
 
         candidate = NOT_A_BOT_ADDRESS;
         assertFalse(candidate + " matched IP patterns",
-                spiderDetector.isSpiderAgent(candidate, null, null, null));
+                spiderDetectorService.isSpider(candidate, null, null, null));
 
         // Test DNS patterns
         candidate = "baiduspider-dspace-test.crawl.baidu.com";
         assertTrue(candidate + " did not match DNS patterns",
-                spiderDetector.isSpiderAgent(NOT_A_BOT_ADDRESS, null, candidate, null));
+                spiderDetectorService.isSpider(NOT_A_BOT_ADDRESS, null, candidate, null));
 
         candidate = "wiki.dspace.org";
         assertFalse(candidate + " matched DNS patterns",
-                spiderDetector.isSpiderAgent(NOT_A_BOT_ADDRESS, null, candidate, null));
+                spiderDetectorService.isSpider(NOT_A_BOT_ADDRESS, null, candidate, null));
 
         // Test agent patterns
         candidate = "msnbot is watching you";
         assertTrue("'" + candidate + "' did not match agent patterns",
-                spiderDetector.isSpiderAgent(NOT_A_BOT_ADDRESS, null, null, candidate));
+                spiderDetectorService.isSpider(NOT_A_BOT_ADDRESS, null, null, candidate));
 
         candidate = "Firefox";
         assertFalse("'" + candidate + "' matched agent patterns",
-                spiderDetector.isSpiderAgent(NOT_A_BOT_ADDRESS, null, null, candidate));
+                spiderDetectorService.isSpider(NOT_A_BOT_ADDRESS, null, null, candidate));
     }
 
     /**
-     * Test method for {@link org.dspace.statistics.util.SpiderDetector#isSpider(java.lang.String)}.
+     * Test method for {@link org.dspace.statistics.util.SpiderDetectorService#isSpider(java.lang.String)}.
      */
     @Test
     public void testIsSpiderString()
@@ -190,16 +186,19 @@ public class SpiderDetectorTest extends AbstractDSpaceTest
 
         candidate = "192.168.2.1";
         assertTrue(candidate + " did not match IP patterns",
-                spiderDetector.isSpiderAgent(candidate, null, null, null));
+                spiderDetectorService.isSpider(candidate, null, null, null));
 
         candidate = NOT_A_BOT_ADDRESS;
         assertFalse(candidate + " matched IP patterns",
-                spiderDetector.isSpiderAgent(candidate, null, null, null));
+                spiderDetectorService.isSpider(candidate, null, null, null));
 
     }
 
 
-
+    /**
+     * Test if Case Sensitive matching still works after adding the option
+     * @throws Exception
+     */
     @Test
     public void testCaseSensitiveMatching() throws Exception
     {
@@ -213,32 +212,32 @@ public class SpiderDetectorTest extends AbstractDSpaceTest
 
         // Test agent patterns
         req.setAgent("msnboT Is WaTching you");
-        assertFalse("'msnbot' matched pattern", spiderDetector.isSpiderAgent(req));
+        assertFalse("'msnbot' matched pattern", spiderDetectorService.isSpider(req));
 
         req.setAgent("FirefOx");
-        assertFalse("'Firefox' matched a pattern", spiderDetector.isSpiderAgent(req));
+        assertFalse("'Firefox' matched a pattern", spiderDetectorService.isSpider(req));
 
         // Test IP patterns
         candidate = "192.168.2.1";
         req.setAddress(candidate);
-        assertTrue(candidate + " did not match IP patterns", spiderDetector.isSpiderAgent(req));
+        assertTrue(candidate + " did not match IP patterns", spiderDetectorService.isSpider(req));
 
         req.setAddress(NOT_A_BOT_ADDRESS);
-        assertFalse(NOT_A_BOT_ADDRESS + " matched IP patterns", spiderDetector.isSpiderAgent(req));
+        assertFalse(NOT_A_BOT_ADDRESS + " matched IP patterns", spiderDetectorService.isSpider(req));
 
         // Test DNS patterns
         candidate = "baiduspiDer-dSPace-test.crawl.baIDu.com";
         req.setRemoteHost(candidate);
-        assertFalse(candidate + " did match DNS patterns", spiderDetector.isSpiderAgent(req));
+        assertFalse(candidate + " did match DNS patterns", spiderDetectorService.isSpider(req));
 
         candidate = "wIki.dsPace.oRg";
         req.setRemoteHost(candidate);
-        assertFalse(candidate + " matched DNS patterns", spiderDetector.isSpiderAgent(req));
+        assertFalse(candidate + " matched DNS patterns", spiderDetectorService.isSpider(req));
 
     }
 
     /**
-     * Test to see that lowercased will be matched but uppercase won't
+     * Test to see that lowercase will be matched but uppercase won't
      */
     @Test
     public void testInsensitiveSensitiveDifference() {
@@ -252,19 +251,19 @@ public class SpiderDetectorTest extends AbstractDSpaceTest
 
         // Test agent patterns
         req.setAgent("msnbot is WaTching you");
-        assertTrue("'msnbot' didn't match pattern", spiderDetector.isSpiderAgent(req));
+        assertTrue("'msnbot' didn't match pattern", spiderDetectorService.isSpider(req));
 
         req.setAgent("MSNBOT Is WaTching you");
-        assertFalse("'msnbot' matched pattern", spiderDetector.isSpiderAgent(req));
+        assertFalse("'msnbot' matched pattern", spiderDetectorService.isSpider(req));
 
         // Test DNS patterns
         candidate = "baiduspider-dspace-test.crawl.baidu.com";
         req.setRemoteHost(candidate);
-        assertTrue(candidate + " did not match DNS patterns", spiderDetector.isSpiderAgent(req));
+        assertTrue(candidate + " did not match DNS patterns", spiderDetectorService.isSpider(req));
 
         candidate = "baiduspiDer-dSPace-test.crawl.baIDu.com";
         req.setRemoteHost(candidate);
-        assertFalse(candidate + " matched DNS patterns", spiderDetector.isSpiderAgent(req));
+        assertFalse(candidate + " matched DNS patterns", spiderDetectorService.isSpider(req));
     }
 
     /**
@@ -274,7 +273,7 @@ public class SpiderDetectorTest extends AbstractDSpaceTest
     public void testBothLowerAndUpperCaseGetMatched() {
 
         configurationService.setProperty("usage-statistics.bots.case-insensitive", true);
-        spiderDetector = new SpiderDetector(configurationService);
+        spiderDetectorService = new SpiderDetectorServiceImpl(configurationService);
 
         DummyHttpServletRequest req = new DummyHttpServletRequest();
         req.setAddress(NOT_A_BOT_ADDRESS); // avoid surprises
@@ -285,19 +284,19 @@ public class SpiderDetectorTest extends AbstractDSpaceTest
 
         // Test agent patterns
         req.setAgent("msnbot is WaTching you");
-        assertTrue("'msnbot' didn't match pattern", spiderDetector.isSpiderAgent(req));
+        assertTrue("'msnbot' didn't match pattern", spiderDetectorService.isSpider(req));
 
         req.setAgent("MSNBOT Is WaTching you");
-        assertTrue("'msnbot' didn't match pattern", spiderDetector.isSpiderAgent(req));
+        assertTrue("'msnbot' didn't match pattern", spiderDetectorService.isSpider(req));
 
         // Test DNS patterns
         candidate = "baiduspider-dspace-test.crawl.baidu.com";
         req.setRemoteHost(candidate);
-        assertTrue(candidate + " did not match DNS patterns", spiderDetector.isSpiderAgent(req));
+        assertTrue(candidate + " did not match DNS patterns", spiderDetectorService.isSpider(req));
 
         candidate = "baiduspiDer-dSPace-test.crawl.baIDu.com";
         req.setRemoteHost(candidate);
-        assertTrue(candidate + " didn't match DNS patterns", spiderDetector.isSpiderAgent(req));
+        assertTrue(candidate + " didn't match DNS patterns", spiderDetectorService.isSpider(req));
     }
 
     /**
@@ -306,7 +305,7 @@ public class SpiderDetectorTest extends AbstractDSpaceTest
     @Test
     public void testNonBooleanConfig() {
         configurationService.setProperty("usage-statistics.bots.case-insensitive", "RandomNonBooleanString");
-        spiderDetector = new SpiderDetector(configurationService);
+        spiderDetectorService = new SpiderDetectorServiceImpl(configurationService);
 
         DummyHttpServletRequest req = new DummyHttpServletRequest();
         req.setAddress(NOT_A_BOT_ADDRESS); // avoid surprises
@@ -317,19 +316,19 @@ public class SpiderDetectorTest extends AbstractDSpaceTest
 
         // Test agent patterns
         req.setAgent("msnbot is WaTching you");
-        assertTrue("'msnbot' didn't match pattern", spiderDetector.isSpiderAgent(req));
+        assertTrue("'msnbot' didn't match pattern", spiderDetectorService.isSpider(req));
 
         req.setAgent("MSNBOT Is WaTching you");
-        assertFalse("'msnbot' matched pattern", spiderDetector.isSpiderAgent(req));
+        assertFalse("'msnbot' matched pattern", spiderDetectorService.isSpider(req));
 
         // Test DNS patterns
         candidate = "baiduspider-dspace-test.crawl.baidu.com";
         req.setRemoteHost(candidate);
-        assertTrue(candidate + " did not match DNS patterns", spiderDetector.isSpiderAgent(req));
+        assertTrue(candidate + " did not match DNS patterns", spiderDetectorService.isSpider(req));
 
         candidate = "baiduspiDer-dSPace-test.crawl.baIDu.com";
         req.setRemoteHost(candidate);
-        assertFalse(candidate + " matched DNS patterns", spiderDetector.isSpiderAgent(req));
+        assertFalse(candidate + " matched DNS patterns", spiderDetectorService.isSpider(req));
 
 
     }
@@ -342,7 +341,7 @@ public class SpiderDetectorTest extends AbstractDSpaceTest
      */
     @After
     public void cleanup() throws Exception {
-        spiderDetector = null;
+        spiderDetectorService = null;
         configurationService.setProperty("usage-statistics.bots.case-insensitive", false);;
     }
 

--- a/dspace-api/src/test/java/org/dspace/statistics/util/SpiderDetectorTest.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/util/SpiderDetectorTest.java
@@ -10,8 +10,12 @@ package org.dspace.statistics.util;
 import mockit.Mock;
 import mockit.MockUp;
 import org.dspace.AbstractDSpaceTest;
+import org.dspace.servicemanager.config.DSpaceConfigurationService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.statistics.SolrLoggerServiceImpl;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -21,16 +25,33 @@ import java.lang.reflect.Field;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 /**
  * @author mwood
  */
+@RunWith(MockitoJUnitRunner.class)
 public class SpiderDetectorTest extends AbstractDSpaceTest
 {
     private static final String NOT_A_BOT_ADDRESS = "192.168.0.1";
 
+    @org.mockito.Mock
+    private ConfigurationService configurationService;
     /**
      * Test method for {@link org.dspace.statistics.util.SpiderDetector#readPatterns(java.io.File)}.
      */
+
+    private SpiderDetector spiderDetector;
+
+    @Before
+    public void init() {
+        configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+        spiderDetector = new SpiderDetector(configurationService);
+
+    }
+
     @Test
     public void testReadPatterns()
     {
@@ -44,6 +65,45 @@ public class SpiderDetectorTest extends AbstractDSpaceTest
     public void testGetSpiderIpAddresses()
     {
 // FIXME        fail("Not yet implemented");
+    }
+
+    @Test
+    public void testCaseInsensitiveMatching() throws Exception
+    {
+        configurationService.setProperty("usage-statistics.bots.case-insensitive", true);
+        spiderDetector = new SpiderDetector(configurationService);
+
+        DummyHttpServletRequest req = new DummyHttpServletRequest();
+        req.setAddress(NOT_A_BOT_ADDRESS); // avoid surprises
+        req.setRemoteHost("notabot.example.com"); // avoid surprises
+        req.setAgent("Firefox"); // avoid surprises
+
+        String candidate;
+
+        // Test agent patterns
+        req.setAgent("msnboT Is WaTching you");
+        assertTrue("'msnbot' didn't match pattern", spiderDetector.isSpiderAgent(req));
+
+        req.setAgent("FirefOx");
+        assertFalse("'Firefox' matched a pattern", spiderDetector.isSpiderAgent(req));
+
+        // Test IP patterns
+        candidate = "192.168.2.1";
+        req.setAddress(candidate);
+        assertTrue(candidate + " did not match IP patterns", spiderDetector.isSpiderAgent(req));
+
+        req.setAddress(NOT_A_BOT_ADDRESS);
+        assertFalse(NOT_A_BOT_ADDRESS + " matched IP patterns", spiderDetector.isSpiderAgent(req));
+
+        // Test DNS patterns
+        candidate = "baiduspiDer-dSPace-test.crawl.baIDu.com";
+        req.setRemoteHost(candidate);
+        assertTrue(candidate + " did match DNS patterns", spiderDetector.isSpiderAgent(req));
+
+        candidate = "wIki.dsPace.oRg";
+        req.setRemoteHost(candidate);
+        assertFalse(candidate + " matched DNS patterns", spiderDetector.isSpiderAgent(req));
+
     }
 
     /**
@@ -61,27 +121,27 @@ public class SpiderDetectorTest extends AbstractDSpaceTest
 
         // Test agent patterns
         req.setAgent("msnbot is watching you");
-        assertTrue("'msnbot' did not match any pattern", SpiderDetector.isSpider(req));
+        assertTrue("'msnbot' did not match any pattern", spiderDetector.isSpiderAgent(req));
 
         req.setAgent("Firefox");
-        assertFalse("'Firefox' matched a pattern", SpiderDetector.isSpider(req));
+        assertFalse("'Firefox' matched a pattern", spiderDetector.isSpiderAgent(req));
 
         // Test IP patterns
         candidate = "192.168.2.1";
         req.setAddress(candidate);
-        assertTrue(candidate + " did not match IP patterns", SpiderDetector.isSpider(req));
+        assertTrue(candidate + " did not match IP patterns", spiderDetector.isSpiderAgent(req));
 
         req.setAddress(NOT_A_BOT_ADDRESS);
-        assertFalse(NOT_A_BOT_ADDRESS + " matched IP patterns", SpiderDetector.isSpider(req));
+        assertFalse(NOT_A_BOT_ADDRESS + " matched IP patterns", spiderDetector.isSpiderAgent(req));
 
         // Test DNS patterns
         candidate = "baiduspider-dspace-test.crawl.baidu.com";
         req.setRemoteHost(candidate);
-        assertTrue(candidate + " did not match DNS patterns", SpiderDetector.isSpider(req));
+        assertTrue(candidate + " did not match DNS patterns", spiderDetector.isSpiderAgent(req));
 
         candidate = "wiki.dspace.org";
         req.setRemoteHost(candidate);
-        assertFalse(candidate + " matched DNS patterns", SpiderDetector.isSpider(req));
+        assertFalse(candidate + " matched DNS patterns", spiderDetector.isSpiderAgent(req));
     }
 
     /**
@@ -95,29 +155,29 @@ public class SpiderDetectorTest extends AbstractDSpaceTest
         // Test IP patterns
         candidate = "192.168.2.1";
         assertTrue(candidate + " did not match IP patterns",
-                SpiderDetector.isSpider(candidate, null, null, null));
+                spiderDetector.isSpiderAgent(candidate, null, null, null));
 
         candidate = NOT_A_BOT_ADDRESS;
         assertFalse(candidate + " matched IP patterns",
-                SpiderDetector.isSpider(candidate, null, null, null));
+                spiderDetector.isSpiderAgent(candidate, null, null, null));
 
         // Test DNS patterns
         candidate = "baiduspider-dspace-test.crawl.baidu.com";
         assertTrue(candidate + " did not match DNS patterns",
-                SpiderDetector.isSpider(NOT_A_BOT_ADDRESS, null, candidate, null));
+                spiderDetector.isSpiderAgent(NOT_A_BOT_ADDRESS, null, candidate, null));
 
         candidate = "wiki.dspace.org";
         assertFalse(candidate + " matched DNS patterns",
-                SpiderDetector.isSpider(NOT_A_BOT_ADDRESS, null, candidate, null));
+                spiderDetector.isSpiderAgent(NOT_A_BOT_ADDRESS, null, candidate, null));
 
         // Test agent patterns
         candidate = "msnbot is watching you";
         assertTrue("'" + candidate + "' did not match agent patterns",
-                SpiderDetector.isSpider(NOT_A_BOT_ADDRESS, null, null, candidate));
+                spiderDetector.isSpiderAgent(NOT_A_BOT_ADDRESS, null, null, candidate));
 
         candidate = "Firefox";
         assertFalse("'" + candidate + "' matched agent patterns",
-                SpiderDetector.isSpider(NOT_A_BOT_ADDRESS, null, null, candidate));
+                spiderDetector.isSpiderAgent(NOT_A_BOT_ADDRESS, null, null, candidate));
     }
 
     /**
@@ -130,51 +190,15 @@ public class SpiderDetectorTest extends AbstractDSpaceTest
 
         candidate = "192.168.2.1";
         assertTrue(candidate + " did not match IP patterns",
-                SpiderDetector.isSpider(candidate, null, null, null));
+                spiderDetector.isSpiderAgent(candidate, null, null, null));
 
         candidate = NOT_A_BOT_ADDRESS;
         assertFalse(candidate + " matched IP patterns",
-                SpiderDetector.isSpider(candidate, null, null, null));
+                spiderDetector.isSpiderAgent(candidate, null, null, null));
 
     }
 
-    @Test
-    public void testCaseInsensitiveMatching() throws Exception
-    {
-        enableCaseInsensitiveMatching();
 
-        DummyHttpServletRequest req = new DummyHttpServletRequest();
-        req.setAddress(NOT_A_BOT_ADDRESS); // avoid surprises
-        req.setRemoteHost("notabot.example.com"); // avoid surprises
-        req.setAgent("Firefox"); // avoid surprises
-
-        String candidate;
-
-        // Test agent patterns
-        req.setAgent("msnboT Is WaTching you");
-        assertTrue("'msnbot' did not match any pattern", SpiderDetector.isSpider(req));
-
-        req.setAgent("FirefOx");
-        assertFalse("'Firefox' matched a pattern", SpiderDetector.isSpider(req));
-
-        // Test IP patterns
-        candidate = "192.168.2.1";
-        req.setAddress(candidate);
-        assertTrue(candidate + " did not match IP patterns", SpiderDetector.isSpider(req));
-
-        req.setAddress(NOT_A_BOT_ADDRESS);
-        assertFalse(NOT_A_BOT_ADDRESS + " matched IP patterns", SpiderDetector.isSpider(req));
-
-        // Test DNS patterns
-        candidate = "baiduspider-dSPace-test.crawl.BaiDu.com";
-        req.setRemoteHost(candidate);
-        assertTrue(candidate + " did not match DNS patterns", SpiderDetector.isSpider(req));
-
-        candidate = "wIki.dsPace.oRg";
-        req.setRemoteHost(candidate);
-        assertFalse(candidate + " matched DNS patterns", SpiderDetector.isSpider(req));
-
-    }
 
     @Test
     public void testCaseSensitiveMatching() throws Exception
@@ -189,27 +213,27 @@ public class SpiderDetectorTest extends AbstractDSpaceTest
 
         // Test agent patterns
         req.setAgent("msnboT Is WaTching you");
-        assertFalse("'msnbot' matched pattern", SpiderDetector.isSpider(req));
+        assertFalse("'msnbot' matched pattern", spiderDetector.isSpiderAgent(req));
 
         req.setAgent("FirefOx");
-        assertFalse("'Firefox' matched a pattern", SpiderDetector.isSpider(req));
+        assertFalse("'Firefox' matched a pattern", spiderDetector.isSpiderAgent(req));
 
         // Test IP patterns
         candidate = "192.168.2.1";
         req.setAddress(candidate);
-        assertTrue(candidate + " did not match IP patterns", SpiderDetector.isSpider(req));
+        assertTrue(candidate + " did not match IP patterns", spiderDetector.isSpiderAgent(req));
 
         req.setAddress(NOT_A_BOT_ADDRESS);
-        assertFalse(NOT_A_BOT_ADDRESS + " matched IP patterns", SpiderDetector.isSpider(req));
+        assertFalse(NOT_A_BOT_ADDRESS + " matched IP patterns", spiderDetector.isSpiderAgent(req));
 
         // Test DNS patterns
         candidate = "baiduspiDer-dSPace-test.crawl.baIDu.com";
         req.setRemoteHost(candidate);
-        assertFalse(candidate + " did match DNS patterns", SpiderDetector.isSpider(req));
+        assertFalse(candidate + " did match DNS patterns", spiderDetector.isSpiderAgent(req));
 
         candidate = "wIki.dsPace.oRg";
         req.setRemoteHost(candidate);
-        assertFalse(candidate + " matched DNS patterns", SpiderDetector.isSpider(req));
+        assertFalse(candidate + " matched DNS patterns", spiderDetector.isSpiderAgent(req));
 
     }
 
@@ -228,23 +252,29 @@ public class SpiderDetectorTest extends AbstractDSpaceTest
 
         // Test agent patterns
         req.setAgent("msnbot is WaTching you");
-        assertTrue("'msnbot' didn't match pattern", SpiderDetector.isSpider(req));
+        assertTrue("'msnbot' didn't match pattern", spiderDetector.isSpiderAgent(req));
 
         req.setAgent("MSNBOT Is WaTching you");
-        assertFalse("'msnbot' matched pattern", SpiderDetector.isSpider(req));
+        assertFalse("'msnbot' matched pattern", spiderDetector.isSpiderAgent(req));
 
         // Test DNS patterns
         candidate = "baiduspider-dspace-test.crawl.baidu.com";
         req.setRemoteHost(candidate);
-        assertTrue(candidate + " did not match DNS patterns", SpiderDetector.isSpider(req));
+        assertTrue(candidate + " did not match DNS patterns", spiderDetector.isSpiderAgent(req));
 
         candidate = "baiduspiDer-dSPace-test.crawl.baIDu.com";
         req.setRemoteHost(candidate);
-        assertFalse(candidate + " matched DNS patterns", SpiderDetector.isSpider(req));
+        assertFalse(candidate + " matched DNS patterns", spiderDetector.isSpiderAgent(req));
     }
 
+    /**
+     * Test to check if the same agent gets caught with and without upper-casing
+     */
     @Test
     public void testBothLowerAndUpperCaseGetMatched() {
+
+        configurationService.setProperty("usage-statistics.bots.case-insensitive", true);
+        spiderDetector = new SpiderDetector(configurationService);
 
         DummyHttpServletRequest req = new DummyHttpServletRequest();
         req.setAddress(NOT_A_BOT_ADDRESS); // avoid surprises
@@ -255,30 +285,56 @@ public class SpiderDetectorTest extends AbstractDSpaceTest
 
         // Test agent patterns
         req.setAgent("msnbot is WaTching you");
-        assertTrue("'msnbot' didn't match pattern", SpiderDetector.isSpider(req));
+        assertTrue("'msnbot' didn't match pattern", spiderDetector.isSpiderAgent(req));
 
         req.setAgent("MSNBOT Is WaTching you");
-        assertTrue("'msnbot' matched pattern", SpiderDetector.isSpider(req));
+        assertTrue("'msnbot' didn't match pattern", spiderDetector.isSpiderAgent(req));
 
         // Test DNS patterns
         candidate = "baiduspider-dspace-test.crawl.baidu.com";
         req.setRemoteHost(candidate);
-        assertTrue(candidate + " did not match DNS patterns", SpiderDetector.isSpider(req));
+        assertTrue(candidate + " did not match DNS patterns", spiderDetector.isSpiderAgent(req));
 
         candidate = "baiduspiDer-dSPace-test.crawl.baIDu.com";
         req.setRemoteHost(candidate);
-        assertTrue(candidate + " matched DNS patterns", SpiderDetector.isSpider(req));
+        assertTrue(candidate + " didn't match DNS patterns", spiderDetector.isSpiderAgent(req));
     }
 
     /**
-     * Help method to change the configuration to CaseInsensitiveMatching
-     * @throws Exception
+     * Test if wrong value is used for property
      */
-    public void enableCaseInsensitiveMatching() throws Exception {
-        Field useCaseField = SpiderDetector.class.getDeclaredField("useCaseInsensitiveMatching");
-        useCaseField.setAccessible(true);
-        useCaseField.set(Boolean.class, true);
+    @Test
+    public void testNonBooleanConfig() {
+        configurationService.setProperty("usage-statistics.bots.case-insensitive", "RandomNonBooleanString");
+        spiderDetector = new SpiderDetector(configurationService);
+
+        DummyHttpServletRequest req = new DummyHttpServletRequest();
+        req.setAddress(NOT_A_BOT_ADDRESS); // avoid surprises
+        req.setRemoteHost("notabot.example.com"); // avoid surprises
+        req.setAgent("Firefox"); // avoid surprises
+
+        String candidate;
+
+        // Test agent patterns
+        req.setAgent("msnbot is WaTching you");
+        assertTrue("'msnbot' didn't match pattern", spiderDetector.isSpiderAgent(req));
+
+        req.setAgent("MSNBOT Is WaTching you");
+        assertFalse("'msnbot' matched pattern", spiderDetector.isSpiderAgent(req));
+
+        // Test DNS patterns
+        candidate = "baiduspider-dspace-test.crawl.baidu.com";
+        req.setRemoteHost(candidate);
+        assertTrue(candidate + " did not match DNS patterns", spiderDetector.isSpiderAgent(req));
+
+        candidate = "baiduspiDer-dSPace-test.crawl.baIDu.com";
+        req.setRemoteHost(candidate);
+        assertFalse(candidate + " matched DNS patterns", spiderDetector.isSpiderAgent(req));
+
+
     }
+
+
 
     /**
      * Method to make sure the SpiderDetector is using CaseSensitive matching again after each test
@@ -286,9 +342,8 @@ public class SpiderDetectorTest extends AbstractDSpaceTest
      */
     @After
     public void cleanup() throws Exception {
-        Field useCaseField = SpiderDetector.class.getDeclaredField("useCaseInsensitiveMatching");
-        useCaseField.setAccessible(true);
-        useCaseField.set(Boolean.class, false);
+        spiderDetector = null;
+        configurationService.setProperty("usage-statistics.bots.case-insensitive", false);;
     }
 
 

--- a/dspace/config/modules/usage-statistics.cfg
+++ b/dspace/config/modules/usage-statistics.cfg
@@ -35,4 +35,7 @@ usage-statistics.authorization.admin.workflow=true
 # (see query.filter.* for query filter options)
 # Default value is true.
 #usage-statistics.logBots = true
-usage-statistics.bots.case-insensitive=false
+
+# Enable/disable if a matching for a bot should be case sensitive
+# Setting this value to true will increase cpu usage, but bots will be found more accurately
+usage-statistics.bots.case-insensitive=true

--- a/dspace/config/modules/usage-statistics.cfg
+++ b/dspace/config/modules/usage-statistics.cfg
@@ -35,3 +35,4 @@ usage-statistics.authorization.admin.workflow=true
 # (see query.filter.* for query filter options)
 # Default value is true.
 #usage-statistics.logBots = true
+usage-statistics.bots.case-insensitive=false

--- a/dspace/config/modules/usage-statistics.cfg
+++ b/dspace/config/modules/usage-statistics.cfg
@@ -38,4 +38,4 @@ usage-statistics.authorization.admin.workflow=true
 
 # Enable/disable if a matching for a bot should be case sensitive
 # Setting this value to true will increase cpu usage, but bots will be found more accurately
-usage-statistics.bots.case-insensitive=false
+#usage-statistics.bots.case-insensitive = false

--- a/dspace/config/modules/usage-statistics.cfg
+++ b/dspace/config/modules/usage-statistics.cfg
@@ -38,4 +38,4 @@ usage-statistics.authorization.admin.workflow=true
 
 # Enable/disable if a matching for a bot should be case sensitive
 # Setting this value to true will increase cpu usage, but bots will be found more accurately
-usage-statistics.bots.case-insensitive=true
+usage-statistics.bots.case-insensitive=false

--- a/dspace/config/spring/api/core-services.xml
+++ b/dspace/config/spring/api/core-services.xml
@@ -96,6 +96,8 @@
     <bean id="elasticSearchLoggerService" class="org.dspace.statistics.ElasticSearchLoggerServiceImpl" lazy-init="true"/>
     <bean id="solrLoggerService" class="org.dspace.statistics.SolrLoggerServiceImpl" lazy-init="true"/>
 
+    <bean id="spiderDetectorService" class="org.dspace.statistics.util.SpiderDetectorServiceImpl"/>
+
     <bean class="org.dspace.versioning.VersionHistoryServiceImpl"/>
 
     <!--Basic workflow services, comment or remove when switching to the configurable workflow -->


### PR DESCRIPTION
Made case-insensitive matching for user-agents configurable to solve performance issues with large repositories. Also changed Pattern.CASE_INSENSITIVE to "toLowerCase()" because this gave an increase in performance.

Fix for jira issue: DS-3558

Also note that because of this PR, these configs are also now reloadable. (comment added at the suggestion of Tim Donohue)