### PR TITLE
[DS-3901] Small bug in DefaultItemVersionProvider. deleteVersionedItem()

### DIFF
--- a/dspace-api/src/main/java/org/dspace/versioning/DefaultItemVersionProvider.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/DefaultItemVersionProvider.java
@@ -80,8 +80,8 @@ public class DefaultItemVersionProvider extends AbstractVersionProvider implemen
                 // version gets archived.
                 Item item = versionHistoryService.getPrevious(c, history, versionToDelete).getItem();
                 if (!item.isArchived()
-                        || workspaceItemService.findByItem(c, versionToDelete.getItem()) != null
-                        || workflowItemService.findByItem(c, versionToDelete.getItem()) != null)
+                        && workspaceItemService.findByItem(c, versionToDelete.getItem()) == null
+                        && workflowItemService.findByItem(c, versionToDelete.getItem()) == null)
                 {
                     item.setArchived(true);
                     itemService.update(c, item);


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3901

I did run the unit tests, but I'm not sure if this is covered at all and didn't run any manual tests. I think the change is quite obvious. If some DSpace committers agree, I don't think we need manual tests. If you want to test this, the following steps could be helpful:

1. Create three versions of an item, delete the third version, check if the second one is marked as "in_archive", and can be found in search an browsing.
2. Allow submitters to create new versions (in config/modules/versioning.cfg). Open the item in JSPUI, login with the credentials of the submitter and create a new version, but don't finish the submission process. Instead delete the item while being in submission.
3. Run a test compared to the second one, but delete the item enduring the Workflow process.

This should be cherry-picked to master.