### PR TITLE
Dspace 6 x translation pl

### DIFF
--- a/dspace/config/emails/bte_batch_import_error
+++ b/dspace/config/emails/bte_batch_import_error
@@ -6,14 +6,14 @@
 #
 # See org.dspace.core.Email for information on the format of this file.
 #
-Subject: DSpace - The batch import was not completed.
-The batch import you initiated from the DSpace UI was not completed, due to the following reason:
+Subject: DSpace - Import wsadowy nie zakończył się.
+Import wsadowy, który zainicjowano z interfejsu użytkownika DSpace nie zakończył się z następującego powodu:
  {0}
 
-For more information you may contact your system administrator:
+Aby uzyskać więcej informacji, skontaktuj się z administratorem systemu:
  {1}
 
 
 
-The DSpace Team
+Oprogramowanie DSpace
 

--- a/dspace/config/emails/bte_batch_import_success
+++ b/dspace/config/emails/bte_batch_import_success
@@ -5,11 +5,11 @@
 #
 # See org.dspace.core.Email for information on the format of this file.
 #
-Subject: DSpace - Batch import successfully completed
-The batch item import you initiated from the DSpace UI has completed successfully.
+Subject: DSpace - Import wsadowy zakończony pomyślnie
+Import wsadowy, który rozpoczęto na stronie DSpace, zakończył się pomyślnie.
 
-You may find the mapfile for the import in the following path: {0}
+Plik mapfile dla importu znajdziesz tutaj: {0}
 
 
-The DSpace Team
+Ekipa DSpace
 

--- a/dspace/config/emails/change_password
+++ b/dspace/config/emails/change_password
@@ -4,13 +4,13 @@
 #
 # See org.dspace.core.Email for information on the format of this file.
 #
-Subject: Change Password Request
-To change the password for your DSpace account, please click the link
-below:
+Subject: Żądanie zmiany hasła
+Aby zmienić hasło Twojego konta DSpace, uprzejmie proszę kliknij
+poniższy link:
 
   {0}
 
-If you need assistance with your account, please email
-dspace-help@myu.edu or call us at xxx-555-xxxx.
+Jeżeli potrzebujesz pomocy w korzystaniu ze swojego konta, skontaktuj się
+z administratorem systemu DSpace.
 
-The DSpace Team
+E-mail został wygenerowany automatycznie. 

--- a/dspace/config/emails/doi_maintenance_error
+++ b/dspace/config/emails/doi_maintenance_error
@@ -10,9 +10,9 @@
 #
 # See org.dspace.core.Email for information on the format of this file.
 #
-Subject: DSpace: Error {0} DOI {3}
+Subject: DSpace: Błąd {0} DOI {3}
 
-Date:    {1}
+Data:    {1}
 
-{0} DOI {4} for {2} with ID {3} failed:
+Niepowodzenie: {0} DOI {4} dla {2} o ID {3}
 {5}

--- a/dspace/config/emails/export_error
+++ b/dspace/config/emails/export_error
@@ -6,14 +6,14 @@
 #
 # See org.dspace.core.Email for information on the format of this file.
 #
-Subject: DSpace - The item export you requested was not completed.
-The item export you requested was not completed, due to the following reason:
+Subject: DSpace - Nie ukończono eksportu pozycji
+Pozycja o której eksport proszono nie została wyeksportowana z powodu:
  {0}
 
-For more information you may contact your system administrator:
+Aby uzyskać więcej informacji, skontaktuj się z administratorem systemu:
  {1}
 
 
 
-The DSpace Team
+Ekipa DSpace
 

--- a/dspace/config/emails/export_success
+++ b/dspace/config/emails/export_success
@@ -5,14 +5,14 @@
 #
 # See org.dspace.core.Email for information on the format of this file.
 #
-Subject: DSpace - Item export requested is ready for download
-The item export you requested from the repository is now ready for download.
+Subject: DSpace - Weksportowana pozycja gotowa do pobrania
+Pozycja, o której eksport z repozytorium poprosiłeś/aś jest gotowa do pobrania.
 
-You may download the compressed file using the following link:
+Możesz pobrać skompresowany plik korzystając z adresu:
 {0}
 
-This file will remain available for at least {1} hours.  
+Ten plik pozostanie dostępny przez przynajmniej {1} godzin.
 
 
-The DSpace Team
+Ekipa DSpace
 

