### PR TITLE
Speed up Travis CI build by removing Mirage2 dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,25 +22,6 @@ jdk:
 before_install:
   # Remove outdated settings.xml from Travis builds. Workaround for https://github.com/travis-ci/travis-ci/issues/4629
   - rm ~/.m2/settings.xml
-  # Install Node.js 6.5.0 & print version info
-  - nvm install 6.5.0
-  - node --version
-  # Install npm 3.10.8 & print version info
-  - npm install -g npm@3.10.8
-  - npm --version
-  # Install Bower
-  - npm install -g bower
-  # Install Grunt & print version info
-  - npm install -g grunt && npm install -g grunt-cli
-  - grunt --version
-  # Print ruby version info (should be installed)
-  - ruby -v
-  # Install Sass & print version info
-  - gem install sass -v 3.3.14
-  - sass -v
-  # Install Compass & print version info
-  - gem install compass -v 1.0.1
-  - compass version
 
 # Skip install stage, as we'll do it below
 install: "echo 'Skipping install stage, dependencies will be downloaded during build and test stages.'"
@@ -58,8 +39,6 @@ script:
   #        -V => Display Maven version info before build
   #        -Dsurefire.rerunFailingTestsCount=2 => try again for flakey tests, and keep track of/report on number of retries
   - "mvn clean install license:check -Dmaven.test.skip=false -DskipITs=false -P !assembly -B -V -Dsurefire.rerunFailingTestsCount=2"
-  # 2. [Assemble DSpace] Ensure assembly process works (from [src]/dspace/), including Mirage 2
-  #        -Dmirage2.on=true => Build Mirage2
-  #        -Dmirage2.deps.included=false => Don't include Mirage2 build dependencies (We installed them in before_install)
+  # 2. [Assemble DSpace] Ensure overlay & assembly process works (from [src]/dspace/)
   #        -P !assembly => SKIP the actual building of [src]/dspace/dspace-installer (as it can be memory intensive)
-  - "cd dspace && mvn package -Dmirage2.on=true -Dmirage2.deps.included=false -P !assembly -B -V -Dsurefire.rerunFailingTestsCount=2"
+  - "cd dspace && mvn package -P !assembly -B -V -Dsurefire.rerunFailingTestsCount=2"


### PR DESCRIPTION
The Travis CI build settings on `master` still include a lot of stuff specific to XMLUI / Mirage2.  This minor update to our `.travis.yml` removes all the unnecessary installation steps now that XMLUI no longer exists on `master`. 

At the very least, this should speed up our Travis builds on `master`.