### PR TITLE
DS-3593 allow aggregation of endpoints by category / Include UUID in serialization

### DIFF
--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/RepositoryNotFoundException.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/RepositoryNotFoundException.java
@@ -18,9 +18,11 @@ import org.springframework.web.bind.annotation.ResponseStatus;
  */
 @ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "This endpoint is not found in the system")
 public class RepositoryNotFoundException extends RuntimeException {
+	String apiCategory;
 	String model;
 
-	public RepositoryNotFoundException(String model) {
+	public RepositoryNotFoundException(String apiCategory, String model) {
+		this.apiCategory = apiCategory;
 		this.model = model;
 	}
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/BitstreamFormatRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/BitstreamFormatRest.java
@@ -21,7 +21,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  */
 public class BitstreamFormatRest extends BaseObjectRest<Integer> {
 	public static final String NAME = "bitstreamformat";
-
+	
+	public static final String CATEGORY = RestModel.CORE;
+	
 	private String shortDescription;
 
 	private String description;
@@ -82,6 +84,12 @@ public class BitstreamFormatRest extends BaseObjectRest<Integer> {
 		this.extensions = extensions;
 	}
 
+	@JsonIgnore
+	@Override
+	public String getCategory() {
+		return CATEGORY;
+	}
+	
 	@Override
 	public String getType() {
 		return NAME;

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/BitstreamRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/BitstreamRest.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonProperty.Access;
  */
 public class BitstreamRest extends DSpaceObjectRest {
 	public static final String NAME = "bitstream";
+	public static final String CATEGORY = RestModel.CORE;
 	private String bundleName;
 
 	// avoid to serialize this object inline as we want a full resource embedded
@@ -68,6 +69,11 @@ public class BitstreamRest extends DSpaceObjectRest {
 		this.sequenceId = sequenceId;
 	}
 
+	@Override
+	public String getCategory() {
+		return CATEGORY;
+	}
+	
 	@Override
 	public String getType() {
 		return NAME;

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/CollectionRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/CollectionRest.java
@@ -15,7 +15,13 @@ package org.dspace.app.rest.model;
  */
 public class CollectionRest extends DSpaceObjectRest {
 	public static final String NAME = "collection";
+	public static final String CATEGORY = RestModel.CORE;
 
+	@Override
+	public String getCategory() {
+		return CATEGORY;
+	}
+	
 	@Override
 	public String getType() {
 		return NAME;

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/CommunityRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/CommunityRest.java
@@ -15,7 +15,13 @@ package org.dspace.app.rest.model;
  */
 public class CommunityRest extends DSpaceObjectRest {
 	public static final String NAME = "community";
-
+	public static final String CATEGORY = RestModel.CORE;
+	
+	@Override
+	public String getCategory() {
+		return CATEGORY;
+	}
+	
 	@Override
 	public String getType() {
 		return NAME;

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/DSpaceObjectRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/DSpaceObjectRest.java
@@ -11,8 +11,6 @@ import java.util.List;
 
 import org.dspace.app.rest.RestResourceController;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 /**
  * Base REST representation for all the DSpaceObjects
  * 
@@ -20,17 +18,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  *
  */
 public abstract class DSpaceObjectRest extends BaseObjectRest<String> {
-	@JsonIgnore
 	private String uuid;
 
 	private String name;
 	private String handle;
-	private String type;
 
 	List<MetadataEntryRest> metadata;
 
 	@Override
-	@JsonIgnore
 	public String getId() {
 		return uuid;
 	}
@@ -68,7 +63,6 @@ public abstract class DSpaceObjectRest extends BaseObjectRest<String> {
 	}
 
 	@Override
-	@JsonIgnore
 	public Class getController() {
 		return RestResourceController.class;
 	}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/EPersonRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/EPersonRest.java
@@ -12,8 +12,6 @@ import java.util.List;
 
 import org.dspace.app.rest.RestResourceController;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 /**
  * The EPerson REST Resource
  * 
@@ -22,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  */
 public class EPersonRest extends DSpaceObjectRest {
 	public static final String NAME = "eperson";
-
+	public static final String CATEGORY = RestModel.EPERSON;
 	private String netid;
 
 	private Date lastActive;
@@ -102,7 +100,11 @@ public class EPersonRest extends DSpaceObjectRest {
 	}
 
 	@Override
-	@JsonIgnore
+	public String getCategory() {
+		return CATEGORY;
+	}
+	
+	@Override
 	public Class getController() {
 		return RestResourceController.class;
 	}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/GroupRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/GroupRest.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  */
 public class GroupRest extends DSpaceObjectRest {
 	public static final String NAME = "group";
+	
+	public static final String CATEGORY = RestModel.EPERSON;
 
 	private String name;
 
@@ -31,6 +33,11 @@ public class GroupRest extends DSpaceObjectRest {
 	// https://jira.duraspace.org/browse/DS-3483
 	private List<GroupRest> groups;
 
+	@Override
+	public String getCategory() {
+		return CATEGORY;
+	}
+	
 	@Override
 	public String getType() {
 		return NAME;

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/ItemRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/ItemRest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  */
 public class ItemRest extends DSpaceObjectRest {
 	public static final String NAME = "item";
+	public static final String CATEGORY = RestModel.CORE;
 	private boolean inArchive = false;
 	private boolean discoverable = false;
 	private boolean withdrawn = false;
@@ -31,6 +32,11 @@ public class ItemRest extends DSpaceObjectRest {
 	//private EPerson submitter;
 
 	List<BitstreamRest> bitstreams;
+	
+	@Override
+	public String getCategory() {
+		return CATEGORY;
+	}
 	
 	@Override
 	public String getType() {

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataFieldRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataFieldRest.java
@@ -19,7 +19,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  */
 public class MetadataFieldRest extends BaseObjectRest<Integer> {
 	public static final String NAME = "metadatafield";
-
+	public static final String CATEGORY = RestModel.CORE;
+	
 	@JsonIgnore
 	private MetadataSchemaRest schema;
 	
@@ -67,8 +68,12 @@ public class MetadataFieldRest extends BaseObjectRest<Integer> {
 	}
 
 	@Override
-	@JsonIgnore
 	public Class getController() {
 		return RestResourceController.class;
+	}
+
+	@Override
+	public String getCategory() {
+		return CATEGORY;
 	}
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataSchemaRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataSchemaRest.java
@@ -21,7 +21,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  */
 public class MetadataSchemaRest extends BaseObjectRest<Integer> {
 	public static final String NAME = "metadataschema";
-
+	public static final String CATEGORY = RestModel.CORE;
+	
 	private String prefix;
 
 	private String namespace;
@@ -48,8 +49,12 @@ public class MetadataSchemaRest extends BaseObjectRest<Integer> {
 	}
 
 	@Override
-	@JsonIgnore
 	public Class getController() {
 		return RestResourceController.class;
+	}
+	
+	@Override
+	public String getCategory() {
+		return CATEGORY;
 	}
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/RestModel.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/RestModel.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.app.rest.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 /**
  * Methods to implement to make a REST resource addressable
  * 
@@ -14,7 +16,15 @@ package org.dspace.app.rest.model;
  *
  */
 public interface RestModel {
+	public static final String CORE = "core";
+	public static final String EPERSON = "eperson";
+	public static final String DISCOVER = "discover";
+	
+	@JsonIgnore
+	public String getCategory();
+	
 	public String getType();
 
+	@JsonIgnore
 	public Class getController();
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/SiteRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/SiteRest.java
@@ -15,7 +15,13 @@ package org.dspace.app.rest.model;
  */
 public class SiteRest extends DSpaceObjectRest {
 	public static final String NAME = "site";
-
+	public static final String CATEGORY = RestModel.CORE;
+	
+	@Override
+	public String getCategory() {
+		return CATEGORY;
+	}
+	
 	@Override
 	public String getType() {
 		return NAME;

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/DSpaceResource.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/DSpaceResource.java
@@ -55,11 +55,12 @@ public abstract class DSpaceResource<T extends RestModel> extends ResourceSuppor
 							RestModel linkedObject = (RestModel) readMethod.invoke(data);
 							if (linkedObject != null) {
 								embedded.put(pd.getName(),
-										utils.getResourceRepository(linkedObject.getType()).wrapResource(linkedObject));
+										utils.getResourceRepository(linkedObject.getCategory(), linkedObject.getType())
+												.wrapResource(linkedObject));
 							} else {
 								embedded.put(pd.getName(), null);
 							}
-	
+
 							Method writeMethod = pd.getWriteMethod();
 							writeMethod.invoke(data, new Object[] { null });
 						}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/BitstreamFormatRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/BitstreamFormatRestRepository.java
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Component;
  * @author Andrea Bollini (andrea.bollini at 4science.it)
  *
  */
-@Component(BitstreamFormatRest.NAME)
+@Component(BitstreamFormatRest.CATEGORY + "." + BitstreamFormatRest.NAME)
 public class BitstreamFormatRestRepository extends DSpaceRestRepository<BitstreamFormatRest, Integer> {
 	BitstreamFormatService bfs = ContentServiceFactory.getInstance().getBitstreamFormatService();
 	@Autowired

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/BitstreamRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/BitstreamRestRepository.java
@@ -33,7 +33,7 @@ import org.springframework.stereotype.Component;
  *
  */
 
-@Component(BitstreamRest.NAME)
+@Component(BitstreamRest.CATEGORY + "." + BitstreamRest.NAME)
 public class BitstreamRestRepository extends DSpaceRestRepository<BitstreamRest, UUID> {
 	BitstreamService bs = ContentServiceFactory.getInstance().getBitstreamService();
 	@Autowired

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
@@ -32,7 +32,7 @@ import org.springframework.stereotype.Component;
  *
  */
 
-@Component(CollectionRest.NAME)
+@Component(CollectionRest.CATEGORY + "." + CollectionRest.NAME)
 public class CollectionRestRepository extends DSpaceRestRepository<CollectionRest, UUID> {
 	CollectionService cs = ContentServiceFactory.getInstance().getCollectionService();
 	@Autowired

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
@@ -32,7 +32,7 @@ import org.springframework.stereotype.Component;
  *
  */
 
-@Component(CommunityRest.NAME)
+@Component(CommunityRest.CATEGORY + "." + CommunityRest.NAME)
 public class CommunityRestRepository extends DSpaceRestRepository<CommunityRest, UUID> {
 	CommunityService cs = ContentServiceFactory.getInstance().getCommunityService();
 	@Autowired

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component;
  *
  */
 
-@Component(EPersonRest.NAME)
+@Component(EPersonRest.CATEGORY + "." + EPersonRest.NAME)
 public class EPersonRestRepository extends DSpaceRestRepository<EPersonRest, UUID> {
 	EPersonService es = EPersonServiceFactory.getInstance().getEPersonService();
 	

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/GroupRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/GroupRestRepository.java
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component;
  *
  */
 
-@Component(GroupRest.NAME)
+@Component(GroupRest.CATEGORY + "." + GroupRest.NAME)
 public class GroupRestRepository extends DSpaceRestRepository<GroupRest, UUID> {
 	GroupService gs = EPersonServiceFactory.getInstance().getGroupService();
 	

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/ItemRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/ItemRestRepository.java
@@ -33,7 +33,7 @@ import org.springframework.stereotype.Component;
  *
  */
 
-@Component(ItemRest.NAME)
+@Component(ItemRest.CATEGORY + "." + ItemRest.NAME)
 public class ItemRestRepository extends DSpaceRestRepository<ItemRest, UUID> {
 	ItemService is = ContentServiceFactory.getInstance().getItemService();
 	@Autowired

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/SiteRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/SiteRestRepository.java
@@ -32,7 +32,7 @@ import org.springframework.stereotype.Component;
  *
  */
 
-@Component(SiteRest.NAME)
+@Component(SiteRest.CATEGORY + "." + SiteRest.NAME)
 public class SiteRestRepository extends DSpaceRestRepository<SiteRest, UUID> {
 	SiteService sitesv = ContentServiceFactory.getInstance().getSiteService();
 	@Autowired

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/Utils.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/Utils.java
@@ -59,19 +59,19 @@ public class Utils {
 	}
 
 	public Link linkToSingleResource(RestModel data, String rel) {
-		return linkTo(data.getController(), data.getType()).slash(data).withRel(rel);
+		return linkTo(data.getController(), data.getCategory(), data.getType()).slash(data).withRel(rel);
 	}
 
 	public Link linkToSubResource(RestModel data, String rel) {
-		return linkTo(data.getController(), data.getType()).slash(data).slash(rel).withRel(rel);
+		return linkTo(data.getController(), data.getCategory(), data.getType()).slash(data).slash(rel).withRel(rel);
 	}
 
-	public DSpaceRestRepository getResourceRepository(String modelPlural) {
+	public DSpaceRestRepository getResourceRepository(String apiCategory, String modelPlural) {
 		String model = makeSingular(modelPlural);
 		try {
-			return applicationContext.getBean(model, DSpaceRestRepository.class);
+			return applicationContext.getBean(apiCategory + "." + model, DSpaceRestRepository.class);
 		} catch (NoSuchBeanDefinitionException e) {
-			throw new RepositoryNotFoundException(model);
+			throw new RepositoryNotFoundException(apiCategory, model);
 		}
 	}
 	


### PR DESCRIPTION
Add a category to each REST Repository so to structure the endpoints by categories

/api/core/communities
/api/core/collections
...

/api/eperson/groups
/api/eperson/epersons
...

etc.

It is easy to change the categories just editing the CATEGORY constant in each REST domain object