### PR TITLE
DS-3702 & DS-3703: Rebuild the old behavior of bitstreams during vers…

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -96,6 +96,37 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
     }
 
     @Override
+    public Bitstream clone(Context context, Bitstream bitstream)
+            throws SQLException 
+    {
+        // Create a new bitstream with a new ID.
+        Bitstream clonedBitstream = bitstreamDAO.create(context, new Bitstream());
+        // Set the internal identifier, file size, checksum, and 
+        // checksum algorithm as same as the given bitstream. 
+        clonedBitstream.setInternalId(bitstream.getInternalId());
+        clonedBitstream.setSizeBytes(bitstream.getSize());
+        clonedBitstream.setChecksum(bitstream.getChecksum());
+        clonedBitstream.setChecksumAlgorithm(bitstream.getChecksumAlgorithm());
+
+        try 
+        {
+            //Update our bitstream but turn off the authorization system since permissions haven't been set at this point in time.
+            context.turnOffAuthorisationSystem();
+            update(context, clonedBitstream);
+        } 
+        catch (AuthorizeException e) 
+        {
+            log.error(e);
+            //Can never happen since we turn off authorization before we update
+        } 
+        finally 
+        {
+            context.restoreAuthSystemState();
+        }
+        return clonedBitstream;
+    }
+    
+    @Override
     public Bitstream create(Context context, InputStream is) throws IOException, SQLException {
         // Store the bits
         UUID bitstreamID = bitstreamStorageService.store(context, bitstreamDAO.create(context, new Bitstream()), is);

--- a/dspace-api/src/main/java/org/dspace/content/service/BitstreamService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/BitstreamService.java
@@ -28,6 +28,22 @@ public interface BitstreamService extends DSpaceObjectService<Bitstream>, DSpace
     public List<Bitstream> findAll(Context context) throws SQLException;
 
     /**
+     * Clone the given bitstream by firstly creating a new bitstream, with a new ID.
+     * Then set the internal identifier, file size, checksum, and 
+     * checksum algorithm as same as the given bitstream. 
+     * This allows multiple bitstreams to share the same internal identifier of assets . 
+     * An example of such a use case scenario is versioning.
+     * 
+     * @param context
+     *            DSpace context object
+     * @param bitstream
+     *            Bitstream to be cloned
+     * @return the clone 
+     * @throws SQLException if database error
+     */
+    public Bitstream clone(Context context, Bitstream bitstream) throws SQLException; 
+   
+    /**
      * Create a new bitstream, with a new ID. The checksum and file size are
      * calculated. No authorization checks are made in this method.
      * The newly created bitstream has the "unknown" format.
@@ -62,7 +78,7 @@ public interface BitstreamService extends DSpaceObjectService<Bitstream>, DSpace
      * @throws AuthorizeException if authorization error
      */
     public Bitstream create(Context context, Bundle bundle, InputStream is) throws IOException, SQLException, AuthorizeException;
-
+ 
     /**
      * Register a new bitstream, with a new ID.  The checksum and file size
      * are calculated. The newly created bitstream has the "unknown"

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
@@ -84,8 +84,8 @@ public class BitstreamStorageServiceImpl implements BitstreamStorageService, Ini
     public void afterPropertiesSet() throws Exception {
         for(Map.Entry<Integer, BitStoreService> storeEntry : stores.entrySet()) {
             storeEntry.getValue().init();
+            }
         }
-    }
 
     @Override
     public UUID store(Context context, Bitstream bitstream, InputStream is) throws SQLException, IOException
@@ -102,7 +102,7 @@ public class BitstreamStorageServiceImpl implements BitstreamStorageService, Ini
          * where it should go
          */
         bitstream.setStoreNumber(incoming);
-
+        
         //For efficiencies sake, PUT is responsible for setting bitstream size_bytes, checksum, and checksum_algorithm
         stores.get(incoming).put(bitstream, is);
         //bitstream.setSizeBytes(file.length());
@@ -339,23 +339,22 @@ public class BitstreamStorageServiceImpl implements BitstreamStorageService, Ini
         }
     }
 
