### PR TITLE
DS-3889 Change Content-Type in OAI-Response (DSpace 6 port)

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/controller/DSpaceOAIDataProvider.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/controller/DSpaceOAIDataProvider.java
@@ -94,7 +94,7 @@ public class DSpaceOAIDataProvider
             OutputStream out = response.getOutputStream();
             OAIRequestParameters parameters = new OAIRequestParameters(buildParametersMap(request));
 
-            response.setContentType("application/xml");
+            response.setContentType("text/xml");
             response.setCharacterEncoding("UTF-8");
 
             String identification = xoaiContext + parameters.requestID();


### PR DESCRIPTION
DSpace 6 Port for https://github.com/DSpace/DSpace/pull/1804, commit cherrypicked against dspace-6_x:

As per OAI 2.0 spec (3.1.2.1) the response content type *must* be text/xml.
http://www.openarchives.org/OAI/openarchivesprotocol.html#HTTPResponseFormat

Our OAI client is rejecting the response from DSpace OAI server.