### PR TITLE
DS-3883: Speed up Item summary lists by being smarter about when we load Thumbnails/Bitstreams (port to 5.x)

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/ItemAdapter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/ItemAdapter.java
@@ -18,6 +18,7 @@ import org.dspace.content.authority.Choices;
 import org.dspace.content.crosswalk.ContextAwareDisseminationCrosswalk;
 import org.dspace.content.crosswalk.CrosswalkException;
 import org.dspace.content.crosswalk.DisseminationCrosswalk;
+import org.dspace.content.service.ItemService;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
@@ -719,13 +720,32 @@ public class ItemAdapter extends AbstractAdapter
                 continue;
             }
 
+            // /////////////////////////////////////
+            // Determine which bitstreams to include in bundle
+            Bitstream[] bitstreams = new Bitstream[0];
+
+            // If this is the THUMBNAIL bundle, and we are NOT including content bundle,
+            // Then assume this is an item summary page, and we can just include the main thumbnail.
+            if ("THUMBNAIL".equals(bundle.getName()) && !includeContentBundle)
+            {
+                Thumbnail thumbnail = ItemService.getThumbnail(context, item.getID(), false);
+                if(thumbnail != null) {
+                    bitstreams = new Bitstream[] { thumbnail.getThumb() };
+                }
+            }
+            else
+            {   // Default to including all bitstreams
+                bitstreams = bundle.getBitstreams();
+            }
+
+
             // ///////////////////
             // Start bundle's file group
             attributes = new AttributeMap();
             attributes.put("USE", use);
             startElement(METS,"fileGrp",attributes);
-            
-            for (Bitstream bitstream : bundle.getBitstreams())
+
+            for (Bitstream bitstream : bitstreams)
             {
                 // //////////////////////////////
                 // Determine the file's IDs

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/ItemAdapter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/ItemAdapter.java
@@ -691,7 +691,10 @@ public class ItemAdapter extends AbstractAdapter
 
         // Suppress license?
         Boolean showLicense = ConfigurationManager.getBooleanProperty("webui.licence_bundle.show");
-        
+
+        // Check if ORIGINAL bundle included (either explicitly or via include all fileGrp types)
+        boolean includeContentBundle = this.fileGrpTypes.isEmpty() ? true : this.fileGrpTypes.contains("ORIGINAL");
+
         // Loop over all requested bundles
         for (Bundle bundle : bundles)
         {
@@ -729,7 +732,9 @@ public class ItemAdapter extends AbstractAdapter
                 String fileID = getFileID(bitstream);
                 
                 Bitstream originalBitstream = null;
-                if (isDerivedBundle)
+                // If we are looping through a derived bundle and content bundle is included,
+                // ensure each derived bitstream and original bitstream share the same groupID
+                if (isDerivedBundle && includeContentBundle)
                 {
                     originalBitstream = findOriginalBitstream(item, bitstream);
                 }


### PR DESCRIPTION
This is simply a port of #2016 to 5.x branch.

https://jira.duraspace.org/browse/DS-3883

This should likely be lightly tested before merging, as the 5.x API and 6.x API differ, and this PR had to have minor updates to adapt it to 5.x