### PR TITLE
DS-3648: Fix LazyInitializationExceptions in Batch Import Failure

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
@@ -184,19 +184,20 @@ public class HibernateDBConnection implements DBConnection<Session> {
                 }
             }
 
+            // ITEM
             if (entity instanceof Item) {
                 Item item = (Item) entity;
 
                 //DO NOT uncache the submitter. This could be the current eperson. Uncaching him could lead to
                 //LazyInitializationExceptions (see DS-3648)
-                //if(Hibernate.isInitialized(item.getSubmitter())) {
-                //    uncacheEntity(item.getSubmitter());
-                //}
+
                 if(Hibernate.isInitialized(item.getBundles())) {
                     for (Bundle bundle : Utils.emptyIfNull(item.getBundles())) {
                         uncacheEntity(bundle);
                     }
                 }
+
+            // BUNDLE
             } else if (entity instanceof Bundle) {
                 Bundle bundle = (Bundle) entity;
 
@@ -205,45 +206,32 @@ public class HibernateDBConnection implements DBConnection<Session> {
                         uncacheEntity(bitstream);
                     }
                 }
-            //} else if(entity instanceof Bitstream) {
-            //    Bitstream bitstream = (Bitstream) entity;
-            //    No specific child entities to decache
+
+            // BITSTREAM
+            // No specific child entities to decache
+
+            // COMMUNITY
             } else if (entity instanceof Community) {
                 Community community = (Community) entity;
 
                 //We don't uncache groups as they might still be referenced from the Context object
-                //if(Hibernate.isInitialized(community.getAdministrators())) {
-                //    uncacheEntity(community.getAdministrators());
-                //}
 
                 if(Hibernate.isInitialized(community.getLogo())) {
                     uncacheEntity(community.getLogo());
                 }
+
+            // COLLECTION
             } else if (entity instanceof Collection) {
                 Collection collection = (Collection) entity;
+
+                //We don't uncache groups as they might still be referenced from the Context object
+
                 if(Hibernate.isInitialized(collection.getLogo())) {
                     uncacheEntity(collection.getLogo());
                 }
                 if(Hibernate.isInitialized(collection.getTemplateItem())) {
                     uncacheEntity(collection.getTemplateItem());
                 }
-
-                //We don't uncache groups as they might still be referenced from the Context object
-                //if(Hibernate.isInitialized(collection.getAdministrators())) {
-                //    uncacheEntity(collection.getAdministrators());
-                //}
-                //if(Hibernate.isInitialized(collection.getSubmitters())) {
-                //    uncacheEntity(collection.getSubmitters());
-                //}
-                //if(Hibernate.isInitialized(collection.getWorkflowStep1())) {
-                //    uncacheEntity(collection.getWorkflowStep1());
-                //}
-                //if(Hibernate.isInitialized(collection.getWorkflowStep2())) {
-                //    uncacheEntity(collection.getWorkflowStep2());
-                //}
-                //if(Hibernate.isInitialized(collection.getWorkflowStep3())) {
-                //    uncacheEntity(collection.getWorkflowStep3());
-                //}
             }
 
             if(!readOnlyEnabled && getSession().isDirty()) {

--- a/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
@@ -187,9 +187,11 @@ public class HibernateDBConnection implements DBConnection<Session> {
             if (entity instanceof Item) {
                 Item item = (Item) entity;
 
-                if(Hibernate.isInitialized(item.getSubmitter())) {
-                    uncacheEntity(item.getSubmitter());
-                }
+                //DO NOT uncache the submitter. This could be the current eperson. Uncaching him could lead to
+                //LazyInitializationExceptions (see DS-3648)
+                //if(Hibernate.isInitialized(item.getSubmitter())) {
+                //    uncacheEntity(item.getSubmitter());
+                //}
                 if(Hibernate.isInitialized(item.getBundles())) {
                     for (Bundle bundle : Utils.emptyIfNull(item.getBundles())) {
                         uncacheEntity(bundle);
@@ -208,9 +210,11 @@ public class HibernateDBConnection implements DBConnection<Session> {
             //    No specific child entities to decache
             } else if (entity instanceof Community) {
                 Community community = (Community) entity;
-                if(Hibernate.isInitialized(community.getAdministrators())) {
-                    uncacheEntity(community.getAdministrators());
-                }
+
+                //We don't uncache groups as they might still be referenced from the Context object
+                //if(Hibernate.isInitialized(community.getAdministrators())) {
+                //    uncacheEntity(community.getAdministrators());
+                //}
 
                 if(Hibernate.isInitialized(community.getLogo())) {
                     uncacheEntity(community.getLogo());
@@ -220,24 +224,26 @@ public class HibernateDBConnection implements DBConnection<Session> {
                 if(Hibernate.isInitialized(collection.getLogo())) {
                     uncacheEntity(collection.getLogo());
                 }
-                if(Hibernate.isInitialized(collection.getAdministrators())) {
-                    uncacheEntity(collection.getAdministrators());
-                }
-                if(Hibernate.isInitialized(collection.getSubmitters())) {
-                    uncacheEntity(collection.getSubmitters());
-                }
                 if(Hibernate.isInitialized(collection.getTemplateItem())) {
                     uncacheEntity(collection.getTemplateItem());
                 }
-                if(Hibernate.isInitialized(collection.getWorkflowStep1())) {
-                    uncacheEntity(collection.getWorkflowStep1());
-                }
-                if(Hibernate.isInitialized(collection.getWorkflowStep2())) {
-                    uncacheEntity(collection.getWorkflowStep2());
-                }
-                if(Hibernate.isInitialized(collection.getWorkflowStep3())) {
-                    uncacheEntity(collection.getWorkflowStep3());
-                }
+
+                //We don't uncache groups as they might still be referenced from the Context object
+                //if(Hibernate.isInitialized(collection.getAdministrators())) {
+                //    uncacheEntity(collection.getAdministrators());
+                //}
+                //if(Hibernate.isInitialized(collection.getSubmitters())) {
+                //    uncacheEntity(collection.getSubmitters());
+                //}
+                //if(Hibernate.isInitialized(collection.getWorkflowStep1())) {
+                //    uncacheEntity(collection.getWorkflowStep1());
+                //}
+                //if(Hibernate.isInitialized(collection.getWorkflowStep2())) {
+                //    uncacheEntity(collection.getWorkflowStep2());
+                //}
+                //if(Hibernate.isInitialized(collection.getWorkflowStep3())) {
+                //    uncacheEntity(collection.getWorkflowStep3());
+                //}
             }
 
             getSession().evict(entity);

--- a/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
@@ -240,6 +240,9 @@ public class HibernateDBConnection implements DBConnection<Session> {
                 }
             }
 
+            if(!readOnlyEnabled && getSession().isDirty()) {
+                getSession().flush();
+            }
             getSession().evict(entity);
         }
     }


### PR DESCRIPTION
The org.dspace.core.HibernateDBConnection#uncacheEntity() method in 6.1 is a bit too eager in uncaching submitters and Groups. This breaks the batch import (SAF ZIP) in XMLUI (not via the CLI) by causing a LazyInitializationExceptions when the metadata of the uncached submitter is accessed.

The fix is to not automatically uncache a submitter and groups related to a DSpace Object as we cannot be sure that the Context doesn't hold a reference to them. Not uncaching the submitter or DSO related groups is not necessarily a problem because:
* They are not initialised automatically
* The number of different submitters and groups is relatively limited so it won't lead to memory problems in big repositories.
