### PR TITLE
[DS-3671] find-by-metadata not always working correctly

### DIFF
--- a/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
@@ -990,7 +990,7 @@ public class ItemsResource extends Resource
                     "ELEMENT= ? AND ";
                     parameterList.add(metadata[0]);
                     parameterList.add(metadata[1]);
-            if (metadata.length > 3)
+            if (metadata.length == 3)
             {
                 sql += "QUALIFIER= ? AND ";
                 parameterList.add(metadata[2]);

--- a/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
@@ -997,22 +997,25 @@ public class ItemsResource extends Resource
             }
             if (org.dspace.storage.rdbms.DatabaseManager.isOracle())
             {
-                sql += "dbms_lob.compare(TEXT_VALUE, ?) = 0 AND ";
+                sql += "dbms_lob.compare(TEXT_VALUE, ?) = 0";
                 parameterList.add(metadataEntry.getValue());
             }
             else
             {
-                sql += "TEXT_VALUE=? AND ";
+                sql += "TEXT_VALUE=?";
                 parameterList.add(metadataEntry.getValue());
             }
             if (metadataEntry.getLanguage() != null)
             {
-                sql += "TEXT_LANG=?";
-                parameterList.add(metadataEntry.getLanguage());
+                // omit text_lang from where clause if we have *
+                if(!metadataEntry.getLanguage().equals(org.dspace.content.Item.ANY)){
+                    sql += " AND TEXT_LANG=?";
+                    parameterList.add(metadataEntry.getLanguage());
+                }
             }
             else
             {
-                sql += "TEXT_LANG is null";
+                sql += " AND TEXT_LANG is null";
             }
 
             Object[] parameters = parameterList.toArray();


### PR DESCRIPTION
In /find-by-metadata-field the qualifier was never added and the wildcard `*` was used as any other value