### PR TITLE
DS-3829 Oracle Flyway migration from old DSpace versions broken

### DIFF
--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V6.0_2015.03.07__DS-2701_Hibernate_migration.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V6.0_2015.03.07__DS-2701_Hibernate_migration.sql
@@ -356,9 +356,9 @@ UPDATE versionitem SET version_number = -1 WHERE version_number IS NULL;
 ALTER TABLE handle RENAME COLUMN resource_id to resource_legacy_id;
 ALTER TABLE handle ADD resource_id RAW(16) REFERENCES dspaceobject(uuid);
 CREATE INDEX handle_object on handle(resource_id);
-UPDATE handle SET resource_id = (SELECT community.uuid FROM community WHERE handle.resource_legacy_id = community.community_id AND handle.resource_type_id = 4);
-UPDATE handle SET resource_id = (SELECT collection.uuid FROM collection WHERE handle.resource_legacy_id = collection.collection_id AND handle.resource_type_id = 3);
-UPDATE handle SET resource_id = (SELECT item.uuid FROM item WHERE handle.resource_legacy_id = item.item_id AND handle.resource_type_id = 2);
+UPDATE handle SET resource_id = (SELECT community.uuid FROM community WHERE handle.resource_legacy_id = community.community_id AND handle.resource_type_id = 4) where resource_type_id = 4;
+UPDATE handle SET resource_id = (SELECT collection.uuid FROM collection WHERE handle.resource_legacy_id = collection.collection_id AND handle.resource_type_id = 3) where resource_type_id = 3;
+UPDATE handle SET resource_id = (SELECT item.uuid FROM item WHERE handle.resource_legacy_id = item.item_id AND handle.resource_type_id = 2) where resource_type_id = 2;
 
 -- Migrate metadata value table
 DROP VIEW dcvalue;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V6.0_2016.04.04__DS-3086-OAI-Performance-fix.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V6.0_2016.04.04__DS-3086-OAI-Performance-fix.sql
@@ -15,7 +15,26 @@
 -- "ON DELETE CASCADE" to improve the performance of Item deletion.
 ---------------------------------------------------------------
 
-CREATE UNIQUE INDEX metadataschema_idx_short_id on metadataschemaregistry(short_id);
+--CREATE UNIQUE INDEX metadataschema_idx_short_id on metadataschemaregistry(short_id);
+DECLARE
+  COUNT_INDEXES INTEGER;
+  INDEX_NAME VARCHAR(256);
+  TABLE_NAME_D VARCHAR(256) := 'metadataschemaregistry';
+  COLUMN_NAME_D VARCHAR(256) := 'short_id';
+BEGIN
+  select count(c.INDEX_NAME) into COUNT_INDEXES
+  from USER_INDEXES i, USER_IND_COLUMNS c
+  where i.TABLE_NAME = upper(TABLE_NAME_D)
+        and i.UNIQUENESS = 'UNIQUE'
+        and i.TABLE_NAME = c.TABLE_NAME
+        and i.INDEX_NAME = c.INDEX_NAME
+        and c.COLUMN_NAME = upper(COLUMN_NAME_D);
+
+  IF COUNT_INDEXES = 0 THEN
+    EXECUTE IMMEDIATE 'CREATE UNIQUE INDEX metadataschema_idx_short_id on metadataschemaregistry(short_id);';
+  END IF;
+END;
+/
 
 CREATE INDEX metadatafield_idx_elem_qual on metadatafieldregistry(element, qualifier);
 

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V6.0_2016.11.29__DS-3410-lost-indexes.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V6.0_2016.11.29__DS-3410-lost-indexes.sql
@@ -1,0 +1,17 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+---------------------------------------------------------------
+-- DS-3410
+---------------------------------------------------------------
+-- This script will create lost indexes 
+---------------------------------------------------------------
+
+CREATE INDEX resourcepolicy_object on resourcepolicy(dspace_object);
+CREATE INDEX metadatavalue_object on metadatavalue(dspace_object_id);
+CREATE INDEX metadatavalue_field_object on metadatavalue(metadata_field_id, dspace_object_id);

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/workflow/oracle/xmlworkflow/V6.0_2015.08.11__DS-2701_Xml_Workflow_Migration.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/workflow/oracle/xmlworkflow/V6.0_2015.08.11__DS-2701_Xml_Workflow_Migration.sql
@@ -18,11 +18,65 @@ UPDATE collection SET workflow_step_3 = null;
 ALTER TABLE cwf_workflowitem RENAME COLUMN item_id to item_legacy_id;
 ALTER TABLE cwf_workflowitem ADD item_id RAW(16) REFERENCES Item(uuid);
 UPDATE cwf_workflowitem SET item_id = (SELECT item.uuid FROM item WHERE cwf_workflowitem.item_legacy_id = item.item_id);
