### PR TITLE
[DS-3377] Solr queries too long  (change search GET requests to POST)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -1996,7 +1996,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
         HttpPost post = new HttpPost(hostURL.toHostString());
         List<NameValuePair> postParameters = new ArrayList<>();
-        postParameters.add(new BasicNameValuePair("q",query.toString());
+        postParameters.add(new BasicNameValuePair("q",query.toString()));
 
         HttpResponse response = getSolr().getHttpClient().execute(post);
 

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -1995,6 +1995,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         HttpPost post = new HttpPost(hostURL.toHostString());
         List<NameValuePair> postParameters = new ArrayList<>();
         postParameters.add(new BasicNameValuePair("q",query.toString()));
+        post.setEntity(new UrlEncodedFormEntity(postParameters));
 
         HttpResponse response = getSolr().getHttpClient().execute(post);
 

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -1810,10 +1810,11 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                 }
 
             }
-            else if(solrParameter.getValue() instanceof String) {postParameters.add(new BasicNameValuePair(solrParameter.getKey(), solrParameter.getValue().toString()));
+            else if(solrParameter.getValue() instanceof String) {
+                postParameters.add(new BasicNameValuePair(solrParameter.getKey(), solrParameter.getValue().toString()));
             }
             else {
-                // Is this a problem?
+                log.warn("Search parameters contain non-string value: " + solrParameter.getValue().toString());
             }
         }
 

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -1994,17 +1994,11 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         }
         HttpHost hostURL = (HttpHost)(getSolr().getHttpClient().getParams().getParameter(ClientPNames.DEFAULT_HOST));
 
-        HttpGet method = new HttpGet(hostURL.toHostString() + "");
-        try
-        {
-            URI uri = new URIBuilder(method.getURI()).addParameter("q",query.toString()).build();
-        }
-        catch (URISyntaxException e)
-        {
-            throw new SearchServiceException(e);
-        }
+        HttpPost post = new HttpPost(hostURL.toHostString());
+        List<NameValuePair> postParameters = new ArrayList<>();
+        postParameters.add(new BasicNameValuePair("q",query.toString());
 
-        HttpResponse response = getSolr().getHttpClient().execute(method);
+        HttpResponse response = getSolr().getHttpClient().execute(post);
 
         return response.getEntity().getContent();
     }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -1806,7 +1806,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                 // Multi-valued solr parameter
                 for(String val : (String[])solrParameter.getValue()) {
                     postParameters.add(new BasicNameValuePair(solrParameter.getKey(), val));
-                    log.info("String array: " + solrParameter.getKey() + " : " + val;
+                    log.info("String array: " + solrParameter.getKey() + " : " + val);
                 }
 
             }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -25,6 +25,7 @@ import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.log4j.Logger;
 import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpSolrServer;
 import org.apache.solr.client.solrj.request.AbstractUpdateRequest;
@@ -155,7 +156,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                             .setQuery(RESOURCE_TYPE_FIELD + ":2 AND " + RESOURCE_ID_FIELD + ":1");
                     // Only return obj identifier fields in result doc
                     solrQuery.setFields(RESOURCE_TYPE_FIELD, RESOURCE_ID_FIELD);
-                    solr.query(solrQuery);
+                    solr.query(solrQuery, SolrRequest.METHOD.POST);
 
                     // As long as Solr initialized, check with DatabaseUtils to see
                     // if a reindex is in order. If so, reindex everything
@@ -461,7 +462,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                 // returning just their handle
                 query.setFields(HANDLE_FIELD);
                 query.setQuery(RESOURCE_TYPE_FIELD + ":[2 TO 4]");
-                QueryResponse rsp = getSolr().query(query);
+                QueryResponse rsp = getSolr().query(query, SolrRequest.METHOD.POST);
                 SolrDocumentList docs = rsp.getResults();
 
                 Iterator iter = docs.iterator();
@@ -537,7 +538,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
             SolrQuery solrQuery = new SolrQuery();
             solrQuery.set("spellcheck", true);
             solrQuery.set(SpellingParams.SPELLCHECK_BUILD, true);
-            getSolr().query(solrQuery);
+            getSolr().query(solrQuery, SolrRequest.METHOD.POST);
         }catch (SolrServerException e)
         {
             //Make sure to also log the exception since this command is usually run from a crontab.
@@ -620,7 +621,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
             {
                 return false;
             }
-            rsp = getSolr().query(query);
+            rsp = getSolr().query(query, SolrRequest.METHOD.POST);
         } catch (SolrServerException e)
         {
             throw new SearchServiceException(e.getMessage(),e);
@@ -1606,7 +1607,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
             SolrQuery solrQuery = resolveToSolrQuery(context, discoveryQuery, includeUnDiscoverable);
 
 
-            QueryResponse queryResponse = getSolr().query(solrQuery);
+            QueryResponse queryResponse = getSolr().query(solrQuery, SolrRequest.METHOD.POST);
             return retrieveResult(context, discoveryQuery, queryResponse);
 
         } catch (Exception e)
@@ -1806,16 +1807,13 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                 // Multi-valued solr parameter
                 for(String val : (String[])solrParameter.getValue()) {
                     postParameters.add(new BasicNameValuePair(solrParameter.getKey(), val));
-                    log.info("String array: " + solrParameter.getKey() + " : " + val);
                 }
 
             }
-            else if(solrParameter.getValue() instanceof String) {
-                log.info("String scalar: " + solrParameter.getKey() + " : " + solrParameter.getValue().toString());
-                postParameters.add(new BasicNameValuePair(solrParameter.getKey(), solrParameter.getValue().toString()));
+            else if(solrParameter.getValue() instanceof String) {postParameters.add(new BasicNameValuePair(solrParameter.getKey(), solrParameter.getValue().toString()));
             }
             else {
-                log.info("Non-array, non-string?!: " + solrParameter.getKey() + " : " + solrParameter.getValue().toString());
+                // Is this a problem?
             }
         }
 
@@ -2032,7 +2030,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
             {
                 solrQuery.addFilterQuery(filterquery);
             }
-            QueryResponse rsp = getSolr().query(solrQuery);
+            QueryResponse rsp = getSolr().query(solrQuery, SolrRequest.METHOD.POST);
             SolrDocumentList docs = rsp.getResults();
 
             Iterator iter = docs.iterator();
@@ -2155,7 +2153,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
             {
                 return Collections.emptyList();
             }
-            QueryResponse rsp = getSolr().query(solrQuery);
+            QueryResponse rsp = getSolr().query(solrQuery, SolrRequest.METHOD.POST);
             NamedList mltResults = (NamedList) rsp.getResponse().get("moreLikeThis");
             if(mltResults != null && mltResults.get(item.getType() + "-" + item.getID()) != null)
             {


### PR DESCRIPTION
This PR changes Solr searches to use POST method instead of GET, including the searchJSON recommendation searches, as a way of avoiding large queries (eg. queries with lots of group restriction / policy params) failing due to URI length / header length constraints.

This PR is currently work-in-progress -- I think I've changed all the queries but there could be some missing. I've only changed discovery/search, have not touched authority, stats, oai Solr implementations.