### PR TITLE
DS-3406: Sort communities and collections iteration 2

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/Collection.java
+++ b/dspace-api/src/main/java/org/dspace/content/Collection.java
@@ -13,13 +13,13 @@ import org.dspace.content.service.CollectionService;
 import org.dspace.core.*;
 import org.dspace.eperson.Group;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.Sort;
+import org.hibernate.annotations.SortType;
 import org.hibernate.proxy.HibernateProxyHelper;
 
 import javax.persistence.*;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 /**
  * Class representing a collection.
@@ -88,7 +88,8 @@ public class Collection extends DSpaceObject implements DSpaceObjectLegacySuppor
             joinColumns = {@JoinColumn(name = "collection_id") },
             inverseJoinColumns = {@JoinColumn(name = "community_id") }
     )
-    private final List<Community> communities = new ArrayList<>();
+    @Sort(type = SortType.COMPARATOR, comparator = NameAscendingComparator.class)
+    private Set<Community> communities = new TreeSet<>(new NameAscendingComparator());
 
     @Transient
     private transient CollectionService collectionService;
@@ -268,8 +269,8 @@ public class Collection extends DSpaceObject implements DSpaceObjectLegacySuppor
      */
     public List<Community> getCommunities() throws SQLException
     {
-        Collections.sort(communities, new NameAscendingComparator());
-        return communities;
+        // We return a copy because we do not want people to add elements to this collection directly.
+        return Arrays.asList(communities.toArray(new Community[]{}));
     }
 
     void addCommunity(Community community) {

--- a/dspace-api/src/main/java/org/dspace/content/Collection.java
+++ b/dspace-api/src/main/java/org/dspace/content/Collection.java
@@ -88,8 +88,7 @@ public class Collection extends DSpaceObject implements DSpaceObjectLegacySuppor
             joinColumns = {@JoinColumn(name = "collection_id") },
             inverseJoinColumns = {@JoinColumn(name = "community_id") }
     )
-    @Sort(type = SortType.COMPARATOR, comparator = NameAscendingComparator.class)
-    private Set<Community> communities = new TreeSet<>(new NameAscendingComparator());
+    private Set<Community> communities = new HashSet<>();
 
     @Transient
     private transient CollectionService collectionService;
@@ -270,7 +269,10 @@ public class Collection extends DSpaceObject implements DSpaceObjectLegacySuppor
     public List<Community> getCommunities() throws SQLException
     {
         // We return a copy because we do not want people to add elements to this collection directly.
-        return Arrays.asList(communities.toArray(new Community[]{}));
+        // We return a list to maintain backwards compatibility
+        Community[] output = communities.toArray(new Community[]{});
+        Arrays.sort(output, new NameAscendingComparator());
+        return Arrays.asList(output);
     }
 
     void addCommunity(Community community) {
@@ -278,7 +280,7 @@ public class Collection extends DSpaceObject implements DSpaceObjectLegacySuppor
         setModified();
     }
 
-    void removeCommunity(Community community){
+    void removeCommunity(Community community) {
         this.communities.remove(community);
         setModified();
     }

--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -749,8 +749,8 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
         while (owningCommunities.hasNext())
         {
             Community owningCommunity = owningCommunities.next();
-            owningCommunities.remove();
-            owningCommunity.getCollections().remove(collection);
+            collection.removeCommunity(owningCommunity);
+            owningCommunity.removeCollection(collection);
         }
 
         collectionDAO.delete(context, collection);

--- a/dspace-api/src/main/java/org/dspace/content/Community.java
+++ b/dspace-api/src/main/java/org/dspace/content/Community.java
@@ -50,16 +50,13 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
             joinColumns = {@JoinColumn(name = "parent_comm_id") },
             inverseJoinColumns = {@JoinColumn(name = "child_comm_id") }
     )
-    @Sort(type = SortType.COMPARATOR, comparator = NameAscendingComparator.class)
-    private Set<Community> subCommunities = new TreeSet<Community>(new NameAscendingComparator());
+    private Set<Community> subCommunities = new HashSet<>();
 
     @ManyToMany(fetch = FetchType.LAZY, mappedBy = "subCommunities")
