### PR TITLE
Enable RDF mapping of community/collection metadata

### DIFF
--- a/dspace-api/src/main/java/org/dspace/rdf/conversion/MetadataConverterPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/rdf/conversion/MetadataConverterPlugin.java
@@ -127,15 +127,6 @@ public class MetadataConverterPlugin implements ConverterPlugin
             if (mapping != null) mappings.add(mapping);
         }
         
-        // should be changed, if Communities and Collections have metadata as well.
-        if (!(dso instanceof Item))
-        {
-            log.error("This DspaceObject (" + dsoService.getTypeText(dso) + " " 
-                    + dso.getID() + ") should not have bin submitted to this "
-                    + "plugin, as it supports Items only!");
-            return null;
-        }
-        
         List<MetadataValue> metadata_values = dsoService.getMetadata(dso, MetadataSchema.DC_SCHEMA, Item.ANY, Item.ANY, Item.ANY);
         for (MetadataValue value : metadata_values)
         {
@@ -199,8 +190,7 @@ public class MetadataConverterPlugin implements ConverterPlugin
 
     @Override
     public boolean supports(int type) {
-        // should be changed, if Communities and Collections have metadata as well.
-        return (type == Constants.ITEM);
+        return (type == Constants.ITEM || type == Constants.COLLECTION || type == Constants.COMMUNITY);
     }
     
     protected Model loadConfiguration()

--- a/dspace/config/modules/rdf.cfg
+++ b/dspace/config/modules/rdf.cfg
@@ -55,7 +55,7 @@ rdf.constant.data.ITEM = ${dspace.dir}/config/modules/rdf/constant-data-item.ttl
 rdf.constant.data.SITE = ${dspace.dir}/config/modules/rdf/constant-data-site.ttl
 
 ## MetadataConverterPlugin ##
-rdf.metadata.mappings = ${dspace.dir}/config/modules/rdf/metadata-rdf-mapping.ttl
+rdf.metadata.mappings = ${dspace.dir}/config/modules/rdf/metadata-rdf-mapping
 rdf.metadata.schema = file://${dspace.dir}/config/modules/rdf/metadata-rdf-schema.ttl
 rdf.metadata.prefixes = ${dspace.dir}/config/modules/rdf/metadata-prefixes.ttl
 

--- a/dspace/config/modules/rdf/metadata-rdf-mapping-collection.ttl
+++ b/dspace/config/modules/rdf/metadata-rdf-mapping-collection.ttl
@@ -1,0 +1,103 @@
+@prefix rdf:        <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:       <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl:        <http://www.w3.org/2002/07/owl#> .
+@prefix xsd:        <http://www.w3.org/2001/XMLSchema#> .
+@prefix dc:         <http://purl.org/dc/elements/1.1/> .
+@prefix dcterms:    <http://purl.org/dc/terms/> .
+@prefix bibo:       <http://purl.org/ontology/bibo/> .
+
+@prefix dm:         <http://digital-repositories.org/ontologies/dspace-metadata-mapping/0.2.0#> .
+
+@prefix :           <#> .
+
+
+:title
+  dm:metadataName "dc.title" ;
+  dm:creates [
+    dm:subject dm:DSpaceObjectIRI ;
+    dm:predicate dcterms:title ;
+    dm:object dm:DSpaceValue ;
+  ] ;
+  .
+
+:description
+  dm:metadataName "dc.description.abstract" ;
+  dm:creates [
+    dm:subject dm:DSpaceObjectIRI ;
+    dm:predicate dc:description ;
+    dm:object [
+      a dm:LiteralGenerator ;
+      dm:pattern "$DSpaceValue" ;
+      dm:dspaceLanguageTag "true"^^xsd:boolean ;
+    ] ;
+  ];
+  .
+
+:news
+  dm:metadataName "dc.description.tableofcontents" ;
+  dm:creates [
+    dm:subject dm:DSpaceObjectIRI ;
+    dm:predicate dc:description ;
+    dm:object [
+      a dm:LiteralGenerator ;
+      dm:pattern "$DSpaceValue" ;
+      dm:dspaceLanguageTag "true"^^xsd:boolean ;
+    ] ;
+  ];
+  .
+
+:rights
+  dm:metadataName "dc.rights" ;
+  dm:creates [
+    dm:subject dm:DSpaceObjectIRI ;
+    dm:predicate dc:rights ;
+    dm:object dm:DSpaceValue ;
+  ];
+  .
+
+:handle
+  dm:metadataName "dc.identifier.uri" ;
+  dm:condition "^http://hdl.handle.net/.*$" ;
+  dm:creates [
+    dm:subject dm:DSpaceObjectIRI ;
+    dm:predicate bibo:handle ;
+    dm:object [
+      a dm:LiteralGenerator ;
+      dm:modifier [
+        dm:matcher "^http://hdl.handle.net/(.*)$" ;
+        dm:replacement "hdl:$1";
+      ];
+    ];
+  ];
+  .
+
+:localHandleURI
+  dm:metadataName "dc.identifier.uri" ;
+  dm:condition "^http://localhost:8080/jspui/handle/" ;
+  dm:creates [
+    dm:subject dm:DSpaceObjectIRI ;
+    dm:predicate bibo:handle ;
+    dm:object [
+      a dm:LiteralGenerator ;
+      dm:modifier [
+        dm:matcher "^http://localhost:8080/jspui/handle/(.*)$" ;
+        dm:replacement "hdl:$1";
+      ];
+      dm:pattern "$DSpaceValue";
+    ];
+  ];
+  .
+
+:uri
+  dm:metadataName "dc.identifier.uri" ;
+  dm:condition "^((?!http://dx.doi.org/)(?!http://hdl.handle.net/)(?!http://localhost:8080/jspui/handle/)).*" ;
+  dm:creates [
+    dm:subject dm:DSpaceObjectIRI ;
+    dm:predicate bibo:uri ;
+    dm:object [
+      a dm:ResourceGenerator ;
+      dm:pattern "$DSpaceValue" ;
+    ] ;
+  ];
+  .
+

--- a/dspace/config/modules/rdf/metadata-rdf-mapping-community.ttl
+++ b/dspace/config/modules/rdf/metadata-rdf-mapping-community.ttl
@@ -1,0 +1,117 @@
+@prefix rdf:        <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:       <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl:        <http://www.w3.org/2002/07/owl#> .
+@prefix xsd:        <http://www.w3.org/2001/XMLSchema#> .
+@prefix dc:         <http://purl.org/dc/elements/1.1/> .
+@prefix dcterms:    <http://purl.org/dc/terms/> .
+@prefix bibo:       <http://purl.org/ontology/bibo/> .
+
+@prefix dm:         <http://digital-repositories.org/ontologies/dspace-metadata-mapping/0.2.0#> .
+
+@prefix :           <#> .
+
+
+:name
+  dm:metadataName "dc.title" ;
+  dm:creates [
+    dm:subject dm:DSpaceObjectIRI ;
+    dm:predicate dcterms:title ;
+    dm:object dm:DSpaceValue ;
+  ] ;
+  .
+
+:description
+  dm:metadataName "dc.description.abstract" ;
+  dm:creates [
+    dm:subject dm:DSpaceObjectIRI ;
+    dm:predicate dc:description ;
+    dm:object [
+      a dm:LiteralGenerator ;
+      dm:pattern "$DSpaceValue" ;
+      dm:dspaceLanguageTag "true"^^xsd:boolean ;
+    ] ;
+  ];
+  .
+
+:introduction
+  dm:metadataName "dc.description" ;
+  dm:creates [
+    dm:subject dm:DSpaceObjectIRI ;
+    dm:predicate dc:description ;
+    dm:object [
+      a dm:LiteralGenerator ;
+      dm:pattern "$DSpaceValue" ;
+      dm:dspaceLanguageTag "true"^^xsd:boolean ;
+    ] ;
+  ];
+  .
+
+:news
+  dm:metadataName "dc.description.tableofcontents" ;
+  dm:creates [
+    dm:subject dm:DSpaceObjectIRI ;
+    dm:predicate dc:description ;
+    dm:object [
+      a dm:LiteralGenerator ;
+      dm:pattern "$DSpaceValue" ;
+      dm:dspaceLanguageTag "true"^^xsd:boolean ;
+    ] ;
+  ];
+  .
+
+:copyright
+  dm:metadataName "dc.rights" ;
+  dm:creates [
+    dm:subject dm:DSpaceObjectIRI ;
+    dm:predicate dc:rights ;
+    dm:object dm:DSpaceValue ;
+  ];
+  .
+
+:handle
+  dm:metadataName "dc.identifier.uri" ;
+  dm:condition "^http://hdl.handle.net/.*$" ;
+  dm:creates [
+    dm:subject dm:DSpaceObjectIRI ;
+    dm:predicate bibo:handle ;
+    dm:object [
+      a dm:LiteralGenerator ;
+      dm:modifier [
+        dm:matcher "^http://hdl.handle.net/(.*)$" ;
+        dm:replacement "hdl:$1";
+      ];
+    ];
+  ];
+  .
+
+:localHandleURI
+  dm:metadataName "dc.identifier.uri" ;
+  dm:condition "^http://localhost:8080/jspui/handle/" ;
+  dm:creates [
+    dm:subject dm:DSpaceObjectIRI ;
+    dm:predicate bibo:handle ;
+    dm:object [
+      a dm:LiteralGenerator ;
+      dm:modifier [
+        dm:matcher "^http://localhost:8080/jspui/handle/(.*)$" ;
+        dm:replacement "hdl:$1";
+      ];
+      dm:pattern "$DSpaceValue";
+    ];
+  ];
+  .
+
+:uri
+  dm:metadataName "dc.identifier.uri" ;
+  dm:condition "^((?!http://dx.doi.org/)(?!http://hdl.handle.net/)(?!http://localhost:8080/jspui/handle/)).*" ;
+  dm:creates [
+    dm:subject dm:DSpaceObjectIRI ;
+    dm:predicate bibo:uri ;
+    dm:object [
+      a dm:ResourceGenerator ;
+      dm:pattern "$DSpaceValue" ;
+    ] ;
+  ];
+  .
+
+

--- a/dspace/config/modules/rdf/metadata-rdf-mapping-item.ttl
+++ b/dspace/config/modules/rdf/metadata-rdf-mapping-item.ttl
@@ -228,7 +228,7 @@
     dm:object dm:DSpaceValue ;
   ];
   .
