### PR TITLE
Revert various `context.dispatchEvents()` calls to `context.commit()`

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/harvest/Harvest.java
+++ b/dspace-api/src/main/java/org/dspace/app/harvest/Harvest.java
@@ -389,7 +389,7 @@ public class Harvest
                 harvestedCollectionService.update(context, hc);
     		}
     		context.restoreAuthSystemState();
-            context.dispatchEvents();
+            context.commit();
     	}
     	catch (Exception e) {
     		System.out.println("Changes could not be committed");

--- a/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
@@ -312,7 +312,7 @@ public class LDAPAuthentication
                             context.turnOffAuthorisationSystem();
                             eperson.setNetid(netid.toLowerCase());
                             ePersonService.update(context, eperson);
-                            context.dispatchEvents();
+                            context.commit();
                             context.restoreAuthSystemState();
                             context.setCurrentUser(eperson);
 
@@ -350,7 +350,7 @@ public class LDAPAuthentication
                                     eperson.setCanLogIn(true);
                                     authenticationService.initEPerson(context, request, eperson);
                                     ePersonService.update(context, eperson);
-                                    context.dispatchEvents();
+                                    context.commit();
                                     context.setCurrentUser(eperson);
 
                                     // assign user to groups based on ldap dn

--- a/dspace-api/src/main/java/org/dspace/authenticate/ShibAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/ShibAuthentication.java
@@ -739,7 +739,7 @@ public class ShibAuthentication implements AuthenticationMethod
 		// Commit the new eperson
 		AuthenticateServiceFactory.getInstance().getAuthenticationService().initEPerson(context, request, eperson);
         ePersonService.update(context, eperson);
-		context.dispatchEvents();
+		context.commit();
 
 		// Turn authorizations back on.
 		context.restoreAuthSystemState();
@@ -845,7 +845,7 @@ public class ShibAuthentication implements AuthenticationMethod
 			log.debug("Updated the eperson's '"+field+"' metadata using header: '"+header+"' = '"+value+"'.");
 		}
         ePersonService.update(context, eperson);
-        context.dispatchEvents();
+        context.commit();
 		context.restoreAuthSystemState();
 	}
 
@@ -1190,4 +1190,3 @@ public class ShibAuthentication implements AuthenticationMethod
 
 
 }
-

--- a/dspace-api/src/main/java/org/dspace/authenticate/X509Authentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/X509Authentication.java
@@ -619,7 +619,7 @@ public class X509Authentication implements AuthenticationMethod
                         authenticationService.initEPerson(context, request,
                                 eperson);
                         ePersonService.update(context, eperson);
-                        context.dispatchEvents();
+                        context.commit();
                         context.restoreAuthSystemState();
                         context.setCurrentUser(eperson);
                         setSpecialGroupsFlag(request, email);

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -39,8 +39,8 @@ import java.util.*;
  * changes and free up the resources.
  * <P>
  * The context object is also used as a cache for CM API objects.
- * 
- * 
+ *
+ *
  * @version $Revision$
  */
 public class Context
@@ -129,7 +129,7 @@ public class Context
     /**
      * Construct a new context object with the given mode enabled. A database connection is opened.
      * No user is authenticated.
-     * 
+     *
      * @param mode   The mode to use when opening the context.
      */
     public Context(Mode mode)
@@ -139,7 +139,7 @@ public class Context
     }
 
     /**
-     * Initializes a new context object. 
+     * Initializes a new context object.
      *
      * @exception SQLException
      *                if there was an error obtaining a database connection
@@ -185,7 +185,7 @@ public class Context
 
     /**
      * Get the database connection associated with the context
-     * 
+     *
      * @return the database connection
      */
     DBConnection getDBConnection()
@@ -205,7 +205,7 @@ public class Context
     /**
      * Set the current user. Authentication must have been performed by the
      * caller - this call does not attempt any authentication.
-     * 
+     *
      * @param user
      *            the new current user, or <code>null</code> if no user is
      *            authenticated
@@ -217,7 +217,7 @@ public class Context
 
     /**
      * Get the current (authenticated) user
-     * 
+     *
      * @return the current user, or <code>null</code> if no user is
      *         authenticated
      */
@@ -228,7 +228,7 @@ public class Context
 
     /**
      * Gets the current Locale
-     * 
+     *
      * @return Locale the current Locale
      */
     public Locale getCurrentLocale()
