### PR TITLE
[DS-3556] Rollback of Xalan from 2.7.2 to 2.7.0 to fix DS-3556 and DS…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1223,7 +1223,7 @@
             <dependency>
                 <groupId>xalan</groupId>
                 <artifactId>xalan</artifactId>
-                <version>2.7.2</version>
+                <version>2.7.0</version>
             </dependency>
             <dependency>
                 <groupId>xerces</groupId>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3556
https://jira.duraspace.org/browse/DS-3733

There is a bug in Xalan 2.7.1 and 2.7.2 causing certain unicode charcters to throw exceptions.
  