### PR TITLE
DS-3869 Record stats events even if location service fails to init

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
@@ -201,7 +201,7 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
     @Override
     public void postView(DSpaceObject dspaceObject, HttpServletRequest request,
                          EPerson currentUser) {
-        if (solr == null || locationService == null) {
+        if (solr == null) {
             return;
         }
         initSolrYearCores();
@@ -237,7 +237,7 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
     @Override
     public void postView(DSpaceObject dspaceObject,
                          String ip, String userAgent, String xforwardedfor, EPerson currentUser) {
-        if (solr == null || locationService == null) {
+        if (solr == null) {
             return;
         }
         initSolrYearCores();


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3869

When the server starts up, `SolrLoggerServiceImpl` (previously `SolrLogger`) initializes a location `LookupService` using the Geo Database file configured in `usage-statistics.dbfile`. By default this is `${dspace.dir}/config/GeoLiteCity.dat`.

However, if this file is removed, or fails to load, the location service fails to initialize and, as a result, usage events are no longer recorded by `SolrLoggerServiceImpl`. This is due to a `null` check which skips the creation of the solr document. However, it makes more sense to simply omit the location metadata from the Solr document in this case. In fact, a null check is already in place for these code-blocks.