### PR TITLE
[DS-3938] Use JDK7-compatible PostgreSQL JDBC driver in DSpace 5.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1164,7 +1164,7 @@
          <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.1</version>
+            <version>42.2.1.jre7</version>
          </dependency>
          <dependency>
             <groupId>com.oracle</groupId>


### PR DESCRIPTION
#1970 updated the PostgreSQL JDBC driver. However, the default version in the Maven repositories require JDBC4.2 (JDK 8). This PR specifies to require JDK7-compatible version of the driver.