### PR TITLE
DS-3897: OAI harvesting fails on some bitstreams

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/OREIngestionCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/OREIngestionCrosswalk.java
@@ -168,7 +168,7 @@ public class OREIngestionCrosswalk
         	if (href != null) {
         		try {
 		        	// Make sure the url string escapes all the oddball characters
-        			String processedURL = encodeForURL(href);
+        			String processedURL = encodeForURL(href).replace("%20", "+");
         			// Generate a requeset for the aggregated resource
         			ARurl = new URL(processedURL);
 		        	in = ARurl.openStream();


### PR DESCRIPTION
DS-3897: OAI harvesting with bistreams fails on collections that contains bistreams with blanks in filenames.
the inpustStream cannot find those files (FileNotFoundException in line 163) since the URL openStream() method in rt.jar needs to be escaped with '+' char insted of url-escaped '%20'.
(Maybe we could have down that fix in local encodeForURL() method. But I could not for see the side effects of that as the methode is used in a differnet context as well?)

https://jira.duraspace.org/browse/DS-3897