### PR TITLE
DS-3925: The "View More" page of discover facets does not shows results for facet type authority

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SearchFacetFilter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SearchFacetFilter.java
@@ -7,6 +7,19 @@
  */
 package org.dspace.app.xmlui.aspect.discovery;
 
+import static org.dspace.discovery.configuration.DiscoveryConfigurationParameters.SORT;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.avalon.framework.parameters.Parameters;
 import org.apache.cocoon.ProcessingException;
 import org.apache.cocoon.caching.CacheableProcessingComponent;
@@ -19,32 +32,38 @@ import org.apache.excalibur.source.SourceValidity;
 import org.apache.log4j.Logger;
 import org.dspace.app.util.Util;
 import org.dspace.app.xmlui.cocoon.AbstractDSpaceTransformer;
-import org.dspace.app.xmlui.utils.*;
+import org.dspace.app.xmlui.utils.BadRequestException;
+import org.dspace.app.xmlui.utils.DSpaceValidity;
+import org.dspace.app.xmlui.utils.HandleUtil;
+import org.dspace.app.xmlui.utils.RequestUtils;
+import org.dspace.app.xmlui.utils.UIException;
 import org.dspace.app.xmlui.wing.Message;
 import org.dspace.app.xmlui.wing.WingException;
-import org.dspace.app.xmlui.wing.element.*;
+import org.dspace.app.xmlui.wing.element.Body;
+import org.dspace.app.xmlui.wing.element.Cell;
+import org.dspace.app.xmlui.wing.element.Division;
+import org.dspace.app.xmlui.wing.element.PageMeta;
+import org.dspace.app.xmlui.wing.element.Para;
+import org.dspace.app.xmlui.wing.element.Select;
+import org.dspace.app.xmlui.wing.element.Table;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
 import org.dspace.core.Constants;
-import org.dspace.discovery.*;
+import org.dspace.discovery.DiscoverFacetField;
+import org.dspace.discovery.DiscoverQuery;
+import org.dspace.discovery.DiscoverResult;
+import org.dspace.discovery.SearchService;
+import org.dspace.discovery.SearchServiceException;
+import org.dspace.discovery.SearchUtils;
 import org.dspace.discovery.configuration.DiscoveryConfiguration;
 import org.dspace.discovery.configuration.DiscoveryConfigurationParameters;
+import org.dspace.discovery.configuration.DiscoverySearchFilterFacet;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.xml.sax.SAXException;
-
-import java.io.IOException;
-import java.io.Serializable;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.sql.SQLException;
-import java.util.*;
-import java.util.List;
-
-import static org.dspace.discovery.configuration.DiscoveryConfigurationParameters.SORT;
 
 /**
  * Filter which displays facets on which a user can filter his discovery search
@@ -230,14 +249,16 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
 //        queryArgs.setFacetLimit();
 
         String facetField = request.getParameter(SearchFilterParam.FACET_FIELD);
+        String type = getTypeOfFacetField(discoveryConfiguration, facetField);
         DiscoverFacetField discoverFacetField;
         // Enumerations don't handle mixed cases, setting to uppercase to match convention
         SORT requestSortOrder = getSortOrder(request);
-        if(request.getParameter(SearchFilterParam.STARTS_WITH) != null)
-        {
-            discoverFacetField = new DiscoverFacetField(facetField, DiscoveryConfigurationParameters.TYPE_TEXT, getPageSize() + 1, requestSortOrder, request.getParameter(SearchFilterParam.STARTS_WITH).toLowerCase());
-        }else{
-            discoverFacetField = new DiscoverFacetField(facetField, DiscoveryConfigurationParameters.TYPE_TEXT, getPageSize() + 1, requestSortOrder);
+        if (request.getParameter(SearchFilterParam.STARTS_WITH) != null) {
+            discoverFacetField = new DiscoverFacetField(facetField, type, getPageSize() + 1, requestSortOrder,
+                                                        request.getParameter(SearchFilterParam.STARTS_WITH)
+                                                               .toLowerCase());
+        } else {
+            discoverFacetField = new DiscoverFacetField(facetField, type, getPageSize() + 1, requestSortOrder);
         }
 
         queryArgs.addFacetField(discoverFacetField);
@@ -675,4 +696,17 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
         controlsForm.addButton("update").setValue("update");
     }
 
+    private String getTypeOfFacetField(DiscoveryConfiguration discoveryConfiguration, String facetField) {
+        String type = DiscoveryConfigurationParameters.TYPE_TEXT;
+
+        List<DiscoverySearchFilterFacet> sidebarFacets = discoveryConfiguration.getSidebarFacets();
+
+        for (DiscoverySearchFilterFacet sidebarFacet : sidebarFacets) {
+            if (sidebarFacet.getIndexFieldName().equals(facetField)) {
+                type = sidebarFacet.getType();
+            }
+        }
+
+        return type;
+    }
 }


### PR DESCRIPTION
When you click on the "View More" link at the bottom of a discover facet of type authority, in the sidebar menu, the page that is loaded does not show any results. 

The issue was caused by the facet type "text" being hardcoded in java class org.dspace.app.xmlui.aspect.discovery.SearchFacetFilter.java.

Jira ticket: https://jira.duraspace.org/browse/DS-3925
Fixes #7272 