### PR TITLE
DS-3734 Fixed missing trigger of item last modified date when adding a bitstream

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
@@ -147,6 +147,14 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
                 return;
             }
         }
+        
+        //Ensure that the last modified from the item is triggered !
+        Item owningItem = (Item) getParentObject(context, bundle);
+        if(owningItem != null)
+        {
+            itemService.updateLastModified(context, owningItem);
+            itemService.update(context, owningItem);
+        }
 
         bundle.addBitstream(bitstream);
         bitstream.getBundles().add(bundle);


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3734

When a bitstream is added to an item after it was archived the last modified date of the owning item is not triggered.

To reproduce the error:

Go to http://demo.dspace.org/xmlui/
Log in as administrator
Click on any item and hit "Edit this Item"
Click on "Item Bitestreams"
Click on "Upload a new Bitstream"
Upload the file
Click on Item Status
Expected behavior: Last Modified equals current date and time.
Observed behavior: Last Modified didn't change