### PR TITLE
DS-3516 ImageMagick PDF Thumbnail class should only process PDFs

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickPdfThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickPdfThumbnailFilter.java
@@ -43,10 +43,4 @@ public class ImageMagickPdfThumbnailFilter extends ImageMagickThumbnailFilter {
 	    }
     }
 
-   public static final String[] PDF = {"Adobe PDF"};
-   public String[] getInputMIMETypes()
-  {
-      return PDF;
-  }
-
 }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
@@ -34,7 +34,7 @@ import org.dspace.core.ConfigurationManager;
  * thumbnail.maxwidth, thumbnail.maxheight, the size we want our thumbnail to be
  * no bigger than. Creates only JPEGs.
  */
-public abstract class ImageMagickThumbnailFilter extends MediaFilter implements SelfRegisterInputFormats
+public abstract class ImageMagickThumbnailFilter extends MediaFilter
 {
 	private static int width = 180;
 	private static int height = 120;
@@ -183,18 +183,4 @@ public abstract class ImageMagickThumbnailFilter extends MediaFilter implements 
         return true; //assume that the thumbnail is a custom one
     }
 
-     public String[] getInputMIMETypes()
-    {
-        return ImageIO.getReaderMIMETypes();
-    }
-
-    public String[] getInputDescriptions()
-    {
-        return null;
-    }
-
-    public String[] getInputExtensions()
-    {
-        return ImageIO.getReaderFileSuffixes();
-    }
 }


### PR DESCRIPTION
Input formats for ImageMagick mediafilter plugins should be defined in dspace.cfg. Currently they implement `SelfRegisteredInputFormats`, which causes the PDF filter to attempt to process other formats such as JPEGs that might be in the `ORIGINAL` bitstream bundle.