### PR TITLE
[DS-3803] Remove db.jndi setting from dspace.cfg

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -95,12 +95,6 @@ db.maxwait = 5000
 # (default = 10)
 db.maxidle = 10
 
-# Specify a configured database connection pool to be fetched from a
-# directory.  This overrides the pool and driver settings above.  If
-# none can be found, then DSpace will use the above settings to create a
-# pool.
-#db.jndi = jdbc/dspace
-
 # Whether or not to allow for an entire 'clean' of the DSpace database.
 # By default, this setting is 'true', which ensures that the 'dspace database clean' command
 # does nothing (except return an error message saying clean is disabled)


### PR DESCRIPTION
Cherry-picked from 6_x branch:
As of DSpace 6.x this setting is no longer used and is not customizable
by the user. Now DSpace always looks for a pool named "jdbc/dspace" in
JNDI and falls back to creating a pool with the db.* settings located
in dspace.cfg.

See: https://wiki.duraspace.org/display/DSDOC6x/Configuration+Reference
See: dspace/config/spring/api/core-hibernate.xml
See: https://jira.duraspace.org/browse/DS-3434