### PR TITLE
DS-3939 OAI-Harvester, skip item and continue if handle is missing

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -276,8 +276,11 @@ public class XOAI {
             while (iterator.hasNext()) {
                 try {
                     Item item = iterator.next();
-                    
-                    server.add(this.index(item));
+                    if (item.getHandle() == null) {
+                        log.warn("Skipped item without handle: " + item.getID());
+                    } else {
+                        server.add(this.index(item));
+                    }
                     context.uncacheEntity(item);
 
                 } catch (SQLException | MetadataBindException | ParseException | XMLStreamException


### PR DESCRIPTION
Allows OAI Harvester to continue if it encounters an Item missing a handle