### PR TITLE
[DS-3524] Restore maven-enforcer-plugin on rest7

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -492,7 +492,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
+            <artifactId>hamcrest-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -591,7 +591,7 @@
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
-            <version>4.10.3</version>
+            <version>4.10.4</version>
         </dependency>
 
         <dependency>
@@ -728,11 +728,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
             <version>${jackson.version}</version>
         </dependency>
     </dependencies>

--- a/dspace-spring-rest/pom.xml
+++ b/dspace-spring-rest/pom.xml
@@ -146,6 +146,21 @@
         </profile>
     </profiles>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml</groupId>
+                <artifactId>classmate</artifactId>
+                <version>1.3.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-expression</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- These next two dependencies build a WAR that is BOTH executable
              AND deployable into an external container (Tomcat).
@@ -223,7 +238,7 @@
  		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-rest-hal-browser</artifactId>
-			<version>2.5.6.RELEASE</version>
+			<version>2.5.7.RELEASE</version>
 			<!-- if you get a java.util.zip.ZipException: invalid LOC header (bad signature) 
 			during the tomcat startup force the use of the previous version as the jar file 
 			looks corrupted in the maven repository -->

--- a/pom.xml
+++ b/pom.xml
@@ -1231,6 +1231,11 @@
                 <version>3.13</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.poi</groupId>
+                <artifactId>poi-ooxml-schemas</artifactId>
+                <version>3.13</version>
+            </dependency>
+            <dependency>
                 <groupId>rome</groupId>
                 <artifactId>rome</artifactId>
                 <version>1.0</version>
@@ -1362,6 +1367,12 @@
                 <version>1.3</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-core</artifactId>
+                <version>1.3</version>
+                <scope>test</scope>
+            </dependency>
             <!-- H2 is an in-memory database used for Unit/Integration tests -->
             <dependency>
                 <groupId>com.h2database</groupId>
@@ -1436,6 +1447,47 @@
                 <artifactId>mockito-core</artifactId>
                 <version>1.10.19</version>
                 <scope>test</scope>
+            </dependency>
+            <!-- Converge miscellaneous transitive dependencies. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>19.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.lyncode</groupId>
+                <artifactId>builder-commons</artifactId>
+                <version>1.0.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.javassist</groupId>
+                <artifactId>javassist</artifactId>
+                <version>3.20.0-GA</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging</artifactId>
+                <version>3.3.0.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>xom</groupId>
+                <artifactId>xom</artifactId>
+                <version>1.2.5</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
                             </configuration>
                         </execution>
                         <!-- Make sure that we do not have conflicting dependencies-->
-                        <!-- <execution>
+                        <execution>
                             <id>enforce-versions</id>
                             <goals>
                                 <goal>enforce</goal>
@@ -71,7 +71,7 @@
                                     <DependencyConvergence />
                                 </rules>
                             </configuration>
-                        </execution> -->
+                        </execution>
                     </executions>
                 </plugin>
                 <!-- Used to compile all Java classes -->


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3524
Small version adjustments to satisfy the enforcer rule.
This will conflict with DS-3816, which also converges one of these dependencies.  If this patch is adopted, DS-3816 can be discarded.
This patch builds cleanly with all unit and integration tests enabled.  I have not done any other testing yet.