### PR TITLE
DS-3707, DS-3715: Fixes to item level embargo/privacy in OAI-PMH

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -243,7 +243,14 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
     {
         return itemDAO.findAll(context, true, true, true, since);
     }
-
+	
+	@Override
+    public Iterator<Item> findInArchiveOrWithdrawnNonDiscoverableModifiedSince(Context context, Date since)
+            throws SQLException
+    {
+        return itemDAO.findAll(context, true, true, false, since);
+    }
+	
     @Override
     public void updateLastModified(Context context, Item item) throws SQLException, AuthorizeException {
         item.setLastModified(new Date());

--- a/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
@@ -136,6 +136,16 @@ public interface ItemService extends DSpaceObjectService<Item>, DSpaceObjectLega
     public Iterator<Item> findInArchiveOrWithdrawnDiscoverableModifiedSince(Context context, Date since)
             throws SQLException;
 
+	/**
+     * Get all Items installed or withdrawn, NON-discoverable, and modified since a Date.
+     * @param context context
+     * @param since earliest interesting last-modified date, or null for no date test.
+     * @return an iterator over the items in the collection.
+     * @throws SQLException if database error
+     */
+    public Iterator<Item> findInArchiveOrWithdrawnNonDiscoverableModifiedSince(Context context, Date since)
+            throws SQLException;
+			
     /**
      * Get all the items in this collection. The order is indeterminate.
      *

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -219,6 +219,121 @@ public class ItemTest extends AbstractDSpaceObjectTest
     }
 
     /**
+     * Test of findInArchiveOrWithdrawnDiscoverableModifiedSince method, of class Item.
+     */
+    @Test
+    public void testFindInArchiveOrWithdrawnDiscoverableModifiedSince() throws Exception {
+        // Init item to be both withdrawn and discoverable
+        it.setWithdrawn(true);
+        it.setArchived(false);
+        it.setDiscoverable(true);
+
+        // Test 0: Using a future 'modified since' date, we should get non-null list, with no items
+        Iterator<Item> all = itemService.findInArchiveOrWithdrawnDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),1));
+        assertThat("testFindInArchiveOrWithdrawnDiscoverableModifiedSince 0", all, notNullValue());
+
+        boolean added = false;
+        while(all.hasNext()) {
+            Item tmp = all.next();
+            if(tmp.equals(it)) {
+                added = true;
+            }
+        }
+
+        // Test 1: we should NOT find our item in this list
+        assertFalse("testFindInArchiveOrWithdrawnDiscoverableModifiedSince 1", added);
+
+        // Test 2: Using a past 'modified since' date, we should get a non-null list containing our item
+        all = itemService.findInArchiveOrWithdrawnDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),-1));
+        assertThat("testFindInArchiveOrWithdrawnDiscoverableModifiedSince 2", all, notNullValue());
+
+        added = false;
+        while(all.hasNext()) {
+            Item tmp = all.next();
+            if(tmp.equals(it)) {
+                added = true;
+            }
+        }
+        // Test 3: we should find our item in this list
+        assertTrue("testFindInArchiveOrWithdrawnDiscoverableModifiedSince 3", added);
+
+        // Repeat Tests 2, 3 with withdrawn = false and archived = true as this should result in same behaviour
+        it.setWithdrawn(false);
+        it.setArchived(true);
+
+        // Test 4: Using a past 'modified since' date, we should get a non-null list containing our item
+        all = itemService.findInArchiveOrWithdrawnDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),-1));
+        assertThat("testFindInArchiveOrWithdrawnDiscoverableModifiedSince 4", all, notNullValue());
+
+        added = false;
+        while(all.hasNext()) {
+            Item tmp = all.next();
+            if(tmp.equals(it)) {
+                added = true;
+            }
+        }
+        // Test 5: We should find our item in this list
+        assertTrue("testFindInArchiveOrWithdrawnDiscoverableModifiedSince 5", added);
+    }
+
+    /**
+     * Test of findInArchiveOrWithdrawnNonDiscoverableModifiedSince method, of class Item.
+     */
+    @Test
+    public void testFindInArchiveOrWithdrawnNonDiscoverableModifiedSince() throws Exception {
+        // Init item to be both withdrawn and discoverable
+        it.setWithdrawn(true);
+        it.setArchived(false);
+        it.setDiscoverable(false);
+
+        // Test 0: Using a future 'modified since' date, we should get non-null list, with no items
+        Iterator<Item> all = itemService.findInArchiveOrWithdrawnNonDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),1));
+        assertThat("testFindInArchiveOrWithdrawnNonDiscoverableModifiedSince 0", all, notNullValue());
+
+        boolean added = false;
+        while(all.hasNext()) {
+            Item tmp = all.next();
+            if(tmp.equals(it)) {
+                added = true;
+            }
+        }
+
+        // Test 1: We should NOT find our item in this list
+        assertFalse("testFindInArchiveOrWithdrawnNonDiscoverableModifiedSince 1", added);
+
+        // Test 2: Using a past 'modified since' date, we should get a non-null list containing our item
+        all = itemService.findInArchiveOrWithdrawnNonDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),-1));
+        assertThat("testFindInArchiveOrWithdrawnNonDiscoverableModifiedSince 2", all, notNullValue());
+
+        added = false;
+        while(all.hasNext()) {
+            Item tmp = all.next();
+            if(tmp.equals(it)) {
+                added = true;
+            }
+        }
+        // Test 3: We should find our item in this list
+        assertTrue("testFindInArchiveOrWithdrawnNonDiscoverableModifiedSince 3", added);
+
+        // Repeat Tests 2, 3 with discoverable = true
+        it.setDiscoverable(true);
+
+        // Test 4: Now we should still get a non-null list with NO items since item is discoverable
+        all = itemService.findInArchiveOrWithdrawnNonDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),-1));
+        assertThat("testFindInArchiveOrWithdrawnNonDiscoverableModifiedSince 4", all, notNullValue());
+
+        added = false;
+        while(all.hasNext()) {
+            Item tmp = all.next();
+            if(tmp.equals(it)) {
+                added = true;
+            }
+        }
+        // Test 5: We should NOT find our item in this list
+        assertFalse("testFindInArchiveOrWithdrawnNonDiscoverableModifiedSince 5", added);
+    }
+
+    /**
      * Test of getID method, of class Item.
      */
     @Override

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -230,7 +230,7 @@ public class ItemTest extends AbstractDSpaceObjectTest
 
         // Test 0: Using a future 'modified since' date, we should get non-null list, with no items
         Iterator<Item> all = itemService.findInArchiveOrWithdrawnDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),1));
