### PR TITLE
Update Unit Tests to align with new Code Style

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suppressions PUBLIC
+        "-//Puppy Crawl//DTD Suppressions 1.2//EN"
+        "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
+<suppressions>
+    <!-- Temporarily suppress indentation checks for all Tests -->
+    <!-- TODO: We should have these turned on. But, currently there's a known bug with indentation checks
+         on JMockIt Expectations blocks and similar. See https://github.com/checkstyle/checkstyle/issues/3739 -->
+    <suppress checks="Indentation" files="src[/\\]test[/\\]java"/>
+</suppressions>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -22,6 +22,11 @@ For more information on CheckStyle configurations below, see: http://checkstyle.
     <!-- Configure checker to run on files with these extensions -->
     <property name="fileExtensions" value="java, properties, cfg, xml"/>
 
+    <!-- Suppression configurations in checkstyle-suppressions.xml in same directory -->
+    <module name="SuppressionFilter">
+        <property name="file" value="${checkstyle.suppressions.file}" default="checkstyle-suppressions.xml"/>
+    </module>
+
     <!-- No tab characters ('\t') allowed in the source code -->
     <module name="FileTabCharacter">
         <property name="eachLine" value="true"/>
@@ -44,8 +49,8 @@ For more information on CheckStyle configurations below, see: http://checkstyle.
         <!-- Maximum line length is 120 characters -->
         <module name="LineLength">
             <property name="max" value="120"/>
-            <!-- Only exceptions are packages, imports and URLs -->
-            <property name="ignorePattern" value="^package.*|^import.*|http://|https://"/>
+            <!-- Only exceptions for packages, imports, URLs, and JavaDoc {@link} tags -->
+            <property name="ignorePattern" value="^package.*|^import.*|http://|https://|@link"/>
         </module>
 
         <!-- Highlight any TODO or FIXME comments in info messages -->

