### PR TITLE
DS-3127 whitelist of formats allowable in citation pdf url for google scholar

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -642,6 +642,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -639,6 +639,10 @@
             <version>1</version>
             <type>jar</type>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/dspace-api/src/main/java/org/dspace/app/util/GoogleBitstreamComparator.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/GoogleBitstreamComparator.java
@@ -1,6 +1,13 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.app.util;
 
-import org.apache.commons.lang.math.NumberUtils;
+import org.apache.log4j.Logger;
 import org.dspace.content.Bitstream;
 
 import java.util.Comparator;
@@ -12,29 +19,48 @@ import java.util.Map;
  */
 public class GoogleBitstreamComparator implements Comparator<Bitstream>{
 
+    private final static Logger log = Logger.getLogger(GoogleBitstreamComparator.class);
+
     HashMap<String, Integer> priorityMap = new HashMap<>();
 
-    public GoogleBitstreamComparator(Map<String, String> configuredFields){
-        for(Map.Entry<String, String> entry : configuredFields.entrySet()){
-            if(entry.getKey().startsWith("citation_priority_score")){
-                priorityMap.put(entry.getKey().split("\\.", 2)[1], NumberUtils.createInteger(entry.getValue()));
+    public GoogleBitstreamComparator(Map<String, String> googleScholarSettings){
+        String[] types = null;
+        try {
+            types = splitAndTrim(googleScholarSettings.get("citation.prioritized_types"));
+        } catch (NullPointerException e){
+            log.error("Please define citation.prioritized_types in google-metadata.properties");
+        }
+        int priority = 1;
+        for(String s: types){
+            String[] mimetypes = null;
+            try {
+                mimetypes = splitAndTrim(googleScholarSettings.get("citation.mimetypes." + s));
+            } catch (NullPointerException e){
+                log.error("Make sure you define all the mimetypes of the citation.prioritized_types");
             }
+            for (String mimetype: mimetypes) {
+                priorityMap.put(mimetype, priority);
+            }
+            priority++;
         }
     }
 
+    private String[] splitAndTrim(String toSplit){
+        return toSplit.replace(" ", "").split(",");
+    }
+
+
+    /**
+     * Compares two bitstreams based on their mimetypes, if mimetypes are the same,then the largest bitstream comes first
+     * See google-metadata.properties to define the order
+     * @param b1 first bitstream
+     * @param b2 second bitstream
+     * @return
+     */
     public int compare(Bitstream b1, Bitstream b2) {
-        int priority1 = 0;
-        int priority2 = 0;
-        try {
-            priority1 = priorityMap.get(b1.getFormat().getMIMEType());
-        } catch (NullPointerException e){
-            priority1 = 999;
-        }
-        try {
-            priority2 = priorityMap.get(b2.getFormat().getMIMEType());
-        } catch (NullPointerException e){
-            priority2 = 999;
-        }
+        int priority1 = getPriorityFromBitstream(b1);
+        int priority2 = getPriorityFromBitstream(b2);
+
         if(priority1 > priority2){
             return 1;
         }
@@ -48,6 +74,15 @@ public class GoogleBitstreamComparator implements Comparator<Bitstream>{
         }
         else {
             return -1;
+        }
+    }
+
+    private int getPriorityFromBitstream(Bitstream bitstream) {
+        if (priorityMap.containsKey(bitstream.getFormat().getMIMEType())){
+            return priorityMap.get(bitstream.getFormat().getMIMEType());
+        }
+        else {
+            return Integer.MAX_VALUE;
         }
     }
 }

--- a/dspace-api/src/main/java/org/dspace/app/util/GoogleBitstreamComparator.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/GoogleBitstreamComparator.java
@@ -24,19 +24,21 @@ public class GoogleBitstreamComparator implements Comparator<Bitstream>{
     HashMap<String, Integer> priorityMap = new HashMap<>();
 
     public GoogleBitstreamComparator(Map<String, String> googleScholarSettings){
-        String[] types = new String[]{};
-        try {
+        String[] types;
+        if (googleScholarSettings.containsKey("citation.prioritized_types")){
             types = splitAndTrim(googleScholarSettings.get("citation.prioritized_types"));
-        } catch (NullPointerException e){
+        } else {
             log.warn("Please define citation.prioritized_types in google-metadata.properties");
+            types = new String[0];
         }
         int priority = 1;
         for(String s: types){
-            String[] mimetypes = new String[]{};
-            try {
+            String[] mimetypes;
+            if (googleScholarSettings.containsKey("citation.mimetypes." + s)){
                 mimetypes = splitAndTrim(googleScholarSettings.get("citation.mimetypes." + s));
-            } catch (NullPointerException e){
+            } else {
                 log.warn("Make sure you define all the mimetypes of the citation.prioritized_types");
+                mimetypes = new String[0];
             }
             for (String mimetype: mimetypes) {
                 priorityMap.put(mimetype, priority);
@@ -46,7 +48,12 @@ public class GoogleBitstreamComparator implements Comparator<Bitstream>{
     }
 
     private String[] splitAndTrim(String toSplit){
-        return toSplit.replace(" ", "").split(",");
+        if(toSplit != null) {
+            return toSplit.replace(" ", "").split(",");
+        }
+        else {
+            return new String[0];
+        }
     }
 
 
@@ -65,7 +72,7 @@ public class GoogleBitstreamComparator implements Comparator<Bitstream>{
             return 1;
         }
         else if(priority1 == priority2){
-            if(b1.getSize() <= b2 .getSize()){
+            if(b1.getSize() <= b2.getSize()){
                 return 1;
             }
             else {
@@ -78,6 +85,7 @@ public class GoogleBitstreamComparator implements Comparator<Bitstream>{
     }
 
     private int getPriorityFromBitstream(Bitstream bitstream) {
+        String check = bitstream.getFormat().getMIMEType();
         if (priorityMap.containsKey(bitstream.getFormat().getMIMEType())){
             return priorityMap.get(bitstream.getFormat().getMIMEType());
         }

--- a/dspace-api/src/main/java/org/dspace/app/util/GoogleBitstreamComparator.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/GoogleBitstreamComparator.java
@@ -24,19 +24,19 @@ public class GoogleBitstreamComparator implements Comparator<Bitstream>{
     HashMap<String, Integer> priorityMap = new HashMap<>();
 
     public GoogleBitstreamComparator(Map<String, String> googleScholarSettings){
-        String[] types = null;
+        String[] types = new String[]{};
         try {
             types = splitAndTrim(googleScholarSettings.get("citation.prioritized_types"));
         } catch (NullPointerException e){
-            log.error("Please define citation.prioritized_types in google-metadata.properties");
+            log.warn("Please define citation.prioritized_types in google-metadata.properties");
         }
         int priority = 1;
         for(String s: types){
-            String[] mimetypes = null;
+            String[] mimetypes = new String[]{};
             try {
                 mimetypes = splitAndTrim(googleScholarSettings.get("citation.mimetypes." + s));
             } catch (NullPointerException e){
-                log.error("Make sure you define all the mimetypes of the citation.prioritized_types");
+                log.warn("Make sure you define all the mimetypes of the citation.prioritized_types");
             }
             for (String mimetype: mimetypes) {
                 priorityMap.put(mimetype, priority);

--- a/dspace-api/src/main/java/org/dspace/app/util/GoogleBitstreamComparator.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/GoogleBitstreamComparator.java
@@ -1,0 +1,53 @@
+package org.dspace.app.util;
+
+import org.apache.commons.lang.math.NumberUtils;
+import org.dspace.content.Bitstream;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by frederic on 24/04/17.
+ */
+public class GoogleBitstreamComparator implements Comparator<Bitstream>{
+
+    HashMap<String, Integer> priorityMap = new HashMap<>();
+
+    public GoogleBitstreamComparator(Map<String, String> configuredFields){
+        for(Map.Entry<String, String> entry : configuredFields.entrySet()){
+            if(entry.getKey().startsWith("citation_priority_score")){
+                priorityMap.put(entry.getKey().split("\\.", 2)[1], NumberUtils.createInteger(entry.getValue()));
+            }
+        }
+    }
+
+    public int compare(Bitstream b1, Bitstream b2) {
+        int priority1 = 0;
+        int priority2 = 0;
+        try {
+            priority1 = priorityMap.get(b1.getFormat().getMIMEType());
+        } catch (NullPointerException e){
+            priority1 = 999;
+        }
+        try {
+            priority2 = priorityMap.get(b2.getFormat().getMIMEType());
+        } catch (NullPointerException e){
+            priority2 = 999;
+        }
+        if(priority1 > priority2){
+            return 1;
+        }
+        else if(priority1 == priority2){
+            if(b1.getSize() <= b2 .getSize()){
+                return 1;
+            }
+            else {
+                return -1;
+            }
+        }
+        else {
+            return -1;
+        }
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
@@ -186,8 +186,6 @@ public class GoogleMetadata
             logConfiguration();
         }
 
-        googleBitstreamComparator = new GoogleBitstreamComparator(googleScholarSettings);
-
 
     }
 
@@ -218,6 +216,7 @@ public class GoogleMetadata
         // Hold onto the item in case we need to refresh a stale parse
         this.item = item;
         itemURL = HandleManager.resolveToURL(context, item.getHandle());
+        googleBitstreamComparator = new GoogleBitstreamComparator(context, googleScholarSettings);
         parseItem();
     }
 

--- a/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
@@ -1056,7 +1056,6 @@ public class GoogleMetadata
 					}					
 				} else 
 					{
-						
 						if (bestSoFar == null && isPublic(candidate)) { //if bestSoFar is null but the candidate is not public you don't use it and try to find another
 						bestSoFar = candidate;
 						}					

--- a/dspace-api/src/main/java/org/dspace/content/BitstreamFormat.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamFormat.java
@@ -415,7 +415,7 @@ public class BitstreamFormat
      * 
      * @return the internal identifier
      */
-    public final int getID()
+    public int getID()
     {
         return bfRow.getIntColumn("bitstream_format_id");
     }
@@ -425,7 +425,7 @@ public class BitstreamFormat
      * 
      * @return the short description
      */
-    public final String getShortDescription()
+    public String getShortDescription()
     {
         return bfRow.getStringColumn("short_description");
     }
@@ -436,7 +436,7 @@ public class BitstreamFormat
      * @param s
      *            the new short description
      */
-    public final void setShortDescription(String s)
+    public void setShortDescription(String s)
        throws SQLException
     {
         // You can not reset the unknown's registry's name
@@ -464,7 +464,7 @@ public class BitstreamFormat
      * 
      * @return the description
      */
-    public final String getDescription()
+    public String getDescription()
     {
         return bfRow.getStringColumn("description");
     }
@@ -475,7 +475,7 @@ public class BitstreamFormat
      * @param s
      *            the new description
      */
-    public final void setDescription(String s)
+    public void setDescription(String s)
     {
         bfRow.setColumn("description", s);
     }
@@ -486,7 +486,7 @@ public class BitstreamFormat
      * 
      * @return the MIME type
      */
-    public final String getMIMEType()
+    public String getMIMEType()
     {
         return bfRow.getStringColumn("mimetype");
     }
@@ -497,7 +497,7 @@ public class BitstreamFormat
      * @param s
      *            the new MIME type
      */
-    public final void setMIMEType(String s)
+    public void setMIMEType(String s)
     {
         bfRow.setColumn("mimetype", s);
     }
@@ -508,7 +508,7 @@ public class BitstreamFormat
      * 
      * @return the support level
      */
-    public final int getSupportLevel()
+    public int getSupportLevel()
     {
         return bfRow.getIntColumn("support_level");
     }
@@ -530,7 +530,7 @@ public class BitstreamFormat
      * @param sl
      *            the new support level
      */
-    public final void setSupportLevel(int sl)
+    public void setSupportLevel(int sl)
     {
         // Sanity check
         if ((sl < 0) || (sl > 2))
@@ -548,7 +548,7 @@ public class BitstreamFormat
      * 
      * @return <code>true</code> if the bitstream format is an internal type
      */
-    public final boolean isInternal()
+    public boolean isInternal()
     {
         return bfRow.getBooleanColumn("internal");
     }
@@ -560,7 +560,7 @@ public class BitstreamFormat
      *            pass in <code>true</code> if the bitstream format is an
      *            internal type
      */
-    public final void setInternal(boolean b)
+    public void setInternal(boolean b)
     {
         bfRow.setColumn("internal", b);
     }

--- a/dspace-api/src/test/java/org/dspace/app/util/GoogleBitstreamComparatorTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/GoogleBitstreamComparatorTest.java
@@ -1,10 +1,180 @@
 package org.dspace.app.util;
 
+import org.dspace.content.Bitstream;
+import org.dspace.content.BitstreamFormat;
+import org.dspace.content.Bundle;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.*;
+
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by frederic on 24/04/17.
  */
+@RunWith(MockitoJUnitRunner.class)
 public class GoogleBitstreamComparatorTest {
+
+    @Mock
+    private Bundle bundle;
+
+    @Mock
+    private Bitstream bitstream1;
+
+    @Mock
+    private Bitstream bitstream2;
+
+    @Mock
+    private Bitstream bitstream3;
+
+    @Mock
+    private BitstreamFormat bitstreamFormat1;
+
+    @Mock
+    private BitstreamFormat bitstreamFormat2;
+
+    @Mock
+    private BitstreamFormat bitstreamFormat3;
+
+
+    private HashMap<String, String> settings = new HashMap<>();
+
+
+
+    @Before
+    public void setUp() throws Exception {
+        when(bitstream1.getName()).thenReturn("bitstream1");
+        when(bitstream2.getName()).thenReturn("bitstream2");
+        when(bitstream3.getName()).thenReturn("bitstream3");
+        settings.put("citation.prioritized_types", "PDF, WORD, RTF, PS");
+        settings.put("citation.mimetypes.PDF" , "application/pdf");
+        settings.put("citation.mimetypes.WORD", "application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+        settings.put("citation.mimetypes.RTF", "text/richtext");
+        settings.put("citation.mimetypes.PS", "application/x-photoshop");
+        when(bundle.getBitstreams()).thenReturn(new Bitstream[] {bitstream1, bitstream2, bitstream3});
+        when(bitstream1.getFormat()).thenReturn(bitstreamFormat1);
+        when(bitstream2.getFormat()).thenReturn(bitstreamFormat2);
+        when(bitstream3.getFormat()).thenReturn(bitstreamFormat3);
+    }
+
+    @Test
+    public void testPDFDifferentSize() throws Exception {
+        when(bitstreamFormat1.getMIMEType()).thenReturn("application/pdf");
+        when(bitstreamFormat2.getMIMEType()).thenReturn("application/pdf");
+        when(bitstreamFormat3.getMIMEType()).thenReturn("application/pdf");
+        when(bitstream1.getSize()).thenReturn(new Long(100));
+        when(bitstream2.getSize()).thenReturn(new Long(200));
+        when(bitstream3.getSize()).thenReturn(new Long(300));
+
+        List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
+        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        assertEquals(toSort.get(0).getName(), "bitstream3");
+        assertEquals(toSort.get(1).getName(), "bitstream2");
+        assertEquals(toSort.get(2).getName(), "bitstream1");
+    }
+
+    @Test
+    public void testDifferentMimeTypes() throws Exception {
+        when(bitstreamFormat1.getMIMEType()).thenReturn("text/richtext");
+        when(bitstreamFormat2.getMIMEType()).thenReturn("application/msword");
+        when(bitstreamFormat3.getMIMEType()).thenReturn("application/x-photoshop");
+
+        List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
+        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        assertEquals("WORD should be first", toSort.get(0).getName(), "bitstream2");
+        assertEquals("RTF second", toSort.get(1).getName(), "bitstream1");
+        assertEquals("PS next",toSort.get(2).getName(), "bitstream3");
+    }
+
+    @Test
+    public void testDifferentMimeTypesDifferentSizes() throws Exception {
+        when(bitstreamFormat1.getMIMEType()).thenReturn("text/richtext");
+        when(bitstreamFormat2.getMIMEType()).thenReturn("text/richtext");
+        when(bitstreamFormat3.getMIMEType()).thenReturn("application/x-photoshop");
+        when(bitstream1.getSize()).thenReturn(new Long(100));
+        when(bitstream2.getSize()).thenReturn(new Long(200));
+        when(bitstream3.getSize()).thenReturn(new Long(300));
+
+        List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
+        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        assertEquals(toSort.get(0).getName(), "bitstream2");
+        assertEquals(toSort.get(1).getName(), "bitstream1");
+        assertEquals(toSort.get(2).getName(), "bitstream3");
+    }
+
+    @Test
+    public void testSameMimeTypeSameSize() throws Exception {
+        when(bitstreamFormat1.getMIMEType()).thenReturn("application/pdf");
+        when(bitstreamFormat2.getMIMEType()).thenReturn("application/pdf");
+        when(bitstreamFormat3.getMIMEType()).thenReturn("application/pdf");
+        when(bitstream1.getSize()).thenReturn(new Long(200));
+        when(bitstream2.getSize()).thenReturn(new Long(200));
+        when(bitstream3.getSize()).thenReturn(new Long(200));
+
+        List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
+        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        assertEquals("Same size and mimetype, so just pick the first one", toSort.get(0).getName(), "bitstream1");
+        assertEquals(toSort.get(1).getName(), "bitstream2");
+        assertEquals(toSort.get(2).getName(), "bitstream3");
+    }
+
+    @Test
+    public void testUnknownMimeType() throws Exception {
+        when(bitstreamFormat1.getMIMEType()).thenReturn("unknown");
+        when(bitstreamFormat2.getMIMEType()).thenReturn("text/richtext");
+        when(bitstreamFormat3.getMIMEType()).thenReturn("text/richtext");
+        when(bitstream1.getSize()).thenReturn(new Long(100));
+        when(bitstream2.getSize()).thenReturn(new Long(200));
+        when(bitstream3.getSize()).thenReturn(new Long(300));
+
+        List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
+        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        assertEquals(toSort.get(0).getName(), "bitstream3");
+        assertEquals(toSort.get(1).getName(), "bitstream2");
+        assertEquals(toSort.get(2).getName(), "bitstream1");
+    }
+
+    @Test
+    public void testAllUnknown() throws Exception {
+        when(bitstreamFormat1.getMIMEType()).thenReturn("unknown");
+        when(bitstreamFormat2.getMIMEType()).thenReturn("unknown");
+        when(bitstreamFormat3.getMIMEType()).thenReturn("unknown");
+        when(bitstream1.getSize()).thenReturn(new Long(200));
+        when(bitstream2.getSize()).thenReturn(new Long(300));
+        when(bitstream3.getSize()).thenReturn(new Long(100));
+
+        List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
+        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        assertEquals(toSort.get(0).getName(), "bitstream2");
+        assertEquals(toSort.get(1).getName(), "bitstream1");
+        assertEquals(toSort.get(2).getName(), "bitstream3");
+    }
+
+    @Test
+    public void testChangePriority() {
+        settings.put("citation.prioritized_types", "PS, RTF, WORD, PDF");
+        when(bitstreamFormat1.getMIMEType()).thenReturn("text/richtext");
+        when(bitstreamFormat2.getMIMEType()).thenReturn("application/msword");
+        when(bitstreamFormat3.getMIMEType()).thenReturn("application/x-photoshop");
+
+        List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
+        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        assertEquals("PS should be first", toSort.get(0).getName(), "bitstream3");
+        assertEquals("RTF second", toSort.get(1).getName(), "bitstream1");
+        assertEquals("Word third",toSort.get(2).getName(), "bitstream2");
+    }
+
+
+
+
+
+
 
 }

--- a/dspace-api/src/test/java/org/dspace/app/util/GoogleBitstreamComparatorTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/GoogleBitstreamComparatorTest.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.app.util;
 
+import org.dspace.AbstractUnitTest;
 import org.dspace.content.Bitstream;
 import org.dspace.content.BitstreamFormat;
 import org.dspace.content.Bundle;
@@ -26,7 +27,7 @@ import static org.mockito.Mockito.when;
 
 
 @RunWith(MockitoJUnitRunner.class)
-public class GoogleBitstreamComparatorTest {
+public class GoogleBitstreamComparatorTest extends AbstractUnitTest{
 
     @Mock
     private Bundle bundle;
@@ -62,11 +63,7 @@ public class GoogleBitstreamComparatorTest {
         when(bitstream1.getName()).thenReturn("bitstream1");
         when(bitstream2.getName()).thenReturn("bitstream2");
         when(bitstream3.getName()).thenReturn("bitstream3");
-        settings.put("citation.prioritized_types", "PDF, WORD, RTF, PS");
-        settings.put("citation.mimetypes.PDF" , "application/pdf");
-        settings.put("citation.mimetypes.WORD", "application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document");
-        settings.put("citation.mimetypes.RTF", "text/richtext");
-        settings.put("citation.mimetypes.PS", "application/x-photoshop");
+        settings.put("citation.prioritized_types", "Adobe PDF, Microsoft Word, RTF, Photoshop");
         when(bundle.getBitstreams()).thenReturn(new Bitstream[] {bitstream1, bitstream2, bitstream3});
         when(bitstream1.getFormat()).thenReturn(bitstreamFormat1);
         when(bitstream2.getFormat()).thenReturn(bitstreamFormat2);
@@ -87,7 +84,7 @@ public class GoogleBitstreamComparatorTest {
         when(bitstream3.getSize()).thenReturn(new Long(300));
 
         List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
-        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        Collections.sort(toSort, new GoogleBitstreamComparator(context, settings));
         assertEquals("bitstream3", toSort.get(0).getName());
         assertEquals("bitstream2", toSort.get(1).getName());
         assertEquals("bitstream1", toSort.get(2).getName());
@@ -104,7 +101,7 @@ public class GoogleBitstreamComparatorTest {
         when(bitstreamFormat3.getMIMEType()).thenReturn("application/x-photoshop");
 
         List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
-        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        Collections.sort(toSort, new GoogleBitstreamComparator(context, settings));
         assertEquals("WORD should be first",  "bitstream2", toSort.get(0).getName());
         assertEquals("RTF second", "bitstream1", toSort.get(1).getName());
         assertEquals("PS next", "bitstream3", toSort.get(2).getName());
@@ -125,7 +122,7 @@ public class GoogleBitstreamComparatorTest {
         when(bitstream3.getSize()).thenReturn(new Long(300));
 
         List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
-        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        Collections.sort(toSort, new GoogleBitstreamComparator(context, settings));
         assertEquals("bitstream2", toSort.get(0).getName());
         assertEquals("bitstream1", toSort.get(1).getName());
         assertEquals("bitstream3", toSort.get(2).getName());
@@ -145,7 +142,7 @@ public class GoogleBitstreamComparatorTest {
         when(bitstream3.getSize()).thenReturn(new Long(200));
 
         List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
-        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        Collections.sort(toSort, new GoogleBitstreamComparator(context, settings));
         assertEquals("Same size and mimetype, so just pick the first one", "bitstream1", toSort.get(0).getName());
         assertEquals("bitstream2", toSort.get(1).getName());
         assertEquals("bitstream3", toSort.get(2).getName());
@@ -165,7 +162,7 @@ public class GoogleBitstreamComparatorTest {
         when(bitstream3.getSize()).thenReturn(new Long(300));
 
         List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
-        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        Collections.sort(toSort, new GoogleBitstreamComparator(context, settings));
         assertEquals("bitstream3", toSort.get(0).getName());
         assertEquals("bitstream2", toSort.get(1).getName());
         assertEquals("bitstream1",toSort.get(2).getName());
@@ -185,7 +182,7 @@ public class GoogleBitstreamComparatorTest {
         when(bitstream3.getSize()).thenReturn(new Long(100));
 
         List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
-        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        Collections.sort(toSort, new GoogleBitstreamComparator(context, settings));
         assertEquals("bitstream2", toSort.get(0).getName());
         assertEquals("bitstream1", toSort.get(1).getName());
         assertEquals("bitstream3", toSort.get(2).getName());
@@ -195,14 +192,14 @@ public class GoogleBitstreamComparatorTest {
      * Test to see if priority is configurable, order should change according to prioritized_types property
      */
     @Test
-    public void testChangePriority() {
-        settings.put("citation.prioritized_types", "PS, RTF, WORD, PDF");
+    public void testChangePriority() throws Exception{
+        settings.put("citation.prioritized_types", "Photoshop, RTF, Microsoft Word, Adobe PDF");
         when(bitstreamFormat1.getMIMEType()).thenReturn("text/richtext");
         when(bitstreamFormat2.getMIMEType()).thenReturn("application/msword");
         when(bitstreamFormat3.getMIMEType()).thenReturn("application/x-photoshop");
 
         List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
-        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        Collections.sort(toSort, new GoogleBitstreamComparator(context, settings));
         assertEquals("PS should be first", "bitstream3", toSort.get(0).getName());
         assertEquals("RTF second", "bitstream1", toSort.get(1).getName());
         assertEquals("Word third", "bitstream2", toSort.get(2).getName());
@@ -212,13 +209,13 @@ public class GoogleBitstreamComparatorTest {
      * Test what happens when bitstreams have no mimetype, should be just ordered by size
      */
     @Test
-    public void testNoMimeType(){
+    public void testNoMimeType() throws Exception{
         when(bitstream1.getSize()).thenReturn(new Long(200));
         when(bitstream2.getSize()).thenReturn(new Long(300));
         when(bitstream3.getSize()).thenReturn(new Long(100));
 
         List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
-        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        Collections.sort(toSort, new GoogleBitstreamComparator(context, settings));
         assertEquals("bitstream2", toSort.get(0).getName());
         assertEquals("bitstream1", toSort.get(1).getName());
         assertEquals("bitstream3", toSort.get(2).getName());
@@ -235,7 +232,7 @@ public class GoogleBitstreamComparatorTest {
         when(bitstreamFormat3.getMIMEType()).thenReturn("unknown");
 
         List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
-        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        Collections.sort(toSort, new GoogleBitstreamComparator(context, settings));
         assertEquals("bitstream1", toSort.get(0).getName());
         assertEquals("bitstream2", toSort.get(1).getName());
         assertEquals("bitstream3", toSort.get(2).getName());
@@ -245,9 +242,9 @@ public class GoogleBitstreamComparatorTest {
      * Make sure that it doesn't crash when bitstreams have no size or mimetype
      */
     @Test
-    public void testNoMimeTypeNoSize() {
+    public void testNoMimeTypeNoSize() throws Exception {
         List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
-        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        Collections.sort(toSort, new GoogleBitstreamComparator(context, settings));
         assertEquals("bitstream1", toSort.get(0).getName());
         assertEquals("bitstream2", toSort.get(1).getName());
         assertEquals("bitstream3", toSort.get(2).getName());
@@ -257,7 +254,7 @@ public class GoogleBitstreamComparatorTest {
      * Make sure it still works when the citation.prioritized_types property is empty
      */
     @Test
-    public void testNoPrioritizedTypes() {
+    public void testNoPrioritizedTypes() throws Exception {
         settings.put("citation.prioritized_types", "");
         when(bitstreamFormat1.getMIMEType()).thenReturn("text/richtext");
         when(bitstreamFormat2.getMIMEType()).thenReturn("application/msword");
@@ -267,76 +264,18 @@ public class GoogleBitstreamComparatorTest {
         when(bitstream3.getSize()).thenReturn(new Long(300));
 
         List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
-        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        Collections.sort(toSort, new GoogleBitstreamComparator(context, settings));
         assertEquals("PS should be first", "bitstream3", toSort.get(0).getName());
         assertEquals("RTF second", "bitstream2", toSort.get(1).getName());
         assertEquals("Word third", "bitstream1", toSort.get(2).getName());
     }
 
     /**
-     * Test to make sure properties can be empty
-     */
-    @Test
-    public void testNoMimeTypesForType() {
-        settings.put("citation.mimetypes.PDF" , "");
-        when(bitstreamFormat1.getMIMEType()).thenReturn("text/richtext");
-        when(bitstreamFormat2.getMIMEType()).thenReturn("application/pdf");
-        when(bitstreamFormat3.getMIMEType()).thenReturn("application/x-photoshop");
-
-        List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
-        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
-        assertEquals("RTF first because PDF is not defined","bitstream1", toSort.get(0).getName());
-        assertEquals("Word next", "bitstream3", toSort.get(1).getName());
-        assertEquals("Lastly pdf because it is not defined", "bitstream2", toSort.get(2).getName());
-    }
-
-    /**
-     * Test to check if types defined in citation.prioritized_types can be removed safely
-     */
-    @Test
-    public void testNoFieldForType() {
-        settings.remove("citation.mimetypes.PDF");
-        when(bitstreamFormat1.getMIMEType()).thenReturn("text/richtext");
-        when(bitstreamFormat2.getMIMEType()).thenReturn("application/pdf");
-        when(bitstreamFormat3.getMIMEType()).thenReturn("application/x-photoshop");
-
-        List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
-        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
-        assertEquals("RTF first because PDF is not defined","bitstream1", toSort.get(0).getName());
-        assertEquals("Word next", "bitstream3", toSort.get(1).getName());
-        assertEquals("Lastly pdf because it is not defined", "bitstream2", toSort.get(2).getName());
-    }
-
-    /**
-     * Test if the wrong separator is used, types won't be recognized this way
-     */
-    @Test
-    public void testWrongSeparator() {
-        settings.put("citation.mimetypes.WORD", "application/msword; application/vnd.openxmlformats-officedocument.wordprocessingml.document");
-        when(bitstreamFormat1.getMIMEType()).thenReturn("text/richtext");
-        when(bitstreamFormat2.getMIMEType()).thenReturn("application/msword");
-        when(bitstreamFormat3.getMIMEType()).thenReturn("application/x-photoshop");
-        when(bitstream1.getSize()).thenReturn(new Long(100));
-        when(bitstream2.getSize()).thenReturn(new Long(200));
-        when(bitstream3.getSize()).thenReturn(new Long(300));
-
-        List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
-        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
-        assertEquals("RTF", "bitstream1", toSort.get(0).getName());
-        assertEquals("PS", "bitstream3", toSort.get(1).getName());
-        assertEquals("Word last because wrong separator", "bitstream2", toSort.get(2).getName());
-    }
-
-    /**
      * Test to check for no crash when nothing is configured, just checks for size
      */
     @Test
-    public void testNoConfig() {
+    public void testNoConfig() throws Exception{
         settings.remove("citation.prioritized_types");
-        settings.remove("citation.mimetypes.PDF");
-        settings.remove("citation.mimetypes.WORD");
-        settings.remove("citation.mimetypes.RTF");
-        settings.remove("citation.mimetypes.PS");
         when(bitstreamFormat1.getMIMEType()).thenReturn("text/richtext");
         when(bitstreamFormat2.getMIMEType()).thenReturn("application/msword");
         when(bitstreamFormat3.getMIMEType()).thenReturn("application/x-photoshop");
@@ -345,10 +284,50 @@ public class GoogleBitstreamComparatorTest {
         when(bitstream3.getSize()).thenReturn(new Long(300));
 
         List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
-        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        Collections.sort(toSort, new GoogleBitstreamComparator(context, settings));
         assertEquals("bitstream3", toSort.get(0).getName());
         assertEquals("bitstream2", toSort.get(1).getName());
         assertEquals("bitstream1", toSort.get(2).getName());
+    }
+
+    /**
+     * Test to see what happens when you choose a short description that's not defined in bitstream-formats.xml
+     */
+    @Test
+    public void testUndefinedShortDescription() {
+        settings.put("citation.prioritized_types", "Photoshop, RTF, Undefined Type, Microsoft Word, Adobe PDF");
+        when(bitstreamFormat1.getMIMEType()).thenReturn("text/richtext");
+        when(bitstreamFormat2.getMIMEType()).thenReturn("application/msword");
+        when(bitstreamFormat3.getMIMEType()).thenReturn("application/x-photoshop");
+        when(bitstream1.getSize()).thenReturn(new Long(100));
+        when(bitstream2.getSize()).thenReturn(new Long(200));
+        when(bitstream3.getSize()).thenReturn(new Long(300));
+
+        List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
+        Collections.sort(toSort, new GoogleBitstreamComparator(context, settings));
+        assertEquals("bitstream3", toSort.get(0).getName());
+        assertEquals("bitstream1", toSort.get(1).getName());
+        assertEquals("bitstream2", toSort.get(2).getName());
+    }
+
+    /**
+     * Test adding a new format in the priority list
+     */
+    @Test
+    public void testAddingNewFormat() {
+        settings.put("citation.prioritized_types", "WAV, Adobe PDF, Microsoft Word, RTF, Photoshop");
+        when(bitstreamFormat1.getMIMEType()).thenReturn("text/richtext");
+        when(bitstreamFormat2.getMIMEType()).thenReturn("application/msword");
+        when(bitstreamFormat3.getMIMEType()).thenReturn("audio/x-wav");
+        when(bitstream1.getSize()).thenReturn(new Long(100));
+        when(bitstream2.getSize()).thenReturn(new Long(200));
+        when(bitstream3.getSize()).thenReturn(new Long(300));
+
+        List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
+        Collections.sort(toSort, new GoogleBitstreamComparator(context, settings));
+        assertEquals("bitstream3", toSort.get(0).getName());
+        assertEquals("bitstream1", toSort.get(1).getName());
+        assertEquals("bitstream2", toSort.get(2).getName());
     }
 
 

--- a/dspace-api/src/test/java/org/dspace/app/util/GoogleBitstreamComparatorTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/GoogleBitstreamComparatorTest.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.app.util;
 
 import org.dspace.content.Bitstream;
@@ -17,9 +24,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-/**
- * Created by frederic on 24/04/17.
- */
+
 @RunWith(MockitoJUnitRunner.class)
 public class GoogleBitstreamComparatorTest {
 

--- a/dspace-api/src/test/java/org/dspace/app/util/GoogleBitstreamComparatorTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/GoogleBitstreamComparatorTest.java
@@ -326,8 +326,8 @@ public class GoogleBitstreamComparatorTest extends AbstractUnitTest{
         List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
         Collections.sort(toSort, new GoogleBitstreamComparator(context, settings));
         assertEquals("bitstream3", toSort.get(0).getName());
-        assertEquals("bitstream1", toSort.get(1).getName());
-        assertEquals("bitstream2", toSort.get(2).getName());
+        assertEquals("bitstream2", toSort.get(1).getName());
+        assertEquals("bitstream1", toSort.get(2).getName());
     }
 
 

--- a/dspace-api/src/test/java/org/dspace/app/util/GoogleBitstreamComparatorTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/GoogleBitstreamComparatorTest.java
@@ -3,6 +3,7 @@ package org.dspace.app.util;
 import org.dspace.content.Bitstream;
 import org.dspace.content.BitstreamFormat;
 import org.dspace.content.Bundle;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,7 +48,10 @@ public class GoogleBitstreamComparatorTest {
     private HashMap<String, String> settings = new HashMap<>();
 
 
-
+    /**
+     * Create a bundle with three bitstreams
+     * @throws Exception
+     */
     @Before
     public void setUp() throws Exception {
         when(bitstream1.getName()).thenReturn("bitstream1");
@@ -64,6 +68,10 @@ public class GoogleBitstreamComparatorTest {
         when(bitstream3.getFormat()).thenReturn(bitstreamFormat3);
     }
 
+    /**
+     * Create three pdf bitstreams and give them a different size, the largest one should come first
+     * @throws Exception
+     */
     @Test
     public void testPDFDifferentSize() throws Exception {
         when(bitstreamFormat1.getMIMEType()).thenReturn("application/pdf");
@@ -75,11 +83,15 @@ public class GoogleBitstreamComparatorTest {
 
         List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
         Collections.sort(toSort, new GoogleBitstreamComparator(settings));
-        assertEquals(toSort.get(0).getName(), "bitstream3");
-        assertEquals(toSort.get(1).getName(), "bitstream2");
-        assertEquals(toSort.get(2).getName(), "bitstream1");
+        assertEquals("bitstream3", toSort.get(0).getName());
+        assertEquals("bitstream2", toSort.get(1).getName());
+        assertEquals("bitstream1", toSort.get(2).getName());
     }
 
+    /**
+     * Create three bitstreams with different mimetypes, order is defined in settings
+     * @throws Exception
+     */
     @Test
     public void testDifferentMimeTypes() throws Exception {
         when(bitstreamFormat1.getMIMEType()).thenReturn("text/richtext");
@@ -88,13 +100,18 @@ public class GoogleBitstreamComparatorTest {
 
         List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
         Collections.sort(toSort, new GoogleBitstreamComparator(settings));
-        assertEquals("WORD should be first", toSort.get(0).getName(), "bitstream2");
-        assertEquals("RTF second", toSort.get(1).getName(), "bitstream1");
-        assertEquals("PS next",toSort.get(2).getName(), "bitstream3");
+        assertEquals("WORD should be first",  "bitstream2", toSort.get(0).getName());
+        assertEquals("RTF second", "bitstream1", toSort.get(1).getName());
+        assertEquals("PS next", "bitstream3", toSort.get(2).getName());
     }
 
+    /**
+     * Test for two bitstreams with same mimetype, but different size.
+     * Should be first ordered by mimetype and then by size (largest first)
+     * @throws Exception
+     */
     @Test
-    public void testDifferentMimeTypesDifferentSizes() throws Exception {
+    public void testMimeTypesDifferentSizes() throws Exception {
         when(bitstreamFormat1.getMIMEType()).thenReturn("text/richtext");
         when(bitstreamFormat2.getMIMEType()).thenReturn("text/richtext");
         when(bitstreamFormat3.getMIMEType()).thenReturn("application/x-photoshop");
@@ -104,11 +121,15 @@ public class GoogleBitstreamComparatorTest {
 
         List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
         Collections.sort(toSort, new GoogleBitstreamComparator(settings));
-        assertEquals(toSort.get(0).getName(), "bitstream2");
-        assertEquals(toSort.get(1).getName(), "bitstream1");
-        assertEquals(toSort.get(2).getName(), "bitstream3");
+        assertEquals("bitstream2", toSort.get(0).getName());
+        assertEquals("bitstream1", toSort.get(1).getName());
+        assertEquals("bitstream3", toSort.get(2).getName());
     }
 
+    /**
+     * Test for same Mimetype and same Size, if this is the case, then ordering is just as it was before sorting
+     * @throws Exception
+     */
     @Test
     public void testSameMimeTypeSameSize() throws Exception {
         when(bitstreamFormat1.getMIMEType()).thenReturn("application/pdf");
@@ -120,27 +141,35 @@ public class GoogleBitstreamComparatorTest {
 
         List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
         Collections.sort(toSort, new GoogleBitstreamComparator(settings));
-        assertEquals("Same size and mimetype, so just pick the first one", toSort.get(0).getName(), "bitstream1");
-        assertEquals(toSort.get(1).getName(), "bitstream2");
-        assertEquals(toSort.get(2).getName(), "bitstream3");
+        assertEquals("Same size and mimetype, so just pick the first one", "bitstream1", toSort.get(0).getName());
+        assertEquals("bitstream2", toSort.get(1).getName());
+        assertEquals("bitstream3", toSort.get(2).getName());
     }
 
+    /**
+     * Test if sorting still works when there is an undefined Mimetype, undefined mimetypes have the lowest priority
+     * @throws Exception
+     */
     @Test
     public void testUnknownMimeType() throws Exception {
         when(bitstreamFormat1.getMIMEType()).thenReturn("unknown");
         when(bitstreamFormat2.getMIMEType()).thenReturn("text/richtext");
         when(bitstreamFormat3.getMIMEType()).thenReturn("text/richtext");
-        when(bitstream1.getSize()).thenReturn(new Long(100));
+        when(bitstream1.getSize()).thenReturn(new Long(400));
         when(bitstream2.getSize()).thenReturn(new Long(200));
         when(bitstream3.getSize()).thenReturn(new Long(300));
 
         List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
         Collections.sort(toSort, new GoogleBitstreamComparator(settings));
-        assertEquals(toSort.get(0).getName(), "bitstream3");
-        assertEquals(toSort.get(1).getName(), "bitstream2");
-        assertEquals(toSort.get(2).getName(), "bitstream1");
+        assertEquals("bitstream3", toSort.get(0).getName());
+        assertEquals("bitstream2", toSort.get(1).getName());
+        assertEquals("bitstream1",toSort.get(2).getName());
     }
 
+    /**
+     * Test with all unknown mimetypes, ordered by size if this is the case
+     * @throws Exception
+     */
     @Test
     public void testAllUnknown() throws Exception {
         when(bitstreamFormat1.getMIMEType()).thenReturn("unknown");
@@ -152,11 +181,14 @@ public class GoogleBitstreamComparatorTest {
 
         List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
         Collections.sort(toSort, new GoogleBitstreamComparator(settings));
-        assertEquals(toSort.get(0).getName(), "bitstream2");
-        assertEquals(toSort.get(1).getName(), "bitstream1");
-        assertEquals(toSort.get(2).getName(), "bitstream3");
+        assertEquals("bitstream2", toSort.get(0).getName());
+        assertEquals("bitstream1", toSort.get(1).getName());
+        assertEquals("bitstream3", toSort.get(2).getName());
     }
 
+    /**
+     * Test to see if priority is configurable, order should change according to prioritized_types property
+     */
     @Test
     public void testChangePriority() {
         settings.put("citation.prioritized_types", "PS, RTF, WORD, PDF");
@@ -166,10 +198,161 @@ public class GoogleBitstreamComparatorTest {
 
         List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
         Collections.sort(toSort, new GoogleBitstreamComparator(settings));
-        assertEquals("PS should be first", toSort.get(0).getName(), "bitstream3");
-        assertEquals("RTF second", toSort.get(1).getName(), "bitstream1");
-        assertEquals("Word third",toSort.get(2).getName(), "bitstream2");
+        assertEquals("PS should be first", "bitstream3", toSort.get(0).getName());
+        assertEquals("RTF second", "bitstream1", toSort.get(1).getName());
+        assertEquals("Word third", "bitstream2", toSort.get(2).getName());
     }
+
+    /**
+     * Test what happens when bitstreams have no mimetype, should be just ordered by size
+     */
+    @Test
+    public void testNoMimeType(){
+        when(bitstream1.getSize()).thenReturn(new Long(200));
+        when(bitstream2.getSize()).thenReturn(new Long(300));
+        when(bitstream3.getSize()).thenReturn(new Long(100));
+
+        List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
+        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        assertEquals("bitstream2", toSort.get(0).getName());
+        assertEquals("bitstream1", toSort.get(1).getName());
+        assertEquals("bitstream3", toSort.get(2).getName());
+    }
+
+    /**
+     * Three bitstreams without a size, just the same ordering as given
+     * @throws Exception
+     */
+    @Test
+    public void testNoSize() throws Exception {
+        when(bitstreamFormat1.getMIMEType()).thenReturn("unknown");
+        when(bitstreamFormat2.getMIMEType()).thenReturn("unknown");
+        when(bitstreamFormat3.getMIMEType()).thenReturn("unknown");
+
+        List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
+        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        assertEquals("bitstream1", toSort.get(0).getName());
+        assertEquals("bitstream2", toSort.get(1).getName());
+        assertEquals("bitstream3", toSort.get(2).getName());
+    }
+
+    /**
+     * Make sure that it doesn't crash when bitstreams have no size or mimetype
+     */
+    @Test
+    public void testNoMimeTypeNoSize() {
+        List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
+        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        assertEquals("bitstream1", toSort.get(0).getName());
+        assertEquals("bitstream2", toSort.get(1).getName());
+        assertEquals("bitstream3", toSort.get(2).getName());
+    }
+
+    /**
+     * Make sure it still works when the citation.prioritized_types property is empty
+     */
+    @Test
+    public void testNoPrioritizedTypes() {
+        settings.put("citation.prioritized_types", "");
+        when(bitstreamFormat1.getMIMEType()).thenReturn("text/richtext");
+        when(bitstreamFormat2.getMIMEType()).thenReturn("application/msword");
+        when(bitstreamFormat3.getMIMEType()).thenReturn("application/x-photoshop");
+        when(bitstream1.getSize()).thenReturn(new Long(100));
+        when(bitstream2.getSize()).thenReturn(new Long(200));
+        when(bitstream3.getSize()).thenReturn(new Long(300));
+
+        List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
+        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        assertEquals("PS should be first", "bitstream3", toSort.get(0).getName());
+        assertEquals("RTF second", "bitstream2", toSort.get(1).getName());
+        assertEquals("Word third", "bitstream1", toSort.get(2).getName());
+    }
+
+    /**
+     * Test to make sure properties can be empty
+     */
+    @Test
+    public void testNoMimeTypesForType() {
+        settings.put("citation.mimetypes.PDF" , "");
+        when(bitstreamFormat1.getMIMEType()).thenReturn("text/richtext");
+        when(bitstreamFormat2.getMIMEType()).thenReturn("application/pdf");
+        when(bitstreamFormat3.getMIMEType()).thenReturn("application/x-photoshop");
+
+        List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
+        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        assertEquals("RTF first because PDF is not defined","bitstream1", toSort.get(0).getName());
+        assertEquals("Word next", "bitstream3", toSort.get(1).getName());
+        assertEquals("Lastly pdf because it is not defined", "bitstream2", toSort.get(2).getName());
+    }
+
+    /**
+     * Test to check if types defined in citation.prioritized_types can be removed safely
+     */
+    @Test
+    public void testNoFieldForType() {
+        settings.remove("citation.mimetypes.PDF");
+        when(bitstreamFormat1.getMIMEType()).thenReturn("text/richtext");
+        when(bitstreamFormat2.getMIMEType()).thenReturn("application/pdf");
+        when(bitstreamFormat3.getMIMEType()).thenReturn("application/x-photoshop");
+
+        List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
+        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        assertEquals("RTF first because PDF is not defined","bitstream1", toSort.get(0).getName());
+        assertEquals("Word next", "bitstream3", toSort.get(1).getName());
+        assertEquals("Lastly pdf because it is not defined", "bitstream2", toSort.get(2).getName());
+    }
+
+    /**
+     * Test if the wrong separator is used, types won't be recognized this way
+     */
+    @Test
+    public void testWrongSeparator() {
+        settings.put("citation.mimetypes.WORD", "application/msword; application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+        when(bitstreamFormat1.getMIMEType()).thenReturn("text/richtext");
+        when(bitstreamFormat2.getMIMEType()).thenReturn("application/msword");
+        when(bitstreamFormat3.getMIMEType()).thenReturn("application/x-photoshop");
+        when(bitstream1.getSize()).thenReturn(new Long(100));
+        when(bitstream2.getSize()).thenReturn(new Long(200));
+        when(bitstream3.getSize()).thenReturn(new Long(300));
+
+        List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
+        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        assertEquals("RTF", "bitstream1", toSort.get(0).getName());
+        assertEquals("PS", "bitstream3", toSort.get(1).getName());
+        assertEquals("Word last because wrong separator", "bitstream2", toSort.get(2).getName());
+    }
+
+    /**
+     * Test to check for no crash when nothing is configured, just checks for size
+     */
+    @Test
+    public void testNoConfig() {
+        settings.remove("citation.prioritized_types");
+        settings.remove("citation.mimetypes.PDF");
+        settings.remove("citation.mimetypes.WORD");
+        settings.remove("citation.mimetypes.RTF");
+        settings.remove("citation.mimetypes.PS");
+        when(bitstreamFormat1.getMIMEType()).thenReturn("text/richtext");
+        when(bitstreamFormat2.getMIMEType()).thenReturn("application/msword");
+        when(bitstreamFormat3.getMIMEType()).thenReturn("application/x-photoshop");
+        when(bitstream1.getSize()).thenReturn(new Long(100));
+        when(bitstream2.getSize()).thenReturn(new Long(200));
+        when(bitstream3.getSize()).thenReturn(new Long(300));
+
+        List<Bitstream> toSort = Arrays.asList(bundle.getBitstreams());
+        Collections.sort(toSort, new GoogleBitstreamComparator(settings));
+        assertEquals("bitstream3", toSort.get(0).getName());
+        assertEquals("bitstream2", toSort.get(1).getName());
+        assertEquals("bitstream1", toSort.get(2).getName());
+    }
+
+
+    @After
+    public void destroy()
+    {
+      settings = null;
+    }
+
 
 
 

--- a/dspace-api/src/test/java/org/dspace/app/util/GoogleBitstreamComparatorTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/GoogleBitstreamComparatorTest.java
@@ -1,0 +1,10 @@
+package org.dspace.app.util;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by frederic on 24/04/17.
+ */
+public class GoogleBitstreamComparatorTest {
+
+}

--- a/dspace-api/src/test/java/org/dspace/content/GoogleMetadataTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/GoogleMetadataTest.java
@@ -1,0 +1,73 @@
+package org.dspace.app.util;
+
+import org.dspace.content.Bitstream;
+import org.dspace.content.BitstreamFormat;
+import org.dspace.content.Bundle;
+import org.dspace.content.Item;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by frederic on 25/04/17.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class GoogleMetadataTest {
+    @InjectMocks
+    private GoogleMetadata googleMetadata;
+
+    @Mock
+    private GoogleBitstreamComparator googleBitstreamComparator;
+
+    @Mock
+    private Item item;
+
+    @Mock
+    private Bundle bundle;
+
+    @Mock
+    private Bitstream bitstream1;
+
+    @Mock
+    private Bitstream bitstream2;
+
+    @Mock
+    private Bitstream bitstream3;
+
+    @Mock
+    private BitstreamFormat bitstreamFormat1;
+
+    @Mock
+    private BitstreamFormat bitstreamFormat2;
+
+    @Mock
+    private BitstreamFormat bitstreamFormat3;
+
+
+    @Before
+    public void setUp() throws Exception {
+        HashMap<String, String> settings = new HashMap<>();
+        settings.put("citation.prioritized_types", "PDF, WORD, RTF, PS");
+        settings.put("citation.mimetypes.PDF" , "application/pdf");
+        settings.put("citation.mimetypes.WORD", "application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+        settings.put("citation.mimetypes.RTF", "text/richtext");
+        settings.put("citation.mimetypes.PS", "application/x-photoshop");
+        googleBitstreamComparator = new GoogleBitstreamComparator(settings);
+        when(item.getBundles("ORIGINAL")).thenReturn(new Bundle[] {bundle});
+    }
+
+    @Test
+    public void testFindLinkableFulltext() throws Exception {
+
+    }
+
+
+}

--- a/dspace-api/src/test/java/org/dspace/content/GoogleMetadataTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/GoogleMetadataTest.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.content;
 
 import org.apache.commons.io.Charsets;
@@ -22,9 +29,6 @@ import java.util.HashMap;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
 
-/**
- * Created by frederic on 25/04/17.
- */
 public class GoogleMetadataTest extends AbstractUnitTest {
 
     /** log4j category */

--- a/dspace-api/src/test/java/org/dspace/content/GoogleMetadataTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/GoogleMetadataTest.java
@@ -1,16 +1,22 @@
-package org.dspace.app.util;
+package org.dspace.content;
 
-import org.dspace.content.Bitstream;
-import org.dspace.content.BitstreamFormat;
-import org.dspace.content.Bundle;
-import org.dspace.content.Item;
+import org.apache.commons.io.Charsets;
+import org.apache.log4j.Logger;
+import org.dspace.AbstractUnitTest;
+import org.dspace.app.util.GoogleMetadata;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.*;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import sun.net.www.content.text.PlainTextInputStream;
 
+import java.io.*;
+import java.sql.SQLException;
 import java.util.HashMap;
 
 import static org.junit.Assert.*;
@@ -19,54 +25,239 @@ import static org.mockito.Mockito.when;
 /**
  * Created by frederic on 25/04/17.
  */
-@RunWith(MockitoJUnitRunner.class)
-public class GoogleMetadataTest {
-    @InjectMocks
-    private GoogleMetadata googleMetadata;
+public class GoogleMetadataTest extends AbstractUnitTest {
 
-    @Mock
-    private GoogleBitstreamComparator googleBitstreamComparator;
+    /** log4j category */
+    private static final Logger log = Logger.getLogger(GoogleMetadataTest.class);
 
-    @Mock
-    private Item item;
+    /**
+     * Item instance for the tests
+     */
+    private Item it;
 
-    @Mock
-    private Bundle bundle;
-
-    @Mock
-    private Bitstream bitstream1;
-
-    @Mock
-    private Bitstream bitstream2;
-
-    @Mock
-    private Bitstream bitstream3;
-
-    @Mock
-    private BitstreamFormat bitstreamFormat1;
-
-    @Mock
-    private BitstreamFormat bitstreamFormat2;
-
-    @Mock
-    private BitstreamFormat bitstreamFormat3;
-
-
+    /**
+     * This method will be run before every test as per @Before. It will
+     * initialize resources required for the tests.
+     *
+     * Other methods can be annotated with @Before here or in subclasses
+     * but no execution order is guaranteed
+     */
     @Before
-    public void setUp() throws Exception {
-        HashMap<String, String> settings = new HashMap<>();
-        settings.put("citation.prioritized_types", "PDF, WORD, RTF, PS");
-        settings.put("citation.mimetypes.PDF" , "application/pdf");
-        settings.put("citation.mimetypes.WORD", "application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document");
-        settings.put("citation.mimetypes.RTF", "text/richtext");
-        settings.put("citation.mimetypes.PS", "application/x-photoshop");
-        googleBitstreamComparator = new GoogleBitstreamComparator(settings);
-        when(item.getBundles("ORIGINAL")).thenReturn(new Bundle[] {bundle});
+    @Override
+    public void init() {
+        super.init();
+        try
+        {
+            context.turnOffAuthorisationSystem();
+            Collection c = Collection.create(context);
+            WorkspaceItem wi = WorkspaceItem.create(context, c, false);
+            Item item = wi.getItem();
+
+            InstallItem.installItem(context, wi, null);
+            item.update();
+            context.restoreAuthSystemState();
+            context.commit();
+            it = item;
+        }
+        catch (AuthorizeException ex)
+        {
+            log.error("Authorization Error in init", ex);
+            fail("Authorization Error in init: " + ex.getMessage());
+        }
+        catch (SQLException ex)
+        {
+            log.error("SQL Error in init", ex);
+            fail("SQL Error in init: " + ex.getMessage());
+        }
+        catch (IOException ex) {
+            log.error("IO Error in init", ex);
+            fail("SQL Error in init: " + ex.getMessage());
+        }
     }
 
+    /**
+     * Test to see the priorities work, the PDF should be returned
+     * @throws Exception
+     */
     @Test
-    public void testFindLinkableFulltext() throws Exception {
+    public void testGetPDFURLDifferentMimeTypes() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = it.createBundle("ORIGINAL");
+        Bitstream b = bundle.createBitstream(new ByteArrayInputStream("Bitstream 1".getBytes(Charsets.UTF_8)));
+        b.setName("Word");
+        b.setFormat(BitstreamFormat.create(context));
+        b.getFormat().setMIMEType("application/msword");
+        bundle.addBitstream(b);
+        Bitstream b2 = bundle.createBitstream(new ByteArrayInputStream("Bitstream 2".getBytes(Charsets.UTF_8)));
+        b2.setName("Pdf");
+        b2.setFormat(BitstreamFormat.create(context));
+        b2.getFormat().setMIMEType("application/pdf");
+        bundle.addBitstream(b2);
+        Bitstream b3 = bundle.createBitstream(new ByteArrayInputStream("Bitstream 3".getBytes(Charsets.UTF_8)));
+        b3.setName("Rtf");
+        b3.setFormat(BitstreamFormat.create(context));
+        b3.getFormat().setMIMEType("text/richtext");
+        bundle.addBitstream(b3);
+        context.restoreAuthSystemState();
+        context.commit();
+        GoogleMetadata gm = new GoogleMetadata(this.context, it);
+        String[] urlSplitted = gm.getPDFURL().get(0).split("/");
+        assertEquals("Pdf", urlSplitted[urlSplitted.length - 1]);
+    }
 
+    /**
+     * When multiple bitstreams with the sametype are found, it returns the largest one
+     * @throws Exception
+     */
+    @Test
+    public void testGetPDFURLSameMimeTypes() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = it.createBundle("ORIGINAL");
+        Bitstream b = bundle.createBitstream(new ByteArrayInputStream("123456789".getBytes(Charsets.UTF_8)));
+        b.setName("size9");
+        b.setFormat(BitstreamFormat.create(context));
+        b.getFormat().setMIMEType("application/pdf");
+        bundle.addBitstream(b);
+        Bitstream b2 = bundle.createBitstream(new ByteArrayInputStream("1".getBytes(Charsets.UTF_8)));
+        b2.setName("size1");
+        b2.setFormat(BitstreamFormat.create(context));
+        b2.getFormat().setMIMEType("application/pdf");
+        bundle.addBitstream(b2);
+        Bitstream b3 = bundle.createBitstream(new ByteArrayInputStream("12345".getBytes(Charsets.UTF_8)));
+        b3.setName("size5");
+        b3.setFormat(BitstreamFormat.create(context));
+        b3.getFormat().setMIMEType("text/richtext");
+        bundle.addBitstream(b3);
+        context.restoreAuthSystemState();
+        context.commit();
+        GoogleMetadata gm = new GoogleMetadata(this.context, it);
+        String[] urlSplitted = gm.getPDFURL().get(0).split("/");
+        assertEquals("size9", urlSplitted[urlSplitted.length - 1]);
+    }
+
+    /**
+     * Multiple bitstreams with same mimetype and size, just returns the first one
+     * @throws Exception
+     */
+    @Test
+    public void testGetPDFURLSameMimeTypesSameSize() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = it.createBundle("ORIGINAL");
+        Bitstream b = bundle.createBitstream(new ByteArrayInputStream("1".getBytes(Charsets.UTF_8)));
+        b.setName("first");
+        b.setFormat(BitstreamFormat.create(context));
+        b.getFormat().setMIMEType("application/pdf");
+        bundle.addBitstream(b);
+        Bitstream b2 = bundle.createBitstream(new ByteArrayInputStream("1".getBytes(Charsets.UTF_8)));
+        b2.setName("second");
+        b2.setFormat(BitstreamFormat.create(context));
+        b2.getFormat().setMIMEType("application/pdf");
+        bundle.addBitstream(b2);
+        Bitstream b3 = bundle.createBitstream(new ByteArrayInputStream("1".getBytes(Charsets.UTF_8)));
+        b3.setName("third");
+        b3.setFormat(BitstreamFormat.create(context));
+        b3.getFormat().setMIMEType("application/pdf");
+        bundle.addBitstream(b3);
+        context.restoreAuthSystemState();
+        context.commit();
+        GoogleMetadata gm = new GoogleMetadata(this.context, it);
+        String[] urlSplitted = gm.getPDFURL().get(0).split("/");
+        assertEquals("first", urlSplitted[urlSplitted.length - 1]);
+    }
+
+    /**
+     * Test to see if that when an item is marked as primary, that it will still be the result of getPdfURL()
+     * @throws Exception
+     */
+    @Test
+    public void testGetPDFURLWithPrimaryBitstream() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = it.createBundle("ORIGINAL");
+        Bitstream b = bundle.createBitstream(new ByteArrayInputStream("Larger file than primary".getBytes(Charsets.UTF_8)));
+        b.setName("first");
+        b.setFormat(BitstreamFormat.create(context));
+        b.getFormat().setMIMEType("unknown");
+        bundle.addBitstream(b);
+        Bitstream b2 = bundle.createBitstream(new ByteArrayInputStream("Bitstream with more prioritized mimetype than primary".getBytes(Charsets.UTF_8)));
+        b2.setName("second");
+        b2.setFormat(BitstreamFormat.create(context));
+        b2.getFormat().setMIMEType("application/pdf");
+        bundle.addBitstream(b2);
+        Bitstream b3 = bundle.createBitstream(new ByteArrayInputStream("1".getBytes(Charsets.UTF_8)));
+        b3.setName("primary");
+        b3.setFormat(BitstreamFormat.create(context));
+        b3.getFormat().setMIMEType("Primary");
+        bundle.addBitstream(b3);
+        bundle.setPrimaryBitstreamID(b3.getID());
+        context.restoreAuthSystemState();
+        context.commit();
+        GoogleMetadata gm = new GoogleMetadata(this.context, it);
+        String[] urlSplitted = gm.getPDFURL().get(0).split("/");
+        assertEquals("primary", urlSplitted[urlSplitted.length - 1]);
+    }
+
+    /**
+     * Test to make sure mimetypes can be undefined in the property file, just give them lowest priority if
+     * this is the case and return the largest.
+     * @throws Exception
+     */
+    @Test
+    public void testGetPDFURLWithUndefinedMimeTypes() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = it.createBundle("ORIGINAL");
+        Bitstream b = bundle.createBitstream(new ByteArrayInputStream("12".getBytes(Charsets.UTF_8)));
+        b.setName("small");
+        b.setFormat(BitstreamFormat.create(context));
+        b.getFormat().setMIMEType("unknown type 1");
+        bundle.addBitstream(b);
+        Bitstream b2 = bundle.createBitstream(new ByteArrayInputStream("12121212".getBytes(Charsets.UTF_8)));
+        b2.setName("medium");
+        b2.setFormat(BitstreamFormat.create(context));
+        b2.getFormat().setMIMEType("unknown type 2");
+        bundle.addBitstream(b2);
+        Bitstream b3 = bundle.createBitstream(new ByteArrayInputStream("12121212121212".getBytes(Charsets.UTF_8)));
+        b3.setName("large");
+        b3.setFormat(BitstreamFormat.create(context));
+        b3.getFormat().setMIMEType("unknown type ");
+        bundle.addBitstream(b3);
+        context.restoreAuthSystemState();
+        context.commit();
+        GoogleMetadata gm = new GoogleMetadata(this.context, it);
+        String[] urlSplitted = gm.getPDFURL().get(0).split("/");
+        assertEquals("large", urlSplitted[urlSplitted.length - 1]);
+    }
+
+
+    /**
+     * Test for crash when no bundle is given
+     * @throws Exception
+     */
+    @Test
+    public void testGetPDFURLWithNoBundle() throws Exception {
+        GoogleMetadata gm = new GoogleMetadata(this.context, it);
+        assertEquals(0, gm.getPDFURL().size());
+    }
+
+    /**
+     * Test for crash when no bitstreams are in the bundle
+     * @throws Exception
+     */
+    @Test
+    public void testGetPDFURLWithNoBitstreams() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = it.createBundle("ORIGINAL");
+        context.restoreAuthSystemState();
+        context.commit();
+        GoogleMetadata gm = new GoogleMetadata(this.context, it);
+        assertEquals(0, gm.getPDFURL().size());
+    }
+
+    @After
+    @Override
+    public void destroy()
+    {
+        it = null;
+        super.destroy();
     }
 
 

--- a/dspace-api/src/test/java/org/dspace/content/GoogleMetadataTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/GoogleMetadataTest.java
@@ -218,7 +218,7 @@ public class GoogleMetadataTest extends AbstractUnitTest {
         Bitstream b3 = bundle.createBitstream(new ByteArrayInputStream("12121212121212".getBytes(Charsets.UTF_8)));
         b3.setName("large");
         b3.setFormat(BitstreamFormat.create(context));
-        b3.getFormat().setMIMEType("unknown type ");
+        b3.getFormat().setMIMEType("unknown type 3");
         bundle.addBitstream(b3);
         context.restoreAuthSystemState();
         context.commit();
@@ -250,6 +250,35 @@ public class GoogleMetadataTest extends AbstractUnitTest {
         context.commit();
         GoogleMetadata gm = new GoogleMetadata(this.context, it);
         assertEquals(0, gm.getPDFURL().size());
+    }
+
+    /**
+     * Test empty bitstreams
+     */
+    @Test
+    public void testGetPDFURLWithEmptyBitstreams() throws Exception{
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = it.createBundle("ORIGINAL");
+        Bitstream b = bundle.createBitstream(new ByteArrayInputStream("".getBytes(Charsets.UTF_8)));
+        b.setName("small");
+        b.setFormat(BitstreamFormat.create(context));
+        b.getFormat().setMIMEType("unknown type 1");
+        bundle.addBitstream(b);
+        Bitstream b2 = bundle.createBitstream(new ByteArrayInputStream("".getBytes(Charsets.UTF_8)));
+        b2.setName("medium");
+        b2.setFormat(BitstreamFormat.create(context));
+        b2.getFormat().setMIMEType("unknown type 2");
+        bundle.addBitstream(b2);
+        Bitstream b3 = bundle.createBitstream(new ByteArrayInputStream("".getBytes(Charsets.UTF_8)));
+        b3.setName("large");
+        b3.setFormat(BitstreamFormat.create(context));
+        b3.getFormat().setMIMEType("unknown type 3");
+        bundle.addBitstream(b3);
+        context.restoreAuthSystemState();
+        context.commit();
+        GoogleMetadata gm = new GoogleMetadata(this.context, it);
+        String[] urlSplitted = gm.getPDFURL().get(0).split("/");
+        assertEquals("small", urlSplitted[urlSplitted.length - 1]);
     }
 
     @After

--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -182,7 +182,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>1.9.5</version>
         </dependency>
         <dependency>
             <groupId>com.lyncode</groupId>

--- a/dspace/config/crosswalks/google-metadata.properties
+++ b/dspace/config/crosswalks/google-metadata.properties
@@ -73,15 +73,15 @@ google.citation_patent_number =
 google.citation_technical_report_number =
 google.citation_technical_report_institution = dc.publisher
 
-#priority whitelist for citation pdf url, define the matching mimetypes below
+#priority whitelist for citation_pdf_url, define the matching mimetypes below
 #priority order is defined here, where the first type is the most important
-google.citation.prioritized_types = PDF, WORD, RTF, PS
+google.citation.prioritized_types = PDF, WORD, RTF, PS, EPUB
 
-#Define for each type each applicable mimetype, every type defined in prioritized_types has to reoccur here
+#Define for each type each applicable mimetype, every type defined in prioritized_types should reoccur here
 google.citation.mimetypes.PDF = application/pdf
 google.citation.mimetypes.WORD = application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document
 google.citation.mimetypes.RTF = text/richtext
 google.citation.mimetypes.PS = application/x-photoshop
-
+google.citation.mimetypes.EPUB = application/epub+zip
 
 

--- a/dspace/config/crosswalks/google-metadata.properties
+++ b/dspace/config/crosswalks/google-metadata.properties
@@ -73,5 +73,15 @@ google.citation_patent_number =
 google.citation_technical_report_number =
 google.citation_technical_report_institution = dc.publisher
 
+#priority whitelist for citation pdf url, define the matching mimetypes below
+#priority order is defined here, where the first type is the most important
+google.citation.prioritized_types = PDF, WORD, RTF, PS
+
+#Define for each type each applicable mimetype, every type defined in prioritized_types has to reoccur here
+google.citation.mimetypes.PDF = application/pdf
+google.citation.mimetypes.WORD = application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document
+google.citation.mimetypes.RTF = text/richtext
+google.citation.mimetypes.PS = application/x-photoshop
+
 
 

--- a/dspace/config/crosswalks/google-metadata.properties
+++ b/dspace/config/crosswalks/google-metadata.properties
@@ -73,15 +73,10 @@ google.citation_patent_number =
 google.citation_technical_report_number =
 google.citation_technical_report_institution = dc.publisher
 
-#priority whitelist for citation_pdf_url, define the matching mimetypes below
+#priority whitelist for citation_pdf_url, shortnames are defined in dspace/config/registries/bitstream-formats.xml
 #priority order is defined here, where the first type is the most important
-google.citation.prioritized_types = PDF, WORD, RTF, PS, EPUB
+google.citation.prioritized_types = Adobe PDF, Microsoft Word, Microsoft Word XML, RTF, Photoshop
 
-#Define for each type each applicable mimetype, every type defined in prioritized_types should reoccur here
-google.citation.mimetypes.PDF = application/pdf
-google.citation.mimetypes.WORD = application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document
-google.citation.mimetypes.RTF = text/richtext
-google.citation.mimetypes.PS = application/x-photoshop
-google.citation.mimetypes.EPUB = application/epub+zip
+
 
 

--- a/dspace/config/crosswalks/google-metadata.properties
+++ b/dspace/config/crosswalks/google-metadata.properties
@@ -75,7 +75,7 @@ google.citation_technical_report_institution = dc.publisher
 
 #priority whitelist for citation_pdf_url, shortnames are defined in dspace/config/registries/bitstream-formats.xml
 #priority order is defined here, where the first type is the most important
-google.citation.prioritized_types = Adobe PDF, Microsoft Word, Microsoft Word XML, RTF, Photoshop
+google.citation.prioritized_types = Adobe PDF, Microsoft Word, Microsoft Word XML, RTF, Photoshop, EPUB
 
 
 

--- a/dspace/config/registries/bitstream-formats.xml
+++ b/dspace/config/registries/bitstream-formats.xml
@@ -714,7 +714,7 @@
 	  <internal>false</internal>
 	  <extension>sds</extension>
 	</bitstream-type>
-	
+
 	<bitstream-type>
 	  <mimetype>application/vnd.stardivision.mail</mimetype>
 	  <short_description>StarMail 5.x mail files</short_description>
@@ -733,5 +733,13 @@
       <extension>rdf</extension>
     </bitstream-type>
 
+    <bitstream-type>
+        <mimetype>application/epub+zip</mimetype>
+        <short_description>EPUB</short_description>
+        <description>Electronic publishing</description>
+        <support_level>1</support_level>
+        <internal>false</internal>
+        <extension>epub</extension>
+    </bitstream-type>
 
 </dspace-bitstream-types>

--- a/pom.xml
+++ b/pom.xml
@@ -1297,6 +1297,7 @@
               <groupId>org.mockito</groupId>
               <artifactId>mockito-all</artifactId>
               <version>1.9.5</version>
+              <scope>test</scope>
           </dependency>
       </dependencies>
    </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1292,6 +1292,12 @@
               <version>3.0.0</version>
               <scope>provided</scope>
           </dependency>
+          <!-- Testing -->
+          <dependency>
+              <groupId>org.mockito</groupId>
+              <artifactId>mockito-all</artifactId>
+              <version>1.9.5</version>
+          </dependency>
       </dependencies>
    </dependencyManagement>
 


### PR DESCRIPTION
This new functionality makes it so that the citation_pdf_url is more accurate, according to the recommended solution on the following JIRA ticket: https://jira.duraspace.org/browse/DS-3127

# Whitelist of formats allowable in citation_pdf_url for Google Scholar 

## Default configuration

The default configuration will give priority the following formats in the following order PDF, word documents, Rich Text Files, Photoshop files and EPUB files. If an item has multiple files of the same type, it will choose the largest to put in the citation_pdf_url. If there's no matching files with the specified types it will also just choose the largest one.

## Enabling an extra mimetype

To enable a new mimetype two things have to be done. First define a format short description, which will contain the mimetype. 

To do this just choose a name for the type and put it after `google.citation.prioritized_types` in google-metadata.properties (separated by ","). For example:
```
google.citation.prioritized_types = Adobe PDF, Microsoft Word, Microsoft Word XML, RTF, Photoshop, {NEWTYPE}
```

Next define the matching mimetype for this new format in bitstream-formats.xml

## Change the priority of types

The priority of the types is decided by the order they are written in the google.citation.prioritized_types property, where the first type will be the most prioritized one.

Changing this order will change which url will be used in the citation_pdf_url metadata field and this will decide which link Google Scholar will use.

Removing this property or not putting any types in it will have as effect that DSpace will just put the largest bitstream link in the ORIGINAL bundle of that item in citation_pdf_url.