### PR TITLE
DS-3618 Expose the browse system over the new REST API

### DIFF
--- a/dspace-api/src/main/java/org/dspace/sort/SortOption.java
+++ b/dspace-api/src/main/java/org/dspace/sort/SortOption.java
@@ -13,6 +13,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.dspace.core.ConfigurationManager;
 
@@ -314,6 +315,26 @@ public class SortOption
         }
 
         return SortOption.sortOptionsSet;
+    }
+    
+    /**
+     * Get the defined sort option by name
+     * @param name
+     *     the name of the sort option as given in the config file
+     * @return the configured sort option with given name
+     * @throws SortException if sort error
+     */
+    public static SortOption getSortOption(String name) throws SortException
+    {
+        for (SortOption so : SortOption.getSortOptions())
+        {
+            if (StringUtils.equals(name, so.getName()))
+            {
+                return so;
+            }
+        }
+        
+        return null;
     }
     
     /**

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -8,12 +8,14 @@
 package org.dspace.app.rest;
 
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import org.apache.commons.lang3.StringUtils;
 import org.atteo.evo.inflector.English;
 import org.dspace.app.rest.exception.PaginationException;
 import org.dspace.app.rest.exception.RepositoryNotFoundException;
@@ -54,12 +56,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class RestResourceController implements InitializingBean {
 	@Autowired
 	DiscoverableEndpointsService discoverableEndpointsService;
-	
+
 	@Autowired
 	Utils utils;
 
 	@Override
-	public void afterPropertiesSet()  {
+	public void afterPropertiesSet() {
 		List<Link> links = new ArrayList<Link>();
 		for (String r : utils.getRepositories()) {
 			// this doesn't work as we don't have an active http request
@@ -76,17 +78,28 @@ public class RestResourceController implements InitializingBean {
 	
 	@RequestMapping(method = RequestMethod.GET, value = "/{id:\\d+}")
 	@SuppressWarnings("unchecked")
-	DSpaceResource<RestModel> findOne(@PathVariable String apiCategory, @PathVariable String model, @PathVariable Integer id, @RequestParam(required=false) String projection) {
+	public DSpaceResource<RestModel> findOne(@PathVariable String apiCategory, @PathVariable String model,
+			@PathVariable Integer id, @RequestParam(required = false) String projection) {
 		return findOneInternal(apiCategory, model, id, projection);
 	}
-	
+
+	@RequestMapping(method = RequestMethod.GET, value = "/{id:[A-z0-9]+}")
+	@SuppressWarnings("unchecked")
+	public DSpaceResource<RestModel> findOne(@PathVariable String apiCategory, @PathVariable String model,
+			@PathVariable String id, @RequestParam(required = false) String projection) {
+		return findOneInternal(apiCategory, model, id, projection);
+	}
+
 	@RequestMapping(method = RequestMethod.GET, value = "/{uuid:[0-9a-fxA-FX]{8}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{12}}")
 	@SuppressWarnings("unchecked")
-	DSpaceResource<RestModel> findOne(@PathVariable String apiCategory, @PathVariable String model, @PathVariable UUID uuid, @RequestParam(required=false) String projection) {
+	public DSpaceResource<RestModel> findOne(@PathVariable String apiCategory, @PathVariable String model,
+			@PathVariable UUID uuid, @RequestParam(required = false) String projection) {
 		return findOneInternal(apiCategory, model, uuid, projection);
 	}
-	
-	private <ID extends Serializable> DSpaceResource<RestModel> findOneInternal(String apiCategory, String model, ID id, String projection) {
+
+	private <ID extends Serializable> DSpaceResource<RestModel> findOneInternal(String apiCategory, String model, ID id,
+			String projection) {
+		checkModelPluralForm(apiCategory, model);
 		DSpaceRestRepository<RestModel, ID> repository = utils.getResourceRepository(apiCategory, model);
 		RestModel modelObject = null;
 		try {
@@ -113,6 +126,7 @@ public class RestResourceController implements InitializingBean {
 	private <ID extends Serializable> ResourceSupport findRelInternal(String apiCategory, String model, ID uuid, String rel, String projection) {
 		// FIXME this is a very bad implementation as it leads most of times to
 		// more round-trip on the database and retrieval of unneeded infromation
+		checkModelPluralForm(apiCategory, model);
 		DSpaceRestRepository<RestModel, ID> repository = utils.getResourceRepository(apiCategory, model);
 		RestModel modelObject = repository.findOne(uuid);
 		DSpaceResource result = repository.wrapResource(modelObject, rel);
@@ -127,21 +141,30 @@ public class RestResourceController implements InitializingBean {
 
 	@RequestMapping(method = RequestMethod.GET)
 	@SuppressWarnings("unchecked")
-	<T extends RestModel> PagedResources<DSpaceResource<T>> findAll(@PathVariable String apiCategory, @PathVariable String model, Pageable page, PagedResourcesAssembler assembler, @RequestParam(required=false) String projection) {
+	public <T extends RestModel> PagedResources<DSpaceResource<T>> findAll(@PathVariable String apiCategory,
+			@PathVariable String model, Pageable page, PagedResourcesAssembler assembler,
+			@RequestParam(required = false) String projection) {
 		DSpaceRestRepository<T, ?> repository = utils.getResourceRepository(apiCategory, model);
-//		Link link = entityLinks.linkFor(getResourceClass(model), model, page).withSelfRel();
-		Link link = linkTo(this.getClass(), apiCategory, model).withSelfRel();
-		
+		Link link = linkTo(methodOn(this.getClass(), apiCategory, English.plural(model)).findAll(apiCategory, model, page, assembler, projection)).withSelfRel();
+
 		Page<DSpaceResource<T>> resources;
 		try {
 			resources = repository.findAll(page).map(repository::wrapResource);
-//				Link linkToSingleResource = Utils.linkToSingleResource(r, Link.REL_SELF);
-//				r.add(linkToSingleResource);
-//			});
 		} catch (PaginationException pe) {
 			resources = new PageImpl<DSpaceResource<T>>(new ArrayList<DSpaceResource<T>>(), page, pe.getTotal());
 		}
 		PagedResources<DSpaceResource<T>> result = assembler.toResource(resources, link);
 		return result;
+	}
+
+	/**
+	 * Check that the model is specified in its plural form, otherwise throw a RepositoryNotFound exception
+	 *  
+	 * @param model
+	 */
+	private void checkModelPluralForm(String apiCategory, String model) {
+		if (StringUtils.equals(utils.makeSingular(model), model)) {
+			throw new RepositoryNotFoundException(apiCategory, model);
+		}
 	}
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -11,18 +11,24 @@ import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
 import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+
