### PR TITLE
[DS-3770] always uncache item after performed curation task 

### DIFF
--- a/dspace-api/src/main/java/org/dspace/curate/AbstractCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/curate/AbstractCurationTask.java
@@ -93,7 +93,9 @@ public abstract class AbstractCurationTask implements CurationTask
                 Iterator<Item> iter = itemService.findByCollection(Curator.curationContext(), (Collection) dso);
                 while (iter.hasNext())
                 {
-                    performObject(iter.next());
+                    Item item = iter.next();
+                    performObject(item);
+                    Curator.curationContext().uncacheEntity(item);
                 }
             }
             else if (Constants.COMMUNITY == type)
@@ -147,7 +149,7 @@ public abstract class AbstractCurationTask implements CurationTask
         if(dso.getType()==Constants.ITEM)
         {
             performItem((Item)dso);
-        }    
+        }
         
         //no-op for all other types of DSpace Objects
     }


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3770

The hibernate cache makes curation task on a large number of items very slow.