### PR TITLE
[DS-3836] dspace-rest old dependencies break command line

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -696,7 +696,7 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>2.22.1</version>
+            <version>${jersey.version}</version>
         </dependency>
         <!-- S3 -->
         <dependency>

--- a/dspace-rest/pom.xml
+++ b/dspace-rest/pom.xml
@@ -51,17 +51,17 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
-            <version>2.22.1</version>
+            <version>${jersey.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet</artifactId>
-            <version>2.22.1</version>
+            <version>${jersey.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
-            <version>2.22.1</version>
+            <version>${jersey.version}</version>
             <exclusions>
                 <!-- Pinned to 2.5.4 below, this is because the current version number includes both 2.5.4 AND 2.5.0 jackson-annotations-->
                 <exclusion>
@@ -96,8 +96,8 @@
         <!-- Jersey + Spring -->
         <dependency>
             <groupId>org.glassfish.jersey.ext</groupId>
-            <artifactId>jersey-spring3</artifactId>
-            <version>2.22.1</version>
+            <artifactId>jersey-spring4</artifactId>
+            <version>${jersey.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework</groupId>

--- a/dspace-spring-rest/pom.xml
+++ b/dspace-spring-rest/pom.xml
@@ -149,11 +149,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.fasterxml</groupId>
-                <artifactId>classmate</artifactId>
-                <version>1.3.0</version>
-            </dependency>
-            <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-expression</artifactId>
                 <version>${spring.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <jena.version>2.13.0</jena.version>
         <slf4j.version>1.7.22</slf4j.version>
         <jackson.version>2.8.6</jackson.version>
+        <jersey.version>2.26</jersey.version>
         <hibernate.version>5.2.8.Final</hibernate.version>
         <spring.version>4.3.6.RELEASE</spring.version>
         <!-- 'root.basedir' is the path to the root [dspace-src] dir. It must be redefined by each child POM,
@@ -1443,6 +1444,11 @@
                 <scope>test</scope>
             </dependency>
             <!-- Converge miscellaneous transitive dependencies. -->
+            <dependency>
+                <groupId>com.fasterxml</groupId>
+                <artifactId>classmate</artifactId>
+                <version>1.3.0</version>
+            </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>


### PR DESCRIPTION
This passes the test suite, but should be tried by someone who knows how to seriously exercise dspace-rest.  This patch upgrades from jersey-spring3 to jersey-spring4.