### PR TITLE
DS-3489: Fix links of resources in embedded page

### DIFF
--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/HalLinkService.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/HalLinkService.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.log4j.Logger;
+import org.dspace.app.rest.model.hateoas.EmbeddedPage;
 import org.dspace.app.rest.model.hateoas.HALResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
@@ -59,6 +60,12 @@ public class HalLinkService {
                 }
             } else if(obj instanceof Map) {
                 for (Object subObj : ((Map) obj).values()) {
+                    if(subObj instanceof HALResource) {
+                        addLinks((HALResource) subObj);
+                    }
+                }
+            } else if(obj instanceof EmbeddedPage) {
+                for (Object subObj : ((EmbeddedPage) obj).getPageContent()) {
                     if(subObj instanceof HALResource) {
                         addLinks((HALResource) subObj);
                     }

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -16,7 +16,6 @@ import org.dspace.content.Community;
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 
 import java.util.UUID;
 
@@ -40,14 +39,18 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
                 .withName("Sub Community")
                 .build();
-        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+
+        Collection col1 = CollectionBuilder.createCollection(context, child1)
+                .withName("Collection 1")
+                .withLogo("Test Logo")
+                .build();
 
         getClient().perform(get("/api/core/communities"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(contentType))
                 .andExpect(jsonPath("$._embedded.communities", Matchers.containsInAnyOrder(
                         CommunityMatcher.matchCommunityEntry(parentCommunity.getName(), parentCommunity.getID(), parentCommunity.getHandle()),
-                        CommunityMatcher.matchCommunityEntry(child1.getName(), child1.getID(), child1.getHandle())
+                        CommunityMatcher.matchCommunityWithCollectionEntry(child1.getName(), child1.getID(), child1.getHandle(), col1)
                 )))
                 .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/communities")))
                 .andExpect(jsonPath("$.page.size", is(20)))

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/BitstreamMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/BitstreamMatcher.java
@@ -35,6 +35,20 @@ public class BitstreamMatcher {
         );
     }
 
+    public static Matcher<? super Object> matchBitstreamEntry(UUID uuid, long size) {
+        return allOf(
+                //Check ID and size
+                hasJsonPath("$.uuid", is(uuid.toString())),
+                hasJsonPath("$.sizeBytes", is((int) size)),
+                //Make sure we have a checksum
+                hasJsonPath("$.checkSum", matchChecksum()),
+                //Make sure we have a valid format
+                hasJsonPath("$._embedded.format", matchFormat()),
+                //Check links
+                matchBitstreamLinks(uuid)
+        );
+    }
+
     private static Matcher<? super Object> matchBitstreamLinks(UUID uuid) {
         return allOf(
                 hasJsonPath("$._links.format.href", containsString("/api/core/bitstreams/" + uuid + "/format")),
@@ -53,7 +67,8 @@ public class BitstreamMatcher {
     private static Matcher<? super Object> matchFormat(){
         return allOf(
                 hasJsonPath("$.mimetype", not(empty())),
-                hasJsonPath("$.type", is("bitstreamformat"))
+                hasJsonPath("$.type", is("bitstreamformat")),
+                hasJsonPath("$._links.self.href", not(empty()))
         );
     }
 

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/CollectionMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/CollectionMatcher.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.app.rest.matcher;
 
+import org.dspace.content.Bitstream;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 
@@ -20,6 +21,10 @@ import static org.hamcrest.Matchers.is;
 public class CollectionMatcher {
 
     public static Matcher<? super Object> matchCollectionEntry(String name, UUID uuid, String handle) {
+        return matchCollectionEntry(name, uuid, handle, null);
+    }
+
+    public static Matcher<? super Object> matchCollectionEntry(String name, UUID uuid, String handle, Bitstream logo) {
         return allOf(
                 hasJsonPath("$.uuid", is(uuid.toString())),
                 hasJsonPath("$.name", is(name)),
@@ -29,21 +34,25 @@ public class CollectionMatcher {
                         CollectionMetadataMatcher.matchTitle(name)
                 )),
                 matchLinks(uuid),
-                matchLogo()
+                matchLogo(logo)
         );
     }
 
-    private static Matcher<? super Object> matchLogo() {
-        return allOf(
-                hasJsonPath("$._embedded.logo", Matchers.not(Matchers.empty()))
-        );
-    }
-
-    public static Matcher<? super Object> matchLinks(UUID uuid){
+    private static Matcher<? super Object> matchLinks(UUID uuid){
         return allOf(
                 hasJsonPath("$._links.logo.href", containsString("api/core/collections/" + uuid.toString() + "/logo")),
                 hasJsonPath("$._links.self.href", containsString("api/core/collections/" + uuid.toString()))
         );
+    }
+
+    private static Matcher<? super Object> matchLogo(Bitstream logo) {
+        return logo == null ?
+                allOf(
+                    hasJsonPath("$._embedded.logo", Matchers.not(Matchers.empty()))
+                ) :
+                allOf(
+                    hasJsonPath("$._embedded.logo", BitstreamMatcher.matchBitstreamEntry(logo.getID(), logo.getSize()))
+                );
     }
 
 }

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/CommunityMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/CommunityMatcher.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.app.rest.matcher;
 
+import org.dspace.content.Collection;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 
@@ -18,8 +19,16 @@ import static org.hamcrest.Matchers.is;
 
 public class CommunityMatcher {
 
-
     public static Matcher<? super Object> matchCommunityEntry(String name, UUID uuid, String handle) {
+        return allOf(
+                matchProperties(name, uuid, handle),
+                hasJsonPath("$._embedded.collections", Matchers.not(Matchers.empty())),
+                hasJsonPath("$._embedded.logo", Matchers.not(Matchers.empty())),
+                matchLinks(uuid)
+        );
+    }
+
+    public static Matcher<? super Object> matchProperties(String name, UUID uuid, String handle){
         return allOf(
                 hasJsonPath("$.uuid", is(uuid.toString())),
                 hasJsonPath("$.name", is(name)),
@@ -27,10 +36,7 @@ public class CommunityMatcher {
                 hasJsonPath("$.type", is("community")),
                 hasJsonPath("$.metadata", Matchers.contains(
                         CommunityMetadataMatcher.matchTitle(name)
-                )),
-                hasJsonPath("$._embedded.collections", Matchers.not(Matchers.empty())),
-                hasJsonPath("$._embedded.logo", Matchers.not(Matchers.empty())),
-                matchLinks(uuid)
+                ))
         );
     }
 
@@ -41,4 +47,15 @@ public class CommunityMatcher {
                 hasJsonPath("$._links.self.href", Matchers.containsString("/api/core/communities/" + uuid.toString()))
         );
     }
+
+    public static Matcher<? super Object> matchCommunityWithCollectionEntry(String name, UUID uuid, String handle, Collection col) {
+        return allOf(
+                matchProperties(name, uuid, handle),
+                hasJsonPath("$._embedded.collections._embedded[0]",
+                        CollectionMatcher.matchCollectionEntry(col.getName(), col.getID(), col.getHandle(), col.getLogo())),
+                hasJsonPath("$._embedded.logo", Matchers.not(Matchers.empty())),
+                matchLinks(uuid)
+        );
+    }
+
 }


### PR DESCRIPTION
This PR restores the links on resources that are inside an embedded page. 

Currently they are not present on the logos of collections embedded inside a community resources returned by the `/api/core/communities` endpoint.