### PR TITLE
DS-3542: Fix REST authentication error with empty request + test

### DIFF
--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/security/DSpaceAuthentication.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/security/DSpaceAuthentication.java
@@ -31,7 +31,7 @@ public class DSpaceAuthentication implements Authentication {
     private boolean authenticated = true;
 
 
-    public DSpaceAuthentication (EPerson ePerson, List<GrantedAuthority> authorities) {
+    public DSpaceAuthentication(EPerson ePerson, List<GrantedAuthority> authorities) {
         this.previousLoginDate = ePerson.getPreviousActive();
         this.username = ePerson.getEmail();
         this.authorities = authorities;

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/security/EPersonRestAuthenticationProvider.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/security/EPersonRestAuthenticationProvider.java
@@ -13,6 +13,7 @@ import static org.dspace.app.rest.security.WebSecurityConfiguration.EPERSON_GRAN
 import java.sql.SQLException;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -37,7 +38,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
 /**
- * This class is reponsible for authenticating a user via REST
+ * This class is responsible for authenticating a user via REST
  *
  * @author Frederic Van Reet (frederic dot vanreet at atmire dot com)
  * @author Tom Desair (tom dot desair at atmire dot com)
@@ -78,11 +79,11 @@ public class EPersonRestAuthenticationProvider implements AuthenticationProvider
         Context newContext = null;
         Authentication output = null;
 
-        if(authentication != null && authentication.getCredentials() != null) {
+        if(authentication != null) {
             try {
                 newContext = new Context();
                 String name = authentication.getName();
-                String password = authentication.getCredentials().toString();
+                String password = Objects.toString(authentication.getCredentials(), null);
 
                 int implicitStatus = authenticationService.authenticateImplicit(newContext, null, null, null, request);
 
@@ -104,8 +105,6 @@ public class EPersonRestAuthenticationProvider implements AuthenticationProvider
                         throw new BadCredentialsException("Login failed");
                     }
                 }
-            } catch (Exception e) {
-                log.error("Error while authenticating in the rest api", e);
             } finally {
                 if (newContext != null && newContext.isValid()) {
                     try {
@@ -156,7 +155,8 @@ public class EPersonRestAuthenticationProvider implements AuthenticationProvider
         return authorities;
     }
 
+    @Override
     public boolean supports(Class<?> authentication) {
-        return authentication.equals(DSpaceAuthentication.class);
+        return DSpaceAuthentication.class.isAssignableFrom(authentication);
     }
 }

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/AuthenticationRestControllerIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/AuthenticationRestControllerIT.java
@@ -8,6 +8,7 @@
 package org.dspace.app.rest;
 
 import static java.lang.Thread.sleep;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
@@ -284,5 +285,12 @@ public class AuthenticationRestControllerIT extends AbstractControllerIntegratio
                 .andExpect(jsonPath("$.type", is("status")));
 
 
+    }
+
+    @Test
+    public void testLoginEmptyRequest() throws Exception {
+        getClient().perform(get("/api/authn/login"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(status().reason(containsString("Login failed")));
     }
 }


### PR DESCRIPTION
When a user currently calls the `login` endpoint without any request data, they receive the error message 

> Authentication Failed: No AuthenticationProvider found for org.dspace.app.rest.security.DSpaceAuthentication

This is confusing. This PR corrects that behaviour and makes sure the "Login failed" error is shown.

There is also an additional test to explicitly verify this behaviour.