### PR TITLE
DS-3712: Add Error Prone checks to catch common Java code mistakes

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSDisseminator.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSDisseminator.java
@@ -142,7 +142,7 @@ public abstract class AbstractMETSDisseminator
      * change whenever Zip is regenerated (even if compressed files are unchanged)
      * 1036368000 seconds * 1000 = Nov 4, 2002 GMT (the date DSpace 1.0 was released)
      */
-    protected static final int DEFAULT_MODIFIED_DATE = 1036368000 * 1000;
+    protected static final long DEFAULT_MODIFIED_DATE = 1036368000L * 1000;
 
     /**
      * Suffix for Template objects (e.g. Item Templates)

--- a/dspace-api/src/main/java/org/dspace/content/packager/DSpaceAIPDisseminator.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/DSpaceAIPDisseminator.java
@@ -483,6 +483,7 @@ public class DSpaceAIPDisseminator extends AbstractMETSDisseminator
                 {
                     parentHandle = parents.get(0).getHandle();
                 }
+                break;
            case Constants.SITE:
                 break;
         }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -1508,10 +1508,13 @@ public class SolrServiceImpl implements SearchService, IndexingService {
             // for all the SimpleDateFormat
             case 1:
                 t = "0" + t;
+                // fall through
             case 2:
                 t = "0" + t;
+                // fall through
             case 3:
                 t = "0" + t;
+                // fall through
             case 4:
                 dfArr = new SimpleDateFormat[]{new SimpleDateFormat("yyyy")};
                 break;

--- a/dspace-api/src/main/java/org/dspace/harvest/HarvestConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/HarvestConsumer.java
@@ -94,6 +94,7 @@ public class HarvestConsumer implements Consumer
                         log.debug("Deleted collection '" + id + "' and the associated harvested_collection.");
                     }
                 }
+                break;
             default:
                 log.warn("consume() got unrecognized event: " + event.toString());
         }

--- a/dspace-api/src/main/java/org/dspace/health/ItemCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/ItemCheck.java
@@ -166,7 +166,7 @@ public class ItemCheck extends Check {
         List<Bitstream> bitstreamOrphans = bitstreamService.getNotReferencedBitstreams(context);
         for (Bitstream orphan : bitstreamOrphans) {
             UUID id = orphan.getID();
-            list_str += String.format("%d, ", id);
+            list_str += String.format("%s, ", id);
         }
         ret.append(String.format(
                 "Orphan bitstreams:       %d [%s]\n", bitstreamOrphans.size(), list_str));

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedDOIIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedDOIIdentifierProvider.java
@@ -274,7 +274,7 @@ public class VersionedDOIIdentifierProvider extends DOIIdentifierProvider
 
             if (version.getVersionNumber() > 1)
             {
-                identifier.concat(String.valueOf(DOT).concat(String.valueOf(version.getVersionNumber())));
+                identifier = identifier.concat(String.valueOf(DOT).concat(String.valueOf(version.getVersionNumber())));
             }
 
             doi.setDoi(identifier);

--- a/dspace-api/src/main/java/org/dspace/rdf/RDFConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/rdf/RDFConsumer.java
@@ -74,6 +74,7 @@ public class RDFConsumer implements Consumer
             case (Constants.BITSTREAM) :
             {
                 this.consumeBitstream(ctx, event);
+                return;
             }
             case (Constants.BUNDLE) :
             {

--- a/dspace-oai/src/main/java/org/dspace/xoai/util/DateUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/DateUtils.java
@@ -40,9 +40,9 @@ public class DateUtils
         // http://www.openarchives.org/OAI/openarchivesprotocol.html#DatestampsResponses
         SimpleDateFormat sdf = new SimpleDateFormat(
                 "yyyy-MM-dd'T'HH:mm:ss'Z'");
-        // We indicate that the returned date is in Zulu time (UTC) so we have
+        // We indicate that the returned date is in UTC so we have
         // to set the time zone of sdf correctly
-        sdf.setTimeZone(TimeZone.getTimeZone("ZULU"));
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
         String ret = sdf.format(date);
         return ret;
     }
@@ -57,7 +57,7 @@ public class DateUtils
         // First try to parse as a full UTC date/time, e.g. 2008-01-01T00:00:00Z
         SimpleDateFormat format = new SimpleDateFormat(
                 "yyyy-MM-dd'T'HH:mm:ss'Z'");
-        format.setTimeZone(TimeZone.getTimeZone("ZULU"));
+        format.setTimeZone(TimeZone.getTimeZone("UTC"));
         Date ret;
         try
         {
@@ -113,7 +113,7 @@ public class DateUtils
     {
         SimpleDateFormat format = new SimpleDateFormat(
                 "yyyy-MM-dd'T'HH:mm:ss'Z'");
-        format.setTimeZone(TimeZone.getTimeZone("ZULU"));
+        format.setTimeZone(TimeZone.getTimeZone("UTC"));
         Date ret;
         try
         {

--- a/dspace-rest/src/main/java/org/dspace/rest/FilteredCollectionsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/FilteredCollectionsResource.java
@@ -227,7 +227,7 @@ public class FilteredCollectionsResource extends Resource {
         }
         catch (ContextException e)
         {
-            processException(String.format("Could not read collection %d.  %s", collection_id, e.getMessage()), context);
+            processException(String.format("Could not read collection %s.  %s", collection_id, e.getMessage()), context);
         } finally {
             processFinally(context);
         }

--- a/dspace-rest/src/main/java/org/dspace/rest/common/Bitstream.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/common/Bitstream.java
@@ -71,7 +71,7 @@ public class Bitstream extends DSpaceObject {
         }
 
         //A logo bitstream might not have a bundle...
-        if (bitstream.getBundles() != null & bitstream.getBundles().size() >= 0)
+        if (bitstream.getBundles() != null && !bitstream.getBundles().isEmpty())
         {
             if (bitstreamService.getParentObject(context, bitstream).getType() == Constants.ITEM)
             {

--- a/dspace-services/src/test/java/org/dspace/servicemanager/config/DSpaceConfigurationServiceTest.java
+++ b/dspace-services/src/test/java/org/dspace/servicemanager/config/DSpaceConfigurationServiceTest.java
@@ -64,6 +64,7 @@ public class DSpaceConfigurationServiceTest {
     /**
      * A generic method to test that variable replacement is happening properly.
      */
