### PR TITLE
The behavior of an update of the metadata on a collection and community

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowContainerUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowContainerUtils.java
@@ -67,7 +67,10 @@ import java.util.UUID;
  */
 public class FlowContainerUtils 
 {
-
+	/** Language Strings */
+	private static final Message T_edit_entity_metadata_success_notice =
+			new Message("default","xmlui.administrative.FlowContainerUtils.entity.update_metadate_succuess");
+	
 	/** Possible Collection roles */
 	public static final String ROLE_ADMIN 	 	 = "ADMIN";
 	public static final String ROLE_WF_STEP1 	 = "WF_STEP1";
@@ -183,12 +186,11 @@ public class FlowContainerUtils
     		}
         }
         
-        // Save everything
-        collectionService.update(context, collection);
-
-        
-        // No notice...
-        result.setContinue(true);
+       	// Save everything
+		collectionService.update(context, collection);
+			
+        result.setOutcome(true);
+        result.setMessage(T_edit_entity_metadata_success_notice);
 		
 		return result;
 	}
@@ -1002,11 +1004,12 @@ public class FlowContainerUtils
         }
         
         // Save everything
-        communityService.update(context, community);
-
-        // No notice...
-        result.setContinue(true);
-		return result;
+		communityService.update(context, community);
+			
+        result.setOutcome(true);
+        result.setMessage(T_edit_entity_metadata_success_notice);
+		
+        return result;
 	}
 
 	/**

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/community/EditCommunityMetadataForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/community/EditCommunityMetadataForm.java
@@ -62,7 +62,7 @@ public class EditCommunityMetadataForm extends AbstractDSpaceTransformer
 
     private static final Message T_submit_delete_logo = message("xmlui.administrative.community.EditCommunityMetadataForm.submit_delete_logo");
     private static final Message T_submit_delete = message("xmlui.administrative.community.EditCommunityMetadataForm.submit_delete");
-    private static final Message T_submit_update = message("xmlui.general.update");
+    private static final Message T_submit_update = message("xmlui.administrative.community.EditCommunityMetadataForm.submit_save");
     private static final Message T_submit_return = message("xmlui.general.return");
 
     protected AuthorizeService authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();

--- a/dspace-xmlui/src/main/resources/aspects/Administrative/administrative.js
+++ b/dspace-xmlui/src/main/resources/aspects/Administrative/administrative.js
@@ -2483,12 +2483,12 @@ function doEditCollection(collectionID,newCollectionP)
 
 	do {
 
-		if (cocoon.request.get("submit_return") || cocoon.request.get("submit_save"))
+		if (cocoon.request.get("submit_return"))
 		{
 			// go back to wherever we came from.
 			return null;
 		}
-		else if (cocoon.request.get("submit_metadata"))
+		else if (cocoon.request.get("submit_metadata") || cocoon.request.get("submit_save"))
 		{
 			// go edit collection metadata
 			doEditCollectionMetadata(collectionID)
@@ -2544,8 +2544,8 @@ function doEditCollectionMetadata(collectionID)
 		{
 			// Save updates
 			result = FlowContainerUtils.processEditCollection(getDSContext(), collectionID, false, cocoon.request);
-      if (result.getContinue())
-         return null;
+            if (result.getContinue())
+               return null;
 		}
 		else if (cocoon.request.get("submit_delete"))
 		{

--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -984,6 +984,7 @@
 	<message key="xmlui.administrative.FlowItemUtils.bitstream_delete">The selected bitstreams have been deleted.</message>
 	<message key="xmlui.administrative.FlowMapperUtils.map_items">The items were successfully mapped.</message>
 	<message key="xmlui.administrative.FlowMapperUtils.unmaped_items">The items have been unmapped.</message>
+	<message key="xmlui.administrative.FlowContainerUtils.entity.update_metadate_succuess">The metadata was successfully updated.</message>
 
 	<!-- general items for all of the eperson classes -->
 	<message key="xmlui.administrative.eperson.general.epeople_trail">Manage E-people</message>
@@ -1932,7 +1933,8 @@
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_existing_logo">Current logo</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete_logo">Remove logo</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete">Delete community</message>
-
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_save">Save Updates</message>
+	
 	<!-- org.dspace.app.xmlui.administrative.community.CreateCommunityForm.java -->
 	<message key="xmlui.administrative.community.CreateCommunityForm.title">Create Community</message>
 	<message key="xmlui.administrative.community.CreateCommunityForm.trail">Create Community</message>


### PR DESCRIPTION
After saving, you will be sent to the metadata page for both units. Furthermore, the text of the save button is the same in both elements. The user now receives a visual feedback that the metadata has been saved successfully.