### PR TITLE
DS-3683 Check if workflow group is empty or not

### DIFF
--- a/dspace-api/src/main/java/org/dspace/workflow/WorkflowManager.java
+++ b/dspace-api/src/main/java/org/dspace/workflow/WorkflowManager.java
@@ -417,8 +417,7 @@ public class WorkflowManager
             // advance(...) will call itself if no workflow step group exists
             // so we need to check permissions only if a workflow step group is
             // in place.
-                if (wi.getCollection().getWorkflowGroup(1) != null && !wi.getCollection().getWorkflowGroup(1).isEmpty())
-            {
+            if (wi.getCollection().getWorkflowGroup(1) != null && !wi.getCollection().getWorkflowGroup(1).isEmpty()) {
                 // FIXME note:  authorizeAction ASSUMES that c.getCurrentUser() == e!
                 AuthorizeManager.authorizeAction(c, wi.getCollection(), Constants.WORKFLOW_STEP_1, true);
             }
@@ -436,8 +435,7 @@ public class WorkflowManager
             // advance(...) will call itself if no workflow step group exists
             // so we need to check permissions only if a workflow step group is
             // in place.
-                if (wi.getCollection().getWorkflowGroup(1) != null && !wi.getCollection().getWorkflowGroup(1).isEmpty())
-            {
+            if (wi.getCollection().getWorkflowGroup(1) != null && !wi.getCollection().getWorkflowGroup(1).isEmpty()) {
                 AuthorizeManager.authorizeAction(c, wi.getCollection(), Constants.WORKFLOW_STEP_2, true);
             }
 
@@ -454,8 +452,7 @@ public class WorkflowManager
             // advance(...) will call itself if no workflow step group exists
             // so we need to check permissions only if a workflow step group is
             // in place.
-                if (wi.getCollection().getWorkflowGroup(3) != null && !wi.getCollection().getWorkflowGroup(3).isEmpty())
-            {
+            if (wi.getCollection().getWorkflowGroup(3) != null && !wi.getCollection().getWorkflowGroup(3).isEmpty()) {
                 AuthorizeManager.authorizeAction(c, wi.getCollection(), Constants.WORKFLOW_STEP_3, true);
             }
 

--- a/dspace-api/src/main/java/org/dspace/workflow/WorkflowManager.java
+++ b/dspace-api/src/main/java/org/dspace/workflow/WorkflowManager.java
@@ -301,22 +301,27 @@ public class WorkflowManager
         {
         case WFSTATE_STEP1POOL:
 
-            // FIXME note:  authorizeAction ASSUMES that c.getCurrentUser() == e!
-            AuthorizeManager.authorizeAction(c, wi.getCollection(), Constants.WORKFLOW_STEP_1, true);
-            doState(c, wi, WFSTATE_STEP1, e);
+                if (wi.getCollection().getWorkflowGroup(1) != null && !wi.getCollection().getWorkflowGroup(1).isEmpty())
+                {
+                    AuthorizeManager.authorizeAction(c, wi.getCollection(), Constants.WORKFLOW_STEP_1, true);
+                }                doState(c, wi, WFSTATE_STEP1, e);
 
             break;
 
         case WFSTATE_STEP2POOL:
 
-            AuthorizeManager.authorizeAction(c, wi.getCollection(), Constants.WORKFLOW_STEP_2, true);
-            doState(c, wi, WFSTATE_STEP2, e);
+                if (wi.getCollection().getWorkflowGroup(2) != null && !wi.getCollection().getWorkflowGroup(2).isEmpty())
+                {
+                    AuthorizeManager.authorizeAction(c, wi.getCollection(), Constants.WORKFLOW_STEP_2, true);
+                }                doState(c, wi, WFSTATE_STEP2, e);
 
             break;
 
         case WFSTATE_STEP3POOL:
-
-            AuthorizeManager.authorizeAction(c, wi.getCollection(), Constants.WORKFLOW_STEP_3, true);
+                if (wi.getCollection().getWorkflowGroup(3) != null && !wi.getCollection().getWorkflowGroup(3).isEmpty())
+                {
+                    AuthorizeManager.authorizeAction(c, wi.getCollection(), Constants.WORKFLOW_STEP_3, true);
+                }
             doState(c, wi, WFSTATE_STEP3, e);
 
             break;
@@ -412,7 +417,7 @@ public class WorkflowManager
             // advance(...) will call itself if no workflow step group exists
             // so we need to check permissions only if a workflow step group is
             // in place.
-            if (wi.getCollection().getWorkflowGroup(1) != null)
+                if (wi.getCollection().getWorkflowGroup(1) != null && !wi.getCollection().getWorkflowGroup(1).isEmpty())
             {
                 // FIXME note:  authorizeAction ASSUMES that c.getCurrentUser() == e!
                 AuthorizeManager.authorizeAction(c, wi.getCollection(), Constants.WORKFLOW_STEP_1, true);
@@ -431,7 +436,7 @@ public class WorkflowManager
             // advance(...) will call itself if no workflow step group exists
             // so we need to check permissions only if a workflow step group is
             // in place.
-            if (wi.getCollection().getWorkflowGroup(2) != null)
+                if (wi.getCollection().getWorkflowGroup(1) != null && !wi.getCollection().getWorkflowGroup(1).isEmpty())
             {
                 AuthorizeManager.authorizeAction(c, wi.getCollection(), Constants.WORKFLOW_STEP_2, true);
             }
@@ -449,7 +454,7 @@ public class WorkflowManager
             // advance(...) will call itself if no workflow step group exists
             // so we need to check permissions only if a workflow step group is
             // in place.
-            if (wi.getCollection().getWorkflowGroup(3) != null)
+                if (wi.getCollection().getWorkflowGroup(3) != null && !wi.getCollection().getWorkflowGroup(3).isEmpty())
             {
                 AuthorizeManager.authorizeAction(c, wi.getCollection(), Constants.WORKFLOW_STEP_3, true);
             }


### PR DESCRIPTION
PR for 
https://jira.duraspace.org/browse/DS-3683

The following fixes that problem that a workflowgroup might be present, but might not actually contain anything, resulting in the advancing of a step to fail on authorization