### PR TITLE
DS-3544 add support to search methods for repositories

### DIFF
--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -7,7 +7,6 @@
  */
 package org.dspace.app.rest;
 
-import static org.springframework.data.rest.webmvc.ControllerUtils.EMPTY_RESOURCE_LIST;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
@@ -17,10 +16,10 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.Map.Entry;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.atteo.evo.inflector.English;
 import org.dspace.app.rest.exception.PaginationException;
@@ -28,51 +27,26 @@ import org.dspace.app.rest.exception.RepositoryNotFoundException;
 import org.dspace.app.rest.exception.RepositorySearchMethodNotFoundException;
 import org.dspace.app.rest.exception.RepositorySearchNotFoundException;
 import org.dspace.app.rest.model.LinkRest;
-import org.dspace.app.rest.model.LinksRest;
 import org.dspace.app.rest.model.RestModel;
 import org.dspace.app.rest.model.hateoas.DSpaceResource;
 import org.dspace.app.rest.model.hateoas.EmbeddedPage;
 import org.dspace.app.rest.repository.DSpaceRestRepository;
 import org.dspace.app.rest.repository.LinkRestRepository;
+import org.dspace.app.rest.utils.RestRepositoryUtils;
 import org.dspace.app.rest.utils.Utils;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.core.MethodParameter;