-    @Sort(type = SortType.COMPARATOR, comparator = NameAscendingComparator.class)
-    private Set<Community> parentCommunities = new TreeSet<Community>(new NameAscendingComparator());;
+    private Set<Community> parentCommunities = new HashSet<>();
 
     @ManyToMany(fetch = FetchType.LAZY, mappedBy = "communities", cascade = {CascadeType.PERSIST})
-    @Sort(type = SortType.COMPARATOR, comparator = NameAscendingComparator.class)
-    private Set<Collection> collections =new TreeSet<Collection>(new NameAscendingComparator());;
+    private Set<Collection> collections = new HashSet<>();
 
     @OneToOne
     @JoinColumn(name = "admin")
@@ -150,7 +147,10 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
     public List<Collection> getCollections()
     {
         // We return a copy because we do not want people to add elements to this collection directly.
-        return Arrays.asList(collections.toArray(new Collection[]{}));
+        // We return a list to maintain backwards compatibility
+        Collection[] output = collections.toArray(new Collection[]{});
+        Arrays.sort(output, new NameAscendingComparator());
+        return Arrays.asList(output);
     }
 
     void addCollection(Collection collection)
@@ -173,7 +173,10 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
     public List<Community> getSubcommunities()
     {
         // We return a copy because we do not want people to add elements to this collection directly.
-        return Arrays.asList(subCommunities.toArray(new Community[]{}));
+        // We return a list to maintain backwards compatibility
+        Community[] output = subCommunities.toArray(new Community[]{});
+        Arrays.sort(output, new NameAscendingComparator());
+        return Arrays.asList(output);
     }
 
     /**
@@ -185,7 +188,10 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
     public List<Community> getParentCommunities()
     {
         // We return a copy because we do not want people to add elements to this collection directly.
-        return Arrays.asList(parentCommunities.toArray(new Community[]{}));
+        // We return a list to maintain backwards compatibility
+        Community[] output = parentCommunities.toArray(new Community[]{});
+        Arrays.sort(output, new NameAscendingComparator());
+        return Arrays.asList(output);
     }
 
     void addParentCommunity(Community parentCommunity) {
@@ -193,13 +199,13 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
     }
 
     void clearParentCommunities(){
-        this.parentCommunities.clear();
-        this.parentCommunities = null;
+        parentCommunities.clear();
     }
 
     public void removeParentCommunity(Community parentCommunity)
     {
-        this.parentCommunities.remove(parentCommunity);
+        parentCommunities.remove(parentCommunity);
+        setModified();
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/Community.java
+++ b/dspace-api/src/main/java/org/dspace/content/Community.java
@@ -15,6 +15,8 @@ import org.dspace.content.service.CommunityService;
 import org.dspace.core.*;
 import org.dspace.eperson.Group;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.Sort;
+import org.hibernate.annotations.SortType;
 import org.hibernate.proxy.HibernateProxyHelper;
 
 import javax.persistence.*;
@@ -48,13 +50,16 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
             joinColumns = {@JoinColumn(name = "parent_comm_id") },
             inverseJoinColumns = {@JoinColumn(name = "child_comm_id") }
     )
-    private final List<Community> subCommunities = new ArrayList<>();
+    @Sort(type = SortType.COMPARATOR, comparator = NameAscendingComparator.class)
+    private Set<Community> subCommunities = new TreeSet<Community>(new NameAscendingComparator());
 
     @ManyToMany(fetch = FetchType.LAZY, mappedBy = "subCommunities")
-    private List<Community> parentCommunities = new ArrayList<>();
+    @Sort(type = SortType.COMPARATOR, comparator = NameAscendingComparator.class)
+    private Set<Community> parentCommunities = new TreeSet<Community>(new NameAscendingComparator());;
 
     @ManyToMany(fetch = FetchType.LAZY, mappedBy = "communities", cascade = {CascadeType.PERSIST})
-    private final List<Collection> collections = new ArrayList<>();
+    @Sort(type = SortType.COMPARATOR, comparator = NameAscendingComparator.class)
+    private Set<Collection> collections =new TreeSet<Collection>(new NameAscendingComparator());;
 
     @OneToOne
     @JoinColumn(name = "admin")
@@ -89,13 +94,13 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
 
     void addSubCommunity(Community subCommunity)
     {
-        getSubcommunities().add(subCommunity);
+        subCommunities.add(subCommunity);
         setModified();
     }
 
     void removeSubCommunity(Community subCommunity)
     {
-        getSubcommunities().remove(subCommunity);
+        subCommunities.remove(subCommunity);
         setModified();
     }
 
@@ -144,18 +149,18 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
      */
     public List<Collection> getCollections()
     {
-        Collections.sort(collections, new NameAscendingComparator());
-        return collections;
+        // We return a copy because we do not want people to add elements to this collection directly.
+        return Arrays.asList(collections.toArray(new Collection[]{}));
     }
 
     void addCollection(Collection collection)
     {
-        getCollections().add(collection);
+        collections.add(collection);
     }
 
     void removeCollection(Collection collection)
     {
-        getCollections().remove(collection);
+        collections.remove(collection);
     }
 
     /**
@@ -167,8 +172,8 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
      */
     public List<Community> getSubcommunities()
     {
-        Collections.sort(subCommunities, new NameAscendingComparator());
-        return subCommunities;
+        // We return a copy because we do not want people to add elements to this collection directly.
+        return Arrays.asList(subCommunities.toArray(new Community[]{}));
     }
 
     /**
@@ -179,17 +184,22 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
      */
     public List<Community> getParentCommunities()
     {
-        Collections.sort(parentCommunities, new NameAscendingComparator());
-        return parentCommunities;
+        // We return a copy because we do not want people to add elements to this collection directly.
+        return Arrays.asList(parentCommunities.toArray(new Community[]{}));
     }
 
     void addParentCommunity(Community parentCommunity) {
-        getParentCommunities().add(parentCommunity);
+        parentCommunities.add(parentCommunity);
     }
 
     void clearParentCommunities(){
         this.parentCommunities.clear();
         this.parentCommunities = null;
+    }
+
+    public void removeParentCommunity(Community parentCommunity)
+    {
+        this.parentCommunities.remove(parentCommunity);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
@@ -455,7 +455,7 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
 
         rawDelete(context, childCommunity);
 
-        childCommunity.getParentCommunities().remove(parentCommunity);
+        childCommunity.removeParentCommunity(parentCommunity);
         parentCommunity.removeSubCommunity(childCommunity);
 
         log.info(LogManager.getHeader(context, "remove_subcommunity",
@@ -492,7 +492,7 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
             Iterator<Community> subcommunities = community.getSubcommunities().iterator();
             while (subcommunities.hasNext()) {
                 Community subCommunity = subcommunities.next();
-                subcommunities.remove();
+                community.removeSubCommunity(subCommunity);
                 delete(context, subCommunity);
             }
             // now let the parent remove the community
@@ -535,7 +535,7 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
         while (collections.hasNext())
         {
             Collection collection = collections.next();
-            collections.remove();
+            community.removeCollection(collection);
             removeCollection(context, community, collection);
         }
         // delete subcommunities
@@ -544,7 +544,7 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
         while (subCommunities.hasNext())
         {
             Community subComm = subCommunities.next();
-            subCommunities.remove();
+            community.removeSubCommunity(subComm);
             delete(context, subComm);
         }
 

--- a/dspace-api/src/main/java/org/dspace/content/Item.java
+++ b/dspace-api/src/main/java/org/dspace/content/Item.java
@@ -13,13 +13,12 @@ import org.dspace.content.service.ItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
+import org.hibernate.annotations.Sort;
+import org.hibernate.annotations.SortType;
 import org.hibernate.proxy.HibernateProxyHelper;
 
 import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 
 /**
  * Class representing an item in DSpace.
@@ -80,7 +79,8 @@ public class Item extends DSpaceObject implements DSpaceObjectLegacySupport
             joinColumns = {@JoinColumn(name = "item_id") },
             inverseJoinColumns = {@JoinColumn(name = "collection_id") }
     )
-    private final List<Collection> collections = new ArrayList<>();
+    @Sort(type = SortType.COMPARATOR, comparator = NameAscendingComparator.class)
+    private final Set<Collection> collections = new TreeSet<>(new NameAscendingComparator());
 
     @ManyToMany(fetch = FetchType.LAZY, mappedBy = "items")
     private final List<Bundle> bundles = new ArrayList<>();
@@ -232,18 +232,22 @@ public class Item extends DSpaceObject implements DSpaceObjectLegacySupport
      */
     public List<Collection> getCollections()
     {
-        Collections.sort(collections, new NameAscendingComparator());
-        return collections;
+        // We return a copy because we do not want people to add elements to this collection directly.
+        return Arrays.asList(collections.toArray(new Collection[]{}));
     }
 
     void addCollection(Collection collection)
     {
-        getCollections().add(collection);
+        collections.add(collection);
     }
 
     void removeCollection(Collection collection)
     {
-        getCollections().remove(collection);
+        collections.remove(collection);
+    }
+
+    public void clearCollections(){
+        collections.clear();
     }
 
     public Collection getTemplateItemOf() {

--- a/dspace-api/src/main/java/org/dspace/content/Item.java
+++ b/dspace-api/src/main/java/org/dspace/content/Item.java
@@ -79,8 +79,7 @@ public class Item extends DSpaceObject implements DSpaceObjectLegacySupport
             joinColumns = {@JoinColumn(name = "item_id") },
             inverseJoinColumns = {@JoinColumn(name = "collection_id") }
     )
-    @Sort(type = SortType.COMPARATOR, comparator = NameAscendingComparator.class)
-    private final Set<Collection> collections = new TreeSet<>(new NameAscendingComparator());
+    private final Set<Collection> collections = new HashSet<>();
 
     @ManyToMany(fetch = FetchType.LAZY, mappedBy = "items")
     private final List<Bundle> bundles = new ArrayList<>();
@@ -233,7 +232,10 @@ public class Item extends DSpaceObject implements DSpaceObjectLegacySupport
     public List<Collection> getCollections()
     {
         // We return a copy because we do not want people to add elements to this collection directly.
-        return Arrays.asList(collections.toArray(new Collection[]{}));
+        // We return a list to maintain backwards compatibility
+        Collection[] output = collections.toArray(new Collection[]{});
+        Arrays.sort(output, new NameAscendingComparator());
+        return Arrays.asList(output);
     }
 
     void addCollection(Collection collection)

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -651,7 +651,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         }
 
         //Only clear collections after we have removed everything else from the item
-        item.getCollections().clear();
+        item.clearCollections();
         item.setOwningCollection(null);
 
         // Finally remove item row

--- a/dspace-api/src/main/java/org/dspace/content/comparator/NameAscendingComparator.java
+++ b/dspace-api/src/main/java/org/dspace/content/comparator/NameAscendingComparator.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.content.comparator;
 
+import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.StringUtils;
 import org.dspace.content.DSpaceObject;
 
@@ -25,7 +26,14 @@ public class NameAscendingComparator implements Comparator<DSpaceObject>{
         }else {
             String name1 = StringUtils.trimToEmpty(dso1.getName());
             String name2 = StringUtils.trimToEmpty(dso2.getName());
-            return name1.compareToIgnoreCase(name2);
+
+            //When two DSO's have the same name, use their UUID to put them in an order
+            if(name1.equals(name2)) {
+                return ObjectUtils.compare(dso1.getID(), dso2.getID());
+            } else {
+                return name1.compareToIgnoreCase(name2);
+            }
         }
     }
+
 }

