### PR TITLE
[DS-3564] Limit maximum idle database connections by default (port from dspace-6_x)

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -96,8 +96,8 @@ db.maxconnections = 30
 db.maxwait = 5000
 
 # Maximum number of idle connections in pool (-1 = unlimited)
-# (default = -1, unlimited)
-db.maxidle = -1
+# (default = 10)
+db.maxidle = 10
 
 # Specify a configured database connection pool to be fetched from a
 # directory.  This overrides the pool and driver settings above.  If

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -103,8 +103,8 @@ db.schema = public
 #db.maxwait = 5000
 
 # Maximum number of idle connections in pool (-1 = unlimited)
-# (default = -1, unlimited)
-#db.maxidle = -1
+# (default = 10)
+#db.maxidle = 10
 
 
 #######################


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3564

If there are "too many" idle database connections, have the pool close some. By default keep no more than 10.