### PR TITLE
DS-3781: Make sure Flyway is only executed once

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -24,6 +24,7 @@ import org.springframework.util.CollectionUtils;
 
 import java.sql.SQLException;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Class representing the context of a particular DSpace operation. This stores
@@ -45,6 +46,7 @@ import java.util.*;
 public class Context
 {
     private static final Logger log = Logger.getLogger(Context.class);
+    private static final AtomicBoolean databaseUpdated = new AtomicBoolean(false);
 
     /** Current user - null means anonymous access */
     private EPerson currentUser;
@@ -128,7 +130,7 @@ public class Context
      * @throws SQLException
      *                if there was an error obtaining a database connection
      */
-    private void init()
+    protected void init()
     {
         updateDatabase();
 
@@ -160,15 +162,22 @@ public class Context
         setMode(this.mode);
     }
 
-    protected void updateDatabase() {
-        // Before initializing a Context object, we need to ensure the database
-        // is up-to-date. This ensures any outstanding Flyway migrations are run
-        // PRIOR to Hibernate initializing (occurs when DBConnection is loaded in calling init() method).
-        try {
-            DatabaseUtils.updateDatabase();
-        } catch (SQLException sqle) {
-            log.fatal("Cannot initialize database via Flyway!", sqle);
+    public static boolean updateDatabase() {
+        //If the database has not been updated yet, update it and remember that.
+        if (databaseUpdated.compareAndSet(false, true)) {
+
+            // Before initializing a Context object, we need to ensure the database
+            // is up-to-date. This ensures any outstanding Flyway migrations are run
+            // PRIOR to Hibernate initializing (occurs when DBConnection is loaded in calling init() method).
+            try {
+                DatabaseUtils.updateDatabase();
+            } catch (SQLException sqle) {
+                log.fatal("Cannot initialize database via Flyway!", sqle);
+                databaseUpdated.set(false);
+            }
         }
+
+        return databaseUpdated.get();
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -46,7 +46,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class Context
 {
     private static final Logger log = Logger.getLogger(Context.class);
-    private static final AtomicBoolean databaseUpdated = new AtomicBoolean(false);
+    protected static final AtomicBoolean databaseUpdated = new AtomicBoolean(false);
 
     /** Current user - null means anonymous access */
     private EPerson currentUser;

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -466,63 +466,62 @@ public class DatabaseUtils
      *      DataSource object initialized by DatabaseManager
      * @return initialized Flyway object
      */
-    private static Flyway setupFlyway(DataSource datasource) {
+    private synchronized static Flyway setupFlyway(DataSource datasource)
+    {
         ConfigurationService config = DSpaceServicesFactory.getInstance().getConfigurationService();
 
-        if (flywaydb == null) {
-            synchronized (log) {
-                if (flywaydb != null) {
-                    return flywaydb;
+        if (flywaydb==null)
+        {
+            try(Connection connection = datasource.getConnection())
+            {
+                // Initialize Flyway DB API (http://flywaydb.org/), used to perform DB migrations
+                flywaydb = new Flyway();
+                flywaydb.setDataSource(datasource);
+                flywaydb.setEncoding("UTF-8");
+
+                // Default cleanDisabled to "true" (which disallows the ability to run 'database clean')
+                flywaydb.setCleanDisabled(config.getBooleanProperty("db.cleanDisabled", true));
+
+                // Migration scripts are based on DBMS Keyword (see full path below)
+                String dbType = getDbType(connection);
+                connection.close();
+
+                // Determine location(s) where Flyway will load all DB migrations
+                ArrayList<String> scriptLocations = new ArrayList<String>();
+
+                // First, add location for custom SQL migrations, if any (based on DB Type)
+                // e.g. [dspace.dir]/etc/[dbtype]/
+                // (We skip this for H2 as it's only used for unit testing)
+                if(!dbType.equals(DBMS_H2))
+                {
+                    scriptLocations.add("filesystem:" + config.getProperty("dspace.dir") +
+                                        "/etc/" + dbType);
                 }
 
-                try (Connection connection = datasource.getConnection()) {
-                    // Initialize Flyway DB API (http://flywaydb.org/), used to perform DB migrations
-                    flywaydb = new Flyway();
-                    flywaydb.setDataSource(datasource);
-                    flywaydb.setEncoding("UTF-8");
+                // Also add the Java package where Flyway will load SQL migrations from (based on DB Type)
+                scriptLocations.add("classpath:org.dspace.storage.rdbms.sqlmigration." + dbType);
 
-                    // Default cleanDisabled to "true" (which disallows the ability to run 'database clean')
-                    flywaydb.setCleanDisabled(config.getBooleanProperty("db.cleanDisabled", true));
+                // Also add the Java package where Flyway will load Java migrations from
+                // NOTE: this also loads migrations from any sub-package
+                scriptLocations.add("classpath:org.dspace.storage.rdbms.migration");
 
-                    // Migration scripts are based on DBMS Keyword (see full path below)
-                    String dbType = getDbType(connection);
-                    connection.close();
+                //Add all potential workflow migration paths
+                List<String> workflowFlywayMigrationLocations = WorkflowServiceFactory.getInstance().getWorkflowService().getFlywayMigrationLocations();
+                scriptLocations.addAll(workflowFlywayMigrationLocations);
 
-                    // Determine location(s) where Flyway will load all DB migrations
-                    ArrayList<String> scriptLocations = new ArrayList<String>();
+                // Now tell Flyway which locations to load SQL / Java migrations from
+                log.info("Loading Flyway DB migrations from: " + StringUtils.join(scriptLocations, ", "));
+                flywaydb.setLocations(scriptLocations.toArray(new String[scriptLocations.size()]));
 
-                    // First, add location for custom SQL migrations, if any (based on DB Type)
-                    // e.g. [dspace.dir]/etc/[dbtype]/
-                    // (We skip this for H2 as it's only used for unit testing)
-                    if (!dbType.equals(DBMS_H2)) {
-                        scriptLocations.add("filesystem:" + config.getProperty("dspace.dir") +
-                                "/etc/" + dbType);
-                    }
-
-                    // Also add the Java package where Flyway will load SQL migrations from (based on DB Type)
-                    scriptLocations.add("classpath:org.dspace.storage.rdbms.sqlmigration." + dbType);
-
-                    // Also add the Java package where Flyway will load Java migrations from
-                    // NOTE: this also loads migrations from any sub-package
-                    scriptLocations.add("classpath:org.dspace.storage.rdbms.migration");
-
-                    //Add all potential workflow migration paths
-                    List<String> workflowFlywayMigrationLocations = WorkflowServiceFactory.getInstance().getWorkflowService().getFlywayMigrationLocations();
-                    scriptLocations.addAll(workflowFlywayMigrationLocations);
-
-                    // Now tell Flyway which locations to load SQL / Java migrations from
-                    log.info("Loading Flyway DB migrations from: " + StringUtils.join(scriptLocations, ", "));
-                    flywaydb.setLocations(scriptLocations.toArray(new String[scriptLocations.size()]));
-
-                    // Set flyway callbacks (i.e. classes which are called post-DB migration and similar)
-                    // In this situation, we have a Registry Updater that runs PRE-migration
-                    // NOTE: DatabaseLegacyReindexer only indexes in Legacy Lucene & RDBMS indexes. It can be removed once those are obsolete.
-                    List<FlywayCallback> flywayCallbacks = DSpaceServicesFactory.getInstance().getServiceManager().getServicesByType(FlywayCallback.class);
-                    flywaydb.setCallbacks(flywayCallbacks.toArray(new FlywayCallback[flywayCallbacks.size()]));
-
-                } catch (SQLException e) {
-                    log.error("Unable to setup Flyway against DSpace database", e);
-                }
+                // Set flyway callbacks (i.e. classes which are called post-DB migration and similar)
+                // In this situation, we have a Registry Updater that runs PRE-migration
+                // NOTE: DatabaseLegacyReindexer only indexes in Legacy Lucene & RDBMS indexes. It can be removed once those are obsolete.
+                List<FlywayCallback> flywayCallbacks = DSpaceServicesFactory.getInstance().getServiceManager().getServicesByType(FlywayCallback.class);
+                flywaydb.setCallbacks(flywayCallbacks.toArray(new FlywayCallback[flywayCallbacks.size()]));
+            }
+            catch(SQLException e)
+            {
+                log.error("Unable to setup Flyway against DSpace database", e);
             }
         }
 
@@ -541,7 +540,7 @@ public class DatabaseUtils
      * @throws SQLException if database error
      *      If database cannot be upgraded.
      */
-    public static void updateDatabase()
+    public static synchronized void updateDatabase()
             throws SQLException
     {
         // Get our configured dataSource
@@ -607,11 +606,22 @@ public class DatabaseUtils
             // Setup Flyway API against our database
             Flyway flyway = setupFlyway(datasource);
 
+            // Set whethe Flyway will run migrations "out of order". By default, this is false,
+            // and Flyway ONLY runs migrations that have a higher version number.
+            flyway.setOutOfOrder(outOfOrder);
+
+            // If a target version was specified, tell Flyway to ONLY migrate to that version
+            // (i.e. all later migrations are left as "pending"). By default we always migrate to latest version.
+            if(!StringUtils.isBlank(targetVersion))
+            {
+                flyway.setTargetAsString(targetVersion);
+            }
+
             // Does the necessary Flyway table ("schema_version") exist in this database?
             // If not, then this is the first time Flyway has run, and we need to initialize
             // NOTE: search is case sensitive, as flyway table name is ALWAYS lowercase,
             // See: http://flywaydb.org/documentation/faq.html#case-sensitive
-            if (!tableExists(connection, flyway.getTable(), true))
+            if(!tableExists(connection, flyway.getTable(), true))
             {
                 // Try to determine our DSpace database version, so we know what to tell Flyway to do
                 String dbVersion = determineDBVersion(connection);
@@ -631,40 +641,26 @@ public class DatabaseUtils
                 }
             }
 
+            // Determine pending Database migrations
             MigrationInfo[] pending = flyway.info().pending();
-            if(ArrayUtils.isEmpty(pending)) {
-                log.info("DSpace database schema is up to date");
-            } else {
-                synchronized (log) {
-                    // Set whethe Flyway will run migrations "out of order". By default, this is false,
-                    // and Flyway ONLY runs migrations that have a higher version number.
-                    flyway.setOutOfOrder(outOfOrder);
 
-                    // If a target version was specified, tell Flyway to ONLY migrate to that version
-                    // (i.e. all later migrations are left as "pending"). By default we always migrate to latest version.
-                    if (!StringUtils.isBlank(targetVersion)) {
-                        flyway.setTargetAsString(targetVersion);
-                    }
-
-                    // Determine pending Database migrations
-                    pending = flyway.info().pending();
-
-                    // As long as there are pending migrations, log them and run migrate()
-                    if (pending != null && pending.length > 0) {
-                        log.info("Pending DSpace database schema migrations:");
-                        for (MigrationInfo info : pending) {
-                            log.info("\t" + info.getVersion() + " " + info.getDescription() + " " + info.getType() + " " + info.getState());
-                        }
-
-                        // Run all pending Flyway migrations to ensure the DSpace Database is up to date
-                        flyway.migrate();
-
-                        // Flag that Discovery will need reindexing, since database was updated
-                        setReindexDiscovery(true);
-                    } else
-                        log.info("DSpace database schema is up to date");
+            // As long as there are pending migrations, log them and run migrate()
+            if (pending!=null && pending.length>0)
+            {
+                log.info("Pending DSpace database schema migrations:");
+                for (MigrationInfo info : pending)
+                {
+                    log.info("\t" + info.getVersion() + " " + info.getDescription() + " " + info.getType() + " " + info.getState());
                 }
+
+                // Run all pending Flyway migrations to ensure the DSpace Database is up to date
+                flyway.migrate();
+
+                // Flag that Discovery will need reindexing, since database was updated
+                setReindexDiscovery(true);
             }
+            else
+                log.info("DSpace database schema is up to date");
         }
         catch(FlywayException fe)
         {

--- a/dspace-api/src/test/java/org/dspace/core/ContextTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/ContextTest.java
@@ -422,13 +422,35 @@ public class ContextTest extends AbstractUnitTest
     public void testFinalize() throws Throwable {
         // We need a new Context object
         Context instance = new Context();
-        
+
         instance.finalize();
-        
+
         // Finalize is like abort()...should invalidate our context
         assertThat("testSetSpecialGroup 0", instance.isValid(), equalTo(false));
 
         // Cleanup our context
         cleanupContext(instance);
     }
+
+    /**
+     * Test of updateDatabase method, of class Context.
+     */
+    @Test
+    public void testUpdateDatabase() throws Throwable {
+        // We create a new Context object and force the databaseUpdated flag to false
+        Context instance = new Context() {
+            @Override
+            protected void init() {
+                super.init();
+                databaseUpdated.set(false);
+            }
+        };
+
+        // Finalize is like abort()...should invalidate our context
+        assertThat("updateDatabase 0", Context.updateDatabase(), equalTo(true));
+
+        // Cleanup our context
+        cleanupContext(instance);
+    }
+
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/Application.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/Application.java
@@ -243,22 +243,8 @@ public class Application extends SpringBootServletInitializer {
     private class FlywayDatabaseMigrationInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
         @Override
         public void initialize(ConfigurableApplicationContext applicationContext) {
-            //Run the Flyway migrations by create a Context and Database connection
-            org.dspace.core.Context context = new org.dspace.core.Context();
-            boolean failed = false;
-
-            try {
-                if(context.getDBConfig() == null || StringUtils.isBlank(context.getDBConfig().getDatabaseUrl())) {
-                    failed = true;
-                }
-
-                context.complete();
-
-            } catch (SQLException e) {
-                failed = true;
-            }
-
-            if(failed) {
+            //If we fail to update the database, throw an exception
+            if(!org.dspace.core.Context.updateDatabase()) {
                 throw new RuntimeException("Unable to initialize the database");
             }
         }


### PR DESCRIPTION
This is a fix for https://jira.duraspace.org/browse/DS-3781

You can validate that Flyway still runs correctly by starting from a clean database or by running on a DSpace 6 DB and checking that the "V7.0_2017.10.12__DS-3542-stateless-sessions.sql" is executed.
