### PR TITLE
[DS-3087] removed inlineMath setting from MathJax config in Mirage1/2

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/core/page-structure.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/core/page-structure.xsl
@@ -307,7 +307,6 @@
                 <script type="text/x-mathjax-config">
                     MathJax.Hub.Config({
                       tex2jax: {
-                        inlineMath: [['$','$'], ['\\(','\\)']],
                         ignoreClass: "detail-field-data|detailtable|exception"
                       },
                       TeX: {

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
@@ -316,7 +316,6 @@
                 <script type="text/x-mathjax-config">
                     MathJax.Hub.Config({
                       tex2jax: {
-                        inlineMath: [['$','$'], ['\\(','\\)']],
                         ignoreClass: "detail-field-data|detailtable|exception"
                       },
                       TeX: {


### PR DESCRIPTION
the MathJax defaults are sensible and preferable, this PR replaces #1608, which was closed after it was observed to target the wrong branch