### PR TITLE
DS-3888 Respect primary bitstreams with text html mime types in item …

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/item-view.xsl
@@ -358,18 +358,39 @@
                                 </xsl:otherwise>
                             </xsl:choose>
                     </xsl:variable>
+                    <!-- Primary bitstream is always first fptr child of mets:div[@TYPE='DSpace Item'] -->
+                    <xsl:variable name="primaryBitstream" select="//mets:structMap[@TYPE='LOGICAL']/mets:div[@TYPE='DSpace Item']/mets:fptr/@FILEID"/>
 
-                    <xsl:for-each select="//mets:fileSec/mets:fileGrp[@USE='CONTENT' or @USE='ORIGINAL' or @USE='LICENSE']/mets:file">
-                        <xsl:call-template name="itemSummaryView-DIM-file-section-entry">
-                            <xsl:with-param name="href" select="mets:FLocat[@LOCTYPE='URL']/@xlink:href" />
-                            <xsl:with-param name="mimetype" select="@MIMETYPE" />
-                            <xsl:with-param name="label-1" select="$label-1" />
-                            <xsl:with-param name="label-2" select="$label-2" />
-                            <xsl:with-param name="title" select="mets:FLocat[@LOCTYPE='URL']/@xlink:title" />
-                            <xsl:with-param name="label" select="mets:FLocat[@LOCTYPE='URL']/@xlink:label" />
-                            <xsl:with-param name="size" select="@SIZE" />
-                        </xsl:call-template>
-                    </xsl:for-each>
+                    <!-- If primary bitstream has text/html MIME type ONLY list that bitstream -->
+                    <xsl:choose>
+                        <xsl:when test="//mets:file[@ID=$primaryBitstream]/@MIMETYPE='text/html'">
+                            <xsl:for-each select="//mets:fileSec/mets:fileGrp[@USE='CONTENT' or @USE='ORIGINAL' or @USE='LICENSE']/mets:file[@ID=$primaryBitstream]">
+                                <xsl:call-template name="itemSummaryView-DIM-file-section-entry">
+                                    <xsl:with-param name="href" select="mets:FLocat[@LOCTYPE='URL']/@xlink:href" />
+                                    <xsl:with-param name="mimetype" select="@MIMETYPE" />
+                                    <xsl:with-param name="label-1" select="$label-1" />
+                                    <xsl:with-param name="label-2" select="$label-2" />
+                                    <xsl:with-param name="title" select="mets:FLocat[@LOCTYPE='URL']/@xlink:title" />
+                                    <xsl:with-param name="label" select="mets:FLocat[@LOCTYPE='URL']/@xlink:label" />
+                                    <xsl:with-param name="size" select="@SIZE" />
+                                </xsl:call-template>
+                            </xsl:for-each>
+                        </xsl:when>
+                        <!-- Otherwise, iterate over and display all of them -->
+                        <xsl:otherwise>
+                            <xsl:for-each select="//mets:fileSec/mets:fileGrp[@USE='CONTENT' or @USE='ORIGINAL' or @USE='LICENSE']/mets:file">
+                                <xsl:call-template name="itemSummaryView-DIM-file-section-entry">
+                                    <xsl:with-param name="href" select="mets:FLocat[@LOCTYPE='URL']/@xlink:href" />
+                                    <xsl:with-param name="mimetype" select="@MIMETYPE" />
+                                    <xsl:with-param name="label-1" select="$label-1" />
+                                    <xsl:with-param name="label-2" select="$label-2" />
+                                    <xsl:with-param name="title" select="mets:FLocat[@LOCTYPE='URL']/@xlink:title" />
+                                    <xsl:with-param name="label" select="mets:FLocat[@LOCTYPE='URL']/@xlink:label" />
+                                    <xsl:with-param name="size" select="@SIZE" />
+                                </xsl:call-template>
+                            </xsl:for-each>
+                        </xsl:otherwise>
+                    </xsl:choose>
                 </div>
             </xsl:when>
             <!-- Special case for handling ORE resource maps stored as DSpace bitstreams -->


### PR DESCRIPTION
Background: If an item has a primary bitstream with an text/html mime type with additional bitstreams in the respective `ORIGINAL` or `CONTENT` bundle, said bitstream is not respected. As in, there's no conditional to filter all the other bitstreams from being listed. This functionality existed in 4.x but was not ported for some reason. Maybe someone could explain to me if this is expected behavior .

Visual example sourced from a client:
https://imgur.com/a/0ncOo

6.x community code base where bitstreams are listed from the METS:
https://github.com/DSpace/DSpace/blob/dspace-6_x/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/item-view.xsl#L362

5.x community code base where bitstreams are listed from the METS:
https://github.com/DSpace/DSpace/blob/dspace-5_x/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/item-view.xsl#L356

4.x community code base where this case is handled:
https://github.com/DSpace/DSpace/blob/dspace-4_x/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/aspect/artifactbrowser/item-view.xsl#L47

----------------------------------------------------------------------------------------------------
EDIT: It has been pointed out to me that this issue has been defined incorrectly.

The behavior was never ported over to Mirage 2, BUT still exist in Mirage v1 in both DSpace 6.x and 5.x. So the difference is between theme versions of Mirage and not versions of DSpace. 

So my question that still stands is do we want to port that behavior from Mirage 1 into Mirage 2? 

 

Although an edge case, as a situation that has been presented to me by a client I would consider handling this case with the code I provided as the PR is very low impact and I can see this issue coming up again from other clients in the future.
