### PR TITLE
DS-3854: Update to latest PostgreSQL JDBC driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>
         <java.version>1.7</java.version>
-        <postgresql.driver.version>9.4.1211</postgresql.driver.version>
+        <postgresql.driver.version>42.2.1</postgresql.driver.version>
         <solr.version>4.10.4</solr.version>
         <jena.version>2.13.0</jena.version>
         <slf4j.version>1.7.14</slf4j.version>


### PR DESCRIPTION
Port of #1945 to 6.x

This upgrade 6.x dependencies to use the latest PostgreSQL JDBC Driver.  See also: https://jira.duraspace.org/browse/DS-3854