### PR TITLE
DS-3827 LazyInitializationException in formats.jsp

### DIFF
--- a/dspace-jspui/src/main/webapp/help/formats.jsp
+++ b/dspace-jspui/src/main/webapp/help/formats.jsp
@@ -62,13 +62,7 @@
         UIUtil.sendAlert(request, se);
 
         JSPManager.showInternalError(request, response);
-    } finally {
-        // we need to close the database connection and free the resources
-        if(context != null && context.isValid())
-        {
-            context.abort();
-        }
-    }
+    } 
 %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html>
@@ -164,6 +158,10 @@
                 </td>
         </tr>
 <%
+      }
+      if(context != null && context.isValid())
+      {
+          context.abort();
       }
 %>
     </table>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3827

This JSP produces an internal error due to a LazyInitializationException. The exception is produced because the dspace context is aborted before completing all database queries. JIRA ticket: DS-3827