--- a/dspace-api/src/test/java/org/dspace/content/CollectionTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/CollectionTest.java
@@ -7,6 +7,20 @@
  */
 package org.dspace.content;
 
+import mockit.NonStrictExpectations;
+import org.apache.log4j.Logger;
+import org.dspace.app.util.AuthorizeUtil;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.core.factory.CoreServiceFactory;
+import org.dspace.core.service.LicenseService;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -15,20 +29,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 
-
-import org.dspace.authorize.AuthorizeException;
-import org.apache.log4j.Logger;
-import org.dspace.core.Context;
-import org.dspace.core.factory.CoreServiceFactory;
-import org.dspace.core.service.LicenseService;
-import org.dspace.eperson.EPerson;
-import org.dspace.eperson.Group;
-import org.junit.*;
-import static org.junit.Assert.* ;
 import static org.hamcrest.CoreMatchers.*;
-import mockit.NonStrictExpectations;
-import org.dspace.app.util.AuthorizeUtil;
-import org.dspace.core.Constants;
+import static org.junit.Assert.*;
 
 /**
  * Unit Tests for class Collection
@@ -1823,8 +1825,22 @@ public class CollectionTest extends AbstractDSpaceObjectTest
     @Test
     public void testGetCommunities() throws Exception
     {
-        assertThat("testGetCommunities 0",collection.getCommunities(), notNullValue());
-        assertTrue("testGetCommunities 1",collection.getCommunities().size() == 1);
+        context.turnOffAuthorisationSystem();
+        Community community = communityService.create(null, context);
+        communityService.setMetadataSingleValue(context, community, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY, "community 3");
+        this.collection.addCommunity(community);
+        community = communityService.create(null, context);
+        communityService.setMetadataSingleValue(context, community, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY, "community 1");
+        this.collection.addCommunity(community);
+        community = communityService.create(null, context);
+        communityService.setMetadataSingleValue(context, community, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY, "community 2");
+        this.collection.addCommunity(community);
+        context.restoreAuthSystemState();
+        assertTrue("testGetCommunities 0",collection.getCommunities().size() == 4);
+        //Communities should be sorted by name
+        assertTrue("testGetCommunities 1",collection.getCommunities().get(1).getName().equals("community 1"));
+        assertTrue("testGetCommunities 1",collection.getCommunities().get(2).getName().equals("community 2"));
+        assertTrue("testGetCommunities 1",collection.getCommunities().get(3).getName().equals("community 3"));
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/content/CollectionTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/CollectionTest.java
@@ -103,6 +103,7 @@ public class CollectionTest extends AbstractDSpaceObjectTest
                 if(collection != null)
                 {
                     collectionService.delete(context, collection);
+                    context.commit();
                     communityService.delete(context, communityService.find(context, owningCommunity.getID()));
                 }
                 context.restoreAuthSystemState();

--- a/dspace-api/src/test/java/org/dspace/content/CollectionTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/CollectionTest.java
@@ -7,6 +7,20 @@
  */
 package org.dspace.content;
 
