### PR TITLE
DS-3511: Fix HTTP 500 errors on REST API bitstream updates (7.0)

### DIFF
--- a/dspace-rest/src/main/java/org/dspace/rest/BitstreamResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/BitstreamResource.java
@@ -550,7 +550,7 @@ public class BitstreamResource extends Resource {
 
             UUID newBitstreamId = bitstreamStorageService.store(context, dspaceBitstream, is);
             log.trace("Bitstream data stored: " + newBitstreamId);
-
+            context.complete();
         } catch (SQLException e) {
             processException("Could not update bitstream(id=" + bitstreamId + ") data, SQLException. Message: " + e,
                              context);
@@ -690,6 +690,7 @@ public class BitstreamResource extends Resource {
                 log.trace("Policy for bitstream(id=" + bitstreamId + ") was successfully removed.");
             }
 
+            context.complete();
         } catch (SQLException e) {
             processException(
                 "Someting went wrong while deleting policy(id=" + policyId + ") to bitstream(id=" + bitstreamId


### PR DESCRIPTION
This is a replacement pull request for #1840, rebased against the master branch.

When trying to update the content of a bitstream or delete a bitstream policy HTTP 500 error occurs (tested with DSpace 6.0-6.2). Fixed by adding context.complete() to the end of the respective methods (adapted the original patch submitted to DS-3511).