@@ -238,7 +238,7 @@ public class Context
 
     /**
      * set the current Locale
-     * 
+     *
      * @param locale
      *            the current Locale
      */
@@ -249,7 +249,7 @@ public class Context
 
     /**
      * Find out if the authorisation system should be ignored for this context.
-     * 
+     *
      * @return <code>true</code> if authorisation should be ignored for this
      *         session.
      */
@@ -282,7 +282,7 @@ public class Context
      * <code>
      *     mycontext.turnOffAuthorisationSystem();
      *     some java code that require no authorisation check
-     *     mycontext.restoreAuthSystemState(); 
+     *     mycontext.restoreAuthSystemState();
          * </code> If Context debug is enabled, the correct sequence calling will be
      * checked and a warning will be displayed if not.
      */
@@ -331,7 +331,7 @@ public class Context
      * current Web user's session:
      * <P>
      * <code>setExtraLogInfo("session_id="+request.getSession().getId());</code>
-     * 
+     *
      * @param info
      *            the extra information to log
      */
@@ -343,7 +343,7 @@ public class Context
     /**
      * Get extra information to be logged with message logged in the scope of
      * this context.
-     * 
+     *
      * @return the extra log info - guaranteed non- <code>null</code>
      */
     public String getExtraLogInfo()
@@ -358,7 +358,7 @@ public class Context
      * <p>
      * Calling complete() on a Context which is no longer valid (isValid()==false),
      * is a no-op.
-     * 
+     *
      * @exception SQLException
      *                if there was an error completing the database transaction
      *                or closing the connection
@@ -406,34 +406,26 @@ public class Context
         // If Context is no longer open/valid, just note that it has already been closed
         if(!isValid()) {
             log.info("commit() was called on a closed Context object. No changes to commit.");
+            return;
         }
 
         if(isReadOnly()) {
             throw new UnsupportedOperationException("You cannot commit a read-only context");
         }
 
-        // Our DB Connection (Hibernate) will decide if an actual commit is required or not
-        try
-        {
-            // As long as we have a valid, writeable database connection,
-            // commit any changes made as part of the transaction
-            if (isValid())
-            {
-                dispatchEvents();
-            }
-
-        } finally {
-            if(log.isDebugEnabled()) {
-                log.debug("Cache size on commit is " + getCacheSize());
-            }
-
-            if(dbConnection != null)
-            {
-                //Commit our changes
-                dbConnection.commit();
-                reloadContextBoundEntities();
-            }
+        // As long as we have a valid, writeable database connection,
+        // commit any changes made as part of the transaction
+        if(log.isDebugEnabled()) {
+            log.debug("Cache size on commit is " + getCacheSize());
         }
+
+        //Commit our changes to database, finalizing the transaction
+        dbConnection.commit();
+        // Refresh any entities required to be in Context
+        reloadContextBoundEntities();
+
+        // Finally, dispatch events to event consumers
+        dispatchEvents();
     }
 
 
@@ -462,7 +454,7 @@ public class Context
 
     /**
      * Select an event dispatcher, <code>null</code> selects the default
-     * 
+     *
      * @param dispatcher dispatcher
      */
     public void setDispatcher(String dispatcher)
@@ -477,12 +469,12 @@ public class Context
 
     /**
      * Add an event to be dispatched when this context is committed.
-     * 
+     *
      * @param event
      */
     public void addEvent(Event event)
     {
-        /* 
+        /*
          * invalid condition if in read-only mode: events - which
          * indicate mutation - are firing: no recourse but to bail
          */
@@ -501,7 +493,7 @@ public class Context
     /**
      * Get the current event list. If there is a separate list of events from
      * already-committed operations combine that with current list.
-     * 
+     *
      * @return List of all available events.
      */
     public LinkedList<Event> getEvents()
@@ -574,10 +566,10 @@ public class Context
     }
 
     /**
-     * 
+     *
      * Find out if this context is valid. Returns <code>false</code> if this
      * context has been aborted or completed.
-     * 
+     *
      * @return <code>true</code> if the context is still valid, otherwise
      *         <code>false</code>
      */
@@ -589,7 +581,7 @@ public class Context
 
     /**
      * Reports whether context supports updating DSpaceObjects, or only reading.
-     * 
+     *
      * @return <code>true</code> if the context is read-only, otherwise
      *         <code>false</code>
      */