+import mockit.NonStrictExpectations;
+import org.apache.log4j.Logger;
+import org.dspace.app.util.AuthorizeUtil;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.core.factory.CoreServiceFactory;
+import org.dspace.core.service.LicenseService;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -15,20 +29,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 
-
-import org.dspace.authorize.AuthorizeException;
-import org.apache.log4j.Logger;
-import org.dspace.core.Context;
-import org.dspace.core.factory.CoreServiceFactory;
-import org.dspace.core.service.LicenseService;
-import org.dspace.eperson.EPerson;
-import org.dspace.eperson.Group;
-import org.junit.*;
-import static org.junit.Assert.* ;
 import static org.hamcrest.CoreMatchers.*;
-import mockit.NonStrictExpectations;
-import org.dspace.app.util.AuthorizeUtil;
-import org.dspace.core.Constants;
+import static org.junit.Assert.*;
 
 /**
  * Unit Tests for class Collection
@@ -103,7 +105,6 @@ public class CollectionTest extends AbstractDSpaceObjectTest
                 if(collection != null)
                 {
                     collectionService.delete(context, collection);
-                    context.commit();
                     communityService.delete(context, communityService.find(context, owningCommunity.getID()));
                 }
                 context.restoreAuthSystemState();

--- a/dspace-api/src/test/java/org/dspace/content/CollectionTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/CollectionTest.java
@@ -7,20 +7,6 @@
  */
 package org.dspace.content;
 