-        assertThat("testFindInArchiveOrWithdrawnDiscoverableModifiedSince 0", all, notNullValue());
+        assertThat("Returned list should not be null", all, notNullValue());
 
         boolean added = false;
         while(all.hasNext()) {
@@ -241,11 +241,11 @@ public class ItemTest extends AbstractDSpaceObjectTest
         }
 
         // Test 1: we should NOT find our item in this list
-        assertFalse("testFindInArchiveOrWithdrawnDiscoverableModifiedSince 1", added);
+        assertFalse("List should not contain item when passing a date newer than item last-modified date", added);
 
         // Test 2: Using a past 'modified since' date, we should get a non-null list containing our item
         all = itemService.findInArchiveOrWithdrawnDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),-1));
-        assertThat("testFindInArchiveOrWithdrawnDiscoverableModifiedSince 2", all, notNullValue());
+        assertThat("Returned list should not be null", all, notNullValue());
 
         added = false;
         while(all.hasNext()) {
@@ -255,7 +255,7 @@ public class ItemTest extends AbstractDSpaceObjectTest
             }
         }
         // Test 3: we should find our item in this list
-        assertTrue("testFindInArchiveOrWithdrawnDiscoverableModifiedSince 3", added);
+        assertTrue("List should contain item when passing a date older than item last-modified date", added);
 
         // Repeat Tests 2, 3 with withdrawn = false and archived = true as this should result in same behaviour
         it.setWithdrawn(false);
@@ -263,7 +263,7 @@ public class ItemTest extends AbstractDSpaceObjectTest
 
         // Test 4: Using a past 'modified since' date, we should get a non-null list containing our item
         all = itemService.findInArchiveOrWithdrawnDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),-1));
-        assertThat("testFindInArchiveOrWithdrawnDiscoverableModifiedSince 4", all, notNullValue());
+        assertThat("Returned list should not be null", all, notNullValue());
 
         added = false;
         while(all.hasNext()) {
@@ -273,7 +273,23 @@ public class ItemTest extends AbstractDSpaceObjectTest
             }
         }
         // Test 5: We should find our item in this list
