### PR TITLE
DS-3930 Remove extra space

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -2129,7 +2129,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         try{
             SolrQuery solrQuery = new SolrQuery();
             //Set the query to handle since this is unique
-            solrQuery.setQuery(HANDLE_FIELD + ": " + item.getHandle());
+            solrQuery.setQuery(HANDLE_FIELD + ":" + item.getHandle());
             //Only return obj identifier fields in result doc
             solrQuery.setFields(HANDLE_FIELD, RESOURCE_TYPE_FIELD, RESOURCE_ID_FIELD);
             //Add the more like this parameters !


### PR DESCRIPTION
SolrServiceImpl [line 2002](https://github.com/DSpace/DSpace/blob/fa6dc2d07d6807a76fc474f112b132ca8c1686d8/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java#L2002) in DSpace6 adds an extra space after a colon, making queries behave wrong in some cases. 

JIRA report: https://jira.duraspace.org/browse/DS-3930