--- a/dspace/config/emails/feedback
+++ b/dspace/config/emails/feedback
@@ -10,17 +10,17 @@
 #
 # See org.dspace.core.Email for information on the format of this file.
 #
-Subject: Feedback Form Information
+Subject: Informacje z formularza kontaktowego
 
-Comments:
+Wiadomość:
 
 {6}
 
 
-Date: {0}
+Data: {0}
 Email: {1}
-Logged In As: {2}
-Referring Page: {3}
-User Agent: {4}
-Session: {5}
+Zalogowany jako: {2}
+Ze strony: {3}
+Przeglądarka: {4}
+Sesja: {5}
 

--- a/dspace/config/emails/flowtask_notify
+++ b/dspace/config/emails/flowtask_notify
@@ -7,17 +7,16 @@
 # {4}  Task result
 # {5}  Workflow action taken
 #
-Subject: DSpace: Curation Task Report
+Subject: DSpace: Raport z zadania porządkowego
 
-Title:         {0}
-Collection:    {1}
-Submitted by:  {2}
+Tytuł:       {0}
+Zbiór:       {1}
+Przesłał/a:  {2}
 
-Curation task {3} has been performed
-with the following result:
+Zadanie porządkowania {3} zostało przeprowadzone z następującym rezultatem:
 
 {4}
 
-Action taken on the submission: {5}
+Podjęto następujące działania: {5}
 
 DSpace

--- a/dspace/config/emails/harvesting_error
+++ b/dspace/config/emails/harvesting_error
@@ -8,13 +8,13 @@
 #
 # See org.dspace.core.Email for information on the format of this file.
 #
-Subject: DSpace: Harvesting Error
-Collection {0} failed on harvest:
+Subject: DSpace: Błąd zbierania danych
+Zbiór {0} zawiódł podczas zbierania danych:
 
-Date:       	{1}
-Status Flag: 	{2}
+Data:       	{1}
+Status: 	{2}
 
 {3}
 
-Exception:
+Wyjątek:
 {4}

--- a/dspace/config/emails/healthcheck
+++ b/dspace/config/emails/healthcheck
@@ -3,8 +3,8 @@
 # Parameters: {0} is the output of healthcheck command
 # See org.dspace.core.Email for information on the format of this file.
 #
-Subject: Repository healthcheck
-The healthcheck finished with the following output:
+Subject: Sprawdzenie integralności repozytorium
+Sprawdzenie integralności repozytorium ukończone z następującym rezultatem:
 
 {0}
 

--- a/dspace/config/emails/internal_error
+++ b/dspace/config/emails/internal_error
@@ -10,15 +10,15 @@
 #
 # See org.dspace.core.Email for information on the format of this file.
 #
-Subject: DSpace: Internal Server Error
-An internal server error occurred on {0}:
+Subject: DSpace: Wewnętrzny błąd serwera
+Wystąpił wewnętrzny błąd serwera w {0}:
 
-Date:       {1}
-Session ID: {2}
-User:       {5}
-IP address: {6}
+Data:       {1}
+ID sesji:   {2}
+Użytkownik: {5}
+Adres IP:   {6}
 
 {3}
 
-Exception:
+Wyjątek:
 {4}

--- a/dspace/config/emails/register
+++ b/dspace/config/emails/register
@@ -4,13 +4,11 @@
 #
 # See org.dspace.core.Email for information on the format of this file.
 #
-Subject: DSpace Account Registration
-To complete registration for a DSpace account, please click the link
-below:
+Subject: Rejestracja konta w DSpace
+Aby ukończyć rejestrację konta DSpace, kliknij adres poniżej:
 
   {0}
 
-If you need assistance with your account, please email
-dspace-help@myu.edu or call us at xxx-555-xxxx.
+Jeżeli potrzebujesz pomocy, skontaktuj się z administratorem systemu.
 
-The DSpace Team
+Ekipa DSpace

--- a/dspace/config/emails/registration_notify
+++ b/dspace/config/emails/registration_notify
@@ -8,10 +8,10 @@
 #
 # See org.dspace.core.Email for information on the format of this file.
 #
-Subject: DSpace: Registration Notification
+Subject: DSpace: Powiadomienie o rejestracji
 
-A new user has registered on {0} at {1}:
+Zarejestrował się nowy użytkownik na {0} przez {1}:
 
