### PR TITLE
DS-3909: Adding withdraw, reinstate, and isDiscoverable support to item repository.

### DIFF
--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -542,17 +542,17 @@ public class RestResourceController implements InitializingBean {
      * @param request
      * @param apiCategory
      * @param model
-     * @param id
+     * @param uuid
      * @param jsonNode
      * @return
      * @throws HttpRequestMethodNotSupportedException
      */
     @RequestMapping(method = RequestMethod.PATCH, value = REGEX_REQUESTMAPPING_IDENTIFIER_AS_UUID)
     public ResponseEntity<ResourceSupport> patch(HttpServletRequest request, @PathVariable String apiCategory,
-                                                 @PathVariable String model, @PathVariable UUID id,
+                                                 @PathVariable String model, @PathVariable UUID uuid,
                                                  @RequestBody(required = true) JsonNode jsonNode)
         throws HttpRequestMethodNotSupportedException {
-        return patchInternal(request, apiCategory, model, id, jsonNode);
+        return patchInternal(request, apiCategory, model, uuid, jsonNode);
     }
 
     /**

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -585,9 +585,6 @@ public class RestResourceController implements InitializingBean {
             PatchBadRequestException | ResourceNotFoundException e) {
             log.error(e.getMessage(), e);
             throw e;
-        } catch (Exception e) {
-            log.error(e.getMessage(), e);
-            return ControllerUtils.toEmptyResponse(HttpStatus.INTERNAL_SERVER_ERROR);
         }
         DSpaceResource result = repository.wrapResource(modelObject);
         linkService.addLinks(result);

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -542,17 +542,18 @@ public class RestResourceController implements InitializingBean {
      * @param request
      * @param apiCategory
      * @param model
-     * @param uuid
+     * @param id
      * @param jsonNode
      * @return
      * @throws HttpRequestMethodNotSupportedException
      */
     @RequestMapping(method = RequestMethod.PATCH, value = REGEX_REQUESTMAPPING_IDENTIFIER_AS_UUID)
     public ResponseEntity<ResourceSupport> patch(HttpServletRequest request, @PathVariable String apiCategory,
-                                                 @PathVariable String model, @PathVariable UUID uuid,
+                                                 @PathVariable String model,
+                                                 @PathVariable(name = "uuid") UUID id,
                                                  @RequestBody(required = true) JsonNode jsonNode)
         throws HttpRequestMethodNotSupportedException {
-        return patchInternal(request, apiCategory, model, uuid, jsonNode);
+        return patchInternal(request, apiCategory, model, id, jsonNode);
     }
 
     /**
@@ -580,7 +581,7 @@ public class RestResourceController implements InitializingBean {
             Patch patch = patchConverter.convert(jsonNode);
             modelObject = repository.patch(request, apiCategory, model, id, patch);
         } catch (RepositoryMethodNotImplementedException | UnprocessableEntityException |
-            PatchBadRequestException e) {
+            PatchBadRequestException | ResourceNotFoundException e) {
             log.error(e.getMessage(), e);
             throw e;
         } catch (Exception e) {

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/ItemRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/ItemRestRepository.java
@@ -12,10 +12,17 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
+import javax.servlet.http.HttpServletRequest;
 
+import org.apache.log4j.Logger;
 import org.dspace.app.rest.converter.ItemConverter;
+import org.dspace.app.rest.exception.PatchBadRequestException;
+import org.dspace.app.rest.exception.PatchUnprocessableEntityException;
 import org.dspace.app.rest.model.ItemRest;
 import org.dspace.app.rest.model.hateoas.ItemResource;
+import org.dspace.app.rest.model.patch.Operation;
+import org.dspace.app.rest.model.patch.Patch;
+import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Item;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
@@ -34,12 +41,19 @@ import org.springframework.stereotype.Component;
 @Component(ItemRest.CATEGORY + "." + ItemRest.NAME)
 public class ItemRestRepository extends DSpaceRestRepository<ItemRest, UUID> {
 
+    private static final String OPERATION_PATH_WITHDRAW = "withdraw";
+
+    private static final String OPERATION_PATH_REINSTATE = "reinstate";
+
+    private static final String OPERATION_PATH_DISCOVERABLE = "discoverable";
+
+    private static final Logger log = Logger.getLogger(ItemRestRepository.class);
+
     @Autowired
     ItemService is;
 
     @Autowired
     ItemConverter converter;
-
 
     public ItemRestRepository() {
         System.out.println("Repository initialized by Spring");
@@ -76,6 +90,77 @@ public class ItemRestRepository extends DSpaceRestRepository<ItemRest, UUID> {
         }
         Page<ItemRest> page = new PageImpl<Item>(items, pageable, total).map(converter);
         return page;
+    }
+
+    @Override
+    public void patch(Context context, HttpServletRequest request, String apiCategory, String model, UUID id, Patch
+            patch)
+            throws PatchUnprocessableEntityException, PatchBadRequestException, SQLException, AuthorizeException {
+
+        Item item;
+        try {
+            item = is.find(context, id);
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
+            throw new RuntimeException(e.getMessage(), e);
+        }
+
+        // temporarily turn off authorization
+        context.turnOffAuthorisationSystem();
+
+        List<Operation> operations = patch.getOperations();
+        for (Operation op : operations) {
+            if ("replace".equals(op.getOp())) {
+
+                String path = op.getPath();
+                switch (path) {
+                    case OPERATION_PATH_WITHDRAW:
+                        withdraw(context, item);
+                        break;
+                    case OPERATION_PATH_REINSTATE:
+                        reinstate(context, item);
+                        break;
+                    case OPERATION_PATH_DISCOVERABLE:
+                        item.setDiscoverable((boolean) op.getValue());
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        // restore authorization
+        context.restoreAuthSystemState();
+
+        // Do we want to return the updated item json? Something else?
+        findOne(context, id);
+    }
+
+    private void withdraw(Context context, Item item) throws PatchUnprocessableEntityException,
+            SQLException, AuthorizeException {
+
+        try {
+            if (!item.isArchived()) {
+                throw new PatchUnprocessableEntityException("Item is not in the archive. Cannot be withdrawn.");
+            }
+            is.withdraw(context, item);
+
+        } catch (SQLException | AuthorizeException e) {
+            log.error(e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    private void reinstate(Context context, Item item) throws PatchUnprocessableEntityException,
+            SQLException, AuthorizeException {
+
+        try {
+            is.reinstate(context, item);
+
+        } catch (SQLException | AuthorizeException e) {
+            log.error(e.getMessage(), e);
+            throw e;
+        }
     }
 
     @Override

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/patch/AbstractResourcePatch.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/patch/AbstractResourcePatch.java
@@ -1,0 +1,110 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.repository.patch;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.dspace.app.rest.exception.PatchBadRequestException;
+import org.dspace.app.rest.exception.UnprocessableEntityException;
+import org.dspace.app.rest.model.RestModel;
+import org.dspace.app.rest.model.patch.Operation;
+import org.dspace.app.rest.model.patch.Patch;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.core.Context;
+
+/**
+ * The base class for resource PATCH operations.
+ *
+ * @author Michael Spalti
+ */
+public abstract class AbstractResourcePatch<R extends RestModel> {
+
+    /**
+     * Handles the patch operations, delegating actions to sub-class implementations. If no sub-class method
+     * is provided, the default method throws a UnprocessableEntityException.
+     *
+     * @param restModel the REST resource to patch
+     * @param context
+     * @param patch
+     * @throws UnprocessableEntityException
+     * @throws PatchBadRequestException
+     * @throws SQLException
+     * @throws AuthorizeException
+     */
+    public void patch(R restModel, Context context, Patch patch)
+        throws UnprocessableEntityException, PatchBadRequestException, SQLException, AuthorizeException {
+
+        List<Operation> operations = patch.getOperations();
+
+        // Note: the list of possible operations is taken from JsonPatchConverter class. Does not implement
+        // test https://tools.ietf.org/html/rfc6902#section-4.6
+        ops: for (Operation op : operations) {
+            switch (op.getOp()) {
+                case "add":
+                    add(restModel, context, op);
+                    continue ops;
+                case "replace":
+                    replace(restModel, context, op);
+                    continue ops;
+                case "remove":
+                    remove(restModel, context, op);
+                    continue ops;
+                case "copy":
+                    copy(restModel, context, op);
+                    continue ops;
+                case "move":
+                    move(restModel, context, op);
+                    continue ops;
+                default:
+                    // JsonPatchConverter should have thrown error before this point.
+                    throw new PatchBadRequestException("Missing or illegal patch operation: " + op.getOp());
+            }
+        }
+    }
+    // The default patch methods throw an error when no sub-class implementation is provided.
+
+    protected void add(R restModel, Context context, Operation operation)
+        throws UnprocessableEntityException, PatchBadRequestException, SQLException, AuthorizeException {
+        throw new UnprocessableEntityException(
+            "The add operation is not supported."
+        );
+    }
+
+    protected void replace(R restModel, Context context, Operation operation)
+        throws UnprocessableEntityException, PatchBadRequestException, SQLException, AuthorizeException {
+        // The replace operation is functionally identical to a "remove" operation for
+        // a value, followed immediately by an "add" operation at the same
+        // location with the replacement value. https://tools.ietf.org/html/rfc6902#section-4.3
+        remove(restModel, context, operation);
+        add(restModel, context, operation);
+    }
+
+    protected void remove(R restModel, Context context, Operation operation)
+
+        throws UnprocessableEntityException, PatchBadRequestException, SQLException, AuthorizeException {
+        throw new UnprocessableEntityException(
+            "The remove operation is not supported."
+        );
+    }
+
+    protected void copy(R restModel, Context context, Operation operation)
+        throws UnprocessableEntityException, PatchBadRequestException, SQLException, AuthorizeException {
+        throw new UnprocessableEntityException(
+            "The copy operation is not supported."
+        );
+    }
+
+    protected void move(R restModel, Context context, Operation operation)
+        throws UnprocessableEntityException, PatchBadRequestException, SQLException, AuthorizeException {
+        throw new UnprocessableEntityException(
+            "The move operation is not supported."
+        );
+    }
+
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/patch/ItemPatch.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/patch/ItemPatch.java
@@ -120,10 +120,11 @@ public class ItemPatch extends AbstractResourcePatch<ItemRest> {
      * @param restModel
      * @param context
      * @param isDiscoverable
-     * @throws PatchBadRequestException
+     * @throws SQLException
+     * @throws AuthorizeException
      */
     private void discoverable(ItemRest restModel, Context context, Boolean isDiscoverable)
-        throws PatchBadRequestException {
+        throws SQLException, AuthorizeException {
 
         if (isDiscoverable == null) {
             throw new PatchBadRequestException("Boolean value not provided for discoverable operation.");
@@ -131,8 +132,10 @@ public class ItemPatch extends AbstractResourcePatch<ItemRest> {
         try {
             Item item = is.find(context, UUID.fromString(restModel.getUuid()));
             item.setDiscoverable(isDiscoverable);
-        } catch (SQLException e) {
-            e.printStackTrace();
+            is.update(context, item);
+        } catch (SQLException | AuthorizeException e) {
+            log.error(e.getMessage(), e);
+            throw e;
         }
 
     }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/patch/ItemPatch.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/patch/ItemPatch.java
@@ -1,0 +1,140 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.repository.patch;
+
+import java.sql.SQLException;
+import java.util.UUID;
+
+import org.apache.log4j.Logger;
+import org.dspace.app.rest.exception.PatchBadRequestException;
+import org.dspace.app.rest.exception.UnprocessableEntityException;
+import org.dspace.app.rest.model.ItemRest;
+import org.dspace.app.rest.model.patch.Operation;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.Item;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * This is the implementation for Item resource patches.
+ *
+ * @author Michael Spalti
+ */
+@Component
+public class ItemPatch extends AbstractResourcePatch<ItemRest> {
+
+    private static final String OPERATION_PATH_WITHDRAW = "/withdrawn";
+
+    private static final String OPERATION_PATH_DISCOVERABLE = "/discoverable";
+
+    private static final Logger log = Logger.getLogger(ItemPatch.class);
+
+    @Autowired
+    ItemService is;
+
+    /**
+     * Implementation of the PATCH replace operation.
+     *
+     * @param restModel
+     * @param context
+     * @param operation
+     * @throws UnprocessableEntityException
+     * @throws PatchBadRequestException
+     * @throws SQLException
+     * @throws AuthorizeException
+     */
+    @Override
+    protected void replace(ItemRest restModel, Context context, Operation operation)
+        throws UnprocessableEntityException, PatchBadRequestException, SQLException, AuthorizeException {
+
+        switch (operation.getPath()) {
+            case OPERATION_PATH_WITHDRAW:
+                withdraw(restModel, context, (Boolean) operation.getValue());
+                break;
+            case OPERATION_PATH_DISCOVERABLE:
+                discoverable(restModel, context, (Boolean) operation.getValue());
+                break;
+            default:
+                throw new UnprocessableEntityException(
+                    "Unrecognized patch operation path: " + operation.getPath()
+                );
+        }
+    }
+
+    /**
+     * Withdraws or reinstates the item based on boolean value provided in the patch request.
+     *
+     * @param restModel
+     * @param context
+     * @param withdrawItem
+     * @throws PatchBadRequestException
+     * @throws SQLException
+     * @throws AuthorizeException
+     */
+    private void withdraw(ItemRest restModel, Context context, Boolean withdrawItem)
+        throws PatchBadRequestException, SQLException, AuthorizeException {
+
+        try {
+            if (withdrawItem == null) {
+                throw new PatchBadRequestException("Boolean value not provided for withdrawal operation.");
+            }
+            if (withdrawItem) {
+                // Item is not withdrawn but is also NOT archived. Is this a possible situation?
+                if (!restModel.getWithdrawn() && !restModel.getInArchive()) {
+                    throw new UnprocessableEntityException("Cannot withdraw item because it is not archived.");
+                }
+                // Item is already withdrawn. No-op, 200 response.
+                // (The operation is not idempotent since it results in a provenance note in the record.)
+                if (restModel.getWithdrawn()) {
+                    return;
+                }
+                Item item = is.find(context, UUID.fromString(restModel.getUuid()));
+                is.withdraw(context, item);
+            } else {
+                // No need to reinstate item if it has not previously been not withdrawn.
+                // No-op, 200 response. (The operation is not idempotent since it results
+                // in a provenance note in the record.)
+                if (!restModel.getWithdrawn()) {
+                    return;
+                }
+                Item item = is.find(context, UUID.fromString(restModel.getUuid()));
+                is.reinstate(context, item);
+            }
+
+        } catch (SQLException | AuthorizeException e) {
+            log.error(e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    /**
+     * Sets discoverable field on the item.
+     *
+     * @param restModel
+     * @param context
+     * @param isDiscoverable
+     * @throws PatchBadRequestException
+     */
+    private void discoverable(ItemRest restModel, Context context, Boolean isDiscoverable)
+        throws PatchBadRequestException {
+
+        if (isDiscoverable == null) {
+            throw new PatchBadRequestException("Boolean value not provided for discoverable operation.");
+        }
+        try {
+            Item item = is.find(context, UUID.fromString(restModel.getUuid()));
+            item.setDiscoverable(isDiscoverable);
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+
+    }
+
+}

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -9,12 +9,15 @@ package org.dspace.app.rest;
 
 import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.io.InputStream;
 import java.util.UUID;
+
+import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.CharEncoding;
@@ -40,48 +43,48 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+            .withName("Parent Community")
+            .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+            .withName("Sub Community")
+            .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Public item 1")
-                                      .withIssueDate("2017-10-17")
-                                      .withAuthor("Smith, Donald").withAuthor("Doe, John")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+            .withTitle("Public item 1")
+            .withIssueDate("2017-10-17")
+            .withAuthor("Smith, Donald").withAuthor("Doe, John")
+            .withSubject("ExtraEntry")
+            .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2016-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .build();
+            .withTitle("Public item 2")
+            .withIssueDate("2016-02-13")
+            .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+            .withSubject("TestingForMore").withSubject("ExtraEntry")
+            .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 3")
-                                      .withIssueDate("2016-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+            .withTitle("Public item 3")
+            .withIssueDate("2016-02-13")
+            .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+            .withSubject("AnotherTest").withSubject("TestingForMore")
+            .withSubject("ExtraEntry")
+            .build();
 
 
         getClient().perform(get("/api/core/items"))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$._embedded.items", Matchers.containsInAnyOrder(
-                       ItemMatcher.matchItemWithTitleAndDateIssued(publicItem1, "Public item 1", "2017-10-17"),
-                       ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2, "Public item 2", "2016-02-13"),
-                       ItemMatcher.matchItemWithTitleAndDateIssued(publicItem3, "Public item 3", "2016-02-13")
-                   )))
-                   .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/items")))
-                   .andExpect(jsonPath("$.page.size", is(20)))
-                   .andExpect(jsonPath("$.page.totalElements", is(3)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.items", Matchers.containsInAnyOrder(
+                ItemMatcher.matchItemWithTitleAndDateIssued(publicItem1, "Public item 1", "2017-10-17"),
+                ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2, "Public item 2", "2016-02-13"),
+                ItemMatcher.matchItemWithTitleAndDateIssued(publicItem3, "Public item 3", "2016-02-13")
+            )))
+            .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/items")))
+            .andExpect(jsonPath("$.page.size", is(20)))
+            .andExpect(jsonPath("$.page.totalElements", is(3)))
         ;
     }
 
@@ -92,68 +95,68 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+            .withName("Parent Community")
+            .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+            .withName("Sub Community")
+            .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Public item 1")
-                                      .withIssueDate("2017-10-17")
-                                      .withAuthor("Smith, Donald").withAuthor("Doe, John")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+            .withTitle("Public item 1")
+            .withIssueDate("2017-10-17")
+            .withAuthor("Smith, Donald").withAuthor("Doe, John")
+            .withSubject("ExtraEntry")
+            .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2016-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .build();
+            .withTitle("Public item 2")
+            .withIssueDate("2016-02-13")
+            .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+            .withSubject("TestingForMore").withSubject("ExtraEntry")
+            .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 3")
-                                      .withIssueDate("2016-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+            .withTitle("Public item 3")
+            .withIssueDate("2016-02-13")
+            .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+            .withSubject("AnotherTest").withSubject("TestingForMore")
+            .withSubject("ExtraEntry")
+            .build();
 
         getClient().perform(get("/api/core/items")
-                                .param("size", "2"))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$._embedded.items", Matchers.containsInAnyOrder(
-                       ItemMatcher.matchItemWithTitleAndDateIssued(publicItem1, "Public item 1", "2017-10-17"),
-                       ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2, "Public item 2", "2016-02-13")
-                   )))
-                   .andExpect(jsonPath("$._embedded.items", Matchers.not(
-                       Matchers.contains(
-                           ItemMatcher.matchItemWithTitleAndDateIssued(publicItem3, "Public item 3", "2016-02-13")
-                       )
-                   )))
-                   .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/items")))
+            .param("size", "2"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.items", Matchers.containsInAnyOrder(
+                ItemMatcher.matchItemWithTitleAndDateIssued(publicItem1, "Public item 1", "2017-10-17"),
+                ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2, "Public item 2", "2016-02-13")
+            )))
+            .andExpect(jsonPath("$._embedded.items", Matchers.not(
+                Matchers.contains(
+                    ItemMatcher.matchItemWithTitleAndDateIssued(publicItem3, "Public item 3", "2016-02-13")
+                )
+            )))
+            .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/items")))
         ;
 
         getClient().perform(get("/api/core/items")
-                                .param("size", "2")
-                                .param("page", "1"))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$._embedded.items", Matchers.contains(
-                       ItemMatcher.matchItemWithTitleAndDateIssued(publicItem3, "Public item 3", "2016-02-13")
-                   )))
-                   .andExpect(jsonPath("$._embedded.items", Matchers.not(
-                       Matchers.contains(
-                           ItemMatcher.matchItemWithTitleAndDateIssued(publicItem1, "Public item 1", "2017-10-17"),
-                           ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2, "Public item 2", "2016-02-13")
-                       )
-                   )))
-                   .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/items")))
-                   .andExpect(jsonPath("$.page.size", is(2)))
-                   .andExpect(jsonPath("$.page.totalElements", is(3)))
+            .param("size", "2")
+            .param("page", "1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.items", Matchers.contains(
+                ItemMatcher.matchItemWithTitleAndDateIssued(publicItem3, "Public item 3", "2016-02-13")
+            )))
+            .andExpect(jsonPath("$._embedded.items", Matchers.not(
+                Matchers.contains(
+                    ItemMatcher.matchItemWithTitleAndDateIssued(publicItem1, "Public item 1", "2017-10-17"),
+                    ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2, "Public item 2", "2016-02-13")
+                )
+            )))
+            .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/items")))
+            .andExpect(jsonPath("$.page.size", is(2)))
+            .andExpect(jsonPath("$.page.totalElements", is(3)))
         ;
     }
 
