### PR TITLE
DS-3682: Fix reusing of the same vocabulary dialog

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/scripts/vocabulary-support.js
+++ b/dspace-xmlui-mirage2/src/main/webapp/scripts/vocabulary-support.js
@@ -36,6 +36,7 @@
             var vocabularyDialog = $('div#'+id);
             if(0 < vocabularyDialog.length){
                 //Open the modal
+                vocabularyDialog.find('input[type="hidden"][name="metadataFieldName"]').val(inputFieldName);
                 vocabularyDialog.modal('show')
             }else{
 

--- a/dspace-xmlui/src/main/webapp/static/js/vocabulary-support.js
+++ b/dspace-xmlui/src/main/webapp/static/js/vocabulary-support.js
@@ -35,6 +35,7 @@
             var vocabularyDialog = $('div#aspect_submission_ControlledVocabularyTransformer_div_vocabulary_dialog_' + vocabularyIdentifier);
             if(0 < vocabularyDialog.length){
                 //Open the dialog
+                vocabularyDialog.find('input[type="hidden"][name="metadataFieldName"]').val(inputFieldName);
                 vocabularyDialog.dialog( 'open' );
             }else{
                 //No dialog window found, create a new one by requesting our data by json


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3682

If the same vocabulary is used multiple times on the same input page, the
dialog is only fetched the first time from the server and reused afterwards.
The problem is, that the target input field is contained in the dialog. When
reusing the dialog the target field should be updated.