+    @Test
     public void testVariableReplacement() {
 
         Map<String,Object> l = new HashMap<String,Object>();

--- a/pom.xml
+++ b/pom.xml
@@ -78,9 +78,27 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.5.1</version>
                     <configuration>
+                      <!-- Turn on http://errorprone.info -->
+                      <compilerId>javac-with-errorprone</compilerId>
+                      <forceJavacCompilerUse>true</forceJavacCompilerUse>
                       <source>${java.version}</source>
                       <target>${java.version}</target>
                     </configuration>
+                    <!-- Extra dependencies for http://errorprone.info -->
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.codehaus.plexus</groupId>
+                        <artifactId>plexus-compiler-javac-errorprone</artifactId>
+                        <version>2.8.2</version>
+                      </dependency>
+                      <!-- Override plexus-compiler-javac-errorprone's dependency on
+                           Error Prone with the latest version -->
+                      <dependency>
+                        <groupId>com.google.errorprone</groupId>
+                        <artifactId>error_prone_core</artifactId>
+                        <version>2.1.1</version>
+                      </dependency>
+                    </dependencies>
                 </plugin>
                 <!-- Used to package all DSpace JARs -->
                 <plugin>


### PR DESCRIPTION
This PR adds and enables Google's ErrorProne checks: https://github.com/google/error-prone

https://jira.duraspace.org/browse/DS-3712

It also fixes bugs reported by ErrorProne in the main API, REST-API (old one), and OAI-PMH. I've included each module's fixes as a separate commit so that they can potentially be backported (as necessary) to 6.x.

None of the bugs seem significant (and there aren't too many overall). But, ErrorProne definitely found some undiscovered issues in our codebase. Here's just a few patterns that were discovered (and fixed):
* http://errorprone.info/bugpattern/FallThrough (found in API in several areas)
* http://errorprone.info/bugpattern/FormatString (found in API and REST API)
* http://errorprone.info/bugpattern/SizeGreaterThanOrEqualsZero (found in REST API)
* http://errorprone.info/bugpattern/InvalidTimeZoneID (found in OAI-PMH)