@@ -164,49 +167,49 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+            .withName("Parent Community")
+            .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+            .withName("Sub Community")
+            .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Public item 1")
-                                      .withIssueDate("2017-10-17")
-                                      .withAuthor("Smith, Donald").withAuthor("Doe, John")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+            .withTitle("Public item 1")
+            .withIssueDate("2017-10-17")
+            .withAuthor("Smith, Donald").withAuthor("Doe, John")
+            .withSubject("ExtraEntry")
+            .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2016-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .build();
+            .withTitle("Public item 2")
+            .withIssueDate("2016-02-13")
+            .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+            .withSubject("TestingForMore").withSubject("ExtraEntry")
+            .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 3")
-                                      .withIssueDate("2016-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+            .withTitle("Public item 3")
+            .withIssueDate("2016-02-13")
+            .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+            .withSubject("AnotherTest").withSubject("TestingForMore")
+            .withSubject("ExtraEntry")
+            .build();
 
 
         getClient().perform(get("/api/core/items/" + publicItem1.getID()))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$", Matchers.is(
-                       ItemMatcher.matchItemWithTitleAndDateIssued(publicItem1, "Public item 1", "2017-10-17")
-                   )))
-                   .andExpect(jsonPath("$", Matchers.not(
-                       Matchers.is(
-                           ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2, "Public item 2", "2016-02-13")
-                       )
-                   )))
-                   .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/items")))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", Matchers.is(
+                ItemMatcher.matchItemWithTitleAndDateIssued(publicItem1, "Public item 1", "2017-10-17")
+            )))
+            .andExpect(jsonPath("$", Matchers.not(
+                Matchers.is(
+                    ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2, "Public item 2", "2016-02-13")
+                )
+            )))
+            .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/items")))
         ;
     }
 
