### PR TITLE
DS-2291 Autocomplete not working on Mirage2

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/scripts.xml
+++ b/dspace-xmlui-mirage2/src/main/webapp/scripts.xml
@@ -13,6 +13,10 @@
     <script src="vendor/jquery/jquery.min.js">&#160;</script>
     <script src="vendor/jquery-ui/ui/jquery.ui.core.js">&#160;</script>
     <script src="vendor/jquery-ui/ui/jquery.ui.datepicker.js">&#160;</script>
+    <script src="vendor/jquery-ui/ui/jquery.ui.widget.js">&#160;</script>
+    <script src="vendor/jquery-ui/ui/jquery.ui.position.js">&#160;</script>
+    <script src="vendor/jquery-ui/ui/jquery.ui.menu.js">&#160;</script>
+    <script src="vendor/jquery-ui/ui/jquery.ui.autocomplete.js">&#160;</script>
     <script src="vendor/handlebars/handlebars.js">&#160;</script>
     <script src="vendor/holderjs/holder.js">&#160;</script>
     <!--<script src="vendor/bootstrap-sass-official/assets/javascripts/bootstrap/affix.js">&#160;</script>-->

--- a/dspace-xmlui-mirage2/src/main/webapp/styles/classic_mirage_color_scheme/_jquery_ui.scss
+++ b/dspace-xmlui-mirage2/src/main/webapp/styles/classic_mirage_color_scheme/_jquery_ui.scss
@@ -16,7 +16,7 @@
 }
 
 input[type='text'].ui-autocomplete-loading{
-    background-image: url("../../images/authority_control/lookup-indicator.gif");
+    background-image: url("../images/authority_control/lookup-indicator.gif");
     background-repeat: no-repeat;
     background-position: 99% 50%;
     background-size: 25px 25px;

--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/general/choice-authority-control.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/general/choice-authority-control.xsl
@@ -322,9 +322,9 @@
                     <xsl:value-of select="$confidenceIndicatorID"/>
                     <xsl:text>', confidenceName: '</xsl:text>
                     <xsl:value-of select="$confidenceName"/>
-                    <xsl:text>', collection: </xsl:text>
+                    <xsl:text>', collection: '</xsl:text>
                     <xsl:value-of select="$collectionID"/>
-                    <xsl:text>, contextPath: '</xsl:text>
+                    <xsl:text>', contextPath: '</xsl:text>
                     <xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='contextPath'][not(@qualifier)]"/>
                 <xsl:text>'});</xsl:text>
             <xsl:text>});</xsl:text>

--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/general/choice-authority-control.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/general/choice-authority-control.xsl
@@ -74,7 +74,9 @@
           <!-- Collection ID for context -->
           <xsl:choose>
             <xsl:when test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='choice'][@qualifier='collection']">
+              <xsl:text>'</xsl:text>
               <xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='choice'][@qualifier='collection']"/>
+              <xsl:text>'</xsl:text>
             </xsl:when>
             <xsl:otherwise>
               <xsl:text>-1</xsl:text>


### PR DESCRIPTION
Fixes DS-2291.

The autocomplete was not working due to it not being included in the scripts.xml.

Also, the collection wasn't between single quotes, which threw another javascript error.

End result:

![image](https://cloud.githubusercontent.com/assets/4061767/25672172/e58007da-3008-11e7-8be0-4213b551568c.png)
