### PR TITLE
DS-3656: DOIOrganiser CLI does not change the database anymore (v2)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/identifier/doi/DOIOrganiser.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/DOIOrganiser.java
@@ -192,6 +192,7 @@ public class DOIOrganiser {
 
                 for (DOI doi : dois) {
                     organiser.reserve(doi);
+                    context.commit();
                     context.uncacheEntity(doi);
                 }
             } catch (SQLException ex) {
@@ -213,6 +214,7 @@ public class DOIOrganiser {
                 for (DOI doi : dois)
                 {
                     organiser.register(doi);
+                    context.commit();
                     context.uncacheEntity(doi);
                 }
             } catch (SQLException ex) {
@@ -238,6 +240,7 @@ public class DOIOrganiser {
                 for (DOI doi : dois)
                 {
                     organiser.update(doi);
+                    context.commit();
                     context.uncacheEntity(doi);
                 }
             } catch (SQLException ex) {
@@ -262,6 +265,7 @@ public class DOIOrganiser {
                     DOI doi = iterator.next();
                     iterator.remove();
                     organiser.delete(doi.getDoi());
+                    context.commit();
                     context.uncacheEntity(doi);
                 }
             } catch (SQLException ex) {


### PR DESCRIPTION
This is an alternative for #1812.

It does not add `Session.flush()` in `uncacheEntity()` because that may cause other problems in other places. It now adds an explicit `Context.commit()` before `uncacheEntity()` (like discussed in [slack](https://dspace-org.slack.com/messages/C4CDUH9JB/) yesterday).
