### PR TITLE
[DS-3783] Change http return code when required parameter is missing

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -729,12 +729,10 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
     </dependencies>
 

--- a/dspace-solr/pom.xml
+++ b/dspace-solr/pom.xml
@@ -228,6 +228,10 @@
                     <artifactId>jetty-xml</artifactId>
                     <groupId>org.eclipse.jetty</groupId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -235,7 +239,7 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <version>3.4.6</version>
+            <version>3.4.10</version>
         </dependency>
 
         <!-- Replace J.U.L. logging with log4j -->

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/AuthenticationRestController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/AuthenticationRestController.java
@@ -91,11 +91,14 @@ public class AuthenticationRestController implements InitializingBean {
         //see org.dspace.app.rest.security.StatelessLoginFilter
 
         //If we don't have an EPerson here, this means authentication failed and we should return an error message.
-    	log.info("\n\n***n\nGot Here\n\n***\n\n");
-
         return getLoginResponse(request,
                                 "Authentication failed for user " + user + ": The credentials you provided are not " +
                                     "valid.");
+    }
+    
+    @RequestMapping(value = "/login", method = {RequestMethod.GET, RequestMethod.PUT, RequestMethod.PATCH, RequestMethod.DELETE})
+    public ResponseEntity login() {
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).body("Only POST is allowed for login requests.");
     }
 
     @RequestMapping(value = "/logout", method = {RequestMethod.GET, RequestMethod.POST})

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/AuthenticationRestController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/AuthenticationRestController.java
@@ -96,7 +96,7 @@ public class AuthenticationRestController implements InitializingBean {
                                     "valid.");
     }
 
