### PR TITLE
Avoid NullPointerException with empty sub-communities.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExport.java
@@ -122,7 +122,9 @@ public class MetadataExport {
                 System.out.print(" ");
             }
             Iterator<Item> items = buildFromCommunity(context, subCommunity, indent + 1);
-            result = addItemsToResult(result, items);
+            if (items != null) {
+                result = addItemsToResult(result, items);
+            }
         }
 
         return result;

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExport.java
@@ -122,22 +122,20 @@ public class MetadataExport {
                 System.out.print(" ");
             }
             Iterator<Item> items = buildFromCommunity(context, subCommunity, indent + 1);
-            if (items != null) {
-                result = addItemsToResult(result, items);
-            }
+            result = addItemsToResult(result, items);
         }
 
         return result;
     }
 
     private Iterator<Item> addItemsToResult(Iterator<Item> result, Iterator<Item> items) {
-        if (result == null) {
-            result = items;
-        } else {
-            result = Iterators.concat(result, items);
+        if (items == null) {
+            return result;
         }
-
-        return result;
+        if (result == null) {
+            return items;
+        } 
+        return Iterators.concat(result, items);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExport.java
@@ -134,7 +134,7 @@ public class MetadataExport {
         }
         if (result == null) {
             return items;
-        } 
+        }
         return Iterators.concat(result, items);
     }
 


### PR DESCRIPTION
If there are sub-communities that contain nothing, a community metadata export will fail with a NullPointerException, because the buildFromCommunity method will return null when called recursively and then the code will try to add that null to the result Iterator. This patch just checks whether the buildFromCommunity call returned null before trying to append it, avoiding the exception.