--- a/dspace-api/src/test/java/org/dspace/AbstractDSpaceTest.java
+++ b/dspace-api/src/test/java/org/dspace/AbstractDSpaceTest.java
@@ -41,6 +41,12 @@ import org.junit.runner.RunWith;
 @Ignore
 @RunWith(JMockit.class)
 public class AbstractDSpaceTest {
+
+    /**
+     * Default constructor
+     */
+    protected AbstractDSpaceTest() { }
+
     /**
      * log4j category
      */

--- a/dspace-api/src/test/java/org/dspace/authenticate/IPMatcherTest.java
+++ b/dspace-api/src/test/java/org/dspace/authenticate/IPMatcherTest.java
@@ -266,7 +266,10 @@ public class IPMatcherTest {
 
 
     private ArrayList<String> getAllIp4Except(ArrayList<String> exceptions) {
-        int d1 = 0, d2 = 0, d3 = 0, d4 = 0;
+        int d1 = 0;
+        int d2 = 0;
+        int d3 = 0;
+        int d4 = 0;
         ArrayList<String> ips = new ArrayList<String>();
         for (d1 = 0; d1 <= 255; d1 += increment) {
             for (d2 = 0; d2 <= 255; d2 += increment) {
@@ -285,7 +288,10 @@ public class IPMatcherTest {
 
     private void verifyAllIp4Except(ArrayList<String> exceptions, boolean asserted, IPMatcher ipMatcher)
         throws IPMatcherException {
-        int d1 = 0, d2 = 0, d3 = 0, d4 = 0;
+        int d1 = 0;
+        int d2 = 0;
+        int d3 = 0;
+        int d4 = 0;
         for (d1 = 0; d1 <= 255; d1 += increment) {
             for (d2 = 0; d2 <= 255; d2 += increment) {
                 for (d3 = 0; d3 <= 255; d3 += increment) {

--- a/dspace-api/src/test/java/org/dspace/content/BundleTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/BundleTest.java
@@ -584,9 +584,8 @@ public class BundleTest extends AbstractDSpaceObjectTest {
     @Test
     public void testInheritCollectionDefaultPolicies() throws AuthorizeException, SQLException {
         //TODO: we would need a method to get policies from collection, probably better!
-        List<ResourcePolicy> defaultCollectionPolicies = authorizeService.getPoliciesActionFilter(context, collection,
-                                                                                                  Constants
-                                                                                                      .DEFAULT_BITSTREAM_READ);
+        List<ResourcePolicy> defaultCollectionPolicies =
+            authorizeService.getPoliciesActionFilter(context, collection, Constants.DEFAULT_BITSTREAM_READ);
         Iterator<ResourcePolicy> it = defaultCollectionPolicies.iterator();
 
         bundleService.inheritCollectionDefaultPolicies(context, b, collection);

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -120,16 +120,19 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         try {
             itemService.delete(context, it);
         } catch (Exception e) {
+            // ignore
         }
 
         try {
             collectionService.delete(context, collection);
         } catch (Exception e) {
+            // ignore
         }
 
         try {
             communityService.delete(context, owningCommunity);
         } catch (Exception e) {
+            // ignore
         }
 
         context.restoreAuthSystemState();
@@ -139,6 +142,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         try {
             super.destroy();
         } catch (Exception e) {
+            // ignore
         }
     }
 
@@ -1396,9 +1400,8 @@ public class ItemTest extends AbstractDSpaceObjectTest {
 
         Collection c = createCollection();
 
-        List<ResourcePolicy> defaultCollectionPolicies = authorizeService.getPoliciesActionFilter(context, c,
-                                                                                                  Constants
-                                                                                                      .DEFAULT_BITSTREAM_READ);
+        List<ResourcePolicy> defaultCollectionPolicies =
+            authorizeService.getPoliciesActionFilter(context, c, Constants.DEFAULT_BITSTREAM_READ);
         List<ResourcePolicy> newPolicies = new ArrayList<ResourcePolicy>();
         for (ResourcePolicy collRp : defaultCollectionPolicies) {
             ResourcePolicy rp = resourcePolicyService.clone(context, collRp);

--- a/dspace-api/src/test/java/org/dspace/core/CoreHelpers.java
+++ b/dspace-api/src/test/java/org/dspace/core/CoreHelpers.java
@@ -13,6 +13,12 @@ package org.dspace.core;
  * @author mwood
  */
 public class CoreHelpers {
+
+    /**
+     * Default constructor
+     */
+    private CoreHelpers() { }
+
     /**
      * Expose a Context's DBConnection.
      *

--- a/dspace-api/src/test/java/org/dspace/core/I18nUtilTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/I18nUtilTest.java
@@ -27,9 +27,6 @@ import org.junit.Test;
  */
 public class I18nUtilTest extends AbstractDSpaceTest {
 
-    public I18nUtilTest() {
-    }
-
     @BeforeClass
     public static void setUpClass() {
     }
@@ -147,12 +144,10 @@ public class I18nUtilTest extends AbstractDSpaceTest {
         // Assert our overridden default.locale is set in I18nUtil
         assertEquals("Default locale", new Locale("en", "US", "UTF-8"), I18nUtil.getDefaultLocale());
 
-        String key, expResult, result;
-
         // Test for a stock key
-        key = "jsp.general.home";
-        expResult = "DSpace Home";
-        result = I18nUtil.getMessage(key);
+        String key = "jsp.general.home";
+        String expResult = "DSpace Home";
+        String result = I18nUtil.getMessage(key);
         assertEquals("Returns the translation of the key if it is defined",
                      expResult, result);
 
@@ -168,13 +163,12 @@ public class I18nUtilTest extends AbstractDSpaceTest {
     @Test
     public void testGetMessage_String_Locale() {
         System.out.println("getMessage");
-        String key, expResult, result;
         Locale locale = Locale.US;
 
         // Test for a stock key
-        key = "jsp.general.home";
-        expResult = "DSpace Home";
-        result = I18nUtil.getMessage(key, locale);
+        String key = "jsp.general.home";
+        String expResult = "DSpace Home";
+        String result = I18nUtil.getMessage(key, locale);
         assertEquals("Returns the translation of the key if it is defined",
                      expResult, result);
 

--- a/dspace-api/src/test/java/org/dspace/eperson/PasswordHashTest.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/PasswordHashTest.java
@@ -44,7 +44,8 @@ public class PasswordHashTest extends AbstractDSpaceTest {
     @Test
     public void testConstructors()
         throws DecoderException {
-        PasswordHash h1, h3;
+        PasswordHash h1;
+        PasswordHash h3;
 
         // Test null inputs, as from NULL database columns (old EPerson using
         // unsalted hash, for example).

--- a/dspace-api/src/test/java/org/dspace/statistics/util/SpiderDetectorServiceImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/util/SpiderDetectorServiceImplTest.java
@@ -7,7 +7,6 @@
  */
 package org.dspace.statistics.util;
 
-
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 

--- a/dspace-api/src/test/java/org/dspace/workflowbasic/BasicWorkflowAuthorizationIT.java
+++ b/dspace-api/src/test/java/org/dspace/workflowbasic/BasicWorkflowAuthorizationIT.java
@@ -69,8 +69,8 @@ public class BasicWorkflowAuthorizationIT
     protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();
     protected InstallItemService installItemService = ContentServiceFactory.getInstance().getInstallItemService();
     protected WorkspaceItemService workspaceItemService = ContentServiceFactory.getInstance().getWorkspaceItemService();
-    protected BasicWorkflowItemService basicWorkflowItemService = BasicWorkflowServiceFactory.getInstance()
-                                                                                             .getBasicWorkflowItemService();
+    protected BasicWorkflowItemService basicWorkflowItemService =
+        BasicWorkflowServiceFactory.getInstance().getBasicWorkflowItemService();
     protected BasicWorkflowService basicWorkflowService = BasicWorkflowServiceFactory.getInstance()
                                                                                      .getBasicWorkflowService();
     protected EPersonService ePersonService = EPersonServiceFactory.getInstance().getEPersonService();

--- a/dspace-api/src/test/java/org/dspace/workflowbasic/BasicWorkflowAuthorizationRolesIT.java
+++ b/dspace-api/src/test/java/org/dspace/workflowbasic/BasicWorkflowAuthorizationRolesIT.java
@@ -72,8 +72,8 @@ public class BasicWorkflowAuthorizationRolesIT
     protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();
     protected InstallItemService installItemService = ContentServiceFactory.getInstance().getInstallItemService();
     protected WorkspaceItemService workspaceItemService = ContentServiceFactory.getInstance().getWorkspaceItemService();
-    protected BasicWorkflowItemService basicWorkflowItemService = BasicWorkflowServiceFactory.getInstance()
-                                                                                             .getBasicWorkflowItemService();
+    protected BasicWorkflowItemService basicWorkflowItemService =
+        BasicWorkflowServiceFactory.getInstance().getBasicWorkflowItemService();
     protected BasicWorkflowService basicWorkflowService = BasicWorkflowServiceFactory.getInstance()
                                                                                      .getBasicWorkflowService();
     protected EPersonService ePersonService = EPersonServiceFactory.getInstance().getEPersonService();
@@ -90,7 +90,7 @@ public class BasicWorkflowAuthorizationRolesIT
     protected EPerson member;
     protected WorkspaceItem wsi;
 
-    protected enum ROLE {ADMIN, SUB, STEP1, STEP2, STEP3;}
+    protected enum ROLE { ADMIN, SUB, STEP1, STEP2, STEP3 }
 
     protected HashMap<ROLE, Group> roleGroups = new HashMap<>();
     protected HashMap<ROLE, EPerson> roleEPersons = new HashMap<>();

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/helpers/SyntacticSugar.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/helpers/SyntacticSugar.java
@@ -8,6 +8,12 @@
 package org.dspace.xoai.tests.helpers;
 
 public class SyntacticSugar {
+
+    /**
+     * Default constructor
+     */
+    private SyntacticSugar() { }
+
     public static <T> T given(T elem) {
         return elem;
     }

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/helpers/stubs/StubbedSetRepository.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/helpers/stubs/StubbedSetRepository.java
@@ -7,7 +7,6 @@
  */
 package org.dspace.xoai.tests.helpers.stubs;
 
-
 import static java.lang.Math.min;
 import static org.apache.commons.lang.RandomStringUtils.randomAlphabetic;
 

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/services/impl/solr/DSpaceSolrQueryResolverTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/services/impl/solr/DSpaceSolrQueryResolverTest.java
@@ -40,7 +40,6 @@ public class DSpaceSolrQueryResolverTest extends AbstractQueryResolverTest {
     private static final String FIELD_2 = "dc.type";
 
     private DSpaceSolrQueryResolver underTest = new DSpaceSolrQueryResolver();
-    ;
 
     @Before
     public void autowire() {

--- a/dspace-services/src/test/java/org/dspace/services/caching/CachingServiceTest.java
+++ b/dspace-services/src/test/java/org/dspace/services/caching/CachingServiceTest.java
@@ -176,7 +176,7 @@ public class CachingServiceTest extends DSpaceAbstractKernelTest {
         Cache c1 = cachingService.getCache("org.dspace.timtest.newcache", null);
         assertNotNull(c1);
 
-        // Test that new cache was created and total caches increases by one 
+        // Test that new cache was created and total caches increases by one
         caches = cachingService.getCaches();
         assertNotNull(caches);
         assertEquals(curSize + 1, caches.size());

--- a/dspace-spring-rest/pom.xml
+++ b/dspace-spring-rest/pom.xml
@@ -35,7 +35,7 @@
 
     <profiles>
         <!-- If Unit Testing is enabled, then setup the Unit Test Environment.
-     See also the 'skiptests' profile in Parent POM. -->
+             See also the 'skiptests' profile in Parent POM. -->
         <profile>
             <id>test-environment</id>
             <activation>

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/AuthenticationRestControllerIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/AuthenticationRestControllerIT.java
@@ -15,9 +15,9 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertNotEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 
 import java.util.Base64;
 

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/BitstreamContentRestControllerIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/BitstreamContentRestControllerIT.java
@@ -343,7 +343,7 @@ public class BitstreamContentRestControllerIT extends AbstractControllerIntegrat
         File originalPdf = new File(testProps.getProperty("test.bitstream"));
 
 
-        try(InputStream is = new FileInputStream(originalPdf)) {
+        try (InputStream is = new FileInputStream(originalPdf)) {
 
             Item publicItem1 = ItemBuilder.createItem(context, col1)
                     .withTitle("Public item citation cover page test 1")
@@ -376,12 +376,14 @@ public class BitstreamContentRestControllerIT extends AbstractControllerIntegrat
                     //THe bytes of the content must match the original content
                     .andReturn().getResponse().getContentAsByteArray();
 
-            // The citation cover page contains the item title. We will now verify that the pdf text contains this title.
+            // The citation cover page contains the item title.
+            // We will now verify that the pdf text contains this title.
             String pdfText = extractPDFText(content);
             System.out.println(pdfText);
             assertTrue(StringUtils.contains(pdfText,"Public item citation cover page test 1"));
 
-            // The dspace-api/src/test/data/dspaceFolder/assetstore/ConstitutionofIreland.pdf file contains 64 pages, manually counted + 1 citation cover page
+            // The dspace-api/src/test/data/dspaceFolder/assetstore/ConstitutionofIreland.pdf file contains 64 pages,
+            // manually counted + 1 citation cover page
             assertEquals(65,getNumberOfPdfPages(content));
 
             //A If-None-Match HEAD request on the ETag must tell is the bitstream is not modified
@@ -399,8 +401,8 @@ public class BitstreamContentRestControllerIT extends AbstractControllerIntegrat
         pts.setSortByPosition(true);
 
         try (ByteArrayInputStream source = new ByteArrayInputStream(content);
-            Writer writer = new StringWriter();
-            PDDocument pdfDoc = PDDocument.load(source)){
+             Writer writer = new StringWriter();
+             PDDocument pdfDoc = PDDocument.load(source)) {
 
             pts.writeText(pdfDoc, writer);
             return writer.toString();
@@ -409,7 +411,7 @@ public class BitstreamContentRestControllerIT extends AbstractControllerIntegrat
 
     private int getNumberOfPdfPages(byte[] content) throws IOException {
         try (ByteArrayInputStream source = new ByteArrayInputStream(content);
-             PDDocument pdfDoc = PDDocument.load(source)){
+             PDDocument pdfDoc = PDDocument.load(source)) {
             return pdfDoc.getNumberOfPages();
         }
     }

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/converter/DiscoverConfigurationConverterTest.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/converter/DiscoverConfigurationConverterTest.java
@@ -7,7 +7,6 @@
  */
 package org.dspace.app.rest.converter;
 
-
 import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/converter/DiscoverFacetConfigurationConverterTest.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/converter/DiscoverFacetConfigurationConverterTest.java
@@ -7,7 +7,6 @@
  */
 package org.dspace.app.rest.converter;
 
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/AppliedFilterMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/AppliedFilterMatcher.java
@@ -15,6 +15,8 @@ import org.hamcrest.Matcher;
 
 public class AppliedFilterMatcher {
 
+    private AppliedFilterMatcher() { }
+
     public static Matcher<? super Object> appliedFilterEntry(String filter, String operator, String value,
                                                              String label) {
         return allOf(

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/BitstreamFormatMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/BitstreamFormatMatcher.java
@@ -18,6 +18,8 @@ import org.hamcrest.Matcher;
  */
 public class BitstreamFormatMatcher {
 
+    private BitstreamFormatMatcher() { }
+
     public static Matcher<? super Object> matchBitstreamFormat(String mimetype, String description) {
         return allOf(
             hasJsonPath("$.mimetype", is(mimetype)),

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/BitstreamMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/BitstreamMatcher.java
@@ -22,6 +22,8 @@ import org.hamcrest.Matcher;
 
 public class BitstreamMatcher {
 
+    private BitstreamMatcher() { }
+
     public static Matcher<? super Object> matchBitstreamEntry(Bitstream bitstream) {
         return allOf(
             //Check core metadata (the JSON Path expression evaluates to a collection so we have to use contains)

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/BitstreamMetadataMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/BitstreamMetadataMatcher.java
@@ -15,6 +15,8 @@ import org.hamcrest.Matcher;
 
 public class BitstreamMetadataMatcher {
 
+    private BitstreamMetadataMatcher() { }
+
     public static Matcher<? super Object> matchTitle(String title) {
         return allOf(
             hasJsonPath("$.key", is("dc.title")),

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/BrowseEntryResourceMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/BrowseEntryResourceMatcher.java
@@ -22,6 +22,9 @@ import org.hamcrest.Matcher;
  * @author Raf Ponsaerts (raf dot ponsaerts at atmire dot com)
  */
 public class BrowseEntryResourceMatcher {
+
+    private BrowseEntryResourceMatcher() { }
+
     public static Matcher<? super Object> matchBrowseEntry(String value, int expectedCount) {
         return allOf(
             //Check core metadata (the JSON Path expression evaluates to a collection so we have to use contains)

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/BrowseIndexMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/BrowseIndexMatcher.java
@@ -26,9 +26,7 @@ import org.hamcrest.Matchers;
  */
 public class BrowseIndexMatcher {
 
-    public BrowseIndexMatcher() {
-
-    }
+    private BrowseIndexMatcher() { }
 
     public static Matcher<? super Object> subjectBrowseIndex(final String order) {
         return allOf(

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/CollectionMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/CollectionMatcher.java
@@ -20,6 +20,8 @@ import org.hamcrest.Matchers;
 
 public class CollectionMatcher {
 
+    private CollectionMatcher() { }
+
     public static Matcher<? super Object> matchCollectionEntry(String name, UUID uuid, String handle) {
         return matchCollectionEntry(name, uuid, handle, null);
     }

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/CollectionMetadataMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/CollectionMetadataMatcher.java
@@ -15,6 +15,8 @@ import org.hamcrest.Matcher;
 
 public class CollectionMetadataMatcher {
 
+    private CollectionMetadataMatcher() { }
+
     public static Matcher<? super Object> matchTitle(String title) {
         return allOf(
             hasJsonPath("$.key", is("dc.title")),

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/CommunityMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/CommunityMatcher.java
@@ -19,6 +19,8 @@ import org.hamcrest.Matchers;
 
 public class CommunityMatcher {
 
+    private CommunityMatcher() { }
+
     public static Matcher<? super Object> matchCommunityEntry(String name, UUID uuid, String handle) {
         return allOf(
             matchProperties(name, uuid, handle),

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/CommunityMetadataMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/CommunityMetadataMatcher.java
@@ -15,6 +15,8 @@ import org.hamcrest.Matcher;
 
 public class CommunityMetadataMatcher {
 
+    private CommunityMetadataMatcher() { }
+
     public static Matcher<? super Object> matchTitle(String title) {
         return allOf(
             hasJsonPath("$.key", is("dc.title")),

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/DSpaceObjectMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/DSpaceObjectMatcher.java
@@ -15,6 +15,8 @@ import org.hamcrest.Matcher;
 
 public class DSpaceObjectMatcher {
 
+    private DSpaceObjectMatcher() { }
+
     public static Matcher<? super Object> match() {
         return allOf(
             hasJsonPath("$.uuid", notNullValue())

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/EPersonMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/EPersonMatcher.java
@@ -20,6 +20,8 @@ import org.hamcrest.Matchers;
 
 public class EPersonMatcher {
 
+    private EPersonMatcher() { }
+
     public static Matcher<? super Object> matchEPersonEntry(EPerson ePerson) {
         return allOf(
             hasJsonPath("$.uuid", is(ePerson.getID().toString())),

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/EPersonMetadataMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/EPersonMetadataMatcher.java
@@ -15,6 +15,8 @@ import org.hamcrest.Matcher;
 
 public class EPersonMetadataMatcher {
 
+    private EPersonMetadataMatcher() { }
+
     public static Matcher<? super Object> matchFirstName(String firstName) {
         return allOf(
             hasJsonPath("$.key", is("eperson.firstname")),

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/FacetEntryMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/FacetEntryMatcher.java
@@ -17,9 +17,7 @@ import org.hamcrest.Matcher;
 
 public class FacetEntryMatcher {
 
-    public FacetEntryMatcher() {
-
-    }
+    private FacetEntryMatcher() { }
 
     public static Matcher<? super Object> authorFacet(boolean hasNext) {
         return allOf(

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/FacetValueMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/FacetValueMatcher.java
@@ -17,6 +17,8 @@ import org.hamcrest.Matchers;
 
 public class FacetValueMatcher {
 
+    private FacetValueMatcher() { }
+
     public static Matcher<? super Object> entryAuthor(String label) {
         return allOf(
             hasJsonPath("$.label", is(label)),

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/GroupMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/GroupMatcher.java
@@ -18,6 +18,8 @@ import org.hamcrest.Matcher;
 
 public class GroupMatcher {
 
+    private GroupMatcher() { }
+
     public static Matcher<? super Object> matchGroupEntry(UUID uuid, String name) {
         return allOf(
             hasJsonPath("$.uuid", is(uuid.toString())),

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/HitHighlightMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/HitHighlightMatcher.java
@@ -16,6 +16,8 @@ import org.hamcrest.Matcher;
 
 public class HitHighlightMatcher {
 
+    private HitHighlightMatcher() { }
+
     public static Matcher<? super Object> entry(String value, String expectedField) {
         return allOf(
             hasJsonPath("$.['" + expectedField + "']", contains(containsString("Public")))

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/ItemMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/ItemMatcher.java
@@ -26,6 +26,8 @@ import org.hamcrest.Matcher;
  */
 public class ItemMatcher {
 
+    private ItemMatcher() { }
+
     public static Matcher<? super Object> matchItemWithTitleAndDateIssued(Item item, String title, String dateIssued) {
         return allOf(
             //Check item properties

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/MetadataFieldMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/MetadataFieldMatcher.java
@@ -17,6 +17,8 @@ import org.hamcrest.Matchers;
 
 public class MetadataFieldMatcher {
 
+    private MetadataFieldMatcher() { }
+
     public static Matcher<? super Object> matchMetadataField() {
         return allOf(
             hasJsonPath("$.element", Matchers.not(Matchers.empty())),

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/MetadataschemaMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/MetadataschemaMatcher.java
@@ -17,6 +17,8 @@ import org.hamcrest.Matchers;
 
 public class MetadataschemaMatcher {
 
+    private MetadataschemaMatcher() { }
+
     public static Matcher<? super Object> matchEntry() {
         return allOf(
             hasJsonPath("$.prefix", Matchers.not(Matchers.empty())),

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/PageMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/PageMatcher.java
@@ -15,6 +15,7 @@ import org.hamcrest.Matcher;
 
 public class PageMatcher {
 
+    private PageMatcher() { }
 
     public static Matcher<? super Object> pageEntry(int number, int size) {
         return allOf(

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/SearchFilterMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/SearchFilterMatcher.java
@@ -15,9 +15,8 @@ import static org.hamcrest.Matchers.is;
 import org.hamcrest.Matcher;
 
 public class SearchFilterMatcher {
-    public SearchFilterMatcher() {
 
-    }
+    private SearchFilterMatcher() { }
 
     public static Matcher<? super Object> titleFilter() {
         return allOf(

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/SearchResultMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/SearchResultMatcher.java
@@ -17,6 +17,7 @@ import org.hamcrest.Matcher;
 
 public class SearchResultMatcher {
 
+    private SearchResultMatcher() { }
 
     public static Matcher<? super Object> match(String type, String typePlural) {
         return allOf(

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/SiteMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/SiteMatcher.java
@@ -17,6 +17,8 @@ import org.hamcrest.Matcher;
 
 public class SiteMatcher {
 
+    private SiteMatcher() { }
+
     public static Matcher<? super Object> matchEntry(Site site) {
         return allOf(
             hasJsonPath("$.uuid", is(site.getID().toString())),

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/SortOptionMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/SortOptionMatcher.java
@@ -15,6 +15,8 @@ import org.hamcrest.Matcher;
 
 public class SortOptionMatcher {
 
+    private SortOptionMatcher() { }
+
     public static Matcher<? super Object> titleSortOption() {
         return allOf(
             hasJsonPath("$.name", is("dc.title"))

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/SubmissionDefinitionsMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/SubmissionDefinitionsMatcher.java
@@ -19,9 +19,7 @@ import org.hamcrest.Matcher;
  */
 public class SubmissionDefinitionsMatcher {
 
-    public SubmissionDefinitionsMatcher() {
-
-    }
+    private SubmissionDefinitionsMatcher() { }
 
     public static Matcher<Object> matchSubmissionDefinition(boolean isDefault, String name, String id) {
         return allOf(

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/test/AbstractDSpaceIntegrationTest.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/test/AbstractDSpaceIntegrationTest.java
@@ -44,6 +44,11 @@ public class AbstractDSpaceIntegrationTest {
     protected static DSpaceKernelImpl kernelImpl;
 
     /**
+     * Default constructor
+     */
+    protected AbstractDSpaceIntegrationTest() { }
+
+    /**
      * This method will be run before the first test as per @BeforeClass. It will
      * initialize shared resources required for all tests of this class.
      *

--- a/pom.xml
+++ b/pom.xml
@@ -198,8 +198,11 @@
                         <encoding>${project.build.sourceEncoding}</encoding>
                         <logViolationsToConsole>true</logViolationsToConsole>
                         <failOnViolation>true</failOnViolation>
-                        <!-- TODO: Enable checks on tests too. Currently, they are excluded by default -->
-                        <!--<includeTestSourceDirectory>true</includeTestSourceDirectory>-->
+                        <!-- Enable checks on all test source files -->
+                        <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                        <!-- Define our suppressions file location, and the key used to pass it to checkstyle.xml-->
+                        <suppressionsLocation>${root.basedir}/checkstyle-suppressions.xml</suppressionsLocation>
+                        <suppressionsFileExpression>checkstyle.suppressions.file</suppressionsFileExpression>
                     </configuration>
                     <dependencies>
                         <!-- Override dependencies to use latest version of checkstyle -->

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,7 @@
                     </executions>
                 </plugin>
                 <!-- Used to validate all code style rules in source code via the Checkstyle config in checkstyle.xml -->
+                <!-- Can be skipped by passing -Dcheckstyle.skip=true to Maven. -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
@@ -186,8 +187,8 @@
                     <executions>
                         <execution>
                             <id>verify-style</id>
-                            <!-- Bind to process-classes so it runs after compile, but before package -->
-                            <phase>process-classes</phase>
+                            <!-- Bind to verify so it runs after package & unit tests, but before install -->
+                            <phase>verify</phase>
                             <goals>
                                 <goal>check</goal>
                             </goals>


### PR DESCRIPTION
This is a follow-up to #1952 (which aligned all our Java code with the new [Code Style Guide](https://wiki.duraspace.org/display/DSPACE/Code+Style+Guide)).

By default, maven-checkstyle-plugin does *not* validate the code style of any code under `src/test/java` (i.e. unit or integration tests).

This PR does the following:
1. Updates our maven-checkstyle-plugin config (in Parent POM) to enable validation of unit test sources in `src/test/java`
2. Aligns the unit/integration test source code in all modules with the current Code Style Guide.  This is again done as a series of commits to align `dspace-api`, `dspace-oai`, `dspace-services` and `dspace-spring-rest` unit testing code.
3. Adds a new `checkstyle-suppressions.xml` configuration file to allow suppressing specific Code Style checks as needed. 
    * Configured to suppress all indentation/code alignment tests for `src/test/java` directories.  Unfortunately, CheckStyle has a known issue (see checkstyle/checkstyle#3739) where it throws indentation errors on valid JMockIt expectation blocks.  All the current `src/test/java` code obeys our indentation rules, but unfortunately we cannot enable this check until the issue is resolved in CheckStyle (or a valid workaround is found).  A TODO comment was added to `checkstyle-suppressions.xml` as a reminder.

Assuming Travis approves this, it should be ready to review/merge.  It should be easily reviewable as this is a much smaller PR than its predecessor.  

(As a sidenote, the reason why this PR is so small is that the batch updates performed in PR #1952 had already done most of the "heavy lifting" in terms of aligning `src/test/java` sources with our Code Style. So, this follow-up only had to cleanup the areas that were not caught by batch updates)