-	@RequestMapping(value = "/login", method = { RequestMethod.GET, RequestMethod.PUT, RequestMethod.PATCH,
+    @RequestMapping(value = "/login", method = { RequestMethod.GET, RequestMethod.PUT, RequestMethod.PATCH,
             RequestMethod.DELETE })
     public ResponseEntity login() {
         return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).body("Only POST is allowed for login requests.");

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/AuthenticationRestController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/AuthenticationRestController.java
@@ -84,13 +84,14 @@ public class AuthenticationRestController implements InitializingBean {
         return authenticationStatusResource;
     }
 
-    @RequestMapping(value = "/login", method = {RequestMethod.GET, RequestMethod.POST})
+    @RequestMapping(value = "/login", method = {RequestMethod.POST})
     public ResponseEntity login(HttpServletRequest request, @RequestParam(name = "user", required = false) String user,
                                 @RequestParam(name = "password", required = false) String password) {
         //If you can get here, you should be authenticated, the actual login is handled by spring security
         //see org.dspace.app.rest.security.StatelessLoginFilter
 
         //If we don't have an EPerson here, this means authentication failed and we should return an error message.
+    	log.info("\n\n***n\nGot Here\n\n***\n\n");
 
         return getLoginResponse(request,
                                 "Authentication failed for user " + user + ": The credentials you provided are not " +

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/AuthenticationRestController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/AuthenticationRestController.java
@@ -95,8 +95,9 @@ public class AuthenticationRestController implements InitializingBean {
                                 "Authentication failed for user " + user + ": The credentials you provided are not " +
                                     "valid.");
     }
-    
-    @RequestMapping(value = "/login", method = {RequestMethod.GET, RequestMethod.PUT, RequestMethod.PATCH, RequestMethod.DELETE})
+
+	@RequestMapping(value = "/login", method = { RequestMethod.GET, RequestMethod.PUT, RequestMethod.PATCH,
+            RequestMethod.DELETE })
     public ResponseEntity login() {
         return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).body("Only POST is allowed for login requests.");
     }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/IdentifierRestController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/IdentifierRestController.java
@@ -9,10 +9,9 @@ package org.dspace.app.rest;
 
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 
-import java.net.URI;
 import java.io.IOException;
+import java.net.URI;
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
@@ -22,7 +21,6 @@ import org.apache.log4j.Logger;
 import org.atteo.evo.inflector.English;
 
 import org.dspace.app.rest.converter.DSpaceObjectConverter;
-import org.dspace.app.rest.link.HalLinkService;
 import org.dspace.app.rest.model.DSpaceObjectRest;
 import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.content.DSpaceObject;
@@ -35,7 +33,6 @@ import org.dspace.identifier.service.IdentifierService;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.Link;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/IdentifierRestController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/IdentifierRestController.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ * 
  * http://www.dspace.org/license/
  */
 package org.dspace.app.rest;
@@ -48,7 +48,7 @@ public class IdentifierRestController implements InitializingBean {
     private static final String REGEX_HANDLE = "^\\d+/\\d+$";
 
     private static final Logger log =
-        Logger.getLogger(IdentifierRestController.class);
+            Logger.getLogger(IdentifierRestController.class);
 
     @Autowired
     private List<DSpaceObjectConverter> converters;
@@ -66,19 +66,19 @@ public class IdentifierRestController implements InitializingBean {
     public void getDSObyIdentifier(HttpServletRequest request,
                                    HttpServletResponse response,
                                    @RequestParam("id") String id)
-        throws IOException, SQLException {
+            throws IOException, SQLException {
 
         DSpaceObject dso = null;
         Context context = ContextUtil.obtainContext(request);
         IdentifierService identifierService = IdentifierServiceFactory
-            .getInstance().getIdentifierService();
+                .getInstance().getIdentifierService();
         try {
             dso = identifierService.resolve(context, id);
             if (dso != null) {
                 DSpaceObjectRest dsor = convertDSpaceObject(dso);
                 URI link = linkTo(dsor.getController(), dsor.getCategory(),
-                    English.plural(dsor.getType()))
-                    .slash(dsor.getId()).toUri();
+                        English.plural(dsor.getType()))
+                        .slash(dsor.getId()).toUri();
                 response.setStatus(HttpServletResponse.SC_FOUND);
                 response.sendRedirect(link.toString());
             } else {

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/IdentifierRestController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/IdentifierRestController.java
@@ -34,9 +34,10 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.TemplateVariable;
+import org.springframework.hateoas.TemplateVariable.VariableType;
 import org.springframework.hateoas.TemplateVariables;
 import org.springframework.hateoas.UriTemplate;
-import org.springframework.hateoas.TemplateVariable.VariableType;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -45,11 +46,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/" + IdentifierRestController.CATEGORY)
 public class IdentifierRestController implements InitializingBean {
-	public static final String CATEGORY = "pid";
+    public static final String CATEGORY = "pid";
 
-	public static final String ACTION = "find";
+    public static final String ACTION = "find";
 
-	public static final String PARAM = "id";
+    public static final String PARAM = "id";
 
     private static final Logger log =
             Logger.getLogger(IdentifierRestController.class);

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/IdentifierRestController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/IdentifierRestController.java
@@ -1,0 +1,105 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
+import java.sql.SQLException;
+import org.dspace.app.rest.link.HalLinkService;
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.dspace.content.DSpaceObject;
+import org.dspace.core.Context;
+import org.dspace.handle.factory.HandleServiceFactory;
+import org.dspace.handle.service.HandleService;
+import org.apache.log4j.Logger;
+import org.springframework.hateoas.Link;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/pid")
+public class IdentifierRestController implements InitializingBean {
+
+    private static final Logger log = Logger.getLogger(IdentifierRestController.class);
+
+    @Autowired
+    DiscoverableEndpointsService discoverableEndpointsService;
+
+    @Autowired
+    private HalLinkService halLinkService;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+	List<Link> links = new ArrayList<Link>();
+
+        Link l = new Link("/api/pid/handles", "handles");
+	links.add ( l );
+    }
+
+    /**
+     *
+     */
+    @RequestMapping(method = {RequestMethod.GET,RequestMethod.HEAD}, value = "/handles/{prefix}/{suffix}")
+    @SuppressWarnings("unchecked")
+    public void getDSObyHandle (@PathVariable String prefix, 
+				@PathVariable String suffix, 
+				HttpServletResponse response, 
+				HttpServletRequest request)  throws IOException, SQLException {
+
+	HandleService handleService = HandleServiceFactory.getInstance().getHandleService();
+	Context context = null;
+	DSpaceObject dso = null;
+	try {
+	    context = new Context();
+	    dso = handleService.resolveToObject ( context, 
+						  prefix + "/" + suffix );
+	    if ( dso != null ) {
+		int type = dso.getType();
+		String model = getModel ( dso.getType() );
+		response.setStatus ( HttpServletResponse.SC_FOUND );
+		response.sendRedirect ( "/spring-rest/api/core/" 
+					+ model + "/" + dso.getID() );
+	    }
+	    else {
+		response.setStatus ( HttpServletResponse.SC_NOT_FOUND );
+	    }
+	}
+	catch ( SQLException e ) {
+	    log.error ( "DBG " + e.getMessage() );
+	}
+    }
+
+    /**
+     *
+     */
+    private String getModel ( int i ) {
+
+	String model = new String();
+	switch ( i ) {
+	    case 2:
+		model =  "items";
+		break;
+	    case 3:
+		model = "collections";
+		break;
+	    case 4:
+		model =  "communities";
+		break;
+	    default:
+		model =  "items";
+	}
+	return model;
+    }
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/IdentifierRestController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/IdentifierRestController.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- *
+ * <p>
  * http://www.dspace.org/license/
  */
 package org.dspace.app.rest;
@@ -45,7 +45,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class IdentifierRestController implements InitializingBean {
 
     private static final Logger log =
-	Logger.getLogger(IdentifierRestController.class);
+        Logger.getLogger(IdentifierRestController.class);
 
     @Autowired
     DiscoverableEndpointsService discoverableEndpointsService;
@@ -58,49 +58,45 @@ public class IdentifierRestController implements InitializingBean {
 
     @Override
     public void afterPropertiesSet() throws Exception {
-	List<Link> links = new ArrayList<Link>();
+        List<Link> links = new ArrayList<Link>();
 
         Link l = new Link("/api", "pid");
-	links.add ( l );
+        links.add(l);
     }
 
     @RequestMapping(method = RequestMethod.GET, value = "/{prefix}/{suffix}")
     @SuppressWarnings("unchecked")
-    public void getDSObyIdentifier(@PathVariable String prefix, 
-				   @PathVariable String suffix,
-				   HttpServletResponse response,
-				   HttpServletRequest request)
-	throws IOException, SQLException {
+    public void getDSObyIdentifier(@PathVariable String prefix,
+                                   @PathVariable String suffix,
+                                   HttpServletResponse response,
+                                   HttpServletRequest request)
+        throws IOException, SQLException {
 
-	DSpaceObject dso = null;
-	Context context = ContextUtil.obtainContext(request);
-	IdentifierService identifierService = IdentifierServiceFactory
-	    .getInstance().getIdentifierService();
+        DSpaceObject dso = null;
+        Context context = ContextUtil.obtainContext(request);
+        IdentifierService identifierService = IdentifierServiceFactory
+            .getInstance().getIdentifierService();
 
-	try {
-	    dso = identifierService.resolve(context, prefix + "/" + suffix);
-	    if ( dso != null ) {
-		DSpaceObjectRest dsor = convertDSpaceObject(dso);
+        try {
+            dso = identifierService.resolve(context, prefix + "/" + suffix);
+            if (dso != null) {
+                DSpaceObjectRest dsor = convertDSpaceObject(dso);
                 URI link = linkTo(dsor.getController(), dsor.getCategory(),
-				     English.plural(dsor.getType()))
-		    .slash(dsor.getId()).toUri();
-		response.setStatus ( HttpServletResponse.SC_FOUND );
-		response.sendRedirect ( link.toString() );
-	    }
-	    else {
-		response.setStatus ( HttpServletResponse.SC_NOT_FOUND );
-	    }
-	}
-	catch (IdentifierNotFoundException e ) {
-	    response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-	}
-	catch (IdentifierNotResolvableException e) {
-	    response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-	}
-	finally {
-	    log.info("DBG " + "aborting context");
-	    context.abort();
-	}
+                    English.plural(dsor.getType()))
+                    .slash(dsor.getId()).toUri();
+                response.setStatus(HttpServletResponse.SC_FOUND);
+                response.sendRedirect(link.toString());
+            } else {
+                response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            }
+        } catch (IdentifierNotFoundException e) {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+        } catch (IdentifierNotResolvableException e) {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+        } finally {
+            log.info("DBG " + "aborting context");
+            context.abort();
+        }
     }
 
     /**

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/Parameter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/Parameter.java
@@ -12,8 +12,18 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * This annotation provides extra information about method parameters of a
+ * SearchRestMethod allowing automatic bind of request parameters
+ * 
+ * @see SearchRestMethod
+ * 
+ * @author Terry Brady
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PARAMETER)
-public @interface RequiredParameter {
-    String name() default "";
+public @interface Parameter {
+    String value() default "";
+    boolean required() default false;
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RequiredParameter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RequiredParameter.java
@@ -1,0 +1,19 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface RequiredParameter {
+    String name() default "";
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/CommunityConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/CommunityConverter.java
@@ -14,6 +14,7 @@ import org.dspace.app.rest.model.CollectionRest;
 import org.dspace.app.rest.model.CommunityRest;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Collection;
+import org.dspace.content.Community;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -31,6 +32,9 @@ public class CommunityConverter
 
     @Autowired
     private CollectionConverter collectionConverter;
+
+    @Autowired
+    private CommunityConverter communityConverter;
 
     @Override
     public org.dspace.content.Community toModel(org.dspace.app.rest.model.CommunityRest obj) {
@@ -52,6 +56,15 @@ public class CommunityConverter
                 collectionsRest.add(colrest);
             }
             com.setCollections(collectionsRest);
+        }
+        List<Community> subCommunities = obj.getSubcommunities();
+        if (subCommunities != null) {
+            List<CommunityRest> communityRest = new ArrayList<CommunityRest>();
+            for (Community scom : subCommunities) {
+                CommunityRest scomrest = communityConverter.fromModel(scom);
+                communityRest.add(scomrest);
+            }
+            com.setSubCommunities(communityRest);
         }
         return com;
     }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/CommunityConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/CommunityConverter.java
@@ -46,23 +46,25 @@ public class CommunityConverter
             com.setLogo(bitstreamConverter.convert(logo));
         }
         List<Collection> collections = obj.getCollections();
+        List<CollectionRest> collectionsRest = new ArrayList<CollectionRest>();
         if (collections != null) {
-            List<CollectionRest> collectionsRest = new ArrayList<CollectionRest>();
             for (Collection col : collections) {
                 CollectionRest colrest = collectionConverter.fromModel(col);
                 collectionsRest.add(colrest);
             }
-            com.setCollections(collectionsRest);
         }
+        com.setCollections(collectionsRest);
+
         List<Community> subCommunities = obj.getSubcommunities();
+        List<CommunityRest> communityRest = new ArrayList<CommunityRest>();
         if (subCommunities != null) {
-            List<CommunityRest> communityRest = new ArrayList<CommunityRest>();
             for (Community scom : subCommunities) {
                 CommunityRest scomrest = this.fromModel(scom);
                 communityRest.add(scomrest);
             }
-            com.setSubCommunities(communityRest);
         }
+        com.setSubCommunities(communityRest);
+
         return com;
     }
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/CommunityConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/CommunityConverter.java
@@ -33,9 +33,6 @@ public class CommunityConverter
     @Autowired
     private CollectionConverter collectionConverter;
 
-    @Autowired
-    private CommunityConverter communityConverter;
-
     @Override
     public org.dspace.content.Community toModel(org.dspace.app.rest.model.CommunityRest obj) {
         return (org.dspace.content.Community) super.toModel(obj);
@@ -61,7 +58,7 @@ public class CommunityConverter
         if (subCommunities != null) {
             List<CommunityRest> communityRest = new ArrayList<CommunityRest>();
             for (Community scom : subCommunities) {
-                CommunityRest scomrest = communityConverter.fromModel(scom);
+                CommunityRest scomrest = this.fromModel(scom);
                 communityRest.add(scomrest);
             }
             com.setSubCommunities(communityRest);

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -55,8 +55,9 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
         throws IOException {
 
         //422 is not defined in HttpServletResponse.  Its meaning is "Unprocessable Entity".
-        sendErrorResponse(request, response, ex,
-                          "Illegal Argument Exception.",
+        //Since this is a handled exception case, the stack trace will not be returned.
+        sendErrorResponse(request, response, null,
+                          String.format("Illegal argument for operation: %s", ex.getMessage()),
                           422);
     }
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -51,15 +51,15 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
                           HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
     }
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    protected void IllegalArgumentException(HttpServletRequest request, HttpServletResponse response, Exception ex)
+    @ExceptionHandler(MissingParameterException.class)
+    protected void MissingParameterException(HttpServletRequest request, HttpServletResponse response, Exception ex)
         throws IOException {
 
         //422 is not defined in HttpServletResponse.  Its meaning is "Unprocessable Entity".
         //Using the value from HttpStatus.
         //Since this is a handled exception case, the stack trace will not be returned.
         sendErrorResponse(request, response, null,
-                          String.format("Illegal argument for operation: %s", ex.getMessage()),
+                          ex.getMessage(),
                           HttpStatus.UNPROCESSABLE_ENTITY.value());
     }
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -15,6 +15,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.dspace.authorize.AuthorizeException;
+import org.springframework.data.repository.support.QueryMethodParameterConversionException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -53,6 +54,18 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
 
     @ExceptionHandler(MissingParameterException.class)
     protected void MissingParameterException(HttpServletRequest request, HttpServletResponse response, Exception ex)
+        throws IOException {
+
+        //422 is not defined in HttpServletResponse.  Its meaning is "Unprocessable Entity".
+        //Using the value from HttpStatus.
+        //Since this is a handled exception case, the stack trace will not be returned.
+        sendErrorResponse(request, response, null,
+                          ex.getMessage(),
+                          HttpStatus.UNPROCESSABLE_ENTITY.value());
+    }
+
+    @ExceptionHandler(QueryMethodParameterConversionException.class)
+    protected void ParameterConversionException(HttpServletRequest request, HttpServletResponse response, Exception ex)
         throws IOException {
 
         //422 is not defined in HttpServletResponse.  Its meaning is "Unprocessable Entity".

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -50,6 +50,16 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
                           HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
     }
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    protected void IllegalArgumentException(HttpServletRequest request, HttpServletResponse response, Exception ex)
+        throws IOException {
+
+        //422 is not defined in HttpServletResponse.  Its meaning is "Unprocessable Entity".
+        sendErrorResponse(request, response, ex,
+                          "Illegal Argument Exception.",
+                          422);
+    }
+
     private void sendErrorResponse(final HttpServletRequest request, final HttpServletResponse response,
                                    final Exception ex, final String message, final int statusCode) throws IOException {
         //Make sure Spring picks up this exception

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -15,6 +15,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.dspace.authorize.AuthorizeException;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
@@ -55,10 +56,11 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
         throws IOException {
 
         //422 is not defined in HttpServletResponse.  Its meaning is "Unprocessable Entity".
+        //Using the value from HttpStatus.
         //Since this is a handled exception case, the stack trace will not be returned.
         sendErrorResponse(request, response, null,
                           String.format("Illegal argument for operation: %s", ex.getMessage()),
-                          422);
+                          HttpStatus.UNPROCESSABLE_ENTITY.value());
     }
 
     private void sendErrorResponse(final HttpServletRequest request, final HttpServletResponse response,

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/MissingParameterException.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/MissingParameterException.java
@@ -1,0 +1,21 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.exception;
+
+/**
+ * This class provides an exception to be used when the SearchFilter given is invalid
+ */
+public class MissingParameterException extends InvalidRequestException {
+    public MissingParameterException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public MissingParameterException(final String message) {
+        super(message);
+    }
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/MissingParameterException.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/MissingParameterException.java
@@ -10,7 +10,7 @@ package org.dspace.app.rest.exception;
 /**
  * This class provides an exception to be used when the SearchFilter given is invalid
  */
-public class MissingParameterException extends InvalidRequestException {
+public class MissingParameterException extends IllegalArgumentException {
     public MissingParameterException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/CommunityRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/CommunityRest.java
@@ -35,16 +35,16 @@ public class CommunityRest extends DSpaceObjectRest {
         this.collections = collections;
     }
 
-    private List<CommunityRest> subCommunities;
+    private List<CommunityRest> subcommunities;
 
     @LinkRest(linkClass = CommunityRest.class)
     @JsonIgnore
-    public List<CommunityRest> getSubCommunities() {
-        return subCommunities;
+    public List<CommunityRest> getSubcommunities() {
+        return subcommunities;
     }
 
-    public void setSubCommunities(List<CommunityRest> subCommunities) {
-        this.subCommunities = subCommunities;
+    public void setSubCommunities(List<CommunityRest> subcommunities) {
+        this.subcommunities = subcommunities;
     }
 
     public BitstreamRest getLogo() {

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/CommunityRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/CommunityRest.java
@@ -23,7 +23,6 @@ public class CommunityRest extends DSpaceObjectRest {
     @JsonIgnore
     private BitstreamRest logo;
 
-
     private List<CollectionRest> collections;
 
     @LinkRest(linkClass = CollectionRest.class)
@@ -36,16 +35,16 @@ public class CommunityRest extends DSpaceObjectRest {
         this.collections = collections;
     }
 
-    private List<CommunityRest> subcommunities;
+    private List<CommunityRest> subCommunities;
 
     @LinkRest(linkClass = CommunityRest.class)
     @JsonIgnore
-    public List<CommunityRest> getSubcommunities() {
-        return subcommunities;
+    public List<CommunityRest> getSubCommunities() {
+        return subCommunities;
     }
 
-    public void setSubcommunities(List<CommunityRest> subcommunities) {
-        this.subcommunities = subcommunities;
+    public void setSubCommunities(List<CommunityRest> subCommunities) {
+        this.subCommunities = subCommunities;
     }
 
     public BitstreamRest getLogo() {

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/CommunityRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/CommunityRest.java
@@ -36,6 +36,18 @@ public class CommunityRest extends DSpaceObjectRest {
         this.collections = collections;
     }
 
+    private List<CommunityRest> subcommunities;
+
+    @LinkRest(linkClass = CommunityRest.class)
+    @JsonIgnore
+    public List<CommunityRest> getSubcommunities() {
+        return subcommunities;
+    }
+
+    public void setSubcommunities(List<CommunityRest> subcommunities) {
+        this.subcommunities = subcommunities;
+    }
+
     public BitstreamRest getLogo() {
         return logo;
     }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
@@ -25,6 +25,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
+import org.springframework.data.repository.support.QueryMethodParameterConversionException;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.stereotype.Component;
 
@@ -97,7 +98,7 @@ public class CommunityRestRepository extends DSpaceRestRepository<CommunityRest,
     // with pagination and authorization check
     @SearchRestMethod(name = "subCommunities")
     public Page<CommunityRest> findSubCommunities(@Param(value = "parent") UUID parentCommunity, Pageable pageable)
-            throws MissingParameterException {
+            throws MissingParameterException, QueryMethodParameterConversionException {
         if (parentCommunity == null) {
             throw new MissingParameterException("Missing parameter 'parent'.  "
                     + "This parameter should contain the UUID of a parent community");

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 
 import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.converter.CommunityConverter;
+import org.dspace.app.rest.exception.MissingParameterException;
 import org.dspace.app.rest.model.CommunityRest;
 import org.dspace.app.rest.model.hateoas.CommunityResource;
 import org.dspace.content.Community;
@@ -95,9 +96,10 @@ public class CommunityRestRepository extends DSpaceRestRepository<CommunityRest,
     // TODO: add method in dspace api to support direct query for subcommunities
     // with pagination and authorization check
     @SearchRestMethod(name = "subCommunities")
-    public Page<CommunityRest> findSubCommunities(@Param(value = "parent") UUID parentCommunity, Pageable pageable) {
+    public Page<CommunityRest> findSubCommunities(@Param(value = "parent") UUID parentCommunity, Pageable pageable)
+            throws MissingParameterException {
         if (parentCommunity == null) {
-            throw new IllegalArgumentException("Missing parameter 'parent'.  "
+            throw new MissingParameterException("Missing parameter 'parent'.  "
                     + "This parameter should contain the UUID of a parent community");
         }
         Context context = obtainContext();

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
@@ -96,6 +96,10 @@ public class CommunityRestRepository extends DSpaceRestRepository<CommunityRest,
     // with pagination and authorization check
     @SearchRestMethod(name = "subCommunities")
     public Page<CommunityRest> findSubCommunities(@Param(value = "parent") UUID parentCommunity, Pageable pageable) {
+        if (parentCommunity == null) {
+            throw new IllegalArgumentException("Missing parameter 'parent'.  "
+                    + "This parameter should contain the UUID of a parent community");
+        }
         Context context = obtainContext();
         List<Community> subCommunities = new ArrayList<Community>();
         try {

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import org.dspace.app.rest.RequiredParameter;
 import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.converter.CommunityConverter;
 import org.dspace.app.rest.exception.MissingParameterException;
@@ -97,12 +98,9 @@ public class CommunityRestRepository extends DSpaceRestRepository<CommunityRest,
     // TODO: add method in dspace api to support direct query for subcommunities
     // with pagination and authorization check
     @SearchRestMethod(name = "subCommunities")
-    public Page<CommunityRest> findSubCommunities(@Param(value = "parent") UUID parentCommunity, Pageable pageable)
+    public Page<CommunityRest> findSubCommunities(@RequiredParameter @Param(value = "parent") UUID parentCommunity,
+            Pageable pageable)
             throws MissingParameterException, QueryMethodParameterConversionException {
-        if (parentCommunity == null) {
-            throw new MissingParameterException("Missing parameter 'parent'.  "
-                    + "This parameter should contain the UUID of a parent community");
-        }
         Context context = obtainContext();
         List<Community> subCommunities = new ArrayList<Community>();
         try {

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
@@ -12,10 +12,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import org.dspace.app.rest.RequiredParameter;
+import org.dspace.app.rest.Parameter;
 import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.converter.CommunityConverter;
-import org.dspace.app.rest.exception.MissingParameterException;
 import org.dspace.app.rest.model.CommunityRest;
 import org.dspace.app.rest.model.hateoas.CommunityResource;
 import org.dspace.content.Community;
@@ -25,8 +24,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.repository.query.Param;
-import org.springframework.data.repository.support.QueryMethodParameterConversionException;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.stereotype.Component;
 
@@ -98,9 +95,8 @@ public class CommunityRestRepository extends DSpaceRestRepository<CommunityRest,
     // TODO: add method in dspace api to support direct query for subcommunities
     // with pagination and authorization check
     @SearchRestMethod(name = "subCommunities")
-    public Page<CommunityRest> findSubCommunities(@RequiredParameter @Param(value = "parent") UUID parentCommunity,
-            Pageable pageable)
-            throws MissingParameterException, QueryMethodParameterConversionException {
+    public Page<CommunityRest> findSubCommunities(@Parameter(value = "parent", required = true) UUID parentCommunity,
+            Pageable pageable) {
         Context context = obtainContext();
         List<Community> subCommunities = new ArrayList<Community>();
         try {

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/SubmissionDefinitionRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/SubmissionDefinitionRestRepository.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import org.dspace.app.rest.Parameter;
 import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.converter.SubmissionDefinitionConverter;
 import org.dspace.app.rest.model.SubmissionDefinitionRest;
@@ -27,7 +28,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Component;
 
 /**
@@ -67,7 +67,8 @@ public class SubmissionDefinitionRestRepository extends DSpaceRestRepository<Sub
     }
 
     @SearchRestMethod(name = "findByCollection")
-    public SubmissionDefinitionRest findByCollection(@Param(value = "uuid") UUID collectionUuid) throws SQLException {
+    public SubmissionDefinitionRest findByCollection(@Parameter(value = "uuid", required = true) UUID collectionUuid)
+            throws SQLException {
         Collection col = collectionService.find(obtainContext(), collectionUuid);
         if (col == null) {
             return null;

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/WorkspaceItemRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/WorkspaceItemRestRepository.java
@@ -13,9 +13,11 @@ import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.UUID;
+
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.log4j.Logger;
+import org.dspace.app.rest.Parameter;
 import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.converter.WorkspaceItemConverter;
 import org.dspace.app.rest.exception.PatchBadRequestException;
@@ -51,7 +53,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -122,7 +123,8 @@ public class WorkspaceItemRestRepository extends DSpaceRestRepository<WorkspaceI
     }
 
     @SearchRestMethod(name = "findBySubmitter")
-    public Page<WorkspaceItemRest> findBySubmitter(@Param(value = "uuid") UUID submitterID, Pageable pageable) {
+    public Page<WorkspaceItemRest> findBySubmitter(@Parameter(value = "uuid", required = true) UUID submitterID,
+            Pageable pageable) {
         List<WorkspaceItem> witems = null;
         int total = 0;
         try {

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
@@ -15,6 +15,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -51,6 +52,18 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
     private CustomLogoutHandler customLogoutHandler;
 
     @Override
+    public void configure(WebSecurity webSecurity) throws Exception
+    {
+        webSecurity
+            .ignoring()
+                .antMatchers(HttpMethod.GET, "/api/authn/login")
+                .antMatchers(HttpMethod.PUT, "/api/authn/login")
+                .antMatchers(HttpMethod.PATCH, "/api/authn/login")
+                .antMatchers(HttpMethod.DELETE, "/api/authn/login");
+    }
+
+
+    @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.headers().cacheControl();
         http
@@ -81,8 +94,9 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
             //Configure the URL patterns with their authentication requirements
             .authorizeRequests()
-            //Allow GET and POST by anyone on the login endpoint
-            .antMatchers("/api/authn/login").permitAll()
+            //Allow POST by anyone on the login endpoint
+            .antMatchers(HttpMethod.POST,"/api/authn/login").permitAll()
+            //TRACE, CONNECT, OPTIONS, HEAD
             //Everyone can call GET on the status endpoint
             .antMatchers(HttpMethod.GET, "/api/authn/status").permitAll()
             .and()

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
@@ -52,8 +52,7 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
     private CustomLogoutHandler customLogoutHandler;
 
     @Override
-    public void configure(WebSecurity webSecurity) throws Exception
-    {
+    public void configure(WebSecurity webSecurity) throws Exception {
         webSecurity
             .ignoring()
                 .antMatchers(HttpMethod.GET, "/api/authn/login")

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/RestRepositoryUtils.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/RestRepositoryUtils.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map.Entry;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Logger;
 import org.dspace.app.rest.RequiredParameter;
 import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.exception.MissingParameterException;
@@ -48,6 +49,8 @@ public class RestRepositoryUtils {
     private static final AnnotationAttribute PARAM_ANNOTATION = new AnnotationAttribute(Param.class);
     private static final String NAME_NOT_FOUND = "Unable to detect parameter names for query method %s! Use @Param or" +
         " compile with -parameters on JDK 8.";
+
+    private static final Logger log = Logger.getLogger(RestRepositoryUtils.class);
 
     @Autowired(required = true)
     @Qualifier(value = "mvcConversionService")
@@ -123,19 +126,22 @@ public class RestRepositoryUtils {
         MultiValueMap<String, Object> result = new LinkedMultiValueMap<String, Object>(parameters);
         MethodParameters methodParameters = new MethodParameters(method, new AnnotationAttribute(Param.class));
 
-        for (Entry<String, List<Object>> entry : parameters.entrySet()) {
+        for (MethodParameter mparam: methodParameters.getParameters()) {
+            if (mparam.hasParameterAnnotation(RequiredParameter.class)) {
+                if (!parameters.containsKey(mparam.getParameterName())) {
+                    throw new MissingParameterException(
+                        String.format("Required Parameter[%s] Missing",
+                            mparam.getParameterName()));
+                }
+            }
+        }
 
+        for (Entry<String, List<Object>> entry : parameters.entrySet()) {
             MethodParameter parameter = methodParameters.getParameter(entry.getKey());
 
             if (parameter == null) {
                 continue;
             }
-
-            if (parameter.hasMethodAnnotation(RequiredParameter.class) && entry.getValue() == null) {
-                throw new MissingParameterException(String.format("Missing Parameter: %s",
-                        parameter.getParameterName()));
-            }
-
             result.put(parameter.getParameterName(), entry.getValue());
         }
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/RestRepositoryUtils.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/RestRepositoryUtils.java
@@ -13,7 +13,9 @@ import java.util.List;
 import java.util.Map.Entry;
 
 import org.apache.commons.lang3.StringUtils;
+import org.dspace.app.rest.RequiredParameter;
 import org.dspace.app.rest.SearchRestMethod;
+import org.dspace.app.rest.exception.MissingParameterException;
 import org.dspace.app.rest.repository.DSpaceRestRepository;
 import org.dspace.app.rest.repository.LinkRestRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -127,6 +129,11 @@ public class RestRepositoryUtils {
 
             if (parameter == null) {
                 continue;
+            }
+
+            if (parameter.hasMethodAnnotation(RequiredParameter.class) && entry.getValue() == null) {
+                throw new MissingParameterException(String.format("Missing Parameter: %s",
+                        parameter.getParameterName()));
             }
 
             result.put(parameter.getParameterName(), entry.getValue());

--- a/dspace-spring-rest/src/main/webapp/login.html
+++ b/dspace-spring-rest/src/main/webapp/login.html
@@ -88,6 +88,7 @@
 
         $.ajax({
           url : window.location.href.replace("login.html", "") + 'api/authn/login',
+          type : 'POST',
           success : successHandler,
           error : function(result, status, xhr) {
               if (xhr == 401) {

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
@@ -231,11 +231,25 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child2).withName("Collection 2").build();
 
-        getClient().perform(get("/api/core/collections/search/findAuthorizedByCommunity"))
+        getClient().perform(get("/api/core/collections/search/findAuthorizedByCommunity")
+                                .param("uuid", parentCommunity.getID().toString()))
                    .andExpect(status().isOk())
                    .andExpect(content().contentType(contentType))
                    .andExpect(jsonPath("$.page.totalElements", is(0)))
                    .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    @Test
+    public void findAuthorizedByCommunityWithoutUUIDTest() throws Exception {
+        getClient().perform(get("/api/core/collections/search/findAuthorizedByCommunity"))
+                   .andExpect(status().isUnprocessableEntity());
+    }
+
+    @Test
+    public void findAuthorizedByCommunityWithUnexistentUUIDTest() throws Exception {
+        getClient().perform(get("/api/core/collections/search/findAuthorizedByCommunity")
+                                .param("uuid", UUID.randomUUID().toString()))
+                   .andExpect(status().isNotFound());
     }
 
     @Test

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -362,9 +362,7 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
         ;
     }
 
-    //TODO The test fails, 404 resource not found. remove @Ignore when this is implemented
     @Test
-    @Ignore
     public void findAllSubCommunitiesWithoutUUID() throws Exception {
 
         //We turn off the authorization system in order to create the structure as defined below

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -190,6 +190,7 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
         getClient().perform(get("/api/core/communities/" + child1.getID().toString() + "/logo"))
                    .andExpect(status().isOk());
 
+        //Main community has no collections, therefore contentType is not set
         getClient().perform(get("/api/core/communities/" + parentCommunity.getID().toString() + "/collections"))
                    .andExpect(status().isOk());
 
@@ -197,12 +198,12 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                    .andExpect(status().isOk())
                    .andExpect(content().contentType(contentType));
 
+        //child1 subcommunity has no subcommunities, therefore contentType is not set
         getClient().perform(get("/api/core/communities/" + parentCommunity.getID().toString() + "/subcommunities"))
                    .andExpect(status().isOk());
 
         getClient().perform(get("/api/core/communities/" + child1.getID().toString() + "/subcommunities"))
-                   .andExpect(status().isOk())
-                   .andExpect(content().contentType(contentType));
+                   .andExpect(status().isOk());
     }
 
 

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -193,17 +193,20 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
         //Main community has no collections, therefore contentType is not set
         getClient().perform(get("/api/core/communities/" + parentCommunity.getID().toString() + "/collections"))
                    .andExpect(status().isOk());
+                   //.andExpect(status().isNoContent()); //TODO After DS-3808 is implemented
 
         getClient().perform(get("/api/core/communities/" + child1.getID().toString() + "/collections"))
                    .andExpect(status().isOk())
                    .andExpect(content().contentType(contentType));
 
-        //child1 subcommunity has no subcommunities, therefore contentType is not set
         getClient().perform(get("/api/core/communities/" + parentCommunity.getID().toString() + "/subcommunities"))
-                   .andExpect(status().isOk());
+                   .andExpect(status().isOk())
+                   .andExpect(content().contentType(contentType));
 
+        //child1 subcommunity has no subcommunities, therefore contentType is not set
         getClient().perform(get("/api/core/communities/" + child1.getID().toString() + "/subcommunities"))
                    .andExpect(status().isOk());
+                   .andExpect(status().isNoContent()); //TODO After DS-3808 is implemented
     }
 
 

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -22,7 +22,6 @@ import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest {

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -377,43 +377,16 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
 
     @Test
     public void findAllSubCommunitiesWithoutUUID() throws Exception {
-
-        //We turn off the authorization system in order to create the structure as defined below
-        context.turnOffAuthorisationSystem();
-
-        //** GIVEN **
-        //1. A community-collection structure with one parent community with sub-community and one collection.
-        parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .withLogo("ThisIsSomeDummyText")
-                                          .build();
-
-        Community parentCommunity2 = CommunityBuilder.createCommunity(context)
-                                                     .withName("Parent Community 2")
-                                                     .withLogo("SomeTest")
-                                                     .build();
-
-        Community parentCommunityChild1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                .withName("Sub Community")
-                .build();
-
-        Community parentCommunityChild1Child1 = CommunityBuilder.createSubCommunity(context, parentCommunityChild1)
-                .withName("Sub Sub Community")
-                .build();
-
-        Community parentCommunity2Child1 = CommunityBuilder.createSubCommunity(context, parentCommunity2)
-                .withName("Sub2 Community")
-                .build();
-
-        Collection col1 = CollectionBuilder.createCollection(context, parentCommunityChild1)
-                                           .withName("Collection 1")
-                                           .build();
-
         getClient().perform(get("/api/core/communities/search/subCommunities"))
-                   .andExpect(status().isUnprocessableEntity())
-        ;
+                 .andExpect(status().isUnprocessableEntity());
     }
 
+    @Test
+    public void findAllSubCommunitiesWithUnexistentUUID() throws Exception {
+        getClient().perform(get("/api/core/communities/search/subCommunities")
+                 .param("parent", UUID.randomUUID().toString()))
+                 .andExpect(status().isNotFound());
+    }
 
     @Test
     public void findOneTestWrongUUID() throws Exception {

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -178,6 +178,9 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                        .containsString("/api/core/communities/" + parentCommunity.getID().toString() + "/logo")))
                    .andExpect(jsonPath("$._links.collections.href", Matchers
                        .containsString("/api/core/communities/" + parentCommunity.getID().toString() + "/collections")))
+                   .andExpect(jsonPath("$._links.subcommunities.href", Matchers
+                        .containsString("/api/core/communities/" + parentCommunity.getID().toString() +
+                                "/subcommunities")))
         ;
 
         getClient().perform(get("/api/core/communities/" + parentCommunity.getID().toString() + "/logo"))
@@ -191,6 +194,13 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                    .andExpect(status().isOk());
 
         getClient().perform(get("/api/core/communities/" + child1.getID().toString() + "/collections"))
+                   .andExpect(status().isOk())
+                   .andExpect(content().contentType(contentType));
+
+        getClient().perform(get("/api/core/communities/" + parentCommunity.getID().toString() + "/subcommunities"))
+                   .andExpect(status().isOk());
+
+        getClient().perform(get("/api/core/communities/" + child1.getID().toString() + "/subcommunities"))
                    .andExpect(status().isOk())
                    .andExpect(content().contentType(contentType));
     }

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -206,7 +206,7 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
         //child1 subcommunity has no subcommunities, therefore contentType is not set
         getClient().perform(get("/api/core/communities/" + child1.getID().toString() + "/subcommunities"))
                    .andExpect(status().isOk());
-                   .andExpect(status().isNoContent()); //TODO After DS-3808 is implemented
+                   //.andExpect(status().isNoContent()); //TODO After DS-3808 is implemented
     }
 
 

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/IdentifierRestControllerIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/IdentifierRestControllerIT.java
@@ -1,0 +1,58 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.dspace.app.rest.builder.CommunityBuilder;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Integration test for the identifier resolver
+ *
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ */
+public class IdentifierRestControllerIT extends AbstractControllerIntegrationTest {
+
+    @Before
+    public void setup() throws Exception {
+        super.setUp();
+   }
+
+    @Test
+    public void testValidIdentifier() throws Exception {
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        // We create a top community to receive an identifier
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+
+        context.restoreAuthSystemState();
+
+        String handle = parentCommunity.getHandle();
+        String communityDetail = REST_SERVER_URL + "core/communities/" + parentCommunity.getID();
+
+        getClient().perform(get("/api/pid/find?id={handle}",handle))
+                        .andExpect(status().isFound())
+                        //We expect a Location header to redirect to the community details
+                        .andExpect(header().string("Location", communityDetail));
+    }
+
+    @Test
+    public void testUnexistentIdentifier() throws Exception {
+        getClient().perform(get("/api/pid/find?{id}","fakeIdentifier"))
+                        .andExpect(status().isNotFound());
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1104,7 +1104,7 @@
             <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant</artifactId>
-                <version>1.7.0</version>
+                <version>1.9.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.jena</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1512,7 +1512,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
+                <version>2.8.11.1</version> <!-- TODO sync. with jackson.version -->
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3783

Note: My intention was to not include the stack trace in the return message, but it is still being returned.  

Questions: rather than 422, should we use a code known to HttpServletResponse?

Are we comfortable having all IllegalArgumentException instances generating this return code?