### PR TITLE
Pin versions of SASS and Compass that Travis CI uses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,10 @@ before_install:
   # Print ruby version info (should be installed)
   - ruby -v
   # Install Sass & print version info
-  - gem install sass
+  - gem install sass -v 3.3.14
   - sass -v
   # Install Compass & print version info
-  - gem install compass
+  - gem install compass -v 1.0.1
   - compass version
 
 # Skip install stage, as we'll do it below


### PR DESCRIPTION
For Mirage2, we should be pinning the version of SASS and Compass that Travis CI uses.  

Currently, without this pinning to specific versions, we are getting incompatibility errors from Travis CI on the `dspace-6_x` branch, see for example: https://travis-ci.org/DSpace/DSpace/builds/253227463

This PR simply pins SASS and Compass to the versions recommended in the Mirage 2 docs at https://github.com/DSpace/DSpace/tree/dspace-6_x/dspace-xmlui-mirage2#installation