### PR TITLE
DS-3659: Database migrate fails to create the initial groups

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -546,8 +546,8 @@ public class Context
 
         try
         {
-            // Rollback if we have a database connection, and it is NOT Read Only
-            if (isValid())
+            // Rollback ONLY if we have a database connection, and it is NOT Read Only
+            if (isValid() && !isReadOnly())
             {
                 dbConnection.rollback();
             }


### PR DESCRIPTION
Fix DS-3659 by ensuring that a READ-ONLY connection can never rollback.

https://jira.duraspace.org/browse/DS-3659

As noted in the ticket, this bug seems to result from the fact that a database connection may be shared (within the current running thread). A READ-ONLY connection should never revert/rollback previous changes that occurred in the same thread.

This bug was found on demo.dspace.org, with significant help from @AlexanderS and @tomdesair.  So, a huge thanks to both of them for finding the core issue and the correct fix.  It has been validated as working on http://demo.dspace.org (which was previously unable to recreate initial groups after a full content reset).