### PR TITLE
DS-3648: Fix LazyInitializationExceptions in Batch Import Failure (v2)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -405,6 +405,7 @@ public class MetadataImport
 
                 if (change) {
                     //only clear cache if changes have been made.
+                    c.commit();
                     c.uncacheEntity(wsItem);
                     c.uncacheEntity(wfItem);
                     c.uncacheEntity(item);

--- a/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
@@ -184,17 +184,20 @@ public class HibernateDBConnection implements DBConnection<Session> {
                 }
             }
 
+            // ITEM
             if (entity instanceof Item) {
                 Item item = (Item) entity;
 
-                if(Hibernate.isInitialized(item.getSubmitter())) {
-                    uncacheEntity(item.getSubmitter());
-                }
+                //DO NOT uncache the submitter. This could be the current eperson. Uncaching him could lead to
+                //LazyInitializationExceptions (see DS-3648)
+
                 if(Hibernate.isInitialized(item.getBundles())) {
                     for (Bundle bundle : Utils.emptyIfNull(item.getBundles())) {
                         uncacheEntity(bundle);
                     }
                 }
+
+            // BUNDLE
             } else if (entity instanceof Bundle) {
                 Bundle bundle = (Bundle) entity;
 
@@ -203,40 +206,31 @@ public class HibernateDBConnection implements DBConnection<Session> {
                         uncacheEntity(bitstream);
                     }
                 }
-            //} else if(entity instanceof Bitstream) {
-            //    Bitstream bitstream = (Bitstream) entity;
-            //    No specific child entities to decache
+
+            // BITSTREAM
+            // No specific child entities to decache
+
+            // COMMUNITY
             } else if (entity instanceof Community) {
                 Community community = (Community) entity;
-                if(Hibernate.isInitialized(community.getAdministrators())) {
-                    uncacheEntity(community.getAdministrators());
-                }
+
+                //We don't uncache groups as they might still be referenced from the Context object
 
                 if(Hibernate.isInitialized(community.getLogo())) {
                     uncacheEntity(community.getLogo());
                 }
+
+            // COLLECTION
             } else if (entity instanceof Collection) {
                 Collection collection = (Collection) entity;
+
+                //We don't uncache groups as they might still be referenced from the Context object
+
                 if(Hibernate.isInitialized(collection.getLogo())) {
                     uncacheEntity(collection.getLogo());
                 }
-                if(Hibernate.isInitialized(collection.getAdministrators())) {
-                    uncacheEntity(collection.getAdministrators());
-                }
-                if(Hibernate.isInitialized(collection.getSubmitters())) {
-                    uncacheEntity(collection.getSubmitters());
-                }
                 if(Hibernate.isInitialized(collection.getTemplateItem())) {
                     uncacheEntity(collection.getTemplateItem());
-                }
-                if(Hibernate.isInitialized(collection.getWorkflowStep1())) {
-                    uncacheEntity(collection.getWorkflowStep1());
-                }
-                if(Hibernate.isInitialized(collection.getWorkflowStep2())) {
-                    uncacheEntity(collection.getWorkflowStep2());
-                }
-                if(Hibernate.isInitialized(collection.getWorkflowStep3())) {
-                    uncacheEntity(collection.getWorkflowStep3());
                 }
             }
 


### PR DESCRIPTION
This is an alternative for #1813.

It does not pull the changes from #1812 and commits the `Context` before calling `uncacheEntity()`. I squashed the two commits from @tomdesair and slightly adjusted the commit message.