@@ -607,7 +599,7 @@ public class Context
 
     /**
      * test if member of special group
-     * 
+     *
      * @param groupID
      *            ID of special group to test
      * @return true if member

--- a/dspace-api/src/main/java/org/dspace/harvest/HarvestScheduler.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/HarvestScheduler.java
@@ -283,11 +283,12 @@ public class HarvestScheduler implements Runnable
         log.debug("****** Entered the addThread method. Active threads: " + harvestThreads.toString());
         context.setCurrentUser(harvestAdmin);
 
+        UUID collectionID = harvestedCollection.getCollection().getID();
         harvestedCollection.setHarvestStatus(HarvestedCollection.STATUS_QUEUED);
         harvestedCollectionService.update(context, harvestedCollection);
-        context.dispatchEvents();
+        context.commit();
 
-        HarvestThread ht = new HarvestThread(harvestedCollection.getCollection().getID());
+        HarvestThread ht = new HarvestThread(collectionID);
         harvestThreads.push(ht);
 
         log.debug("****** Queued up a thread. Active threads: " + harvestThreads.toString());

--- a/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
@@ -365,8 +365,6 @@ public class OAIHarvester {
 						currentRecord++;
 
 						processRecord(record, OREPrefix, currentRecord, totalListSize);
-						ourContext.dispatchEvents();
-
 						intermediateCommit();
 					}
 				}
@@ -390,7 +388,6 @@ public class OAIHarvester {
                     ourContext.restoreAuthSystemState();
                 }
 
-				ourContext.dispatchEvents();
 				intermediateCommit();
 			}
 		}

--- a/dspace-api/src/main/java/org/dspace/submit/step/AccessStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/AccessStep.java
@@ -130,7 +130,7 @@ public class AccessStep extends AbstractProcessingStep
         // SELECTED OPERATION: Remove Policies
         if(wasRemovePolicyPressed(buttonPressed)){
             removePolicy(context, buttonPressed);
-            context.dispatchEvents();
+            context.commit();
             return STATUS_COMPLETE;
         }
 
@@ -160,7 +160,7 @@ public class AccessStep extends AbstractProcessingStep
                 return STATUS_DUPLICATED_POLICY;
             }
             resourcePolicyService.update(context, rp);
-            context.dispatchEvents();
+            context.commit();
             return STATUS_COMPLETE;
         }
 
@@ -188,7 +188,7 @@ public class AccessStep extends AbstractProcessingStep
             item.setDiscoverable(false);
         }
         itemService.update(context, item);
-        context.dispatchEvents();
+        context.commit();
 
         return STATUS_COMPLETE;
     }
@@ -229,7 +229,7 @@ public class AccessStep extends AbstractProcessingStep
             }
 
             resourcePolicyService.update(context, resourcePolicy);
-            context.dispatchEvents();
+            context.commit();
         }
         return STATUS_COMPLETE;
     }

--- a/dspace-api/src/main/java/org/dspace/submit/step/CCLicenseStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/CCLicenseStep.java
@@ -185,7 +185,7 @@ public class CCLicenseStep extends AbstractProcessingStep
     		creativeCommonsService.removeLicense(context, uriField, nameField, item);
     		
 			itemService.update(context, item);
-            context.dispatchEvents();
+            context.commit();
 			removeRequiredAttributes(session);
 			
     		return STATUS_COMPLETE;
@@ -211,7 +211,7 @@ public class CCLicenseStep extends AbstractProcessingStep
     		}
             
     		itemService.update(context, item);
-            context.dispatchEvents();
+            context.commit();
     		removeRequiredAttributes(session);
     		session.removeAttribute("inProgress");
     	} 

--- a/dspace-api/src/main/java/org/dspace/submit/step/CompleteStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/CompleteStep.java
@@ -30,16 +30,16 @@ import org.dspace.workflow.factory.WorkflowServiceFactory;
  * This is the class which defines what happens once a submission completes!
  * <P>
  * This class performs all the behind-the-scenes processing that
- * this particular step requires.  This class's methods are utilized 
+ * this particular step requires.  This class's methods are utilized
  * by both the JSP-UI and the Manakin XML-UI
  * <P>
  * This step is non-interactive (i.e. no user interface), and simply performs
  * the processing that is necessary after a submission has been completed!
- * 
+ *
  * @see org.dspace.app.util.SubmissionConfig
  * @see org.dspace.app.util.SubmissionStepConfig
  * @see org.dspace.submit.AbstractProcessingStep
- * 
+ *
  * @author Tim Donohue
  * @version $Revision$
  */
