### PR TITLE
DS-3854: Update to latest PostgreSQL JDBC driver

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -569,7 +569,7 @@
 
 
         <dependency>
-            <groupId>postgresql</groupId>
+            <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
         </dependency>
 		

--- a/dspace-rest/pom.xml
+++ b/dspace-rest/pom.xml
@@ -111,7 +111,7 @@
             <artifactId>commons-dbcp</artifactId>
         </dependency>
         <dependency>
-            <groupId>postgresql</groupId>
+            <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
         </dependency>
         <dependency>

--- a/dspace-swordv2/pom.xml
+++ b/dspace-swordv2/pom.xml
@@ -81,7 +81,7 @@
             </activation>
             <dependencies>
                 <dependency>
-                    <groupId>postgresql</groupId>
+                    <groupId>org.postgresql</groupId>
                     <artifactId>postgresql</artifactId>
                 </dependency>
             </dependencies>

--- a/dspace/modules/swordv2/pom.xml
+++ b/dspace/modules/swordv2/pom.xml
@@ -82,7 +82,7 @@
          </activation>
          <dependencies>
             <dependency>
-               <groupId>postgresql</groupId>
+               <groupId>org.postgresql</groupId>
                <artifactId>postgresql</artifactId>
             </dependency>
          </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1160,9 +1160,9 @@
             <version>51.1</version>
          </dependency>
          <dependency>
-            <groupId>postgresql</groupId>
+            <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>9.1-901-1.jdbc4</version>
+            <version>42.2.1</version>
          </dependency>
          <dependency>
             <groupId>com.oracle</groupId>


### PR DESCRIPTION
Port of #1945 to 5.x

This updates 5.x to use the latest PostgreSQL database drivers.  According to PostgreSQL JDBC docs, this latest driver should work for PostgreSQL version 8.2 or above (See README at https://github.com/pgjdbc/pgjdbc).  DSpace 5 required PostgreSQL 9.0 or later.  So, this update should work for all 5.x sites.

It also fixes the bug noted in this ticket when using Postgres 10 with DSpace 5: https://jira.duraspace.org/browse/DS-3854

This changeset is a bit larger than the one in #1945, as the 5.x codebase was using now obsolete Maven dependencies for PostgreSQL. All PostgreSQL dependencies are now under the groupID `org.postgresql`

I've had this update in Production for DSpaceDirect sites (currently running 5.8 with PostgreSQL v10) for a few weeks. I've seen no issues so far.