### PR TITLE
DS-3724: Missing readonly in input-forms.dtd

### DIFF
--- a/dspace/config/input-forms.dtd
+++ b/dspace/config/input-forms.dtd
@@ -14,7 +14,7 @@
  <!ATTLIST form name NMTOKEN #REQUIRED>
  <!ELEMENT page (field)+ >
  <!ATTLIST page number NMTOKEN #REQUIRED>
- <!ELEMENT field (dc-schema, dc-element, dc-qualifier?, language?, repeatable?, label, type-bind?, input-type, hint, required?, vocabulary?, visibility?) >
+ <!ELEMENT field (dc-schema, dc-element, dc-qualifier?, language?, repeatable?, label, type-bind?, input-type, hint, required?, vocabulary?, visibility?, readonly?) >
  <!ELEMENT dc-schema (#PCDATA) >
  <!ELEMENT dc-element (#PCDATA) >
  <!ELEMENT dc-qualifier (#PCDATA) >
@@ -57,3 +57,5 @@
  <!ELEMENT visibility (#PCDATA) >
 
  <!ATTLIST language value-pairs-name CDATA  #IMPLIED>  
+
+ <!ELEMENT readonly (#PCDATA) >


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3724

The `input-forms.dtd` is missing the `readonly` element, that is already handled by JSPUI and XMLUI.