@@ -217,72 +220,72 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+            .withName("Parent Community")
+            .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+            .withName("Sub Community")
+            .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Public item 1")
-                                      .withIssueDate("2017-10-17")
-                                      .withAuthor("Smith, Donald").withAuthor("Doe, John")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+            .withTitle("Public item 1")
+            .withIssueDate("2017-10-17")
+            .withAuthor("Smith, Donald").withAuthor("Doe, John")
+            .withSubject("ExtraEntry")
+            .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2016-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .build();
+            .withTitle("Public item 2")
+            .withIssueDate("2016-02-13")
+            .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+            .withSubject("TestingForMore").withSubject("ExtraEntry")
+            .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 3")
-                                      .withIssueDate("2016-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+            .withTitle("Public item 3")
+            .withIssueDate("2016-02-13")
+            .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+            .withSubject("AnotherTest").withSubject("TestingForMore")
+            .withSubject("ExtraEntry")
+            .build();
 
         //Add a bitstream to an item
         String bitstreamContent = "ThisIsSomeDummyText";
         Bitstream bitstream1 = null;
         try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
             bitstream1 = BitstreamBuilder.
-                                             createBitstream(context, publicItem1, is)
-                                         .withName("Bitstream1")
-                                         .withMimeType("text/plain")
-                                         .build();
+                createBitstream(context, publicItem1, is)
+                .withName("Bitstream1")
+                .withMimeType("text/plain")
+                .build();
         }
 
         getClient().perform(get("/api/core/items/" + publicItem1.getID()))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$", Matchers.is(
