### PR TITLE
[DS-3816] Converge on one version of jboss-logging.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1437,6 +1437,12 @@
                 <version>1.10.19</version>
                 <scope>test</scope>
             </dependency>
+            <!-- Hibernate depends on several different versions of this. -->
+            <dependency>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging</artifactId>
+                <version>3.3.0.Final</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Hibernate pulls in both 3.2.1 and 3.3.0, and 3.2.1 causes problems.
https://jira.duraspace.org/browse/DS-3816