### PR TITLE
DS-3568. UTF-8 characters are now supported in configuration files

### DIFF
--- a/dspace/config/config-definition.xml
+++ b/dspace/config/config-definition.xml
@@ -31,14 +31,14 @@
 
         <!-- Allow user to override any configs in a local.cfg -->
         <!-- Any properties in this config will override defaults in dspace.cfg (or any included *.cfg file) -->
-        <properties fileName="local.cfg" throwExceptionOnMissing="false" config-name="local" config-optional="true">
+        <properties fileName="local.cfg" throwExceptionOnMissing="false" config-name="local" config-optional="true" encoding="UTF-8">
             <!-- Reload this file if it has changed, and at least 5 seconds (5,000 ms) have passed -->
             <reloadingStrategy refreshDelay="5000"
                 config-class="org.apache.commons.configuration.reloading.FileChangedReloadingStrategy"/>
         </properties>
 
         <!-- Load our dspace.cfg (which in turn loads all module configs via "include=" statements) -->
-        <properties fileName="dspace.cfg" throwExceptionOnMissing="true">
+        <properties fileName="dspace.cfg" throwExceptionOnMissing="true" encoding="UTF-8">
             <!-- Reload this file if it has changed, and at least 5 seconds (5,000 ms) have passed -->
             <reloadingStrategy refreshDelay="5000"
                 config-class="org.apache.commons.configuration.reloading.FileChangedReloadingStrategy"/>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3568

To reproduce the error add a UTF-8 character to dspace.cfg and look at the result before and after the patch.

1. Change configuration like this: `dspace.name = DSpace at My Univörsity`
2. View the outcome at http://YOUR_TEST_INSTALLATION/oai/driver?verb=Identify

This sets the encoding for the configuration files dspace.cfg and local.cfg to UTF-8.
This works on all included configuration files to.