### PR TITLE
XMLUI: Remove doubled translation key

### DIFF
--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -2502,7 +2502,6 @@
     <message key="xmlui.Submission.submit.StartSubmissionLookupStep.lookup_help">Fill in a publication ID, DOI, Title or Author and then press "Search".  A list of all matching publications will be shown to you to select in order to proceed with the submission process.</message>
     <message key="xmlui.Submission.submit.StartSubmissionLookupStep.submit_publication_item">Imported publication Record</message>
     <message key="xmlui.Submission.submit.progressbar.lookup">Lookup</message>
-    <message key="xmlui.ChoiceLookupTransformer.lookup">Lookup</message>
 
 
 </catalogue>


### PR DESCRIPTION
This is just another quick cleanup of the messages.xml.

The key "xmlui.ChoiceLookupTransformer.lookup" is already in line 2368 of the
same file: https://github.com/DSpace/DSpace/blob/dspace-6_x/dspace-xmlui/src/main/webapp/i18n/messages.xml#L2368