-import org.springframework.core.convert.ConversionException;
-import org.springframework.core.convert.ConversionService;
-import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.repository.query.Param;
-import org.springframework.data.repository.support.QueryMethodParameterConversionException;
-import org.springframework.data.repository.support.RepositoryInvoker;
-import org.springframework.data.rest.core.mapping.ResourceMetadata;
-import org.springframework.data.rest.webmvc.PersistentEntityResourceAssembler;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
-import org.springframework.data.rest.webmvc.RootResourceInformation;
-import org.springframework.data.rest.webmvc.support.DefaultedPageable;
-import org.springframework.data.util.ClassTypeInformation;
-import org.springframework.data.util.TypeInformation;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.PagedResources;
-import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.ResourceSupport;
-import org.springframework.hateoas.Resources;
-import org.springframework.hateoas.core.AnnotationAttribute;
-import org.springframework.hateoas.core.MethodParameters;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
-import org.springframework.util.Assert;
-import org.springframework.util.ClassUtils;
-import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.util.ReflectionUtils;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -91,17 +65,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/{apiCategory}/{model}")
 @SuppressWarnings("rawtypes")
 public class RestResourceController implements InitializingBean {
-	private static final AnnotationAttribute PARAM_ANNOTATION = new AnnotationAttribute(Param.class);
-	private static final String NAME_NOT_FOUND = "Unable to detect parameter names for query method %s! Use @Param or compile with -parameters on JDK 8.";
-	@Autowired(required=true)
-	@Qualifier(value="mvcConversionService")
-	private ConversionService conversionService;
-	
 	@Autowired
 	DiscoverableEndpointsService discoverableEndpointsService;
 
 	@Autowired
 	Utils utils;
+
+	@Autowired
+	RestRepositoryUtils repositoryUtils;
 
 	@Override
 	public void afterPropertiesSet() {
@@ -118,7 +89,7 @@ public class RestResourceController implements InitializingBean {
 		}
 		discoverableEndpointsService.register(this, links);
 	}
-	
+
 	@RequestMapping(method = RequestMethod.GET, value = "/{id:\\d+}")
 	@SuppressWarnings("unchecked")
 	public DSpaceResource<RestModel> findOne(@PathVariable String apiCategory, @PathVariable String model,
@@ -157,63 +128,62 @@ public class RestResourceController implements InitializingBean {
 	}
 
 	@RequestMapping(method = RequestMethod.GET, value = "/{id:\\d+}/{rel}")
-	public ResourceSupport findRel(HttpServletRequest request, @PathVariable String apiCategory, @PathVariable String model, @PathVariable Integer id,
-			@PathVariable String rel, Pageable page, PagedResourcesAssembler assembler,
-			@RequestParam(required = false) String projection) {
+	public ResourceSupport findRel(HttpServletRequest request, @PathVariable String apiCategory,
+			@PathVariable String model, @PathVariable Integer id, @PathVariable String rel, Pageable page,
+			PagedResourcesAssembler assembler, @RequestParam(required = false) String projection) {
 		return findRelInternal(request, apiCategory, model, id, rel, page, assembler, projection);
 	}
-	
+
 	@RequestMapping(method = RequestMethod.GET, value = "/{id:[A-z0-9]+}/{rel}")
-	public ResourceSupport findRel(HttpServletRequest request,  @PathVariable String apiCategory, @PathVariable String model, @PathVariable String id,
-			@PathVariable String rel, Pageable page, PagedResourcesAssembler assembler,
-			@RequestParam(required = false) String projection) {
+	public ResourceSupport findRel(HttpServletRequest request, @PathVariable String apiCategory,
+			@PathVariable String model, @PathVariable String id, @PathVariable String rel, Pageable page,
+			PagedResourcesAssembler assembler, @RequestParam(required = false) String projection) {
 		return findRelInternal(request, apiCategory, model, id, rel, page, assembler, projection);
 	}
 
 	@RequestMapping(method = RequestMethod.GET, value = "/{uuid:[0-9a-fxA-FX]{8}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{12}}/{rel}")
-	public ResourceSupport findRel(HttpServletRequest request, @PathVariable String apiCategory, @PathVariable String model, @PathVariable UUID uuid,
-			@PathVariable String rel, Pageable page, PagedResourcesAssembler assembler,
-			@RequestParam(required = false) String projection) {
+	public ResourceSupport findRel(HttpServletRequest request, @PathVariable String apiCategory,
+			@PathVariable String model, @PathVariable UUID uuid, @PathVariable String rel, Pageable page,
+			PagedResourcesAssembler assembler, @RequestParam(required = false) String projection) {
 		return findRelInternal(request, apiCategory, model, uuid, rel, page, assembler, projection);
 	}
 
-	private <ID extends Serializable> ResourceSupport findRelInternal(HttpServletRequest request, String apiCategory, String model, ID uuid,
-			String rel, Pageable page, PagedResourcesAssembler assembler, String projection) {
+	private <ID extends Serializable> ResourceSupport findRelInternal(HttpServletRequest request, String apiCategory,
+			String model, ID uuid, String rel, Pageable page, PagedResourcesAssembler assembler, String projection) {
 		checkModelPluralForm(apiCategory, model);
 		DSpaceRestRepository<RestModel, ID> repository = utils.getResourceRepository(apiCategory, model);
+		Class<RestModel> domainClass = repository.getDomainClass();
 		
-		LinksRest linksAnnotation = repository.getDomainClass().getDeclaredAnnotation(LinksRest.class);
-		if (linksAnnotation != null) {
-			LinkRest[] links = linksAnnotation.links();
-			for (LinkRest l : links) {
-				if (StringUtils.equals(rel, l.name())) {
-					LinkRestRepository linkRepository = utils.getLinkResourceRepository(apiCategory, model, rel);
-					Method[] methods = linkRepository.getClass().getMethods();
-					for (Method m : methods) { 
-						if (StringUtils.equals(m.getName(), l.method())) {
-							try {
-								Page<? extends Serializable> pageResult = (Page<? extends RestModel>) m.invoke(linkRepository, request, uuid, page, projection);
-								Link link = linkTo(this.getClass(), apiCategory, English.plural(model)).slash(uuid).slash(rel).withSelfRel();
-								PagedResources<? extends ResourceSupport> result = assembler.toResource(pageResult.map(linkRepository::wrapResource), link);
-								return result;
-							} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-								throw new RuntimeException(e.getMessage(), e);
-							}
-						}
-					}
-					// TODO custom exception
-					throw new RuntimeException("Method for relation " + rel + " not found: " + l.name());
+		LinkRest linkRest = utils.getLinkRest(rel, domainClass);
+
+		if (linkRest != null) {
+			LinkRestRepository linkRepository = utils.getLinkResourceRepository(apiCategory, model, linkRest.name());
+			Method linkMethod = repositoryUtils.getLinkMethod(linkRest.method(), linkRepository);
+			
+			if (linkMethod == null) {
+				// TODO custom exception
+				throw new RuntimeException("Method for relation " + rel + " not found: " + linkRest.name());
+			}
+			else {
+				try {
+					Page<? extends Serializable> pageResult = (Page<? extends RestModel>) linkMethod
+							.invoke(linkRepository, request, uuid, page, projection);
+					Link link = linkTo(this.getClass(), apiCategory, English.plural(model)).slash(uuid)
+							.slash(rel).withSelfRel();
+					PagedResources<? extends ResourceSupport> result = assembler
+							.toResource(pageResult.map(linkRepository::wrapResource), link);
+					return result;
+				} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+					throw new RuntimeException(e.getMessage(), e);
 				}
 			}
 		}
-		
 		RestModel modelObject = repository.findOne(uuid);
 		DSpaceResource result = repository.wrapResource(modelObject, rel);
 		if (result.getLink(rel) == null) {
-			//TODO create a custom exception
-			throw new ResourceNotFoundException(rel + "undefined for "+ model);
-		}
-		else if (result.getEmbedded().get(rel) instanceof EmbeddedPage){
+			// TODO create a custom exception
+			throw new ResourceNotFoundException(rel + "undefined for " + model);
+		} else if (result.getEmbedded().get(rel) instanceof EmbeddedPage) {
 			// this is a very inefficient scenario. We have an embedded list
 			// already fully retrieved that we need to limit with pagination
 			// parameter. BTW change the default sorting is not implemented at
@@ -222,14 +192,15 @@ public class RestResourceController implements InitializingBean {
 			// link repository so to fall in the previous block code
 			EmbeddedPage ep = (EmbeddedPage) result.getEmbedded().get(rel);
 			List<? extends RestModel> fullList = ep.getFullList();
-			if (fullList == null || fullList.size() == 0) return null;
+			if (fullList == null || fullList.size() == 0)
+				return null;
 			int start = page.getOffset();
 			int end = (start + page.getPageSize()) > fullList.size() ? fullList.size() : (start + page.getPageSize());
-			DSpaceRestRepository<RestModel, ?> resourceRepository = utils.getResourceRepository(fullList.get(0).getCategory(), fullList.get(0).getType());
+			DSpaceRestRepository<RestModel, ?> resourceRepository = utils
+					.getResourceRepository(fullList.get(0).getCategory(), fullList.get(0).getType());
 			PageImpl<RestModel> pageResult = new PageImpl(fullList.subList(start, end), page, fullList.size());
-			return assembler.toResource(pageResult	.map(resourceRepository::wrapResource));
-		}
-		else {
+			return assembler.toResource(pageResult.map(resourceRepository::wrapResource));
+		} else {
 			ResourceSupport resu = (ResourceSupport) result.getEmbedded().get(rel);
 			return resu;
 		}
@@ -241,7 +212,8 @@ public class RestResourceController implements InitializingBean {
 			@PathVariable String model, Pageable page, PagedResourcesAssembler assembler,
 			@RequestParam(required = false) String projection) {
 		DSpaceRestRepository<T, ?> repository = utils.getResourceRepository(apiCategory, model);
-		Link link = linkTo(methodOn(this.getClass(), apiCategory, English.plural(model)).findAll(apiCategory, model, page, assembler, projection)).withSelfRel();
+		Link link = linkTo(methodOn(this.getClass(), apiCategory, English.plural(model)).findAll(apiCategory, model,
+				page, assembler, projection)).withSelfRel();
 
 		Page<DSpaceResource<T>> resources;
 		try {
@@ -250,15 +222,16 @@ public class RestResourceController implements InitializingBean {
 			resources = new PageImpl<DSpaceResource<T>>(new ArrayList<DSpaceResource<T>>(), page, pe.getTotal());
 		}
 		PagedResources<DSpaceResource<T>> result = assembler.toResource(resources, link);
-		if (haveSearchMethods(repository)) {
+		if (repositoryUtils.haveSearchMethods(repository)) {
 			result.add(linkTo(this.getClass(), apiCategory, model).slash("search").withRel("search"));
 		}
 		return result;
 	}
 
 	/**
-	 * Check that the model is specified in its plural form, otherwise throw a RepositoryNotFound exception
-	 *  
+	 * Check that the model is specified in its plural form, otherwise throw a
+	 * RepositoryNotFound exception
+	 * 
 	 * @param model
 	 */
 	private void checkModelPluralForm(String apiCategory, String model) {
@@ -266,190 +239,58 @@ public class RestResourceController implements InitializingBean {
 			throw new RepositoryNotFoundException(apiCategory, model);
 		}
 	}
-	
-	@RequestMapping(method = RequestMethod.GET, value="/search")
-	ResourceSupport listSearchMethods(@PathVariable String apiCategory, @PathVariable String model) {
+
+	@RequestMapping(method = RequestMethod.GET, value = "/search")
+	public ResourceSupport listSearchMethods(@PathVariable String apiCategory, @PathVariable String model) {
 		ResourceSupport root = new ResourceSupport();
 		DSpaceRestRepository repository = utils.getResourceRepository(apiCategory, model);
-		boolean searchEnabled = false;
-		for (Method method : repository.getClass().getMethods()) {
-			SearchRestMethod ann = method.getAnnotation(SearchRestMethod.class);
-			if (ann != null) {
-				String name = ann.name();
-				if (name.isEmpty()) {
-					name = method.getName();
-				}
-				Link link = linkTo(this.getClass(), apiCategory, model).slash("search").slash(name).withRel(name);
-				root.add(link);
-				searchEnabled = true;
-			}
-		}
-		if (!searchEnabled) {
+
+		List<String> searchMethods = repositoryUtils.listSearchMethods(repository);
+
+		if (CollectionUtils.isEmpty(searchMethods)) {
 			throw new RepositorySearchNotFoundException(model);
+		}
+
+		for (String name : searchMethods) {
+			Link link = linkTo(this.getClass(), apiCategory, model).slash("search").slash(name).withRel(name);
+			root.add(link);
 		}
 		return root;
 	}
-	
-	
-	@RequestMapping(method = RequestMethod.GET, value="/search/{searchMethod}")
+
+	@RequestMapping(method = RequestMethod.GET, value = "/search/{searchMethodName}")
 	@SuppressWarnings("unchecked")
-	<T extends RestModel> ResourceSupport executeSearchMethods(@PathVariable String apiCategory, 
-			@PathVariable String model, @PathVariable String searchMethod, Pageable pageable, Sort sort, PagedResourcesAssembler assembler, 
-			@RequestParam MultiValueMap<String, Object> parameters) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-			
-		Link link = linkTo(this.getClass(), apiCategory, model).slash("search").slash(searchMethod).withSelfRel();
+	public <T extends RestModel> ResourceSupport executeSearchMethods(@PathVariable String apiCategory,
+			@PathVariable String model, @PathVariable String searchMethodName, Pageable pageable, Sort sort,
+			PagedResourcesAssembler assembler, @RequestParam MultiValueMap<String, Object> parameters)
+			throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+
+		Link link = linkTo(this.getClass(), apiCategory, model).slash("search").slash(searchMethodName).withSelfRel();
 		DSpaceRestRepository repository = utils.getResourceRepository(apiCategory, model);
-		Object searchResult = null;
-		boolean searchEnabled = false;
-		boolean searchMethodFound = false;
 		boolean returnPage = false;
-		for (Method method : repository.getClass().getMethods()) {
-			SearchRestMethod ann = method.getAnnotation(SearchRestMethod.class);
-			if (ann != null) {
-				searchEnabled = true;
-				String name = ann.name();
-				if (name.isEmpty()) {
-					name = method.getName();
-				}
-				if (StringUtils.equals(name, searchMethod)) {
-					returnPage = method.getReturnType().isAssignableFrom(List.class);
-					searchMethodFound = true;
-					searchResult = executeQueryMethod(repository, parameters, method, pageable, sort, assembler);
-					break;
-				}
+		Object searchResult = null;
+		
+		Method searchMethod = repositoryUtils.getSearchMethod(searchMethodName, repository);
+		
+		if (searchMethod == null) {
+			if (repositoryUtils.haveSearchMethods(repository)) {
+				throw new RepositorySearchMethodNotFoundException(model, searchMethodName);	
+			}
+			else {
+				throw new RepositorySearchNotFoundException(model);	
 			}
 		}
-		if (!searchMethodFound && searchEnabled) {
-			throw new RepositorySearchMethodNotFoundException(model, searchMethod);
-		}
-		if (!searchEnabled) {
-			throw new RepositorySearchNotFoundException(model);
-		}
 		
+		searchResult = repositoryUtils.executeQueryMethod(repository, parameters, searchMethod, pageable, sort, assembler);
+		
+		returnPage = searchMethod.getReturnType().isAssignableFrom(List.class);
 		ResourceSupport result = null;
 		if (returnPage) {
 			Page<DSpaceResource<T>> resources = ((Page<T>) searchResult).map(repository::wrapResource);
 			result = assembler.toResource(resources, link);
-		}
-		else {
+		} else {
 			result = repository.wrapResource((T) searchResult);
 		}
 		return result;
 	}
-	
-	private boolean haveSearchMethods(DSpaceRestRepository repository) {
-		for (Method method : repository.getClass().getMethods()) {
-			SearchRestMethod ann = method.getAnnotation(SearchRestMethod.class);
-			if (ann != null) {
-				return true;
-			}
-		}
-		return false;
-	}
-	
-	/*
-	 * Adapted from org.springframework.data.rest.webmvc.RepositorySearchController.executeQueryMethod(RepositoryInvoker, MultiValueMap<String, Object>, Method, DefaultedPageable, Sort, PersistentEntityResourceAssembler)
-	 */
-	private Object executeQueryMethod(DSpaceRestRepository repository,
-			MultiValueMap<String, Object> parameters, Method method, Pageable pageable, Sort sort,
-			PagedResourcesAssembler assembler) {
-
-		MultiValueMap<String, Object> result = new LinkedMultiValueMap<String, Object>(parameters);
-		MethodParameters methodParameters = new MethodParameters(method, new AnnotationAttribute(Param.class));
-
-		for (Entry<String, List<Object>> entry : parameters.entrySet()) {
-
-			MethodParameter parameter = methodParameters.getParameter(entry.getKey());
-
-			if (parameter == null) {
-				continue;
-			}
-
-			result.put(parameter.getParameterName(), entry.getValue());
-		}
-
-		return invokeQueryMethod(repository, method, result, pageable, sort);
-	}
-	
-	/*
-	 * Adapted from org.springframework.data.repository.support.ReflectionRepositoryInvoker.invokeQueryMethod(Method, MultiValueMap<String, ? extends Object>, Pageable, Sort)
-	 */
-	public Object invokeQueryMethod(DSpaceRestRepository repository, Method method, MultiValueMap<String, ? extends Object> parameters, Pageable pageable,
-			Sort sort) {
-
-		Assert.notNull(method, "Method must not be null!");
-		Assert.notNull(parameters, "Parameters must not be null!");
-
-		ReflectionUtils.makeAccessible(method);
-
-		return ReflectionUtils.invokeMethod(method, repository, prepareParameters(method, parameters, pageable, sort));
-	}
-
-	/*
-	 * Taken from org.springframework.data.repository.support.ReflectionRepositoryInvoker.prepareParameters(Method, MultiValueMap<String, ? extends Object>, Pageable, Sort)
-	 */
-	private Object[] prepareParameters(Method method, MultiValueMap<String, ? extends Object> rawParameters,
-			Pageable pageable, Sort sort) {
-
-		List<MethodParameter> parameters = new MethodParameters(method, PARAM_ANNOTATION).getParameters();
-
-		if (parameters.isEmpty()) {
-			return new Object[0];
-		}
-
-		Object[] result = new Object[parameters.size()];
-		Sort sortToUse = pageable == null ? sort : pageable.getSort();
-
-		for (int i = 0; i < result.length; i++) {
-
-			MethodParameter param = parameters.get(i);
-			Class<?> targetType = param.getParameterType();
-
-			if (Pageable.class.isAssignableFrom(targetType)) {
-				result[i] = pageable;
-			} else if (Sort.class.isAssignableFrom(targetType)) {
-				result[i] = sortToUse;
-			} else {
-
-				String parameterName = param.getParameterName();
-
-				if (!StringUtils.isNotBlank(parameterName)) {
-					throw new IllegalArgumentException(String.format(NAME_NOT_FOUND, ClassUtils.getQualifiedMethodName(method)));
-				}
-
-				Object value = unwrapSingleElement(rawParameters.get(parameterName));
-
-				result[i] = targetType.isInstance(value) ? value : convert(value, param);
-			}
-		}
-
-		return result;
-	}
-	
-	/**
-	 * Unwraps the first item if the given source has exactly one element. Taken from
-	 * org.springframework.data.repository.support.ReflectionRepositoryInvoker.unwrapSingleElement(List<? extends Object>)
-	 * 
-	 * @param source can be {@literal null}.
-	 * @return
-	 */
-	private static Object unwrapSingleElement(List<? extends Object> source) {
-		return source == null ? null : source.size() == 1 ? source.get(0) : source;
-	}
-	
-	/**
-	 * Taken from org.springframework.data.repository.support.ReflectionRepositoryInvoker.convert(Object, MethodParameter)
-	 * @param value
-	 * @param parameter
-	 * @return
-	 */
-	private Object convert(Object value, MethodParameter parameter) {
-
-		try {
-			return conversionService.convert(value, TypeDescriptor.forObject(value), new TypeDescriptor(parameter));
-		} catch (ConversionException o_O) {
-			throw new QueryMethodParameterConversionException(value, parameter, o_O);
-		}
-	}
-	
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -250,7 +250,9 @@ public class RestResourceController implements InitializingBean {
 			resources = new PageImpl<DSpaceResource<T>>(new ArrayList<DSpaceResource<T>>(), page, pe.getTotal());
 		}
 		PagedResources<DSpaceResource<T>> result = assembler.toResource(resources, link);
-		result.add(linkTo(this.getClass(), apiCategory, model).slash("search").withRel("search"));
+		if (haveSearchMethods(repository)) {
+			result.add(linkTo(this.getClass(), apiCategory, model).slash("search").withRel("search"));
+		}
 		return result;
 	}
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -283,7 +283,7 @@ public class RestResourceController implements InitializingBean {
 		
 		searchResult = repositoryUtils.executeQueryMethod(repository, parameters, searchMethod, pageable, sort, assembler);
 		
-		returnPage = searchMethod.getReturnType().isAssignableFrom(List.class);
+		returnPage = searchMethod.getReturnType().isAssignableFrom(Page.class);
 		ResourceSupport result = null;
 		if (returnPage) {
 			Page<DSpaceResource<T>> resources = ((Page<T>) searchResult).map(repository::wrapResource);

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/SearchRestMethod.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/SearchRestMethod.java
@@ -1,0 +1,19 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD) 
+public @interface SearchRestMethod {
+	String name() default "";
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/RepositorySearchMethodNotFoundException.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/RepositorySearchMethodNotFoundException.java
@@ -1,0 +1,29 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * This is the exception to capture details about call to a search methods not
+ * exposed by the repository
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+@ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "This repository doesn't provide the requested search method")
+public class RepositorySearchMethodNotFoundException extends RuntimeException {
+	String model;
+	String method;
+	public RepositorySearchMethodNotFoundException(String model, String method) {
+		this.model = model;
+		this.method = method;
+	}
+
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/RepositorySearchNotFoundException.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/RepositorySearchNotFoundException.java
@@ -1,0 +1,28 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * This is the exception to capture details about call to search endpoint over
+ * not search enabled repositories
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+@ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "This repository doesn't provide search options")
+public class RepositorySearchNotFoundException extends RuntimeException {
+	String model;
+
+	public RepositorySearchNotFoundException(String model) {
+		this.model = model;
+	}
+
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.converter.CommunityConverter;
 import org.dspace.app.rest.model.CommunityRest;
 import org.dspace.app.rest.model.hateoas.CommunityResource;
@@ -37,8 +38,7 @@ public class CommunityRestRepository extends DSpaceRestRepository<CommunityRest,
 	CommunityService cs = ContentServiceFactory.getInstance().getCommunityService();
 	@Autowired
 	CommunityConverter converter;
-	
-	
+
 	public CommunityRestRepository() {
 		System.out.println("Repository initialized by Spring");
 	}
@@ -65,7 +65,7 @@ public class CommunityRestRepository extends DSpaceRestRepository<CommunityRest,
 		try {
 			total = cs.countTotal(context);
 			it = cs.findAll(context, pageable.getPageSize(), pageable.getOffset());
-			for (Community c: it) {
+			for (Community c : it) {
 				communities.add(c);
 			}
 		} catch (SQLException e) {
@@ -74,12 +74,31 @@ public class CommunityRestRepository extends DSpaceRestRepository<CommunityRest,
 		Page<CommunityRest> page = new PageImpl<Community>(communities, pageable, total).map(converter);
 		return page;
 	}
-	
+
+	// TODO: Add methods in dspace api to support pagination of top level
+	// communities
+	@SearchRestMethod(name="top")
+	public Page<CommunityRest> findAllTop(Pageable pageable) {
+		List<Community> topCommunities = new ArrayList<Community>();
+		int total = 0;
+		try {
+			List<Community> it = cs.findAllTop(obtainContext());
+			total = it.size();
+			for (Community c : it) {
+				topCommunities.add(c);
+			}
+		} catch (SQLException e) {
+			throw new RuntimeException(e.getMessage(), e);
+		}
+		Page<CommunityRest> page = new PageImpl<Community>(topCommunities, pageable, total).map(converter);
+		return page;
+	}
+
 	@Override
 	public Class<CommunityRest> getDomainClass() {
 		return CommunityRest.class;
 	}
-	
+
 	@Override
 	public CommunityResource wrapResource(CommunityRest community, String... rels) {
 		return new CommunityResource(community, utils, rels);

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
@@ -81,14 +81,9 @@ public class CommunityRestRepository extends DSpaceRestRepository<CommunityRest,
 	// communities
 	@SearchRestMethod(name="top")
 	public Page<CommunityRest> findAllTop(Pageable pageable) {
-		List<Community> topCommunities = new ArrayList<Community>();
-		int total = 0;
+		List<Community> topCommunities = null;
 		try {
-			List<Community> it = cs.findAllTop(obtainContext());
-			total = it.size();
-			for (Community c : it) {
-				topCommunities.add(c);
-			}
+			topCommunities = cs.findAllTop(obtainContext());
 		} catch (SQLException e) {
 			throw new RuntimeException(e.getMessage(), e);
 		}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/RestRepositoryUtils.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/RestRepositoryUtils.java
@@ -1,0 +1,247 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.utils;
+
+import java.lang.reflect.Method;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map.Entry;
+
+import org.apache.commons.lang3.StringUtils;
+import org.dspace.app.rest.SearchRestMethod;
+import org.dspace.app.rest.repository.DSpaceRestRepository;
+import org.dspace.app.rest.repository.LinkRestRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.MethodParameter;
+import org.springframework.core.convert.ConversionException;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.repository.query.Param;
+import org.springframework.data.repository.support.QueryMethodParameterConversionException;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.hateoas.core.AnnotationAttribute;
+import org.springframework.hateoas.core.MethodParameters;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Collection of utility methods to work with the Rest Repositories
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ * 
+ */
+@Component
+public class RestRepositoryUtils {
+	private static final AnnotationAttribute PARAM_ANNOTATION = new AnnotationAttribute(Param.class);
+	private static final String NAME_NOT_FOUND = "Unable to detect parameter names for query method %s! Use @Param or compile with -parameters on JDK 8.";
+
+	@Autowired(required = true)
+	@Qualifier(value = "mvcConversionService")
+	private ConversionService conversionService;
+
+	/**
+	 * 
+	 * @param repository
+	 * @return if the repository have at least one search method
+	 */
+	public boolean haveSearchMethods(DSpaceRestRepository repository) {
+		for (Method method : repository.getClass().getMethods()) {
+			SearchRestMethod ann = method.getAnnotation(SearchRestMethod.class);
+			if (ann != null) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * 
+	 * @param repository
+	 * @return the names of the search methods if any. Otherwise an empty list
+	 */
+	public List<String> listSearchMethods(DSpaceRestRepository repository) {
+		List<String> searchMethods = new LinkedList<String>();
+		for (Method method : repository.getClass().getMethods()) {
+			SearchRestMethod ann = method.getAnnotation(SearchRestMethod.class);
+			if (ann != null) {
+				String name = ann.name();
+				if (name.isEmpty()) {
+					name = method.getName();
+				}
+				searchMethods.add(name);
+			}
+		}
+
+		return searchMethods;
+	}
+
+	/**
+	 * 
+	 * @param searchMethodName
+	 * @param repository
+	 * @return the search method in the repository with the specified name or
+	 *         null if it is not found
+	 */
+	public Method getSearchMethod(String searchMethodName, DSpaceRestRepository repository) {
+		Method searchMethod = null;
+		for (Method method : repository.getClass().getMethods()) {
+			SearchRestMethod ann = method.getAnnotation(SearchRestMethod.class);
+			if (ann != null) {
+				String name = ann.name();
+				if (name.isEmpty()) {
+					name = method.getName();
+				}
+				if (StringUtils.equals(name, searchMethodName)) {
+					searchMethod = method;
+					break;
+				}
+			}
+		}
+		return searchMethod;
+	}
+
+	/*
+	 * Adapted from
+	 * org.springframework.data.rest.webmvc.RepositorySearchController.
+	 * executeQueryMethod(RepositoryInvoker, MultiValueMap<String, Object>,
+	 * Method, DefaultedPageable, Sort, PersistentEntityResourceAssembler)
+	 */
+	public Object executeQueryMethod(DSpaceRestRepository repository, MultiValueMap<String, Object> parameters,
+			Method method, Pageable pageable, Sort sort, PagedResourcesAssembler assembler) {
+
+		MultiValueMap<String, Object> result = new LinkedMultiValueMap<String, Object>(parameters);
+		MethodParameters methodParameters = new MethodParameters(method, new AnnotationAttribute(Param.class));
+
+		for (Entry<String, List<Object>> entry : parameters.entrySet()) {
+
+			MethodParameter parameter = methodParameters.getParameter(entry.getKey());
+
+			if (parameter == null) {
+				continue;
+			}
+
+			result.put(parameter.getParameterName(), entry.getValue());
+		}
+
+		return invokeQueryMethod(repository, method, result, pageable, sort);
+	}
+
+	/*
+	 * Adapted from
+	 * org.springframework.data.repository.support.ReflectionRepositoryInvoker.
+	 * invokeQueryMethod(Method, MultiValueMap<String, ? extends Object>,
+	 * Pageable, Sort)
+	 */
+	public Object invokeQueryMethod(DSpaceRestRepository repository, Method method,
+			MultiValueMap<String, ? extends Object> parameters, Pageable pageable, Sort sort) {
+
+		Assert.notNull(method, "Method must not be null!");
+		Assert.notNull(parameters, "Parameters must not be null!");
+
+		ReflectionUtils.makeAccessible(method);
+
+		return ReflectionUtils.invokeMethod(method, repository, prepareParameters(method, parameters, pageable, sort));
+	}
+
+	/*
+	 * Taken from
+	 * org.springframework.data.repository.support.ReflectionRepositoryInvoker.
+	 * prepareParameters(Method, MultiValueMap<String, ? extends Object>,
+	 * Pageable, Sort)
+	 */
+	private Object[] prepareParameters(Method method, MultiValueMap<String, ? extends Object> rawParameters,
+			Pageable pageable, Sort sort) {
+
+		List<MethodParameter> parameters = new MethodParameters(method, PARAM_ANNOTATION).getParameters();
+
+		if (parameters.isEmpty()) {
+			return new Object[0];
+		}
+
+		Object[] result = new Object[parameters.size()];
+		Sort sortToUse = pageable == null ? sort : pageable.getSort();
+
+		for (int i = 0; i < result.length; i++) {
+
+			MethodParameter param = parameters.get(i);
+			Class<?> targetType = param.getParameterType();
+
+			if (Pageable.class.isAssignableFrom(targetType)) {
+				result[i] = pageable;
+			} else if (Sort.class.isAssignableFrom(targetType)) {
+				result[i] = sortToUse;
+			} else {
+
+				String parameterName = param.getParameterName();
+
+				if (StringUtils.isBlank(parameterName)) {
+					throw new IllegalArgumentException(
+							String.format(NAME_NOT_FOUND, ClassUtils.getQualifiedMethodName(method)));
+				}
+
+				Object value = unwrapSingleElement(rawParameters.get(parameterName));
+
+				result[i] = targetType.isInstance(value) ? value : convert(value, param);
+			}
+		}
+
+		return result;
+	}
+
+	/**
+	 * Unwraps the first item if the given source has exactly one element. Taken
+	 * from
+	 * org.springframework.data.repository.support.ReflectionRepositoryInvoker.unwrapSingleElement(List<?
+	 * extends Object>)
+	 * 
+	 * @param source
+	 *            can be {@literal null}.
+	 * @return
+	 */
+	private static Object unwrapSingleElement(List<? extends Object> source) {
+		return source == null ? null : source.size() == 1 ? source.get(0) : source;
+	}
+
+	/**
+	 * Taken from
+	 * org.springframework.data.repository.support.ReflectionRepositoryInvoker.convert(Object,
+	 * MethodParameter)
+	 * 
+	 * @param value
+	 * @param parameter
+	 * @return
+	 */
+	private Object convert(Object value, MethodParameter parameter) {
+
+		try {
+			return conversionService.convert(value, TypeDescriptor.forObject(value), new TypeDescriptor(parameter));
+		} catch (ConversionException o_O) {
+			throw new QueryMethodParameterConversionException(value, parameter, o_O);
+		}
+	}
+
+	public Method getLinkMethod(String methodName, LinkRestRepository linkRepository) {
+		Method linkMethod = null;
+		Method[] methods = linkRepository.getClass().getMethods();
+		for (Method m : methods) {
+			if (StringUtils.equals(m.getName(), methodName)) {
+				linkMethod = m;
+				break;
+			}
+		}
+		return linkMethod;
+	}
+
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/Utils.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/Utils.java
@@ -11,10 +11,13 @@ import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.atteo.evo.inflector.English;
 import org.dspace.app.rest.exception.PaginationException;
 import org.dspace.app.rest.exception.RepositoryNotFoundException;
 import org.dspace.app.rest.model.CommunityRest;
+import org.dspace.app.rest.model.LinkRest;
+import org.dspace.app.rest.model.LinksRest;
 import org.dspace.app.rest.model.RestModel;
 import org.dspace.app.rest.model.hateoas.DSpaceResource;
 import org.dspace.app.rest.repository.DSpaceRestRepository;
@@ -60,17 +63,19 @@ public class Utils {
 	}
 
 	public Link linkToSingleResource(RestModel data, String rel) {
-		return linkTo(data.getController(), data.getCategory(), English.plural(data.getType())).slash(data).withRel(rel);
+		return linkTo(data.getController(), data.getCategory(), English.plural(data.getType())).slash(data)
+				.withRel(rel);
 	}
 
 	public Link linkToSubResource(RestModel data, String rel) {
-		return linkToSubResource(data, rel, rel) ;
+		return linkToSubResource(data, rel, rel);
 	}
 
 	public Link linkToSubResource(RestModel data, String rel, String path) {
-		return linkTo(data.getController(), data.getCategory(), English.plural(data.getType())).slash(data).slash(path).withRel(rel);
+		return linkTo(data.getController(), data.getCategory(), English.plural(data.getType())).slash(data).slash(path)
+				.withRel(rel);
 	}
-	
+
 	public DSpaceRestRepository getResourceRepository(String apiCategory, String modelPlural) {
 		String model = makeSingular(modelPlural);
 		try {
@@ -79,13 +84,14 @@ public class Utils {
 			throw new RepositoryNotFoundException(apiCategory, model);
 		}
 	}
-	
+
 	public String[] getRepositories() {
 		return applicationContext.getBeanNamesForType(DSpaceRestRepository.class);
 	}
-	
+
 	public static String makeSingular(String modelPlural) {
-		//The old dspace res package includes the evo inflection library which has a plural() function but no singular function
+		// The old dspace res package includes the evo inflection library which
+		// has a plural() function but no singular function
 		if (modelPlural.equals("communities")) {
 			return CommunityRest.NAME;
 		}
@@ -111,5 +117,27 @@ public class Utils {
 		} catch (NoSuchBeanDefinitionException e) {
 			throw new RepositoryNotFoundException(apiCategory, model);
 		}
+	}
+
+	/**
+	 * 
+	 * @param rel
+	 * @param domainClass
+	 * @return the LinkRest annotation corresponding to the specified rel in the
+	 *         domainClass. Null if not found
+	 */
+	public LinkRest getLinkRest(String rel, Class<RestModel> domainClass) {
+		LinkRest linkRest = null;
+		LinksRest linksAnnotation = domainClass.getDeclaredAnnotation(LinksRest.class);
+		if (linksAnnotation != null) {
+			LinkRest[] links = linksAnnotation.links();
+			for (LinkRest l : links) {
+				if (StringUtils.equals(rel, l.name())) {
+					linkRest = l;
+					break;
+				}
+			}
+		}
+		return linkRest;
 	}
 }


### PR DESCRIPTION
initial draft with sample implementation of the find top level communities.
When a repository have a method annotated with @SearchRestMethods the resource endpoint (i.e. /api/core/communities) return a link to the /search (/api/core/communities/search).
The repository search endpoint is implemented listing all the available search methods i.e. for communities 
/api/core/communities/search/top

The search method endpoint works right now but we need to improve the invocation strategy discovering via reflection which parameters need to be used (now it is assumed that only a pagination is required but of course we need for other use cases to add query parameters). See
https://github.com/DSpace/DSpace/compare/master...4Science:DS-3544?expand=1#diff-091f26fa1a213c77e1ff0275f1da97d4R195