-                       ItemMatcher.matchItemWithTitleAndDateIssued(publicItem1, "Public item 1", "2017-10-17")
-                   )))
-                   .andExpect(jsonPath("$", Matchers.not(
-                       Matchers.is(
-                           ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2, "Public item 2", "2016-02-13")
-                       )
-                   )))
-                   .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/items")))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", Matchers.is(
+                ItemMatcher.matchItemWithTitleAndDateIssued(publicItem1, "Public item 1", "2017-10-17")
+            )))
+            .andExpect(jsonPath("$", Matchers.not(
+                Matchers.is(
+                    ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2, "Public item 2", "2016-02-13")
+                )
+            )))
+            .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/items")))
         ;
 
         getClient().perform(get("/api/core/items/" + publicItem1.getID() + "/bitstreams"))
-                   .andExpect(status().isOk())
-                   .andExpect(content().contentType(contentType))
-                   .andExpect(jsonPath("$._links.self.href", Matchers
-                       .containsString("/api/core/items/" + publicItem1.getID() + "/bitstreams")))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._links.self.href", Matchers
+                .containsString("/api/core/items/" + publicItem1.getID() + "/bitstreams")))
         ;
 
         getClient().perform(get("/api/core/items/" + publicItem1.getID() + "/owningCollection"))
-                   .andExpect(status().isOk())
-                   .andExpect(content().contentType(contentType))
-                   .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/collections")))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/collections")))
         ;
 
         getClient().perform(get("/api/core/items/" + publicItem1.getID() + "/templateItemOf"))
@@ -298,17 +301,76 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+            .withName("Parent Community")
+            .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+            .withName("Sub Community")
+            .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         getClient().perform(get("/api/core/items/" + UUID.randomUUID()))
-                   .andExpect(status().isNotFound());
+            .andExpect(status().isNotFound());
         ;
