### PR TITLE
[DS-3602] Ensure Consistent Use of Legacy Id in Usage Queries

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataSearches.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataSearches.java
@@ -12,6 +12,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.util.ClientUtils;
 import org.dspace.content.DSpaceObject;
+import org.dspace.content.DSpaceObjectLegacySupport;
 import org.dspace.core.Context;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.statistics.Dataset;
@@ -201,8 +202,12 @@ public class StatisticsDataSearches extends StatisticsData {
     protected String getQuery() {
         String query;
         if(currentDso != null){
-            query = "scopeType: " + currentDso.getType() + " AND scopeId: " + currentDso.getID();
-
+            query = "scopeType: " + currentDso.getType() + " AND ";
+            if(currentDso instanceof DSpaceObjectLegacySupport){
+                query += " (scopeId:" + currentDso.getID() + " OR " + ((DSpaceObjectLegacySupport) currentDso).getLegacyId() + ")";
+            }else{
+                query += "scopeId:" + currentDso.getID();
+            }
         }else{
             query = "*:*";
         }

--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataSearches.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataSearches.java
@@ -204,7 +204,7 @@ public class StatisticsDataSearches extends StatisticsData {
         if(currentDso != null){
             query = "scopeType: " + currentDso.getType() + " AND ";
             if(currentDso instanceof DSpaceObjectLegacySupport){
-                query += " (scopeId:" + currentDso.getID() + " OR " + ((DSpaceObjectLegacySupport) currentDso).getLegacyId() + ")";
+                query += " (scopeId:" + currentDso.getID() + " OR scopeId:" + ((DSpaceObjectLegacySupport) currentDso).getLegacyId() + ")";
             }else{
                 query += "scopeId:" + currentDso.getID();
             }

--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
@@ -829,7 +829,8 @@ public class StatisticsDataVisits extends StatisticsData
                             break;
                     }
                     if(currentDso instanceof DSpaceObjectLegacySupport){
-                        owningStr = "(" + owningStr + ":" + currentDso.getID() + " OR " + ((DSpaceObjectLegacySupport) currentDso).getLegacyId() + ")";
+                        owningStr = "(" + owningStr + ":" + currentDso.getID() + " OR " 
+                            + owningStr + ":" + ((DSpaceObjectLegacySupport) currentDso).getLegacyId() + ")";
                     }else{
                         owningStr += ":" + currentDso.getID();
                     }

--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
@@ -805,6 +805,9 @@ public class StatisticsDataVisits extends StatisticsData
                 if(dso != null)
                 {
                     query += (query.equals("") ? "" : " AND ");
+
+                    //DS-3602: For clarity, adding "id:" to the right hand side of the search
+                    //In the solr schema, "id" has been declared as the defaultSearchField so the field name is optional
                     if(dso instanceof DSpaceObjectLegacySupport){
                         query += " (id:" + dso.getID() + " OR id:" + ((DSpaceObjectLegacySupport) dso).getLegacyId() + ")";
                     }else{

--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
@@ -806,7 +806,7 @@ public class StatisticsDataVisits extends StatisticsData
                 {
                     query += (query.equals("") ? "" : " AND ");
                     if(dso instanceof DSpaceObjectLegacySupport){
-                        query += " (id:" + dso.getID() + " OR " + ((DSpaceObjectLegacySupport) dso).getLegacyId() + ")";
+                        query += " (id:" + dso.getID() + " OR id:" + ((DSpaceObjectLegacySupport) dso).getLegacyId() + ")";
                     }else{
                         query += "id:" + dso.getID();
                     }

--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
@@ -487,6 +487,9 @@ public class StatisticsDataVisits extends StatisticsData
             //TODO: CHANGE & THROW AWAY THIS ENTIRE METHOD
             //Check if int
             String dsoId;
+            //DS 3602: Until all legacy stats records have been upgraded to using UUID, 
+            //duplicate reports may be presented for each DSO.  A note will be appended when reporting legacy counts.
+            String legacyNote = "";
             int dsoLength = query.getDsoLength();
             try {
                 dsoId = UUID.fromString(value).toString();
@@ -494,6 +497,7 @@ public class StatisticsDataVisits extends StatisticsData
                 try {
                     //Legacy identifier support
                     dsoId = String.valueOf(Integer.parseInt(value));
+                    legacyNote="(legacy)";
                 } catch (NumberFormatException e1) {
                     dsoId = null;
                 }
@@ -511,7 +515,7 @@ public class StatisticsDataVisits extends StatisticsData
                         {
                             break;
                         }
-                        return bit.getName();
+                        return bit.getName() + legacyNote;
                     case Constants.ITEM:
                         Item item = itemService.findByIdOrLegacyId(context, dsoId);
                         if(item == null)
@@ -532,7 +536,7 @@ public class StatisticsDataVisits extends StatisticsData
                             }
                         }
 
-                        return name;
+                        return name + legacyNote;
 
                     case Constants.COLLECTION:
                         Collection coll = collectionService.findByIdOrLegacyId(context, dsoId);
@@ -549,7 +553,7 @@ public class StatisticsDataVisits extends StatisticsData
                                 name = name.substring(0, firstSpace) + " ...";
                             }
                         }
-                        return name;
+                        return name + legacyNote;
 
                     case Constants.COMMUNITY:
                         Community comm = communityService.findByIdOrLegacyId(context, dsoId);
@@ -566,7 +570,7 @@ public class StatisticsDataVisits extends StatisticsData
                                 name = name.substring(0, firstSpace) + " ...";
                             }
                         }
-                        return name;
+                        return name + legacyNote;
                 }
             }
         }

--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
@@ -828,7 +828,12 @@ public class StatisticsDataVisits extends StatisticsData
                             owningStr = "owningComm";
                             break;
                     }
-                    owningStr += ":" + currentDso.getID();
+                    if(currentDso instanceof DSpaceObjectLegacySupport){
+                        owningStr = "(" + owningStr + ":" + currentDso.getID() + " OR " + ((DSpaceObjectLegacySupport) currentDso).getLegacyId() + ")";
+                    }else{
+                        owningStr += ":" + currentDso.getID();
+                    }
+                    
                     query += owningStr;
                 }
 


### PR DESCRIPTION
@kshepherd identified that the initial issue reported in the following ticket was that statistics records with a legacyId in owningItem were not being included in the Usage reports.

https://jira.duraspace.org/browse/DS-3602

It appears that the legacy id was also not used in queries for scopeId, owningColl, and owningComm.

There is an another PR (https://github.com/DSpace/DSpace/pull/1774) for this ticket to migrate all legacy ids in statistics records.  This PR is recommended in addition to that PR.  This PR can be merged without merging 1774.

This PR will ensure the accessibility of legacy statistics records until that upgrade is performed.