### PR TITLE
DS-3511 Fix HTTP 500 errors on REST API bitstream updates

### DIFF
--- a/dspace-rest/src/main/java/org/dspace/rest/BitstreamResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/BitstreamResource.java
@@ -564,6 +564,7 @@ public class BitstreamResource extends Resource
             UUID newBitstreamId = bitstreamStorageService.store(context, dspaceBitstream, is);
             log.trace("Bitstream data stored: " + newBitstreamId);
 
+            context.complete();
         }
         catch (SQLException e)
         {
@@ -701,7 +702,7 @@ public class BitstreamResource extends Resource
                 }
                 log.trace("Policy for bitstream(id=" + bitstreamId + ") was successfully removed.");
             }
-
+            context.complete();
         }
         catch (SQLException e)
         {


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3511 and
https://groups.google.com/forum/#!topic/dspace-tech/ZEvYkjqbx8s

When trying to update the content of a bitstream or delete  a bitstream policy HTTP 500 error occurs (Dspace 6.0-6.2). Fixed by adding context.complete() to the end of the respective methods (adapted the original patch submitted to DS-3511).