+
+    }
+
+    @Test
+    public void patchTest() throws Exception {
+
+        String token = getAuthToken(eperson.getEmail(), password);
+
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and one collection.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+            .withName("Sub Community")
+            .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+
+        //2. One public item
+        Item item = ItemBuilder.createItem(context, col1)
+            .withTitle("Public item 1")
+            .withIssueDate("2017-10-17")
+            .withAuthor("Smith, Donald").withAuthor("Doe, John")
+            .withSubject("ExtraEntry")
+            .build();
+
+        // withdraw item
+        getClient(token).perform(patch("/api/core/items/" + item.getID())
+            .content("[{\"op\":\"replace\",\"path\":\"withdraw\"}]")
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.uuid", Matchers.is(item.getID().toString())))
+            .andExpect(jsonPath("$.withdrawn", Matchers.is(true)))
+            .andExpect(jsonPath("$.inArchive", Matchers.is(false)));
+
+        // should return 422 because item is not in archive
+        getClient(token).perform(patch("/api/core/items/" + item.getID())
+            .content("[{\"op\":\"replace\",\"path\":\"withdraw\"}]")
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .andExpect(status().isUnprocessableEntity());
+
+        // reinstate item
+        getClient(token).perform(patch("/api/core/items/" + item.getID())
+            .content("[{\"op\":\"replace\",\"path\":\"reinstate\"}]")
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.uuid", Matchers.is(item.getID().toString())))
+            .andExpect(jsonPath("$.withdrawn", Matchers.is(false)))
+            .andExpect(jsonPath("$.inArchive", Matchers.is(true)));
+
+        // make private
+        getClient(token).perform(patch("/api/core/items/" + item.getID())
+            .content("[{\"op\":\"replace\",\"path\":\"discoverable\",\"value\":false}]")
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.uuid", Matchers.is(item.getID().toString())))
+            .andExpect(jsonPath("$.discoverable", Matchers.is(false)));
     }
 
 }

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -15,8 +15,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
-
 import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.io.IOUtils;
@@ -26,6 +27,8 @@ import org.dspace.app.rest.builder.CollectionBuilder;
 import org.dspace.app.rest.builder.CommunityBuilder;
 import org.dspace.app.rest.builder.ItemBuilder;
 import org.dspace.app.rest.matcher.ItemMatcher;
+import org.dspace.app.rest.model.patch.Operation;
+import org.dspace.app.rest.model.patch.ReplaceOperation;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Collection;
@@ -43,48 +46,48 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-            .withName("Parent Community")
-            .build();
+                                          .withName("Parent Community")
+                                          .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-            .withName("Sub Community")
-            .build();
+                                           .withName("Sub Community")
+                                           .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-            .withTitle("Public item 1")
-            .withIssueDate("2017-10-17")
-            .withAuthor("Smith, Donald").withAuthor("Doe, John")
-            .withSubject("ExtraEntry")
-            .build();
+                                      .withTitle("Public item 1")
+                                      .withIssueDate("2017-10-17")
+                                      .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                                      .withSubject("ExtraEntry")
+                                      .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-            .withTitle("Public item 2")
-            .withIssueDate("2016-02-13")
-            .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-            .withSubject("TestingForMore").withSubject("ExtraEntry")
-            .build();
+                                      .withTitle("Public item 2")
+                                      .withIssueDate("2016-02-13")
+                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
+                                      .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-            .withTitle("Public item 3")
-            .withIssueDate("2016-02-13")
-            .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-            .withSubject("AnotherTest").withSubject("TestingForMore")
-            .withSubject("ExtraEntry")
-            .build();
+                                      .withTitle("Public item 3")
+                                      .withIssueDate("2016-02-13")
+                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                                      .withSubject("AnotherTest").withSubject("TestingForMore")
+                                      .withSubject("ExtraEntry")
+                                      .build();
 
 
         getClient().perform(get("/api/core/items"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$._embedded.items", Matchers.containsInAnyOrder(
-                ItemMatcher.matchItemWithTitleAndDateIssued(publicItem1, "Public item 1", "2017-10-17"),
-                ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2, "Public item 2", "2016-02-13"),
-                ItemMatcher.matchItemWithTitleAndDateIssued(publicItem3, "Public item 3", "2016-02-13")
-            )))
-            .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/items")))
-            .andExpect(jsonPath("$.page.size", is(20)))
-            .andExpect(jsonPath("$.page.totalElements", is(3)))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$._embedded.items", Matchers.containsInAnyOrder(
+                       ItemMatcher.matchItemWithTitleAndDateIssued(publicItem1, "Public item 1", "2017-10-17"),
+                       ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2, "Public item 2", "2016-02-13"),
+                       ItemMatcher.matchItemWithTitleAndDateIssued(publicItem3, "Public item 3", "2016-02-13")
+                   )))
+                   .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/items")))
+                   .andExpect(jsonPath("$.page.size", is(20)))
+                   .andExpect(jsonPath("$.page.totalElements", is(3)))
         ;
     }
 