+DECLARE
+  COUNT_INDEXES INTEGER;
+  INDEX_NAME VARCHAR(256);
+  TABLE_NAME_D VARCHAR(256) := 'cwf_workflowitem';
+  COLUMN_NAME_D VARCHAR(256) := 'item_legacy_id';
+BEGIN
+  select count(c.INDEX_NAME) into COUNT_INDEXES
+  from USER_INDEXES i, USER_IND_COLUMNS c
+  where i.TABLE_NAME = upper(TABLE_NAME_D)
+        and i.UNIQUENESS = 'UNIQUE'
+        and i.TABLE_NAME = c.TABLE_NAME
+        and i.INDEX_NAME = c.INDEX_NAME
+        and c.COLUMN_NAME = upper(COLUMN_NAME_D);
+
+  IF COUNT_INDEXES > 0 THEN
+    select c.INDEX_NAME into INDEX_NAME
+    from USER_INDEXES i, USER_IND_COLUMNS c
+    where i.TABLE_NAME = upper(TABLE_NAME_D)
+          and i.UNIQUENESS = 'UNIQUE'
+          and i.TABLE_NAME = c.TABLE_NAME
+          and i.INDEX_NAME = c.INDEX_NAME
+          and c.COLUMN_NAME = upper(COLUMN_NAME_D);
+    EXECUTE IMMEDIATE 'ALTER TABLE ' || TABLE_NAME_D || ' DROP constraint ' || INDEX_NAME;
+  END IF;
+END;
+/
+
 ALTER TABLE cwf_workflowitem DROP COLUMN item_legacy_id;
 
 ALTER TABLE cwf_workflowitem RENAME COLUMN collection_id to collection_legacy_id;
 ALTER TABLE cwf_workflowitem ADD collection_id RAW(16) REFERENCES Collection(uuid);
 UPDATE cwf_workflowitem SET collection_id = (SELECT collection.uuid FROM collection WHERE cwf_workflowitem.collection_legacy_id = collection.collection_id);
+DECLARE
+  COUNT_INDEXES INTEGER;
+  INDEX_NAME VARCHAR(256);
+  TABLE_NAME_D VARCHAR(256) := 'cwf_workflowitem';
+  COLUMN_NAME_D VARCHAR(256) := 'collection_legacy_id';
+BEGIN
+  select count(c.INDEX_NAME) into COUNT_INDEXES
+  from USER_INDEXES i, USER_IND_COLUMNS c
+  where i.TABLE_NAME = upper(TABLE_NAME_D)
+        and i.UNIQUENESS = 'UNIQUE'
+        and i.TABLE_NAME = c.TABLE_NAME
+        and i.INDEX_NAME = c.INDEX_NAME
+        and c.COLUMN_NAME = upper(COLUMN_NAME_D);
+
+  IF COUNT_INDEXES > 0 THEN
+    select c.INDEX_NAME into INDEX_NAME
+    from USER_INDEXES i, USER_IND_COLUMNS c
+    where i.TABLE_NAME = upper(TABLE_NAME_D)
+          and i.UNIQUENESS = 'UNIQUE'
+          and i.TABLE_NAME = c.TABLE_NAME
+          and i.INDEX_NAME = c.INDEX_NAME
+          and c.COLUMN_NAME = upper(COLUMN_NAME_D);
+    EXECUTE IMMEDIATE 'ALTER TABLE ' || TABLE_NAME_D || ' DROP constraint ' || INDEX_NAME;
+  END IF;
+END;
+/
+
 ALTER TABLE cwf_workflowitem DROP COLUMN collection_legacy_id;
 
 UPDATE cwf_workflowitem SET multiple_titles = '0' WHERE multiple_titles IS NULL;
