### PR TITLE
DS-3588 configuration of CORS headers for the API

### DIFF
--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/Application.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/Application.java
@@ -33,6 +33,9 @@ import org.springframework.boot.web.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.annotation.Order;
 import org.springframework.hateoas.RelProvider;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
 /**
  * Define the Spring Boot Application settings itself. This class takes the place 
@@ -171,5 +174,18 @@ public class Application extends SpringBootServletInitializer
     @Bean
     protected RelProvider dspaceRelProvider() {
     	return new DSpaceRelProvider();
+    }
+    
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurerAdapter() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                String[] corsAllowedOrigins = configuration.getCorsAllowedOrigins();
+                if (corsAllowedOrigins != null) {
+                	registry.addMapping("/api/**").allowedOrigins(corsAllowedOrigins);
+                }
+            }
+        };
     }
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/ApplicationConfig.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/ApplicationConfig.java
@@ -25,7 +25,16 @@ public class ApplicationConfig {
 	@Value("${dspace.dir}")
 	private String dspaceHome;
 
+	@Value("${cors.allowed-origins}")
+	private String corsAllowedOrigins;
+
 	public String getDspaceHome() {
 		return dspaceHome;
+	}
+
+	public String[] getCorsAllowedOrigins() {
+		if (corsAllowedOrigins != null)
+			return corsAllowedOrigins.split("\\s*,\\s*");
+		return null;
 	}
 }

--- a/dspace-spring-rest/src/main/resources/application.properties
+++ b/dspace-spring-rest/src/main/resources/application.properties
@@ -26,6 +26,11 @@ dspace.dir=${dspace.dir}
 #dspace.dir=d:/install/dspace7
 
 ########################
+# DSpace API CORS Settings
+#
+cors.allowed-origins = *
+
+########################
 # Spring Boot Settings
 #
 # Testing an "application Name"


### PR DESCRIPTION
It allows the use of the application.properties to set the allowed origin for cross origin call.
It solves CORS issues that can be observed using the HAL browser in a domain and the REST API on a different one. It supports pre-flight requests as by spring documentation and tested using custom header on the HAL browse that force the client to send a preflight request also for GET methods (that are the only one implemented right now in the DSpace API).