-import mockit.NonStrictExpectations;
-import org.apache.log4j.Logger;
-import org.dspace.app.util.AuthorizeUtil;
-import org.dspace.authorize.AuthorizeException;
-import org.dspace.core.Constants;
-import org.dspace.core.Context;
-import org.dspace.core.factory.CoreServiceFactory;
-import org.dspace.core.service.LicenseService;
-import org.dspace.eperson.EPerson;
-import org.dspace.eperson.Group;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -29,8 +15,20 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 
+
+import org.dspace.authorize.AuthorizeException;
+import org.apache.log4j.Logger;
+import org.dspace.core.Context;
+import org.dspace.core.factory.CoreServiceFactory;
+import org.dspace.core.service.LicenseService;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
+import org.junit.*;
+import static org.junit.Assert.* ;
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import mockit.NonStrictExpectations;
+import org.dspace.app.util.AuthorizeUtil;
+import org.dspace.core.Constants;
 
 /**
  * Unit Tests for class Collection

--- a/dspace-api/src/test/java/org/dspace/content/CommunityTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/CommunityTest.java
@@ -8,22 +8,25 @@
 
 package org.dspace.content;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.sql.SQLException;
-import java.util.List;
-import java.util.UUID;
-
+import mockit.NonStrictExpectations;
 import org.apache.log4j.Logger;
 import org.dspace.app.util.AuthorizeUtil;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.eperson.Group;
-import org.junit.*;
-import static org.junit.Assert.* ;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+
 import static org.hamcrest.CoreMatchers.*;
-import mockit.NonStrictExpectations;
+import static org.junit.Assert.*;
 
 /**
  * Unit Tests for class Community
@@ -681,10 +684,20 @@ public class CommunityTest extends AbstractDSpaceObjectTest
         assertThat("testGetCollections 0",c.getCollections(), notNullValue());
         assertTrue("testGetCollections 1", c.getCollections().size() == 0);
 
-        Collection result = collectionService.create(context, c);
-        assertThat("testGetCollections 2",c.getCollections(), notNullValue());
-        assertTrue("testGetCollections 3", c.getCollections().size() == 1);
-        assertThat("testGetCollections 4",c.getCollections().get(0), equalTo(result));
+        context.turnOffAuthorisationSystem();
+        Collection collection = collectionService.create(context, c);
+        collectionService.setMetadataSingleValue(context, collection, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY, "collection B");
+        collection = collectionService.create(context, c);
+        collectionService.setMetadataSingleValue(context, collection, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY, "collection C");
+        collection = collectionService.create(context, c);
+        collectionService.setMetadataSingleValue(context, collection, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY, "collection A");
+        //we need to commit the changes so we don't block the table for testing
+        context.restoreAuthSystemState();
+
+        //sorted
+        assertTrue("testGetCollections 2",c.getCollections().get(0).getName().equals("collection A"));
+        assertTrue("testGetCollections 3",c.getCollections().get(1).getName().equals("collection B"));
+        assertTrue("testGetCollections 4",c.getCollections().get(2).getName().equals("collection C"));
     }
 
     /**
@@ -707,11 +720,20 @@ public class CommunityTest extends AbstractDSpaceObjectTest
         assertThat("testGetSubcommunities 0",c.getSubcommunities(), notNullValue());
         assertTrue("testGetSubcommunities 1", c.getSubcommunities().size() == 0);
 
-        //community with parent
-        Community son = communityService.create(c, context);
-        assertThat("testGetSubcommunities 2",c.getSubcommunities(), notNullValue());
-        assertTrue("testGetSubcommunities 3", c.getSubcommunities().size() == 1);
-        assertThat("testGetSubcommunities 4", c.getSubcommunities().get(0), equalTo(son));
+        context.turnOffAuthorisationSystem();
+        Community community = communityService.create(c, context);
+        communityService.setMetadataSingleValue(context, community, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY, "subcommunity B");
+        community = communityService.create(c, context);
+        communityService.setMetadataSingleValue(context, community, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY, "subcommunity A");
+        community = communityService.create(c, context);
+        communityService.setMetadataSingleValue(context, community, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY, "subcommunity C");
+        //we need to commit the changes so we don't block the table for testing
+        context.restoreAuthSystemState();
+
+        //get Subcommunities sorted
+        assertTrue("testGetCollections 2",c.getSubcommunities().get(0).getName().equals("subcommunity A"));
+        assertTrue("testGetCollections 3",c.getSubcommunities().get(1).getName().equals("subcommunity B"));
+        assertTrue("testGetCollections 4",c.getSubcommunities().get(2).getName().equals("subcommunity C"));
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -1478,6 +1478,7 @@ public class ItemTest  extends AbstractDSpaceObjectTest
         context.turnOffAuthorisationSystem();
         Collection from = createCollection();
         Collection to = createCollection();
+        it.addCollection(from);
         it.setOwningCollection(from);
 
         itemService.move(context, it, from, to);

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -7,38 +7,39 @@
  */
 package org.dspace.content;
 