@@ -33,11 +87,65 @@ UPDATE cwf_workflowitem SET multiple_files = '0' WHERE multiple_files IS NULL;
 ALTER TABLE cwf_collectionrole RENAME COLUMN collection_id to collection_legacy_id;
 ALTER TABLE cwf_collectionrole ADD collection_id RAW(16) REFERENCES Collection(uuid);
 UPDATE cwf_collectionrole SET collection_id = (SELECT collection.uuid FROM collection WHERE cwf_collectionrole.collection_legacy_id = collection.collection_id);
+DECLARE
+  COUNT_INDEXES INTEGER;
+  INDEX_NAME VARCHAR(256);
+  TABLE_NAME_D VARCHAR(256) := 'cwf_collectionrole';
+  COLUMN_NAME_D VARCHAR(256) := 'collection_legacy_id';
+BEGIN
+  select count(c.INDEX_NAME) into COUNT_INDEXES
+  from USER_INDEXES i, USER_IND_COLUMNS c
+  where i.TABLE_NAME = upper(TABLE_NAME_D)
+        and i.UNIQUENESS = 'UNIQUE'
+        and i.TABLE_NAME = c.TABLE_NAME
+        and i.INDEX_NAME = c.INDEX_NAME
+        and c.COLUMN_NAME = upper(COLUMN_NAME_D);
+
+  IF COUNT_INDEXES > 0 THEN
+    select c.INDEX_NAME into INDEX_NAME
+    from USER_INDEXES i, USER_IND_COLUMNS c
+    where i.TABLE_NAME = upper(TABLE_NAME_D)
+          and i.UNIQUENESS = 'UNIQUE'
+          and i.TABLE_NAME = c.TABLE_NAME
+          and i.INDEX_NAME = c.INDEX_NAME
+          and c.COLUMN_NAME = upper(COLUMN_NAME_D);
+    EXECUTE IMMEDIATE 'ALTER TABLE ' || TABLE_NAME_D || ' DROP constraint ' || INDEX_NAME;
+  END IF;
+END;
+/
+
 ALTER TABLE cwf_collectionrole DROP COLUMN collection_legacy_id;
 
 ALTER TABLE cwf_collectionrole RENAME COLUMN group_id to group_legacy_id;
 ALTER TABLE cwf_collectionrole ADD group_id RAW(16) REFERENCES epersongroup(uuid);
 UPDATE cwf_collectionrole SET group_id = (SELECT epersongroup.uuid FROM epersongroup WHERE cwf_collectionrole.group_legacy_id = epersongroup.eperson_group_id);
+DECLARE
+  COUNT_INDEXES INTEGER;
+  INDEX_NAME VARCHAR(256);
+  TABLE_NAME_D VARCHAR(256) := 'cwf_collectionrole';
+  COLUMN_NAME_D VARCHAR(256) := 'group_legacy_id';
+BEGIN
+  select count(c.INDEX_NAME) into COUNT_INDEXES
+  from USER_INDEXES i, USER_IND_COLUMNS c
+  where i.TABLE_NAME = upper(TABLE_NAME_D)
+        and i.UNIQUENESS = 'UNIQUE'
+        and i.TABLE_NAME = c.TABLE_NAME
+        and i.INDEX_NAME = c.INDEX_NAME
+        and c.COLUMN_NAME = upper(COLUMN_NAME_D);
+
+  IF COUNT_INDEXES > 0 THEN
+    select c.INDEX_NAME into INDEX_NAME
+    from USER_INDEXES i, USER_IND_COLUMNS c
+    where i.TABLE_NAME = upper(TABLE_NAME_D)
+          and i.UNIQUENESS = 'UNIQUE'
+          and i.TABLE_NAME = c.TABLE_NAME
+          and i.INDEX_NAME = c.INDEX_NAME
+          and c.COLUMN_NAME = upper(COLUMN_NAME_D);
+    EXECUTE IMMEDIATE 'ALTER TABLE ' || TABLE_NAME_D || ' DROP constraint ' || INDEX_NAME;
+  END IF;
+END;
+/
+
 ALTER TABLE cwf_collectionrole DROP COLUMN group_legacy_id;
 
 
