### PR TITLE
[DS-3524] Align versions of Apache Poi artifacts using a property.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
+        <poi-version>3.17</poi-version>
         <postgresql.driver.version>9.4.1211</postgresql.driver.version>
         <solr.version>4.10.4</solr.version>
         <jena.version>2.13.0</jena.version>
@@ -1218,22 +1219,22 @@
             <dependency>
                 <groupId>org.apache.poi</groupId>
                 <artifactId>poi</artifactId>
-                <version>3.17</version>
+                <version>${poi-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.poi</groupId>
                 <artifactId>poi-scratchpad</artifactId>
-                <version>3.17</version>
+                <version>${poi-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.poi</groupId>
                 <artifactId>poi-ooxml</artifactId>
-                <version>3.17</version>
+                <version>${poi-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.poi</groupId>
                 <artifactId>poi-ooxml-schemas</artifactId>
-                <version>3.13</version>
+                <version>${poi-version}</version>
             </dependency>
             <dependency>
                 <groupId>rome</groupId>


### PR DESCRIPTION
I think that someone updated the Poi versions while I was converging
on the old versions.  Testing the branch can't find that, but testing
the merged trunk did.  We need to be more consistent in using symbolic
<version> values when related artifacts should be on the same version.