### PR TITLE
[DS-3811] Integrate Shibboleth into DSpace REST Report Tools

### DIFF
--- a/dspace-rest/src/main/java/org/dspace/rest/FilteredCollectionsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/FilteredCollectionsResource.java
@@ -85,9 +85,6 @@ public class FilteredCollectionsResource extends Resource {
         try
         {
             context = createContext();
-            if (!configurationService.getBooleanProperty("rest.reporting-authenticate", true)) {
-                context.turnOffAuthorisationSystem();            	
-            }
 
             if (!((limit != null) && (limit >= 0) && (offset != null) && (offset >= 0)))
             {
@@ -171,9 +168,6 @@ public class FilteredCollectionsResource extends Resource {
         FilteredCollection retColl = new org.dspace.rest.common.FilteredCollection();
         try {
             context = createContext();
-            if (!configurationService.getBooleanProperty("rest.reporting-authenticate", true)) {
-                context.turnOffAuthorisationSystem();            	
-            }
 
             org.dspace.content.Collection collection = collectionService.findByIdOrLegacyId(context, collection_id);
             if(authorizeService.authorizeActionBoolean(context, collection, org.dspace.core.Constants.READ)) {

--- a/dspace-rest/src/main/java/org/dspace/rest/FilteredItemsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/FilteredItemsResource.java
@@ -114,9 +114,6 @@ public class FilteredItemsResource extends Resource {
         ItemFilter result = itemFilterSet.getAllFiltersFilter();
         try {
             context = createContext();
-            if (!configurationService.getBooleanProperty("rest.reporting-authenticate", true)) {
-                context.turnOffAuthorisationSystem();            	
-            }
             
             int index = Math.min(query_field.size(), Math.min(query_op.size(), query_val.size()));
             List<ItemFilterQuery> itemFilterQueries = new ArrayList<ItemFilterQuery>();

--- a/dspace-rest/src/main/java/org/dspace/rest/HierarchyResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/HierarchyResource.java
@@ -74,9 +74,6 @@ public class HierarchyResource extends Resource {
 		
         try {
             context = createContext();
-            if (!configurationService.getBooleanProperty("rest.hierarchy-authenticate", true)) {
-                context.turnOffAuthorisationSystem();            	
-            }
 
             Site site = siteService.findSite(context);
             repo.setId(site.getID().toString());

--- a/dspace-rest/src/main/webapp/static/reports/restCollReport.js
+++ b/dspace-rest/src/main/webapp/static/reports/restCollReport.js
@@ -9,7 +9,12 @@ var CollReport = function() {
     Report.call(this);
     //If sortable.js is included, uncomment the following
     //this.hasSorttable = function(){return true;}
-    
+
+    //Indicate if Password Authentication is supported
+    //this.makeAuthLink = function(){return true;};
+    //Indicate if Shibboleth Authentication is supported
+    //this.makeShibLink = function(){return true;};
+
     this.COLL_LIMIT = 20;
     this.TOOBIG = 10000;
     this.loadId = 0;

--- a/dspace-rest/src/main/webapp/static/reports/restQueryReport.js
+++ b/dspace-rest/src/main/webapp/static/reports/restQueryReport.js
@@ -10,7 +10,12 @@ var QueryReport = function() {
     
     //If sortable.js is included, uncomment the following
     //this.hasSorttable = function(){return true;}
-    
+
+    //Indicate if Password Authentication is supported
+    //this.makeAuthLink = function(){return true;};
+    //Indicate if Shibboleth Authentication is supported
+    //this.makeShibLink = function(){return true;};
+
     this.getDefaultParameters = function(){
         return {
             "collSel[]"     : [],

--- a/dspace-rest/src/main/webapp/static/reports/restReport.js
+++ b/dspace-rest/src/main/webapp/static/reports/restReport.js
@@ -21,6 +21,7 @@ var Report = function() {
 
     //Indicate if Shibboleth Authentication is supported
     this.makeShibLink = function(){return false;};
+    this.shibPath = "/Shibboleth.sso/Login";
 
     //Override this to return obj.id for DSpace 5 versions
     this.getId = function(obj) {
@@ -269,7 +270,7 @@ var Auth = function(report) {
                 }
                 var anchor = $("<a/>").text(user);
                 if (self.report.makeShibLink()) {
-                    anchor.attr("href","/Shibboleth.sso/Login?target="+document.location);
+                    anchor.attr("href", self.report.shibPath + "?target="+document.location);
                 }
                 if (self.report.makeAuthLink()) {
                     anchor.attr("href","javascript:window.open('authenticate.html','Authenticate (Password Auth Only)','height=200,width=500')");

--- a/dspace-rest/src/main/webapp/static/reports/restReport.js
+++ b/dspace-rest/src/main/webapp/static/reports/restReport.js
@@ -16,8 +16,11 @@ var Report = function() {
     //this.ROOTPATH = "/jspui/handle/"
     //this.ROOTPATH = "/handle/"
     
-    //disable this setting if Password Authentication is not supported
+    //Indicate if Password Authentication is supported
     this.makeAuthLink = function(){return false;};
+
+    //Indicate if Shibboleth Authentication is supported
+    this.makeShibLink = function(){return false;};
 
     //Override this to return obj.id for DSpace 5 versions
     this.getId = function(obj) {
@@ -225,6 +228,15 @@ var Auth = function(report) {
             }
         });        
     }
+
+    this.verifyShibLogin = function() {
+        var self = this;
+        $.ajax({
+            url: "/rest/shibboleth-login", 
+            success: self.authStat
+        });
+    }
+  
     this.authStat = function() {
         var self = this;
         $.ajax({
@@ -234,20 +246,27 @@ var Auth = function(report) {
                 alert("Error in /rest/status "+ status+ " " + errorThrown);
             },
             success: function(data) {
-              var user = "";
-              if (data.email != undefined) {
-                user = data.email;                  
-              } else {
-                user = "You are not logged in.  Some items may be excluded from reports.";
-              }
-              var anchor = $("<a/>").text(user);
-              if (self.report.makeAuthLink()) {
-                  anchor.attr("href","javascript:window.open('authenticate.html','Authenticate (Password Auth Only)','height=200,width=500')");
-              }
-              $("#currentUser").empty().append("<b>Current User: </b>").append(anchor);
-            }
+                var user = "";
+                if (data.email != undefined) {
+                    user = data.email;                  
+                } else {
+                    user = "You are not logged in.  Some items may be excluded from reports.";
+                }
+                var anchor = $("<a/>").text(user);
+                if (self.report.makeShibLink()) {
+                    anchor.attr("href","/Shibboleth.sso/Login?target="+document.location);
+                }
+                if (self.report.makeAuthLink()) {
+                    anchor.attr("href","javascript:window.open('authenticate.html','Authenticate (Password Auth Only)','height=200,width=500')");
+                }
+                $("#currentUser").empty().append("<b>Current User: </b>").append(anchor);
+                if (data.email == undefined && self.report.makeShibLink()) {
+                    self.verifyShibLogin();
+                }
+            } 
         });     
     }
+  
     this.logout = function() {
         var self = this;
         $.ajax({

--- a/dspace/config/modules/rest.cfg
+++ b/dspace/config/modules/rest.cfg
@@ -8,9 +8,6 @@
 rest.stats = true
 
 ##### Enable/disable authorization for the hierarchy listing. #####
-# By default, the DSpace REST API will only return communities/collections/items that are accessible to a particular user.
-# Set the rest.hierarchy-authenticate option to false to bypass authorization
-# rest.hierarchy-authenticate = false
 
 #------------------------------------------------------------------#
 # REST API Reporting Tools                                         #
@@ -30,13 +27,6 @@ rest.stats = true
 # If these reports are deployed in a protected manner, the reporting 
 # tools can be configured to bypass DSpace authorization when 
 # reporting on collections and items. 
-
-##### Enable/disable authorization for the reporting tools. #####
-# By default, the DSpace REST API will only return communities/collections/items that are accessible to a particular user.
-# If the REST API has been deployed in a protected manner, the reporting tools can be configured to bypass authorization checks.
-# This will allow all items/collections/communities to be returned to the report user.
-# Set the rest-reporting-authenticate option to false to bypass authorization
-# rest.reporting-authenticate = false
 
 ##### Configure the report pages that can be requested by name #####
 # Create a map of named reports that are available to a report tool user


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3811

To enable password authentication or shibboleth authentication for the reports, see the comments at the top of restCollReport.js and restQueryReport.js.

This change has permitted the removal of the optional configuration setting that bypassed authentication checks when running the report tools from a protected rest api.