-        assertTrue("testFindInArchiveOrWithdrawnDiscoverableModifiedSince 5", added);
+        assertTrue("List should contain item when passing a date older than item last-modified date", added);
+
+        // Test 6: Make sure non-discoverable items are not returned, regardless of archived/withdrawn state
+        it.setDiscoverable(false);
+        all = itemService.findInArchiveOrWithdrawnDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),-1));
+        assertThat("Returned list should not be null", all, notNullValue());
+
+        added = false;
+        while(all.hasNext()) {
+            Item tmp = all.next();
+            if(tmp.equals(it)) {
+                added = true;
+            }
+        }
+        // Test 7: We should not find our item in this list
+        assertFalse("List should not contain non-discoverable items", added);
+
     }
 
     /**
@@ -288,7 +304,7 @@ public class ItemTest extends AbstractDSpaceObjectTest
 
         // Test 0: Using a future 'modified since' date, we should get non-null list, with no items
         Iterator<Item> all = itemService.findInArchiveOrWithdrawnNonDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),1));
-        assertThat("testFindInArchiveOrWithdrawnNonDiscoverableModifiedSince 0", all, notNullValue());
+        assertThat("Returned list should not be null", all, notNullValue());
 
         boolean added = false;
         while(all.hasNext()) {
@@ -299,11 +315,11 @@ public class ItemTest extends AbstractDSpaceObjectTest
         }
 
         // Test 1: We should NOT find our item in this list
-        assertFalse("testFindInArchiveOrWithdrawnNonDiscoverableModifiedSince 1", added);
+        assertFalse("List should not contain item when passing a date newer than item last-modified date", added);
 
         // Test 2: Using a past 'modified since' date, we should get a non-null list containing our item
         all = itemService.findInArchiveOrWithdrawnNonDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),-1));
-        assertThat("testFindInArchiveOrWithdrawnNonDiscoverableModifiedSince 2", all, notNullValue());
+        assertThat("Returned list should not be null", all, notNullValue());
 
         added = false;
         while(all.hasNext()) {
@@ -313,14 +329,14 @@ public class ItemTest extends AbstractDSpaceObjectTest
             }
         }
         // Test 3: We should find our item in this list
-        assertTrue("testFindInArchiveOrWithdrawnNonDiscoverableModifiedSince 3", added);
+        assertTrue("List should contain item when passing a date older than item last-modified date", added);
 
         // Repeat Tests 2, 3 with discoverable = true
         it.setDiscoverable(true);
 
         // Test 4: Now we should still get a non-null list with NO items since item is discoverable
         all = itemService.findInArchiveOrWithdrawnNonDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),-1));
-        assertThat("testFindInArchiveOrWithdrawnNonDiscoverableModifiedSince 4", all, notNullValue());
+        assertThat("Returned list should not be null", all, notNullValue());
 
         added = false;
         while(all.hasNext()) {
@@ -330,7 +346,7 @@ public class ItemTest extends AbstractDSpaceObjectTest
             }
         }
         // Test 5: We should NOT find our item in this list
-        assertFalse("testFindInArchiveOrWithdrawnNonDiscoverableModifiedSince 5", added);
+        assertFalse("List should not contain discoverable items", added);
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -230,7 +230,7 @@ public class ItemTest extends AbstractDSpaceObjectTest
 
         // Test 0: Using a future 'modified since' date, we should get non-null list, with no items
         Iterator<Item> all = itemService.findInArchiveOrWithdrawnDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),1));
-        assertThat("Returned list should not be null (findInArchiveOrWithdrawnDiscoverableModifiedSince Test 0)", all, notNullValue());
+        assertThat("Returned list should not be null", all, notNullValue());
 
         boolean added = false;
         while(all.hasNext()) {
@@ -241,11 +241,11 @@ public class ItemTest extends AbstractDSpaceObjectTest
         }
 
         // Test 1: we should NOT find our item in this list
-        assertFalse("List should not contain item when passing a date newer than item last-modified date (findInArchiveOrWithdrawnDiscoverableModifiedSince Test 1)", added);
+        assertFalse("List should not contain item when passing a date newer than item last-modified date", added);
 
         // Test 2: Using a past 'modified since' date, we should get a non-null list containing our item
         all = itemService.findInArchiveOrWithdrawnDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),-1));
-        assertThat("Returned list should not be null (findInArchiveOrWithdrawnDiscoverableModifiedSince Test 2)", all, notNullValue());
+        assertThat("Returned list should not be null", all, notNullValue());
 
         added = false;
         while(all.hasNext()) {
@@ -255,7 +255,7 @@ public class ItemTest extends AbstractDSpaceObjectTest
             }
         }
         // Test 3: we should find our item in this list
-        assertTrue("List should contain item when passing a date older than item last-modified date (findInArchiveOrWithdrawnDiscoverableModifiedSince Test 3)", added);
+        assertTrue("List should contain item when passing a date older than item last-modified date", added);
 
         // Repeat Tests 2, 3 with withdrawn = false and archived = true as this should result in same behaviour
         it.setWithdrawn(false);
@@ -263,7 +263,7 @@ public class ItemTest extends AbstractDSpaceObjectTest
 
         // Test 4: Using a past 'modified since' date, we should get a non-null list containing our item
         all = itemService.findInArchiveOrWithdrawnDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),-1));
-        assertThat("Returned list should not be null (findInArchiveOrWithdrawnDiscoverableModifiedSince Test 4)", all, notNullValue());
+        assertThat("Returned list should not be null", all, notNullValue());
 
         added = false;
         while(all.hasNext()) {
@@ -273,12 +273,12 @@ public class ItemTest extends AbstractDSpaceObjectTest
             }
         }
         // Test 5: We should find our item in this list
-        assertTrue("List should contain item when passing a date older than item last-modified date (findInArchiveOrWithdrawnDiscoverableModifiedSince Test 5)", added);
+        assertTrue("List should contain item when passing a date older than item last-modified date", added);
 
         // Test 6: Make sure non-discoverable items are not returned, regardless of archived/withdrawn state
         it.setDiscoverable(false);
         all = itemService.findInArchiveOrWithdrawnDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),-1));
-        assertThat("Returned list should not be null (findInArchiveOrWithdrawnDiscoverableModifiedSince Test 6)", all, notNullValue());
+        assertThat("Returned list should not be null", all, notNullValue());
 
         added = false;
         while(all.hasNext()) {
@@ -304,7 +304,7 @@ public class ItemTest extends AbstractDSpaceObjectTest
 
         // Test 0: Using a future 'modified since' date, we should get non-null list, with no items
         Iterator<Item> all = itemService.findInArchiveOrWithdrawnNonDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),1));
-        assertThat("Returned list should not be null (findInArchiveOrWithdrawnNonDiscoverableModifiedSince Test 0)", all, notNullValue());
+        assertThat("Returned list should not be null", all, notNullValue());
 
         boolean added = false;
         while(all.hasNext()) {
@@ -315,11 +315,11 @@ public class ItemTest extends AbstractDSpaceObjectTest
         }
 
         // Test 1: We should NOT find our item in this list
-        assertFalse("List should not contain item when passing a date newer than item last-modified date (findInArchiveOrWithdrawnNonDiscoverableModifiedSince Test 1)", added);
+        assertFalse("List should not contain item when passing a date newer than item last-modified date", added);
 
         // Test 2: Using a past 'modified since' date, we should get a non-null list containing our item
         all = itemService.findInArchiveOrWithdrawnNonDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),-1));
-        assertThat("Returned list should not be null (findInArchiveOrWithdrawnNonDiscoverableModifiedSince Test 2)", all, notNullValue());
+        assertThat("Returned list should not be null", all, notNullValue());
 
         added = false;
         while(all.hasNext()) {
@@ -330,14 +330,14 @@ public class ItemTest extends AbstractDSpaceObjectTest
         }
 
         // Test 3: We should find our item in this list
-        assertTrue("List should contain item when passing a date older than item last-modified date (findInArchiveOrWithdrawnNonDiscoverableModifiedSince Test 3)", added);
+        assertTrue("List should contain item when passing a date older than item last-modified date", added);
 
         // Repeat Tests 2, 3 with discoverable = true
         it.setDiscoverable(true);
 
         // Test 4: Now we should still get a non-null list with NO items since item is discoverable
         all = itemService.findInArchiveOrWithdrawnNonDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),-1));
-        assertThat("Returned list should not be null (findInArchiveOrWithdrawnNonDiscoverableModifiedSince Test 4)", all, notNullValue());
+        assertThat("Returned list should not be null", all, notNullValue());
 
         added = false;
         while(all.hasNext()) {
@@ -348,7 +348,7 @@ public class ItemTest extends AbstractDSpaceObjectTest
         }
 
         // Test 5: We should NOT find our item in this list
-        assertFalse("List should not contain discoverable items (findInArchiveOrWithdrawnNonDiscoverableModifiedSince Test 5)", added);
+        assertFalse("List should not contain discoverable items", added);
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -230,7 +230,7 @@ public class ItemTest extends AbstractDSpaceObjectTest
 
         // Test 0: Using a future 'modified since' date, we should get non-null list, with no items
         Iterator<Item> all = itemService.findInArchiveOrWithdrawnDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),1));
-        assertThat("Returned list should not be null", all, notNullValue());
+        assertThat("Returned list should not be null (findInArchiveOrWithdrawnDiscoverableModifiedSince Test 0)", all, notNullValue());
 
         boolean added = false;
         while(all.hasNext()) {
@@ -241,11 +241,11 @@ public class ItemTest extends AbstractDSpaceObjectTest
         }
 
         // Test 1: we should NOT find our item in this list
-        assertFalse("List should not contain item when passing a date newer than item last-modified date", added);
+        assertFalse("List should not contain item when passing a date newer than item last-modified date (findInArchiveOrWithdrawnDiscoverableModifiedSince Test 1)", added);
 
         // Test 2: Using a past 'modified since' date, we should get a non-null list containing our item
         all = itemService.findInArchiveOrWithdrawnDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),-1));
-        assertThat("Returned list should not be null", all, notNullValue());
+        assertThat("Returned list should not be null (findInArchiveOrWithdrawnDiscoverableModifiedSince Test 2)", all, notNullValue());
 
         added = false;
         while(all.hasNext()) {
@@ -255,7 +255,7 @@ public class ItemTest extends AbstractDSpaceObjectTest
             }
         }
         // Test 3: we should find our item in this list
-        assertTrue("List should contain item when passing a date older than item last-modified date", added);
+        assertTrue("List should contain item when passing a date older than item last-modified date (findInArchiveOrWithdrawnDiscoverableModifiedSince Test 3)", added);
 
         // Repeat Tests 2, 3 with withdrawn = false and archived = true as this should result in same behaviour
         it.setWithdrawn(false);
@@ -263,7 +263,7 @@ public class ItemTest extends AbstractDSpaceObjectTest
 
         // Test 4: Using a past 'modified since' date, we should get a non-null list containing our item
         all = itemService.findInArchiveOrWithdrawnDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),-1));
-        assertThat("Returned list should not be null", all, notNullValue());
+        assertThat("Returned list should not be null (findInArchiveOrWithdrawnDiscoverableModifiedSince Test 4)", all, notNullValue());
 
         added = false;
         while(all.hasNext()) {
@@ -273,12 +273,12 @@ public class ItemTest extends AbstractDSpaceObjectTest
             }
         }
         // Test 5: We should find our item in this list
-        assertTrue("List should contain item when passing a date older than item last-modified date", added);
+        assertTrue("List should contain item when passing a date older than item last-modified date (findInArchiveOrWithdrawnDiscoverableModifiedSince Test 5)", added);
 
         // Test 6: Make sure non-discoverable items are not returned, regardless of archived/withdrawn state
         it.setDiscoverable(false);
         all = itemService.findInArchiveOrWithdrawnDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),-1));
-        assertThat("Returned list should not be null", all, notNullValue());
+        assertThat("Returned list should not be null (findInArchiveOrWithdrawnDiscoverableModifiedSince Test 6)", all, notNullValue());
 
         added = false;
         while(all.hasNext()) {
@@ -304,7 +304,7 @@ public class ItemTest extends AbstractDSpaceObjectTest
 
         // Test 0: Using a future 'modified since' date, we should get non-null list, with no items
         Iterator<Item> all = itemService.findInArchiveOrWithdrawnNonDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),1));
-        assertThat("Returned list should not be null", all, notNullValue());
+        assertThat("Returned list should not be null (findInArchiveOrWithdrawnNonDiscoverableModifiedSince Test 0)", all, notNullValue());
 
         boolean added = false;
         while(all.hasNext()) {
@@ -315,11 +315,11 @@ public class ItemTest extends AbstractDSpaceObjectTest
         }
 
         // Test 1: We should NOT find our item in this list
-        assertFalse("List should not contain item when passing a date newer than item last-modified date", added);
+        assertFalse("List should not contain item when passing a date newer than item last-modified date (findInArchiveOrWithdrawnNonDiscoverableModifiedSince Test 1)", added);
 
         // Test 2: Using a past 'modified since' date, we should get a non-null list containing our item
         all = itemService.findInArchiveOrWithdrawnNonDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),-1));
-        assertThat("Returned list should not be null", all, notNullValue());
+        assertThat("Returned list should not be null (findInArchiveOrWithdrawnNonDiscoverableModifiedSince Test 2)", all, notNullValue());
 
         added = false;
         while(all.hasNext()) {
@@ -328,15 +328,16 @@ public class ItemTest extends AbstractDSpaceObjectTest
                 added = true;
             }
         }
+
         // Test 3: We should find our item in this list
-        assertTrue("List should contain item when passing a date older than item last-modified date", added);
+        assertTrue("List should contain item when passing a date older than item last-modified date (findInArchiveOrWithdrawnNonDiscoverableModifiedSince Test 3)", added);
 
         // Repeat Tests 2, 3 with discoverable = true
         it.setDiscoverable(true);
 
         // Test 4: Now we should still get a non-null list with NO items since item is discoverable
         all = itemService.findInArchiveOrWithdrawnNonDiscoverableModifiedSince(context,DateUtils.addDays(it.getLastModified(),-1));
-        assertThat("Returned list should not be null", all, notNullValue());
+        assertThat("Returned list should not be null (findInArchiveOrWithdrawnNonDiscoverableModifiedSince Test 4)", all, notNullValue());
 
         added = false;
         while(all.hasNext()) {
@@ -345,8 +346,9 @@ public class ItemTest extends AbstractDSpaceObjectTest
                 added = true;
             }
         }
+
         // Test 5: We should NOT find our item in this list
-        assertFalse("List should not contain discoverable items", added);
+        assertFalse("List should not contain discoverable items (findInArchiveOrWithdrawnNonDiscoverableModifiedSince Test 5)", added);
     }
 
     /**

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -58,6 +58,8 @@ import java.util.*;
 import static com.lyncode.xoai.dataprovider.core.Granularity.Second;
 import static org.dspace.xoai.util.ItemUtils.retrieveMetadata;
 
+import org.dspace.authorize.ResourcePolicy;
+
 /**
  * @author Lyncode Development Team <dspace@lyncode.com>
  */