-Name:                   {2}
-Email:                  {3}
-Date:                   {4}
+Imię i nazwisko:         {2}
+E-mail:                  {3}
+Data:                    {4}

--- a/dspace/config/emails/request_item.admin
+++ b/dspace/config/emails/request_item.admin
@@ -1,8 +1,8 @@
-Subject: Request for Open Access
+Subject: Prośba o Open Access
 
-{3}, with address {4},
-requested the following document/file to be in Open Access: 
+{3}, adres {4},
+poprosił/a aby następujące dokumenty/pliki udostępnione zostały jako OpenAccess:
 
-Document Handle:{1} 
-File ID: {0} 
+Dokument:{1} 
+ID pliku: {0} 
 Token:{2}

--- a/dspace/config/emails/request_item.author
+++ b/dspace/config/emails/request_item.author
@@ -1,17 +1,17 @@
-Subject: Request copy of document
+Subject: Prośba o udostępnienie kopii dokumentu
 
-Dear {7},
+Szanowny/a {7},
 
-A user of {9}, named {0} and using the email {1}, requested a copy of the file(s) associated with the document: "{4}" ({3}) submitted by you.
+Użytkownik {9}, przedstawiający się jako {0}, korzystający z adresu e-mail {1}, poprosił/a o kopię pliku powiązanego z pozycją: "{4}" ({3}), która to pozycja została zgłoszona przez Ciebie. 
 
-This request came along with the following message:
+Ta prośba została wysłana z następującym komunikatem:
 
 "{5}"
 
-To answer, click {6}. Whether you choose to grant or deny the request, we think that it''s in your best interest to respond.
+Aby udzielić odpowiedzi, kliknij {6}. Niezależnie od tego, czy zdecydujesz się udostępnić lub odmówić dostępu, sądzimy, że dobrze by było, abyś udzielił/a odpowiedzi.
 
-IF YOU ARE NOT AN AUTHOR OF THIS DOCUMENT, and only submitted the document on the author''s behalf, PLEASE REDIRECT THIS MESSAGE TO THE AUTHOR(S).  Only the author(s) should answer the request to send a copy.
+JEŻELI NIE JESTEŚ AUTOREM TEGO DOKUMENTU, a jedynie zgłosiłeś/aś tę pozycję na życzenie autora, PROSIMY PRZEKIERUJ TĄ WIADOMOŚĆ DO AUTORA(AUTORÓW). Wyłącznie autor(autorzy) powinien(powinni) odpowiadać na prośbę o udostępnienie kopii dokumentu.
 
-IF YOU ARE AN AUTHOR OF THE REQUESTED DOCUMENT, thank you for your cooperation!
+JEŻELI JESTEŚ AUTOREM TEGO DOKUMENTU, serdecznie dziękujemy za współpracę!
 
-If you have any questions concerning this request, please contact {10}.
+Jeżeli masz pytania dotyczące tej prośby, prosimy o kontakt z {10}.

--- a/dspace/config/emails/submit_archive
+++ b/dspace/config/emails/submit_archive
@@ -4,18 +4,18 @@
 # {1}  Name of collection
 # {2}  handle 
 #
-Subject: DSpace: Submission Approved and Archived 
+Subject: DSpace: Zgłoszenie przyjęte i zarchiwizowane
 
-You submitted: {0}
+Zgłosiłeś/aś: {0}
 
-To collection: {1}
+Do zbioru:    {1}
 
-Your submission has been accepted and archived in DSpace,
-and it has been assigned the following identifier:
+Twoje zgłoszenie zostało przyjęte i zarchiwizowane w DSpace,
+otrzymując następujący identyfikator:
 {2}
 
-Please use this identifier when citing your submission.
+Użyj tego identyfikatora cytując zgłoszoną pracę.
 
-Many thanks!
+Dziękujemy!
 
-DSpace
+Ekipa DSpace

--- a/dspace/config/emails/submit_reject
+++ b/dspace/config/emails/submit_reject
@@ -6,18 +6,18 @@
 # {3}  Reason for the rejection
 # {4}  Link to 'My DSpace' page
 #
-Subject: DSpace: Submission Rejected
+Subject: DSpace: Zgłoszenie odrzucone
 
-You submitted: {0}
+Zgłosiłeś/aś: {0}
 
-To collection: {1}
+Do zbioru:    {1}
 
