### PR TITLE
DS-2359 Error when depositing large files via browser (over 2Gb)

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowBatchImportUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowBatchImportUtils.java
@@ -7,23 +7,21 @@
  */
 package org.dspace.app.xmlui.aspect.administrative;
 
-import org.apache.cocoon.environment.Request;
-import org.apache.cocoon.servlet.multipart.Part;
-import org.apache.cocoon.servlet.multipart.PartOnDisk;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
-import org.dspace.app.itemimport.ItemImport;
-import org.dspace.app.xmlui.wing.Message;
-import org.dspace.authorize.AuthorizeException;
-import org.dspace.content.Collection;
+import java.io.*;
+import java.sql.*;
+import org.apache.cocoon.environment.*;
+import org.apache.cocoon.servlet.multipart.*;
+import org.apache.commons.io.*;
+import org.apache.commons.lang.*;
+import org.apache.log4j.*;
+import org.dspace.app.itemimport.*;
+import org.dspace.app.xmlui.cocoon.servlet.multipart.*;
+import org.dspace.app.xmlui.wing.*;
+import org.dspace.authorize.*;
+import org.dspace.content.*;
 import org.dspace.core.Context;
 import org.dspace.core.LogManager;
-import org.dspace.handle.HandleManager;
-
-import java.io.File;
-import java.io.IOException;
-import java.sql.SQLException;
+import org.dspace.handle.*;
 
 /**
  * Utility methods to processes BatchImport actions. These methods are used
@@ -90,7 +88,7 @@ public class FlowBatchImportUtils {
 
             if (object instanceof Part) {
                 filePart = (Part) object;
-                file = ((PartOnDisk) filePart).getFile();
+                file = ((DSpacePartOnDisk) filePart).getFile();
             }
 
             if (filePart != null && filePart.getSize() > 0) {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowMetadataImportUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowMetadataImportUtils.java
@@ -7,24 +7,18 @@
  */
 package org.dspace.app.xmlui.aspect.administrative;
 
-import java.io.IOException;
-import java.sql.SQLException;
-import java.io.File;
-import java.util.List;
-
-import org.apache.log4j.Logger;
-import org.apache.cocoon.environment.Request;
-import org.apache.cocoon.servlet.multipart.Part;
-import org.apache.cocoon.servlet.multipart.PartOnDisk;
-import org.dspace.app.bulkedit.BulkEditChange;
-import org.dspace.app.bulkedit.DSpaceCSV;
-import org.dspace.app.bulkedit.MetadataImport;
-import org.dspace.app.bulkedit.MetadataImportException;
-import org.dspace.app.bulkedit.MetadataImportInvalidHeadingException;
-import org.dspace.app.xmlui.wing.Message;
-import org.dspace.authorize.AuthorizeException;
+import java.io.*;
+import java.sql.*;
+import java.util.*;
+import org.apache.cocoon.environment.*;
+import org.apache.cocoon.servlet.multipart.*;
+import org.apache.log4j.*;
+import org.dspace.app.bulkedit.*;
+import org.dspace.app.xmlui.cocoon.servlet.multipart.*;
+import org.dspace.app.xmlui.wing.*;
+import org.dspace.authorize.*;
+import org.dspace.core.*;
 import org.dspace.core.Context;
-import org.dspace.core.ConfigurationManager;
 import org.dspace.core.LogManager;
 
 /**
@@ -121,7 +115,7 @@ public class FlowMetadataImportUtils
             if (object instanceof Part)
             {
                     filePart = (Part) object;
-                    file = ((PartOnDisk)filePart).getFile();
+                    file = ((DSpacePartOnDisk)filePart).getFile();
             }
 
             if (filePart != null && filePart.getSize() > 0)

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/servlet/multipart/DSpaceMultipartParser.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/servlet/multipart/DSpaceMultipartParser.java
@@ -318,7 +318,7 @@ public class DSpaceMultipartParser {
             byte[] bytes = ((ByteArrayOutputStream) out).toByteArray();
             this.parts.put(name, new PartInMemory(headers, bytes));
         } else {
-            this.parts.put(name, new PartOnDisk(headers, file));
+            this.parts.put(name, new DSpacePartOnDisk(headers, file));
         }
     }
 

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/servlet/multipart/DSpacePartOnDisk.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/servlet/multipart/DSpacePartOnDisk.java
@@ -1,0 +1,99 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.xmlui.cocoon.servlet.multipart;
+
+import java.io.*;
+import java.util.*;
+import org.apache.cocoon.servlet.multipart.*;
+
+/**
+ * This class represents a file part parsed from a http post stream.
+ *
+ * @version $Id: PartOnDisk.java 587750 2007-10-24 02:35:22Z vgritsenko $
+ */
+public class DSpacePartOnDisk extends Part {
+
+    /** Field file */
+    private File file = null;
+    private int size;
+
+    /**
+     * Constructor PartOnDisk
+     *
+     * @param headers
+     * @param file
+     */
+    public DSpacePartOnDisk(Map headers, File file) {
+        super(headers);
+        this.file = file;
+
+        // Ensure the file will be deleted when we exit the JVM
+        this.file.deleteOnExit();
+
+        this.size = file.length()>new Long(Integer.MAX_VALUE)?Integer.MAX_VALUE:((int) file.length());
+    }
+
+    /**
+     * Returns the file name
+     */
+    public String getFileName() {
+        return file.getName();
+    }
+
+    /**
+     * Returns the file size in bytes
+     */
+    public int getSize() {
+        return this.size;
+    }
+
+    /**
+     * Returns the file
+     */
+    public File getFile() {
+        return file;
+    }
+
+    /**
+     * Returns a (ByteArray)InputStream containing the file data
+     *
+     * @throws IOException
+     */
+    public InputStream getInputStream() throws IOException {
+        if (this.file != null) {
+            return new FileInputStream(file);
+        }
+        throw new IllegalStateException("This part has already been disposed.");
+    }
+
+    /**
+     * Returns the filename
+     */
+    public String toString() {
+        return file.getPath();
+    }
+
+    /**
+     * Delete the underlying file.
+     */
+    public void dispose() {
+        if (this.file != null) {
+            this.file.delete();
+            this.file = null;
+        }
+    }
+
+    /**
+     * Ensures the underlying file has been deleted
+     */
+    public void finalize() throws Throwable {
+        // Ensure the file has been deleted
+        dispose();
+        super.finalize();
+    }
+}


### PR DESCRIPTION
Implemented the change proposed by Bram in jira ticket:
https://jira.duraspace.org/browse/DS-2359

I created a new DSpacePartOnDisk class based on the cocoon PartOnDisk class. This class contains the fix to replace the nast that was causing problems with file uploads that are larger than 2GB.
Update classes that used the PartOnDisk class to use the DSpacePartOnDisk class instead.
