### PR TITLE
DS-950: OAI should respect metadata.hidden... config properties.

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -276,10 +276,10 @@ public class XOAI {
         }
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        XmlOutputContext context = XmlOutputContext.emptyContext(out, Second);
-        retrieveMetadata(item).write(context);
-        context.getWriter().flush();
-        context.getWriter().close();
+        XmlOutputContext xmlContext = XmlOutputContext.emptyContext(out, Second);
+        retrieveMetadata(context, item).write(xmlContext);
+        xmlContext.getWriter().flush();
+        xmlContext.getWriter().close();
         doc.addField("item.compile", out.toString());
 
         if (verbose) {
@@ -466,7 +466,7 @@ public class XOAI {
             while (iterator.hasNext()) {
                 Item item = iterator.next();
                 if (verbose) System.out.println("Compiling item with handle: " + item.getHandle());
-                xoaiItemCacheService.put(item, retrieveMetadata(item));
+                xoaiItemCacheService.put(item, retrieveMetadata(context, item));
                 context.clearCache();
             }
 

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceItemDatabaseRepository.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceItemDatabaseRepository.java
@@ -68,13 +68,13 @@ public class DSpaceItemDatabaseRepository extends DSpaceItemRepository
         this.useCache = configurationService.getBooleanProperty("oai", "cache.enabled", true);
     }
     
-    private Metadata getMetadata (org.dspace.content.Item item) throws IOException {
+    private Metadata getMetadata (org.dspace.content.Item item) throws IOException, ContextServiceException {
         if (this.useCache) {
             if (!cacheService.hasCache(item))
-                cacheService.put(item, ItemUtils.retrieveMetadata(item));
+                cacheService.put(item, ItemUtils.retrieveMetadata(context.getContext(), item));
             
             return cacheService.get(item);
-        } else return ItemUtils.retrieveMetadata(item);
+        } else return ItemUtils.retrieveMetadata(context.getContext(), item);
     }
 
     private List<ReferenceSet> getSets(org.dspace.content.Item item)

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -893,6 +893,10 @@ webui.licence_bundle.show = false
 # logged-in user is an Administrator:
 #  1. XMLUI metadata XML view, and Item splash pages (long and short views).
 #  2. JSPUI Item splash pages
+#  3. OAI (every where as there is currently no possibility to authenticate)
+#     Attention: You need to rebuild the OAI SOLR index after every change of
+#     this property. Run [dspace-install]/bin/dspace oai import -c to do so.
+#
 # To designate a field as hidden, add a property here in the form:
 #    metadata.hide.SCHEMA.ELEMENT.QUALIFIER = true
 #


### PR DESCRIPTION
This is a port of #1113 to 5.x. This fix was first released in 6.0, but was never backported to previous releases.

https://jira.duraspace.org/browse/DS-950

This PR is slightly larger than the one in #1113, because I had to backport some additional minor refactors to OAI-PMH code that were made during the 6.x Java API refactor.

This has not been heavily tested, but the code compiles and the logic is the same as in 6.0. Testers/verifiers are welcome!