### PR TITLE
[DS-3852]OAI indexer message not helpful in locating problems

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -283,7 +283,8 @@ public class XOAI {
         doc.addField("item.compile", out.toString());
 
         if (verbose) {
-            println("Item with handle " + handle + " indexed");
+            println(String.format("Item %d with handle %s indexed",
+                    item.getID(), handle));
         }
 
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3852
This identical patch is in production, in our somewhat modified 5.6 instance, and the affected command has been run multiple times while chasing another problem.