### PR TITLE
DS-3563: Fix Oracle Flyway migration error

### DIFF
--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V5.7_2017.04.11__DS-3563_Index_metadatavalue_resource_type_id_column.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V5.7_2017.04.11__DS-3563_Index_metadatavalue_resource_type_id_column.sql
@@ -19,5 +19,5 @@ begin
   exception
   when index_not_exists then null;
 end;
-
+/
 CREATE INDEX metadatavalue_type_id_idx ON metadatavalue (resource_type_id);


### PR DESCRIPTION
Today we noticed that there is a bug in the Oracle script of https://github.com/DSpace/DSpace/pull/1706 😞  

The script worked when executed directly on a Oracle database, but fails through Flyway. I've now triple checked that it also works through Flyway.

This commit should also be cherry-picked to master and dspace-6_x.

Sorry for the inconvenience!
