### PR TITLE
DS-3795: Update Apache POI library to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1218,17 +1218,17 @@
             <dependency>
                 <groupId>org.apache.poi</groupId>
                 <artifactId>poi</artifactId>
-                <version>3.13</version>
+                <version>3.17</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.poi</groupId>
                 <artifactId>poi-scratchpad</artifactId>
-                <version>3.13</version>
+                <version>3.17</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.poi</groupId>
                 <artifactId>poi-ooxml</artifactId>
-                <version>3.13</version>
+                <version>3.17</version>
             </dependency>
             <dependency>
                 <groupId>rome</groupId>


### PR DESCRIPTION
Linked to DS-3795, which is a general ticket for library updates on `master`: https://jira.duraspace.org/browse/DS-3795

A new DDOS attack just listed for the Apache POI library. This upgrades us to v3.17 to resolve that.

For more info, see: https://snyk.io/vuln/SNYK-JAVA-ORGAPACHEPOI-32049?utm_campaign=vuln_alert&utm_medium=email&utm_source=Vuln

This fix should also be cherry-picked to 6.x branch.