### PR TITLE
Fix DS-3871: Stop pinning legacy REST API to old version of Jackson libraries

### DIFF
--- a/dspace-rest/pom.xml
+++ b/dspace-rest/pom.xml
@@ -63,19 +63,6 @@
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
             <version>${jersey.version}</version>
-            <exclusions>
-                <!-- Pinned to 2.5.4 below, this is because the current version number includes both 2.5.4 AND 2.5.0 jackson-annotations-->
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-annotations</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>2.5.4</version>
         </dependency>
 
         <!-- Spring 3 dependencies -->


### PR DESCRIPTION
Fix for https://jira.duraspace.org/browse/DS-3871

This fixes a minor dependency issue in the legacy REST API on `master`, which caused it to throw errors when using the legacy REST Quality Control Reports (and similar).

The issue was a dependency conflict, where the legacy REST API was pinning an older version of the FasterXML Jackson libraries than the one used in the current version of Jersey (and Jersey was recently upgraded in #1955).  I simply removed the pinned version, and everything works now.

A test procedure is documented in the comments of DS-3871.