-Your submission has been rejected by {2}
-with the following explanation:
+Twoje zgłoszenie zostało odrzucone przez {2}
+z następującym wyjaśnieniem:
 
 {3}
 
-Your submission has not been deleted.  You can access it from your
-"My DSpace" page: {4}
+Twoje zgłoszenie nie zostało usunięte. Masz do niego dostęp przez stronę "Mój DSpace":
+{4}
 
-DSpace
+Ekipa DSpace

--- a/dspace/config/emails/submit_task
+++ b/dspace/config/emails/submit_task
@@ -6,19 +6,18 @@
 # {3}  Description of task
 # {4}  link to 'my DSpace' page 
 #
-Subject: DSpace: You have a new task
+Subject: DSpace: Masz nowe zadanie
 
-A new item has been submitted:
+Zgłoszona została nowa pozycja:
 
-Title:        {0}
-Collection:   {1}
-Submitted by: {2}
+Tytuł:	   {0}
+Zbiór:	   {1}
+Zgłosił/a: {2}
 
 {3}
 
-To claim this task, please visit your "My DSpace"
-page:  {4}
+Aby zająć się tym zadaniem, odwiedź swoją stronę "Mój DSpace" tutaj: {4}
 
-Many thanks!
+Dziękujemy!
 
-DSpace
+Oprogramowanie DSpace

--- a/dspace/config/emails/subscription
+++ b/dspace/config/emails/subscription
@@ -4,8 +4,8 @@
 # Parameters: {0} is the details of the new collections and items
 # See org.dspace.core.Email for information on the format of this file.
 #
-Subject: DSpace Subscription
-New items are available in the collections you have subscribed to:
+Subject: Subskrypcja DSpace
+W zbiorach, które zasubskrybowałeś/aś dostępne są nowe pozycje:
 
 {0}
 

--- a/dspace/config/emails/suggest
+++ b/dspace/config/emails/suggest
@@ -10,17 +10,16 @@
 #             {7} sender message 
 # See org.dspace.core.Email for information on the format of this file.
 #
-Subject: An item of interest from DSpace
+Subject: Wiadomość od serwisu DSpace
 
-Hello {0}:
+Witaj {0}:
 
-{1} requested we send you this email regarding an item available in {2}.
+{1} poprosił/a żebyśmy wysłali Tobie ten e-mail, dotyczący pozycji dostępnej w {2}.
 
-Title: {3}
-Location: {5}
-In Collection: {6}
-Personal Message: {7}
+Tytuł: {3}
+Lokalizacja: {5}
+W zbiorze: {6}
+Komunikat: {7}
 
-The DSpace digital repository system captures, stores, indexes, preserves, and distributes digital material.
-For more information, visit www.dspace.org
+Cyfrowe repozytorium DSpace przechowuje, indeksuje, zachowuje i dystrybuuje materiały cyfrowe. Aby dowiedzieć się więcej, wejdź na www.dspace.org
 

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -43,9 +43,9 @@
          <dc-element>contributor</dc-element>
          <dc-qualifier>author</dc-qualifier>
          <repeatable>true</repeatable>
-         <label>Authors</label>
+         <label>Autorzy</label>
          <input-type>name</input-type>
-         <hint>Enter the names of the authors of this item.</hint>
+         <hint>Wpisz imiona i nazwiska autorów dla tej pozycji</hint>
          <required></required>
        </field>
 
@@ -54,10 +54,10 @@
          <dc-element>title</dc-element>
          <dc-qualifier></dc-qualifier>
          <repeatable>false</repeatable>
-         <label>Title</label>
+         <label>Tytuł</label>
          <input-type>onebox</input-type>
-         <hint>Enter the main title of the item.</hint>
-         <required>You must enter a main title for this item.</required>
+         <hint>Wpisz tytuł tej pozycji.</hint>
+         <required>Musisz określić tytuł dla tej pozycji.</required>
        </field>
 
        <field>
@@ -65,9 +65,9 @@
          <dc-element>title</dc-element>
          <dc-qualifier>alternative</dc-qualifier>
          <repeatable>true</repeatable>
-         <label>Other Titles</label>
+         <label>Inne tytuły</label>
          <input-type>onebox</input-type>
-         <hint>If the item has any alternative titles, please enter them here.</hint>
+         <hint>Jeżeli ta pozycja ma alternatywne tytuły, wpisz je tutaj.</hint>
          <required></required>
        </field>
 
