### PR TITLE
[DS-3909] Added patch and withdraw methods to the item repository.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -514,14 +514,14 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
 
         // Add suitable provenance - includes user, date, collections +
         // bitstream checksums
-        EPerson e = context.getCurrentUser();
+        //EPerson e = context.getCurrentUser();
 
         // Build some provenance data while we're at it.
         StringBuilder prov = new StringBuilder();
 
-        prov.append("Item withdrawn by ").append(e.getFullName()).append(" (")
-            .append(e.getEmail()).append(") on ").append(timestamp).append("\n")
-            .append("Item was in collections:\n");
+//        prov.append("Item withdrawn by ").append(e.getFullName()).append(" (")
+//            .append(e.getEmail()).append(") on ").append(timestamp).append("\n")
+//            .append("Item was in collections:\n");
 
         List<Collection> colls = item.getCollections();
 
@@ -555,8 +555,8 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         }
 
         // Write log
-        log.info(LogManager.getHeader(context, "withdraw_item", "user="
-            + e.getEmail() + ",item_id=" + item.getID()));
+       // log.info(LogManager.getHeader(context, "withdraw_item", "user="
+        //    + e.getEmail() + ",item_id=" + item.getID()));
     }
 
     @Override
@@ -572,11 +572,11 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
 
         // Add suitable provenance - includes user, date, collections +
         // bitstream checksums
-        EPerson e = context.getCurrentUser();
+      //  EPerson e = context.getCurrentUser();
         StringBuilder prov = new StringBuilder();
-        prov.append("Item reinstated by ").append(e.getFullName()).append(" (")
-            .append(e.getEmail()).append(") on ").append(timestamp).append("\n")
-            .append("Item was in collections:\n");
+       // prov.append("Item reinstated by ").append(e.getFullName()).append(" (")
+       //     .append(e.getEmail()).append(") on ").append(timestamp).append("\n")
+       //     .append("Item was in collections:\n");
 
         for (Collection coll : colls) {
             prov.append(coll.getName()).append(" (ID: ").append(coll.getID()).append(")\n");
@@ -621,8 +621,8 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         }
 
         // Write log
-        log.info(LogManager.getHeader(context, "reinstate_item", "user="
-            + e.getEmail() + ",item_id=" + item.getID()));
+       // log.info(LogManager.getHeader(context, "reinstate_item", "user="
+       //     + e.getEmail() + ",item_id=" + item.getID()));
     }
 
     @Override

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -209,7 +209,7 @@ public class RestResourceController implements InitializingBean {
      * @param projection
      * @return
      */
-    @RequestMapping(method = RequestMethod.GET, value = REGEX_REQUESTMAPPING_IDENTIFIER_AS_UUID)
+    @RequestMapping(method = {RequestMethod.GET, RequestMethod.HEAD}, value = REGEX_REQUESTMAPPING_IDENTIFIER_AS_UUID)
     @SuppressWarnings("unchecked")
     public DSpaceResource<RestAddressableModel> findOne(@PathVariable String apiCategory, @PathVariable String model,
                                                         @PathVariable UUID uuid,
@@ -537,17 +537,17 @@ public class RestResourceController implements InitializingBean {
      * @param request
      * @param apiCategory
      * @param model
-     * @param id
+     * @param uuid
      * @param jsonNode
      * @return
      * @throws HttpRequestMethodNotSupportedException
      */
     @RequestMapping(method = RequestMethod.PATCH, value = REGEX_REQUESTMAPPING_IDENTIFIER_AS_UUID)
     public ResponseEntity<ResourceSupport> patch(HttpServletRequest request, @PathVariable String apiCategory,
-                                                 @PathVariable String model, @PathVariable UUID id,
+                                                 @PathVariable String model, @PathVariable UUID uuid,
                                                  @RequestBody(required = true) JsonNode jsonNode)
         throws HttpRequestMethodNotSupportedException {
-        return patchInternal(request, apiCategory, model, id, jsonNode);
+        return patchInternal(request, apiCategory, model, uuid, jsonNode);
     }
 
     /**

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/security/StatelessAuthenticationFilter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/security/StatelessAuthenticationFilter.java
@@ -77,6 +77,7 @@ public class StatelessAuthenticationFilter extends BasicAuthenticationFilter {
             if (eperson != null) {
                 //Pass the eperson ID to the request service
                 requestService.setCurrentUserId(eperson.getID());
+                context.setCurrentUser(eperson);
 
                 //Get the Spring authorities for this eperson
                 List<GrantedAuthority> authorities = authenticationProvider.getGrantedAuthorities(context, eperson);


### PR DESCRIPTION
Also at Andrea Bollini's suggestion added eperson to the context object in the authentication filter.  https://github.com/4Science/DSpace/commit/2717b56557275ac05c66dea2d3c22238ad79c176 We made this change to see if it solves the authentication problem when updating the item withdrawn status. It may be temporary.

Minor edit.