### PR TITLE
DS-3818 Fixes wrong language code for CC metadata fields.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/license/LicenseMetadataValue.java
+++ b/dspace-api/src/main/java/org/dspace/license/LicenseMetadataValue.java
@@ -104,17 +104,15 @@ public class LicenseMetadataValue {
     {
         if (value != null)
         {
-            List<MetadataValue> dcvalues = itemService.getMetadata(item, params[0], params[1], params[2], params[3]);
-            ArrayList<String> arrayList = new ArrayList<String>();
-            for (MetadataValue dcvalue : dcvalues)
+            List<MetadataValue> metadataValues = itemService.getMetadata(item, params[0], params[1], params[2], params[3]);
+            itemService.clearMetadata(context, item, params[0], params[1], params[2], params[3]);
+            for (MetadataValue metadataValue : metadataValues)
             {
-                if (!dcvalue.getValue().equals(value))
+                if (!metadataValue.getValue().equals(value))
                 {
-                    arrayList.add(dcvalue.getValue());
+                    itemService.addMetadata(context, item, params[0], params[1], params[2], metadataValue.getLanguage(), metadataValue.getValue());
                 }
             }
-            itemService.clearMetadata(context, item, params[0], params[1], params[2], params[3]);
-            itemService.addMetadata(context, item, params[0], params[1], params[2], params[3], arrayList);
         }
     }
 
@@ -124,8 +122,8 @@ public class LicenseMetadataValue {
      * @param item - the item to update
      * @param value - the value to add in this field
      */
-    public void addItemValue(Context context, Item item, String value) throws SQLException {
-        itemService.addMetadata(context, item, params[0], params[1], params[2], params[3], value);
+    public void addItemValue(Context context, Item item, String value, String language) throws SQLException {
+        itemService.addMetadata(context, item, params[0], params[1], params[2], language, value);
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/submit/step/CCLicenseStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/CCLicenseStep.java
@@ -196,18 +196,19 @@ public class CCLicenseStep extends AbstractProcessingStep
     	}
     	
     	CCLookup ccLookup = new CCLookup();
-    	ccLookup.issue(licenseclass, map, configurationService.getProperty("cc.license.locale"));
+    	String licenseLocale = configurationService.getProperty("cc.license.locale");
+    	ccLookup.issue(licenseclass, map, licenseLocale);
 
     	if (ccLookup.isSuccess()) 
     	{
     		creativeCommonsService.removeLicense(context, uriField, nameField, item);
     		
-    		uriField.addItemValue(context, item, ccLookup.getLicenseUrl());
+    		uriField.addItemValue(context, item, ccLookup.getLicenseUrl(), null);
     		if (configurationService.getBooleanProperty("cc.submit.addbitstream")) {
                 creativeCommonsService.setLicenseRDF(context, item, ccLookup.getRdf());
     		}	
     		if (configurationService.getBooleanProperty("cc.submit.setname")) {
-    			nameField.addItemValue(context, item, ccLookup.getLicenseName());
+    			nameField.addItemValue(context, item, ccLookup.getLicenseName(), licenseLocale);
     		}
             
     		itemService.update(context, item);

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EditItemServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EditItemServlet.java
@@ -432,16 +432,17 @@ public class EditItemServlet extends DSpaceServlet
 
 			if (!exit) {
 				CCLookup ccLookup = new CCLookup();
-				ccLookup.issue(licenseclass, map, configurationService.getProperty("cc.license.locale"));
+				String licenceLocale = configurationService.getProperty("cc.license.locale");
+				ccLookup.issue(licenseclass, map, licenceLocale);
 				if (ccLookup.isSuccess()) {
 					creativeCommonsService.removeLicense(context, uriField, nameField, item);
 
-					uriField.addItemValue(context, item, ccLookup.getLicenseUrl());
+					uriField.addItemValue(context, item, ccLookup.getLicenseUrl(), null);
 					if (configurationService.getBooleanProperty("cc.submit.addbitstream")) {
 						creativeCommonsService.setLicenseRDF(context, item, ccLookup.getRdf());
 					}
 					if (configurationService.getBooleanProperty("cc.submit.setname")) {
-						nameField.addItemValue(context, item, ccLookup.getLicenseName());
+						nameField.addItemValue(context, item, ccLookup.getLicenseName(), licenceLocale);
 					}
 
 					itemService.update(context, item);


### PR DESCRIPTION
Language for dc.rights and dc.rights.uri was stored as * when a CC licence was added. 

To reproduce. Submit an item at demo.dspace.org. Add CC licence. Check metadata values after item is archived.

This pull request stores null as locale for dc.rights.uri and the locale that is configured in dspace.cfg for the CC licence (cc.license.locale) as locale for dc.rights.