### PR TITLE
DS-3710 Fix ehcache config conflict (Reapply to 6.x)

### DIFF
--- a/dspace/config/hibernate-ehcache-config.xml
+++ b/dspace/config/hibernate-ehcache-config.xml
@@ -12,9 +12,7 @@
          xsi:noNamespaceSchemaLocation="ehcache.xsd"
          updateCheck='false'>
 
-    <!-- WARNING: If you are running multiple DSpace instances on the same server, make sure to start
-         each DSpace instance with another value for java.io.tmpdir !!! -->
-    <diskStore path="java.io.tmpdir/DSpaceHibernateCache"/>
+    <diskStore path="java.io.tmpdir"/>
 
     <!--
     Mandatory Default Cache configuration. These settings will be applied to caches


### PR DESCRIPTION
This PR simply reapplies the fix from #1860 to the 6.x branch.  We accidentally reverted these changes in #2014, and they need to be re-synced.

@kshepherd can you give this a quick review & merge immediately for 6.3. It's simply reapplying changes that we already accepted/reviewed, but accidentally reverted.