### PR TITLE
DS-3693: Add plugin to index filenames and file descriptions for files in ORIGINAL bundle

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceFileInfoPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceFileInfoPlugin.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.discovery;
 
 import org.apache.solr.common.SolrInputDocument;

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceFileInfoPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceFileInfoPlugin.java
@@ -1,0 +1,70 @@
+package org.dspace.discovery;
+
+import org.apache.solr.common.SolrInputDocument;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+
+import java.util.List;
+
+/**
+ * <p>
+ * Adds filenames and file descriptions of all files in the ORIGINAL bundle
+ * to the Solr search index.
+ *
+ * <p>
+ * To activate the plugin, add the following line to discovery.xml
+ * <pre>
+ * {@code <bean id="solrServiceFileInfoPlugin" class="org.dspace.discovery.SolrServiceFileInfoPlugin"/>}
+ * </pre>
+ *
+ * <p>
+ * After activating the plugin, rebuild the discovery index by executing:
+ * <pre>
+ * [dspace]/bin/dspace index-discovery -b
+ * </pre>
+ *
+ * @author Martin Walk
+ */
+public class SolrServiceFileInfoPlugin implements SolrServiceIndexPlugin
+{
+    private static final String BUNDLE_NAME = "ORIGINAL";
+    private static final String SOLR_FIELD_NAME_FOR_FILENAMES = "original_bundle_filenames";
+    private static final String SOLR_FIELD_NAME_FOR_DESCRIPTIONS = "original_bundle_descriptions";
+
+    @Override
+    public void additionalIndex(Context context, DSpaceObject dso, SolrInputDocument document)
+    {
+        if (dso instanceof Item)
+        {
+            Item item = (Item) dso;
+            List<Bundle> bundles = item.getBundles();
+            if (bundles != null)
+            {
+                for (Bundle bundle : bundles)
+                {
+                    String bundleName = bundle.getName();
+                    if ((bundleName != null) && bundleName.equals(BUNDLE_NAME))
+                    {
+                        List<Bitstream> bitstreams = bundle.getBitstreams();
+                        if (bitstreams != null)
+                        {
+                            for (Bitstream bitstream : bitstreams)
+                            {
+                                document.addField(SOLR_FIELD_NAME_FOR_FILENAMES, bitstream.getName());
+
+                                String description = bitstream.getDescription();
+                                if ((description != null) && (!description.isEmpty()))
+                                {
+                                    document.addField(SOLR_FIELD_NAME_FOR_DESCRIPTIONS, description);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/dspace-xmlui/src/main/resources/aspects/Discovery/i18n/messages.xml
+++ b/dspace-xmlui/src/main/resources/aspects/Discovery/i18n/messages.xml
@@ -103,6 +103,8 @@
     <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.title">Title</message>
     <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued">Date issued</message>
     <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.has_content_in_original_bundle">Has File(s)</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.original_bundle_filenames">Filename</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.original_bundle_descriptions">File description</message>
 
 
     <message key="xmlui.dri2xhtml.structural.pagination-info.nototal">Now showing items {0}-{1}</message>

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -113,6 +113,8 @@
                 <ref bean="searchFilterSubject" />
                 <ref bean="searchFilterIssued" />
 		        <ref bean="searchFilterContentInOriginalBundle"/>
+                <ref bean="searchFilterFileNameInOriginalBundle" />
+                <ref bean="searchFilterFileDescriptionInOriginalBundle" />
             </list>
         </property>
         <!--The sort filters for the discovery search-->
@@ -220,6 +222,8 @@
                 <ref bean="searchFilterSubject" />
                 <ref bean="searchFilterIssued" />
 		        <ref bean="searchFilterContentInOriginalBundle"/>
+                <ref bean="searchFilterFileNameInOriginalBundle" />
+                <ref bean="searchFilterFileDescriptionInOriginalBundle" />
             </list>
         </property>
         <!--The sort filters for the discovery search (same as defaultConfiguration above)-->
@@ -423,6 +427,20 @@
         <property name="type" value="standard"/>
         <property name="sortOrderSidebar" value="COUNT"/>
         <property name="sortOrderFilterPage" value="COUNT"/>
+    </bean>
+
+    <bean id="searchFilterFileNameInOriginalBundle" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="original_bundle_filenames"/>
+        <property name="metadataFields">
+            <list/>
+        </property>
+    </bean>
+
+    <bean id="searchFilterFileDescriptionInOriginalBundle" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="original_bundle_descriptions"/>
+        <property name="metadataFields">
+            <list/>
+        </property>
     </bean>
 
     <!--Sort properties-->

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -31,6 +31,9 @@
     <!-- Additional indexing plugin make filtering by has content in original bundle (like pdf's, images) posible via SOLR -->
     <bean id="hasContentInOriginalBundle" class="org.dspace.discovery.SolrServiceContentInOriginalBundleFilterPlugin"/>
 
+    <!-- Additional indexing plugin enables searching by filenames and by file descriptions for files in ORIGINAL bundle -->
+    <bean id="solrServiceFileInfoPlugin" class="org.dspace.discovery.SolrServiceFileInfoPlugin"/>
+
     <!--Bean that is used for mapping communities/collections to certain discovery configurations.-->
     <bean id="org.dspace.discovery.configuration.DiscoveryConfigurationService" class="org.dspace.discovery.configuration.DiscoveryConfigurationService">
         <property name="map">


### PR DESCRIPTION
Hi. I wrote a tiny plugin, `SolrServiceFileInfoPlugin`, (implementing `SolrServiceIndexPlugin`) to make filenames and file descriptions from the ORIGINAL bundle searchable.

The plugin must be added as a `bean` to `discovery.xml`.
To see it's effect, you have to reindex the Solr search core by executing:
`[dspace]/bin/dspace index-discovery -b`

I documented it on https://gist.github.com/MW3000/5771c0488f8952bb888357ce8c655279

Andrea Schweer and Terry Brady encouraged me to make a pull request.