### PR TITLE
New Code Style rules for DSpace "master" branch

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<!--
+DSpace CodeStyle Requirements
+
+  1. 4-space indents for Java, and 2-space indents for XML. NO TABS ALLOWED.
+     (Only exception is throws clause, which should be indented 8 spaces if on a new line)
+  2. K&R style braces required. Braces required on all blocks.
+  3. Do not use wildcard imports (e.g. import java.util.*). Duplicated or unused imports also not allowed.
+  4. Javadocs required for all public classes and methods. Keep it short and to the point
+  5. Maximum line length is 120 characters
+  6. No trailing spaces allowed (except in comments)
+  7. Tokens should be surrounded by whitespace (see http://checkstyle.sourceforge.net/config_whitespace.html#WhitespaceAround)
+  8. Each source file must include our license header (validated separately by license-maven-plugin, see pom.xml)
+
+For more information on CheckStyle configurations below, see: http://checkstyle.sourceforge.net/checks.html
+-->
+<module name="Checker">
+    <!-- Configure checker to use UTF-8 encoding -->
+    <property name="charset" value="UTF-8"/>
+    <!-- Configure checker to run on files with these extensions -->
+    <property name="fileExtensions" value="java, properties, cfg, xml"/>
+
+    <!-- No tab characters ('\t') allowed in the source code -->
+    <module name="FileTabCharacter">
+        <property name="eachLine" value="true"/>
+        <property name="fileExtensions" value="java, properties, cfg, css, js, xml"/>
+    </module>
+
+    <!-- No Trailing Whitespace, except on lines that only have an asterisk (e.g. Javadoc comments) -->
+    <module name="RegexpSingleline">
+        <property name="format" value="(?&lt;!\*)\s+$|\*\s\s+$"/>
+        <property name="message" value="Line has trailing whitespace"/>
+        <property name="fileExtensions" value="java, properties, cfg, css, js, xml"/>
+    </module>
+
+    <!-- Allow individual lines of code to be excluded from these rules, if they are annotated
+         with @SuppressWarnings. See also SuppressWarningsHolder below -->
+    <module name="SuppressWarningsFilter" />
+
+    <!-- Check individual Java source files for specific rules -->
+    <module name="TreeWalker">
+        <!-- Maximum line length is 120 characters -->
+        <module name="LineLength">
+            <property name="max" value="120"/>
+        </module>
+
+        <!-- Check for and report back any TODO or FIXME comments as info messages -->
+        <module name="TodoComment">
+            <property name="severity" value="info"/>
+            <property name="format" value="(TODO)|(FIXME)"/>
+        </module>
+
+        <!-- Do not report errors on any lines annotated with @SuppressWarnings -->
+        <module name="SuppressWarningsHolder"/>
+
+        <!-- ##### Import statement requirements ##### -->
+        <!-- Star imports (e.g. import java.util.*) are NOT ALLOWED -->
+        <module name="AvoidStarImport"/>
+        <!-- Redundant import statements are NOT ALLOWED -->
+        <module name="RedundantImport"/>
+        <!-- Unused import statements are NOT ALLOWED -->
+        <module name="UnusedImports"/>
+
+        <!-- ##### Javadocs requirements ##### -->
+        <!-- Requirements for Javadocs for classes/interfaces -->
+        <module name="JavadocType">
+            <!-- All public classes/interfaces MUST HAVE Javadocs -->
+            <property name="scope" value="public"/>
+            <!-- Add an exception for anonymous inner classes -->
+            <property name="excludeScope" value="anoninner"/>
+            <!-- Ignore errors related to unknown tags -->
+            <property name="allowUnknownTags" value="true"/>
+            <!-- Allow params tags to be optional -->
+            <property name="allowMissingParamTags" value="false"/>
+        </module>
+        <!-- Requirements for Javadocs for methods -->
+        <module name="JavadocMethod">
+            <!-- All public methods MUST HAVE Javadocs -->
+            <property name="scope" value="public"/>
+            <!-- Allow RuntimeExceptions to be undeclared -->
+            <property name="allowUndeclaredRTE" value="true"/>
+            <!-- Allow params, throws and return tags to be optional -->
+            <property name="allowMissingParamTags" value="true"/>
+            <property name="allowMissingThrowsTags" value="true"/>
+            <property name="allowMissingReturnTag" value="true"/>
+        </module>
+
+        <!-- ##### Requirements for K&R Style braces ##### -->
+        <!-- Code blocks MUST HAVE braces, even single line statements (if, while, etc) -->
+        <module name="NeedBraces"/>
+        <!-- Left braces should be at the end of current line (default value)-->
+        <module name="LeftCurly"/>
+        <!-- Right braces should be on start of a new line (default value) -->
+        <module name="RightCurly"/>
+
+        <!-- ##### Indentation / Whitespace requirements ##### -->
+        <!-- Require 4-space indentation (default value), except "throws" clauses should be indented 8 spaces -->
+        <module name="Indentation">
+            <property name="throwsIndent" value="8"/>
+        </module>
+        <!-- Whitespace should exist around all major tokens -->
+        <module name="WhitespaceAround">
+            <!-- However, make an exception for empty constructors, methods, types, etc. -->
+            <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyMethods" value="true"/>
+            <property name="allowEmptyTypes" value="true"/>
+            <property name="allowEmptyLoops" value="true"/>
+        </module>
+        <!-- Validate whitespace around Generics (angle brackets) per typical conventions
+             http://checkstyle.sourceforge.net/config_whitespace.html#GenericWhitespace -->
+        <module name="GenericWhitespace"/>
+
+        <!-- ##### Other / Miscellaneous requirements ##### -->
+        <!-- Require utility classes do not have a public constructor -->
+        <module name="HideUtilityClassConstructor"/>
+        <!-- Require each variable declaration is its own statement on its own line -->
+        <module name="MultipleVariableDeclarations"/>
+    </module>
+</module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -45,6 +45,8 @@ For more information on CheckStyle configurations below, see: http://checkstyle.
         <!-- Maximum line length is 120 characters -->
         <module name="LineLength">
             <property name="max" value="120"/>
+            <!-- Only exceptions are packages, imports and URLs -->
+            <property name="ignorePattern" value="^package.*|^import.*|http://|https://"/>
         </module>
 
         <!-- Check for and report back any TODO or FIXME comments as info messages -->
@@ -63,6 +65,12 @@ For more information on CheckStyle configurations below, see: http://checkstyle.
         <module name="RedundantImport"/>
         <!-- Unused import statements are NOT ALLOWED -->
         <module name="UnusedImports"/>
+        <!-- Ensure imports appear alphabetically and grouped -->
+        <module name="CustomImportOrder">
+            <property name="sortImportsInGroupAlphabetically" value="true"/>
+            <property name="separateLineBetweenGroups" value="true"/>
+            <property name="customImportOrderRules" value="STATIC###STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE"/>
+        </module>
 
         <!-- ##### Javadocs requirements ##### -->
         <!-- Requirements for Javadocs for classes/interfaces -->
@@ -113,10 +121,20 @@ For more information on CheckStyle configurations below, see: http://checkstyle.
              http://checkstyle.sourceforge.net/config_whitespace.html#GenericWhitespace -->
         <module name="GenericWhitespace"/>
 
+        <!-- ##### Requirements for "switch" statements ##### -->
+        <!-- "switch" statements MUST have a "default" clause -->
+        <module name="MissingSwitchDefault"/>
+        <!-- "case" clauses in switch statements MUST include break, return, throw or continue -->
+        <module name="FallThrough"/>
+
         <!-- ##### Other / Miscellaneous requirements ##### -->
         <!-- Require utility classes do not have a public constructor -->
         <module name="HideUtilityClassConstructor"/>
         <!-- Require each variable declaration is its own statement on its own line -->
         <module name="MultipleVariableDeclarations"/>
+        <!-- Each line of code can only include one statement -->
+        <module name="OneStatementPerLine"/>
+        <!-- Require that "catch" statements are not empty (must at least contain a comment) -->
+        <module name="EmptyCatchBlock"/>
     </module>
 </module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -87,7 +87,9 @@ For more information on CheckStyle configurations below, see: http://checkstyle.
         <!-- Requirements for Javadocs for methods -->
         <module name="JavadocMethod">
             <!-- All public methods MUST HAVE Javadocs -->
-            <property name="scope" value="public"/>
+            <!-- <property name="scope" value="public"/> -->
+            <!-- TODO: Above rule has been disabled because of large amount of missing public method Javadocs -->
+            <property name="scope" value="nothing"/>
             <!-- Allow RuntimeExceptions to be undeclared -->
             <property name="allowUndeclaredRTE" value="true"/>
             <!-- Allow params, throws and return tags to be optional -->
@@ -105,10 +107,8 @@ For more information on CheckStyle configurations below, see: http://checkstyle.
         <module name="RightCurly"/>
 
         <!-- ##### Indentation / Whitespace requirements ##### -->
-        <!-- Require 4-space indentation (default value), except "throws" clauses should be indented 8 spaces -->
-        <module name="Indentation">
-            <property name="throwsIndent" value="8"/>
-        </module>
+        <!-- Require 4-space indentation (default value) -->
+        <module name="Indentation"/>
         <!-- Whitespace should exist around all major tokens -->
         <module name="WhitespaceAround">
             <!-- However, make an exception for empty constructors, methods, types, etc. -->

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC
-        "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 <!--
 DSpace CodeStyle Requirements
 
   1. 4-space indents for Java, and 2-space indents for XML. NO TABS ALLOWED.
-     (Only exception is throws clause, which should be indented 8 spaces if on a new line)
   2. K&R style braces required. Braces required on all blocks.
   3. Do not use wildcard imports (e.g. import java.util.*). Duplicated or unused imports also not allowed.
-  4. Javadocs required for all public classes and methods. Keep it short and to the point
-  5. Maximum line length is 120 characters
+  4. Javadocs should exist for all public classes and methods. (Methods rule is unenforced at this time.) Keep it short and to the point
+  5. Maximum line length is 120 characters (except for long URLs, packages or imports)
   6. No trailing spaces allowed (except in comments)
   7. Tokens should be surrounded by whitespace (see http://checkstyle.sourceforge.net/config_whitespace.html#WhitespaceAround)
   8. Each source file must include our license header (validated separately by license-maven-plugin, see pom.xml)
@@ -49,7 +48,7 @@ For more information on CheckStyle configurations below, see: http://checkstyle.
             <property name="ignorePattern" value="^package.*|^import.*|http://|https://"/>
         </module>
 
-        <!-- Check for and report back any TODO or FIXME comments as info messages -->
+        <!-- Highlight any TODO or FIXME comments in info messages -->
         <module name="TodoComment">
             <property name="severity" value="info"/>
             <property name="format" value="(TODO)|(FIXME)"/>

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,35 @@
                         </execution>
                     </executions>
                 </plugin>
+                <!-- Used to validate all code style rules in source code via the Checkstyle config in checkstyle.xml -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>2.17</version>
+                    <executions>
+                        <execution>
+                            <id>verify-style</id>
+                            <phase>process-classes</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <configLocation>${root.basedir}/checkstyle.xml</configLocation>
+                        <encoding>${project.build.sourceEncoding}</encoding>
+                        <logViolationsToConsole>true</logViolationsToConsole>
+                        <linkXRef>false</linkXRef>
+                    </configuration>
+                    <dependencies>
+                        <!-- Override dependencies to use latest version of checkstyle -->
+                        <dependency>
+                            <groupId>com.puppycrawl.tools</groupId>
+                            <artifactId>checkstyle</artifactId>
+                            <version>8.5</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>findbugs-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>2.17</version>
+                    <version>3.0.0</version>
                     <executions>
                         <execution>
                             <id>verify-style</id>
@@ -201,7 +201,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>8.5</version>
+                            <version>8.8</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
**PR is now considered ready for merger, though any additional comments are more than welcome.**

I'd like to propose the following new Java Code Style Rules for DSpace `master` branch (these rules will not be backported to any previous branches):

> 1. 4-space indents for Java, and 2-space indents for XML. NO TABS ALLOWED.
> 2. K&R style braces required. Braces required on all blocks.
> 3. Do not use wildcard imports (e.g. import java.util.*). Duplicated or unused imports also not allowed.
> 4. Javadocs should exist for all public classes and methods. (Methods rule is unenforced at this time.) Keep it short and to the point
> 5. Maximum line length is 120 characters (except for long URLs, packages or imports)
> 6. No trailing spaces allowed (except in comments)
> 7. Tokens should be surrounded by whitespace (see http://checkstyle.sourceforge.net/config_whitespace.html#WhitespaceAround)
> 8. No empty `catch` blocks in `try / catch` (must at least include a comment)
> 9. Each source file must include our license header (validated separately by license-maven-plugin, see pom.xml)

These rules are both listed and enforced in the [`checkstyle.xml` configuration](https://github.com/DSpace/DSpace/blob/6b749fb4c69533524608e2bdb22519055d5cc3a4/checkstyle.xml) applied to this PR's branch.  More information on Checkstyle settings can be found at http://checkstyle.sourceforge.net/checks.html

**This PR serves as public notification of this proposal, and I ask that all interested developers add your feedback into this PR (feel free to comment on individual line numbers in the `checkstyle.xml` file).  Please let us know if you have objections to any proposed rule, or propose tweaks or additions to the set of rules.**  If you approve of these code style rules as-is, you are also welcome to 👍 this PR.

By default, the Checkstyle configuration is currently not executed (as the existing code has many violations to these new rules, see below).  However, you can test them locally by running:

```
# First, you may wish to ensure SNAPSHOT versions of JARs are installed in your local maven cache
mvn install
# Then, you can run this in any single module's (e.g. dspace-api) directory
mvn -U checkstyle:check
```

Currently, based on the rules proposed above, here's the counts of violations in each DSpace module:
* dspace: 0 violations
* dspace-api:  41,619 violations
* dspace-oai: 775 violations
* dspace-rdf: 72 violations
* dspace-rest: 1,952 violations
* dspace-services: 1,115 violations
* dspace-solr: 26 violations
* dspace-spring-rest: 7,482 violations
* dspace-sword: 7,134 violations
* dspace-swordv2: 1,640 violations

As the number of violations are significant, this work is being performed on a shared, public branch (`code-style-rules`). That way we can collaborate on fixing the violations.

More information on this effort (including other sample Checkstyle configs from other projects) can be found at: https://wiki.duraspace.org/pages/viewpage.action?pageId=90967266