### PR TITLE
DS-3787 Impossible to retrieve the community or collection logo

### DIFF
--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
@@ -360,6 +360,50 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
     }
 
     @Test
+    public void findOneLogoBitstreamTest() throws Exception {
+
+        // We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        // ** GIVEN **
+        // 1. A community with a logo
+        parentCommunity = CommunityBuilder.createCommunity(context).withName("Community").withLogo("logo_community")
+                .build();
+
+        // 2. A collection with a logo
+        Collection col = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection")
+                .withLogo("logo_collection").build();
+
+        getClient().perform(get("/api/core/bitstreams/" + parentCommunity.getLogo().getID()))
+                .andExpect(status().isOk());
+
+        getClient().perform(get("/api/core/bitstreams/" + col.getLogo().getID())).andExpect(status().isOk());
+
+    }
+
+    @Test
+    public void findOneLogoBitstreamRelsTest() throws Exception {
+
+        // We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        // ** GIVEN **
+        // 1. A community with a logo
+        parentCommunity = CommunityBuilder.createCommunity(context).withName("Community").withLogo("logo_community")
+                .build();
+
+        // 2. A collection with a logo
+        Collection col = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection")
+                .withLogo("logo_collection").build();
+
+        getClient().perform(get("/api/core/bitstreams/" + parentCommunity.getLogo().getID() + "/content"))
+                .andExpect(status().isOk()).andExpect(content().string("logo_community"));
+
+        getClient().perform(get("/api/core/bitstreams/" + col.getLogo().getID() + "/content"))
+                .andExpect(status().isOk()).andExpect(content().string("logo_collection"));
+    }
+
+    @Test
     public void findOneWrongUUID() throws Exception {
 
         //We turn off the authorization system in order to create the structure as defined below

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/builder/BitstreamBuilder.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/builder/BitstreamBuilder.java
@@ -123,15 +123,6 @@ public class BitstreamBuilder extends AbstractDSpaceObjectBuilder<Bitstream> {
 
     protected void cleanup() throws Exception {
         delete(bitstream);
-
-        try(Context c = new Context()) {
-            bitstream = c.reloadEntity(bitstream);
-            c.turnOffAuthorisationSystem();
-            if (bitstream != null) {
-                bitstreamService.expunge(c, bitstream);
-            }
-            c.complete();
-        }
     }
 
     protected DSpaceObjectService<Bitstream> getService() {


### PR DESCRIPTION
Trying to access the logo of a community or collection results in a 500 error code.
After investigation I found that the issue is related to the absence of a dc.title for such bitstreams that is used to store the name of the file. The Bitstream endpoint (MultipartFileSender) want to force a name in the response header so flag the response as not valid in absence of the file name

I have also added tests to show the bug see the result of the build of the first commit https://travis-ci.org/4Science/DSpace/builds/315096151#L5562

nevertheless, we now have a failure on the findAllBitstreamTest...