### PR TITLE
DS-3245: CSV linebreaks not supported by Bulkedit - DSpace 5 backport

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSV.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSV.java
@@ -187,7 +187,7 @@ public class DSpaceCSV implements Serializable
             StringBuilder lineBuilder = new StringBuilder();
             String lineRead;
 
-            while (StringUtils.isNotBlank(lineRead = input.readLine()))
+            while ((lineRead = input.readLine()) != null)
             {
                 if (lineBuilder.length() > 0) {
                     // Already have a previously read value - add this line

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/DSpaceCSVTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/DSpaceCSVTest.java
@@ -44,8 +44,9 @@ public class DSpaceCSVTest extends AbstractUnitTest
                             "2,2,Two authors,\"Lewis, Stuart||Bloggs, Joe\",Two people wrote this item",
                             "3,2,Three authors,\"Lewis, Stuart||Bloggs, Joe||Loaf, Meat\",Three people wrote this item",
                             "4,2,\"Two line\ntitle\",\"Lewis, Stuart\",abstract",
-                            "5,2,\"\"\"Embedded quotes\"\" here\",\"Lewis, Stuart\",\"Abstract with\ntwo\nnew lines\"",
-                            "6,2,\"\"\"Unbalanced embedded\"\" quotes\"\" here\",\"Lewis, Stuart\",\"Abstract with\ntwo\nnew lines\"",};
+                            "5,2,\"Empty lines\n\nshould work too (DS-3245).\",\"Lewis, Stuart\",abstract",
+                            "6,2,\"\"\"Embedded quotes\"\" here\",\"Lewis, Stuart\",\"Abstract with\ntwo\nnew lines\"",
+                            "7,2,\"\"\"Unbalanced embedded\"\" quotes\"\" here\",\"Lewis, Stuart\",\"Abstract with\ntwo\nnew lines\"",};
             // Write the string to a file
             String filename = "test.csv";
             BufferedWriter out = new BufferedWriter(
@@ -61,7 +62,7 @@ public class DSpaceCSVTest extends AbstractUnitTest
             // Test the CSV parsing was OK
             DSpaceCSV dcsv = new DSpaceCSV(new File(filename), context);
             String[] lines = dcsv.getCSVLinesAsStringArray();
-            assertThat("testDSpaceCSV Good CSV", lines.length, equalTo(7));
+            assertThat("testDSpaceCSV Good CSV", lines.length, equalTo(8));
 
             // Check the new lines are OK
             List<DSpaceCSVLine> csvLines = dcsv.getCSVLines();
@@ -99,7 +100,7 @@ public class DSpaceCSVTest extends AbstractUnitTest
                 assertThat("testDSpaceCSV Bad heading CSV", e.getMessage(), equalTo("Unknown metadata element in column 4: dc.contributor.foobar"));
             }
             lines = dcsv.getCSVLinesAsStringArray();
-            assertThat("testDSpaceCSV Good CSV", lines.length, equalTo(7));
+            assertThat("testDSpaceCSV Good CSV", lines.length, equalTo(8));
 
 
             // Test the CSV parsing with a bad heading schema value


### PR DESCRIPTION
Backport of #1784 for DSpace 5. Tested.

https://jira.duraspace.org/browse/DS-3245