### PR TITLE
XMLUI/SwordClient: Fix typo in i18n key

### DIFF
--- a/dspace-xmlui/src/main/resources/aspects/SwordClient/i18n/messages.xml
+++ b/dspace-xmlui/src/main/resources/aspects/SwordClient/i18n/messages.xml
@@ -65,7 +65,7 @@
     <message key="xmlui.swordclient.SelectPackagingAction.packageFormat_error">Unsupported package format selected</message>
 
     <message key="xmlui.swordclient.DepositAction.success">Item successfully copied</message>
-    <message key="xmlui.swordclient.DepositAction.package_error">Package format error</message>
+    <message key="xmlui.swordclient.DepositAction.package_format_error">Package format error</message>
     <message key="xmlui.swordclient.DepositAction.invalid_handle">Invalid handle</message>
     <message key="xmlui.swordclient.DepositAction.package_error">An error occurred creating the packaging object</message>
     <message key="xmlui.swordclient.DepositAction.error">Error encountered during deposit: {0}</message>


### PR DESCRIPTION
The previous key was twice in the `messages.xml` and `xmlui.swordclient.DepositAction.package_format_error` one was not there but is used in [DepositAction.java](https://github.com/DSpace/DSpace/blob/dspace-6_x/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/swordclient/DepositAction.java#L30).