### PR TITLE
DS-3854: Update to latest PostgreSQL JDBC driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
         <poi-version>3.17</poi-version>
-        <postgresql.driver.version>9.4.1211</postgresql.driver.version>
+        <postgresql.driver.version>42.2.1</postgresql.driver.version>
         <solr.version>4.10.4</solr.version>
         <jena.version>2.13.0</jena.version>
         <slf4j.version>1.7.22</slf4j.version>


### PR DESCRIPTION
Our PostgreSQL JDBC driver is outdated. See https://jira.duraspace.org/browse/DS-3854

The latest version (42.2.1) is said to work for Java 8 and Postgres 8.2 or above, see the README here: https://github.com/pgjdbc/pgjdbc

This simply updates us to the latest on `master`.

This minor change can also be cherry-picked / backported to `dspace-6.x`, as the 6.x `pom.xml` already knows how to select the proper JDBC driver if you are using Java 7, see: https://github.com/DSpace/DSpace/blob/dspace-6_x/pom.xml#L516