### PR TITLE
DS-3604: Fix Bitstream reordering in JSPUI

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
@@ -269,29 +269,60 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
     public void setOrder(Context context, Bundle bundle, UUID[] bitstreamIds) throws AuthorizeException, SQLException {
         authorizeService.authorizeAction(context, bundle, Constants.WRITE);
 
-        bundle.getBitstreams().clear();
+        List<Bitstream> currentBitstreams = bundle.getBitstreams();
+        List<Bitstream> updatedBitstreams = new ArrayList<Bitstream>();
+
+        // Loop through and ensure these Bitstream IDs are all valid. Add them to list of updatedBitstreams.
         for (int i = 0; i < bitstreamIds.length; i++) {
             UUID bitstreamId = bitstreamIds[i];
             Bitstream bitstream = bitstreamService.find(context, bitstreamId);
-            if(bitstream == null){
+
+            // If we have an invalid Bitstream ID, just ignore it, but log a warning
+            if(bitstream == null) {
                 //This should never occur but just in case
                 log.warn(LogManager.getHeader(context, "Invalid bitstream id while changing bitstream order", "Bundle: " + bundle.getID() + ", bitstream id: " + bitstreamId));
                 continue;
             }
-            bitstream.getBundles().remove(bundle);
-            bundle.getBitstreams().add(bitstream);
-            bitstream.getBundles().add(bundle);
 
-            bitstreamService.update(context, bitstream);
+            // If we have a Bitstream not in the current list, log a warning & exit immediately
+            if(!currentBitstreams.contains(bitstream))
+            {
+                log.warn(LogManager.getHeader(context, "Encountered a bitstream not in this bundle while changing bitstream order. Bitstream order will not be changed.", "Bundle: " + bundle.getID() + ", bitstream id: " + bitstreamId));
+                return;
+            }
+            updatedBitstreams.add(bitstream);
         }
 
-        //The order of the bitstreams has changed, ensure that we update the last modified of our item
-        Item owningItem = (Item) getParentObject(context, bundle);
-        if(owningItem != null)
+        // If our lists are different sizes, exit immediately
+        if(updatedBitstreams.size()!=currentBitstreams.size())
         {
-            itemService.updateLastModified(context, owningItem);
-            itemService.update(context, owningItem);
+            log.warn(LogManager.getHeader(context, "Size of old list and new list do not match. Bitstream order will not be changed.", "Bundle: " + bundle.getID()));
+            return;
+        }
 
+        // As long as the order has changed, update it
+        if(CollectionUtils.isNotEmpty(updatedBitstreams) && !updatedBitstreams.equals(currentBitstreams))
+        {
+            //First clear out the existing list of bitstreams
+            bundle.getBitstreams().clear();
+
+            // Now add them back in the proper order
+            for (Bitstream bitstream : updatedBitstreams)
+            {
+                bitstream.getBundles().remove(bundle);
+                bundle.getBitstreams().add(bitstream);
+                bitstream.getBundles().add(bundle);
+                bitstreamService.update(context, bitstream);
+            }
+
+            //The order of the bitstreams has changed, ensure that we update the last modified of our item
+            Item owningItem = (Item) getParentObject(context, bundle);
+            if(owningItem != null)
+            {
+                itemService.updateLastModified(context, owningItem);
+                itemService.update(context, owningItem);
+
+            }
         }
     }
 

--- a/dspace-api/src/test/java/org/dspace/content/BundleTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/BundleTest.java
@@ -719,26 +719,42 @@ public class BundleTest extends AbstractDSpaceObjectTest
         bundleService.addBitstream(context, b, bs3);
 
         // Assert Bitstreams are in the order added
-        List<Bitstream> bitstreams = b.getBitstreams();
-        assertTrue("testSetOrder: starting count correct", bitstreams.size() == 3);
-        assertThat("testSetOrder: Bitstream 1 is first", bitstreams.get(0).getName(), equalTo(bs.getName()));
-        assertThat("testSetOrder: Bitstream 2 is second", bitstreams.get(1).getName(), equalTo(bs2.getName()));
-        assertThat("testSetOrder: Bitstream 3 is third", bitstreams.get(2).getName(), equalTo(bs3.getName()));
+        Bitstream[] bitstreams = b.getBitstreams().toArray(new Bitstream[b.getBitstreams().size()]);
+        assertTrue("testSetOrder: starting count correct", bitstreams.length == 3);
+        assertThat("testSetOrder: Bitstream 1 is first", bitstreams[0].getName(), equalTo(bs.getName()));
+        assertThat("testSetOrder: Bitstream 2 is second", bitstreams[1].getName(), equalTo(bs2.getName()));
+        assertThat("testSetOrder: Bitstream 3 is third", bitstreams[2].getName(), equalTo(bs3.getName()));
 
         UUID bsID1 = bs.getID();
         UUID bsID2 = bs2.getID();
         UUID bsID3 = bs3.getID();
 
         // Now define a new order and call setOrder()
-        UUID[] newBitstreamOrder = { bsID3, bsID1, bsID2 };
+        UUID[] newBitstreamOrder = new UUID[] { bsID3, bsID1, bsID2 };
         bundleService.setOrder(context, b, newBitstreamOrder);
 
         // Assert Bitstreams are in the new order
-        bitstreams = b.getBitstreams();
-        assertTrue("testSetOrder: new count correct", bitstreams.size() == 3);
-        assertThat("testSetOrder: Bitstream 3 is now first", bitstreams.get(0).getName(), equalTo(bs3.getName()));
-        assertThat("testSetOrder: Bitstream 1 is now second", bitstreams.get(1).getName(), equalTo(bs.getName()));
-        assertThat("testSetOrder: Bitstream 2 is now third", bitstreams.get(2).getName(), equalTo(bs2.getName()));
+        bitstreams = b.getBitstreams().toArray(new Bitstream[b.getBitstreams().size()]);
+        assertTrue("testSetOrder: new count correct", bitstreams.length == 3);
+        assertThat("testSetOrder: Bitstream 3 is now first", bitstreams[0].getName(), equalTo(bs3.getName()));
+        assertThat("testSetOrder: Bitstream 1 is now second", bitstreams[1].getName(), equalTo(bs.getName()));
+        assertThat("testSetOrder: Bitstream 2 is now third", bitstreams[2].getName(), equalTo(bs2.getName()));
+
+        // Now give only a partial list of bitstreams
+        newBitstreamOrder = new UUID[] { bsID1, bsID2 };
+        bundleService.setOrder(context, b, newBitstreamOrder);
+
+        // Assert Bitstream order is unchanged
+        Bitstream[] bitstreamsAfterPartialData = b.getBitstreams().toArray(new Bitstream[b.getBitstreams().size()]);
+        assertThat("testSetOrder: Partial data doesn't change order", bitstreamsAfterPartialData, equalTo(bitstreams));
+
+        // Now give bad data in the list of bitstreams
+        newBitstreamOrder = new UUID[] { bsID1, null, bsID2 };
+        bundleService.setOrder(context, b, newBitstreamOrder);
+
+        // Assert Bitstream order is unchanged
+        Bitstream[] bitstreamsAfterBadData = b.getBitstreams().toArray(new Bitstream[b.getBitstreams().size()]);
+        assertThat("testSetOrder: Partial data doesn't change order", bitstreamsAfterBadData, equalTo(bitstreams));
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/content/BundleTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/BundleTest.java
@@ -40,7 +40,7 @@ public class BundleTest extends AbstractDSpaceObjectTest
 {
     /** log4j category */
     private static final Logger log = Logger.getLogger(BundleTest.class);
- 
+
     /**
      * Bundle instance for the tests
      */
@@ -214,7 +214,7 @@ public class BundleTest extends AbstractDSpaceObjectTest
      * Test of getPrimaryBitstreamID method, of class Bundle.
      */
     @Test
-    public void testGetPrimaryBitstreamID() 
+    public void testGetPrimaryBitstreamID()
     {
         //is -1 when not set
         assertThat("testGetPrimaryBitstreamID 0", b.getPrimaryBitstream(), equalTo(null));
@@ -275,7 +275,7 @@ public class BundleTest extends AbstractDSpaceObjectTest
      */
     @Override
     @Test
-    public void testGetHandle() 
+    public void testGetHandle()
     {
         //no handle for bundles
         assertThat("testGetHandle 0", b.getHandle(), nullValue());
@@ -300,7 +300,7 @@ public class BundleTest extends AbstractDSpaceObjectTest
         String name = "name";
         //by default there is no bitstream
         assertThat("testGetHandle 0", bundleService.getBitstreamByName(b, name), nullValue());
-        
+
         //let's add a bitstream
         File f = new File(testProps.get("test.bitstream").toString());
         Bitstream bs = bitstreamService.create(context, new FileInputStream(f));
@@ -397,12 +397,12 @@ public class BundleTest extends AbstractDSpaceObjectTest
         assertThat("testCreateBitstreamAuth 1", bundleService.getBitstreamByName(b, name), equalTo(bs));
         assertThat("testCreateBitstreamAuth 2", bundleService.getBitstreamByName(b, name).getName(), equalTo(name));
     }
-    
+
     /**
      * Test of registerBitstream method, of class Bundle.
      */
     @Test(expected=AuthorizeException.class)
-    public void testRegisterBitstreamNoAuth() throws AuthorizeException, IOException, SQLException 
+    public void testRegisterBitstreamNoAuth() throws AuthorizeException, IOException, SQLException
     {
         new NonStrictExpectations(authorizeService.getClass())
         {{
@@ -422,7 +422,7 @@ public class BundleTest extends AbstractDSpaceObjectTest
      * Test of registerBitstream method, of class Bundle.
      */
     @Test
-    public void testRegisterBitstreamAuth() throws AuthorizeException, IOException, SQLException 
+    public void testRegisterBitstreamAuth() throws AuthorizeException, IOException, SQLException
     {
         new NonStrictExpectations(authorizeService.getClass())
         {{
@@ -436,7 +436,7 @@ public class BundleTest extends AbstractDSpaceObjectTest
 
         int assetstore = 0;  //default assetstore
         String name = "name bitstream";
-        File f = new File(testProps.get("test.bitstream").toString());        
+        File f = new File(testProps.get("test.bitstream").toString());
         Bitstream bs = bitstreamService.register(context, b, assetstore, f.getName());
         bs.setName(context, name);
         assertThat("testRegisterBitstream 0", bundleService.getBitstreamByName(b, name), notNullValue());
@@ -481,7 +481,7 @@ public class BundleTest extends AbstractDSpaceObjectTest
                     Constants.WRITE); result = null;
 
         }};
-        
+
         File f = new File(testProps.get("test.bitstream").toString());
         Bitstream bs = bitstreamService.create(context, new FileInputStream(f));
         bs.setName(context, "name");
@@ -546,7 +546,7 @@ public class BundleTest extends AbstractDSpaceObjectTest
      * Test of update method, of class Bundle.
      */
     @Test
-    public void testUpdate() throws SQLException, AuthorizeException 
+    public void testUpdate() throws SQLException, AuthorizeException
     {
         //TODO: we only check for sql errors
         //TODO: note that update can't throw authorize exception!!
@@ -632,7 +632,7 @@ public class BundleTest extends AbstractDSpaceObjectTest
             }
         }
         assertTrue("testInheritCollectionDefaultPolicies 2", exists);
-        
+
     }
 
     /**
@@ -646,7 +646,7 @@ public class BundleTest extends AbstractDSpaceObjectTest
         newpolicies.add(resourcePolicyService.create(context));
         newpolicies.add(resourcePolicyService.create(context));
         bundleService.replaceAllBitstreamPolicies(context, b, newpolicies);
-        
+
         List<ResourcePolicy> bspolicies = bundleService.getBundlePolicies(context, b);
         assertTrue("testReplaceAllBitstreamPolicies 0", newpolicies.size() == bspolicies.size());
 
@@ -692,6 +692,53 @@ public class BundleTest extends AbstractDSpaceObjectTest
         //empty by default
         List<ResourcePolicy> bspolicies = bundleService.getBitstreamPolicies(context, b);
         assertTrue("testGetBitstreamPolicies 0", bspolicies.isEmpty());
+    }
+
+    @Test
+    public void testSetOrder() throws SQLException, AuthorizeException, FileNotFoundException, IOException
+    {
+        new NonStrictExpectations(authorizeService.getClass())
+        {{
+            // Allow Bundle ADD perms
+            authorizeService.authorizeAction((Context) any, (Bundle) any,
+                Constants.ADD); result = null;
+            authorizeService.authorizeAction((Context) any, (Bitstream) any,
+                Constants.WRITE); result = null;
+        }};
+
+        // Create three Bitstreams to test ordering with. Give them different names
+        File f = new File(testProps.get("test.bitstream").toString());
+        Bitstream bs = bitstreamService.create(context, new FileInputStream(f));
+        bs.setName(context, "bitstream1");
+        bundleService.addBitstream(context, b, bs);
+        Bitstream bs2 = bitstreamService.create(context, new FileInputStream(f));
+        bs2.setName(context, "bitstream2");
+        bundleService.addBitstream(context, b, bs2);
+        Bitstream bs3 = bitstreamService.create(context, new FileInputStream(f));
+        bs3.setName(context, "bitstream3");
+        bundleService.addBitstream(context, b, bs3);
+
+        // Assert Bitstreams are in the order added
+        List<Bitstream> bitstreams = b.getBitstreams();
+        assertTrue("testSetOrder: starting count correct", bitstreams.size() == 3);
+        assertThat("testSetOrder: Bitstream 1 is first", bitstreams.get(0).getName(), equalTo(bs.getName()));
+        assertThat("testSetOrder: Bitstream 2 is second", bitstreams.get(1).getName(), equalTo(bs2.getName()));
+        assertThat("testSetOrder: Bitstream 3 is third", bitstreams.get(2).getName(), equalTo(bs3.getName()));
+
+        UUID bsID1 = bs.getID();
+        UUID bsID2 = bs2.getID();
+        UUID bsID3 = bs3.getID();
+
+        // Now define a new order and call setOrder()
+        UUID[] newBitstreamOrder = { bsID3, bsID1, bsID2 };
+        bundleService.setOrder(context, b, newBitstreamOrder);
+
+        // Assert Bitstreams are in the new order
+        bitstreams = b.getBitstreams();
+        assertTrue("testSetOrder: new count correct", bitstreams.size() == 3);
+        assertThat("testSetOrder: Bitstream 3 is now first", bitstreams.get(0).getName(), equalTo(bs3.getName()));
+        assertThat("testSetOrder: Bitstream 1 is now second", bitstreams.get(1).getName(), equalTo(bs.getName()));
+        assertThat("testSetOrder: Bitstream 2 is now third", bitstreams.get(2).getName(), equalTo(bs2.getName()));
     }
 
     /**

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EditItemServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EditItemServlet.java
@@ -110,7 +110,7 @@ public class EditItemServlet extends DSpaceServlet
 
     /** User updates Creative Commons License */
     public static final int UPDATE_CC = 12;
-    
+
     /** JSP to upload bitstream */
     protected static final String UPLOAD_BITSTREAM_JSP = "/tools/upload-bitstream.jsp";
 
@@ -119,33 +119,33 @@ public class EditItemServlet extends DSpaceServlet
 
     private final transient CollectionService collectionService
              = ContentServiceFactory.getInstance().getCollectionService();
-    
+
     private final transient ItemService itemService
              = ContentServiceFactory.getInstance().getItemService();
-    
+
     private final transient BitstreamFormatService bitstreamFormatService
              = ContentServiceFactory.getInstance().getBitstreamFormatService();
-    
+
     private final transient BitstreamService bitstreamService
              = ContentServiceFactory.getInstance().getBitstreamService();
-    
+
     private final transient BundleService bundleService
              = ContentServiceFactory.getInstance().getBundleService();
-    
+
     private final transient HandleService handleService
              = HandleServiceFactory.getInstance().getHandleService();
-    
+
     private final transient MetadataFieldService metadataFieldService
              = ContentServiceFactory.getInstance().getMetadataFieldService();
-    
+
     private final transient MetadataSchemaService metadataSchemaService
              = ContentServiceFactory.getInstance().getMetadataSchemaService();
-    
+
     private final transient CreativeCommonsService creativeCommonsService
              = LicenseServiceFactory.getInstance().getCreativeCommonsService();
-    
+
     protected ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
-    
+
     @Override
     protected void doDSGet(Context context, HttpServletRequest request,
             HttpServletResponse response) throws ServletException, IOException,
@@ -242,14 +242,14 @@ public class EditItemServlet extends DSpaceServlet
 
         Item item = itemService.find(context, UIUtil.getUUIDParameter(request,
                 "item_id"));
- 
+
         if (request.getParameter("submit_cancel_cc") != null)
         {
             showEditForm(context, request, response, item);
 
             return;
         }
-        
+
         String handle = handleService.findHandle(context, item);
 
         // now check to see if person can edit item
@@ -271,9 +271,9 @@ public class EditItemServlet extends DSpaceServlet
         case CONFIRM_DELETE:
 
             // Delete the item - if "cancel" was pressed this would be
-            // picked up above            
+            // picked up above
             itemService.delete(context, item);
-            
+
             JSPManager.showJSP(request, response, "/tools/get-item-id.jsp");
             context.complete();
 
@@ -314,7 +314,7 @@ public class EditItemServlet extends DSpaceServlet
                         // Display move collection page with fields of collections and communities
                         List<Collection> allNotLinkedCollections = itemService.getCollectionsNotLinked(context, item);
                         List<Collection> allLinkedCollections = item.getCollections();
-                    
+
                         // get only the collection where the current user has the right permission
                         List<Collection> authNotLinkedCollections = new ArrayList<>();
                         for (Collection c : allNotLinkedCollections)
@@ -333,18 +333,18 @@ public class EditItemServlet extends DSpaceServlet
                         authLinkedCollections.add(c);
                     }
                 }
-                        
+
                         request.setAttribute("linkedCollections", authLinkedCollections);
                         request.setAttribute("notLinkedCollections", authNotLinkedCollections);
-                                    
+
                         JSPManager.showJSP(request, response, "/tools/move-item.jsp");
                 } else
                 {
                         throw new ServletException("You must be an administrator to move an item");
                 }
-                
+
                 break;
-                        
+
         case CONFIRM_MOVE_ITEM:
                 if (authorizeService.isAdmin(context, item))
                 {
@@ -361,17 +361,17 @@ public class EditItemServlet extends DSpaceServlet
                         {
                                 throw new ServletException("Missing or incorrect collection IDs for moving item");
                         }
-                                    
+
                         itemService.move(context, item, fromCollection, toCollection, inheritPolicies);
-                    
+
                     showEditForm(context, request, response, item);
-        
+
                     context.complete();
                 } else
                 {
                         throw new ServletException("You must be an administrator to move an item");
                 }
-                
+
                 break;
 
         case START_PRIVATING:
@@ -399,7 +399,7 @@ public class EditItemServlet extends DSpaceServlet
             context.complete();
 
             break;
-                
+
         case UPDATE_CC:
 
            	Map<String, String> map = new HashMap<String, String>();
@@ -412,15 +412,15 @@ public class EditItemServlet extends DSpaceServlet
         		map.put("sampling", request.getParameter("sampling_chooser"));
         	}
         	map.put("jurisdiction", jurisdiction);