@@ -45,28 +153,163 @@ ALTER TABLE cwf_collectionrole DROP COLUMN group_legacy_id;
 ALTER TABLE cwf_workflowitemrole RENAME COLUMN group_id to group_legacy_id;
 ALTER TABLE cwf_workflowitemrole ADD group_id RAW(16) REFERENCES epersongroup(uuid);
 UPDATE cwf_workflowitemrole SET group_id = (SELECT epersongroup.uuid FROM epersongroup WHERE cwf_workflowitemrole.group_legacy_id = epersongroup.eperson_group_id);
+DECLARE
+  COUNT_INDEXES INTEGER;
+  INDEX_NAME VARCHAR(256);
+  TABLE_NAME_D VARCHAR(256) := 'cwf_workflowitemrole';
+  COLUMN_NAME_D VARCHAR(256) := 'group_legacy_id';
+BEGIN
+  select count(c.INDEX_NAME) into COUNT_INDEXES
+  from USER_INDEXES i, USER_IND_COLUMNS c
+  where i.TABLE_NAME = upper(TABLE_NAME_D)
+        and i.UNIQUENESS = 'UNIQUE'
+        and i.TABLE_NAME = c.TABLE_NAME
+        and i.INDEX_NAME = c.INDEX_NAME
+        and c.COLUMN_NAME = upper(COLUMN_NAME_D);
+
+  IF COUNT_INDEXES > 0 THEN
+    select c.INDEX_NAME into INDEX_NAME
+    from USER_INDEXES i, USER_IND_COLUMNS c
+    where i.TABLE_NAME = upper(TABLE_NAME_D)
+          and i.UNIQUENESS = 'UNIQUE'
+          and i.TABLE_NAME = c.TABLE_NAME
+          and i.INDEX_NAME = c.INDEX_NAME
+          and c.COLUMN_NAME = upper(COLUMN_NAME_D);
+    EXECUTE IMMEDIATE 'ALTER TABLE ' || TABLE_NAME_D || ' DROP constraint ' || INDEX_NAME;
+  END IF;
+END;
+/
+
 ALTER TABLE cwf_workflowitemrole DROP COLUMN group_legacy_id;
 
 ALTER TABLE cwf_workflowitemrole RENAME COLUMN eperson_id to eperson_legacy_id;
 ALTER TABLE cwf_workflowitemrole ADD eperson_id RAW(16) REFERENCES eperson(uuid);
 UPDATE cwf_workflowitemrole SET eperson_id = (SELECT eperson.uuid FROM eperson WHERE cwf_workflowitemrole.eperson_legacy_id = eperson.eperson_id);
+DECLARE
+  COUNT_INDEXES INTEGER;
+  INDEX_NAME VARCHAR(256);
+  TABLE_NAME_D VARCHAR(256) := 'cwf_workflowitemrole';
+  COLUMN_NAME_D VARCHAR(256) := 'eperson_legacy_id';
+BEGIN
+  select count(c.INDEX_NAME) into COUNT_INDEXES
+  from USER_INDEXES i, USER_IND_COLUMNS c
+  where i.TABLE_NAME = upper(TABLE_NAME_D)
+        and i.UNIQUENESS = 'UNIQUE'
+        and i.TABLE_NAME = c.TABLE_NAME
+        and i.INDEX_NAME = c.INDEX_NAME
+        and c.COLUMN_NAME = upper(COLUMN_NAME_D);
+
+  IF COUNT_INDEXES > 0 THEN
+    select c.INDEX_NAME into INDEX_NAME
+    from USER_INDEXES i, USER_IND_COLUMNS c
+    where i.TABLE_NAME = upper(TABLE_NAME_D)
+          and i.UNIQUENESS = 'UNIQUE'
+          and i.TABLE_NAME = c.TABLE_NAME
+          and i.INDEX_NAME = c.INDEX_NAME
+          and c.COLUMN_NAME = upper(COLUMN_NAME_D);
+    EXECUTE IMMEDIATE 'ALTER TABLE ' || TABLE_NAME_D || ' DROP constraint ' || INDEX_NAME;
+  END IF;
+END;
+/
+
 ALTER TABLE cwf_workflowitemrole DROP COLUMN eperson_legacy_id;
 
 -- cwf_pooltask
 ALTER TABLE cwf_pooltask RENAME COLUMN group_id to group_legacy_id;
 ALTER TABLE cwf_pooltask ADD group_id RAW(16) REFERENCES epersongroup(uuid);
 UPDATE cwf_pooltask SET group_id = (SELECT epersongroup.uuid FROM epersongroup WHERE cwf_pooltask.group_legacy_id = epersongroup.eperson_group_id);