@@ -58,7 +58,7 @@ public class CompleteStep extends AbstractProcessingStep
      * <P>
      * NOTE: If this step is a non-interactive step (i.e. requires no UI), then
      * it should perform *all* of its processing in this method!
-     * 
+     *
      * @param context
      *            current DSpace context
      * @param request
@@ -100,7 +100,7 @@ public class CompleteStep extends AbstractProcessingStep
         // commit changes to database
             if (success)
             {
-                context.dispatchEvents();
+                context.commit();
             }
         }
         return STATUS_COMPLETE;
@@ -120,12 +120,12 @@ public class CompleteStep extends AbstractProcessingStep
      * Steps which are non-interactive (i.e. they do not display an interface to
      * the user) should return a value of 1, so that they are only processed
      * once!
-     * 
+     *
      * @param request
      *            The HTTP Request
      * @param subInfo
      *            The current submission information object
-     * 
+     *
      * @return the number of pages in this step
      */
     @Override

--- a/dspace-api/src/main/java/org/dspace/submit/step/DescribeStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/DescribeStep.java
@@ -346,7 +346,7 @@ public class DescribeStep extends AbstractProcessingStep
         ContentServiceFactory.getInstance().getInProgressSubmissionService(subInfo.getSubmissionItem()).update(context, subInfo.getSubmissionItem());
 
         // commit changes
-        context.dispatchEvents();
+        context.commit();
 
         // check for request for more input fields, first
         if (moreInput)

--- a/dspace-api/src/main/java/org/dspace/submit/step/InitialQuestionsStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/InitialQuestionsStep.java
@@ -232,7 +232,7 @@ public class InitialQuestionsStep extends AbstractProcessingStep
 
         // commit all changes to DB
         ContentServiceFactory.getInstance().getInProgressSubmissionService(subInfo.getSubmissionItem()).update(context, subInfo.getSubmissionItem());
-        context.dispatchEvents();
+        context.commit();
 
         return STATUS_COMPLETE; // no errors!
     }

--- a/dspace-api/src/main/java/org/dspace/submit/step/LicenseStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/LicenseStep.java
@@ -137,7 +137,7 @@ public class LicenseStep extends AbstractProcessingStep
             LicenseUtils.grantLicense(context, item, license);
 
             // commit changes
-            context.dispatchEvents();
+            context.commit();
         }
 
         // completed without errors

--- a/dspace-api/src/main/java/org/dspace/submit/step/SelectCollectionStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/SelectCollectionStep.java
@@ -113,7 +113,7 @@ public class SelectCollectionStep extends AbstractProcessingStep
             subInfo.setSubmissionItem(wi);
 
             // commit changes to database
-            context.dispatchEvents();
+            context.commit();
 
             // need to reload current submission process config,
             // since it is based on the Collection selected

--- a/dspace-api/src/main/java/org/dspace/submit/step/StartSubmissionLookupStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/StartSubmissionLookupStep.java
@@ -270,7 +270,7 @@ public class StartSubmissionLookupStep extends AbstractProcessingStep
             }
 
             // commit changes to database
-            context.dispatchEvents();
+            context.commit();
 
             // need to reload current submission process config,
             // since it is based on the Collection selected

--- a/dspace-api/src/main/java/org/dspace/submit/step/UploadStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/UploadStep.java
@@ -365,7 +365,7 @@ public class UploadStep extends AbstractProcessingStep
             return STATUS_NO_FILES_ERROR;
         }
 
-        context.dispatchEvents();
+        context.commit();
 
         return STATUS_COMPLETE;
     }
@@ -603,7 +603,7 @@ public class UploadStep extends AbstractProcessingStep
 
                 // If we got this far then everything is more or less ok.
 
-                context.dispatchEvents();
+                context.commit();
 
                 // save this bitstream to the submission info, as the
                 // bitstream we're currently working with
@@ -729,8 +729,6 @@ public class UploadStep extends AbstractProcessingStep
             subInfo.getBitstream().setDescription(context,
                     request.getParameter("description"));
             bitstreamService.update(context, subInfo.getBitstream());