-        	
+
         	LicenseMetadataValue uriField = creativeCommonsService.getCCField("uri");
         	LicenseMetadataValue nameField = creativeCommonsService.getCCField("name");
-        	
+
         	boolean exit = false;
-			if (licenseclass.equals("webui.Submission.submit.CCLicenseStep.no_license")) 
+			if (licenseclass.equals("webui.Submission.submit.CCLicenseStep.no_license"))
         	{
 				creativeCommonsService.removeLicense(context, uriField, nameField, item);
-				
+
 				itemService.update(context, item);
 	            context.dispatchEvents();
     			exit = true;
@@ -429,7 +429,7 @@ public class EditItemServlet extends DSpaceServlet
         		//none
         		exit = true;
 			}
-        	
+
 			if (!exit) {
 				CCLookup ccLookup = new CCLookup();
 				ccLookup.issue(licenseclass, map, configurationService.getProperty("cc.license.locale"));
@@ -504,7 +504,7 @@ public class EditItemServlet extends DSpaceServlet
             HttpServletResponse response, Item item) throws ServletException,
             IOException, SQLException, AuthorizeException
     {
-  
+
         // Get the handle, if any
         String handle = handleService.findHandle(context, item);
 
@@ -513,10 +513,10 @@ public class EditItemServlet extends DSpaceServlet
 
         // All DC types in the registry
         List<MetadataField> types = metadataFieldService.findAll(context);
-        
+
         // Get a HashMap of metadata field ids and a field name to display
         Map<Integer, String> metadataFields = new HashMap<>();
-        
+
         // Get all existing Schemas
         List<MetadataSchema> schemas = metadataSchemaService.findAll(context);
         for (MetadataSchema s : schemas)
@@ -542,7 +542,7 @@ public class EditItemServlet extends DSpaceServlet
         {
             request.setAttribute("policy_button", Boolean.FALSE);
         }
-        
+
         if (authorizeService.authorizeActionBoolean(context, itemService
                 .getParentObject(context, item), Constants.REMOVE))
         {
@@ -552,7 +552,7 @@ public class EditItemServlet extends DSpaceServlet
         {
             request.setAttribute("delete_button", Boolean.FALSE);
         }
-        
+
         try
         {
             authorizeService.authorizeAction(context, item, Constants.ADD);
@@ -562,7 +562,7 @@ public class EditItemServlet extends DSpaceServlet
         {
             request.setAttribute("create_bitstream_button", Boolean.FALSE);
         }
-        
+
         try
         {
             authorizeService.authorizeAction(context, item, Constants.REMOVE);
@@ -572,7 +572,7 @@ public class EditItemServlet extends DSpaceServlet
         {
             request.setAttribute("remove_bitstream_button", Boolean.FALSE);
         }
-        
+
         try
         {
             AuthorizeUtil.authorizeManageCCLicense(context, item);
@@ -582,7 +582,7 @@ public class EditItemServlet extends DSpaceServlet
         {
             request.setAttribute("cclicense_button", Boolean.FALSE);
         }
-        
+
         try
         {
             if( 0 < itemService.getBundles(item, "ORIGINAL").size()){
@@ -620,17 +620,17 @@ public class EditItemServlet extends DSpaceServlet
             }
         }
 
-		if (item.isDiscoverable()) 
+		if (item.isDiscoverable())
 		{
 			request.setAttribute("privating_button", authorizeService
 					.authorizeActionBoolean(context, item, Constants.WRITE));
-		} 
-		else 
+		}
+		else
 		{
 			request.setAttribute("publicize_button", authorizeService
 					.authorizeActionBoolean(context, item, Constants.WRITE));
 		}
-        
+
         request.setAttribute("item", item);
         request.setAttribute("handle", handle);
         request.setAttribute("collections", collections);
@@ -711,7 +711,7 @@ public class EditItemServlet extends DSpaceServlet
 
                 // Get a string with "element" for unqualified or
                 // "element_qualifier"
-                String key = metadataFieldService.findByElement(context, 
+                String key = metadataFieldService.findByElement(context,
                 		schema,element,qualifier).toString();
 
                 // Get the language
@@ -878,7 +878,7 @@ public class EditItemServlet extends DSpaceServlet
         {
             // Show cc-edit page
             request.setAttribute("item", item);
-            
+
             boolean exists = creativeCommonsService.hasLicense(context, item);
             request.setAttribute("cclicense.exists", Boolean.valueOf(exists));
 
@@ -886,15 +886,15 @@ public class EditItemServlet extends DSpaceServlet
             /** Default locale to 'en' */
             ccLocale = (StringUtils.isNotBlank(ccLocale)) ? ccLocale : "en";
             request.setAttribute("cclicense.locale", ccLocale);
-            
+
             CCLookup cclookup = new CCLookup();
             java.util.Collection<CCLicense> collectionLicenses = cclookup.getLicenses(ccLocale);
             request.setAttribute("cclicense.licenses", collectionLicenses);
-            
+
             JSPManager
                     .showJSP(request, response, "/tools/creative-commons-edit.jsp");
         }
-        
+
         if (button.equals("submit_addbitstream"))
         {
             // Show upload bitstream page
@@ -923,11 +923,11 @@ public class EditItemServlet extends DSpaceServlet
                     //Retrieve the button key
                     String inputKey = button.replace("submit_order_", "") + "_value";
                     if(inputKey.startsWith(bundle.getID() + "_")){
-                        List<UUID> vals = Util.getUUIDParameters(request, inputKey);
-                        int idx = 0;
-                        for (UUID v : vals) {
-                            newBitstreamOrder[idx] = v;
-                            idx++;
+                        // Field contains comma-separated, ordered list of Bitstream UUIDs
+                        String[] vals = request.getParameter(inputKey).split(",");
+                        for (int i = 0; i < vals.length; i++) {
+                            String val = vals[i];
+                            newBitstreamOrder[i] = UUID.fromString(val);
                         }
                     }else{
                         newBitstreamOrder = null;
@@ -950,7 +950,7 @@ public class EditItemServlet extends DSpaceServlet
             // Show edit page again
             showEditForm(context, request, response, item);
         }
-        
+
         // Complete transaction
         context.complete();
     }
@@ -976,11 +976,11 @@ public class EditItemServlet extends DSpaceServlet
             Bitstream b = null;
             Item item = itemService.find(context, UIUtil.getUUIDParameter(wrapper, "item_id"));
             File temp = wrapper.getFile("file");
-            
+
             if(temp == null)
             {
                 boolean noFileSelected = true;
-                
+
                 // Show upload bitstream page
                 request.setAttribute("noFileSelected", noFileSelected);
                 request.setAttribute("item", item);
@@ -1010,7 +1010,7 @@ public class EditItemServlet extends DSpaceServlet
                     bundleService.inheritCollectionDefaultPolicies(context, bnd,
                     		owningCollection);
                 }
-            } 
+            }
             else
             {
                 // we have a bundle already, just add bitstream


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3604

Fixes DS-3604 by syncing JSPUI bitstream reorder code with the (working) XMLUI code (see ticket comments). I've manually tested the simple changes in https://github.com/tdonohue/DSpace/commit/ef3afe19eb01c9404a988758059ee7eaef785051 and they work.

However, I'm flagging this as a WIP, as we likely should also still refactor the `BundleServiceImpl.setOrder()` method to be less destructive when it is passed bad data. This method also does not currently have a Unit Test (while most other methods in that class do). https://github.com/DSpace/DSpace/blob/dspace-6_x/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java#L269