### PR TITLE
[DS-3762] fixed test for subCommunities

### DIFF
--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -248,38 +248,40 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                 .withLogo("SomeTest")
                 .build();
 
-        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+        Community parentCommunityChild1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
                 .withName("Sub Community")
                 .build();
 
-        Community child12 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+        Community parentCommunityChild2 = CommunityBuilder.createSubCommunity(context, parentCommunity)
                 .withName("Sub Community2")
                 .build();
 
-        Community child121 = CommunityBuilder.createSubCommunity(context, child12)
+        Community parentCommunityChild2Child1 = CommunityBuilder.createSubCommunity(context, parentCommunityChild2)
                 .withName("Sub Sub Community")
                 .build();
 
 
-        Community child2 = CommunityBuilder.createSubCommunity(context, parentCommunity2)
+        Community parentCommunity2Child1 = CommunityBuilder.createSubCommunity(context, parentCommunity2)
                 .withName("Sub2 Community")
                 .build();
 
-        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunityChild1).withName("Collection 1").build();
 
         getClient().perform(get("/api/core/communities/search/subCommunities/")
                 .param("parent", parentCommunity.getID().toString()))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(contentType))
+                //Checking that these communities are present
                 .andExpect(jsonPath("$._embedded.communities", Matchers.containsInAnyOrder(
-                        CommunityMatcher.matchCommunityEntry(child1.getName(), child1.getID(), child1.getHandle()),
-                        CommunityMatcher.matchCommunityEntry(child12.getName(), child12.getID(), child12.getHandle())
+                        CommunityMatcher.matchCommunityEntry(parentCommunityChild1.getName(), parentCommunityChild1.getID(), parentCommunityChild1.getHandle()),
+                        CommunityMatcher.matchCommunityEntry(parentCommunityChild2.getName(), parentCommunityChild2.getID(), parentCommunityChild2.getHandle())
                 )))
