### PR TITLE
[DS-3694] Re-add the assembly exclusion for the Mirage 2 war

### DIFF
--- a/dspace/src/main/assembly/assembly.xml
+++ b/dspace/src/main/assembly/assembly.xml
@@ -124,6 +124,10 @@
          <includes>
             <include>org.dspace.modules:*:war:*</include>
          </includes>
+         <!-- Exclude Mirage2, as it is copied into the XMLUI WAR when enabled -->
+         <excludes>
+            <exclude>org.dspace.modules:xmlui-mirage2:war:*</exclude>
+         </excludes>
          <binaries>
             <includeDependencies>false</includeDependencies>
             <outputDirectory>webapps/${module.artifactId}</outputDirectory>


### PR DESCRIPTION
 The Mirage 2 war exclusion from assembly.xml was accidentally removed during port from master in PR #2014 ... since we still use XMLUI and Mirage 2 in DSpace 6, we need to add this exclusion back in so we don't unnecessarily copy a war for Mirage2 over during assembly (the theme is already included in the XMLUI war)