### PR TITLE
DS-3914 Fix remove functionality in community filiator

### DIFF
--- a/dspace-api/src/main/java/org/dspace/administer/CommunityFiliator.java
+++ b/dspace-api/src/main/java/org/dspace/administer/CommunityFiliator.java
@@ -261,8 +261,7 @@ public class CommunityFiliator
 
         // OK remove the mappings - but leave the community, which will become
         // top-level
-        child.getParentCommunities().remove(parent);
-        parent.getSubcommunities().remove(child);
+        communityService.removeSubcommunity(c,parent,child,true);
         communityService.update(c, child);
         communityService.update(c, parent);
 

--- a/dspace-api/src/main/java/org/dspace/content/service/CommunityService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/CommunityService.java
@@ -275,9 +275,7 @@ public interface CommunityService extends DSpaceObjectService<Community>, DSpace
             throws SQLException, AuthorizeException, IOException;
 
     /**
-     * Remove a subcommunity. If it only belongs to one parent community,
-     * then it is permanently deleted. If it has more than one parent community,
-     * it is simply unmapped from the current community.
+     * Remove a subcommunity. Deletes all subcommunities, collections and items within the community.
      *
      * @param context context
      * @param childCommunity
@@ -288,6 +286,21 @@ public interface CommunityService extends DSpaceObjectService<Community>, DSpace
      * @throws IOException if IO error
      */
     public void removeSubcommunity(Context context, Community parentCommunity, Community childCommunity)
+            throws SQLException, AuthorizeException, IOException;
+
+    /**
+     * Remove a subcommunity with with its collections and items, or optionally just unmap from the current community.
+     *
+     * @param context context
+     * @param childCommunity
+     *            subcommunity to remove
+     * @param parentCommunity parent community
+     * @param mappingOnly if true, community is unmapped from parent (i.e. converted to a top-level community) but no data is deleted
+     * @throws SQLException if database error
+     * @throws AuthorizeException if authorization error
+     * @throws IOException if IO error
+     */
+    public void removeSubcommunity(Context context, Community parentCommunity, Community childCommunity, boolean mappingOnly)
             throws SQLException, AuthorizeException, IOException;
 
     /**


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3914

Proposed fix for erroneous community filiator remove functionality.

CommunityService.removeSubcommunity method in  is extended with an optional parameter mappingOnly such that the method can be used both to delete the whole subcommunity (+collections/items), or just unlink from the parent community (as used by the CommunityFiliator).