-    /**
-     *
-     * @param context
-     * @param bitstream the bitstream to be cloned
-     * @return id of the clone bitstream.
-     * @throws SQLException if database error
-     */
-	@Override
-    public Bitstream clone(Context context, Bitstream bitstream) throws SQLException, IOException, AuthorizeException {
-		Bitstream clonedBitstream = bitstreamService.create(context, bitstreamService.retrieve(context, bitstream));
-		List<MetadataValue> metadataValues = bitstreamService.getMetadata(bitstream, Item.ANY, Item.ANY, Item.ANY, Item.ANY);
-		for (MetadataValue metadataValue : metadataValues) {
-			bitstreamService.addMetadata(context, clonedBitstream, metadataValue.getMetadataField(), metadataValue.getLanguage(), metadataValue.getValue(), metadataValue.getAuthority(), metadataValue.getConfidence());
-		}
-		return clonedBitstream;
+    @Override
+    public Bitstream clone(Context context, Bitstream bitstream) throws SQLException, IOException, AuthorizeException 
+    {
+        Bitstream clonedBitstream = bitstreamService.clone(context, bitstream);
+        clonedBitstream.setStoreNumber(bitstream.getStoreNumber());
+        
+        List<MetadataValue> metadataValues = bitstreamService.getMetadata(bitstream, Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+        
+        for (MetadataValue metadataValue : metadataValues) 
+        {
+            bitstreamService.addMetadata(context, clonedBitstream, metadataValue.getMetadataField(), metadataValue.getLanguage(), metadataValue.getValue(), metadataValue.getAuthority(), metadataValue.getConfidence());
+        }
+        bitstreamService.update(context, clonedBitstream);
+        return clonedBitstream;
 
-	}
+    }
 
     /**
      * Migrates all assets off of one assetstore to another

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/service/BitstreamStorageService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/service/BitstreamStorageService.java
@@ -147,6 +147,20 @@ public interface BitstreamStorageService {
      */
     public void cleanup(boolean deleteDbRecords, boolean verbose) throws SQLException, IOException, AuthorizeException;
 
+    
+    /**
+     * Clone the given bitstream to a new bitstream with a new ID. 
+     * Metadata of the given bitstream are also copied to the new bitstream.
+     * 
+     * @param context
+     *            DSpace context object
+     * @param bitstream
+     *            the bitstream to be cloned
+     * @return id of the clone bitstream.
+     * @throws SQLException if database error
+     * @throws IOException if IO error
+     * @throws AuthorizeException if authorization error
+     */
     public Bitstream clone(Context context, Bitstream bitstream) throws SQLException, IOException, AuthorizeException;
 
     /**

--- a/dspace-api/src/main/java/org/dspace/versioning/AbstractVersionProvider.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/AbstractVersionProvider.java
@@ -78,7 +78,10 @@ public abstract class AbstractVersionProvider {
             
             for(Bitstream nativeBitstream : nativeBundle.getBitstreams())
             {
-                Bitstream bitstreamNew = createBitstream(c, nativeBitstream);
+                // Metadata and additional information like internal identifier, 
+                // file size, checksum, and checksum algorithm are set by the bitstreamStorageService.clone(...)
+                // and respectively bitstreamService.clone(...) method.
+                Bitstream bitstreamNew =  bitstreamStorageService.clone(c, nativeBitstream);
 
                 bundleService.addBitstream(c, bundleNew, bitstreamNew);
 
@@ -100,16 +103,6 @@ public abstract class AbstractVersionProvider {
                 bitstreamService.update(c, bitstreamNew);
             }
         }
-    }
-
-
-    protected Bitstream createBitstream(Context context, Bitstream nativeBitstream) throws AuthorizeException, SQLException, IOException {
-        Bitstream newBitstream = bitstreamStorageService.clone(context, nativeBitstream);
-	    List<MetadataValue> bitstreamMeta = bitstreamService.getMetadata(nativeBitstream, Item.ANY, Item.ANY, Item.ANY, Item.ANY);
-	    for (MetadataValue value : bitstreamMeta) {
-		    bitstreamService.addMetadata(context, newBitstream, value.getMetadataField(), value.getLanguage(), value.getValue(), value.getAuthority(), value.getConfidence());
-	    }
-	    return newBitstream;
     }
 
     public void setIgnoredMetadataFields(Set<String> ignoredMetadataFields) {


### PR DESCRIPTION
…ioning in DSpace 6. Bitstreams are pointing to the same file on the disk and reuse the same internal id of the predecessor item's bitstreams version as long as the new bitstreams do not differ from them. Bitstream's metadata are also duplicated only for the new version of the item.