+import mockit.NonStrictExpectations;
+import org.apache.commons.lang.time.DateUtils;
+import org.apache.log4j.Logger;
+import org.dspace.app.util.AuthorizeUtil;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.BitstreamFormatService;
+import org.dspace.content.service.MetadataFieldService;
+import org.dspace.content.service.MetadataSchemaService;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.sql.SQLException;
-
-import org.apache.commons.lang.time.DateUtils;
-import org.dspace.authorize.AuthorizeException;
-import org.apache.log4j.Logger;
-
 import java.util.*;
 
-import org.dspace.content.factory.ContentServiceFactory;
-import org.dspace.content.service.BitstreamFormatService;
-import org.dspace.content.service.MetadataFieldService;
-import org.dspace.content.service.MetadataSchemaService;
-import org.dspace.core.Context;
-import org.dspace.eperson.EPerson;
-import org.dspace.eperson.Group;
-import org.junit.*;
-import static org.junit.Assert.* ;
 import static org.hamcrest.CoreMatchers.*;
-import mockit.*;
-import org.dspace.app.util.AuthorizeUtil;
-import org.dspace.authorize.ResourcePolicy;
-import org.dspace.core.Constants;
+import static org.junit.Assert.*;
 
 /**
  * Unit Tests for class Item
  * @author pvillega
  */
