### PR TITLE
DS-3791 : Missing date values while faceting

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SidebarFacetsTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SidebarFacetsTransformer.java
@@ -424,8 +424,9 @@ public class SidebarFacetsTransformer extends AbstractDSpaceTransformer implemen
                         }
 
                         int gap = 1;
-                        //Attempt to retrieve our gap using the algorithm below
-                        int yearDifference = newestYear - oldestYear;
+                        //Attempt to retrieve our gap using the algorithm below.
+                        // One year is added to the "newestYear" to take into account that EXACTLY 10 years apart in values (eg: 2007-2017 entails 11 years)
+                        int yearDifference = (newestYear+1) - oldestYear;
                         if(yearDifference != 0){
                             while (10 < ((double)yearDifference / gap)){
                                 gap *= 10;


### PR DESCRIPTION
Fixes #7138
Make sure the "yearDifference" takes into account that a gap of 10 year contains 11 years 