### PR TITLE
DS-3660: Fix discovery reindex on metadata change

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
@@ -160,11 +160,12 @@ public class IndexEventConsumer implements Consumer {
         if (objectsToUpdate != null && handlesToDelete != null) {
 
             // update the changed Items not deleted because they were on create list
-            for (DSpaceObject iu : objectsToUpdate) {
+            for (DSpaceObject o : objectsToUpdate) {
                 /* we let all types through here and 
                  * allow the search indexer to make 
                  * decisions on indexing and/or removal
                  */
+                DSpaceObject iu = ctx.reloadEntity(o);
                 String hdl = iu.getHandle();
                 if (hdl != null && !handlesToDelete.contains(hdl)) {
                     try {


### PR DESCRIPTION
~~Persisted objects should not be stored. The associated session may be closed
and other lazy loaded attributes, cannot be loaded later. Instead an identifier
should be stored and the object should be retrieved from the database again
when required.
This is now handled in the IndexEventConsumer the same way like in the
AuthorityConsumer.~~

Stored objects may get evicted from the session cache and get into detached
state. Lazy loaded fields are inaccessible and throw an exception on access.

Before using objects they have to be reloaded (retrieved from the
database and associated with the session again).