### PR TITLE
[DS-3662] DSpace 'logging in' without password or with non-existent e-mail using Shib and Password authentication

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/ShibAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/ShibAuthentication.java
@@ -1041,6 +1041,7 @@ public class ShibAuthentication implements AuthenticationMethod
 	 * 
 	 * This method will not interpret the header value in any way.
 	 * 
+	 * This method will return null if value is empty.
 	 * 
 	 * @param request The HTTP request to look for values in.
 	 * @param name The name of the attribute or header
@@ -1064,6 +1065,17 @@ public class ShibAuthentication implements AuthenticationMethod
 			value = request.getHeader(name.toLowerCase());
 		if (StringUtils.isEmpty(value))
 			value = request.getHeader(name.toUpperCase());
+		
+		// Added extra check for empty value of an attribute.
+        // In case that value is Empty, it should not be returned, return 'null' instead.
+		// This prevents passing empty value to other methods, stops the authentication process
+		// and prevents creation of 'empty' DSpace EPerson if autoregister == true and it subsequent
+		// authentication.
+        if (StringUtils.isEmpty(value))
+        {
+        	log.debug("ShibAuthentication - attribute " + name + " is empty!");
+       	 	return null;
+        }
                 
                 boolean reconvertAttributes = 
                 		configurationService.getBooleanProperty(


### PR DESCRIPTION
Added extra check for empty value of an attribute.
In case that value is Empty, it should not be returned, return 'null' instead.
This prevents passing empty value to other methods, stops the authentication process
and prevents creation of 'empty' DSpace EPerson if autoregister == true and its subsequent
authentication.