### PR TITLE
DS-3387 Upgrade handlebars to v4.

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/bower.json
+++ b/dspace-xmlui-mirage2/src/main/webapp/bower.json
@@ -7,7 +7,7 @@
         "jquery": "~1.10.2",
         "jquery-ui": "1.10.3",
         "jqueryuibootstrap": "4f3772cd37b898f456c0126c4b44178ce8d4aad7",
-        "handlebars": "2.0.0",
+        "handlebars": "4.0.0",
         "respond": "1.4.2",
         "html5shiv": "3.7.2",
         "holderjs": "2.4.1",

--- a/dspace-xmlui-mirage2/src/main/webapp/package.json
+++ b/dspace-xmlui-mirage2/src/main/webapp/package.json
@@ -10,7 +10,7 @@
     "grunt-contrib-compass": "^1.1.1",
     "grunt-contrib-concat": "~1.0.1",
     "grunt-contrib-copy": "~1.0.0",
-    "grunt-contrib-handlebars": "0.9.3",
+    "grunt-contrib-handlebars": "1.0.0",
     "grunt-contrib-uglify": "~2.0.0",
     "grunt-usemin": "~3.1.1",
     "load-grunt-tasks": "~3.5.2",

--- a/dspace-xmlui-mirage2/src/main/webapp/templates/discovery_advanced_filters.hbs
+++ b/dspace-xmlui-mirage2/src/main/webapp/templates/discovery_advanced_filters.hbs
@@ -15,7 +15,7 @@
             <select id="aspect_discovery_SimpleSearch_field_filtertype_{{index}}" class="ds-select-field form-control"
                     name="filtertype_{{index}}">
                 {{#set_selected type}}
-                {{#each ../../i18n.filtertype}}
+                {{#each ../i18n.filtertype}}
                 <option value="{{@key}}">{{this}}</option>
                 {{/each}}
                 {{/set_selected}}
@@ -27,7 +27,7 @@
             <select id="aspect_discovery_SimpleSearch_field_filter_relational_operator_{{index}}"
                     class="ds-select-field form-control" name="filter_relational_operator_{{index}}">
                 {{#set_selected relational_operator}}
-                {{#each ../../i18n.filter_relational_operator}}
+                {{#each ../i18n.filter_relational_operator}}
                 <option value="{{@key}}">{{this}}</option>
                 {{/each}}
                 {{/set_selected}}


### PR DESCRIPTION
Fixes [DS-3387](https://jira.duraspace.org/browse/DS-3387)

Fixed advanced filters to work with handlebars v4 (https://github.com/wycats/handlebars.js/issues/1028), which allows them to be displayed normally, as it was not working on #1573.
