### PR TITLE
DS-3724 input-forms.dtd update

### DIFF
--- a/dspace/config/input-forms.dtd
+++ b/dspace/config/input-forms.dtd
@@ -20,7 +20,8 @@
  <!ELEMENT dc-qualifier (#PCDATA) >
  <!ELEMENT language (#PCDATA)>
  <!ELEMENT type-bind (#PCDATA) >
- 
+ <!ELEMENT readonly (#PCDATA) >
+
  <!ELEMENT repeatable (#PCDATA) >
  <!ELEMENT label (#PCDATA) >
  <!ELEMENT input-type (#PCDATA)>


### PR DESCRIPTION
Input forms definition update
https://jira.duraspace.org/projects/DS/issues/DS-3724

TODO
Check out refactoring possibilities for the actual usage of the readonly property 
- It's currently only taken into account when the field is not visible in the current scope
- Is it even useful anymore? Might be a good idea to rework it differently using the scope visibility in combination with more configurable options