### PR TITLE
DS-2862 Fix legacy embargo checks on DSpace 6

### DIFF
--- a/dspace-api/src/main/java/org/dspace/embargo/DefaultEmbargoSetter.java
+++ b/dspace-api/src/main/java/org/dspace/embargo/DefaultEmbargoSetter.java
@@ -168,9 +168,12 @@ public class DefaultEmbargoSetter implements EmbargoSetter
                     // check for ANY read policies and report them:
                     for (ResourcePolicy rp : getAuthorizeService().getPoliciesActionFilter(context, bn, Constants.READ))
                     {
-                        System.out.println("CHECK WARNING: Item "+item.getHandle()+", Bundle "+bn.getName()+" allows READ by "+
-                          ((rp.getEPerson() == null) ? "Group "+rp.getGroup().getName() :
-                                                      "EPerson "+rp.getEPerson().getFullName()));
+                    	if (rp.getStartDate() == null)
+                    	{
+                            System.out.println("CHECK WARNING: Item "+item.getHandle()+", Bundle "+bn.getName()+" allows READ by "+
+                              ((rp.getEPerson() == null) ? "Group "+rp.getGroup().getName() :
+                                                           "EPerson "+rp.getEPerson().getFullName()));
+                    	}
                     }
                 }
 
@@ -178,9 +181,12 @@ public class DefaultEmbargoSetter implements EmbargoSetter
                 {
                     for (ResourcePolicy rp : getAuthorizeService().getPoliciesActionFilter(context, bs, Constants.READ))
                     {
-                        System.out.println("CHECK WARNING: Item "+item.getHandle()+", Bitstream "+bs.getName()+" (in Bundle "+bn.getName()+") allows READ by "+
-                          ((rp.getEPerson() == null) ? "Group "+rp.getGroup().getName() :
-                                                      "EPerson "+rp.getEPerson().getFullName()));
+                    	if (rp.getStartDate() == null)
+                    	{
+                            System.out.println("CHECK WARNING: Item "+item.getHandle()+", Bitstream "+bs.getName()+" (in Bundle "+bn.getName()+") allows READ by "+
+                              ((rp.getEPerson() == null) ? "Group "+rp.getGroup().getName() :
+                                                           "EPerson "+rp.getEPerson().getFullName()));
+                    	}
                     }
                 }
             }

--- a/dspace-api/src/main/java/org/dspace/embargo/DefaultEmbargoSetter.java
+++ b/dspace-api/src/main/java/org/dspace/embargo/DefaultEmbargoSetter.java
@@ -169,7 +169,7 @@ public class DefaultEmbargoSetter implements EmbargoSetter
                     for (ResourcePolicy rp : getAuthorizeService().getPoliciesActionFilter(context, bn, Constants.READ))
                     {
                         System.out.println("CHECK WARNING: Item "+item.getHandle()+", Bundle "+bn.getName()+" allows READ by "+
-                          ((rp.getEPerson() != null) ? "Group "+rp.getGroup().getName() :
+                          ((rp.getEPerson() == null) ? "Group "+rp.getGroup().getName() :
                                                       "EPerson "+rp.getEPerson().getFullName()));
                     }
                 }
@@ -179,7 +179,7 @@ public class DefaultEmbargoSetter implements EmbargoSetter
                     for (ResourcePolicy rp : getAuthorizeService().getPoliciesActionFilter(context, bs, Constants.READ))
                     {
                         System.out.println("CHECK WARNING: Item "+item.getHandle()+", Bitstream "+bs.getName()+" (in Bundle "+bn.getName()+") allows READ by "+
-                          ((rp.getEPerson() != null) ? "Group "+rp.getGroup().getName() :
+                          ((rp.getEPerson() == null) ? "Group "+rp.getGroup().getName() :
                                                       "EPerson "+rp.getEPerson().getFullName()));
                     }
                 }

--- a/dspace-api/src/main/java/org/dspace/embargo/EmbargoServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/embargo/EmbargoServiceImpl.java
@@ -150,8 +150,8 @@ public class EmbargoServiceImpl implements EmbargoService
     public void liftEmbargo(Context context, Item item)
         throws SQLException, AuthorizeException, IOException
     {
-        // new version of Embargo policies remain in place.
-        lifter.liftEmbargo(context, item);
+        // Since 3.0 the lift process for all embargoes is performed through the dates on the authorization process (see DS-2588)
+        // lifter.liftEmbargo(context, item);
         itemService.clearMetadata(context, item, lift_schema, lift_element, lift_qualifier, Item.ANY);
 
         // set the dc.date.available value to right now

--- a/dspace-api/src/main/java/org/dspace/embargo/EmbargoServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/embargo/EmbargoServiceImpl.java
@@ -151,7 +151,7 @@ public class EmbargoServiceImpl implements EmbargoService
         throws SQLException, AuthorizeException, IOException
     {
         // new version of Embargo policies remain in place.
-        //lifter.liftEmbargo(context, item);
+        lifter.liftEmbargo(context, item);
         itemService.clearMetadata(context, item, lift_schema, lift_element, lift_qualifier, Item.ANY);
 
         // set the dc.date.available value to right now


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2862

While running the legacy embargo lifter it turned out that the conditions on legacy embargo checker to detect anonymous read rights (i.e. "CHECK WARNING: Item ..., Bundle ORIGINAL allows READ by Group Anonymous) were not working correctly, producing NullPointerExceptions (trying to get name from null rp.getGroup()). This code fixes the conditions to show the warnings, assuming that the "timed" resource policy is correct compared to the value set in dc.date.embargo field.

The code is tested with data migrated from a legacy DSpace 1.7.3 installation. Initially "dspace migrate-embargo" was not run (which it should have), which was the reason legacy embargo appeared to be broken in DSpace 6 - and Monika Mevenkamp's fix to call legacy embargo lifter on embargo manager (=commented in DSpace 3) appeared to fix this functionality. 