### PR TITLE
DS-3756: Fix "back" on last page of submission

### DIFF
--- a/dspace-xmlui/src/main/resources/aspects/Submission/submission.js
+++ b/dspace-xmlui/src/main/resources/aspects/Submission/submission.js
@@ -360,7 +360,7 @@ function submissionControl(collectionHandle, workspaceID, initStepAndPage)
         	}
         }//User clicked "<- Previous" button
         else if (cocoon.request.get(AbstractProcessingStep.PREVIOUS_BUTTON) && 
-        			(response_flag==AbstractProcessingStep.STATUS_COMPLETE || state.stepAndPage == maxStepAndPage))
+            (response_flag==AbstractProcessingStep.STATUS_COMPLETE || maxStepAndPage.equals(state.stepAndPage)))
         {  
             var stepBack = true;
 
@@ -403,7 +403,7 @@ function submissionControl(collectionHandle, workspaceID, initStepAndPage)
         //User clicked on Progress Bar:
         // only check for a 'step_jump' (i.e. click on progress bar)
         // if there are no errors to be resolved
-        if(response_flag==AbstractProcessingStep.STATUS_COMPLETE || state.stepAndPage == maxStepAndPage)
+        if(response_flag==AbstractProcessingStep.STATUS_COMPLETE || maxStepAndPage.equals(state.stepAndPage))
         {
 	        var names = cocoon.request.getParameterNames();
 	        while(names.hasMoreElements())


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3756

The back button on the last page (the maximum reached) of the current
submission should ignore required fields. Because maxStepAndPage is a Java
object equals have to be used to compare multiple instances.