@@ -76,12 +76,12 @@
          <dc-element>date</dc-element>
          <dc-qualifier>issued</dc-qualifier>
          <repeatable>false</repeatable>
-         <label>Date of Issue</label>
+         <label>Data wydania</label>
          <input-type>date</input-type>
-         <hint>Please give the date of previous publication or public distribution.
-                        You can leave out the day and/or month if they aren't
-                        applicable.</hint>
-         <required>You must enter at least the year.</required>
+         <hint>Proszę podaj datę wydania lub udostępnienia w przypadku gdyby ta
+           pozycja była już opublikowana.
+            Możesz pominąć dzień i/lub miesiąc, jeżeli nie można ich ustalić.</hint>
+         <required>Wpisz przynajmniej rok.</required>
        </field>
 
        <field>
@@ -91,7 +91,7 @@
          <repeatable>false</repeatable>
          <label>Publisher</label>
          <input-type>onebox</input-type>
-         <hint>Enter the name of the publisher of the previously issued instance of this item.</hint>
+         <hint>Wpisz nazwę wydawcy w przypadku, gdy ta pozycja była juz opublikowana.</hint>
          <required></required>
        </field>
 
@@ -100,9 +100,9 @@
          <dc-element>identifier</dc-element>
          <dc-qualifier>citation</dc-qualifier>
          <repeatable>false</repeatable>
-         <label>Citation</label>
+         <label>Cytowanie</label>
          <input-type>onebox</input-type>
-         <hint>Enter the standard citation for the previously issued instance of this item.</hint>
+         <hint>Wpisz cytowanie dla poprzednio opublikowanej pozycji.</hint>
          <required></required>
        </field>
 
@@ -111,9 +111,9 @@
          <dc-element>relation</dc-element>
          <dc-qualifier>ispartofseries</dc-qualifier>
          <repeatable>true</repeatable>
-         <label>Series/Report No.</label>
+         <label>Nr w serii</label>
          <input-type>series</input-type>
-         <hint>Enter the series and number assigned to this item by your community.</hint>
+         <hint>Wpisz nr serii przypisany dla tej pozycji.</hint>
          <required></required>
        </field>
 
@@ -123,10 +123,10 @@
          <dc-qualifier></dc-qualifier>
          <!-- An input-type of qualdrop_value MUST be marked as repeatable -->
          <repeatable>true</repeatable>
-         <label>Identifiers</label>
+         <label>Identyfikatory</label>
          <input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
-         <hint>If the item has any identification numbers or codes associated with
-it, please enter the types and the actual numbers or codes.</hint>
+         <hint>Jeżeli ta pozycja ma już jakieś numery identyfikacyjne, prosimy
+           o uzupełnienie ich.</hint>
          <required></required>
        </field>
 
@@ -135,9 +135,12 @@ it, please enter the types and the actual numbers or codes.</hint>
          <dc-element>type</dc-element>
          <dc-qualifier></dc-qualifier>
          <repeatable>true</repeatable>
-         <label>Type</label>
+         <label>Rodzaj</label>
          <input-type value-pairs-name="common_types">dropdown</input-type>
-         <hint>Select the type(s) of content of the item. To select more than one value in the list, you may have to hold down the "CTRL" or "Shift" key.</hint>
+         <hint>Wybierz rodzaj zawartości dla tej pozycji. Aby wybrać więcej,
+           niż jedną wartość z listy, może być konieczne przytrzymanie "CTRL",
+            "Shift" lub "CMD".
+            </hint>
          <required></required>
        </field>
 
@@ -146,9 +149,12 @@ it, please enter the types and the actual numbers or codes.</hint>
          <dc-element>language</dc-element>
          <dc-qualifier>iso</dc-qualifier>
          <repeatable>false</repeatable>
-         <label>Language</label>
+         <label>Język</label>
          <input-type value-pairs-name="common_iso_languages">dropdown</input-type>
-         <hint>Select the language of the main content of the item.  If the language does not appear in the list, please select 'Other'.  If the content does not really have a language (for example, if it is a dataset or an image) please select 'N/A'.</hint>
+         <hint>
+           Wybierz język dla istotnej częsci tej pozycji. Jeżeli języka nie ma
+           na liście, wybierz "Inny". Jeżeli dla tej pozycji nie można ustalić
+           języka (np. jest to zestaw danych lub obraz), proszę wybrać "N/A".</hint>
          <required></required>
        </field>
      </page>