+DECLARE
+  COUNT_INDEXES INTEGER;
+  INDEX_NAME VARCHAR(256);
+  TABLE_NAME_D VARCHAR(256) := 'cwf_pooltask';
+  COLUMN_NAME_D VARCHAR(256) := 'group_legacy_id';
+BEGIN
+  select count(c.INDEX_NAME) into COUNT_INDEXES
+  from USER_INDEXES i, USER_IND_COLUMNS c
+  where i.TABLE_NAME = upper(TABLE_NAME_D)
+        and i.UNIQUENESS = 'UNIQUE'
+        and i.TABLE_NAME = c.TABLE_NAME
+        and i.INDEX_NAME = c.INDEX_NAME
+        and c.COLUMN_NAME = upper(COLUMN_NAME_D);
+
+  IF COUNT_INDEXES > 0 THEN
+    select c.INDEX_NAME into INDEX_NAME
+    from USER_INDEXES i, USER_IND_COLUMNS c
+    where i.TABLE_NAME = upper(TABLE_NAME_D)
+          and i.UNIQUENESS = 'UNIQUE'
+          and i.TABLE_NAME = c.TABLE_NAME
+          and i.INDEX_NAME = c.INDEX_NAME
+          and c.COLUMN_NAME = upper(COLUMN_NAME_D);
+    EXECUTE IMMEDIATE 'ALTER TABLE ' || TABLE_NAME_D || ' DROP constraint ' || INDEX_NAME;
+  END IF;
+END;
+/
+
 ALTER TABLE cwf_pooltask DROP COLUMN group_legacy_id;
 
 ALTER TABLE cwf_pooltask RENAME COLUMN eperson_id to eperson_legacy_id;
 ALTER TABLE cwf_pooltask ADD eperson_id RAW(16) REFERENCES eperson(uuid);
 UPDATE cwf_pooltask SET eperson_id = (SELECT eperson.uuid FROM eperson WHERE cwf_pooltask.eperson_legacy_id = eperson.eperson_id);
+DECLARE
+  COUNT_INDEXES INTEGER;
+  INDEX_NAME VARCHAR(256);
+  TABLE_NAME_D VARCHAR(256) := 'cwf_pooltask';
+  COLUMN_NAME_D VARCHAR(256) := 'eperson_legacy_id';
+BEGIN
+  select count(c.INDEX_NAME) into COUNT_INDEXES
+  from USER_INDEXES i, USER_IND_COLUMNS c
+  where i.TABLE_NAME = upper(TABLE_NAME_D)
+        and i.UNIQUENESS = 'UNIQUE'
+        and i.TABLE_NAME = c.TABLE_NAME
+        and i.INDEX_NAME = c.INDEX_NAME
+        and c.COLUMN_NAME = upper(COLUMN_NAME_D);
+
+  IF COUNT_INDEXES > 0 THEN
+    select c.INDEX_NAME into INDEX_NAME
+    from USER_INDEXES i, USER_IND_COLUMNS c
+    where i.TABLE_NAME = upper(TABLE_NAME_D)
+          and i.UNIQUENESS = 'UNIQUE'
+          and i.TABLE_NAME = c.TABLE_NAME
+          and i.INDEX_NAME = c.INDEX_NAME
+          and c.COLUMN_NAME = upper(COLUMN_NAME_D);
+    EXECUTE IMMEDIATE 'ALTER TABLE ' || TABLE_NAME_D || ' DROP constraint ' || INDEX_NAME;
+  END IF;
+END;
+/
+
 ALTER TABLE cwf_pooltask DROP COLUMN eperson_legacy_id;
 
 -- cwf_claimtask
 ALTER TABLE cwf_claimtask RENAME COLUMN owner_id to eperson_legacy_id;
 ALTER TABLE cwf_claimtask ADD owner_id RAW(16) REFERENCES eperson(uuid);
 UPDATE cwf_claimtask SET owner_id = (SELECT eperson.uuid FROM eperson WHERE cwf_claimtask.eperson_legacy_id = eperson.eperson_id);