-                .andExpect(jsonPath("$._embedded.communities", Matchers.not(Matchers.containsInAnyOrder(
+                //Checking that these communities are not present
+                .andExpect(jsonPath("$._embedded.communities", Matchers.not(Matchers.anyOf(
                         CommunityMatcher.matchCommunityEntry(parentCommunity.getName(), parentCommunity.getID(), parentCommunity.getHandle()),
                         CommunityMatcher.matchCommunityEntry(parentCommunity2.getName(), parentCommunity2.getID(), parentCommunity2.getHandle()),
-                        CommunityMatcher.matchCommunityEntry(child2.getName(), child2.getID(), child2.getHandle()),
-                        CommunityMatcher.matchCommunityEntry(child121.getName(), child121.getID(), child121.getHandle())
+                        CommunityMatcher.matchCommunityEntry(parentCommunity2Child1.getName(), parentCommunity2Child1.getID(), parentCommunity2Child1.getHandle()),
+                        CommunityMatcher.matchCommunityEntry(parentCommunityChild2Child1.getName(), parentCommunityChild2Child1.getID(), parentCommunityChild2Child1.getHandle())
                 ))))
                 .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/communities/search/subCommunities")))
                 .andExpect(jsonPath("$.page.size", is(20)))
@@ -287,18 +289,20 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
         ;
 
         getClient().perform(get("/api/core/communities/search/subCommunities/")
-                .param("parent", child12.getID().toString()))
+                .param("parent", parentCommunityChild2.getID().toString()))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(contentType))
-                .andExpect(jsonPath("$._embedded.communities", Matchers.containsInAnyOrder(
-                        CommunityMatcher.matchCommunityEntry(child121.getName(), child121.getID(), child121.getHandle())
+                //Checking that these communities are present
+                .andExpect(jsonPath("$._embedded.communities", Matchers.contains(
+                        CommunityMatcher.matchCommunityEntry(parentCommunityChild2Child1.getName(), parentCommunityChild2Child1.getID(), parentCommunityChild2Child1.getHandle())
                 )))
-                .andExpect(jsonPath("$._embedded.communities", Matchers.not(Matchers.containsInAnyOrder(
+                //Checking that these communities are not present
+                .andExpect(jsonPath("$._embedded.communities", Matchers.not(Matchers.anyOf(
                         CommunityMatcher.matchCommunityEntry(parentCommunity.getName(), parentCommunity.getID(), parentCommunity.getHandle()),
                         CommunityMatcher.matchCommunityEntry(parentCommunity2.getName(), parentCommunity2.getID(), parentCommunity2.getHandle()),
-                        CommunityMatcher.matchCommunityEntry(child2.getName(), child2.getID(), child2.getHandle()),
-                        CommunityMatcher.matchCommunityEntry(child121.getName(), child121.getID(), child121.getHandle()),
-                        CommunityMatcher.matchCommunityEntry(child1.getName(), child1.getID(), child1.getHandle())
+                        CommunityMatcher.matchCommunityEntry(parentCommunity2Child1.getName(), parentCommunity2Child1.getID(), parentCommunity2Child1.getHandle()),
+                        CommunityMatcher.matchCommunityEntry(parentCommunityChild2Child1.getName(), parentCommunityChild2Child1.getID(), parentCommunityChild2Child1.getHandle()),
+                        CommunityMatcher.matchCommunityEntry(parentCommunityChild1.getName(), parentCommunityChild1.getID(), parentCommunityChild1.getHandle())
                 ))))
                 .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/communities/search/subCommunities")))
                 .andExpect(jsonPath("$.page.size", is(20)))
@@ -306,7 +310,7 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
         ;
 
         getClient().perform(get("/api/core/communities/search/subCommunities/")
-                .param("parent", child121.getID().toString()))
+                .param("parent", parentCommunityChild2Child1.getID().toString()))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(contentType))
                 .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/communities/search/subCommunities")))
@@ -335,19 +339,19 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                 .withLogo("SomeTest")
                 .build();
 
-        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+        Community parentCommunityChild1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
                 .withName("Sub Community")
                 .build();
 
-        Community child12 = CommunityBuilder.createSubCommunity(context, child1)
+        Community parentCommunityChild1Child1 = CommunityBuilder.createSubCommunity(context, parentCommunityChild1)
                 .withName("Sub Sub Community")
                 .build();
 
-        Community child2 = CommunityBuilder.createSubCommunity(context, parentCommunity2)
+        Community parentCommunity2Child1 = CommunityBuilder.createSubCommunity(context, parentCommunity2)
                 .withName("Sub2 Community")
                 .build();
 
-        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunityChild1).withName("Collection 1").build();
 
         getClient().perform(get("/api/core/communities/search/subCommunities"))
                 .andExpect(status().isUnprocessableEntity())

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -267,7 +267,7 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
 
         Collection col1 = CollectionBuilder.createCollection(context, parentCommunityChild1).withName("Collection 1").build();
 
-        getClient().perform(get("/api/core/communities/search/subCommunities/")
+        getClient().perform(get("/api/core/communities/search/subCommunities")
                 .param("parent", parentCommunity.getID().toString()))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(contentType))
@@ -288,7 +288,7 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                 .andExpect(jsonPath("$.page.totalElements", is(2)))
         ;
 
-        getClient().perform(get("/api/core/communities/search/subCommunities/")
+        getClient().perform(get("/api/core/communities/search/subCommunities")
                 .param("parent", parentCommunityChild2.getID().toString()))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(contentType))
@@ -309,7 +309,7 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                 .andExpect(jsonPath("$.page.totalElements", is(1)))
         ;
 
-        getClient().perform(get("/api/core/communities/search/subCommunities/")
+        getClient().perform(get("/api/core/communities/search/subCommunities")
                 .param("parent", parentCommunityChild2Child1.getID().toString()))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(contentType))


### PR DESCRIPTION
This PR fixes the test on the /communities/search/subCommunities?parent=UUID endpoint as described by @abollini. cfr: https://github.com/DSpace/DSpace/pull/1893 