-  
+
 :issn
   dm:metadataName "dc.identifier.issn" ;
   dm:creates [
@@ -284,7 +284,7 @@
     dm:object dm:DSpaceValue ;
   ];
   .
-  
+
 :publisher
   dm:metadataName "dc.publisher" ;
   dm:creates [
@@ -293,7 +293,7 @@
     dm:object dm:DSpaceValue ;
   ];
   .
-  
+
 :hasPart
   dm:metadataName "dc.relation.haspart";
   dm:creates [

--- a/dspace/config/modules/rdf/metadata-rdf-mapping-site.ttl
+++ b/dspace/config/modules/rdf/metadata-rdf-mapping-site.ttl
@@ -1,0 +1,63 @@
+@prefix rdf:        <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:       <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl:        <http://www.w3.org/2002/07/owl#> .
+@prefix xsd:        <http://www.w3.org/2001/XMLSchema#> .
+@prefix dc:         <http://purl.org/dc/elements/1.1/> .
+@prefix dcterms:    <http://purl.org/dc/terms/> .
+@prefix bibo:       <http://purl.org/ontology/bibo/> .
+
+@prefix dm:         <http://digital-repositories.org/ontologies/dspace-metadata-mapping/0.2.0#> .
+
+@prefix :           <#> .
+
+:name
+  dm:metadataName "dspace.name" ;
+  dm:creates [
+    dm:subject dm:DSpaceObjectIRI ;
+    dm:predicate dcterms:title ;
+    dm:object dm:DSpaceValue ;
+  ] ;
+  .
+
+:hostname
+  dm:metadataName "dspace.hostname" ;
+  dm:creates [
+    dm:subject dm:DSpaceObjectIRI ;
+    dm:predicate bibo:handle ;
+    dm:object dm:DSpaceValue ;
+  ];
+  .
+
+:handle
+  dm:metadataName "dspace.handle" ;
+  dm:creates [
+    dm:subject dm:DSpaceObjectIRI ;
+    dm:predicate bibo:handle ;
+    dm:object dm:DSpaceValue ;
+  ];
+  .
+
+:languageISO
+  dm:metadataName "dc.language.iso" ;
+  dm:creates [
+    dm:subject dm:DSpaceObjectIRI ;
+    dm:predicate dc:language ;
+    dm:object [
+      a dm:LiteralGenerator ;
+      dm:modifier [
+        dm:matcher "^(..)_(.*)$" ;
+        dm:replacement "$1-$2";
+      ];
+      dm:pattern "$DSpaceValue";
+    ];
+  ];
+  .
+
+:language
+  dm:metadataName "dc.language" ;
+  dm:creates [
+    dm:subject dm:DSpaceObjectIRI ;
+    dm:predicate dc:language ;
+    dm:object dm:DSpaceValue ;
+  ];
+  .


### PR DESCRIPTION
This PR allows the MetadataConvertorPlugin to map community and collection metadata to RDF in addition to items.

When this code is in place and the rdfizer has been rerun, visiting a community or collection URI should return metadata enhanced RDF (dc:rights, dcterms:abstract, and dcterms:title) similar to the following:

`@prefix void:  <http://rdfs.org/ns/void#> .
@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
@prefix dcterms: <http://purl.org/dc/terms/> .
@prefix bibo:  <http://purl.org/ontology/bibo/> .
@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
@prefix dspace: <http://digital-repositories.org/ontologies/dspace/0.1.0#> .
@prefix dc:    <http://purl.org/dc/elements/1.1/> .`


`<[server]/rdf/resource/123456789/152547>
        a                         bibo:Collection ;
        dspace:hasItem            <[server]/rdf/resource/123456789/152571> ;
        dspace:isPartOfCommunity  <[server]/rdf/resource/123456789/152545> ;
        dc:rights                 "Copyright text (HTML):" ;
        dcterms:abstract          "Short Description:" ;
        dcterms:hasPart           <[server]/rdf/resource/123456789/152573> ;
        dcterms:isPartOf          <[server]/rdf/resource/123456789/152546> ;
        dcterms:title             "2017-11-06 DSpace 6.2 test collection 1" ;
        void:sparqlEndpoint       <[fuseki server]/fuseki/dspace/sparql> ;
        foaf:homepage             <[server]/xmlui> .`