+DECLARE
+  COUNT_INDEXES INTEGER;
+  INDEX_NAME VARCHAR(256);
+  TABLE_NAME_D VARCHAR(256) := 'cwf_claimtask';
+  COLUMN_NAME_D VARCHAR(256) := 'eperson_legacy_id';
+BEGIN
+  select count(c.INDEX_NAME) into COUNT_INDEXES
+  from USER_INDEXES i, USER_IND_COLUMNS c
+  where i.TABLE_NAME = upper(TABLE_NAME_D)
+        and i.UNIQUENESS = 'UNIQUE'
+        and i.TABLE_NAME = c.TABLE_NAME
+        and i.INDEX_NAME = c.INDEX_NAME
+        and c.COLUMN_NAME = upper(COLUMN_NAME_D);
+
+  IF COUNT_INDEXES > 0 THEN
+    select c.INDEX_NAME into INDEX_NAME
+    from USER_INDEXES i, USER_IND_COLUMNS c
+    where i.TABLE_NAME = upper(TABLE_NAME_D)
+          and i.UNIQUENESS = 'UNIQUE'
+          and i.TABLE_NAME = c.TABLE_NAME
+          and i.INDEX_NAME = c.INDEX_NAME
+          and c.COLUMN_NAME = upper(COLUMN_NAME_D);
+    EXECUTE IMMEDIATE 'ALTER TABLE ' || TABLE_NAME_D || ' DROP constraint ' || INDEX_NAME;
+  END IF;
+END;
+/
+
 ALTER TABLE cwf_claimtask DROP COLUMN eperson_legacy_id;
 
 
@@ -74,6 +317,33 @@ ALTER TABLE cwf_claimtask DROP COLUMN eperson_legacy_id;
 ALTER TABLE cwf_in_progress_user RENAME COLUMN user_id to eperson_legacy_id;
 ALTER TABLE cwf_in_progress_user ADD user_id RAW(16) REFERENCES eperson(uuid);
 UPDATE cwf_in_progress_user SET user_id = (SELECT eperson.uuid FROM eperson WHERE cwf_in_progress_user.eperson_legacy_id = eperson.eperson_id);
+DECLARE
+  COUNT_INDEXES INTEGER;
+  INDEX_NAME VARCHAR(256);
+  TABLE_NAME_D VARCHAR(256) := 'cwf_in_progress_user';
+  COLUMN_NAME_D VARCHAR(256) := 'eperson_legacy_id';
+BEGIN
+  select count(c.INDEX_NAME) into COUNT_INDEXES
+  from USER_INDEXES i, USER_IND_COLUMNS c
+  where i.TABLE_NAME = upper(TABLE_NAME_D)
+        and i.UNIQUENESS = 'UNIQUE'
+        and i.TABLE_NAME = c.TABLE_NAME
+        and i.INDEX_NAME = c.INDEX_NAME
+        and c.COLUMN_NAME = upper(COLUMN_NAME_D);
+
+  IF COUNT_INDEXES > 0 THEN
+    select c.INDEX_NAME into INDEX_NAME
+    from USER_INDEXES i, USER_IND_COLUMNS c
+    where i.TABLE_NAME = upper(TABLE_NAME_D)
+          and i.UNIQUENESS = 'UNIQUE'
+          and i.TABLE_NAME = c.TABLE_NAME
+          and i.INDEX_NAME = c.INDEX_NAME
+          and c.COLUMN_NAME = upper(COLUMN_NAME_D);
+    EXECUTE IMMEDIATE 'ALTER TABLE ' || TABLE_NAME_D || ' DROP constraint ' || INDEX_NAME;
+  END IF;
+END;
+/
+
 ALTER TABLE cwf_in_progress_user DROP COLUMN eperson_legacy_id;
 UPDATE cwf_in_progress_user SET finished = '0' WHERE finished IS NULL;
 


### PR DESCRIPTION
Fixes https://jira.duraspace.org/projects/DS/issues/DS-3829

Reuses https://github.com/DSpace/DSpace/blob/master/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V6.0_2016.11.29__DS-3410-lost-indexes.sql which is not in the DSpace 6 branch yet (only in the master)

Diverts from https://jira.duraspace.org/browse/DS-3788 by first verifying whether the constraints can be dropped or created (I would assume there should be situations where the original code was functional