### PR TITLE
[DS-3894] Fix "No enum constant" exception for facet "View More" links

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SearchFacetFilter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SearchFacetFilter.java
@@ -252,7 +252,7 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
     }
 
     private SORT getSortOrder(Request request) {
-        String sortOrderString = request.getParameter("order");
+        String sortOrderString = request.getParameter("filterorder");
         // First check for an already configured sortOrder (provided a new one is not being set)
         if(sortOrder!=null && StringUtils.isBlank(sortOrderString)){
             return sortOrder;
@@ -261,7 +261,7 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
         if(StringUtils.isBlank(sortOrderString) || SORT.valueOf(sortOrderString.toUpperCase())==null){
             sortOrder= SORT.VALUE;
         }else{
-            sortOrder= SORT.valueOf(request.getParameter("order").toUpperCase());
+            sortOrder= SORT.valueOf(request.getParameter("filterorder").toUpperCase());
         }
         return sortOrder;
     }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SidebarFacetsTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SidebarFacetsTransformer.java
@@ -319,7 +319,7 @@ public class SidebarFacetsTransformer extends AbstractDSpaceTransformer implemen
         facet.addItem().addXref(
                 contextPath +
                         (dso == null ? "" : "/handle/" + dso.getHandle()) +
-                        "/search-filter?" + parameters + BrowseFacet.FACET_FIELD + "=" + field.getIndexFieldName()+"&order="+field.getSortOrderFilterPage(),
+                        "/search-filter?" + parameters + BrowseFacet.FACET_FIELD + "=" + field.getIndexFieldName()+"&filterorder="+field.getSortOrderFilterPage(),
                 T_VIEW_MORE
 
         );


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3894

The "order" parameter is being erroneously reused for "View More" links which is causing an exception to be thrown. To reproduce issue: Perform a discovery search with results, sort results asc or desc. Click a facet's "View More" link. `SearchFacetFilter` tries to interpret "asc" or "desc" as a `DiscoveryConfigurationParameters.SORT` enum element. The solution to the issue is simply to rename the parameter to something else. I renamed to "filterorder". 