### PR TITLE
[DS-3749] Selective enabling of identifier generation per-container

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -47,9 +47,9 @@ import org.dspace.harvest.HarvestedCollection;
 import org.dspace.harvest.service.HarvestedCollectionService;
 import org.dspace.services.ConfigurationService;
 import org.dspace.workflow.factory.WorkflowServiceFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Service implementation for the Collection object.

--- a/dspace-api/src/main/java/org/dspace/content/InstallItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/InstallItemServiceImpl.java
@@ -59,6 +59,7 @@ public class InstallItemServiceImpl implements InstallItemService {
         AuthorizeException {
         Item item = is.getItem();
         Collection collection = is.getCollection();
+        collectionService.addItem(c, collection, item);
         try {
             if (suppliedHandle == null) {
                 identifierService.register(c, item);
@@ -87,6 +88,8 @@ public class InstallItemServiceImpl implements InstallItemService {
                             String suppliedHandle)
         throws SQLException, IOException, AuthorizeException {
         Item item = is.getItem();
+
+        collectionService.addItem(c, is.getCollection(), item);
 
         try {
             if (suppliedHandle == null) {

--- a/dspace-api/src/main/java/org/dspace/identifier/DOI.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/DOI.java
@@ -62,6 +62,8 @@ public class DOI
     protected DOI() {
     }
 
+    public static String getIdentifierTypeName() { return "DOI"; }
+
     public Integer getID() {
         return id;
     }

--- a/dspace-api/src/main/java/org/dspace/identifier/DOI.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/DOI.java
@@ -62,7 +62,13 @@ public class DOI
     protected DOI() {
     }
 
-    public static String getIdentifierTypeName() { return "DOI"; }
+    /**
+     * What type of identifier is this?
+     * @return "DOI"
+     */
+    public static String getIdentifierTypeName() {
+        return "DOI";
+    }
 
     public Integer getID() {
         return id;

--- a/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
@@ -837,5 +837,7 @@ public class DOIIdentifierProvider
     }
 
     @Override
-    public String getIdentifierTypeName() { return DOI.getIdentifierTypeName(); }
+    public String getIdentifierTypeName() {
+        return DOI.getIdentifierTypeName();
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
@@ -835,4 +835,7 @@ public class DOIIdentifierProvider
                                 remainder);
         itemService.update(context, item);
     }
+
+    @Override
+    public String getIdentifierTypeName() { return DOI.getIdentifierTypeName(); }
 }

--- a/dspace-api/src/main/java/org/dspace/identifier/EZIDIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/EZIDIdentifierProvider.java
@@ -644,5 +644,7 @@ public class EZIDIdentifierProvider
     }
 
     @Override
-    public String getIdentifierTypeName() { return DOI.getIdentifierTypeName(); }
+    public String getIdentifierTypeName() {
+        return DOI.getIdentifierTypeName();
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/identifier/EZIDIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/EZIDIdentifierProvider.java
@@ -642,4 +642,7 @@ public class EZIDIdentifierProvider
     protected void setItemService(ItemService itemService) {
         this.itemService = itemService;
     }
+
+    @Override
+    public String getIdentifierTypeName() { return DOI.getIdentifierTypeName(); }
 }

--- a/dspace-api/src/main/java/org/dspace/identifier/Handle.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/Handle.java
@@ -15,6 +15,12 @@ package org.dspace.identifier;
  * @author Ben Bosman (ben at atmire dot com)
  */
 public class Handle implements Identifier {
+    private Handle() { }
+
+    /**
+     * What type of identifier is this?
+     * @return "Handle"
+     */
     public static String getTypeName() {
         return "Handle";
     }

--- a/dspace-api/src/main/java/org/dspace/identifier/Handle.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/Handle.java
@@ -8,9 +8,14 @@
 package org.dspace.identifier;
 
 /**
+ * Identifiers used by the <a href="https://handle.net">Handle System</a>.
+ *
  * @author Fabio Bolognesi (fabio at atmire dot com)
  * @author Mark Diggory (markd at atmire dot com)
  * @author Ben Bosman (ben at atmire dot com)
  */
 public class Handle implements Identifier {
+    public static String getTypeName() {
+        return "Handle";
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
@@ -240,5 +240,7 @@ public class HandleIdentifierProvider extends IdentifierProvider {
     }
 
     @Override
-    public String getIdentifierTypeName() { return Handle.getTypeName(); }
+    public String getIdentifierTypeName() {
+        return Handle.getTypeName();
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
@@ -238,4 +238,7 @@ public class HandleIdentifierProvider extends IdentifierProvider {
             itemService.addMetadata(context, item, MetadataSchema.DC_SCHEMA, "identifier", "uri", null, handleref);
         }
     }
+
+    @Override
+    public String getIdentifierTypeName() { return Handle.getTypeName(); }
 }

--- a/dspace-api/src/main/java/org/dspace/identifier/IdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/IdentifierProvider.java
@@ -34,6 +34,15 @@ public abstract class IdentifierProvider {
     public void setParentService(IdentifierService parentService) {
         this.parentService = parentService;
     }
+     /**
+     * Get a "type name" for the sort of identifier that this provider handles.
+     * All providers which generate, resolve, etc. DOIs, for example, should return
+     * the same string, e.g. "DOI".
+     *
+     * @return a name for the type of identifier provided.
+     */
+    public abstract String getIdentifierTypeName();
+
 
     /**
      * Can this provider provide identifiers of a given type?

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
@@ -36,6 +36,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
+ * Services for identifiers used with <a href='https://handle.net/'>the Handle System</a>,
+ * with support for versioned objects.
+ *
  * @author Fabio Bolognesi (fabio at atmire dot com)
  * @author Mark Diggory (markd at atmire dot com)
  * @author Ben Bosman (ben at atmire dot com)
@@ -456,4 +459,7 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
         }
         itemService.update(context, item);
     }
+
+    @Override
+    public String getIdentifierTypeName() { return Handle.getTypeName(); }
 }

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
@@ -461,5 +461,7 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
     }
 
     @Override
-    public String getIdentifierTypeName() { return Handle.getTypeName(); }
+    public String getIdentifierTypeName() {
+        return Handle.getTypeName();
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
@@ -34,6 +34,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
+ * Services for identifiers used with <a href='https://handle.net/'>the Handle System</a>,
+ * with support for versioned objects.
+ *
  * @author Fabio Bolognesi (fabio at atmire dot com)
  * @author Mark Diggory (markd at atmire dot com)
  * @author Ben Bosman (ben at atmire dot com)
@@ -524,5 +527,10 @@ public class VersionedHandleIdentifierProviderWithCanonicalHandles extends Ident
             itemService.addMetadata(context, item, MetadataSchema.DC_SCHEMA, "identifier", "uri", null, handleref);
         }
         itemService.update(context, item);
+    }
+
+    @Override
+    public String getIdentifierTypeName() {
+        return Handle.getTypeName();
     }
 }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseRegistryUpdater.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseRegistryUpdater.java
@@ -67,12 +67,14 @@ public class DatabaseRegistryUpdater implements FlywayCallback {
             RegistryLoader.loadBitstreamFormats(context, base + "bitstream-formats.xml");
 
             // Load updates to Metadata schema registries (if any)
+            // FIXME this list should not be hard-wired.
             log.info("Updating Metadata Registries based on metadata type configs in " + base);
             MetadataImporter.loadRegistry(base + "dublin-core-types.xml", true);
             MetadataImporter.loadRegistry(base + "dcterms-types.xml", true);
             MetadataImporter.loadRegistry(base + "local-types.xml", true);
             MetadataImporter.loadRegistry(base + "eperson-types.xml", true);
             MetadataImporter.loadRegistry(base + "sword-metadata.xml", true);
+            MetadataImporter.loadRegistry(base + "dspace-types.xml", true);
 
             // Check if XML Workflow is enabled in workflow.cfg
             if (WorkflowServiceFactory.getInstance().getWorkflowService() instanceof XmlWorkflowService) {

--- a/dspace/config/registries/dspace-types.xml
+++ b/dspace/config/registries/dspace-types.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Metadata types for DSpace's internal use.  These explicitly have no meaning to
+any other product, and should be exposed only for backup and restore.
+-->
+<dspace-dc-types>
+    <dspace-header>
+        <title>DSpace internal metadata types</title>
+        <contributor.author>Mark H. Wood</contributor.author>
+        <date-created>04-Nov-2016</date-created>
+    </dspace-header>
+
+    <dc-schema>
+        <name>dspace</name>
+        <namespace>http://dspace.org/local</namespace>
+    </dc-schema>
+
+    <dc-type>
+        <schema>dspace</schema>
+        <element>identifier_generation_disabled</element>
+        <qualifier>Handle</qualifier>
+        <scope_note>True if Handle generation is disabled in this container</scope_note>
+    </dc-type>
+
+    <dc-type>
+        <schema>dspace</schema>
+        <element>identifier_generation_disabled</element>
+        <qualifier>DOI</qualifier>
+        <scope_note>True if DOI generation is disabled in this container</scope_note>
+    </dc-type>
+</dspace-dc-types>


### PR DESCRIPTION
Fixes #7096, fixes #5267
https://jira.duraspace.org/browse/DS-3749

A version for DSpace 5.6 has been lightly tested and was recently placed in service locally.

This still needs a user interface for convenient configuration, hence Work-In-Progress.  (For local reasons we had to build a separate GUI for our use.)