### PR TITLE
DS-3877 Trim bitstream name during filter-media comparison

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -326,7 +326,7 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
                 List<Bitstream> bitstreams = bundle.getBitstreams();
 
                 for (Bitstream bitstream : bitstreams) {
-                    if (bitstream.getName().equals(newName)) {
+                    if (bitstream.getName().trim().equals(newName.trim())) {
                         existingBundle = bundle;
                         existingBitstream = bitstream;
                     }


### PR DESCRIPTION
This is a 6.x version of [PR 2002](https://github.com/DSpace/DSpace/pull/2002)

While the UI usually protects against this case, it is possible to have a bitstream name with a leading space. When `MediaFilterService` attempts to check if a bitstream has already been generated for the filter, the name comparison fails due to the leading space and a duplicate bitstream is generated.

This is solved by simply trimming the name during the comparison.