### PR TITLE
DS-3817: Support the DSpace Cover page functionality in the bitstream endpoint

### DIFF
--- a/dspace-api/src/main/java/org/dspace/curate/CitationPage.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CitationPage.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.curate;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.*;
@@ -150,9 +151,9 @@ public class CitationPage extends AbstractCurationTask {
                             + bitstream.getName() + " is citable.");
                     try {
                         //Create the cited document
-                        File citedDocument = citationDocument.makeCitedDocument(Curator.curationContext(), bitstream);
+                        Pair<InputStream, Long> citedDocument = citationDocument.makeCitedDocument(Curator.curationContext(), bitstream);
                         //Add the cited document to the approiate bundle
-                        this.addCitedPageToItem(citedDocument, bundle, pBundle,
+                        this.addCitedPageToItem(citedDocument.getKey(), bundle, pBundle,
                                 dBundle, displayMap, item, bitstream);
                     } catch (Exception e) {
                         //Could be many things, but nothing that should be
@@ -187,7 +188,7 @@ public class CitationPage extends AbstractCurationTask {
      * A helper function for {@link CitationPage#performItem(Item)}. This function takes in the
      * cited document as a File and adds it to DSpace properly.
      *
-     * @param citedTemp The temporary File that is the cited document.
+     * @param citedDoc The temporary File that is the cited document.
      * @param bundle The bundle the cited file is from.
      * @param pBundle The preservation bundle. The original document should be
      * put in here if it is not already.
@@ -200,7 +201,7 @@ public class CitationPage extends AbstractCurationTask {
      * @throws AuthorizeException if authorization error
      * @throws IOException if IO error
      */
-    protected void addCitedPageToItem(File citedTemp, Bundle bundle, Bundle pBundle,
+    protected void addCitedPageToItem(InputStream citedDoc, Bundle bundle, Bundle pBundle,
                                     Bundle dBundle, Map<String,Bitstream> displayMap, Item item,
                                     Bitstream bitstream) throws SQLException, AuthorizeException, IOException {
         //If we are modifying a file that is not in the
@@ -218,12 +219,11 @@ public class CitationPage extends AbstractCurationTask {
         //Create an input stream form the temporary file
         //that is the cited document and create a
         //bitstream from it.
-        InputStream inp = new FileInputStream(citedTemp);
         if (displayMap.containsKey(bitstream.getName())) {
             bundleService.removeBitstream(context, dBundle, displayMap.get(bitstream.getName()));
         }
-        Bitstream citedBitstream = bitstreamService.create(context, dBundle, inp);
-        inp.close(); //Close up the temporary InputStream
+        Bitstream citedBitstream = bitstreamService.create(context, dBundle, citedDoc);
+        citedDoc.close(); //Close up the temporary InputStream
 
         //Setup a good name for our bitstream and make
         //it the same format as the source document.

--- a/dspace-api/src/main/java/org/dspace/curate/CitationPage.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CitationPage.java
@@ -153,7 +153,7 @@ public class CitationPage extends AbstractCurationTask {
                         //Create the cited document
                         Pair<InputStream, Long> citedDocument = citationDocument.makeCitedDocument(Curator.curationContext(), bitstream);
                         //Add the cited document to the approiate bundle
-                        this.addCitedPageToItem(citedDocument.getKey(), bundle, pBundle,
+                        this.addCitedPageToItem(citedDocument.getLeft(), bundle, pBundle,
                                 dBundle, displayMap, item, bitstream);
                     } catch (Exception e) {
                         //Could be many things, but nothing that should be
@@ -188,7 +188,7 @@ public class CitationPage extends AbstractCurationTask {
      * A helper function for {@link CitationPage#performItem(Item)}. This function takes in the
      * cited document as a File and adds it to DSpace properly.
      *
-     * @param citedDoc The temporary File that is the cited document.
+     * @param citedDoc The inputstream that is the cited document.
      * @param bundle The bundle the cited file is from.
      * @param pBundle The preservation bundle. The original document should be
      * put in here if it is not already.

--- a/dspace-api/src/main/java/org/dspace/disseminate/CitationDocumentServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/disseminate/CitationDocumentServiceImpl.java
@@ -283,7 +283,7 @@ public class CitationDocumentServiceImpl implements CitationDocumentService, Ini
             generateCoverPage(context, document, coverPage, item);
             addCoverPageToDocument(document, sourceDocument, coverPage);
 
-            //We already have the full PDF in memory, so keep it their
+            //We already have the full PDF in memory, so keep it there
             try(ByteArrayOutputStream out = new ByteArrayOutputStream()) {
                 document.save(out);
 

--- a/dspace-api/src/main/java/org/dspace/disseminate/service/CitationDocumentService.java
+++ b/dspace-api/src/main/java/org/dspace/disseminate/service/CitationDocumentService.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.disseminate.service;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.font.PDFont;
@@ -15,8 +16,8 @@ import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 
-import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.sql.SQLException;
 
 /**
@@ -81,7 +82,7 @@ public interface CitationDocumentService {
      * @throws SQLException if database error
      * @throws AuthorizeException if authorization error
      */
-    public File makeCitedDocument(Context context, Bitstream bitstream)
+    public Pair<InputStream, Long> makeCitedDocument(Context context, Bitstream bitstream)
             throws IOException, SQLException, AuthorizeException;
 
     /**


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3817

Added the DSpace 6 coverpage implementation to DSpace 7. Also added a JUnit test. 
When verifying the functionality, make sure the configuration property `citation-page.enable_globally` is enabled. 
