### PR TITLE
DS-3627: Cleanup utility leaves files in assetstore

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
@@ -289,7 +289,7 @@ public class BitstreamStorageServiceImpl implements BitstreamStorageService, Ini
 
 
                 // Since versioning allows for multiple bitstreams, check if the internal identifier isn't used on another place
-                if(0 < bitstreamService.findDuplicateInternalIdentifier(context, bitstream).size())
+                if(bitstreamService.findDuplicateInternalIdentifier(context, bitstream).isEmpty())
                 {
                     stores.get(bitstream.getStoreNumber()).remove(bitstream);
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3627

This fix was confirmed in Slack by other committers and on the DSpace committer mailing list. Any committer should feel free to merge this as soon as Travis is green.

This needs to be cherry-picked to master as well.