### PR TITLE
DS-3626 On item expunge mark bitstreams to be deleted

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -664,6 +664,10 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         while(bundles.hasNext())
         {
             Bundle bundle = bundles.next();
+            //Mark bitstreams to be deleted from all bundles that are about to be deleted
+            for(Bitstream bs : bundle.getBitstreams()){
+                bs.setDeleted(true);
+            }
             bundles.remove();
             deleteBundle(context, item, bundle);
         }


### PR DESCRIPTION
Original report: [DS-3626 Jira](https://jira.duraspace.org/browse/DS-3626)
> When you expunge an item in the UI with DSpace 5.x, it correctly causes bitstreams to be marked as deleted (deleted: true in bitstream table). In DSpace 6.0, this does not occur. This leaves orphan rows in the bitstream table which are not considered to be deletable by the dspace cleanup utility.

I walked through the stack of expunging an item and never came across any code that marks the item's respective bitstreams to be deleted. I simply iterated through all respective bitstreams at the point in time when bundles are being removed from reference. 

Although this solves the bug. I'm curious if there is code in place to handle this issue without my addition. As in am I missing something or is this expected behavior?