### PR TITLE
DS-2687 Check group origin before deletion

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -26,6 +26,7 @@ import org.dspace.event.Event;
 import org.dspace.harvest.HarvestedCollection;
 import org.dspace.harvest.service.HarvestedCollectionService;
 import org.dspace.workflow.factory.WorkflowServiceFactory;
+import org.dspace.xmlworkflow.Role;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.IOException;
@@ -757,24 +758,30 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
         Group g = collection.getWorkflowStep1();
         if (g != null)
         {
-            collection.setWorkflowStep1(null);
-            groupService.delete(context, g);
+            if(!Group.isCustom(g) && !g.isPermanent()){
+                collection.setWorkflowStep1(null);
+                groupService.delete(context, g);
+            }
         }
 
         g = collection.getWorkflowStep2();
 
         if (g != null)
         {
-            collection.setWorkflowStep2(null);
-            groupService.delete(context, g);
+            if(!Group.isCustom(g) && !g.isPermanent()){
+                collection.setWorkflowStep2(null);
+                groupService.delete(context, g);
+            }
         }
 
         g = collection.getWorkflowStep3();
 
         if (g != null)
         {
-            collection.setWorkflowStep3(null);
-            groupService.delete(context, g);
+            if(!Group.isCustom(g) && !g.isPermanent()){
+                collection.setWorkflowStep3(null);
+                groupService.delete(context, g);
+            }
         }
 
         // Remove default administrators group
@@ -782,8 +789,10 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
 
         if (g != null)
         {
-            collection.setAdmins(null);
-            groupService.delete(context, g);
+            if(!Group.isCustom(g) && !g.isPermanent()){
+                collection.setAdmins(null);
+                groupService.delete(context, g);
+            }
         }
 
         // Remove default submitters group
@@ -791,8 +800,10 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
 
         if (g != null)
         {
-            collection.setSubmitters(null);
-            groupService.delete(context, g);
+            if(!Group.isCustom(g) && !g.isPermanent()){
+                collection.setSubmitters(null);
+                groupService.delete(context, g);
+            }
         }
 
         Iterator<Community> owningCommunities = collection.getCommunities().iterator();

--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -26,7 +26,6 @@ import org.dspace.event.Event;
 import org.dspace.harvest.HarvestedCollection;
 import org.dspace.harvest.service.HarvestedCollectionService;
 import org.dspace.workflow.factory.WorkflowServiceFactory;
-import org.dspace.xmlworkflow.Role;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.IOException;

--- a/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
@@ -563,7 +563,9 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
 
         if (g != null)
         {
-            groupService.delete(context, g);
+            if(!Group.isCustom(g) && !g.isPermanent()){
+                groupService.delete(context, g);
+            }
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/eperson/Group.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/Group.java
@@ -23,6 +23,8 @@ import javax.persistence.*;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Class representing a group of e-people.
@@ -251,5 +253,25 @@ public class Group extends DSpaceObject implements DSpaceObjectLegacySupport
     {
         permanent = permanence;
         setModified();
+    }
+
+    /**
+     * Syntactically check if a group was not created by DSpace.
+     * Was this group created by a user directly?
+     *
+     * @param g the group to be evaluated
+     * @return true if the group was not created by the system.
+     */
+    public static boolean isCustom(Group g){
+        String pattern = "^(COMMUNITY|COLLECTION)_[A-Fa-f\\-0-9]+_[A-Z_0-9]+";
+        // Create a Pattern object
+        Pattern r = Pattern.compile(pattern);
+        Matcher m = r.matcher(g.getName());
+        if(m.find()){
+            return false;
+        }
+        else {
+            return true;
+        }
     }
 }


### PR DESCRIPTION
Jira Ticket: [When deleting a collection role the group is also deleted, which is not appropriate for non-system-created groups](https://jira.duraspace.org/browse/DS-2687?jql=project%20%3D%20DS%20AND%20resolution%20%3D%20Unresolved%20AND%20text%20~%20%22group%20deleted%22%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC)

This work utilizes the Group.Permanent property and a syntactical check function on the group name during the community/collection deletion flow, before the group is deleted, to verify that the group is 1. Not the system Administrator or Anonymous group & 2. To verify that the group is still system created by matching on the naming convention in which system groups are created. Deletions of the system Administrator group,  the system Anonymous group, and user created groups via the community collection deletion flow is not appropriate behavior.