### PR TITLE
DS-3681: Refactoring of DSpaceAuthorityIndexer

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authority/AuthorityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authority/AuthorityServiceImpl.java
@@ -47,15 +47,10 @@ public class AuthorityServiceImpl implements AuthorityService{
         }
 
         for (AuthorityIndexerInterface indexerInterface : indexers) {
-
-            indexerInterface.init(context , item);
-            while (indexerInterface.hasMore()) {
-                AuthorityValue authorityValue = indexerInterface.nextValue();
-                if(authorityValue != null)
-                    indexingService.indexContent(authorityValue);
+            List<AuthorityValue> authorityValues = indexerInterface.getAuthorityValues(context , item);
+            for (AuthorityValue authorityValue : authorityValues) {
+                indexingService.indexContent(authorityValue);
             }
-            //Close up
-            indexerInterface.close();
         }
         //Commit to our server
         indexingService.commit();

--- a/dspace-api/src/main/java/org/dspace/authority/AuthorityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authority/AuthorityServiceImpl.java
@@ -52,7 +52,7 @@ public class AuthorityServiceImpl implements AuthorityService{
             while (indexerInterface.hasMore()) {
                 AuthorityValue authorityValue = indexerInterface.nextValue();
                 if(authorityValue != null)
-                    indexingService.indexContent(authorityValue, true);
+                    indexingService.indexContent(authorityValue);
             }
             //Close up
             indexerInterface.close();

--- a/dspace-api/src/main/java/org/dspace/authority/AuthoritySolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authority/AuthoritySolrServiceImpl.java
@@ -62,7 +62,7 @@ public class AuthoritySolrServiceImpl implements AuthorityIndexingService, Autho
     }
 
     @Override
-    public void indexContent(AuthorityValue value, boolean force) {
+    public void indexContent(AuthorityValue value) {
         SolrInputDocument doc = value.getSolrInputDocument();
 
         try{

--- a/dspace-api/src/main/java/org/dspace/authority/indexer/AuthorityIndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/authority/indexer/AuthorityIndexClient.java
@@ -11,9 +11,13 @@ import org.dspace.authority.AuthorityValue;
 import org.apache.log4j.Logger;
 import org.dspace.authority.factory.AuthorityServiceFactory;
 import org.dspace.authority.service.AuthorityService;
+import org.dspace.content.Item;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -31,6 +35,7 @@ public class AuthorityIndexClient {
     protected static final AuthorityService authorityService = AuthorityServiceFactory.getInstance().getAuthorityService();
     protected static final AuthorityIndexingService indexingService = AuthorityServiceFactory.getInstance().getAuthorityIndexingService();
     protected static final List<AuthorityIndexerInterface> indexers = AuthorityServiceFactory.getInstance().getAuthorityIndexers();
+    protected static final ItemService itemService = ContentServiceFactory.getInstance().getItemService();
 
     public static void main(String[] args) throws Exception {
 
@@ -53,18 +58,24 @@ public class AuthorityIndexClient {
 
         //Get all our values from the input forms
         Map<String, AuthorityValue> toIndexValues = new HashMap<>();
+
         for (AuthorityIndexerInterface indexerInterface : indexers) {
             log.info("Initialize " + indexerInterface.getClass().getName());
             System.out.println("Initialize " + indexerInterface.getClass().getName());
-            indexerInterface.init(context, true);
-            while (indexerInterface.hasMore()) {
-                AuthorityValue authorityValue = indexerInterface.nextValue();
-                if(authorityValue != null){
-                    toIndexValues.put(authorityValue.getId(), authorityValue);
+            Iterator<Item> allItems = itemService.findAll(context);
+            while (allItems.hasNext()) {
+                Item item = allItems.next();
+
+                indexerInterface.init(context, item);
+                while (indexerInterface.hasMore()) {
+                    AuthorityValue authorityValue = indexerInterface.nextValue();
+                    if(authorityValue != null){
+                        toIndexValues.put(authorityValue.getId(), authorityValue);
+                    }
                 }
+                //Close up
+                indexerInterface.close();
             }
-            //Close up
-            indexerInterface.close();
         }
 
 

--- a/dspace-api/src/main/java/org/dspace/authority/indexer/AuthorityIndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/authority/indexer/AuthorityIndexClient.java
@@ -74,7 +74,7 @@ public class AuthorityIndexClient {
         log.info("Writing new data");
         System.out.println("Writing new data");
         for(String id : toIndexValues.keySet()){
-            indexingService.indexContent(toIndexValues.get(id), true);
+            indexingService.indexContent(toIndexValues.get(id));
             indexingService.commit();
         }
 

--- a/dspace-api/src/main/java/org/dspace/authority/indexer/AuthorityIndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/authority/indexer/AuthorityIndexClient.java
@@ -64,10 +64,11 @@ public class AuthorityIndexClient {
             System.out.println("Initialize " + indexerInterface.getClass().getName());
 
             Iterator<Item> allItems = itemService.findAll(context);
+            Map<String, AuthorityValue> authorityCache = new HashMap<>();
             while (allItems.hasNext()) {
                 Item item = allItems.next();
 
-                List<AuthorityValue> authorityValues = indexerInterface.getAuthorityValues(context, item);
+                List<AuthorityValue> authorityValues = indexerInterface.getAuthorityValues(context, item, authorityCache);
                 for (AuthorityValue authorityValue : authorityValues) {
                     toIndexValues.put(authorityValue.getId(), authorityValue);
                 }

--- a/dspace-api/src/main/java/org/dspace/authority/indexer/AuthorityIndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/authority/indexer/AuthorityIndexClient.java
@@ -72,6 +72,8 @@ public class AuthorityIndexClient {
                 for (AuthorityValue authorityValue : authorityValues) {
                     toIndexValues.put(authorityValue.getId(), authorityValue);
                 }
+
+                context.uncacheEntity(item);
             }
         }
 

--- a/dspace-api/src/main/java/org/dspace/authority/indexer/AuthorityIndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/authority/indexer/AuthorityIndexClient.java
@@ -62,19 +62,15 @@ public class AuthorityIndexClient {
         for (AuthorityIndexerInterface indexerInterface : indexers) {
             log.info("Initialize " + indexerInterface.getClass().getName());
             System.out.println("Initialize " + indexerInterface.getClass().getName());
+
             Iterator<Item> allItems = itemService.findAll(context);
             while (allItems.hasNext()) {
                 Item item = allItems.next();
 
-                indexerInterface.init(context, item);
-                while (indexerInterface.hasMore()) {
-                    AuthorityValue authorityValue = indexerInterface.nextValue();
-                    if(authorityValue != null){
-                        toIndexValues.put(authorityValue.getId(), authorityValue);
-                    }
+                List<AuthorityValue> authorityValues = indexerInterface.getAuthorityValues(context, item);
+                for (AuthorityValue authorityValue : authorityValues) {
+                    toIndexValues.put(authorityValue.getId(), authorityValue);
                 }
-                //Close up
-                indexerInterface.close();
             }
         }
 

--- a/dspace-api/src/main/java/org/dspace/authority/indexer/AuthorityIndexerInterface.java
+++ b/dspace-api/src/main/java/org/dspace/authority/indexer/AuthorityIndexerInterface.java
@@ -14,6 +14,7 @@ import org.dspace.content.Item;
 import org.dspace.core.Context;
 
 import java.sql.SQLException;
+import java.util.List;
 
 /**
  *
@@ -24,13 +25,8 @@ import java.sql.SQLException;
  */
 public interface AuthorityIndexerInterface {
 
-    public void init(Context context, Item item);
-
-    public AuthorityValue nextValue();
-
-    public boolean hasMore() throws SQLException, AuthorizeException;
-
-    public void close();
+    public List<AuthorityValue> getAuthorityValues(Context context, Item item)
+            throws SQLException, AuthorizeException;
 
     public boolean isConfiguredProperly();
 }

--- a/dspace-api/src/main/java/org/dspace/authority/indexer/AuthorityIndexerInterface.java
+++ b/dspace-api/src/main/java/org/dspace/authority/indexer/AuthorityIndexerInterface.java
@@ -26,10 +26,6 @@ public interface AuthorityIndexerInterface {
 
     public void init(Context context, Item item);
 
-    public void init(Context context, boolean useCache);
-
-    public void init(Context context);
-
     public AuthorityValue nextValue();
 
     public boolean hasMore() throws SQLException, AuthorizeException;

--- a/dspace-api/src/main/java/org/dspace/authority/indexer/AuthorityIndexerInterface.java
+++ b/dspace-api/src/main/java/org/dspace/authority/indexer/AuthorityIndexerInterface.java
@@ -15,6 +15,7 @@ import org.dspace.core.Context;
 
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Map;
 
 /**
  *
@@ -26,6 +27,9 @@ import java.util.List;
 public interface AuthorityIndexerInterface {
 
     public List<AuthorityValue> getAuthorityValues(Context context, Item item)
+            throws SQLException, AuthorizeException;
+
+    public List<AuthorityValue> getAuthorityValues(Context context, Item item, Map<String, AuthorityValue> cache)
             throws SQLException, AuthorizeException;
 
     public boolean isConfiguredProperly();

--- a/dspace-api/src/main/java/org/dspace/authority/indexer/AuthorityIndexingService.java
+++ b/dspace-api/src/main/java/org/dspace/authority/indexer/AuthorityIndexingService.java
@@ -20,7 +20,7 @@ import org.dspace.authority.AuthorityValue;
 public interface AuthorityIndexingService {
 
 
-    public void indexContent(AuthorityValue value, boolean force);
+    public void indexContent(AuthorityValue value);
 
     public void cleanIndex() throws Exception;
 

--- a/dspace-api/src/main/java/org/dspace/authority/indexer/DSpaceAuthorityIndexer.java
+++ b/dspace-api/src/main/java/org/dspace/authority/indexer/DSpaceAuthorityIndexer.java
@@ -100,25 +100,34 @@ public class DSpaceAuthorityIndexer implements AuthorityIndexerInterface, Initia
                     value = cache.get(content);
                 }
 
-                if (value == null)
-                {
-                    value = getAuthorityValue(context, metadataField, content, authorityKey);
+                if (value == null) {
+                    value = getAuthorityValue(context, metadataField, content,authorityKey);
                 }
 
-                if (value != null && requiresItemUpdate) {
-                    value.updateItem(context, item, metadataValue);
-                    try {
-                        itemService.update(context, item);
-                    } catch (Exception e) {
-                        log.error("Error creating a metadatavalue's authority", e);
+                if (value != null) {
+                    if (requiresItemUpdate) {
+                        value.updateItem(context, item, metadataValue);
+
+                        try {
+                            itemService.update(context, item);
+                        }
+                        catch (Exception e) {
+                            log.error("Error creating a metadatavalue's authority", e);
+                        }
                     }
-                }
 
-                if (cache != null) {
-                    cache.put(content, value);
-                }
+                    if (cache != null) {
+                        cache.put(content, value);
+                    }
 
-                values.add(value);
+                    values.add(value);
+                }
+                else {
+                    log.error("Error getting an authority value for " +
+                            "the metadata value \"" + content + "\" " +
+                            "in the field \"" + metadataField + "\" " +
+                            "of the item " + item.getHandle());
+                }
             }
         }
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3681

This is the refactoring of the DSpaceAuthorityIndexer. It now only handles one item at a time and simply returns all the AuthorityValues for this item and the AuthorityIndexClient can uncache the items afterwards. The AuthorityIndexer is also stateless now, so that multiple concurrent calls from different threads should be safe.