+import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang3.StringUtils;
 import org.atteo.evo.inflector.English;
 import org.dspace.app.rest.exception.PaginationException;
 import org.dspace.app.rest.exception.RepositoryNotFoundException;
-import org.dspace.app.rest.model.BitstreamRest;
+import org.dspace.app.rest.model.LinkRest;
+import org.dspace.app.rest.model.LinksRest;
 import org.dspace.app.rest.model.RestModel;
 import org.dspace.app.rest.model.hateoas.DSpaceResource;
 import org.dspace.app.rest.repository.DSpaceRestRepository;
+import org.dspace.app.rest.repository.LinkRestRepository;
 import org.dspace.app.rest.utils.Utils;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,7 +40,6 @@ import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.ResourceSupport;
-import org.springframework.hateoas.core.EvoInflectorRelProvider;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -114,20 +119,56 @@ public class RestResourceController implements InitializingBean {
 	}
 
 	@RequestMapping(method = RequestMethod.GET, value = "/{id:\\d+}/{rel}")
-	ResourceSupport findRel(@PathVariable String apiCategory, @PathVariable String model, @PathVariable Integer id, @PathVariable String rel, @RequestParam(required=false) String projection) {
-		return findRelInternal(apiCategory, model, id, rel, projection);
+	public ResourceSupport findRel(HttpServletRequest request, @PathVariable String apiCategory, @PathVariable String model, @PathVariable Integer id,
+			@PathVariable String rel, Pageable page, PagedResourcesAssembler assembler,
+			@RequestParam(required = false) String projection) {
+		return findRelInternal(request, apiCategory, model, id, rel, page, assembler, projection);
 	}
 	
+	@RequestMapping(method = RequestMethod.GET, value = "/{id:[A-z0-9]+}/{rel}")
+	public ResourceSupport findRel(HttpServletRequest request,  @PathVariable String apiCategory, @PathVariable String model, @PathVariable String id,
+			@PathVariable String rel, Pageable page, PagedResourcesAssembler assembler,
+			@RequestParam(required = false) String projection) {
+		return findRelInternal(request, apiCategory, model, id, rel, page, assembler, projection);
+	}
+
 	@RequestMapping(method = RequestMethod.GET, value = "/{uuid:[0-9a-fxA-FX]{8}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{12}}/{rel}")
-	ResourceSupport findRel(@PathVariable String apiCategory, @PathVariable String model, @PathVariable UUID uuid, @PathVariable String rel, @RequestParam(required=false) String projection) {
-		return findRelInternal(apiCategory, model, uuid, rel, projection);
+	public ResourceSupport findRel(HttpServletRequest request, @PathVariable String apiCategory, @PathVariable String model, @PathVariable UUID uuid,
+			@PathVariable String rel, Pageable page, PagedResourcesAssembler assembler,
+			@RequestParam(required = false) String projection) {
+		return findRelInternal(request, apiCategory, model, uuid, rel, page, assembler, projection);
 	}
-	
-	private <ID extends Serializable> ResourceSupport findRelInternal(String apiCategory, String model, ID uuid, String rel, String projection) {
-		// FIXME this is a very bad implementation as it leads most of times to
-		// more round-trip on the database and retrieval of unneeded infromation
+
+	private <ID extends Serializable> ResourceSupport findRelInternal(HttpServletRequest request, String apiCategory, String model, ID uuid,
+			String rel, Pageable page, PagedResourcesAssembler assembler, String projection) {
 		checkModelPluralForm(apiCategory, model);
 		DSpaceRestRepository<RestModel, ID> repository = utils.getResourceRepository(apiCategory, model);
+		
+		LinksRest linksAnnotation = repository.getDomainClass().getDeclaredAnnotation(LinksRest.class);
+		if (linksAnnotation != null) {
+			LinkRest[] links = linksAnnotation.links();
+			for (LinkRest l : links) {
+				if (StringUtils.equals(rel, l.name())) {
+					LinkRestRepository linkRepository = utils.getLinkResourceRepository(apiCategory, model, rel);
+					Method[] methods = linkRepository.getClass().getMethods();
+					for (Method m : methods) { 
+						if (StringUtils.equals(m.getName(), l.method())) {
+							try {
+								Page<? extends Serializable> pageResult = (Page<? extends RestModel>) m.invoke(linkRepository, request, uuid, page, projection);
+								Link link = linkTo(this.getClass(), apiCategory, English.plural(model)).slash(uuid).slash(rel).withSelfRel();
+								PagedResources<? extends ResourceSupport> result = assembler.toResource(pageResult.map(linkRepository::wrapResource), link);
+								return result;
+							} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+								throw new RuntimeException(e.getMessage(), e);
+							}
+						}
+					}
+					// TODO custom exception
+					throw new RuntimeException("Method for relation " + rel + " not found: " + l.name());
+				}
+			}
+		}
+		
 		RestModel modelObject = repository.findOne(uuid);
 		DSpaceResource result = repository.wrapResource(modelObject, rel);
 		if (result.getLink(rel) == null) {

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/BrowseEntryConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/BrowseEntryConverter.java
@@ -1,0 +1,37 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.converter;
+
+import org.apache.log4j.Logger;
+import org.dspace.app.rest.model.BrowseEntryRest;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+/**
+ * This is the converter from String array returned by the Browse engine for
+ * metadata browse to the BrowseEntryRest DTO
+ * 
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+@Component
+public class BrowseEntryConverter implements Converter<String[], BrowseEntryRest> {
+	private static final Logger log = Logger.getLogger(BrowseEntryConverter.class);
+
+	@Override
+	public BrowseEntryRest convert(String[] source) {
+		BrowseEntryRest entry = new BrowseEntryRest();
+		entry.setValue(source[0]);
+		entry.setAuthority(source[1]);
+		if (source.length == 3 && source[2] != null) {
+			entry.setCount(Long.valueOf(source[2]));
+		}
+		return entry;
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/BrowseIndexConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/BrowseIndexConverter.java
@@ -1,0 +1,60 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.converter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.dspace.app.rest.model.BrowseIndexRest;
+import org.dspace.browse.BrowseIndex;
+import org.dspace.sort.SortException;
+import org.dspace.sort.SortOption;
+import org.springframework.stereotype.Component;
+
+/**
+ * This is the converter from/to the BrowseIndex in the DSpace API data model and
+ * the REST data model
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ */
+@Component
+public class BrowseIndexConverter extends DSpaceConverter<BrowseIndex, BrowseIndexRest> {
+	@Override
+	public BrowseIndexRest fromModel(BrowseIndex obj) {
+		BrowseIndexRest bir = new BrowseIndexRest();
+		bir.setId(obj.getName());
+		bir.setOrder(obj.getDefaultOrder());
+		bir.setMetadataBrowse(obj.isMetadataIndex());
+		List<String> metadataList = new ArrayList<String>();
+		if (obj.isMetadataIndex()) {
+			for (String s : obj.getMetadata().split(",")) {
+				metadataList.add(s.trim());
+			}
+		}
+		else {
+			metadataList.add(obj.getSortOption().getMetadata());
+		}
+		bir.setMetadataList(metadataList);
+		
+		List<BrowseIndexRest.SortOption> sortOptionsList = new ArrayList<BrowseIndexRest.SortOption>();
+		try {
+			for (SortOption so : SortOption.getSortOptions()) {
+				sortOptionsList.add(new BrowseIndexRest.SortOption(so.getName(), so.getMetadata()));
+			}
+		} catch (SortException e) {
+			throw new RuntimeException(e.getMessage(), e);
+		}
+		bir.setSortOptions(sortOptionsList);
+		return bir;
+	}
+
+	@Override
+	public BrowseIndex toModel(BrowseIndexRest obj) {
+		return null;
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/BrowseEntryRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/BrowseEntryRest.java
@@ -1,0 +1,70 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * The Browse Entry REST Resource
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+public class BrowseEntryRest implements Serializable {
+	private static final long serialVersionUID = -3415049466402327251L;
+	public static final String NAME = "browseEntry";
+	private String authority;
+	private String value;
+	private String valueLang;
+	private long count;
+
+	@JsonIgnore
+	private BrowseIndexRest browseIndex;
+	
+	public String getAuthority() {
+		return authority;
+	}
+
+	public void setAuthority(String authority) {
+		this.authority = authority;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+	public String getValueLang() {
+		return valueLang;
+	}
+
+	public void setValueLang(String valueLang) {
+		this.valueLang = valueLang;
+	}
+
+	public long getCount() {
+		return count;
+	}
+
+	public void setCount(long count) {
+		this.count = count;
+	}
+	
+	public BrowseIndexRest getBrowseIndex() {
+		return browseIndex;
+	}
+	
+	public void setBrowseIndex(BrowseIndexRest browseIndex) {
+		this.browseIndex = browseIndex;
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/BrowseIndexRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/BrowseIndexRest.java
@@ -1,0 +1,111 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import java.util.List;
+
+import org.dspace.app.rest.RestResourceController;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * The Browse Index REST Resource
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+@LinksRest(links = {
+		@LinkRest(name = BrowseIndexRest.ITEMS, linkClass = ItemRest.class, method = "listBrowseItems"),
+		@LinkRest(name = BrowseIndexRest.ENTRIES, linkClass = BrowseEntryRest.class, method = "listBrowseEntries", optional=true)
+})
+public class BrowseIndexRest extends BaseObjectRest<String> {
+	private static final long serialVersionUID = -4870333170249999559L;
+
+	public static final String NAME = "browse";
+
+	public static final String CATEGORY = RestModel.DISCOVER;
+	
+	public static final String ITEMS = "items";
+	public static final String ENTRIES = "entries";
+
+	boolean metadataBrowse;
+
+	@JsonProperty(value="metadata")
+	List<String> metadataList;
+	
+	List<SortOption> sortOptions;
+
+	String order;
+
+	@JsonIgnore
+	@Override
+	public String getCategory() {
+		return CATEGORY;
+	}
+
+	@Override
+	public String getType() {
+		return NAME;
+	}
+
+	public boolean isMetadataBrowse() {
+		return metadataBrowse;
+	}
+
+	public void setMetadataBrowse(boolean metadataBrowse) {
+		this.metadataBrowse = metadataBrowse;
+	}
+
+	public List<String> getMetadataList() {
+		return metadataList;
+	}
+
+	public void setMetadataList(List<String> metadataList) {
+		this.metadataList = metadataList;
+	}
+
+	public String getOrder() {
+		return order;
+	}
+
+	public void setOrder(String order) {
+		this.order = order;
+	}
+	
+	public List<SortOption> getSortOptions() {
+		return sortOptions;
+	}
+	
+	public void setSortOptions(List<SortOption> sortOptions) {
+		this.sortOptions = sortOptions;
+	}
+
+	@Override
+	public Class getController() {
+		return RestResourceController.class;
+	}
+	
+	static public class SortOption {
+		private String name;
+		private String metadata;
+		
+		public SortOption(String name, String metadata) {
+			this.name = name;
+			this.metadata = metadata;
+		}
+		
+		public String getName() {
+			return name;
+		}
+		
+		public String getMetadata() {
+			return metadata;
+		}
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/LinkRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/LinkRest.java
@@ -1,0 +1,29 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation allows to specify the direct linked REST entities
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ */
+@Target({ElementType.TYPE, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface LinkRest {
+	String name();
+	String method();
+	Class linkClass();
+	boolean optional() default false;
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/LinksRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/LinksRest.java
@@ -1,0 +1,26 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation allows to specify the direct linked REST entities
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ */
+@Target({ElementType.TYPE, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface LinksRest {
+	LinkRest[] links();
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/RestModel.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/RestModel.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.app.rest.model;
 
+import java.io.Serializable;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 /**
@@ -15,7 +17,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  * @author Andrea Bollini (andrea.bollini at 4science.it)
  *
  */
-public interface RestModel {
+public interface RestModel extends Serializable {
 	public static final String CORE = "core";
 	public static final String EPERSON = "eperson";
 	public static final String DISCOVER = "discover";

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/BrowseEntryResource.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/BrowseEntryResource.java
@@ -10,6 +10,7 @@ package org.dspace.app.rest.model.hateoas;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
+import org.atteo.evo.inflector.English;
 import org.dspace.app.rest.RestResourceController;
 import org.dspace.app.rest.model.BrowseEntryRest;
 import org.dspace.app.rest.model.BrowseIndexRest;
@@ -40,7 +41,7 @@ public class BrowseEntryResource extends ResourceSupport {
 		BrowseIndexRest bix = entry.getBrowseIndex();
 		RestResourceController methodOn = methodOn(RestResourceController.class, bix.getCategory(), bix.getType());
 		UriComponentsBuilder uriComponentsBuilder = linkTo(methodOn
-				.findRel(null, bix.getCategory(), bix.getType(), bix.getId(), BrowseIndexRest.ITEMS, null, null, null))
+				.findRel(null, bix.getCategory(), English.plural(bix.getType()), bix.getId(), BrowseIndexRest.ITEMS, null, null, null))
 				.toUriComponentsBuilder();
 		Link link = new Link(addFilterParams(uriComponentsBuilder).build().toString(), BrowseIndexRest.ITEMS);
 		add(link);

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/BrowseEntryResource.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/BrowseEntryResource.java
@@ -1,0 +1,61 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model.hateoas;
+
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
+
+import org.dspace.app.rest.RestResourceController;
+import org.dspace.app.rest.model.BrowseEntryRest;
+import org.dspace.app.rest.model.BrowseIndexRest;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.ResourceSupport;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
+/**
+ * Browse Entry Rest HAL Resource. The HAL Resource wraps the REST Resource
+ * adding support for the links and embedded resources
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+@RelNameDSpaceResource(BrowseEntryRest.NAME)
+public class BrowseEntryResource extends ResourceSupport {
+	@JsonUnwrapped
+	private final BrowseEntryRest data;
+
+	public BrowseEntryRest getData() {
+		return data;
+	}
+
+	public BrowseEntryResource(BrowseEntryRest entry) {
+		this.data = entry;
+		BrowseIndexRest bix = entry.getBrowseIndex();
+		RestResourceController methodOn = methodOn(RestResourceController.class, bix.getCategory(), bix.getType());
+		UriComponentsBuilder uriComponentsBuilder = linkTo(methodOn
+				.findRel(null, bix.getCategory(), bix.getType(), bix.getId(), BrowseIndexRest.ITEMS, null, null, null))
+				.toUriComponentsBuilder();
+		Link link = new Link(addFilterParams(uriComponentsBuilder).build().toString(), BrowseIndexRest.ITEMS);
+		add(link);
+	}
+
+	// TODO use the reflaction to discover the link repository and additional information on the link annotation to build the parameters? 
+	private UriComponentsBuilder addFilterParams(UriComponentsBuilder uriComponentsBuilder) {
+		UriComponentsBuilder result;
+		if (data.getAuthority() != null) {
+			result = uriComponentsBuilder.queryParam("filterValue", data.getAuthority());
+		}
+		else {
+			result = uriComponentsBuilder.queryParam("filterValue", data.getValue());
+		}
+		return result;
+	}
+
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/BrowseIndexResource.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/BrowseIndexResource.java
@@ -1,0 +1,29 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model.hateoas;
+
+import org.dspace.app.rest.model.BrowseIndexRest;
+import org.dspace.app.rest.utils.Utils;
+
+/**
+ * Browse Index Rest HAL Resource. The HAL Resource wraps the REST Resource
+ * adding support for the links and embedded resources
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+@RelNameDSpaceResource(BrowseIndexRest.NAME)
+public class BrowseIndexResource extends DSpaceResource<BrowseIndexRest> {
+	public BrowseIndexResource(BrowseIndexRest bix, Utils utils, String... rels) {
+		super(bix, utils, rels);
+		if (bix.isMetadataBrowse()) {
+			add(utils.linkToSubResource(bix, BrowseIndexRest.ENTRIES));
+		}
+		add(utils.linkToSubResource(bix, BrowseIndexRest.ITEMS));
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/AbstractDSpaceRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/AbstractDSpaceRestRepository.java
@@ -1,0 +1,41 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.repository;
+
+import org.dspace.app.rest.utils.ContextUtil;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.core.Context;
+import org.dspace.services.RequestService;
+import org.dspace.services.model.Request;
+import org.dspace.utils.DSpace;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * This is the base class for any Rest Repository. It provides utility method to
+ * access the DSpaceContext
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+public abstract class AbstractDSpaceRestRepository {
+	@Autowired
+	protected Utils utils;
+
+	protected RequestService requestService = new DSpace().getRequestService();
+
+	protected Context obtainContext() {
+		Request currentRequest = requestService.getCurrentRequest();
+		Context context = (Context) currentRequest.getAttribute(ContextUtil.DSPACE_CONTEXT);
+		if (context != null && context.isValid()) {
+			return context;
+		}
+		context = new Context();
+		currentRequest.setAttribute(ContextUtil.DSPACE_CONTEXT, context);
+		return context;
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/BrowseEntryLinkRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/BrowseEntryLinkRepository.java
@@ -1,0 +1,138 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.repository;
+
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.lang3.StringUtils;
+import org.dspace.app.rest.converter.BrowseEntryConverter;
+import org.dspace.app.rest.converter.BrowseIndexConverter;
+import org.dspace.app.rest.model.BrowseEntryRest;
+import org.dspace.app.rest.model.BrowseIndexRest;
+import org.dspace.app.rest.model.hateoas.BrowseEntryResource;
+import org.dspace.browse.BrowseEngine;
+import org.dspace.browse.BrowseException;
+import org.dspace.browse.BrowseIndex;
+import org.dspace.browse.BrowseInfo;
+import org.dspace.browse.BrowserScope;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.CollectionService;
+import org.dspace.content.service.CommunityService;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * This is the repository responsible to retrieve the first level values
+ * (Entries) of a metadata browse
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+@Component(BrowseIndexRest.CATEGORY + "." + BrowseIndexRest.NAME + "." + BrowseIndexRest.ENTRIES)
+public class BrowseEntryLinkRepository extends AbstractDSpaceRestRepository
+		implements LinkRestRepository<BrowseEntryRest> {
+	@Autowired
+	BrowseEntryConverter converter;
+
+	@Autowired
+	BrowseIndexConverter bixConverter;
+
+	CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
+
+	CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
+
+	// FIXME It will be nice to drive arguments binding by annotation as in normal spring controller methods
+	public Page<BrowseEntryRest> listBrowseEntries(HttpServletRequest request, String browseName,
+			Pageable pageable, String projection) throws BrowseException, SQLException {
+		// FIXME this should be bind automatically and available as method
+		// argument
+		String scope = request.getParameter("scope");
+
+		Context context = obtainContext();
+		BrowseEngine be = new BrowseEngine(context);
+		BrowserScope bs = new BrowserScope(context);
+		DSpaceObject scopeObj = null;
+		if (scope != null) {
+			UUID uuid = UUID.fromString(scope);
+			scopeObj = communityService.find(context, uuid);
+			if (scopeObj == null) {
+				scopeObj = collectionService.find(context, uuid);
+			}
+		}
+
+		// process the input, performing some inline validation
+		final BrowseIndex bi;
+		if (StringUtils.isNotEmpty(browseName)) {
+			bi = BrowseIndex.getBrowseIndex(browseName);
+		} else {
+			bi = null;
+		}
+		if (bi == null) {
+			throw new IllegalArgumentException("Unknown browse index");
+		}
+		if (!bi.isMetadataIndex()) {
+			throw new IllegalStateException("The requested browse haven't metadata entries");
+		}
+
+		// set up a BrowseScope and start loading the values into it
+		bs.setBrowseIndex(bi);
+		Sort sort = pageable.getSort();
+		if (sort != null) {
+			Iterator<Order> orders = sort.iterator();
+			while (orders.hasNext()) {
+				bs.setOrder(orders.next().getDirection().name());
+			}
+		}
+		// bs.setFilterValue(value != null?value:authority);
+		// bs.setFilterValueLang(valueLang);
+		// bs.setJumpToItem(focus);
+		// bs.setJumpToValue(valueFocus);
+		// bs.setJumpToValueLang(valueFocusLang);
+		// bs.setStartsWith(startsWith);
+		bs.setOffset(pageable.getOffset());
+		bs.setResultsPerPage(pageable.getPageSize());
+		// bs.setEtAl(etAl);
+		// bs.setAuthorityValue(authority);
+
+		if (scopeObj != null) {
+			bs.setBrowseContainer(scopeObj);
+		}
+
+		BrowseInfo binfo = be.browse(bs);
+		Pageable pageResultInfo = new PageRequest((binfo.getStart() - 1) / binfo.getResultsPerPage(),
+				pageable.getPageSize());
+		Page<BrowseEntryRest> page = new PageImpl<String[]>(Arrays.asList(binfo.getStringResults()), pageResultInfo,
+				binfo.getTotal()).map(converter);
+		page.forEach(new Consumer<BrowseEntryRest>() {
+			@Override
+			public void accept(BrowseEntryRest t) {
+				t.setBrowseIndex(bixConverter.convert(bi));
+			}
+		});
+		return page;
+	}
+
+	@Override
+	public BrowseEntryResource wrapResource(BrowseEntryRest entry, String... rels) {
+		return new BrowseEntryResource(entry);
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/BrowseIndexRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/BrowseIndexRestRepository.java
@@ -1,0 +1,84 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.repository;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.dspace.app.rest.converter.BrowseIndexConverter;
+import org.dspace.app.rest.converter.CollectionConverter;
+import org.dspace.app.rest.model.BrowseIndexRest;
+import org.dspace.app.rest.model.CollectionRest;
+import org.dspace.app.rest.model.hateoas.BrowseIndexResource;
+import org.dspace.app.rest.model.hateoas.CollectionResource;
+import org.dspace.browse.BrowseException;
+import org.dspace.browse.BrowseIndex;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.stereotype.Component;
+
+/**
+ * This is the repository responsible to Browse Index Rest object
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+@Component(BrowseIndexRest.CATEGORY + "." + BrowseIndexRest.NAME)
+public class BrowseIndexRestRepository extends DSpaceRestRepository<BrowseIndexRest, String> {
+	@Autowired
+	BrowseIndexConverter converter;
+	
+	@Override
+	public BrowseIndexRest findOne(Context context, String name) {
+		BrowseIndexRest bi = null;
+		BrowseIndex bix;
+		try {
+			bix = BrowseIndex.getBrowseIndex(name);
+		} catch (BrowseException e) {
+			throw new RuntimeException(e.getMessage(), e);
+		}
+		if (bix != null) {
+			bi = converter.convert(bix);
+		}
+		return bi;
+	}
+
+	@Override
+	public Page<BrowseIndexRest> findAll(Context context, Pageable pageable) {
+		List<BrowseIndexRest> it = null;
+		List<BrowseIndex> indexesList = new ArrayList<BrowseIndex>();
+		int total = 0;
+		try {
+			BrowseIndex[] indexes = BrowseIndex.getBrowseIndices();
+			total = indexes.length;
+			for (BrowseIndex bix: indexes) {
+				indexesList.add(bix);
+			}
+		} catch (BrowseException e) {
+			throw new RuntimeException(e.getMessage(), e);
+		}
+		Page<BrowseIndexRest> page = new PageImpl<BrowseIndex>(indexesList, pageable, total).map(converter);
+		return page;
+	}
+	
+	@Override
+	public Class<BrowseIndexRest> getDomainClass() {
+		return BrowseIndexRest.class;
+	}
+	
+	@Override
+	public BrowseIndexResource wrapResource(BrowseIndexRest bix, String... rels) {
+		return new BrowseIndexResource(bix, utils, rels);
+	}
+
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/BrowseItemLinkRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/BrowseItemLinkRepository.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.app.rest.repository;
 
 import java.sql.SQLException;

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/BrowseItemLinkRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/BrowseItemLinkRepository.java
@@ -1,0 +1,153 @@
+package org.dspace.app.rest.repository;
+
+import java.sql.SQLException;
+import java.util.Iterator;
+import java.util.UUID;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.lang3.StringUtils;
+import org.dspace.app.rest.converter.ItemConverter;
+import org.dspace.app.rest.model.BrowseIndexRest;
+import org.dspace.app.rest.model.ItemRest;
+import org.dspace.app.rest.model.hateoas.ItemResource;
+import org.dspace.browse.BrowseEngine;
+import org.dspace.browse.BrowseException;
+import org.dspace.browse.BrowseIndex;
+import org.dspace.browse.BrowseInfo;
+import org.dspace.browse.BrowserScope;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.CollectionService;
+import org.dspace.content.service.CommunityService;
+import org.dspace.core.Context;
+import org.dspace.sort.SortException;
+import org.dspace.sort.SortOption;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * This is the repository to retrieve the items associated with a specific
+ * browse index or entries
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+@Component(BrowseIndexRest.CATEGORY + "." + BrowseIndexRest.NAME + "." + BrowseIndexRest.ITEMS)
+public class BrowseItemLinkRepository extends AbstractDSpaceRestRepository
+		implements LinkRestRepository<ItemRest> {
+	@Autowired
+	ItemConverter converter;
+	
+	@Autowired
+	ItemRestRepository itemRestRepository;
+
+	CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
+	
+	CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
+
+	public Page<ItemRest> listBrowseItems(HttpServletRequest request, String browseName, Pageable pageable, String projection)
+			throws BrowseException, SQLException {
+		//FIXME these should be bind automatically and available as method arguments
+		String scope = request.getParameter("scope");
+		String filterValue = request.getParameter("filterValue");
+		String filterAuthority = request.getParameter("filterAuthority");
+				
+		Context context = obtainContext();
+		BrowseEngine be = new BrowseEngine(context);
+		BrowserScope bs = new BrowserScope(context);
+		DSpaceObject scopeObj = null;
+		if (scope != null) {
+			UUID uuid = UUID.fromString(scope);
+			scopeObj = communityService.find(context, uuid);
+			if (scopeObj == null) {
+				scopeObj = collectionService.find(context, uuid);
+			}
+		}
+
+		// process the input, performing some inline validation
+		BrowseIndex bi = null;
+		if (StringUtils.isNotEmpty(browseName)) {
+			bi = BrowseIndex.getBrowseIndex(browseName);
+		}
+		if (bi == null) {
+			throw new IllegalArgumentException("Unknown browse index");
+		}
+		if (!bi.isItemIndex() && (filterAuthority == null && filterValue==null)) {
+			throw new IllegalStateException("The requested browse doesn't provide direct access to items you must specify a filter");
+		}
+		
+		if (!bi.isMetadataIndex() && (filterAuthority != null || filterValue!=null)) {
+			throw new IllegalStateException("The requested browse doesn't support filtering");
+		}
+
+		// set up a BrowseScope and start loading the values into it
+		bs.setBrowseIndex(bi);
+		Sort sort = pageable.getSort();
+		if (sort != null) {
+			Iterator<Order> orders = sort.iterator();
+			while (orders.hasNext()) {
+				Order order = orders.next();
+				bs.setOrder(order.getDirection().name());
+				String sortBy;
+				if (!StringUtils.equals("default", order.getProperty())) {
+					sortBy = order.getProperty();
+				}
+				else {
+					sortBy = bi.getDefaultOrder();
+				}
+				
+				try {
+					SortOption so = SortOption.getSortOption(sortBy);
+					if (so != null) {
+						bs.setSortBy(so.getNumber());
+					}
+				} catch (SortException e) {
+					throw new RuntimeException(e.getMessage(), e);
+				}
+			}
+		}
+		
+		if (filterValue != null || filterAuthority != null) {
+			bs.setFilterValue(filterValue);
+			bs.setAuthorityValue(filterAuthority);
+			bs.setBrowseLevel(1);
+		}
+		// bs.setFilterValueLang(valueLang);
+		// bs.setJumpToItem(focus);
+		// bs.setJumpToValue(valueFocus);
+		// bs.setJumpToValueLang(valueFocusLang);
+		// bs.setStartsWith(startsWith);
+		bs.setOffset(pageable.getOffset());
+		bs.setResultsPerPage(pageable.getPageSize());
+
+		if (scopeObj != null) {
+			bs.setBrowseContainer(scopeObj);
+		}
+		
+		// For second level browses on metadata indexes, we need to adjust the default sorting
+        if (bi != null && bi.isMetadataIndex() && bs.isSecondLevel() && bs.getSortBy() <= 0)
+        {
+            bs.setSortBy(1);
+        }
+
+		BrowseInfo binfo = be.browse(bs);
+
+		Pageable pageResultInfo = new PageRequest((binfo.getStart() -1) / binfo.getResultsPerPage(), pageable.getPageSize());
+		Page<ItemRest> page = new PageImpl<Item>(binfo.getBrowseItemResults(), pageResultInfo, binfo.getTotal())
+				.map(converter);
+		return page;
+	}
+
+	@Override
+	public ItemResource wrapResource(ItemRest item, String... rels) {
+		return itemRestRepository.wrapResource(item, rels);
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/DSpaceRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/DSpaceRestRepository.java
@@ -32,11 +32,8 @@ import org.springframework.data.repository.PagingAndSortingRepository;
  *
  */
 public abstract class DSpaceRestRepository<T extends RestModel, ID extends Serializable>
+extends AbstractDSpaceRestRepository
 		implements PagingAndSortingRepository<T, ID> {
-	@Autowired
-	protected Utils utils;
-
-	protected RequestService requestService = new DSpace().getRequestService();
 
 	@Override
 	public <S extends T> S save(S entity) {
@@ -116,17 +113,6 @@ public abstract class DSpaceRestRepository<T extends RestModel, ID extends Seria
 	}
 
 	public abstract Page<T> findAll(Context context, Pageable pageable);
-
-	private Context obtainContext() {
-		Request currentRequest = requestService.getCurrentRequest();
-		Context context = (Context) currentRequest.getAttribute(ContextUtil.DSPACE_CONTEXT);
-		if (context != null && context.isValid()) {
-			return context;
-		}
-		context = new Context();
-		currentRequest.setAttribute(ContextUtil.DSPACE_CONTEXT, context);
-		return context;
-	}
 
 	public abstract Class<T> getDomainClass();
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/LinkRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/LinkRestRepository.java
@@ -1,0 +1,22 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.repository;
+
+import java.io.Serializable;
+
+import org.springframework.hateoas.ResourceSupport;
+
+/**
+ * This is the interface for Link Repositories.
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+public interface LinkRestRepository<L extends Serializable> {
+	public abstract ResourceSupport wrapResource(L model, String... rels);
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/Utils.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/Utils.java
@@ -18,6 +18,7 @@ import org.dspace.app.rest.model.CommunityRest;
 import org.dspace.app.rest.model.RestModel;
 import org.dspace.app.rest.model.hateoas.DSpaceResource;
 import org.dspace.app.rest.repository.DSpaceRestRepository;
+import org.dspace.app.rest.repository.LinkRestRepository;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -85,5 +86,26 @@ public class Utils {
 			return CommunityRest.NAME;
 		}
 		return modelPlural.replaceAll("s$", "");
+	}
+
+	/**
+	 * Retrieve the LinkRestRepository associated with a specific link from the
+	 * apiCategory and model specified in the parameters.
+	 * 
+	 * @param apiCategory
+	 *            the apiCategory
+	 * @param modelPlural
+	 *            the model name in its plural form
+	 * @param rel
+	 *            the name of the relation
+	 * @return
+	 */
+	public LinkRestRepository getLinkResourceRepository(String apiCategory, String modelPlural, String rel) {
+		String model = makeSingular(modelPlural);
+		try {
+			return applicationContext.getBean(apiCategory + "." + model + "." + rel, LinkRestRepository.class);
+		} catch (NoSuchBeanDefinitionException e) {
+			throw new RepositoryNotFoundException(apiCategory, model);
+		}
 	}
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/Utils.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/Utils.java
@@ -59,11 +59,11 @@ public class Utils {
 	}
 
 	public Link linkToSingleResource(RestModel data, String rel) {
-		return linkTo(data.getController(), data.getCategory(), data.getType()).slash(data).withRel(rel);
+		return linkTo(data.getController(), data.getCategory(), English.plural(data.getType())).slash(data).withRel(rel);
 	}
 
 	public Link linkToSubResource(RestModel data, String rel) {
-		return linkTo(data.getController(), data.getCategory(), data.getType()).slash(data).slash(rel).withRel(rel);
+		return linkTo(data.getController(), data.getCategory(), English.plural(data.getType())).slash(data).slash(rel).withRel(rel);
 	}
 
 	public DSpaceRestRepository getResourceRepository(String apiCategory, String modelPlural) {

--- a/dspace-spring-rest/src/main/resources/application.properties
+++ b/dspace-spring-rest/src/main/resources/application.properties
@@ -39,7 +39,7 @@ spring.application.name = DSpace Spring Rest
 ########################
 # Spring DATA Rest settings
 #
-spring.data.rest.basePath=/api
+spring.data.rest.basePath=
 
 ########################
 # Jackson serialization settings

--- a/dspace-spring-rest/src/main/webapp/index.html
+++ b/dspace-spring-rest/src/main/webapp/index.html
@@ -12,7 +12,7 @@
 <head>
     <meta charset="utf-8">
     <title>The HAL Browser (customized for Spring Data REST)</title>
-    <link rel="stylesheet" media="screen" href="api/browser/vendor/css/bootstrap.css" />
+    <link rel="stylesheet" media="screen" href="browser/vendor/css/bootstrap.css" />
     <style type="text/css">
         body {
             padding-top: 60px;
@@ -22,8 +22,8 @@
             padding: 9px 0;
         }
     </style>
-    <link rel="stylesheet" media="screen" href="api/browser/vendor/css/bootstrap-responsive.css" />
-    <link rel="stylesheet" media="screen" href="api/browser/styles.css" />
+    <link rel="stylesheet" media="screen" href="browser/vendor/css/bootstrap-responsive.css" />
+    <link rel="stylesheet" media="screen" href="browser/styles.css" />
 </head>
 
 <body>
@@ -249,44 +249,44 @@ Content-Type: application/json
     </div>
 </script>
 
-<script src="api/browser/vendor/js/jquery-1.10.2.min.js"></script>
-<script src="api/browser/vendor/js/underscore.js"></script>
-<script src="api/browser/vendor/js/backbone.js"></script>
-<script src="api/browser/vendor/js/uritemplates.js"></script>
-<script src="api/browser/vendor/js/URI.min.js"></script>
-<script src="api/browser/vendor/js/bootstrap.js"></script>
+<script src="browser/vendor/js/jquery-1.10.2.min.js"></script>
+<script src="browser/vendor/js/underscore.js"></script>
+<script src="browser/vendor/js/backbone.js"></script>
+<script src="browser/vendor/js/uritemplates.js"></script>
+<script src="browser/vendor/js/URI.min.js"></script>
+<script src="browser/vendor/js/bootstrap.js"></script>
 
-<script src="api/browser/js/hal.js"></script>
-<script src="api/browser/js/hal/browser.js"></script>
+<script src="browser/js/hal.js"></script>
+<script src="browser/js/hal/browser.js"></script>
 
-<script src="api/browser/js/hal/http/client.js"></script>
-<script src="api/browser/js/hal/resource.js"></script>
+<script src="browser/js/hal/http/client.js"></script>
+<script src="browser/js/hal/resource.js"></script>
 
-<script src="api/browser/js/hal/views/browser.js"></script>
-<script src="api/browser/js/hal/views/explorer.js"></script>
-<script src="api/browser/js/hal/views/inspector.js"></script>
+<script src="browser/js/hal/views/browser.js"></script>
+<script src="browser/js/hal/views/explorer.js"></script>
+<script src="browser/js/hal/views/inspector.js"></script>
 
-<script src="api/browser/js/hal/views/navigation.js"></script>
-<script src="api/browser/js/hal/views/location_bar.js"></script>
-<script src="api/browser/js/hal/views/request_headers.js"></script>
+<script src="browser/js/hal/views/navigation.js"></script>
+<script src="browser/js/hal/views/location_bar.js"></script>
+<script src="browser/js/hal/views/request_headers.js"></script>
 
-<script src="api/browser/js/hal/views/resource.js"></script>
-<script src="api/browser/js/hal/views/properties.js"></script>
-<script src="api/browser/js/hal/views/links.js"></script>
-<script src="api/browser/js/hal/views/embedded_resources.js"></script>
-<script src="api/browser/js/hal/views/embedded_resource.js"></script>
+<script src="browser/js/hal/views/resource.js"></script>
+<script src="browser/js/hal/views/properties.js"></script>
+<script src="browser/js/hal/views/links.js"></script>
+<script src="browser/js/hal/views/embedded_resources.js"></script>
+<script src="browser/js/hal/views/embedded_resource.js"></script>
 
-<script src="api/browser/js/hal/views/non_safe_request_dialog.js"></script>
-<script src="api/browser/js/hal/views/query_uri_dialog.js"></script>
+<script src="browser/js/hal/views/non_safe_request_dialog.js"></script>
+<script src="browser/js/hal/views/query_uri_dialog.js"></script>
 
-<script src="api/browser/js/hal/views/response.js"></script>
-<script src="api/browser/js/hal/views/response_headers.js"></script>
-<script src="api/browser/js/hal/views/response_body.js"></script>
+<script src="browser/js/hal/views/response.js"></script>
+<script src="browser/js/hal/views/response_headers.js"></script>
+<script src="browser/js/hal/views/response_body.js"></script>
 
-<script src="api/browser/js/hal/views/documentation.js"></script>
+<script src="browser/js/hal/views/documentation.js"></script>
 
-<script src="api/browser/vendor/js/jsoneditor.js"></script>
-<script src="api/browser/js/CustomPostForm.js"></script>
+<script src="browser/vendor/js/jsoneditor.js"></script>
+<script src="browser/js/CustomPostForm.js"></script>
 
 <script>
     var browser = new HAL.Browser({


### PR DESCRIPTION
This PR add the endpoints to expose via REST API the DSpace browse system. To facilitate the review it has been already installed in the demo rest api server http://dspace7.4science.it/dspace-spring-rest
- available indexes 
http://dspace7.4science.it/dspace-spring-rest/#/dspace-spring-rest/api/discover/browses

- list of items in a "item browse" 
http://dspace7.4science.it/dspace-spring-rest/#http://dspace7.4science.it/dspace-spring-rest/api/discover/browses/dateissued/items

- list of entries for a metadata browse
http://dspace7.4science.it/dspace-spring-rest/#http://dspace7.4science.it/dspace-spring-rest/api/discover/browses/author/entries

- list of items associated to a specific entry
http://dspace7.4science.it/dspace-spring-rest/#http://dspace7.4science.it/dspace-spring-rest/api/discover/browses/author/items?filterValue=Cat, Lily

It introduces and use for the first time the concept of LinkRepository something that is responsible to retrieve specific collections of resources or single resource linked to a "source" resource. In this case they were the items linked to a specific browse index.

Finally, this PR fix also the wrong behavior described in https://jira.duraspace.org/browse/DS-3617 