### PR TITLE
DS-3875: Fix the attribute name of <identifier> tag to 'identifierType'.

### DIFF
--- a/dspace/config/crosswalks/DIM2EZID.xsl
+++ b/dspace/config/crosswalks/DIM2EZID.xsl
@@ -63,7 +63,7 @@
             <!--
                  For EZID we need an empty field here.
             -->
-                <identifier type='DOI'/>
+                <identifier identifierType='DOI'/>
 
             <!--
                 DataCite (2)


### PR DESCRIPTION
Fix the attribute name of <identifier> tag to 'identifierType' in DIM2EZID.xsl file. 

https://jira.duraspace.org/browse/DS-3875