### PR TITLE
DS-3873 Limit the usage of PDFBoxThumbnail to PDFs

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFBoxThumbnail.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFBoxThumbnail.java
@@ -77,7 +77,7 @@ public class PDFBoxThumbnail extends MediaFilter implements SelfRegisterInputFor
 
     @Override
     public String[] getInputMIMETypes() {
-        return ImageIO.getReaderMIMETypes();
+        return new String[]{"Adobe PDF"};
     }
 
     @Override


### PR DESCRIPTION
`PDFBoxThumbnail` media filter is currently configured to run on more than just PDFs. This consistently results in an error in the logs:

```ERROR filtering, skipping bitstream #7f142dd0-fca6-4533-b966-19b1354e9a9d java.io.IOException: Error: Header doesn't contain versioninfo
java.io.IOException: Error: Header doesn't contain versioninfo
        at org.apache.pdfbox.pdfparser.PDFParser.parse(PDFParser.java:244)
        at org.apache.pdfbox.pdmodel.PDDocument.load(PDDocument.java:966)
        at org.apache.pdfbox.pdmodel.PDDocument.load(PDDocument.java:868)
        at org.dspace.app.mediafilter.PDFBoxThumbnail.getDestinationStream(PDFBoxThumbnail.java:80)
        at org.dspace.app.mediafilter.MediaFilterServiceImpl.processBitstream(MediaFilterServiceImpl.java:358)
        at org.dspace.app.mediafilter.MediaFilterServiceImpl.filterBitstream(MediaFilterServiceImpl.java:286)
        at org.dspace.app.mediafilter.MediaFilterServiceImpl.filterItem(MediaFilterServiceImpl.java:180)
        at org.dspace.app.mediafilter.MediaFilterServiceImpl.applyFiltersItem(MediaFilterServiceImpl.java:158)
        at org.dspace.app.mediafilter.MediaFilterCLITool.main(MediaFilterCLITool.java:315)```

This can be fixed by modifying `.getInputMIMETypes()` to only return "Adobe PDF" instead of all ImageIO Reader Mimetypes.