### PR TITLE
DS-3731 Readonly attribute for fields and composite attributes

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/core/forms.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/core/forms.xsl
@@ -404,6 +404,9 @@
                 <xsl:if test="../@disabled='yes'">
                     <xsl:attribute name="disabled">disabled</xsl:attribute>
                 </xsl:if>
+                <xsl:if test="../@readonly='yes'">
+                    <xsl:attribute name="readonly">readonly</xsl:attribute>
+                </xsl:if>
             </input>
             <xsl:apply-templates />
         </label>
@@ -768,6 +771,9 @@
                     </xsl:if>
                     <xsl:if test="../@disabled='yes'">
                         <xsl:attribute name="disabled">disabled</xsl:attribute>
+                    </xsl:if>
+                   <xsl:if test="../@readonly='yes'">
+                        <xsl:attribute name="readonly">readonly</xsl:attribute>
                     </xsl:if>
                 </input>
                 <xsl:apply-templates/>
@@ -1343,6 +1349,9 @@
         </xsl:call-template>
         <xsl:if test="@disabled='yes' or ../@rend = 'disabled'">
             <xsl:attribute name="disabled">disabled</xsl:attribute>
+        </xsl:if>
+        <xsl:if test="@readonly='yes' or ../@rend = 'readonly'">
+            <xsl:attribute name="readonly">readonly</xsl:attribute>
         </xsl:if>
         <xsl:if test="@type != 'checkbox' and @type != 'radio' ">
             <xsl:attribute name="name"><xsl:value-of select="@n"/></xsl:attribute>

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Field.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/wing/element/Field.java
@@ -84,6 +84,9 @@ public abstract class Field extends AbstractWingElement implements
     /** The name of the disabled attribute */
     public static final String A_DISABLED = "disabled";
 
+    /** The name of the readonly attribute */
+    public static final String A_READONLY = "readonly";
+
     /** The name of the required attribute */
     public static final String A_REQUIRED = "required";
     
@@ -129,6 +132,9 @@ public abstract class Field extends AbstractWingElement implements
 
     /** Whether this field is disabled */
     protected boolean disabled;
+
+    /** Whether this field is readonly */
+    protected boolean readonly;
 
     /** Whether this field is required */
     protected boolean required;
@@ -194,6 +200,7 @@ public abstract class Field extends AbstractWingElement implements
         this.name = name;
         this.type = type;
         this.disabled = false;
+        this.readonly = false;
         this.required = false;
         this.rend = rend;
     }
@@ -239,6 +246,27 @@ public abstract class Field extends AbstractWingElement implements
     public void setDisabled(boolean disabled)
     {
         this.disabled = disabled;
+    }
+
+    /**
+     * Set this field to be readonly.
+     *
+     */
+    public void setReadonly()
+    {
+        this.readonly = true;
+    }
+
+    /**
+     * Set this field to either be readonly or enabled as determined by the
+     * readonly parameter.
+     *
+     * @param readonly
+     *            Determine if the field is readonly or not.
+     */
+    public void setReadonly(boolean readonly)
+    {
+        this.readonly = readonly;
     }
 
     /**
@@ -531,6 +559,10 @@ public abstract class Field extends AbstractWingElement implements
         {
             attributes.put(A_DISABLED, this.disabled);
         }
+        if (this.readonly)
+        {
+            attributes.put(A_READONLY, this.readonly);
+        }
         if (this.required)
         {
             attributes.put(A_REQUIRED, this.required);
@@ -564,6 +596,12 @@ public abstract class Field extends AbstractWingElement implements
         
         for (Field field : fields)
         {
+            if(this.disabled){
+                field.setDisabled();
+            }
+            if(this.readonly){
+                field.setReadonly();
+            }
             field.toSAX(contentHandler, lexicalHandler, namespaces);
         }
 


### PR DESCRIPTION
PR for https://jira.duraspace.org/browse/DS-3731

Allow "readonly" attribute to be set
Make sure that the disabled and readonly attributes are also propagated to child element fields