-
-            context.dispatchEvents();
         }
         else
         {

--- a/dspace-api/src/main/java/org/dspace/submit/step/UploadWithEmbargoStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/UploadWithEmbargoStep.java
@@ -280,6 +280,7 @@ public class UploadWithEmbargoStep extends UploadStep
                     }
                 }
             }
+            context.commit();
             return STATUS_COMPLETE;
         }
         
@@ -351,6 +352,8 @@ public class UploadWithEmbargoStep extends UploadStep
         {
             return STATUS_NO_FILES_ERROR;
         }
+
+        context.commit();
         return STATUS_COMPLETE;
     }
 
@@ -502,10 +505,6 @@ public class UploadWithEmbargoStep extends UploadStep
 
                 // If we got this far then everything is more or less ok.
 
-                // Comment - not sure if this is the right place for a commit here
-                // but I'm not brave enough to remove it - Robin.
-                context.dispatchEvents();
-
                 // save this bitstream to the submission info, as the
                 // bitstream we're currently working with
                 subInfo.setBitstream(b);
@@ -521,8 +520,6 @@ public class UploadWithEmbargoStep extends UploadStep
 
 
         return STATUS_COMPLETE;
-
-
     }
 
     private void processAccessFields(Context context, HttpServletRequest request, SubmissionInfo subInfo, Bitstream b) throws SQLException, AuthorizeException {
@@ -584,7 +581,7 @@ public class UploadWithEmbargoStep extends UploadStep
                 return STATUS_EDIT_POLICIES_DUPLICATED_POLICY;
             }
             resourcePolicyService.update(context, rp);
-            context.dispatchEvents();
+            context.commit();
             return STATUS_EDIT_POLICIES;
         }
         // FORM: EditBitstreamPolicies SELECTED OPERATION: go to EditPolicyForm
@@ -619,7 +616,7 @@ public class UploadWithEmbargoStep extends UploadStep
             Bitstream b = bitstreamService.find(context, Util.getUUIDParameter(request, "bitstream_id"));
             subInfo.setBitstream(b);
             org.dspace.submit.step.AccessStep.removePolicy(context, buttonPressed);
-            context.dispatchEvents();
+            context.commit();
             return STATUS_EDIT_POLICIES;
         }
         return -1;

--- a/dspace-api/src/main/java/org/dspace/submit/step/XMLUIStartSubmissionLookupStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/XMLUIStartSubmissionLookupStep.java
@@ -61,7 +61,7 @@ public class XMLUIStartSubmissionLookupStep extends AbstractProcessingStep {
 
                 itemService.update(context, item);
 
-                context.dispatchEvents();
+                context.commit();
 
             } catch (MetadataSourceException e) {
                 log.error(e);

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EditItemServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EditItemServlet.java
@@ -422,7 +422,6 @@ public class EditItemServlet extends DSpaceServlet
 				creativeCommonsService.removeLicense(context, uriField, nameField, item);
 
 				itemService.update(context, item);
-	            context.dispatchEvents();
     			exit = true;
         	}
         	else if (licenseclass.equals("webui.Submission.submit.CCLicenseStep.select_change")) {
@@ -445,8 +444,6 @@ public class EditItemServlet extends DSpaceServlet
 					}
 
 					itemService.update(context, item);
-					context.dispatchEvents();
-
 				}
 			}
             showEditForm(context, request, response, item);


### PR DESCRIPTION
During the massive 6.0 API refactor, some API classes had their `context.commit()` calls replaced with `context.dispatchEvents()`.  This seems to be accidental as `dispatchEvents()` does not save the changes made in these classes...it just calls the event service to trigger various event consumers.

In most situations `dispatchEvents()` was replaced with `commit()`.  However, a few other refactors were found:
* In a few instances `dispatchEvents()` was followed by a `commit()` or `complete()`. In those cases, it was removed, as `commit/complete` will call `dispatchEvents()` themselves.
* In at least one instance, minor refactoring was necessary as `commit()` decaches all objects in Session. This means objects cannot be accessed / manipulated after the `commit()`.

This PR builds on #1824 (the first 3 commits are from that PR), and therefore #1824 must be merged first.

This PR essentially only adds this commit:
* https://github.com/DSpace/DSpace/pull/1826/commits/394e01f68853ac2f520feaf8b417917bc1eecd5c