### PR TITLE
DS-3883: Speed up Item summary lists by being smarter about when we load Thumbnails/Bitstreams

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/ItemAdapter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/ItemAdapter.java
@@ -764,13 +764,32 @@ public class ItemAdapter extends AbstractAdapter
                 continue;
             }
 
+            // /////////////////////////////////////
+            // Determine which bitstreams to include in bundle
+            List<Bitstream> bitstreams = new ArrayList<Bitstream>();
+
+            // If this is the THUMBNAIL bundle, and we are NOT including content bundle,
+            // Then assume this is an item summary page, and we can just include the main thumbnail.
+            if ("THUMBNAIL".equals(bundle.getName()) && !includeContentBundle)
+            {
+                Thumbnail thumbnail = itemService.getThumbnail(context, item, false);
+                if(thumbnail != null) {
+                    bitstreams.add(thumbnail.getThumb());
+                }
+            }
+            else
+            {   // Default to including all bitstreams
+                bitstreams = bundle.getBitstreams();
+            }
+
+
             // ///////////////////
             // Start bundle's file group
             attributes = new AttributeMap();
             attributes.put("USE", use);
             startElement(METS,"fileGrp",attributes);
 
-            for (Bitstream bitstream : bundle.getBitstreams())
+            for (Bitstream bitstream : bitstreams)
             {
                 // //////////////////////////////
                 // Determine the file's IDs

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/ItemAdapter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/ItemAdapter.java
@@ -737,6 +737,9 @@ public class ItemAdapter extends AbstractAdapter
         // Suppress license?
         Boolean showLicense = DSpaceServicesFactory.getInstance().getConfigurationService().getBooleanProperty("webui.licence_bundle.show");
 
+        // Check if ORIGINAL bundle included (either explicitly or via include all fileGrp types)
+        boolean includeContentBundle = this.fileGrpTypes.isEmpty() ? true : this.fileGrpTypes.contains("ORIGINAL");
+
         // Loop over all requested bundles
         for (Bundle bundle : bundles)
         {
@@ -774,7 +777,9 @@ public class ItemAdapter extends AbstractAdapter
                 String fileID = getFileID(bitstream);
 
                 Bitstream originalBitstream = null;
-                if (isDerivedBundle)
+                // If we are looping through a derived bundle and content bundle is included,
+                // ensure each derived bitstream and original bitstream share the same groupID
+                if (isDerivedBundle && includeContentBundle)
                 {
                     originalBitstream = findOriginalBitstream(item, bitstream);
                 }


### PR DESCRIPTION
Fixes https://jira.duraspace.org/browse/DS-3883

The Collection/Community performance issues described in this ticket are caused by Items that have a large number of Thumbnails (e.g. Items with many PDF bitstreams or Image bitstreams, where each bitstream has a corresponding Thumbnail).

As a quick fix for this scenario, this PR improves the logic used in the XMLUI `ItemAdapter`. This is the class that generates the Item specific mets.xml files (e.g. http://demo.dspace.org/xmlui/metadata/handle/10673/5/mets.xml) that are used to gather metadata/bitstream information to be used by XMLUI themes.

On Collection / Community homepages (or anywhere an Item Summary is used), the XMLUI accesses this mets.xml document using a special querystring, so that *only* metadata and thumbnails are returned, e.g. http://demo.dspace.org/xmlui/metadata/handle/10673/5/mets.xml?sections=dmdSec,fileSec&fileGrpTypes=THUMBNAIL

Therefore, this PR updates the `ItemAdapter` logic as follows:
* If the `fileGrpTypes` querystring param includes `THUMBNAIL` but NOT the `ORIGINAL` bundle, then _only include the main thumbnail in the mets.xml_.  This ensures that on Item Summary listings only *one* thumbnail is ever loaded.
* In the above scenario, also *avoid* linking the thumbnail bitstream back to its ORIGINAL bitstream in the mets.xml (as that linkage serves no purpose, since the ORIGINAL bitstream isn't even in the mets.xml). This ensures that we do not loop through all the ORIGINAL bitstreams unless they are explicitly included in the list of `fileGrpTypes`

With these two fixes in place, the performance of the Community/Collection homepages is back to normal (and may even be *faster* than in v5.x, as we are only ever loading a single Thumbnail per Item).

(SIDENOTE: it is worth noting that this PR _only improves performance for Item Summary lists_.  On the Item Homepage, performance is still going to be extremely slow for Items having lots of Bitstreams & Thumbnails. This is because the Item homepage always lists all Bitstreams/Thumbnails. We could continue to investigate ways to improve this performance via fewer database queries, better caching, etc. But, it's worth noting this also may be fixable via some form of pagination of Bitstreams -- which is planned for the 7.x REST API . Small performance improvements may also be achieved by customizing the XMLUI Theme to only display a limited set of Bitstreams on the Item page. )
