### PR TITLE
DS-3800 The metadata.hide configuration property does not take into account the boolean value assigned to it.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/MetadataExposureServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/MetadataExposureServiceImpl.java
@@ -7,15 +7,14 @@
  */
 package org.dspace.app.util;
 
-import org.apache.log4j.Logger;
-import org.dspace.app.util.service.MetadataExposureService;
-import org.dspace.authorize.service.AuthorizeService;
-import org.dspace.core.ConfigurationManager;
-import org.dspace.core.Context;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.*;
+import org.apache.log4j.*;
+import org.dspace.app.util.service.*;
+import org.dspace.authorize.service.*;
+import org.dspace.core.*;
+import org.dspace.services.*;
+import org.springframework.beans.factory.annotation.*;
 
 /**
  * Static utility class to manage configuration for exposure (hiding) of
@@ -64,6 +63,9 @@ public class MetadataExposureServiceImpl implements MetadataExposureService
 
     @Autowired(required = true)
     protected AuthorizeService authorizeService;
+
+    @Autowired(required = true)
+    protected ConfigurationService configurationService;
 
     protected MetadataExposureServiceImpl()
     {
@@ -132,12 +134,11 @@ public class MetadataExposureServiceImpl implements MetadataExposureService
             hiddenElementSets = new HashMap<>();
             hiddenElementMaps = new HashMap<>();
 
-            Enumeration pne = ConfigurationManager.propertyNames();
-            while (pne.hasMoreElements())
-            {
-                String key = (String)pne.nextElement();
+            List<String> propertyKeys = configurationService.getPropertyKeys();
+            for (String key : propertyKeys) {
                 if (key.startsWith(CONFIG_PREFIX))
                 {
+                    if(configurationService.getBooleanProperty(key, true)){
                     String mdField = key.substring(CONFIG_PREFIX.length());
                     String segment[] = mdField.split("\\.", 3);
 
@@ -173,6 +174,7 @@ public class MetadataExposureServiceImpl implements MetadataExposureService
                         log.warn("Bad format in hidden metadata directive, field=\""+mdField+"\", config property="+key);
                     }
                 }
+            }
             }
         }
     }

--- a/dspace-api/src/main/java/org/dspace/app/util/MetadataExposureServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/MetadataExposureServiceImpl.java
@@ -7,14 +7,19 @@
  */
 package org.dspace.app.util;
 
-import java.sql.*;
-import java.util.*;
-import org.apache.log4j.*;
-import org.dspace.app.util.service.*;
-import org.dspace.authorize.service.*;
-import org.dspace.core.*;
-import org.dspace.services.*;
-import org.springframework.beans.factory.annotation.*;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.log4j.Logger;
+import org.dspace.app.util.service.MetadataExposureService;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.core.Context;
+import org.dspace.services.ConfigurationService;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Static utility class to manage configuration for exposure (hiding) of
@@ -138,7 +143,7 @@ public class MetadataExposureServiceImpl implements MetadataExposureService
             for (String key : propertyKeys) {
                 if (key.startsWith(CONFIG_PREFIX))
                 {
-                    if(configurationService.getBooleanProperty(key, true)){
+                    if (configurationService.getBooleanProperty(key, true)){
                     String mdField = key.substring(CONFIG_PREFIX.length());
                     String segment[] = mdField.split("\\.", 3);
 


### PR DESCRIPTION
The booleans assigned to the metadata.hide.SCHEMA.ELEMENT.QUALIFIER configuration properties in dspace.cfg were not being used. Updated the MetadataExposureServiceImpl java class to take these booleans into account when checking if a field should be hidden. 

jira ticket:
https://jira.duraspace.org/browse/DS-3800