### PR TITLE
DS-3571 Log hibernate validation errors

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -10,6 +10,7 @@ package org.dspace.core;
 import org.apache.log4j.Logger;
 import org.dspace.authorize.ResourcePolicy;
 import org.dspace.content.DSpaceObject;
+import org.dspace.core.exception.DatabaseSchemaValidationException;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.factory.EPersonServiceFactory;
@@ -155,8 +156,18 @@ public class Context
             dbConnection = new DSpace().getSingletonService(DBConnection.class);
             if(dbConnection == null)
             {
+                //It appears there is a problem with the database, run the Schema validator
+                DatabaseSchemaValidator schemaValidator = new DSpace().getSingletonService(DatabaseSchemaValidator.class);
+
+                String validationError = schemaValidator == null ? "null" : schemaValidator.getDatabaseSchemaValidationError();
+                String message = "The schema validator returned: " +
+                        validationError;
+
                 log.fatal("Cannot obtain the bean which provides a database connection. " +
-                        "Check previous entries in the dspace.log to find why the db failed to initialize.");
+                        "Check previous entries in the dspace.log to find why the db failed to initialize. " + message);
+
+                //Fail fast
+                throw new DatabaseSchemaValidationException(message);
             }
         }
 

--- a/dspace-api/src/main/java/org/dspace/core/DatabaseSchemaValidator.java
+++ b/dspace-api/src/main/java/org/dspace/core/DatabaseSchemaValidator.java
@@ -1,0 +1,17 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.core;
+
+/**
+ * Interface to validate the current domain model against the database schema.
+ */
+public interface DatabaseSchemaValidator {
+
+    String getDatabaseSchemaValidationError();
+
+}

--- a/dspace-api/src/main/java/org/dspace/core/HibernateDatabaseSchemaValidator.java
+++ b/dspace-api/src/main/java/org/dspace/core/HibernateDatabaseSchemaValidator.java
@@ -1,0 +1,38 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.core;
+
+import org.hibernate.HibernateException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.orm.hibernate4.LocalSessionFactoryBean;
+
+/**
+ * Database schema validation when using the Hibernate persistence layer
+ */
+public class HibernateDatabaseSchemaValidator implements DatabaseSchemaValidator {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    public String getDatabaseSchemaValidationError() {
+        String validationError = "";
+
+        try {
+            applicationContext.getBean(LocalSessionFactoryBean.class);
+        } catch (org.springframework.beans.factory.BeanCreationException ex) {
+            //The hibernate validation exception is the cause of this BeanCreationException
+            validationError = ex.getCause() == null ? ex.getMessage() : ex.getCause().getMessage();
+        } catch (HibernateException ex) {
+            validationError = ex.getMessage();
+        }
+
+        return validationError;
+    }
+
+}

--- a/dspace-api/src/main/java/org/dspace/core/exception/DatabaseSchemaValidationException.java
+++ b/dspace-api/src/main/java/org/dspace/core/exception/DatabaseSchemaValidationException.java
@@ -1,0 +1,18 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.core.exception;
+
+/**
+ * Runtime exception that indicates that there is a database schema validation problem.
+ */
+public class DatabaseSchemaValidationException extends RuntimeException {
+
+    public DatabaseSchemaValidationException(final String message) {
+        super(message);
+    }
+}

--- a/dspace-api/src/main/resources/spring/spring-dspace-core-services.xml
+++ b/dspace-api/src/main/resources/spring/spring-dspace-core-services.xml
@@ -34,6 +34,7 @@
     </bean>
 
     <bean name="org.dspace.core.DBConnection" class="org.dspace.core.HibernateDBConnection" lazy-init="true"/>
+    <bean name="org.dspace.core.DatabaseSchemaValidator" class="org.dspace.core.HibernateDatabaseSchemaValidator" lazy-init="true"/>
 
     <!-- Register all our Flyway callback classes (which run before/after database migrations) -->
     <bean class="org.dspace.storage.rdbms.DatabaseRegistryUpdater"/>

--- a/dspace-api/src/test/java/org/dspace/core/ContextTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/ContextTest.java
@@ -7,24 +7,27 @@
  */
 package org.dspace.core;
 
