### PR TITLE
DS-3794 issue when pressing enter in submission lookup popup window (5.x)

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/general/ChoiceLookupTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/general/ChoiceLookupTransformer.java
@@ -123,7 +123,7 @@ public class ChoiceLookupTransformer extends AbstractDSpaceTransformer
             throw new UIException("Missing a required parameter",e);
         }
 
-        Division idiv = body.addInteractiveDivision("lookup", "", "get", "popup");
+        Division idiv = body.addInteractiveDivision("lookup", "javascript:DSpaceChoicesLoad(this);", "get", "popup");
         if (isFieldMessage(field, "title"))
         {
             idiv.setHead(getFieldMessage(field, "title"));


### PR DESCRIPTION
In the ChoiceLookupTransformer, when creating the interactive div, it should be given an action, to prevent the default 'submit' action.
I gave it the 'DSpaceChoiceLoad() action, which takes a form as argument.
I also refactored the choice-lookup.js file, basically:

* in the DSpaceChoiceLookup function: copying the input values to the popup at the time the popup is opened
* in the DSpaceChoicesLoad function: reading the value from the popup input (rather than from a param, which never worked and then from the submission form, thus ignoring the popup input text)
* in the DSpaceChoicesLoad function: deleting some unused variables
* in the DSpaceChoicesLoad function: don't increase the start and end of the results, because this shouldn't be done when altering the search term. Also renamed the 'oldStart' and 'newStart' variables to 'start' and 'end' for clarity.
* in the DSpaceChoicesMoreOnClick function: rather increase the pagination of the results here