-public class ItemTest  extends AbstractDSpaceObjectTest
+public class ItemTest extends AbstractDSpaceObjectTest
 {
 
     /** log4j category */

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -613,8 +613,18 @@ public class ItemTest extends AbstractDSpaceObjectTest
     @Test
     public void testGetCollections() throws Exception
     {
+        context.turnOffAuthorisationSystem();
+        Collection collection = collectionService.create(context, owningCommunity);
+        collectionService.setMetadataSingleValue(context, collection, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY, "collection B");
+        it.addCollection(collection);
+        collection = collectionService.create(context, owningCommunity);
+        collectionService.setMetadataSingleValue(context, collection, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY, "collection A");
+        it.addCollection(collection);
+        context.restoreAuthSystemState();
         assertThat("testGetCollections 0", it.getCollections(), notNullValue());
-        assertTrue("testGetCollections 1", it.getCollections().size() == 1);
+        assertTrue("testGetCollections 1", it.getCollections().size() == 3);
+        assertTrue("testGetCollections 2", it.getCollections().get(1).getName().equals("collection A"));
+        assertTrue("testGetCollections 3", it.getCollections().get(2).getName().equals("collection B"));
     }
 
     /**


### PR DESCRIPTION
This pull request is an alternative fix for https://jira.duraspace.org/browse/DS-3406 which prevents Hibernate from executing `delete` and `insert` statements when sorting Collections or Communities.