### PR TITLE
DS-3936 bower registry needs updating (blocker)

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/.bowerrc
+++ b/dspace-xmlui-mirage2/src/main/webapp/.bowerrc
@@ -1,3 +1,4 @@
 {
     "directory": "vendor"
+    "registry": "https://registry.bower.io"
 }

--- a/dspace-xmlui-mirage2/src/main/webapp/.bowerrc
+++ b/dspace-xmlui-mirage2/src/main/webapp/.bowerrc
@@ -1,4 +1,4 @@
 {
-    "directory": "vendor"
+    "directory": "vendor",
     "registry": "https://registry.bower.io"
 }


### PR DESCRIPTION
Resubmitting #2098 as I'd previously included some other commits in the PR, in error
(license changes now committed to 6.x).

As per https://jira.duraspace.org/browse/DS-3936, 5.x and 6.x are currently broken for anyone trying to build mirage2 because the old registry URL is broken, we need to switch to https://registry.bower.io

(and even if the herokuapp URL is fixed, it remains at risk - it's been deprecated for over 6 months)

This needs backporting to 5.x