-import java.sql.SQLException;
-import java.util.List;
-import java.util.Locale;
-import java.util.UUID;
-
 import mockit.NonStrictExpectations;
+import org.apache.commons.lang.StringUtils;
 import org.dspace.AbstractUnitTest;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.factory.AuthorizeServiceFactory;
 import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.core.exception.DatabaseSchemaValidationException;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
 import org.dspace.eperson.service.GroupService;
-import org.junit.*;
-import static org.junit.Assert.* ;
+import org.junit.Test;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+
 import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
 
 /**
  * Perform some basic unit tests for Context Class
@@ -46,6 +49,40 @@ public class ContextTest extends AbstractUnitTest
         
         assertThat("testGetDBConnection 0", connection, notNullValue());
         assertThat("testGetDBConnection 1", connection.isSessionAlive(), equalTo(true));
+    }
+
+    /**
+     * Test of getDBConnection method, of class Context.
+     */
+    @Test
+    public void testSchemaValidation() throws SQLException
+    {
+        try {
+            //Stop the current kernel and database
+            destroy();
+            destroyKernel();
+
+            //Create a new Kernel but do not init the database. This should trigger missing table validation errors
+            initKernel();
+            init();
+
+            //If we get here without exception, the validation did not happen
+            fail();
+
+        } catch(DatabaseSchemaValidationException ex) {
+            assertTrue(StringUtils.isNotBlank(ex.getMessage()));
+            assertTrue(StringUtils.contains(ex.getMessage(), "Missing table"));
+
+        } finally {
+
+            //restore correct state
+            destroy();
+            destroyKernel();
+
+            initKernel();
+            initDatabase();
+            init();
+        }
     }
 
     /**


### PR DESCRIPTION
# Problem
This problem was detected in DS-3571.

If there is a problem with the database schema (e.g. because of custom database modifications or a Flyway migration that was not executed due to incorrect config), the DSpace logs only output this:

```
2017-06-13 10:33:12,067 INFO  org.hibernate.tool.hbm2ddl.TableMetadata @ HHH000261: Table found: public.resourcepolicy
2017-06-13 10:33:12,068 INFO  org.hibernate.tool.hbm2ddl.TableMetadata @ HHH000037: Columns: [end_date, dspace_object, rptype, resource_type_id, policy_id, eperson_id, action_id, epersongroup_id, start_date_bkp, rpdescription, rpname, start_date]
2017-06-13 10:33:12,068 FATAL org.dspace.core.Context @ Cannot obtain the bean which provides a database connection. Check previous entries in the dspace.log to find why the db failed to initialize.
```

If you run a CLI script, you just see a `NullPointerException` printed on the console.

# Solution
This PR adds information on the validation error:

* In the logs:
```
2017-06-13 10:52:13,087 INFO  org.hibernate.tool.hbm2ddl.TableMetadata @ HHH000261: Table found: public.resourcepolicy
2017-06-13 10:52:13,088 INFO  org.hibernate.tool.hbm2ddl.TableMetadata @ HHH000037: Columns: [end_date, dspace_object, rptype, resource_type_id, policy_id, eperson_id, action_id, epersongroup_id, start_date_bkp, rpdescription, rpname, start_date]
2017-06-13 10:52:13,088 FATAL org.dspace.core.Context @ Cannot obtain the bean which provides a database connection. Check previous entries in the dspace.log to find why the db failed to initialize. The schema validator returned: Wrong column type in public.resourcepolicy for column start_date. Found: timestamp, expected: date
```

* On the CLI:
```
INFO: Using dspace provided log configuration (log.init.config)
INFO: Loading: .../dspace6/config/log4j.properties
Exception: The schema validator returned: Wrong column type in public.resourcepolicy for column start_date. Found: timestamp, expected: date
org.dspace.core.exception.DatabaseSchemaValidationException: The schema validator returned: Wrong column type in public.resourcepolicy for column start_date. Found: timestamp, expected: date
	at org.dspace.core.Context.init(Context.java:170)
	at org.dspace.core.Context.<init>(Context.java:138)
```

# Testing
Before starting Tomcat or any other CLI statement, update the DSpace database schema, e.g. `alter table resourcepolicy alter column start_date type timestamp;`

Then start Tomcat or run a DSpace CLI command. You should see an error describing why the database connection failed to start.
