### PR TITLE
Add Bitstream /content endpoint

### DIFF
--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/BitstreamContentRestController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/BitstreamContentRestController.java
@@ -1,0 +1,71 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.dspace.app.rest.model.BitstreamRest;
+import org.dspace.app.rest.repository.BitstreamRestRepository;
+import org.dspace.core.Utils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.ResourceSupport;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * This is a specialized controller to provide access to the bitstream binary content
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ *
+ */
+@RestController
+@RequestMapping("/api/"+BitstreamRest.CATEGORY +"/"+ BitstreamRest.PLURAL_NAME + "/{uuid:[0-9a-fxA-FX]{8}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{12}}/retrieve")
+public class BitstreamContentRestController {
+	@Autowired
+	private BitstreamRestRepository bitstreamRestRepository; 
+	
+	@RequestMapping(method = RequestMethod.GET)
+	public void retrieve(@PathVariable UUID uuid, HttpServletResponse response,
+            HttpServletRequest request) throws IOException {
+		BitstreamRest bit = bitstreamRestRepository.findOne(uuid);
+		if (bit == null) {
+			response.sendError(HttpServletResponse.SC_NOT_FOUND);
+			return;
+		}
+		response.setHeader("ETag", bit.getCheckSum().getValue());
+		response.setContentLengthLong(bit.getSizeBytes());
+        // Check for if-modified-since header
+        long modSince = request.getDateHeader("If-Modified-Since");
+// we should keep last modification date on the bitstream
+//            if (modSince != -1 && item.getLastModified().getTime() < modSince)
+//            {
+//                // Item has not been modified since requested date,
+//                // hence bitstream has not; return 304
+//                response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
+//                return;
+//            }
+        
+        // Pipe the bits
+        InputStream is = bitstreamRestRepository.retrieve(uuid);
+     
+		// Set the response MIME type
+        response.setContentType(bit.getFormat().getMimetype());
+
+        Utils.bufferedCopy(is, response.getOutputStream());
+        is.close();
+        response.getOutputStream().flush();
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/BitstreamContentRestController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/BitstreamContentRestController.java
@@ -32,7 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  */
 @RestController
-@RequestMapping("/api/"+BitstreamRest.CATEGORY +"/"+ BitstreamRest.PLURAL_NAME + "/{uuid:[0-9a-fxA-FX]{8}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{12}}/retrieve")
+@RequestMapping("/api/"+BitstreamRest.CATEGORY +"/"+ BitstreamRest.PLURAL_NAME + "/{uuid:[0-9a-fxA-FX]{8}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{12}}/content")
 public class BitstreamContentRestController {
 	@Autowired
 	private BitstreamRestRepository bitstreamRestRepository; 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/CollectionConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/CollectionConverter.java
@@ -8,6 +8,8 @@
 package org.dspace.app.rest.converter;
 
 import org.dspace.app.rest.model.CollectionRest;
+import org.dspace.content.Bitstream;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
@@ -20,6 +22,9 @@ import org.springframework.stereotype.Component;
 @Component
 public class CollectionConverter
 		extends DSpaceObjectConverter<org.dspace.content.Collection, org.dspace.app.rest.model.CollectionRest> {
+	@Autowired
+	private BitstreamConverter bitstreamConverter;
+	
 	@Override
 	public org.dspace.content.Collection toModel(org.dspace.app.rest.model.CollectionRest obj) {
 		return (org.dspace.content.Collection) super.toModel(obj);
@@ -27,7 +32,12 @@ public class CollectionConverter
 
 	@Override
 	public CollectionRest fromModel(org.dspace.content.Collection obj) {
-		return (CollectionRest) super.fromModel(obj);
+		CollectionRest col = (CollectionRest) super.fromModel(obj);
+		Bitstream logo = obj.getLogo();
+		if (logo != null) {
+			col.setLogo(bitstreamConverter.convert(logo));
+		}
+		return col;
 	}
 
 	@Override

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/CommunityConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/CommunityConverter.java
@@ -7,7 +7,15 @@
  */
 package org.dspace.app.rest.converter;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.dspace.app.rest.model.BitstreamRest;
+import org.dspace.app.rest.model.CollectionRest;
 import org.dspace.app.rest.model.CommunityRest;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Collection;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
@@ -20,6 +28,12 @@ import org.springframework.stereotype.Component;
 @Component
 public class CommunityConverter
 		extends DSpaceObjectConverter<org.dspace.content.Community, org.dspace.app.rest.model.CommunityRest> {
+	@Autowired
+	private BitstreamConverter bitstreamConverter;
+	
+	@Autowired
+	private CollectionConverter collectionConverter;
+	
 	@Override
 	public org.dspace.content.Community toModel(org.dspace.app.rest.model.CommunityRest obj) {
 		return (org.dspace.content.Community) super.toModel(obj);
@@ -27,7 +41,21 @@ public class CommunityConverter
 
 	@Override
 	public CommunityRest fromModel(org.dspace.content.Community obj) {
-		return (CommunityRest) super.fromModel(obj);
+		CommunityRest com = (CommunityRest) super.fromModel(obj);
+		Bitstream logo = obj.getLogo();
+		if (logo != null) {
+			com.setLogo(bitstreamConverter.convert(logo));
+		}
+		List<Collection> collections = obj.getCollections();
+		if (collections != null) {
+			List<CollectionRest> collectionsRest = new ArrayList<CollectionRest>();
+			for (Collection col : collections) {
+				CollectionRest colrest = collectionConverter.fromModel(col);
+				collectionsRest.add(colrest);
+			}
+			com.setCollections(collectionsRest);
+		}
+		return com;
 	}
 
 	@Override

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/BitstreamRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/BitstreamRest.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.annotation.JsonProperty.Access;
  * @author Andrea Bollini (andrea.bollini at 4science.it)
  */
 public class BitstreamRest extends DSpaceObjectRest {
+	public static final String PLURAL_NAME = "bitstreams";
 	public static final String NAME = "bitstream";
 	public static final String CATEGORY = RestModel.CORE;
 	private String bundleName;

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/CollectionRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/CollectionRest.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.app.rest.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 /**
  * The Collection REST Resource
  * 
@@ -17,6 +19,17 @@ public class CollectionRest extends DSpaceObjectRest {
 	public static final String NAME = "collection";
 	public static final String CATEGORY = RestModel.CORE;
 
+	@JsonIgnore
+	private BitstreamRest logo;
+	
+	public BitstreamRest getLogo() {
+		return logo;
+	}
+	
+	public void setLogo(BitstreamRest logo) {
+		this.logo = logo;
+	}
+	
 	@Override
 	public String getCategory() {
 		return CATEGORY;

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/CommunityRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/CommunityRest.java
@@ -7,6 +7,10 @@
  */
 package org.dspace.app.rest.model;
 
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 /**
  * The Community REST Resource
  * 
@@ -16,6 +20,30 @@ package org.dspace.app.rest.model;
 public class CommunityRest extends DSpaceObjectRest {
 	public static final String NAME = "community";
 	public static final String CATEGORY = RestModel.CORE;
+
+	@JsonIgnore
+	private BitstreamRest logo;
+	
+	
+	private List<CollectionRest> collections;
+	
+	@LinkRest(linkClass = CollectionRest.class)
+	@JsonIgnore
+	public List<CollectionRest> getCollections() {
+		return collections;
+	}
+	
+	public void setCollections(List<CollectionRest> collections) {
+		this.collections = collections;
+	}
+	
+	public BitstreamRest getLogo() {
+		return logo;
+	}
+	
+	public void setLogo(BitstreamRest logo) {
+		this.logo = logo;
+	}
 	
 	@Override
 	public String getCategory() {

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/ItemRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/ItemRest.java
@@ -11,6 +11,8 @@ import java.util.Date;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
 
 /**
  * The Item REST Resource
@@ -79,6 +81,9 @@ public class ItemRest extends DSpaceObjectRest {
 	public void setTemplateItemOf(CollectionRest templateItemOf){
 		this.templateItemOf = templateItemOf;
 	}
+	
+	@LinkRest(linkClass = BitstreamRest.class)
+	@JsonIgnore
 	public List<BitstreamRest> getBitstreams() {
 		return bitstreams;
 	}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/LinkRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/LinkRest.java
@@ -18,12 +18,12 @@ import java.lang.annotation.Target;
  * 
  * @author Andrea Bollini (andrea.bollini at 4science.it)
  */
-@Target({ElementType.TYPE, ElementType.FIELD})
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface LinkRest {
-	String name();
-	String method();
+	String name() default "";
+	String method() default "";
 	Class linkClass();
 	boolean optional() default false;
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/BitstreamResource.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/BitstreamResource.java
@@ -21,6 +21,6 @@ import org.dspace.app.rest.utils.Utils;
 public class BitstreamResource extends DSpaceResource<BitstreamRest> {
 	public BitstreamResource(BitstreamRest bs, Utils utils, String... rels) {
 		super(bs, utils, rels);
-		add(utils.linkToSubResource(bs, "retrieve"));
+		add(utils.linkToSubResource(bs, "retrieve", "content"));
 	}
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/BitstreamResource.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/BitstreamResource.java
@@ -21,9 +21,6 @@ import org.dspace.app.rest.utils.Utils;
 public class BitstreamResource extends DSpaceResource<BitstreamRest> {
 	public BitstreamResource(BitstreamRest bs, Utils utils, String... rels) {
 		super(bs, utils, rels);
-//		if (bs.getFormat() != null) {
-//			BitstreamFormatResource bfr = new BitstreamFormatResource(bs.getFormat());
-//			this.add(new Link(bfr.getLink(Link.REL_SELF).getHref(), "bitstreamformat"));
-//		}
+		add(utils.linkToSubResource(bs, "retrieve"));
 	}
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/BitstreamResource.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/BitstreamResource.java
@@ -22,5 +22,6 @@ public class BitstreamResource extends DSpaceResource<BitstreamRest> {
 	public BitstreamResource(BitstreamRest bs, Utils utils, String... rels) {
 		super(bs, utils, rels);
 		add(utils.linkToSubResource(bs, "retrieve", "content"));
+		add(utils.linkToSubResource(bs, "content"));
 	}
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/BrowseIndexResource.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/BrowseIndexResource.java
@@ -21,6 +21,10 @@ import org.dspace.app.rest.utils.Utils;
 public class BrowseIndexResource extends DSpaceResource<BrowseIndexRest> {
 	public BrowseIndexResource(BrowseIndexRest bix, Utils utils, String... rels) {
 		super(bix, utils, rels);
+		// TODO: the following code will force the embedding of items and
+		// entries in the browseIndex we need to find a way to populate the rels
+		// array from the request/projection right now it is always null
+		// super(bix, utils, "items", "entries");
 		if (bix.isMetadataBrowse()) {
 			add(utils.linkToSubResource(bix, BrowseIndexRest.ENTRIES));
 		}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/DSpaceResource.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/DSpaceResource.java
@@ -7,18 +7,38 @@
  */
 package org.dspace.app.rest.model.hateoas;
 
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
+
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
+import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
+import org.apache.commons.lang3.StringUtils;
+import org.atteo.evo.inflector.English;
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.model.LinkRest;
+import org.dspace.app.rest.model.LinksRest;
 import org.dspace.app.rest.model.RestModel;
+import org.dspace.app.rest.repository.DSpaceRestRepository;
+import org.dspace.app.rest.repository.LinkRestRepository;
 import org.dspace.app.rest.utils.Utils;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.rest.webmvc.EmbeddedResourcesAssembler;
 import org.springframework.hateoas.Link;
+import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.ResourceSupport;
+import org.springframework.hateoas.core.EmbeddedWrappers;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -47,18 +67,131 @@ public abstract class DSpaceResource<T extends RestModel> extends ResourceSuppor
 
 		if (data != null) {
 			try {
+				LinksRest links = data.getClass().getDeclaredAnnotation(LinksRest.class);
+				if (links != null && rels != null) {
+					List<String> relsList = Arrays.asList(rels);
+					for (LinkRest linkAnnotation : links.links()) {
+						if (!relsList.contains(linkAnnotation.name())) {
+							continue;
+						}
+						String name = linkAnnotation.name();
+						Link linkToSubResource = utils.linkToSubResource(data, name);
+						String apiCategory = data.getCategory();
+						String model = data.getType();
+						LinkRestRepository linkRepository = utils.getLinkResourceRepository(apiCategory, model, linkAnnotation.name());
+
+						if (!linkRepository.isEmbbeddableRelation(data, linkAnnotation.name())) {
+							continue;
+						}
+						try {
+							//RestModel linkClass = linkAnnotation.linkClass().newInstance();
+							Method[] methods = linkRepository.getClass().getMethods();
+							boolean found = false;
+							for (Method m : methods) { 
+								if (StringUtils.equals(m.getName(), linkAnnotation.method())) {
+										// TODO add support for single linked object other than for collections
+										Page<? extends Serializable> pageResult = (Page<? extends RestModel>) m.invoke(linkRepository, null, ((BaseObjectRest) data).getId(), null, null);
+										EmbeddedPage ep = new EmbeddedPage(linkToSubResource.getHref(), pageResult, null);
+										embedded.put(name, ep);
+										found = true;
+								}
+							}
+							// TODO custom exception
+							if (!found) {
+								throw new RuntimeException("Method for relation " + linkAnnotation.name() + " not found: " + linkAnnotation.method());
+							}
+						} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+							throw new RuntimeException(e.getMessage(), e);
+						}
+					}
+				}
+				
 				for (PropertyDescriptor pd : Introspector.getBeanInfo(data.getClass()).getPropertyDescriptors()) {
 					Method readMethod = pd.getReadMethod();
-					if (readMethod != null && !"class".equals(pd.getName())) {
-						if (RestModel.class.isAssignableFrom(readMethod.getReturnType())) {
-							this.add(utils.linkToSubResource(data, pd.getName()));
+					String name = pd.getName();
+					if (readMethod != null && !"class".equals(name)) {
+						LinkRest linkAnnotation = readMethod.getAnnotation(LinkRest.class);
+						
+						if (linkAnnotation != null) {
+							if (StringUtils.isNotBlank(linkAnnotation.name())) {
+								name = linkAnnotation.name();
+							}
+							Link linkToSubResource = utils.linkToSubResource(data, name);	
+							// no method is specified to retrieve the linked object(s) so check if it is already here
+							if (StringUtils.isBlank(linkAnnotation.method())) {
+								this.add(linkToSubResource);
+								Object linkedObject = readMethod.invoke(data);
+								Object wrapObject = linkedObject;
+								if (linkedObject instanceof RestModel) {
+									RestModel linkedRM = (RestModel) linkedObject; 
+									wrapObject = utils.getResourceRepository(linkedRM.getCategory(), linkedRM.getType())
+											.wrapResource(linkedRM);
+								}
+								else {
+									if (linkedObject instanceof List) {
+										List<RestModel> linkedRMList = (List<RestModel>) linkedObject; 
+										if (linkedRMList.size() > 0) {
+											
+											DSpaceRestRepository<RestModel, ?> resourceRepository = utils.getResourceRepository(linkedRMList.get(0).getCategory(), linkedRMList.get(0).getType());
+											// TODO should we force pagination also of embedded resource? 
+											// This will force a pagination with size 10 for embedded collections as well
+//											int pageSize = 1;
+//											PageImpl<RestModel> page = new PageImpl(
+//													linkedRMList.subList(0,
+//															linkedRMList.size() > pageSize ? pageSize : linkedRMList.size()), new PageRequest(0, pageSize), linkedRMList.size()); 
+											PageImpl<RestModel> page = new PageImpl(linkedRMList);
+											wrapObject = new EmbeddedPage(linkToSubResource.getHref(), page.map(resourceRepository::wrapResource), linkedRMList);
+										}
+										else {
+											wrapObject = null;
+										}
+									}
+								}
+								if (linkedObject != null) {
+									embedded.put(name, wrapObject);
+								} else {
+									embedded.put(name, null);
+								}
+								Method writeMethod = pd.getWriteMethod();
+								writeMethod.invoke(data, new Object[] { null });
+							}
+							else {
+								// call the link repository
+								try {
+									//RestModel linkClass = linkAnnotation.linkClass().newInstance();
+									String apiCategory = data.getCategory();
+									String model = data.getType();
+									LinkRestRepository linkRepository = utils.getLinkResourceRepository(apiCategory, model, linkAnnotation.name());
+									Method[] methods = linkRepository.getClass().getMethods();
+									boolean found = false;
+									for (Method m : methods) { 
+										if (StringUtils.equals(m.getName(), linkAnnotation.method())) {
+												// TODO add support for single linked object other than for collections
+												Page<? extends Serializable> pageResult = (Page<? extends RestModel>) m.invoke(linkRepository, null, ((BaseObjectRest) data).getId(), null, null);
+												EmbeddedPage ep = new EmbeddedPage(linkToSubResource.getHref(), pageResult, null);
+												embedded.put(name, ep);
+												found = true;
+										}
+									}
+									// TODO custom exception
+									if (!found) {
+										throw new RuntimeException("Method for relation " + linkAnnotation.name() + " not found: " + linkAnnotation.method());
+									}
+								} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+									throw new RuntimeException(e.getMessage(), e);
+								}
+							}
+						}
+						else if (RestModel.class.isAssignableFrom(readMethod.getReturnType())) {
+							Link linkToSubResource = utils.linkToSubResource(data, name);
+							this.add(linkToSubResource);
 							RestModel linkedObject = (RestModel) readMethod.invoke(data);
 							if (linkedObject != null) {
-								embedded.put(pd.getName(),
+								embedded.put(name,
 										utils.getResourceRepository(linkedObject.getCategory(), linkedObject.getType())
 												.wrapResource(linkedObject));
 							} else {
-								embedded.put(pd.getName(), null);
+								embedded.put(name, null);
 							}
 
 							Method writeMethod = pd.getWriteMethod();
@@ -74,6 +207,11 @@ public abstract class DSpaceResource<T extends RestModel> extends ResourceSuppor
 		}
 	}
 
+	@Override
+	public void add(Link link) {
+		System.out.println("Chiamato "+link.getRel());
+		super.add(link);
+	}
 	public Map<String, Object> getEmbedded() {
 		return embedded;
 	}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/EmbeddedPage.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/EmbeddedPage.java
@@ -1,0 +1,78 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model.hateoas;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.data.domain.Page;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class EmbeddedPage {
+
+	private Page page;
+	private List fullList;
+	private UriComponentsBuilder self;
+	
+	public EmbeddedPage(String self, Page page, List fullList) {
+		this.page = page;
+		this.fullList = fullList;
+		this.self = UriComponentsBuilder.fromUriString(self);
+	}
+
+	@JsonProperty(value = "_embedded")
+	public List getPageContent() {
+		return page.getContent();
+	}
+
+	@JsonProperty(value = "page")
+	public Map<String, Long> getPageInfo() {
+		Map<String, Long> pageInfo = new HashMap<String, Long>();
+		pageInfo.put("number", (long) page.getNumber());
+		pageInfo.put("size", (long) page.getSize() != 0?page.getSize():page.getTotalElements());
+		pageInfo.put("totalPages", (long) page.getTotalPages());
+		pageInfo.put("totalElements", page.getTotalElements());
+		return pageInfo;
+	}
+	
+	@JsonProperty(value = "_links")
+	public Map<String, String> getLinks() {
+		Map<String, String> links = new HashMap<String, String>();
+		if (!page.isFirst()) {
+			links.put("first", _link(0));
+			links.put("self", _link(page.getNumber()));
+		}
+		else {
+			links.put("self", self.toUriString());
+		}
+		if (!page.isLast()) {
+			links.put("last", _link(page.getTotalPages()-1));
+		}
+		if (page.hasPrevious()) {
+			links.put("prev", _link(page.getNumber()-1));
+		}
+		if (page.hasNext()) {
+			links.put("next", _link(page.getNumber()+1));
+		}
+		return links;
+	}
+
+	private String _link(int i) {
+		UriComponentsBuilder uriComp = self.cloneBuilder();
+		return uriComp.queryParam("page", i).build().toString();
+	}
+	
+	@JsonIgnore
+	public List getFullList() {
+		return fullList;
+	}
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/BitstreamRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/BitstreamRestRepository.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.app.rest.repository;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -16,6 +18,7 @@ import java.util.UUID;
 import org.dspace.app.rest.converter.BitstreamConverter;
 import org.dspace.app.rest.model.BitstreamRest;
 import org.dspace.app.rest.model.hateoas.BitstreamResource;
+import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bitstream;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.BitstreamService;
@@ -83,5 +86,26 @@ public class BitstreamRestRepository extends DSpaceRestRepository<BitstreamRest,
 	@Override	
 	public BitstreamResource wrapResource(BitstreamRest bs, String... rels) {
 		return new BitstreamResource(bs, utils, rels);
+	}
+
+	public InputStream retrieve(UUID uuid) {
+		Context context = obtainContext();
+		Bitstream bit = null;
+		try {
+			bit = bs.find(context, uuid);
+		} catch (SQLException e) {
+			throw new RuntimeException(e.getMessage(), e);
+		}
+		if (bit == null) {
+			return null;
+		}
+		InputStream is;
+		try {
+			is = bs.retrieve(context, bit);
+		} catch (IOException | SQLException | AuthorizeException e) {
+			throw new RuntimeException(e.getMessage(), e);
+		}
+		context.abort();
+		return is;
 	}
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/BrowseEntryLinkRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/BrowseEntryLinkRepository.java
@@ -65,7 +65,10 @@ public class BrowseEntryLinkRepository extends AbstractDSpaceRestRepository
 			Pageable pageable, String projection) throws BrowseException, SQLException {
 		// FIXME this should be bind automatically and available as method
 		// argument
-		String scope = request.getParameter("scope");
+		String scope = null;
+		if (request != null) {
+			request.getParameter("scope");
+		}
 
 		Context context = obtainContext();
 		BrowseEngine be = new BrowseEngine(context);
@@ -95,7 +98,10 @@ public class BrowseEntryLinkRepository extends AbstractDSpaceRestRepository
 
 		// set up a BrowseScope and start loading the values into it
 		bs.setBrowseIndex(bi);
-		Sort sort = pageable.getSort();
+		Sort sort = null;
+		if (pageable != null) {
+			sort = pageable.getSort();
+		}
 		if (sort != null) {
 			Iterator<Order> orders = sort.iterator();
 			while (orders.hasNext()) {
@@ -108,8 +114,10 @@ public class BrowseEntryLinkRepository extends AbstractDSpaceRestRepository
 		// bs.setJumpToValue(valueFocus);
 		// bs.setJumpToValueLang(valueFocusLang);
 		// bs.setStartsWith(startsWith);
-		bs.setOffset(pageable.getOffset());
-		bs.setResultsPerPage(pageable.getPageSize());
+		if (pageable != null) {
+			bs.setOffset(pageable.getOffset());
+			bs.setResultsPerPage(pageable.getPageSize());
+		}
 		// bs.setEtAl(etAl);
 		// bs.setAuthorityValue(authority);
 
@@ -119,7 +127,7 @@ public class BrowseEntryLinkRepository extends AbstractDSpaceRestRepository
 
 		BrowseInfo binfo = be.browse(bs);
 		Pageable pageResultInfo = new PageRequest((binfo.getStart() - 1) / binfo.getResultsPerPage(),
-				pageable.getPageSize());
+				binfo.getResultsPerPage());
 		Page<BrowseEntryRest> page = new PageImpl<String[]>(Arrays.asList(binfo.getStringResults()), pageResultInfo,
 				binfo.getTotal()).map(converter);
 		page.forEach(new Consumer<BrowseEntryRest>() {
@@ -134,5 +142,14 @@ public class BrowseEntryLinkRepository extends AbstractDSpaceRestRepository
 	@Override
 	public BrowseEntryResource wrapResource(BrowseEntryRest entry, String... rels) {
 		return new BrowseEntryResource(entry);
+	}
+	
+	@Override
+	public boolean isEmbbeddableRelation(Object data, String name) {
+		BrowseIndexRest bir = (BrowseIndexRest) data;
+		if (bir.isMetadataBrowse() && "entries".equals(name)) {
+			return true;
+		}
+		return false;
 	}
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/LinkRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/LinkRestRepository.java
@@ -19,4 +19,8 @@ import org.springframework.hateoas.ResourceSupport;
  */
 public interface LinkRestRepository<L extends Serializable> {
 	public abstract ResourceSupport wrapResource(L model, String... rels);
+
+	public default boolean isEmbbeddableRelation(Object data, String name) {
+		return true;
+	}
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/Utils.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/Utils.java
@@ -64,9 +64,13 @@ public class Utils {
 	}
 
 	public Link linkToSubResource(RestModel data, String rel) {
-		return linkTo(data.getController(), data.getCategory(), English.plural(data.getType())).slash(data).slash(rel).withRel(rel);
+		return linkToSubResource(data, rel, rel) ;
 	}
 
+	public Link linkToSubResource(RestModel data, String rel, String path) {
+		return linkTo(data.getController(), data.getCategory(), English.plural(data.getType())).slash(data).slash(path).withRel(rel);
+	}
+	
 	public DSpaceRestRepository getResourceRepository(String apiCategory, String modelPlural) {
 		String model = makeSingular(modelPlural);
 		try {


### PR DESCRIPTION
Add a /retrieve endpoint under the bitstreams to provide the capability to access to the actual content of a bitstream.
It is a very rough implementation, we need to add documentation and better support for authorization exception that now are simply re-thrown as runtime exception.

Support for HEAD operation to compute the checksum and if-none-match or if-modified-since request header should be also added.

Nevertheless, the code has been already applied to the demo rest 7 server as it was needed for the demonstration at OR2017