@@ -160,9 +166,9 @@ it, please enter the types and the actual numbers or codes.</hint>
          <dc-qualifier></dc-qualifier>
          <!-- An input-type of twobox MUST be marked as repeatable -->
          <repeatable>true</repeatable>
-         <label>Subject Keywords</label>
+         <label>Słowa kluczowe</label>
          <input-type>twobox</input-type>
-         <hint>Enter appropriate subject keywords or phrases. </hint>
+         <hint>Wpisz adekwatne słowa kluczowe i frazy.</hint>
          <required></required>
          <vocabulary>srsc</vocabulary>
        </field>
@@ -172,9 +178,9 @@ it, please enter the types and the actual numbers or codes.</hint>
          <dc-element>description</dc-element>
          <dc-qualifier>abstract</dc-qualifier>
          <repeatable>false</repeatable>
-         <label>Abstract</label>
+         <label>Streszczenie</label>
          <input-type>textarea</input-type>
-         <hint>Enter the abstract of the item. </hint>
+         <hint>Wpisz streszczenie dla tej pozycji</hint>
          <required></required>
        </field>
 
@@ -183,9 +189,9 @@ it, please enter the types and the actual numbers or codes.</hint>
          <dc-element>description</dc-element>
          <dc-qualifier>sponsorship</dc-qualifier>
          <repeatable>false</repeatable>
-         <label>Sponsors</label>
+         <label>Sponsorowani</label>
          <input-type>textarea</input-type>
-         <hint>Enter the names of any sponsors and/or funding codes in the box. </hint>
+         <hint>Wpisz nazwy organizacji sponsorujących tą pozycję.</hint>
          <required></required>
        </field>
 
@@ -194,9 +200,9 @@ it, please enter the types and the actual numbers or codes.</hint>
          <dc-element>description</dc-element>
          <dc-qualifier></dc-qualifier>
          <repeatable>false</repeatable>
-         <label>Description</label>
+         <label>Opis</label>
          <input-type>textarea</input-type>
-         <hint>Enter any other description or comments in this box. </hint>
+         <hint>Wpisz opis lub komentarze. </hint>
          <required></required>
        </field>
      </page>
@@ -209,9 +215,9 @@ it, please enter the types and the actual numbers or codes.</hint>
          <dc-element>contributor</dc-element>
          <dc-qualifier>author</dc-qualifier>
          <repeatable>true</repeatable>
-         <label>One: Authors</label>
+         <label>Jeden: Autorzy</label>
          <input-type>name</input-type>
-         <hint>Enter the names of the authors of this item.</hint>
+         <hint>Wpisz imiona i nazwiska autorów tej pozycji.</hint>
          <required></required>
        </field>
       </page>
@@ -239,7 +245,7 @@ it, please enter the types and the actual numbers or codes.</hint>
        <stored-value>issn</stored-value>
      </pair>
      <pair>
-       <displayed-value>Other</displayed-value>
+       <displayed-value>Inny</displayed-value>
        <stored-value>other</stored-value>
      </pair>
      <pair>
@@ -262,35 +268,35 @@ it, please enter the types and the actual numbers or codes.</hint>
 
    <value-pairs value-pairs-name="common_types" dc-term="type">
      <pair>
-       <displayed-value>Animation</displayed-value>
+       <displayed-value>Animacja</displayed-value>
        <stored-value>Animation</stored-value>
      </pair>
      <pair>
-       <displayed-value>Article</displayed-value>
+       <displayed-value>Artykuł</displayed-value>
        <stored-value>Article</stored-value>
      </pair>
      <pair>
-       <displayed-value>Book</displayed-value>
+       <displayed-value>Książka</displayed-value>
        <stored-value>Book</stored-value>
      </pair>
      <pair>
-       <displayed-value>Book chapter</displayed-value>
+       <displayed-value>Rozdział książki</displayed-value>
        <stored-value>Book chapter</stored-value>
      </pair>
      <pair>
-       <displayed-value>Dataset</displayed-value>
+       <displayed-value>Zestaw danych</displayed-value>
        <stored-value>Dataset</stored-value>
      </pair>
      <pair>
-       <displayed-value>Learning Object</displayed-value>
+       <displayed-value>Materiały szkoleniowe</displayed-value>
        <stored-value>Learning Object</stored-value>
      </pair>
      <pair>