@@ -81,7 +83,6 @@ public class XOAI {
 
     private final AuthorizeService authorizeService;
     private final ItemService itemService;
-
 
     private List<String> getFileFormats(Item item) {
         List<String> formats = new ArrayList<>();
@@ -146,7 +147,6 @@ public class XOAI {
             }
             solrServerResolver.getServer().commit();
 
-
             if (optimize) {
                 println("Optimizing Index");
                 solrServerResolver.getServer().optimize();
@@ -162,16 +162,54 @@ public class XOAI {
     }
 
     private int index(Date last) throws DSpaceSolrIndexerException {
-        System.out
-                .println("Incremental import. Searching for documents modified after: "
-                        + last.toString());
-        // Index both in_archive items AND withdrawn items. Withdrawn items will be flagged withdrawn
-        // (in order to notify external OAI harvesters of their new status)
+        System.out.println("Incremental import. Searching for documents modified after: " + last.toString());
+        /*
+         * Index all changed or new items or items whose visibility is viable to
+         * change due to an embargo.
+         */
         try {
-            Iterator<Item> iterator = itemService.findInArchiveOrWithdrawnDiscoverableModifiedSince(
-                    context, last);
-            return this.index(iterator);
+            Iterator<Item> discoverableChangedItems = itemService
+                    .findInArchiveOrWithdrawnDiscoverableModifiedSince(context, last);
+
+            Iterator<Item> nonDiscoverableChangedItems = itemService
+                    .findInArchiveOrWithdrawnNonDiscoverableModifiedSince(context, last);
+
+            Iterator<Item> possiblyChangedItems = getItemsWithPossibleChangesBefore(last);
+
+            return this.index(discoverableChangedItems) + this.index(nonDiscoverableChangedItems)
+                    + this.index(possiblyChangedItems);
+
         } catch (SQLException ex) {
+            throw new DSpaceSolrIndexerException(ex.getMessage(), ex);
+        }
+    }
+
+    /**
+     * Get all items already in the index which are viable to change visibility
+     * due to an embargo. Only consider those which haven't been modified
+     * anyways since the last update, so they aren't updated twice in one import
+     * run.
+     * 
+     * @param last
+     *            maximum date for an item to be considered for an update
+     * @return Iterator over list of items which might have changed their
+     *         visibility since the last update.
+     * @throws DSpaceSolrIndexerException
+     */
+    private Iterator<Item> getItemsWithPossibleChangesBefore(Date last) throws DSpaceSolrIndexerException {
+        try {
+            SolrQuery params = new SolrQuery("item.willChangeStatus:true").addField("item.id");
+            SolrDocumentList documents = DSpaceSolrSearch.query(solrServerResolver.getServer(), params);
+            List<Item> items = new LinkedList<Item>();
+            for (int i = 0; i < documents.getNumFound(); i++) {
+                Item item = itemService.find(context,
+                        UUID.fromString((String) documents.get(i).getFieldValue("item.id")));
+                if (item.getLastModified().before(last)) {
+                    items.add(item);
+                }
+            }
+            return items.iterator();
+        } catch (SolrServerException | SQLException | DSpaceSolrException ex) {
             throw new DSpaceSolrIndexerException(ex.getMessage(), ex);
         }
     }
@@ -179,35 +217,77 @@ public class XOAI {
     private int indexAll() throws DSpaceSolrIndexerException {
         System.out.println("Full import");
         try {
-            // Index both in_archive items AND withdrawn items. Withdrawn items will be flagged withdrawn
+            // Index both in_archive items AND withdrawn items. Withdrawn items
+            // will be flagged withdrawn
             // (in order to notify external OAI harvesters of their new status)
-            Iterator<Item> iterator = itemService.findInArchiveOrWithdrawnDiscoverableModifiedSince(
-                    context, null);
-            return this.index(iterator);
+            Iterator<Item> discoverableItems = itemService.findInArchiveOrWithdrawnDiscoverableModifiedSince(context,
+                    null);
+            Iterator<Item> nonDiscoverableItems = itemService
+                    .findInArchiveOrWithdrawnNonDiscoverableModifiedSince(context, null);
+            return this.index(discoverableItems) + this.index(nonDiscoverableItems);
         } catch (SQLException ex) {
             throw new DSpaceSolrIndexerException(ex.getMessage(), ex);
         }
     }
 
-    private int index(Iterator<Item> iterator)
-            throws DSpaceSolrIndexerException {
+    /**
+     * Check if an item is already indexed. Using this, it is possible to check
+     * if withdrawn or nondiscoverable items have to be indexed at all.
+     * 
+     * @param item
+     *            Item that should be checked for its presence in the index.
+     * @return has it been indexed?
+     */
+    private boolean checkIfIndexed(Item item) {
+        SolrQuery params = new SolrQuery("item.id:" + item.getID().toString()).addField("item.id");
+        try {
+            SolrDocumentList documents = DSpaceSolrSearch.query(solrServerResolver.getServer(), params);
+            return documents.getNumFound() == 1;
+        } catch (DSpaceSolrException | SolrServerException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Check if an item is flagged visible in the index.
+     * 
+     * @param item
+     *            Item that should be checked for its presence in the index.
+     * @return has it been indexed?
+     */
+    private boolean checkIfVisibleInOAI(Item item) {
+        SolrQuery params = new SolrQuery("item.id:" + item.getID().toString()).addField("item.public");
+        try {
+            SolrDocumentList documents = DSpaceSolrSearch.query(solrServerResolver.getServer(), params);
+            if (documents.getNumFound() == 1) {
+                return (boolean) documents.get(0).getFieldValue("item.public");
+            } else {
+                return false;
+            }
+        } catch (DSpaceSolrException | SolrServerException e) {
+            return false;
+        }
+    }
+
+    private int index(Iterator<Item> iterator) throws DSpaceSolrIndexerException {
         try {
             int i = 0;
             SolrServer server = solrServerResolver.getServer();
             while (iterator.hasNext()) {
                 try {
                     Item item = iterator.next();
-                    server.add(this.index(item));
+                    System.out.println("indexing item " + item.getID());
 
-                    //Uncache the item to keep memory consumption low
+                    server.add(this.index(item));
                     context.uncacheEntity(item);
 
-                } catch (SQLException | MetadataBindException | ParseException
-                        | XMLStreamException | WritingXmlException ex) {
+                } catch (SQLException | MetadataBindException | ParseException | XMLStreamException
+                        | WritingXmlException ex) {
                     log.error(ex.getMessage(), ex);
                 }
                 i++;
-                if (i % 100 == 0) System.out.println(i + " items imported so far...");
+                if (i % 100 == 0)
+                    System.out.println(i + " items imported so far...");
             }
             System.out.println("Total: " + i + " items");
             server.commit();
@@ -217,32 +297,112 @@ public class XOAI {
         }
     }
 
-    private SolrInputDocument index(Item item) throws SQLException, MetadataBindException, ParseException, XMLStreamException, WritingXmlException {
+    /**
+     * Method to get the most recent date on which the item changed concerning
+     * the OAI deleted status (policy start and end dates for all anonymous READ
+     * policies and the standard last modification date)
+     *
+     * @param item
+     *            Item
+     * @return date
+     * @throws SQLException
+     */
+
+    private Date getMostRecentModificationDate(Item item) throws SQLException {
+        List<Date> dates = new LinkedList<Date>();
+        List<ResourcePolicy> policies = authorizeService.getPoliciesActionFilter(context, item, Constants.READ);
+        for (ResourcePolicy policy : policies) {
+            if (policy.getGroup().getName().equals("Anonymous")) {
+                if (policy.getStartDate() != null) {
+                    dates.add(policy.getStartDate());
+                }
+                if (policy.getEndDate() != null) {
+                    dates.add(policy.getEndDate());
+                }
+            }
+        }
+        dates.add(item.getLastModified());
+        Collections.sort(dates);
+        Date now = new Date();
+        Date lastChange = null;
+        for (Date d : dates) {
+            if (d.before(now)) {
+                lastChange = d;
+            }
+        }
+        return lastChange;
+    }
+
+    private SolrInputDocument index(Item item)
+            throws SQLException, MetadataBindException, ParseException, XMLStreamException, WritingXmlException {
         SolrInputDocument doc = new SolrInputDocument();
         doc.addField("item.id", item.getID());
-        boolean pub = this.isPublic(item);
-        doc.addField("item.public", pub);
+
         String handle = item.getHandle();
         doc.addField("item.handle", handle);
-        doc.addField("item.lastmodified", item.getLastModified());
+
+        boolean isEmbargoed = !this.isPublic(item);
+        boolean isCurrentlyVisible = this.checkIfVisibleInOAI(item);
+        boolean isIndexed = this.checkIfIndexed(item);
+
+        /*
+         * If the item is not under embargo, it should be visible. If it is,
+         * make it invisible if this is the first time it is indexed. For
+         * subsequent index runs, keep the current status, so that if the item
+         * is embargoed again, it is flagged as deleted instead and does not
+         * just disappear, or if it is still under embargo, it won't become
+         * visible and be known to harvesters as deleted before it gets
+         * disseminated for the first time. The item has to be indexed directly
+         * after publication even if it is still embargoed, because its
+         * lastModified date will not change when the embargo end date (or start
+         * date) is reached. To circumvent this, an item which will change its
+         * status in the future will be marked as such.
+         */
+
+        boolean isPublic = isEmbargoed ? (isIndexed ? isCurrentlyVisible : false) : true;
+        
+        doc.addField("item.public", isPublic);
+
+        // if the visibility of the item will change in the future due to an
+        // embargo, mark it as such.
+
+        doc.addField("item.willChangeStatus", willChangeStatus(item));
+
+        /*
+         * Mark an item as deleted not only if it is withdrawn, but also if it
+         * is made private, because items should not simply disappear from OAI
+         * with a transient deletion policy. Do not set the flag for still
+         * invisible embargoed items, because this will override the item.public
+         * flag.
+         */
+
+        doc.addField("item.deleted",
+                (item.isWithdrawn() || !item.isDiscoverable() || (isEmbargoed ? isPublic : false)));
+
+        /*
+         * An item that is embargoed will potentially not be harvested by
+         * incremental harvesters if the from and until params do not encompass
+         * both the standard lastModified date and the anonymous-READ resource
+         * policy start date. The same is true for the end date, where
+         * harvesters might not get a tombstone record. Therefore, consider all
+         * relevant policy dates and the standard lastModified date and take the
+         * most recent of those which have already passed.
+         */
+        doc.addField("item.lastmodified", this.getMostRecentModificationDate(item));
+
         if (item.getSubmitter() != null) {
             doc.addField("item.submitter", item.getSubmitter().getEmail());
         }
-        doc.addField("item.deleted", item.isWithdrawn() ? "true" : "false");
-        for (Collection col : item.getCollections())
-            doc.addField("item.collections",
-                    "col_" + col.getHandle().replace("/", "_"));
-        for (Community com : collectionsService.flatParentCommunities(context, item))
-            doc.addField("item.communities",
-                    "com_" + com.getHandle().replace("/", "_"));
 
-        List<MetadataValue> allData = itemService.getMetadata(item,
-                Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+        for (Collection col : item.getCollections())
+            doc.addField("item.collections", "col_" + col.getHandle().replace("/", "_"));
+        for (Community com : collectionsService.flatParentCommunities(context, item))
+            doc.addField("item.communities", "com_" + com.getHandle().replace("/", "_"));
+
+        List<MetadataValue> allData = itemService.getMetadata(item, Item.ANY, Item.ANY, Item.ANY, Item.ANY);
         for (MetadataValue dc : allData) {
             MetadataField field = dc.getMetadataField();
-            String key = "metadata."
-                    + field.getMetadataSchema().getName() + "."
-                    + field.getElement();
+            String key = "metadata." + field.getMetadataSchema().getName() + "." + field.getElement();
             if (field.getQualifier() != null) {
                 key += "." + field.getQualifier();
             }
@@ -271,10 +431,31 @@ public class XOAI {
         return doc;
     }
 
+    private boolean willChangeStatus(Item item) throws SQLException {
+
+        List<ResourcePolicy> policies = authorizeService.getPoliciesActionFilter(context, item, Constants.READ);
+        for (ResourcePolicy policy : policies) {
+            if (policy.getGroup().getName().equals("Anonymous")) {
+                System.out.println("found anonymous READ for item " + item.getID());
+                if (policy.getStartDate() != null && policy.getStartDate().after(new Date())) {
+                    System.out.println("policy has start date after current date: " + policy.getStartDate());
+                    return true;
+                }
+                if (policy.getEndDate() != null && policy.getEndDate().after(new Date())) {
+                    System.out.println("policy has end date after current date: " + policy.getEndDate());
+                    return true;
+                }
+            }
+        }
+        System.out.println("all policies processed for item " + item.getID()
+                + "; based on current information, item will not change visibility in the future.");
+        return false;
+    }
+
     private boolean isPublic(Item item) {
         boolean pub = false;
         try {
-            //Check if READ access allowed on this Item
+            // Check if READ access allowed on this Item
             pub = authorizeService.authorizeActionBoolean(context, item, Constants.READ);
         } catch (SQLException ex) {
             log.error(ex.getMessage());
@@ -282,12 +463,10 @@ public class XOAI {
         return pub;
     }
 
-
     private static boolean getKnownExplanation(Throwable t) {
         if (t instanceof ConnectException) {
-            System.err.println("Solr server ("
-                    + ConfigurationManager.getProperty("oai", "solr.url")
-                    + ") is down, turn it on.");
+            System.err.println(
+                    "Solr server (" + ConfigurationManager.getProperty("oai", "solr.url") + ") is down, turn it on.");
             return true;
         }
 
@@ -313,7 +492,7 @@ public class XOAI {
         }
     }
 
-    private static void cleanCache(XOAIItemCacheService xoaiItemCacheService,  XOAICacheService xoaiCacheService) throws IOException {
+    private static void cleanCache(XOAIItemCacheService xoaiItemCacheService, XOAICacheService xoaiCacheService) throws IOException {
         System.out.println("Purging cached OAI responses.");
         xoaiItemCacheService.deleteAll();
         xoaiCacheService.deleteAll();
@@ -326,10 +505,7 @@ public class XOAI {
 
     public static void main(String[] argv) throws IOException, ConfigurationException {
 
-
-        AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext(new Class[]{
-                BasicConfiguration.class
-        });
+        AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext(new Class[] { BasicConfiguration.class });
 
         ConfigurationService configurationService = applicationContext.getBean(ConfigurationService.class);
         XOAICacheService cacheService = applicationContext.getBean(XOAICacheService.class);
@@ -341,20 +517,18 @@ public class XOAI {
             CommandLineParser parser = new PosixParser();
             Options options = new Options();
             options.addOption("c", "clear", false, "Clear index before indexing");
-            options.addOption("o", "optimize", false,
-                    "Optimize index at the end");
+            options.addOption("o", "optimize", false, "Optimize index at the end");
             options.addOption("v", "verbose", false, "Verbose output");
             options.addOption("h", "help", false, "Shows some help");
             options.addOption("n", "number", true, "FOR DEVELOPMENT MUST DELETE");
             CommandLine line = parser.parse(options, argv);
 
-            String[] validSolrCommands = {COMMAND_IMPORT, COMMAND_CLEAN_CACHE};
-            String[] validDatabaseCommands = {COMMAND_CLEAN_CACHE, COMMAND_COMPILE_ITEMS, COMMAND_ERASE_COMPILED_ITEMS};
-
+            String[] validSolrCommands = { COMMAND_IMPORT, COMMAND_CLEAN_CACHE };
+            String[] validDatabaseCommands = { COMMAND_CLEAN_CACHE, COMMAND_COMPILE_ITEMS,
+                    COMMAND_ERASE_COMPILED_ITEMS };
 
             boolean solr = true; // Assuming solr by default
             solr = !("database").equals(configurationService.getProperty("oai", "storage"));
-
 
             boolean run = false;
             if (line.getArgs().length > 0) {
@@ -377,15 +551,17 @@ public class XOAI {
 
                 if (COMMAND_IMPORT.equals(command)) {
                     ctx = new Context(Context.Mode.READ_ONLY);
-                    XOAI indexer = new XOAI(ctx,
-                            line.hasOption('o'),
-                            line.hasOption('c'),
+                    XOAI indexer = new XOAI(ctx, 
+                            line.hasOption('o'), 
+                            line.hasOption('c'), 
                             line.hasOption('v'));
 
                     applicationContext.getAutowireCapableBeanFactory().autowireBean(indexer);
 
                     int imported = indexer.index();
+                    
                     if (imported > 0) cleanCache(itemCacheService, cacheService);
+                    
                 } else if (COMMAND_CLEAN_CACHE.equals(command)) {
                     cleanCache(itemCacheService, cacheService);
                 } else if (COMMAND_COMPILE_ITEMS.equals(command)) {

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -276,8 +276,7 @@ public class XOAI {
             while (iterator.hasNext()) {
                 try {
                     Item item = iterator.next();
-                    System.out.println("indexing item " + item.getID());
-
+                    
                     server.add(this.index(item));
                     context.uncacheEntity(item);
 
@@ -436,19 +435,18 @@ public class XOAI {
         List<ResourcePolicy> policies = authorizeService.getPoliciesActionFilter(context, item, Constants.READ);
         for (ResourcePolicy policy : policies) {
             if (policy.getGroup().getName().equals("Anonymous")) {
-                System.out.println("found anonymous READ for item " + item.getID());
+                
                 if (policy.getStartDate() != null && policy.getStartDate().after(new Date())) {
-                    System.out.println("policy has start date after current date: " + policy.getStartDate());
+                    
                     return true;
                 }
                 if (policy.getEndDate() != null && policy.getEndDate().after(new Date())) {
-                    System.out.println("policy has end date after current date: " + policy.getEndDate());
+                    
                     return true;
                 }
             }
         }
-        System.out.println("all policies processed for item " + item.getID()
-                + "; based on current information, item will not change visibility in the future.");
+        
         return false;
     }
 

--- a/dspace/solr/oai/conf/schema.xml
+++ b/dspace/solr/oai/conf/schema.xml
@@ -166,6 +166,8 @@
    <field name="item.lastmodified" type="date" indexed="true" stored="true" multiValued="false" />
    <field name="item.submitter" type="string" indexed="true" stored="true" multiValued="false" />
    <field name="item.deleted" type="boolean" indexed="true" stored="true" multiValued="false" />
+   <!-- if true, item.public will change in the future due to an embargo being set/lifted -->
+   <field name="item.willChangeStatus" type="boolean" indexed="true" stored="true" multiValued="false" />																									 
    
    <!-- Item compiled -->
    <field name="item.compile" type="string" indexed="false" stored="true" multiValued="false" />


### PR DESCRIPTION
This PR addresses the bugs described in https://jira.duraspace.org/browse/DS-3707 and https://jira.duraspace.org/browse/DS-3715.

Incremental import into the OAI-PMH Solr index has the following bugs:
- Items that are made private are not updated in the index.
- Items under embargo are also not updated when the embargo is lifted, keeping them invisible.

Furthermore, a full import does not fix all the problems:
- Items that are made private simply disappear, IMHO breaking conformity to the transient deletion policy of DSpace's OAI-PMH implementation.
- Items under embargo are visible after the embargo has been lifted, but for incremental harvesting, there is now another problem: There is no update to item.lastmodified, therefore it might never get harvested.

The following fixes are applied:
- A method findInArchiveOrWithdrawnNonDiscoverableModifiedSince fetches private items for the update
- A flag item.willChangeStatus is added to the Solr scheme, which is used to fetch items currently under embargo from the index, making it possible to update them even if their lastmodified date has not changed since the last incremental update.
- The logic for item.public and item.deleted is changed to take item privacy and item embargoes into consideration: An item which is embargoed at the time it is first indexed will remain hidden until the embargo is lifted; should it be embargoed again, it will remain visible, but a tombstone record will be shown. An item which is private will always get a tombstone record.
- The logic for item.lastmodified is changed: from the list of all resource policy start/end dates and the core lastmodified date, the most recent date before the current date is chosen, so that items appear to have changed when an embargo starts/ends.

