### PR TITLE
[DS-3822] Don't guess XML structure during ingest

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/XSLTIngestionCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/XSLTIngestionCrosswalk.java
@@ -179,7 +179,7 @@ public class XSLTIngestionCrosswalk
         }
         try
         {
-            JDOMSource source = new JDOMSource(new Document((Element)root.cloneContent()));
+            JDOMSource source = new JDOMSource(new Document((Element)root.clone()));
             JDOMResult result = new JDOMResult();
             xform.transform(source, result);
             Document dimDoc = result.getDocument();


### PR DESCRIPTION
The XML document used during ingestion can contain multiple XML nodes directly
inside the XML root. The crosswalk should not modify the source document, but
only hand it over to the XSLT stylesheet.

https://jira.duraspace.org/browse/DS-3822

Note: If there are some XSLT stylesheets, that are using templates with absolute matches from the document root, they may not work anymore after this patch.