-       <displayed-value>Image</displayed-value>
+       <displayed-value>Obraz</displayed-value>
        <stored-value>Image</stored-value>
      </pair>
      <pair>
-       <displayed-value>Image, 3-D</displayed-value>
+       <displayed-value>Obraz, 3-D</displayed-value>
        <stored-value>Image, 3-D</stored-value>
      </pair>
      <pair>

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -154,7 +154,8 @@
          <hint>
            Wybierz język dla istotnej częsci tej pozycji. Jeżeli języka nie ma
            na liście, wybierz "Inny". Jeżeli dla tej pozycji nie można ustalić
-           języka (np. jest to zestaw danych lub obraz), proszę wybrać "N/A".</hint>
+           języka (np. jest to zestaw danych lub obraz), proszę wybrać
+           "nieokreślony".</hint>
          <required></required>
        </field>
      </page>
@@ -362,47 +363,47 @@
      -->
    <value-pairs value-pairs-name="common_iso_languages" dc-term="language_iso">
      <pair>
-       <displayed-value>N/A</displayed-value>
+       <displayed-value>nieokreślony</displayed-value>
        <stored-value></stored-value>
      </pair>
      <pair>
-       <displayed-value>English (United States)</displayed-value>
-       <stored-value>en_US</stored-value>
+       <displayed-value>Polski</displayed-value>
+       <stored-value>pl</stored-value>
       </pair>
      <pair>
-       <displayed-value>English</displayed-value>
+       <displayed-value>Angielski</displayed-value>
        <stored-value>en</stored-value>
      </pair>
      <pair>
-       <displayed-value>Spanish</displayed-value>
+       <displayed-value>Hiszpański</displayed-value>
        <stored-value>es</stored-value>
      </pair>
      <pair>
-       <displayed-value>German</displayed-value>
+       <displayed-value>Niemiecki</displayed-value>
        <stored-value>de</stored-value>
      </pair>
      <pair>
-       <displayed-value>French</displayed-value>
+       <displayed-value>Francuski</displayed-value>
        <stored-value>fr</stored-value>
      </pair>
      <pair>
-       <displayed-value>Italian</displayed-value>
+       <displayed-value>Włoski</displayed-value>
        <stored-value>it</stored-value>
      </pair>
      <pair>
-       <displayed-value>Japanese</displayed-value>
+       <displayed-value>Japoński</displayed-value>
        <stored-value>ja</stored-value>
      </pair>
      <pair>
-       <displayed-value>Chinese</displayed-value>
+       <displayed-value>Chiński</displayed-value>
        <stored-value>zh</stored-value>
      </pair>
      <pair>
-       <displayed-value>Turkish</displayed-value>
+       <displayed-value>Turecki</displayed-value>
        <stored-value>tr</stored-value>
      </pair>
      <pair>
-       <displayed-value>(Other)</displayed-value>
+       <displayed-value>(Inny)</displayed-value>
        <stored-value>other</stored-value>
      </pair>
    </value-pairs>

--- a/dspace/config/news-xmlui.xml
+++ b/dspace/config/news-xmlui.xml
@@ -2,8 +2,8 @@
 <document xmlns="http://di.tamu.edu/DRI/1.0/" xmlns:i18n="http://apache.org/cocoon/i18n/2.1" version="1.1">
 <body>
 <div id="file.news.div.news" n="news" rend="primary">
-<head>DSpace Repository</head>
-<p>DSpace is a digital service that collects, preserves, and distributes digital material. Repositories are important tools for preserving an organization&apos;s legacy; they facilitate digital preservation and scholarly communication.</p>
+<head>Repozytorium DSpace</head>
+<p>DSpace to cyfrowa usługa, która kolekcjonuje, przechowuje i dystrybuuje materiały cyfrowe. Repozytoria to ważne narzędzia dla przechowywania bazy wiedzy; umożliwiają one nie tylko przechowywanie jej, ale także komunikację pomiędzy autorami a czytelnikami.</p>
 </div>
 </body>
 <options/>


### PR DESCRIPTION
**This should NOT be merged, by the way**

Hi. Those are changes needed to make dspace more polish-friendly. I realise that those are changes in main branch and that they can't be merged. Any ideas on how should I re-work this pull request so you can use this translations for new dspace installations without changing the default language of e-mails and news-xml? 