@@ -95,68 +98,68 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-            .withName("Parent Community")
-            .build();
+                                          .withName("Parent Community")
+                                          .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-            .withName("Sub Community")
-            .build();
+                                           .withName("Sub Community")
+                                           .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-            .withTitle("Public item 1")
-            .withIssueDate("2017-10-17")
-            .withAuthor("Smith, Donald").withAuthor("Doe, John")
-            .withSubject("ExtraEntry")
-            .build();
+                                      .withTitle("Public item 1")
+                                      .withIssueDate("2017-10-17")
+                                      .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                                      .withSubject("ExtraEntry")
+                                      .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-            .withTitle("Public item 2")
-            .withIssueDate("2016-02-13")
-            .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-            .withSubject("TestingForMore").withSubject("ExtraEntry")
-            .build();
+                                      .withTitle("Public item 2")
+                                      .withIssueDate("2016-02-13")
+                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
+                                      .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-            .withTitle("Public item 3")
-            .withIssueDate("2016-02-13")
-            .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-            .withSubject("AnotherTest").withSubject("TestingForMore")
-            .withSubject("ExtraEntry")
-            .build();
+                                      .withTitle("Public item 3")
+                                      .withIssueDate("2016-02-13")
+                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                                      .withSubject("AnotherTest").withSubject("TestingForMore")
+                                      .withSubject("ExtraEntry")
+                                      .build();
 
         getClient().perform(get("/api/core/items")
-            .param("size", "2"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$._embedded.items", Matchers.containsInAnyOrder(
-                ItemMatcher.matchItemWithTitleAndDateIssued(publicItem1, "Public item 1", "2017-10-17"),
-                ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2, "Public item 2", "2016-02-13")
-            )))
-            .andExpect(jsonPath("$._embedded.items", Matchers.not(
-                Matchers.contains(
-                    ItemMatcher.matchItemWithTitleAndDateIssued(publicItem3, "Public item 3", "2016-02-13")
-                )
-            )))
-            .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/items")))
+                   .param("size", "2"))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$._embedded.items", Matchers.containsInAnyOrder(
+                       ItemMatcher.matchItemWithTitleAndDateIssued(publicItem1, "Public item 1", "2017-10-17"),
+                       ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2, "Public item 2", "2016-02-13")
+                   )))
+                   .andExpect(jsonPath("$._embedded.items", Matchers.not(
+                       Matchers.contains(
+                           ItemMatcher.matchItemWithTitleAndDateIssued(publicItem3, "Public item 3", "2016-02-13")
+                       )
+                   )))
+                   .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/items")))
         ;
 
         getClient().perform(get("/api/core/items")
-            .param("size", "2")
-            .param("page", "1"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$._embedded.items", Matchers.contains(
-                ItemMatcher.matchItemWithTitleAndDateIssued(publicItem3, "Public item 3", "2016-02-13")
-            )))
-            .andExpect(jsonPath("$._embedded.items", Matchers.not(
-                Matchers.contains(
-                    ItemMatcher.matchItemWithTitleAndDateIssued(publicItem1, "Public item 1", "2017-10-17"),
-                    ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2, "Public item 2", "2016-02-13")
-                )
-            )))
-            .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/items")))
-            .andExpect(jsonPath("$.page.size", is(2)))
-            .andExpect(jsonPath("$.page.totalElements", is(3)))
+                   .param("size", "2")
+                   .param("page", "1"))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$._embedded.items", Matchers.contains(
+                       ItemMatcher.matchItemWithTitleAndDateIssued(publicItem3, "Public item 3", "2016-02-13")
+                   )))
+                   .andExpect(jsonPath("$._embedded.items", Matchers.not(
+                       Matchers.contains(
+                           ItemMatcher.matchItemWithTitleAndDateIssued(publicItem1, "Public item 1", "2017-10-17"),
+                           ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2, "Public item 2", "2016-02-13")
+                       )
+                   )))
+                   .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/items")))
+                   .andExpect(jsonPath("$.page.size", is(2)))
+                   .andExpect(jsonPath("$.page.totalElements", is(3)))
         ;
     }
 
@@ -167,49 +170,49 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-            .withName("Parent Community")
-            .build();
+                                          .withName("Parent Community")
+                                          .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-            .withName("Sub Community")
-            .build();
+                                           .withName("Sub Community")
+                                           .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-            .withTitle("Public item 1")
-            .withIssueDate("2017-10-17")
-            .withAuthor("Smith, Donald").withAuthor("Doe, John")
-            .withSubject("ExtraEntry")
-            .build();
+                                      .withTitle("Public item 1")
+                                      .withIssueDate("2017-10-17")
+                                      .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                                      .withSubject("ExtraEntry")
+                                      .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-            .withTitle("Public item 2")
-            .withIssueDate("2016-02-13")
-            .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-            .withSubject("TestingForMore").withSubject("ExtraEntry")
-            .build();
+                                      .withTitle("Public item 2")
+                                      .withIssueDate("2016-02-13")
+                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
+                                      .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-            .withTitle("Public item 3")
-            .withIssueDate("2016-02-13")
-            .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-            .withSubject("AnotherTest").withSubject("TestingForMore")
-            .withSubject("ExtraEntry")
-            .build();
+                                      .withTitle("Public item 3")
+                                      .withIssueDate("2016-02-13")
+                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                                      .withSubject("AnotherTest").withSubject("TestingForMore")
+                                      .withSubject("ExtraEntry")
+                                      .build();
 
 
         getClient().perform(get("/api/core/items/" + publicItem1.getID()))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$", Matchers.is(
-                ItemMatcher.matchItemWithTitleAndDateIssued(publicItem1, "Public item 1", "2017-10-17")
-            )))
-            .andExpect(jsonPath("$", Matchers.not(
-                Matchers.is(
-                    ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2, "Public item 2", "2016-02-13")
-                )
-            )))
-            .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/items")))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", Matchers.is(
+                       ItemMatcher.matchItemWithTitleAndDateIssued(publicItem1, "Public item 1", "2017-10-17")
+                   )))
+                   .andExpect(jsonPath("$", Matchers.not(
+                       Matchers.is(
+                           ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2, "Public item 2", "2016-02-13")
+                       )
+                   )))
+                   .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/items")))
         ;
     }
 
@@ -220,72 +223,72 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-            .withName("Parent Community")
-            .build();
+                                          .withName("Parent Community")
+                                          .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-            .withName("Sub Community")
-            .build();
+                                           .withName("Sub Community")
+                                           .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-            .withTitle("Public item 1")
-            .withIssueDate("2017-10-17")
-            .withAuthor("Smith, Donald").withAuthor("Doe, John")
-            .withSubject("ExtraEntry")
-            .build();
+                                      .withTitle("Public item 1")
+                                      .withIssueDate("2017-10-17")
+                                      .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                                      .withSubject("ExtraEntry")
+                                      .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-            .withTitle("Public item 2")
-            .withIssueDate("2016-02-13")
-            .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-            .withSubject("TestingForMore").withSubject("ExtraEntry")
-            .build();
+                                      .withTitle("Public item 2")
+                                      .withIssueDate("2016-02-13")
+                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
+                                      .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-            .withTitle("Public item 3")
-            .withIssueDate("2016-02-13")
-            .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-            .withSubject("AnotherTest").withSubject("TestingForMore")
-            .withSubject("ExtraEntry")
-            .build();
+                                      .withTitle("Public item 3")
+                                      .withIssueDate("2016-02-13")
+                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                                      .withSubject("AnotherTest").withSubject("TestingForMore")
+                                      .withSubject("ExtraEntry")
+                                      .build();
 
         //Add a bitstream to an item
         String bitstreamContent = "ThisIsSomeDummyText";
         Bitstream bitstream1 = null;
         try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
             bitstream1 = BitstreamBuilder.
-                createBitstream(context, publicItem1, is)
-                .withName("Bitstream1")
-                .withMimeType("text/plain")
-                .build();
+                                             createBitstream(context, publicItem1, is)
+                                         .withName("Bitstream1")
+                                         .withMimeType("text/plain")
+                                         .build();
         }
 
         getClient().perform(get("/api/core/items/" + publicItem1.getID()))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$", Matchers.is(
