### PR TITLE
DS-3933 Updated Pubmed endpoints from http:// to https://.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/importer/external/pubmed/service/PubmedImportMetadataSourceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/pubmed/service/PubmedImportMetadataSourceServiceImpl.java
@@ -114,7 +114,7 @@ public class PubmedImportMetadataSourceServiceImpl extends AbstractImportMetadat
      */
     @Override
     public String getImportSource() {
-        return "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/";
+        return "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/";
     }
 
     /** Finds records based on an item

--- a/dspace-api/src/main/java/org/dspace/submit/lookup/PubmedService.java
+++ b/dspace-api/src/main/java/org/dspace/submit/lookup/PubmedService.java
@@ -108,7 +108,7 @@ public class PubmedService
                 client.getParams().setIntParameter(CoreConnectionPNames.CONNECTION_TIMEOUT, timeout);
 
                 URIBuilder uriBuilder = new URIBuilder(
-                        "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi");
+                        "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi");
                 uriBuilder.addParameter("db", "pubmed");
                 uriBuilder.addParameter("datetype", "edat");
                 uriBuilder.addParameter("retmax", "10");
@@ -226,7 +226,7 @@ public class PubmedService
 
             try {
                 URIBuilder uriBuilder = new URIBuilder(
-                        "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi");
+                        "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi");
                 uriBuilder.addParameter("db", "pubmed");
                 uriBuilder.addParameter("retmode", "xml");
                 uriBuilder.addParameter("rettype", "full");

--- a/dspace-api/src/main/resources/spring/spring-dspace-addon-import-services.xml
+++ b/dspace-api/src/main/resources/spring/spring-dspace-addon-import-services.xml
@@ -27,14 +27,14 @@
     <!--If multiple importServices have been configured here but only one is to be used during the lookup step (StartSubmissionLookupStep),
         this can be accomplished by specifying the property "publication-lookup.url" to the baseAddress of the required importService
         So for example
-        publication-lookup.url=http://eutils.ncbi.nlm.nih.gov/entrez/eutils/
+        publication-lookup.url=https://eutils.ncbi.nlm.nih.gov/entrez/eutils/
         Will result in using the PubmedImportService for the lookup step
         Omitting this property will default to searching over all configured ImportService implementations
     -->
 
     <bean id="PubmedImportService" class="org.dspace.importer.external.pubmed.service.PubmedImportMetadataSourceServiceImpl" scope="singleton">
         <property name="metadataFieldMapping" ref="PubmedMetadataFieldMapping"/>
-        <property name="baseAddress" value="http://eutils.ncbi.nlm.nih.gov/entrez/eutils/"/>
+        <property name="baseAddress" value="https://eutils.ncbi.nlm.nih.gov/entrez/eutils/"/>
 
     </bean>
     <bean id="PubmedMetadataFieldMapping"

--- a/dspace/config/modules/publication-lookup.cfg
+++ b/dspace/config/modules/publication-lookup.cfg
@@ -9,7 +9,7 @@
 # importServices will be used.
 #
 # Example, this setting will ONLY used the PubMedImportService
-# publication-lookup.url = http://eutils.ncbi.nlm.nih.gov/entrez/eutils/
+# publication-lookup.url = https://eutils.ncbi.nlm.nih.gov/entrez/eutils/
 #
 # Default value is * (which uses all import services)
 # publication-lookup.url = *


### PR DESCRIPTION
Fixes https://jira.duraspace.org/browse/DS-3933 for DSpace 6.x. Leaves DSpace 7 and other versions unchanged.

I didn't find any integration tests for this feature but I'm willing to write some if somebody guides me through specifics like loading MetadataFieldMappings.