-                ItemMatcher.matchItemWithTitleAndDateIssued(publicItem1, "Public item 1", "2017-10-17")
-            )))
-            .andExpect(jsonPath("$", Matchers.not(
-                Matchers.is(
-                    ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2, "Public item 2", "2016-02-13")
-                )
-            )))
-            .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/items")))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", Matchers.is(
+                       ItemMatcher.matchItemWithTitleAndDateIssued(publicItem1, "Public item 1", "2017-10-17")
+                   )))
+                   .andExpect(jsonPath("$", Matchers.not(
+                       Matchers.is(
+                           ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2, "Public item 2", "2016-02-13")
+                       )
+                   )))
+                   .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/items")))
         ;
 
         getClient().perform(get("/api/core/items/" + publicItem1.getID() + "/bitstreams"))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(contentType))
-            .andExpect(jsonPath("$._links.self.href", Matchers
-                .containsString("/api/core/items/" + publicItem1.getID() + "/bitstreams")))
+                   .andExpect(status().isOk())
+                   .andExpect(content().contentType(contentType))
+                   .andExpect(jsonPath("$._links.self.href", Matchers
+                       .containsString("/api/core/items/" + publicItem1.getID() + "/bitstreams")))
         ;
 
         getClient().perform(get("/api/core/items/" + publicItem1.getID() + "/owningCollection"))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(contentType))
-            .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/collections")))
+                   .andExpect(status().isOk())
+                   .andExpect(content().contentType(contentType))
+                   .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/collections")))
         ;
 
         getClient().perform(get("/api/core/items/" + publicItem1.getID() + "/templateItemOf"))
@@ -301,76 +304,272 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-            .withName("Parent Community")
-            .build();
+                                          .withName("Parent Community")
+                                          .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-            .withName("Sub Community")
-            .build();
+                                           .withName("Sub Community")
+                                           .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         getClient().perform(get("/api/core/items/" + UUID.randomUUID()))
-            .andExpect(status().isNotFound());
+                   .andExpect(status().isNotFound())
         ;
 
     }
 
     @Test
-    public void patchTest() throws Exception {
-
-        String token = getAuthToken(eperson.getEmail(), password);
-
+    public void widthdrawPatchTest() throws Exception {
         context.turnOffAuthorisationSystem();
 
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and one collection.
         parentCommunity = CommunityBuilder.createCommunity(context)
-            .withName("Parent Community")
-            .build();
+                                          .withName("Parent Community")
+                                          .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-            .withName("Sub Community")
-            .build();
+                                           .withName("Sub Community")
+                                           .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1)
+                                           .withName("Collection 1").build();
+
+        //2. One public item
+        Item item = ItemBuilder.createItem(context, col1)
+                               .withTitle("Public item 1")
+                               .withIssueDate("2017-10-17")
+                               .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                               .withSubject("ExtraEntry")
+                               .build();
+
+        makeUserAdmin();
+
+        // A token must be provided for withdraw operation. The person
+        // is used in the provenance note.
+        String token = getAuthToken(eperson.getEmail(), password);
+
+        List<Operation> ops = new ArrayList();
+        ReplaceOperation replaceOperation = new ReplaceOperation("/withdrawn", true);
+        ops.add(replaceOperation);
+        String patchBody = getPatchContent(ops);
+
+        // withdraw item
+        getClient(token).perform(patch("/api/core/items/" + item.getID())
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.uuid", Matchers.is(item.getID().toString())))
+                        .andExpect(jsonPath("$.withdrawn", Matchers.is(true)))
+                        .andExpect(jsonPath("$.inArchive", Matchers.is(false)));
+
+        // item already withdrawn, no-op, 200 response
+        getClient(token).perform(patch("/api/core/items/" + item.getID())
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                        .andExpect(status().isOk());
+
+    }
+
+    @Test
+    public void valueMissingForWithdrawalOperation() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and one collection.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community")
+                                           .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1)
+                                           .withName("Collection 1").build();
+
+        //2. One public item
+        Item item = ItemBuilder.createItem(context, col1)
+                               .withTitle("Public item 1")
+                               .withIssueDate("2017-10-17")
+                               .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                               .withSubject("ExtraEntry")
+                               .build();
+
+        makeUserAdmin();
+
+        String token = getAuthToken(eperson.getEmail(), password);
+
+        List<Operation> ops = new ArrayList();
+        ReplaceOperation replaceOperation = new ReplaceOperation("/withdrawn", null);
+        ops.add(replaceOperation);
+        String patchBody = getPatchContent(ops);
+
+        getClient(token).perform(patch("/api/core/items/" + item.getID())
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                        .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void reinstatePatchTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and one collection.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community")
+                                           .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1)
+                                           .withName("Collection 1").build();
+
+        //2. One public item
+        Item item = ItemBuilder.createItem(context, col1)
+                               .withTitle("Public item 1")
+                               .withIssueDate("2017-10-17")
+                               .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                               .withSubject("ExtraEntry")
+                               .build();
+
+        makeUserAdmin();
+
+        // A token must be provided for reinstate operation. The person
+        // is used in the provenance note.
+        String token = getAuthToken(eperson.getEmail(), password);
+
+        List<Operation> ops = new ArrayList();
+        // first, withdraw item
+        ReplaceOperation initalizeOperation = new ReplaceOperation("/withdrawn", true);
+        ops.add(initalizeOperation);
+        String patchInitialState = getPatchContent(ops);
+
+        getClient(token).perform(patch("/api/core/items/" + item.getID())
+            .content(patchInitialState)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                        .andExpect(status().isOk());
+
+        // now reinstate item
+        ops.clear();
+        ReplaceOperation replaceOperation = new ReplaceOperation("/withdrawn", false);
+        ops.add(replaceOperation);
+        String patchBody = getPatchContent(ops);
+
+        getClient(token).perform(patch("/api/core/items/" + item.getID())
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.uuid", Matchers.is(item.getID().toString())))
+                   .andExpect(jsonPath("$.withdrawn", Matchers.is(false)))
+                   .andExpect(jsonPath("$.inArchive", Matchers.is(true)));
+    }
+
+    @Test
+    public void makeDiscoverablePatchTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and one collection.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community")
+                                           .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+
+        //2. One private item
+        Item item = ItemBuilder.createItem(context, col1)
+                               .withTitle("Public item 1")
+                               .withIssueDate("2017-10-17")
+                               .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                               .withSubject("ExtraEntry")
+                               .makePrivate()
+                               .build();
+        List<Operation> ops = new ArrayList();
+        ReplaceOperation replaceOperation = new ReplaceOperation("/discoverable", true);
+        ops.add(replaceOperation);
+        String patchBody = getPatchContent(ops);
+
+        // make discoverable
+        getClient().perform(patch("/api/core/items/" + item.getID())
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.uuid", Matchers.is(item.getID().toString())))
+                        .andExpect(jsonPath("$.discoverable", Matchers.is(true)));
+
+    }
+
+    @Test
+    public void makePrivatePatchTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and one collection.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community")
+                                           .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
 
         //2. One public item
         Item item = ItemBuilder.createItem(context, col1)
-            .withTitle("Public item 1")
-            .withIssueDate("2017-10-17")
-            .withAuthor("Smith, Donald").withAuthor("Doe, John")
-            .withSubject("ExtraEntry")
-            .build();
+                               .withTitle("Public item 1")
+                               .withIssueDate("2017-10-17")
+                               .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                               .withSubject("ExtraEntry")
+                               .build();
 
-        // withdraw item
-        getClient(token).perform(patch("/api/core/items/" + item.getID())
-            .content("[{\"op\":\"replace\",\"path\":\"withdraw\"}]")
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.uuid", Matchers.is(item.getID().toString())))
-            .andExpect(jsonPath("$.withdrawn", Matchers.is(true)))
-            .andExpect(jsonPath("$.inArchive", Matchers.is(false)));
-
-        // should return 422 because item is not in archive
-        getClient(token).perform(patch("/api/core/items/" + item.getID())
-            .content("[{\"op\":\"replace\",\"path\":\"withdraw\"}]")
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
-            .andExpect(status().isUnprocessableEntity());
-
-        // reinstate item
-        getClient(token).perform(patch("/api/core/items/" + item.getID())
-            .content("[{\"op\":\"replace\",\"path\":\"reinstate\"}]")
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.uuid", Matchers.is(item.getID().toString())))
-            .andExpect(jsonPath("$.withdrawn", Matchers.is(false)))
-            .andExpect(jsonPath("$.inArchive", Matchers.is(true)));
+        List<Operation> ops = new ArrayList();
+        ReplaceOperation replaceOperation = new ReplaceOperation("/discoverable", false);
+        ops.add(replaceOperation);
+        String patchBody = getPatchContent(ops);
 
         // make private
-        getClient(token).perform(patch("/api/core/items/" + item.getID())
-            .content("[{\"op\":\"replace\",\"path\":\"discoverable\",\"value\":false}]")
+        getClient().perform(patch("/api/core/items/" + item.getID())
+            .content(patchBody)
             .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.uuid", Matchers.is(item.getID().toString())))
-            .andExpect(jsonPath("$.discoverable", Matchers.is(false)));
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.uuid", Matchers.is(item.getID().toString())))
+                   .andExpect(jsonPath("$.discoverable", Matchers.is(false)));
+
+    }
+
+    @Test
+    public void valueMissingForDiscoverableOperation() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and one collection.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community")
+                                           .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1)
+                                           .withName("Collection 1").build();
+
+        //2. One public item
+        Item item = ItemBuilder.createItem(context, col1)
+                               .withTitle("Public item 1")
+                               .withIssueDate("2017-10-17")
+                               .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                               .withSubject("ExtraEntry")
+                               .build();
+
+        String token = getAuthToken(eperson.getEmail(), password);
+
+        List<Operation> ops = new ArrayList();
+        ReplaceOperation replaceOperation = new ReplaceOperation("/discoverable", null);
+        ops.add(replaceOperation);
+        String patchBody = getPatchContent(ops);
+
+        getClient(token).perform(patch("/api/core/items/" + item.getID())
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                        .andExpect(status().isBadRequest());
     }
 
 }

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/builder/CollectionBuilder.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/builder/CollectionBuilder.java
@@ -70,8 +70,8 @@ public class CollectionBuilder extends AbstractDSpaceObjectBuilder<Collection> {
         try {
             collectionService.update(context, collection);
             context.dispatchEvents();
-
             indexingService.commit();
+
         } catch (Exception e) {
             return handleException(e);
         }

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/builder/ItemBuilder.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/builder/ItemBuilder.java
@@ -24,6 +24,7 @@ import org.dspace.eperson.Group;
  */
 public class ItemBuilder extends AbstractDSpaceObjectBuilder<Item> {
 
+    private boolean withdrawn = false;
     private WorkspaceItem workspaceItem;
     private Item item;
     private Group readerGroup = null;
@@ -71,6 +72,17 @@ public class ItemBuilder extends AbstractDSpaceObjectBuilder<Item> {
         return this;
     }
 
+    /**
+     * Withdrawn the item under build. Please note that an user need to be loggedin the context to avoid NPE during the
+     * creation of the provenance metadata
+     *
+     * @return the ItemBuilder
+     */
+    public ItemBuilder withdrawn() {
+        withdrawn = true;
+        return this;
+    }
+
     public ItemBuilder withEmbargoPeriod(String embargoPeriod) {
         return setEmbargo(embargoPeriod, item);
     }
@@ -89,6 +101,10 @@ public class ItemBuilder extends AbstractDSpaceObjectBuilder<Item> {
             //Check if we need to make this item private. This has to be done after item install.
             if (readerGroup != null) {
                 setOnlyReadPermission(workspaceItem.getItem(), readerGroup, null);
+            }
+
+            if (withdrawn) {
+                itemService.withdraw(context, item);
             }
 
             context.dispatchEvents();

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/test/AbstractControllerIntegrationTest.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/test/AbstractControllerIntegrationTest.java
@@ -16,9 +16,12 @@ import java.util.Arrays;
 import java.util.List;
 import javax.servlet.Filter;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.Charsets;
 import org.apache.commons.lang.StringUtils;
 import org.dspace.app.rest.Application;
+import org.dspace.app.rest.model.patch.Operation;
 import org.dspace.app.rest.security.WebSecurityConfiguration;
 import org.dspace.app.rest.utils.ApplicationConfig;
 import org.junit.Assert;
@@ -117,6 +120,16 @@ public class AbstractControllerIntegrationTest extends AbstractIntegrationTestWi
 
     public String getAuthToken(String user, String password) throws Exception {
         return getAuthResponse(user, password).getHeader(AUTHORIZATION_HEADER);
+    }
+
+    public String getPatchContent(List<Operation> ops) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            return objectMapper.writeValueAsString(ops);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
 }


### PR DESCRIPTION
@abollini  I have a few questions about this work. I think I understand that the task generally. I'm not sure that I've handled exceptions correctly.  And now looking at the documentation at:
 
https://github.com/DSpace/Rest7Contract/blob/master/patch.md
https://github.com/DSpace/Rest7Contract/blob/master/workspaceitem-data-metadata.md

Which again makes me think that we need additional error handling if it's not already provided by default (e.g.: 405 Method Not Allowed)

For usage, see https://github.com/DSpace/Rest7Contract/pull/25/files

