### PR TITLE
DS-3489: Search API query filter operator and facet prefix

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/DiscoverQuery.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/DiscoverQuery.java
@@ -9,6 +9,7 @@ package org.dspace.discovery;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -330,7 +331,6 @@ public class DiscoverQuery {
             // Example: 2001 and a gap from 10 we need the following result: 2010 - 2000 ; 2000 - 1990 hence the top
             // year
             int topYear = getTopYear(newestYear, gap);
-
             if (gap == 1) {
                 //We need a list of our years
                 //We have a date range add faceting for our field
@@ -338,7 +338,8 @@ public class DiscoverQuery {
                 this.addFacetField(new DiscoverFacetField(facet.getIndexFieldName(), facet.getType(), 10,
                                                           facet.getSortOrderSidebar()));
             } else {
-                List<String> facetQueries = buildFacetQueriesWithGap(newestYear, oldestYear, dateFacet, gap, topYear);
+                List<String> facetQueries = buildFacetQueriesWithGap(newestYear, oldestYear, dateFacet, gap, topYear,
+                                                                     facet.getFacetLimit());
                 for (String facetQuery : CollectionUtils.emptyIfNull(facetQueries)) {
                     this.addFacetQuery(facetQuery);
                 }
@@ -347,10 +348,9 @@ public class DiscoverQuery {
     }
 
     private List<String> buildFacetQueriesWithGap(int newestYear, int oldestYear, String dateFacet, int gap,
-                                                  int topYear) {
+                                                  int topYear, int facetLimit) {
         List<String> facetQueries = new LinkedList<>();
-        //Create facet queries but limit them to 11 (11 == when we need to show a "show more" url)
-        for (int year = topYear; year > oldestYear && (facetQueries.size() < 11); year -= gap) {
+        for (int year = topYear; year > oldestYear && (facetQueries.size() < facetLimit); year -= gap) {
             //Add a filter to remove the last year only if we aren't the last year
             int bottomYear = year - gap;
             //Make sure we don't go below our last year found
@@ -368,10 +368,12 @@ public class DiscoverQuery {
             }
             facetQueries.add(dateFacet + ":[" + bottomYear + " TO " + currentTop + "]");
         }
+        Collections.reverse(facetQueries);
         return facetQueries;
     }
 
     private int getTopYear(int newestYear, int gap) {
         return (int) (Math.ceil((float) (newestYear) / gap) * gap);
     }
+
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/SearchService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SearchService.java
@@ -140,4 +140,6 @@ public interface SearchService {
 
     FacetYearRange getFacetYearRange(Context context, DSpaceObject scope, DiscoverySearchFilterFacet facet,
                                      List<String> filterQueries) throws SearchServiceException;
+
+    String calculateExtremeValue(Context context, String valueField, String sortField, DiscoverQuery.SORT_ORDER sortOrder)throws SearchServiceException;
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/SearchService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SearchService.java
@@ -141,5 +141,7 @@ public interface SearchService {
     FacetYearRange getFacetYearRange(Context context, DSpaceObject scope, DiscoverySearchFilterFacet facet,
                                      List<String> filterQueries) throws SearchServiceException;
 
-    String calculateExtremeValue(Context context, String valueField, String sortField, DiscoverQuery.SORT_ORDER sortOrder)throws SearchServiceException;
+    String calculateExtremeValue(Context context, String valueField,
+                                 String sortField, DiscoverQuery.SORT_ORDER sortOrder)
+        throws SearchServiceException;
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/SearchService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SearchService.java
@@ -141,6 +141,19 @@ public interface SearchService {
     FacetYearRange getFacetYearRange(Context context, DSpaceObject scope, DiscoverySearchFilterFacet facet,
                                      List<String> filterQueries) throws SearchServiceException;
 
+    /**
+     * This method returns us either the highest or lowest value for the field that we give to it
+     * depending on what sortOrder we give this method.
+     *
+     * @param context       The relevant DSpace context
+     * @param valueField    The field in solr for which we'll calculate the extreme value
+     * @param sortField     The field in solr for which we'll sort the calculated extreme value on
+     *                      This is typically the valueField appended with "_sort"
+     * @param sortOrder     Entering ascending will return the minimum value
+     *                      Entering descending will return the maximum value
+     * @return              Returns the min or max value based on the field in the parameters.
+     * @throws SearchServiceException
+     */
     String calculateExtremeValue(Context context, String valueField,
                                  String sortField, DiscoverQuery.SORT_ORDER sortOrder)
         throws SearchServiceException;

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -979,7 +979,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                     boolean shouldExposeMinMax = false;
                     DiscoverySearchFilter discoverySearchFilter = discoveryConfiguration.getSearchFilters().get(i);
                     if (StringUtils.equalsIgnoreCase(discoverySearchFilter.getFilterType(), "facet")) {
-                        if (((DiscoverySearchFilterFacet) discoverySearchFilter).isExposeMinMax()) {
+                        if (((DiscoverySearchFilterFacet) discoverySearchFilter).exposeMinAndMaxValue()) {
                             shouldExposeMinMax = true;
                         }
                     }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -1993,17 +1993,20 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         StringBuilder filterQuery = new StringBuilder();
         if (StringUtils.isNotBlank(field) && StringUtils.isNotBlank(value)) {
             filterQuery.append(field);
-            if ("equals".equals(operator)) {
-                //Query the keyword indexed field !
+
+
+            if(operator.endsWith("equals")){
                 filterQuery.append("_keyword");
-            } else if ("authority".equals(operator)) {
-                //Query the authority indexed field !
+            } else if (operator.endsWith("authority")){
                 filterQuery.append("_authority");
-            } else if ("notequals".equals(operator)
-                || "notcontains".equals(operator)
-                || "notauthority".equals(operator)) {
+            }
+
+            if(operator.startsWith("not")){
                 filterQuery.insert(0, "-");
             }
+
+
+
             filterQuery.append(":");
             if ("equals".equals(operator) || "notequals".equals(operator)) {
                 //DO NOT ESCAPE RANGE QUERIES !

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -1995,13 +1995,13 @@ public class SolrServiceImpl implements SearchService, IndexingService {
             filterQuery.append(field);
 
 
-            if(operator.endsWith("equals")){
+            if (operator.endsWith("equals")) {
                 filterQuery.append("_keyword");
-            } else if (operator.endsWith("authority")){
+            } else if (operator.endsWith("authority")) {
                 filterQuery.append("_authority");
             }
 
-            if(operator.startsWith("not")){
+            if (operator.startsWith("not")) {
                 filterQuery.insert(0, "-");
             }
 

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -1020,9 +1020,11 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                         MetadataValue lastMetadataValue = metadataValueList.get(metadataValueList.size() - 1);
 
                         doc.addField(discoverySearchFilter.getIndexFieldName() + "_min", firstMetadataValue.getValue());
-                        doc.addField(discoverySearchFilter.getIndexFieldName() + "_min_sort", firstMetadataValue.getValue());
+                        doc.addField(discoverySearchFilter.getIndexFieldName()
+                                         + "_min_sort", firstMetadataValue.getValue());
                         doc.addField(discoverySearchFilter.getIndexFieldName() + "_max", lastMetadataValue.getValue());
-                        doc.addField(discoverySearchFilter.getIndexFieldName() + "_max_sort", lastMetadataValue.getValue());
+                        doc.addField(discoverySearchFilter.getIndexFieldName()
+                                         + "_max_sort", lastMetadataValue.getValue());
 
                     }
                 }
@@ -2255,5 +2257,30 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         FacetYearRange result = new FacetYearRange(facet);
         result.calculateRange(context, filterQueries, scope, this);
         return result;
+    }
+
+    @Override
+    public String calculateExtremeValue(Context context, String valueField,
+                                        String sortField,
+                                        DiscoverQuery.SORT_ORDER sortOrder)
+        throws SearchServiceException {
+
+        DiscoverQuery maxQuery = new DiscoverQuery();
+        maxQuery.setMaxResults(1);
+        //Set our query to anything that has this value
+        maxQuery.addFieldPresentQueries(valueField);
+        //Set sorting so our last value will appear on top
+        maxQuery.setSortField(sortField, sortOrder);
+        maxQuery.addSearchField(valueField);
+        DiscoverResult maxResult = this.search(context,maxQuery);
+        if (0 < maxResult.getDspaceObjects().size()) {
+            List<DiscoverResult.SearchDocument> searchDocuments = maxResult
+                .getSearchDocument(maxResult.getDspaceObjects().get(0));
+            if (0 < searchDocuments.size() && 0 < searchDocuments.get(0).getSearchFieldValues
+                (valueField).size()) {
+                return searchDocuments.get(0).getSearchFieldValues(valueField).get(0);
+            }
+        }
+        return null;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoverySearchFilter.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoverySearchFilter.java
@@ -22,6 +22,8 @@ public class DiscoverySearchFilter {
     public static final String FILTER_TYPE_DEFAULT = "default";
     protected boolean isOpenByDefault = false;
 
+    protected int pageSize;
+
     public String getIndexFieldName() {
         return indexFieldName;
     }
@@ -70,4 +72,11 @@ public class DiscoverySearchFilter {
         this.isOpenByDefault = isOpenByDefault;
     }
 
+    public int getPageSize() {
+        return pageSize;
+    }
+
+    public void setPageSize(int pageSize) {
+        this.pageSize = pageSize;
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoverySearchFilter.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoverySearchFilter.java
@@ -42,10 +42,23 @@ public class DiscoverySearchFilter {
         this.metadataFields = metadataFields;
     }
 
+    /**
+     * Returns the type of the DiscoverySearchFilter
+     * @return  The type of the DiscoverySearchFilter
+     */
     public String getType() {
         return type;
     }
 
+    /**
+     * Sets the type of the DiscoverySearchFilter to the one given in the parameter if it matches
+     * a set of possible types
+     * The possible types are described in: {@link org.dspace.discovery.configuration.DiscoveryConfigurationParameters}
+     * For the DiscoverySearchFilter only the TYPE_TEXT, TYPE_DATE and TYPE_HIERARCHICAL are allowed
+     *
+     * @param type  The type for this DiscoverySearchFilter
+     * @throws DiscoveryConfigurationException  If none of the types match, this error will be thrown indiciating this
+     */
     public void setType(String type) throws DiscoveryConfigurationException {
         if (type.equalsIgnoreCase(DiscoveryConfigurationParameters.TYPE_TEXT)) {
             this.type = DiscoveryConfigurationParameters.TYPE_TEXT;

--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoverySearchFilter.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoverySearchFilter.java
@@ -62,11 +62,11 @@ public class DiscoverySearchFilter {
         return FILTER_TYPE_DEFAULT;
     }
 
-    public boolean isOpenByDefault(){
+    public boolean isOpenByDefault() {
         return isOpenByDefault;
     }
 
-    public void setIsOpenByDefault(boolean isOpenByDefault){
+    public void setIsOpenByDefault(boolean isOpenByDefault) {
         this.isOpenByDefault = isOpenByDefault;
     }
 

--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoverySearchFilter.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoverySearchFilter.java
@@ -20,6 +20,7 @@ public class DiscoverySearchFilter {
     protected List<String> metadataFields;
     protected String type = DiscoveryConfigurationParameters.TYPE_TEXT;
     public static final String FILTER_TYPE_DEFAULT = "default";
+    protected boolean isOpenByDefault = false;
 
     public String getIndexFieldName() {
         return indexFieldName;
@@ -59,6 +60,14 @@ public class DiscoverySearchFilter {
 
     public String getFilterType() {
         return FILTER_TYPE_DEFAULT;
+    }
+
+    public boolean isOpenByDefault(){
+        return isOpenByDefault;
+    }
+
+    public void setIsOpenByDefault(boolean isOpenByDefault){
+        this.isOpenByDefault = isOpenByDefault;
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoverySearchFilter.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoverySearchFilter.java
@@ -64,10 +64,21 @@ public class DiscoverySearchFilter {
         return FILTER_TYPE_DEFAULT;
     }
 
+    /**
+     * This method returns a boolean value indicating whether the search filter
+     * should be open or closed by default in the UI
+     * @return  A boolean value indicating whether the search filter in the ui should be open
+     *          or closed by default
+     */
     public boolean isOpenByDefault() {
         return isOpenByDefault;
     }
 
+    /**
+     * Sets the DiscoverySearchFilter to be open by default or not depending on the parameter given
+     * @param isOpenByDefault A boolean value that will indicate whether this DiscoverySearchFilter
+     *                        should be open by default or not in the UI.
+     */
     public void setIsOpenByDefault(boolean isOpenByDefault) {
         this.isOpenByDefault = isOpenByDefault;
     }

--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoverySearchFilterFacet.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoverySearchFilterFacet.java
@@ -56,11 +56,22 @@ public class DiscoverySearchFilterFacet extends DiscoverySearchFilter {
         return FILTER_TYPE_FACET;
     }
 
-    public boolean isExposeMinMax() {
+    /**
+     * This method returns whether or not the DiscoverySearchFilterFacet should return a
+     * min and max value.
+     *
+     * @return  A boolean indicating whether or not this DiscoverySearchFilterFacet should expose
+     *          a min and max value
+     */
+    public boolean exposeMinAndMaxValue() {
         return exposeMinMax;
     }
 
-    public void setExposeMinMax(boolean exposeMinMax) {
+    /**
+     * This method sets the boolean for {@link org.dspace.discovery.configuration.DiscoverySearchFilterFacet#exposeMinAndMaxValue}
+     * @param exposeMinMax A boolean value that will be set to return in the above mentioned link
+     */
+    public void setExposeMinAndMaxValue(boolean exposeMinMax) {
         this.exposeMinMax = exposeMinMax;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoverySearchFilterFacet.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoverySearchFilterFacet.java
@@ -21,7 +21,7 @@ public class DiscoverySearchFilterFacet extends DiscoverySearchFilter {
     private DiscoveryConfigurationParameters.SORT sortOrderSidebar = DiscoveryConfigurationParameters.SORT.COUNT;
     private DiscoveryConfigurationParameters.SORT sortOrderFilterPage = DiscoveryConfigurationParameters.SORT.COUNT;
     public static final String FILTER_TYPE_FACET = "facet";
-
+    private boolean exposeMinMax = false;
 
     public int getFacetLimit() {
         if (facetLimit == -1) {
@@ -54,5 +54,13 @@ public class DiscoverySearchFilterFacet extends DiscoverySearchFilter {
     @Override
     public String getFilterType() {
         return FILTER_TYPE_FACET;
+    }
+
+    public boolean isExposeMinMax() {
+        return exposeMinMax;
+    }
+
+    public void setExposeMinMax(boolean exposeMinMax) {
+        this.exposeMinMax = exposeMinMax;
     }
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
@@ -145,7 +145,7 @@ public class DiscoveryRestController implements InitializingBean {
             .getSearchObjects(query, dsoType, dsoScope, configurationName, searchFilters, page);
 
         //Convert the Search JSON results to paginated HAL resources
-        SearchResultsResource searchResultsResource = new SearchResultsResource(searchResultsRest, utils);
+        SearchResultsResource searchResultsResource = new SearchResultsResource(searchResultsRest, utils, page);
         halLinkService.addLinks(searchResultsResource, page);
         return searchResultsResource;
     }
@@ -153,7 +153,8 @@ public class DiscoveryRestController implements InitializingBean {
     @RequestMapping(method = RequestMethod.GET, value = "/facets")
     public FacetConfigurationResource getFacetsConfiguration(
         @RequestParam(name = "scope", required = false) String dsoScope,
-        @RequestParam(name = "configuration", required = false) String configurationName) throws Exception {
+        @RequestParam(name = "configuration", required = false) String configurationName,
+        Pageable pageable) throws Exception {
         if (log.isTraceEnabled()) {
             log.trace("Retrieving facet configuration for scope " + StringUtils.trimToEmpty(dsoScope)
                           + " and configuration name " + StringUtils.trimToEmpty(configurationName));
@@ -163,7 +164,7 @@ public class DiscoveryRestController implements InitializingBean {
             .getFacetsConfiguration(dsoScope, configurationName);
         FacetConfigurationResource facetConfigurationResource = new FacetConfigurationResource(facetConfigurationRest);
 
-        halLinkService.addLinks(facetConfigurationResource);
+        halLinkService.addLinks(facetConfigurationResource, pageable);
         return facetConfigurationResource;
     }
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
@@ -102,7 +102,8 @@ public class DiscoveryRestController implements InitializingBean {
                                     @RequestParam(name = "dsoType", required = false) String dsoType,
                                     @RequestParam(name = "scope", required = false) String dsoScope,
                                     @RequestParam(name = "configuration", required = false) String configurationName,
-                                    List<SearchFilter> searchFilters) throws Exception {
+                                    List<SearchFilter> searchFilters,
+                                    Pageable page) throws Exception {
 
         if (log.isTraceEnabled()) {
             log.trace("Searching with scope: " + StringUtils.trimToEmpty(dsoScope)
@@ -115,8 +116,8 @@ public class DiscoveryRestController implements InitializingBean {
         SearchResultsRest searchResultsRest = discoveryRestRepository
             .getAllFacets(query, dsoType, dsoScope, configurationName, searchFilters);
 
-        FacetsResource facetsResource = new FacetsResource(searchResultsRest);
-        halLinkService.addLinks(facetsResource);
+        FacetsResource facetsResource = new FacetsResource(searchResultsRest, page);
+        halLinkService.addLinks(facetsResource, page);
 
         return facetsResource;
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
@@ -171,6 +171,7 @@ public class DiscoveryRestController implements InitializingBean {
 
     @RequestMapping(method = RequestMethod.GET, value = "/facets/{name}")
     public ResourceSupport getFacetValues(@PathVariable("name") String facetName,
+                                          @RequestParam(name = "prefix", required = false) String prefix,
                                           @RequestParam(name = "query", required = false) String query,
                                           @RequestParam(name = "dsoType", required = false) String dsoType,
                                           @RequestParam(name = "scope", required = false) String dsoScope,
@@ -179,13 +180,14 @@ public class DiscoveryRestController implements InitializingBean {
         if (log.isTraceEnabled()) {
             log.trace("Facetting on facet " + facetName + " with scope: " + StringUtils.trimToEmpty(dsoScope)
                           + ", dsoType: " + StringUtils.trimToEmpty(dsoType)
+                          + ", prefix: " + StringUtils.trimToEmpty(prefix)
                           + ", query: " + StringUtils.trimToEmpty(dsoType)
                           + ", filters: " + Objects.toString(searchFilters)
                           + ", page: " + Objects.toString(page));
         }
 
         FacetResultsRest facetResultsRest = discoveryRestRepository
-            .getFacetObjects(facetName, query, dsoType, dsoScope, searchFilters, page);
+            .getFacetObjects(facetName, prefix, query, dsoType, dsoScope, searchFilters, page);
 
         FacetResultsResource facetResultsResource = new FacetResultsResource(facetResultsRest);
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -707,7 +707,7 @@ public class RestResourceController implements InitializingBean {
             // if we really want to implement pagination we should implement a
             // link repository so to fall in the previous block code
             EmbeddedPage ep = (EmbeddedPage) resource.getEmbeddedResources().get(rel);
-            List<? extends RestAddressableModel> fullList = ep.getFullList();
+            List<? extends RestAddressableModel> fullList = ep.getFullList().get(rel);
             if (fullList == null || fullList.size() == 0) {
                 return null;
             }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -707,7 +707,7 @@ public class RestResourceController implements InitializingBean {
             // if we really want to implement pagination we should implement a
             // link repository so to fall in the previous block code
             EmbeddedPage ep = (EmbeddedPage) resource.getEmbeddedResources().get(rel);
-            List<? extends RestAddressableModel> fullList = ep.getFullList().get(rel);
+            List<? extends RestAddressableModel> fullList = ep.getFullList();
             if (fullList == null || fullList.size() == 0) {
                 return null;
             }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/DiscoverConfigurationConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/DiscoverConfigurationConverter.java
@@ -67,6 +67,7 @@ public class DiscoverConfigurationConverter {
             filter.setType(discoverySearchFilter.getType());
             filter.setOpenByDefault(discoverySearchFilter.isOpenByDefault());
             filter.addDefaultOperatorsToList();
+            filter.setPageSize(discoverySearchFilter.getPageSize());
             searchConfigurationRest.addFilter(filter);
         }
     }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/DiscoverConfigurationConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/DiscoverConfigurationConverter.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
 import org.dspace.app.rest.model.SearchConfigurationRest;
 import org.dspace.discovery.configuration.DiscoveryConfiguration;
 import org.dspace.discovery.configuration.DiscoverySearchFilter;
@@ -29,7 +28,8 @@ public class DiscoverConfigurationConverter {
     public SearchConfigurationRest convert(DiscoveryConfiguration configuration) {
         SearchConfigurationRest searchConfigurationRest = new SearchConfigurationRest();
         if (configuration != null) {
-            addSearchFilters(searchConfigurationRest, configuration.getSearchFilters(), configuration.getSidebarFacets());
+            addSearchFilters(searchConfigurationRest,
+                             configuration.getSearchFilters(), configuration.getSidebarFacets());
             addSortOptions(searchConfigurationRest, configuration.getSearchSortConfiguration());
             setDefaultSortOption(configuration, searchConfigurationRest);
         }
@@ -53,18 +53,22 @@ public class DiscoverConfigurationConverter {
     }
 
 
-    public void addSearchFilters(SearchConfigurationRest searchConfigurationRest, List<DiscoverySearchFilter> searchFilterList, List<DiscoverySearchFilterFacet> facetList){
-        List<String> facetFieldNames = facetList.stream().map(DiscoverySearchFilterFacet::getIndexFieldName).collect(Collectors.toList());
-            for(DiscoverySearchFilter discoverySearchFilter : CollectionUtils.emptyIfNull(searchFilterList)){
-                SearchConfigurationRest.Filter filter = new SearchConfigurationRest.Filter();
-                filter.setFilter(discoverySearchFilter.getIndexFieldName());if(facetFieldNames.stream().anyMatch(str -> str.equals(discoverySearchFilter.getIndexFieldName()))){
+    public void addSearchFilters(SearchConfigurationRest searchConfigurationRest,
+                                 List<DiscoverySearchFilter> searchFilterList,
+                                 List<DiscoverySearchFilterFacet> facetList) {
+        List<String> facetFieldNames = facetList.stream().map(DiscoverySearchFilterFacet::getIndexFieldName)
+                                                .collect(Collectors.toList());
+        for (DiscoverySearchFilter discoverySearchFilter : CollectionUtils.emptyIfNull(searchFilterList)) {
+            SearchConfigurationRest.Filter filter = new SearchConfigurationRest.Filter();
+            filter.setFilter(discoverySearchFilter.getIndexFieldName());
+            if (facetFieldNames.stream().anyMatch(str -> str.equals(discoverySearchFilter.getIndexFieldName()))) {
                 filter.setHasFacets(true);
             }
             filter.setType(discoverySearchFilter.getType());
             filter.setOpenByDefault(discoverySearchFilter.isOpenByDefault());
-                filter.addDefaultOperatorsToList();
-                searchConfigurationRest.addFilter(filter);
-            }
+            filter.addDefaultOperatorsToList();
+            searchConfigurationRest.addFilter(filter);
+        }
     }
 
     private void addSortOptions(SearchConfigurationRest searchConfigurationRest,

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/DiscoverConfigurationConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/DiscoverConfigurationConverter.java
@@ -8,11 +8,14 @@
 package org.dspace.app.rest.converter;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
 import org.dspace.app.rest.model.SearchConfigurationRest;
 import org.dspace.discovery.configuration.DiscoveryConfiguration;
 import org.dspace.discovery.configuration.DiscoverySearchFilter;
+import org.dspace.discovery.configuration.DiscoverySearchFilterFacet;
 import org.dspace.discovery.configuration.DiscoverySortConfiguration;
 import org.dspace.discovery.configuration.DiscoverySortFieldConfiguration;
 import org.springframework.stereotype.Component;
@@ -26,7 +29,7 @@ public class DiscoverConfigurationConverter {
     public SearchConfigurationRest convert(DiscoveryConfiguration configuration) {
         SearchConfigurationRest searchConfigurationRest = new SearchConfigurationRest();
         if (configuration != null) {
-            addSearchFilters(searchConfigurationRest, configuration.getSearchFilters());
+            addSearchFilters(searchConfigurationRest, configuration.getSearchFilters(), configuration.getSidebarFacets());
             addSortOptions(searchConfigurationRest, configuration.getSearchSortConfiguration());
             setDefaultSortOption(configuration, searchConfigurationRest);
         }
@@ -50,14 +53,18 @@ public class DiscoverConfigurationConverter {
     }
 
 
-    public void addSearchFilters(SearchConfigurationRest searchConfigurationRest,
-                                 List<DiscoverySearchFilter> searchFilterList) {
-        for (DiscoverySearchFilter discoverySearchFilter : CollectionUtils.emptyIfNull(searchFilterList)) {
-            SearchConfigurationRest.Filter filter = new SearchConfigurationRest.Filter();
-            filter.setFilter(discoverySearchFilter.getIndexFieldName());
-            filter.addDefaultOperatorsToList();
-            searchConfigurationRest.addFilter(filter);
-        }
+    public void addSearchFilters(SearchConfigurationRest searchConfigurationRest, List<DiscoverySearchFilter> searchFilterList, List<DiscoverySearchFilterFacet> facetList){
+        List<String> facetFieldNames = facetList.stream().map(DiscoverySearchFilterFacet::getIndexFieldName).collect(Collectors.toList());
+            for(DiscoverySearchFilter discoverySearchFilter : CollectionUtils.emptyIfNull(searchFilterList)){
+                SearchConfigurationRest.Filter filter = new SearchConfigurationRest.Filter();
+                filter.setFilter(discoverySearchFilter.getIndexFieldName());if(facetFieldNames.stream().anyMatch(str -> str.equals(discoverySearchFilter.getIndexFieldName()))){
+                filter.setHasFacets(true);
+            }
+            filter.setType(discoverySearchFilter.getType());
+            filter.setOpenByDefault(discoverySearchFilter.isOpenByDefault());
+                filter.addDefaultOperatorsToList();
+                searchConfigurationRest.addFilter(filter);
+            }
     }
 
     private void addSortOptions(SearchConfigurationRest searchConfigurationRest,

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/DiscoverFacetConfigurationConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/DiscoverFacetConfigurationConverter.java
@@ -41,6 +41,7 @@ public class DiscoverFacetConfigurationConverter {
 
             SearchFacetEntryRest facetEntry = new SearchFacetEntryRest(discoverySearchFilterFacet.getIndexFieldName());
             facetEntry.setFacetType(discoverySearchFilterFacet.getType());
+            facetEntry.setFacetLimit(discoverySearchFilterFacet.getFacetLimit());
 
             facetConfigurationRest.addSidebarFacet(facetEntry);
         }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/DiscoverFacetResultsConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/DiscoverFacetResultsConverter.java
@@ -30,13 +30,13 @@ public class DiscoverFacetResultsConverter {
 
     private DiscoverFacetValueConverter facetValueConverter = new DiscoverFacetValueConverter();
 
-    public FacetResultsRest convert(Context context, String facetName, String query, String dsoType, String dsoScope,
-                                    List<SearchFilter> searchFilters, DiscoverResult searchResult,
+    public FacetResultsRest convert(Context context, String facetName, String prefix, String query, String dsoType,
+                                    String dsoScope, List<SearchFilter> searchFilters, DiscoverResult searchResult,
                                     DiscoveryConfiguration configuration, Pageable page) {
         FacetResultsRest facetResultsRest = new FacetResultsRest();
 
-        setRequestInformation(context, facetName, query, dsoType, dsoScope, searchFilters, searchResult, configuration,
-                              facetResultsRest, page);
+        setRequestInformation(context, facetName, prefix, query, dsoType, dsoScope, searchFilters, searchResult,
+                configuration, facetResultsRest, page);
 
         addToFacetResultList(facetName, searchResult, facetResultsRest, configuration, page);
 
@@ -65,11 +65,12 @@ public class DiscoverFacetResultsConverter {
         return facetValueConverter.convert(value);
     }
 
-    private void setRequestInformation(Context context, String facetName, String query, String dsoType, String dsoScope,
-                                       List<SearchFilter> searchFilters, DiscoverResult searchResult,
+    private void setRequestInformation(Context context, String facetName, String prefix, String query, String dsoType,
+                                       String dsoScope, List<SearchFilter> searchFilters, DiscoverResult searchResult,
                                        DiscoveryConfiguration configuration, FacetResultsRest facetResultsRest,
                                        Pageable page) {
         facetResultsRest.setQuery(query);
+        facetResultsRest.setPrefix(prefix);
         facetResultsRest.setScope(dsoScope);
         facetResultsRest.setDsoType(dsoType);
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/DiscoverFacetsConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/DiscoverFacetsConverter.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
 import org.dspace.app.rest.model.SearchFacetEntryRest;
 import org.dspace.app.rest.model.SearchFacetValueRest;
 import org.dspace.app.rest.model.SearchResultsRest;
@@ -28,6 +29,8 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class DiscoverFacetsConverter {
+
+    private static final Logger log = Logger.getLogger(DiscoverFacetsConverter.class);
 
     private DiscoverFacetValueConverter facetValueConverter = new DiscoverFacetValueConverter();
 
@@ -60,8 +63,8 @@ public class DiscoverFacetsConverter {
             SearchFacetEntryRest facetEntry = new SearchFacetEntryRest(field.getIndexFieldName());
             int valueCount = 0;
             facetEntry.setFacetLimit(field.getFacetLimit());
-            facetEntry.setExposeMinMax(field.isExposeMinMax());
-            if (field.isExposeMinMax()) {
+            facetEntry.setExposeMinMax(field.exposeMinAndMaxValue());
+            if (field.exposeMinAndMaxValue()) {
                 handleExposeMinMaxValues(context,field,facetEntry);
             }
             for (DiscoverResult.FacetResult value : CollectionUtils.emptyIfNull(facetValues)) {
@@ -102,7 +105,7 @@ public class DiscoverFacetsConverter {
                 facetEntry.setMaxValue(maxValue);
             }
         } catch (SearchServiceException e) {
-            e.printStackTrace();
+            log.error(e.getMessage(), e);
         }
     }
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/DiscoverFacetsConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/DiscoverFacetsConverter.java
@@ -88,6 +88,12 @@ public class DiscoverFacetsConverter {
         }
     }
 
+    /**
+     * This method will fill the facetEntry with the appropriate min and max values if they're not empty
+     * @param context       The relevant DSpace context
+     * @param field         The DiscoverySearchFilterFacet field to search for this value in solr
+     * @param facetEntry    The SearchFacetEntryRest facetEntry for which this needs to be filled in
+     */
     private void handleExposeMinMaxValues(Context context,DiscoverySearchFilterFacet field,
                                           SearchFacetEntryRest facetEntry) {
         try {

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/DiscoverResultConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/DiscoverResultConverter.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
 import org.dspace.app.rest.converter.query.SearchQueryConverter;
 import org.dspace.app.rest.model.DSpaceObjectRest;
 import org.dspace.app.rest.model.SearchFacetEntryRest;
@@ -38,6 +39,8 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class DiscoverResultConverter {
+
+    private static final Logger log = Logger.getLogger(DiscoverResultConverter.class);
 
     @Autowired
     private List<DSpaceObjectConverter> converters;
@@ -76,10 +79,10 @@ public class DiscoverResultConverter {
             int valueCount = 0;
             facetEntry.setHasMore(false);
             facetEntry.setFacetLimit(field.getFacetLimit());
-            if (field.isExposeMinMax()) {
+            if (field.exposeMinAndMaxValue()) {
                 handleExposeMinMaxValues(context,field,facetEntry);
             }
-            facetEntry.setExposeMinMax(field.isExposeMinMax());
+            facetEntry.setExposeMinMax(field.exposeMinAndMaxValue());
             for (DiscoverResult.FacetResult value : CollectionUtils.emptyIfNull(facetValues)) {
                 //The discover results contains max facetLimit + 1 values. If we reach the "+1", indicate that there are
                 //more results available.
@@ -118,7 +121,7 @@ public class DiscoverResultConverter {
                 facetEntry.setMaxValue(maxValue);
             }
         } catch (SearchServiceException e) {
-            e.printStackTrace();
+            log.error(e.getMessage(), e);
         }
     }
     private void addSearchResults(final DiscoverResult searchResult, final SearchResultsRest resultsRest) {

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/DiscoverResultConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/DiscoverResultConverter.java
@@ -104,6 +104,13 @@ public class DiscoverResultConverter {
             resultsRest.addFacetEntry(facetEntry);
         }
     }
+
+    /**
+     * This method will fill the facetEntry with the appropriate min and max values if they're not empty
+     * @param context       The relevant DSpace context
+     * @param field         The DiscoverySearchFilterFacet field to search for this value in solr
+     * @param facetEntry    The SearchFacetEntryRest facetEntry for which this needs to be filled in
+     */
     private void handleExposeMinMaxValues(Context context,DiscoverySearchFilterFacet field,
                                           SearchFacetEntryRest facetEntry) {
         try {

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/DiscoverResultConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/DiscoverResultConverter.java
@@ -70,6 +70,7 @@ public class DiscoverResultConverter {
             facetEntry.setHasMore(false);
             facetEntry.setFacetLimit(field.getFacetLimit());
 
+            facetEntry.setExposeMinMax(field.isExposeMinMax());
             for (DiscoverResult.FacetResult value : CollectionUtils.emptyIfNull(facetValues)) {
                 //The discover results contains max facetLimit + 1 values. If we reach the "+1", indicate that there are
                 //more results available.

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/DiscoverResultConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/DiscoverResultConverter.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang.StringUtils;
+import org.dspace.app.rest.converter.query.SearchQueryConverter;
 import org.dspace.app.rest.model.DSpaceObjectRest;
 import org.dspace.app.rest.model.SearchFacetEntryRest;
 import org.dspace.app.rest.model.SearchFacetValueRest;
@@ -164,9 +165,12 @@ public class DiscoverResultConverter {
             Sort.Order order = page.getSort().iterator().next();
             resultsRest.setSort(order.getProperty(), order.getDirection().name());
         }
+        SearchQueryConverter searchQueryConverter = new SearchQueryConverter();
+        List<SearchFilter> transformedFilters = searchQueryConverter.convert(searchFilters);
+
         SearchFilterToAppliedFilterConverter searchFilterToAppliedFilterConverter =
             new SearchFilterToAppliedFilterConverter();
-        for (SearchFilter searchFilter : CollectionUtils.emptyIfNull(searchFilters)) {
+        for (SearchFilter searchFilter : CollectionUtils.emptyIfNull(transformedFilters)) {
 
             resultsRest
                 .addAppliedFilter(searchFilterToAppliedFilterConverter.convertSearchFilter(context, searchFilter));

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/query/SearchQueryConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/query/SearchQueryConverter.java
@@ -15,8 +15,19 @@ import org.apache.commons.lang.StringUtils;
 import org.dspace.app.rest.model.query.RestSearchOperator;
 import org.dspace.app.rest.parameter.SearchFilter;
 
+/**
+ * This method will traverse a list of SearchFilters and transform any SearchFilters with an operator
+ * this is equal to 'Query' into a SearchFilter that has a standard DSpace operator like 'contains'
+ */
 public class SearchQueryConverter {
 
+    /**
+     * This method traverses the list of SearchFilters and transforms all of those that contain 'Query'
+     * as the operator into a standard DSpace SearchFilter
+     *
+     * @param   searchFilters The list of SearchFilters to be used
+     * @return  A list of transformed SearchFilters
+     */
     public List<SearchFilter> convert(List<SearchFilter> searchFilters) {
 
         List<SearchFilter> transformedSearchFilters = new LinkedList<>();
@@ -32,6 +43,12 @@ public class SearchQueryConverter {
 
     }
 
+    /**
+     * This method takes care of the converter of a specific SearchFilter given to it
+     *
+     * @param searchFilter  The SearchFilter to be transformed
+     * @return  The transformed SearchFilter
+     */
     public SearchFilter convertQuerySearchFilterIntoStandardSearchFilter(SearchFilter searchFilter) {
         RestSearchOperator restSearchOperator = RestSearchOperator.forQuery(searchFilter.getValue());
         SearchFilter transformedSearchFilter = new SearchFilter(searchFilter.getName(),

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/query/SearchQueryConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/query/SearchQueryConverter.java
@@ -2,18 +2,18 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.app.rest.converter.query;
 
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.dspace.app.rest.model.query.RestSearchOperator;
 import org.dspace.app.rest.parameter.SearchFilter;
-import org.apache.commons.collections4.CollectionUtils;
-
-import java.util.LinkedList;
-import java.util.List;
 
 public class SearchQueryConverter {
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/query/SearchQueryConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/query/SearchQueryConverter.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.app.rest.converter.query;
 
 import org.apache.commons.lang.StringUtils;

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/query/SearchQueryConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/query/SearchQueryConverter.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- *
+ * <p>
  * http://www.dspace.org/license/
  */
 package org.dspace.app.rest.converter.query;
@@ -11,16 +11,17 @@ import org.apache.commons.lang.StringUtils;
 import org.dspace.app.rest.model.query.RestSearchOperator;
 import org.dspace.app.rest.parameter.SearchFilter;
 import org.apache.commons.collections4.CollectionUtils;
+
 import java.util.LinkedList;
 import java.util.List;
 
 public class SearchQueryConverter {
 
-    public List<SearchFilter> convert(List<SearchFilter> searchFilters){
+    public List<SearchFilter> convert(List<SearchFilter> searchFilters) {
 
         List<SearchFilter> transformedSearchFilters = new LinkedList<>();
-        for(SearchFilter searchFilter : CollectionUtils.emptyIfNull(searchFilters)){
-            if(StringUtils.equals(searchFilter.getOperator(), "query")){
+        for (SearchFilter searchFilter : CollectionUtils.emptyIfNull(searchFilters)) {
+            if (StringUtils.equals(searchFilter.getOperator(), "query")) {
                 SearchFilter transformedSearchFilter = convertQuerySearchFilterIntoStandardSearchFilter(searchFilter);
                 transformedSearchFilters.add(transformedSearchFilter);
             } else {
@@ -31,9 +32,10 @@ public class SearchQueryConverter {
 
     }
 
-    public SearchFilter convertQuerySearchFilterIntoStandardSearchFilter(SearchFilter searchFilter){
+    public SearchFilter convertQuerySearchFilterIntoStandardSearchFilter(SearchFilter searchFilter) {
         RestSearchOperator restSearchOperator = RestSearchOperator.forQuery(searchFilter.getValue());
-        SearchFilter transformedSearchFilter = new SearchFilter(searchFilter.getName(), restSearchOperator.getDspaceOperator(), restSearchOperator.extractValue(searchFilter.getValue()));
+        SearchFilter transformedSearchFilter = new SearchFilter(searchFilter.getName(),
+                restSearchOperator.getDspaceOperator(), restSearchOperator.extractValue(searchFilter.getValue()));
         return transformedSearchFilter;
     }
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/query/SearchQueryConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/query/SearchQueryConverter.java
@@ -1,0 +1,32 @@
+package org.dspace.app.rest.converter.query;
+
+import org.apache.commons.lang.StringUtils;
+import org.dspace.app.rest.model.query.RestSearchOperator;
+import org.dspace.app.rest.parameter.SearchFilter;
+import org.apache.commons.collections4.CollectionUtils;
+import java.util.LinkedList;
+import java.util.List;
+
+public class SearchQueryConverter {
+
+    public List<SearchFilter> convert(List<SearchFilter> searchFilters){
+
+        List<SearchFilter> transformedSearchFilters = new LinkedList<>();
+        for(SearchFilter searchFilter : CollectionUtils.emptyIfNull(searchFilters)){
+            if(StringUtils.equals(searchFilter.getOperator(), "query")){
+                SearchFilter transformedSearchFilter = convertQuerySearchFilterIntoStandardSearchFilter(searchFilter);
+                transformedSearchFilters.add(transformedSearchFilter);
+            } else {
+                transformedSearchFilters.add(searchFilter);
+            }
+        }
+        return transformedSearchFilters;
+
+    }
+
+    public SearchFilter convertQuerySearchFilterIntoStandardSearchFilter(SearchFilter searchFilter){
+        RestSearchOperator restSearchOperator = RestSearchOperator.forQuery(searchFilter.getValue());
+        SearchFilter transformedSearchFilter = new SearchFilter(searchFilter.getName(), restSearchOperator.getDspaceOperator(), restSearchOperator.extractValue(searchFilter.getValue()));
+        return transformedSearchFilter;
+    }
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/HalLinkService.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/HalLinkService.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.log4j.Logger;
 import org.dspace.app.rest.model.hateoas.EmbeddedPage;
@@ -65,9 +66,11 @@ public class HalLinkService {
                     }
                 }
             } else if (obj instanceof EmbeddedPage) {
-                for (Object subObj : ((EmbeddedPage) obj).getPageContent().values()) {
-                    if (subObj instanceof HALResource) {
-                        addLinks((HALResource) subObj);
+                for (Map.Entry<String, List> pageContent : ((EmbeddedPage) obj).getPageContent().entrySet()) {
+                    for (Object subObj : CollectionUtils.emptyIfNull(pageContent.getValue())) {
+                        if (subObj instanceof HALResource) {
+                            addLinks((HALResource) subObj);
+                        }
                     }
                 }
             } else if (obj instanceof HALResource) {

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/HalLinkService.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/HalLinkService.java
@@ -65,7 +65,7 @@ public class HalLinkService {
                     }
                 }
             } else if (obj instanceof EmbeddedPage) {
-                for (Object subObj : ((EmbeddedPage) obj).getPageContent()) {
+                for (Object subObj : ((EmbeddedPage) obj).getPageContent().values()) {
                     if (subObj instanceof HALResource) {
                         addLinks((HALResource) subObj);
                     }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/DiscoveryRestHalLinkFactory.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/DiscoveryRestHalLinkFactory.java
@@ -34,7 +34,8 @@ public abstract class DiscoveryRestHalLinkFactory<T> extends HalLinkFactory<T, D
     }
 
     protected UriComponentsBuilder buildFacetBaseLink(final FacetResultsRest data) throws Exception {
-        UriComponentsBuilder uriBuilder = uriBuilder(getMethodOn()
+        try {
+            UriComponentsBuilder uriBuilder = uriBuilder(getMethodOn()
                                                          .getFacetValues(data.getFacetEntry().getName(),
                                                                          data.getPrefix(), data.getQuery(),
                                                                          data.getDsoType(), data.getScope(),

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/DiscoveryRestHalLinkFactory.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/DiscoveryRestHalLinkFactory.java
@@ -33,12 +33,12 @@ public abstract class DiscoveryRestHalLinkFactory<T> extends HalLinkFactory<T, D
         }
     }
 
-    protected UriComponentsBuilder buildFacetBaseLink(final FacetResultsRest data) {
-        try {
-            UriComponentsBuilder uriBuilder = uriBuilder(getMethodOn()
-                    .getFacetValues(data.getFacetEntry().getName(),
-                            data.getQuery(), data.getDsoType(),
-                            data.getScope(), null, null));
+    protected UriComponentsBuilder buildFacetBaseLink(final FacetResultsRest data) throws Exception {
+        UriComponentsBuilder uriBuilder = uriBuilder(getMethodOn()
+                                                         .getFacetValues(data.getFacetEntry().getName(),
+                                                                         data.getPrefix(), data.getQuery(),
+                                                                         data.getDsoType(), data.getScope(),
+                                                                 null, null));
 
             return addFilterParams(uriBuilder, data);
         } catch (Exception ex) {

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/DiscoveryRestHalLinkFactory.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/DiscoveryRestHalLinkFactory.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.app.rest.link.search;

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/DiscoveryRestHalLinkFactory.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/DiscoveryRestHalLinkFactory.java
@@ -51,7 +51,7 @@ public abstract class DiscoveryRestHalLinkFactory<T> extends HalLinkFactory<T, D
         try {
             UriComponentsBuilder uriBuilder = uriBuilder(getMethodOn()
                     .getFacets(data.getQuery(), data.getDsoType(), data.getScope(),
-                            data.getConfigurationName(), null));
+                            data.getConfigurationName(), null, null));
 
             uriBuilder = addSortingParms(uriBuilder, data);
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/DiscoveryRestHalLinkFactory.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/DiscoveryRestHalLinkFactory.java
@@ -19,6 +19,12 @@ import org.springframework.web.util.UriComponentsBuilder;
  */
 public abstract class DiscoveryRestHalLinkFactory<T> extends HalLinkFactory<T, DiscoveryRestController> {
 
+    /**
+     * This method will build the base search link for the data that's been given to it
+     *
+     * @param data  The data for which a link will be constructed
+     * @return      The link without extra filters to the endpoint for this data
+     */
     public UriComponentsBuilder buildSearchBaseLink(final DiscoveryResultsRest data) {
         try {
             UriComponentsBuilder uriBuilder = uriBuilder(getMethodOn()

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/DiscoveryRestHalLinkFactory.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/DiscoveryRestHalLinkFactory.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- *
+ * <p>
  * http://www.dspace.org/license/
  */
 package org.dspace.app.rest.link.search;
@@ -19,32 +19,47 @@ import org.springframework.web.util.UriComponentsBuilder;
  */
 public abstract class DiscoveryRestHalLinkFactory<T> extends HalLinkFactory<T, DiscoveryRestController> {
 
-    protected UriComponentsBuilder buildSearchBaseLink(final DiscoveryResultsRest data) throws Exception {
-        UriComponentsBuilder uriBuilder = uriBuilder(getMethodOn()
-                                                         .getSearchObjects(data.getQuery(), data.getDsoType(),
-                                                                           data.getScope(), data.getConfigurationName(),
-                                                                           null, null));
+    public UriComponentsBuilder buildSearchBaseLink(final DiscoveryResultsRest data) {
+        try {
+            UriComponentsBuilder uriBuilder = uriBuilder(getMethodOn()
+                    .getSearchObjects(data.getQuery(), data.getDsoType(),
+                            data.getScope(), data.getConfigurationName(),
+                            null, null));
 
-        return addFilterParams(uriBuilder, data);
+            return addFilterParams(uriBuilder, data);
+        } catch (Exception ex) {
+            //The method throwing the exception is never really executed, so this exception can never occur
+            return null;
+        }
     }
 
-    protected UriComponentsBuilder buildFacetBaseLink(final FacetResultsRest data) throws Exception {
-        UriComponentsBuilder uriBuilder = uriBuilder(getMethodOn()
-                                                         .getFacetValues(data.getFacetEntry().getName(),
-                                                                         data.getQuery(), data.getDsoType(),
-                                                                         data.getScope(), null, null));
+    protected UriComponentsBuilder buildFacetBaseLink(final FacetResultsRest data) {
+        try {
+            UriComponentsBuilder uriBuilder = uriBuilder(getMethodOn()
+                    .getFacetValues(data.getFacetEntry().getName(),
+                            data.getQuery(), data.getDsoType(),
+                            data.getScope(), null, null));
 
-        return addFilterParams(uriBuilder, data);
+            return addFilterParams(uriBuilder, data);
+        } catch (Exception ex) {
+            //The method throwing the exception is never really executed, so this exception can never occur
+            return null;
+        }
     }
 
-    protected UriComponentsBuilder buildSearchFacetsBaseLink(final SearchResultsRest data) throws Exception {
-        UriComponentsBuilder uriBuilder = uriBuilder(getMethodOn()
-                                                         .getFacets(data.getQuery(), data.getDsoType(), data.getScope(),
-                                                                    data.getConfigurationName(), null));
+    protected UriComponentsBuilder buildSearchFacetsBaseLink(final SearchResultsRest data) {
+        try {
+            UriComponentsBuilder uriBuilder = uriBuilder(getMethodOn()
+                    .getFacets(data.getQuery(), data.getDsoType(), data.getScope(),
+                            data.getConfigurationName(), null));
 
-        uriBuilder = addSortingParms(uriBuilder, data);
+            uriBuilder = addSortingParms(uriBuilder, data);
 
-        return addFilterParams(uriBuilder, data);
+            return addFilterParams(uriBuilder, data);
+        } catch (Exception ex) {
+            //The method throwing the exception is never really executed, so this exception can never occur
+            return null;
+        }
     }
 
     protected UriComponentsBuilder addFilterParams(UriComponentsBuilder uriComponentsBuilder,
@@ -53,7 +68,7 @@ public abstract class DiscoveryRestHalLinkFactory<T> extends HalLinkFactory<T, D
             for (SearchResultsRest.AppliedFilter filter : data.getAppliedFilters()) {
                 //TODO Make sure the filter format is defined in only one place
                 uriComponentsBuilder
-                    .queryParam("f." + filter.getFilter(), filter.getValue() + "," + filter.getOperator());
+                        .queryParam("f." + filter.getFilter(), filter.getValue() + "," + filter.getOperator());
             }
         }
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/FacetConfigurationResourceHalLinkFactory.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/FacetConfigurationResourceHalLinkFactory.java
@@ -32,7 +32,7 @@ public class FacetConfigurationResourceHalLinkFactory extends DiscoveryRestHalLi
 
         if (data != null) {
             list.add(buildLink(Link.REL_SELF, getMethodOn()
-                .getFacetsConfiguration(data.getScope(), data.getConfigurationName())));
+                .getFacetsConfiguration(data.getScope(), data.getConfigurationName(), page)));
         }
     }
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/FacetsResourceHalLinkFactory.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/FacetsResourceHalLinkFactory.java
@@ -8,9 +8,13 @@
 package org.dspace.app.rest.link.search;
 
 import java.util.LinkedList;
+import java.util.List;
 
 import org.dspace.app.rest.model.SearchResultsRest;
+import org.dspace.app.rest.model.hateoas.EmbeddedPageHeader;
 import org.dspace.app.rest.model.hateoas.FacetsResource;
+import org.dspace.app.rest.model.hateoas.SearchFacetEntryResource;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.Link;
 import org.springframework.stereotype.Component;
@@ -19,11 +23,18 @@ import org.springframework.stereotype.Component;
 public class FacetsResourceHalLinkFactory extends DiscoveryRestHalLinkFactory<FacetsResource> {
 
     protected void addLinks(FacetsResource halResource, Pageable pageable, LinkedList<Link> list) throws Exception {
-        SearchResultsRest data = halResource.getContent();
+        List<SearchFacetEntryResource> data = halResource.getFacetResources();
+        SearchResultsRest content = halResource.getContent();
 
 
-        if (data != null) {
-            list.add(buildLink(Link.REL_SELF, buildSearchFacetsBaseLink(data).build().toUriString()));
+        if (content != null && data != null && pageable != null) {
+
+            PageImpl<SearchFacetEntryResource> page = new PageImpl<SearchFacetEntryResource>(
+                    data, pageable, data.size());
+
+            halResource.setPageHeader(new EmbeddedPageHeader(buildSearchBaseLink(content), page));
+
+            list.add(buildLink(Link.REL_SELF, buildSearchFacetsBaseLink(content).build().toUriString()));
         }
     }
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/SearchConfigurationResourceHalLinkFactory.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/SearchConfigurationResourceHalLinkFactory.java
@@ -36,7 +36,7 @@ public class SearchConfigurationResourceHalLinkFactory
                 .getSearchConfiguration(data.getScope(), data.getConfigurationName())));
 
             list.add(buildLink("objects", getMethodOn().getSearchObjects(null, null, null, null, null, null)));
-            list.add(buildLink("facets", getMethodOn().getFacets(null, null, null, null, null)));
+            list.add(buildLink("facets", getMethodOn().getFacets(null, null, null, null, null, null)));
         }
     }
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/SearchFacetEntryHalLinkFactory.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/SearchFacetEntryHalLinkFactory.java
@@ -42,8 +42,8 @@ public class SearchFacetEntryHalLinkFactory extends DiscoveryRestHalLinkFactory<
         String scope = searchData == null ? null : searchData.getScope();
 
         UriComponentsBuilder uriBuilder = uriBuilder(getMethodOn()
-                                                         .getFacetValues(facetData.getName(), query, dsoType, scope,
-                                                                         null, null));
+                                                         .getFacetValues(facetData.getName(), null, query, dsoType,
+                                                                 scope, null, null));
 
         addFilterParams(uriBuilder, searchData);
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/SearchResultsResourceHalLinkFactory.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/SearchResultsResourceHalLinkFactory.java
@@ -9,14 +9,11 @@ package org.dspace.app.rest.link.search;
 
 import java.util.LinkedList;
 
-import org.dspace.app.rest.model.SearchResultsRest;
-import org.dspace.app.rest.model.hateoas.EmbeddedPageHeader;
-import org.dspace.app.rest.model.hateoas.SearchResultEntryResource;
 import org.dspace.app.rest.model.hateoas.SearchResultsResource;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.Link;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * This class will add links to the SearchResultsResource. This method will be called when calling the higher up
@@ -27,15 +24,16 @@ public class SearchResultsResourceHalLinkFactory extends DiscoveryRestHalLinkFac
 
     protected void addLinks(SearchResultsResource halResource, Pageable pageable, LinkedList<Link> list)
         throws Exception {
-        SearchResultsRest data = halResource.getContent();
+        UriComponentsBuilder uriBuilder = uriBuilder(getMethodOn()
+                                                         .getSearchObjects(halResource.getContent().getQuery(),
+                                                                           halResource.getContent().getDsoType(),
+                                                                           halResource.getContent().getScope(),
+                                                                           halResource.getContent()
+                                                                                      .getConfigurationName(),
+                                                                           halResource.getContent().getSearchFilters(),
+                                                                           null));
+        list.add(buildLink(Link.REL_SELF, uriBuilder.build().toUriString()));
 
-        if (data != null && pageable != null) {
-            PageImpl<SearchResultEntryResource> page = new PageImpl<SearchResultEntryResource>(
-                halResource.getEntryResources(),
-                pageable, data.getTotalNumberOfResults());
-
-            halResource.setPageHeader(new EmbeddedPageHeader(buildSearchBaseLink(data), page));
-        }
     }
 
     @Override

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/SearchResultsResourceHalLinkFactory.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/SearchResultsResourceHalLinkFactory.java
@@ -9,11 +9,11 @@ package org.dspace.app.rest.link.search;
 
 import java.util.LinkedList;
 
+import org.dspace.app.rest.model.SearchResultsRest;
 import org.dspace.app.rest.model.hateoas.SearchResultsResource;
 import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.Link;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * This class will add links to the SearchResultsResource. This method will be called when calling the higher up
@@ -24,16 +24,9 @@ public class SearchResultsResourceHalLinkFactory extends DiscoveryRestHalLinkFac
 
     protected void addLinks(SearchResultsResource halResource, Pageable pageable, LinkedList<Link> list)
         throws Exception {
-        UriComponentsBuilder uriBuilder = uriBuilder(getMethodOn()
-                                                         .getSearchObjects(halResource.getContent().getQuery(),
-                                                                           halResource.getContent().getDsoType(),
-                                                                           halResource.getContent().getScope(),
-                                                                           halResource.getContent()
-                                                                                      .getConfigurationName(),
-                                                                           halResource.getContent().getSearchFilters(),
-                                                                           null));
-        list.add(buildLink(Link.REL_SELF, uriBuilder.build().toUriString()));
+        SearchResultsRest resultsRest = halResource.getContent();
 
+        list.add(buildLink(Link.REL_SELF, buildSearchBaseLink(resultsRest).toUriString()));
     }
 
     @Override

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/SearchSupportHalLinkFactory.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/link/search/SearchSupportHalLinkFactory.java
@@ -29,7 +29,7 @@ public class SearchSupportHalLinkFactory extends HalLinkFactory<SearchSupportRes
         list.add(buildLink(Link.REL_SELF, getMethodOn()
             .getSearchSupport(null, null)));
         list.add(buildLink("search", getMethodOn().getSearchConfiguration(null, null)));
-        list.add(buildLink("facets", getMethodOn().getFacetsConfiguration(null, null)));
+        list.add(buildLink("facets", getMethodOn().getFacetsConfiguration(null, null, pageable)));
     }
 
     protected Class<SearchSupportResource> getResourceClass() {

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/FacetResultsRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/FacetResultsRest.java
@@ -20,6 +20,9 @@ public class FacetResultsRest extends DiscoveryResultsRest {
     @JsonUnwrapped
     private SearchFacetEntryRest facetEntry;
 
+    /**
+     * Every facet value needs to start with the given prefix
+     */
     private String prefix;
 
     public void addToFacetResultList(SearchFacetValueRest facetResult) {

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/FacetResultsRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/FacetResultsRest.java
@@ -20,6 +20,8 @@ public class FacetResultsRest extends DiscoveryResultsRest {
     @JsonUnwrapped
     private SearchFacetEntryRest facetEntry;
 
+    private String prefix;
+
     public void addToFacetResultList(SearchFacetValueRest facetResult) {
         facetEntry.addValue(facetResult);
     }
@@ -33,7 +35,15 @@ public class FacetResultsRest extends DiscoveryResultsRest {
         return facetEntry;
     }
 
-    public void setFacetEntry(final SearchFacetEntryRest facetEntry) {
+    public void setFacetEntry(SearchFacetEntryRest facetEntry) {
         this.facetEntry = facetEntry;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String getPrefix() {
+        return prefix;
     }
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/SearchConfigurationRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/SearchConfigurationRest.java
@@ -179,6 +179,7 @@ public class SearchConfigurationRest extends BaseObjectRest<String> {
                 .append(operators)
                 .toHashCode();
         }
+
         public static class Operator {
             private String operator;
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/SearchConfigurationRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/SearchConfigurationRest.java
@@ -116,6 +116,7 @@ public class SearchConfigurationRest extends BaseObjectRest<String> {
         public static final String OPERATOR_NOTAUTHORITY = "notauthority";
         public static final String OPERATOR_CONTAINS = "contains";
         public static final String OPERATOR_NOTCONTAINS = "notcontains";
+        public static final String OPERATOR_QUERY = "query";
 
         public boolean isHasFacets() {
             return hasFacets;
@@ -171,6 +172,7 @@ public class SearchConfigurationRest extends BaseObjectRest<String> {
             operators.add(new Operator(OPERATOR_NOTAUTHORITY));
             operators.add(new Operator(OPERATOR_CONTAINS));
             operators.add(new Operator(OPERATOR_NOTCONTAINS));
+            operators.add(new Operator(OPERATOR_QUERY));
         }
 
         @Override

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/SearchConfigurationRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/SearchConfigurationRest.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.dspace.app.rest.DiscoveryRestController;
+import org.dspace.discovery.configuration.DiscoverySearchFilter;
 
 /**
  * This class' purpose is to store the information that'll be shown on the /search endpoint.
@@ -133,10 +134,19 @@ public class SearchConfigurationRest extends BaseObjectRest<String> {
             this.pageSize = pageSize;
         }
 
+        /**
+         * This is the same type as described in {@link DiscoverySearchFilter#getType()}
+         * @return  The type of this filter
+         */
         public String getType() {
             return type;
         }
 
+        /**
+         * This is the same type as described in {@link org.dspace.discovery.configuration.DiscoverySearchFilter#setType(String)}
+         *
+         * @param type  The type for this Filter to be set to
+         */
         public void setType(String type) {
             this.type = type;
         }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/SearchConfigurationRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/SearchConfigurationRest.java
@@ -11,6 +11,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.dspace.app.rest.DiscoveryRestController;
@@ -104,6 +105,9 @@ public class SearchConfigurationRest extends BaseObjectRest<String> {
 
     public static class Filter {
         private String filter;
+        private boolean hasFacets = false;
+        private String type;
+        private boolean isOpenByDefault = false;
         private List<Operator> operators = new LinkedList<>();
 
         public static final String OPERATOR_EQUALS = "equals";
@@ -113,6 +117,28 @@ public class SearchConfigurationRest extends BaseObjectRest<String> {
         public static final String OPERATOR_CONTAINS = "contains";
         public static final String OPERATOR_NOTCONTAINS = "notcontains";
 
+        public boolean isHasFacets(){
+            return hasFacets;
+        }
+        public void setHasFacets(boolean hasFacets){
+            this.hasFacets = hasFacets;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public boolean isOpenByDefault() {
+            return isOpenByDefault;
+        }
+
+        public void setOpenByDefault(boolean openByDefault) {
+            isOpenByDefault = openByDefault;
+        }
 
         public void setFilter(String filter) {
             this.filter = filter;
@@ -154,8 +180,7 @@ public class SearchConfigurationRest extends BaseObjectRest<String> {
                 .append(operators)
                 .toHashCode();
         }
-
-        public static class Operator {
+        public static class Operator{
             private String operator;
 
             public Operator(String operator) {

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/SearchConfigurationRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/SearchConfigurationRest.java
@@ -11,7 +11,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.dspace.app.rest.DiscoveryRestController;
@@ -117,10 +116,10 @@ public class SearchConfigurationRest extends BaseObjectRest<String> {
         public static final String OPERATOR_CONTAINS = "contains";
         public static final String OPERATOR_NOTCONTAINS = "notcontains";
 
-        public boolean isHasFacets(){
+        public boolean isHasFacets() {
             return hasFacets;
         }
-        public void setHasFacets(boolean hasFacets){
+        public void setHasFacets(boolean hasFacets) {
             this.hasFacets = hasFacets;
         }
 
@@ -180,7 +179,7 @@ public class SearchConfigurationRest extends BaseObjectRest<String> {
                 .append(operators)
                 .toHashCode();
         }
-        public static class Operator{
+        public static class Operator {
             private String operator;
 
             public Operator(String operator) {

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/SearchConfigurationRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/SearchConfigurationRest.java
@@ -108,6 +108,7 @@ public class SearchConfigurationRest extends BaseObjectRest<String> {
         private String type;
         private boolean isOpenByDefault = false;
         private List<Operator> operators = new LinkedList<>();
+        private int pageSize;
 
         public static final String OPERATOR_EQUALS = "equals";
         public static final String OPERATOR_NOTEQUALS = "notequals";
@@ -121,6 +122,14 @@ public class SearchConfigurationRest extends BaseObjectRest<String> {
         }
         public void setHasFacets(boolean hasFacets) {
             this.hasFacets = hasFacets;
+        }
+
+        public int getPageSize() {
+            return pageSize;
+        }
+
+        public void setPageSize(int pageSize) {
+            this.pageSize = pageSize;
         }
 
         public String getType() {

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/SearchFacetEntryRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/SearchFacetEntryRest.java
@@ -97,7 +97,7 @@ public class SearchFacetEntryRest implements RestAddressableModel {
         this.facetLimit = facetLimit;
     }
 
-    public boolean isExposeMinMax() {
+    public boolean exposeMinAndMaxValue() {
         return exposeMinMax;
     }
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/SearchFacetEntryRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/SearchFacetEntryRest.java
@@ -29,6 +29,9 @@ public class SearchFacetEntryRest implements RestAddressableModel {
     private int facetLimit;
 
     @JsonIgnore
+    private boolean exposeMinMax = false;
+
+    @JsonIgnore
     private List<SearchFacetValueRest> values = new LinkedList<>();
 
     public SearchFacetEntryRest(final String name) {
@@ -86,5 +89,13 @@ public class SearchFacetEntryRest implements RestAddressableModel {
 
     public void setFacetLimit(final int facetLimit) {
         this.facetLimit = facetLimit;
+    }
+
+    public boolean isExposeMinMax() {
+        return exposeMinMax;
+    }
+
+    public void setExposeMinMax(boolean exposeMinMax) {
+        this.exposeMinMax = exposeMinMax;
     }
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/SearchFacetEntryRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/SearchFacetEntryRest.java
@@ -11,6 +11,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.dspace.app.rest.DiscoveryRestController;
 
 /**
@@ -30,6 +31,11 @@ public class SearchFacetEntryRest implements RestAddressableModel {
 
     @JsonIgnore
     private boolean exposeMinMax = false;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String minValue;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String maxValue;
 
     @JsonIgnore
     private List<SearchFacetValueRest> values = new LinkedList<>();
@@ -97,5 +103,21 @@ public class SearchFacetEntryRest implements RestAddressableModel {
 
     public void setExposeMinMax(boolean exposeMinMax) {
         this.exposeMinMax = exposeMinMax;
+    }
+
+    public String getMinValue() {
+        return minValue;
+    }
+
+    public void setMinValue(String minValue) {
+        this.minValue = minValue;
+    }
+
+    public String getMaxValue() {
+        return maxValue;
+    }
+
+    public void setMaxValue(String maxValue) {
+        this.maxValue = maxValue;
     }
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/DSpaceResource.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/DSpaceResource.java
@@ -69,7 +69,8 @@ public abstract class DSpaceResource<T extends RestAddressableModel> extends HAL
                                     // TODO add support for single linked object other than for collections
                                     Page<? extends Serializable> pageResult = (Page<? extends RestAddressableModel>) m
                                         .invoke(linkRepository, null, ((BaseObjectRest) data).getId(), null, null);
-                                    EmbeddedPage ep = new EmbeddedPage(linkToSubResource.getHref(), pageResult, null);
+                                    EmbeddedPage ep = new EmbeddedPage(linkToSubResource.getHref(), pageResult,
+                                                                       null, name);
                                     embedded.put(name, ep);
                                     found = true;
                                 }
@@ -125,7 +126,7 @@ public abstract class DSpaceResource<T extends RestAddressableModel> extends HAL
                                             PageImpl<RestAddressableModel> page = new PageImpl(linkedRMList);
                                             wrapObject = new EmbeddedPage(linkToSubResource.getHref(),
                                                                           page.map(resourceRepository::wrapResource),
-                                                                          linkedRMList);
+                                                                          linkedRMList, name);
                                         } else {
                                             wrapObject = null;
                                         }
@@ -150,7 +151,7 @@ public abstract class DSpaceResource<T extends RestAddressableModel> extends HAL
                                                     .invoke(linkRepository, null, ((BaseObjectRest) data).getId(), null,
                                                             null);
                                                 EmbeddedPage ep = new EmbeddedPage(linkToSubResource.getHref(),
-                                                                                   pageResult, null);
+                                                                                   pageResult, null, name);
                                                 embedded.put(name, ep);
                                             } else {
                                                 RestAddressableModel object = (RestAddressableModel) m

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/EmbeddedPage.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/EmbeddedPage.java
@@ -7,7 +7,9 @@
  */
 package org.dspace.app.rest.model.hateoas;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -18,25 +20,27 @@ import org.springframework.data.domain.Page;
  */
 public class EmbeddedPage extends EmbeddedPageHeader {
 
-    private List fullList;
+    //TODO Make map get relation name from constructor
+    private Map<String, List> fullMap;
 
-    public EmbeddedPage(String self, Page page, List fullList) {
-        this(self, page, fullList, true);
+    public EmbeddedPage(String self, Page page, List fullList, String relation) {
+        this(self, page, fullList, true, relation);
     }
 
-    public EmbeddedPage(String self, Page page, List fullList, boolean totalElementsIsKnown) {
+    public EmbeddedPage(String self, Page page, List fullList, boolean totalElementsIsKnown, String relation) {
         super(self, page, totalElementsIsKnown);
-        this.fullList = fullList;
+        fullMap = new HashMap<String, List>();
+        fullMap.put(relation, fullList);
     }
 
     @JsonProperty(value = "_embedded")
-    public List getPageContent() {
-        return page.getContent();
+    public Map<String, List> getPageContent() {
+        return fullMap;
     }
 
     @JsonIgnore
-    public List getFullList() {
-        return fullList;
+    public Map<String, List> getFullList() {
+        return fullMap;
     }
 
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/EmbeddedPage.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/EmbeddedPage.java
@@ -20,8 +20,10 @@ import org.springframework.data.domain.Page;
  */
 public class EmbeddedPage extends EmbeddedPageHeader {
 
-    //TODO Make map get relation name from constructor
-    private Map<String, List> fullMap;
+    private List fullList;
+
+    @JsonIgnore
+    private Map<String, List> embeddedPageContent;
 
     public EmbeddedPage(String self, Page page, List fullList, String relation) {
         this(self, page, fullList, true, relation);
@@ -29,18 +31,19 @@ public class EmbeddedPage extends EmbeddedPageHeader {
 
     public EmbeddedPage(String self, Page page, List fullList, boolean totalElementsIsKnown, String relation) {
         super(self, page, totalElementsIsKnown);
-        fullMap = new HashMap<String, List>();
-        fullMap.put(relation, fullList);
+        this.fullList = fullList;
+        this.embeddedPageContent = new HashMap<>();
+        embeddedPageContent.put(relation, page.getContent());
     }
 
     @JsonProperty(value = "_embedded")
     public Map<String, List> getPageContent() {
-        return fullMap;
+        return embeddedPageContent;
     }
 
     @JsonIgnore
-    public Map<String, List> getFullList() {
-        return fullMap;
+    public List getFullList() {
+        return fullList;
     }
 
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/FacetsResource.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/FacetsResource.java
@@ -10,25 +10,35 @@ package org.dspace.app.rest.model.hateoas;
 import java.util.LinkedList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.collections4.CollectionUtils;
 import org.dspace.app.rest.model.SearchFacetEntryRest;
 import org.dspace.app.rest.model.SearchResultsRest;
 import org.dspace.app.rest.model.hateoas.annotations.RelNameDSpaceResource;
+import org.springframework.data.domain.Pageable;
 
 @RelNameDSpaceResource(SearchResultsRest.NAME)
 public class FacetsResource extends HALResource<SearchResultsRest> {
 
-    public FacetsResource(SearchResultsRest searchResultsRest) {
+    @JsonIgnore
+    private List<SearchFacetEntryResource> facetResources = new LinkedList<>();
+
+    public FacetsResource(SearchResultsRest searchResultsRest, Pageable page) {
         super(searchResultsRest);
 
-        embedFacetResults(searchResultsRest);
-
+        embedFacetResults(searchResultsRest, page);
     }
 
-    private void embedFacetResults(final SearchResultsRest data) {
-        List<SearchFacetEntryResource> facetResources = new LinkedList<>();
+    public List<SearchFacetEntryResource> getFacetResources() {
+        return facetResources;
+    }
+
+    private void embedFacetResults(SearchResultsRest data, Pageable page) {
+        int i = 0;
         for (SearchFacetEntryRest searchFacetEntryRest : CollectionUtils.emptyIfNull(data.getFacets())) {
-            facetResources.add(new SearchFacetEntryResource(searchFacetEntryRest, data));
+            if (i >= page.getOffset() && i < page.getOffset() + page.getPageSize()) {
+                facetResources.add(new SearchFacetEntryResource(searchFacetEntryRest, data));
+            }
         }
 
         embedResource("facets", facetResources);

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/HALResource.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/HALResource.java
@@ -40,7 +40,9 @@ public abstract class HALResource<T> extends Resource<T> {
     public void embedResource(String relationship, HALResource resource) {
         embedded.put(relationship, resource);
     }
-
+    public void embedResource(String relationship, EmbeddedPage embeddedPage) {
+        embedded.put(relationship, embeddedPage);
+    }
     public void embedResource(String relationship, Collection<? extends HALResource> resource) {
         embedded.put(relationship, resource);
     }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/SearchResultsResource.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/SearchResultsResource.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.collections4.CollectionUtils;
+import org.dspace.app.rest.link.search.SearchResultsResourceHalLinkFactory;
 import org.dspace.app.rest.model.SearchFacetEntryRest;
 import org.dspace.app.rest.model.SearchResultEntryRest;
 import org.dspace.app.rest.model.SearchResultsRest;
@@ -53,8 +54,12 @@ public class SearchResultsResource extends HALResource<SearchResultsRest> {
         for (SearchResultEntryRest searchResultEntry : CollectionUtils.emptyIfNull(data.getSearchResults())) {
             entryResources.add(new SearchResultEntryResource(searchResultEntry, utils));
         }
+
         Page page = new PageImpl<>(entryResources, pageable, data.getTotalNumberOfResults());
-        EmbeddedPage embeddedPage = new EmbeddedPage("objects", page, entryResources, "objects");
+
+        SearchResultsResourceHalLinkFactory linkFactory = new SearchResultsResourceHalLinkFactory();
+        EmbeddedPage embeddedPage = new EmbeddedPage(linkFactory.buildSearchBaseLink(data).toUriString(),
+                page, entryResources, "objects");
         embedResource("searchResult", embeddedPage);
     }
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/SearchResultsResource.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/SearchResultsResource.java
@@ -17,6 +17,9 @@ import org.dspace.app.rest.model.SearchResultEntryRest;
 import org.dspace.app.rest.model.SearchResultsRest;
 import org.dspace.app.rest.model.hateoas.annotations.RelNameDSpaceResource;
 import org.dspace.app.rest.utils.Utils;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 /**
  * This class' purpose is to create a container with a list of the SearchResultEntryResources
@@ -27,22 +30,16 @@ public class SearchResultsResource extends HALResource<SearchResultsRest> {
     @JsonIgnore
     private List<SearchResultEntryResource> entryResources;
 
-    public SearchResultsResource(final SearchResultsRest data, final Utils utils) {
+    public SearchResultsResource(final SearchResultsRest data, final Utils utils, Pageable pageable) {
         super(data);
+        addEmbeds(data, utils, pageable);
 
-        addEmbeds(data, utils);
     }
-
-    public List<SearchResultEntryResource> getEntryResources() {
-        return entryResources;
-    }
-
-    private void addEmbeds(final SearchResultsRest data, final Utils utils) {
-        embedSearchResults(data, utils);
+    private void addEmbeds(final SearchResultsRest data, final Utils utils, Pageable pageable) {
+        embedSearchResults(data, utils, pageable);
 
         embedFacetResults(data);
     }
-
     private void embedFacetResults(final SearchResultsRest data) {
         List<SearchFacetEntryResource> facetResources = new LinkedList<>();
         for (SearchFacetEntryRest searchFacetEntryRest : CollectionUtils.emptyIfNull(data.getFacets())) {
@@ -51,14 +48,13 @@ public class SearchResultsResource extends HALResource<SearchResultsRest> {
 
         embedResource("facets", facetResources);
     }
-
-    private void embedSearchResults(final SearchResultsRest data, final Utils utils) {
+    private void embedSearchResults(final SearchResultsRest data, final Utils utils, Pageable pageable) {
         entryResources = new LinkedList<>();
         for (SearchResultEntryRest searchResultEntry : CollectionUtils.emptyIfNull(data.getSearchResults())) {
             entryResources.add(new SearchResultEntryResource(searchResultEntry, utils));
         }
-
-        embedResource("objects", entryResources);
+        Page page = new PageImpl<>(entryResources, pageable, data.getTotalNumberOfResults());
+        EmbeddedPage embeddedPage = new EmbeddedPage("objects", page, entryResources, "objects");
+        embedResource("searchResult", embeddedPage);
     }
-
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/query/RestSearchOperator.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/query/RestSearchOperator.java
@@ -11,14 +11,43 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- *
+ *  This enum defines the different operators that can be used with DSpace
+ *  They've been given a regex and the string value of the operator that is used within DSpace.
+ *  The purpose of this class is so that the front-end can use these specifications to send queries
+ *  using just a search String as defined by the regexes instead of having to pass on the String value
+ *  of the operator separately.
  */
 public enum RestSearchOperator {
+
+    /**
+     * The notcontains operator can be used by adding a - (minus) infront of the search query
+     * and a * at the end
+     * It then becomes -VALUE* to call for a search on the notcontains operator for VALUE
+     */
     NOTCONTAINS("-(.+)\\*", "notcontains"),
+    /**
+     * The notauthority operator can be used by adding a -id: infront of the search query
+     * It then becomes -id:VALUE to call for a search on the notauthority operator for VALUE
+     */
     NOTAUTHORITY("-id:(.+)", "notauthority"),
+    /**
+     * The notequals operator can be used by adding a - infront of the search query
+     * It then becomes -VALUE to call for a search on the notequals operator for VALUE
+     */
     NOTEQUALS("-(.+)", "notequals"),
+    /**
+     * The contains operator can be used by adding a * behind the search query
+     * It then becomes VALUE* to call for a search on the contains operator for VALUE
+     */
     CONTAINS("(.+)\\*", "contains"),
+    /**
+     * The authority operator can be used by adding an id: infront of the search query
+     * It then becomes id:VALUE to call for a search on the authority operator for VALUE
+     */
     AUTHORITY("id:(.+)", "authority"),
+    /**
+     * The equals operator is default and will be used if none of the above are matched
+     */
     EQUALS("(.+)", "equals");
 
 
@@ -31,12 +60,25 @@ public enum RestSearchOperator {
         this.dspaceOperator = dspaceOperator;
     }
 
+    /**
+     * This method extracts the value from the query. It effectively removes the operator parts
+     * and returns only the VALUE
+     * @param query The full query that was used
+     * @return      The value that was passed along in the query without the search operator logic
+     */
     public String extractValue(String query) {
         Matcher matcher = regex.matcher(query);
         matcher.find();
         return matcher.group(1);
     }
 
+    /**
+     * This method will return the correct RestSearchOperator that's bound to the query given in the parameter.
+     * This method will check if the query matches the patterns specified above.
+     *
+     * @param query The query for which we'll return the appropriate RestSearchOperator
+     * @return      The RestSearchOperator that matches with the query
+     */
     public static RestSearchOperator forQuery(String query) {
         for (RestSearchOperator op : RestSearchOperator.values()) {
             if (op.getRegex().matcher(query).matches()) {

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/query/RestSearchOperator.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/query/RestSearchOperator.java
@@ -10,6 +10,9 @@ package org.dspace.app.rest.model.query;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ *
+ */
 public enum RestSearchOperator {
     NOTCONTAINS("-(.+)\\*", "notcontains"),
     NOTAUTHORITY("-id:(.+)", "notauthority"),

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/query/RestSearchOperator.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/query/RestSearchOperator.java
@@ -1,0 +1,53 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model.query;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public enum RestSearchOperator {
+    NOTCONTAINS("-(.+)\\*", "notcontains"),
+    NOTAUTHORITY("-id:(.+)", "notauthority"),
+    NOTEQUALS("-(.+)", "notequals"),
+    CONTAINS("(.+)\\*", "contains"),
+    AUTHORITY("id:(.+)", "authority"),
+    EQUALS("(.+)", "equals");
+
+
+    private Pattern regex;
+
+    private String dspaceOperator;
+
+    RestSearchOperator(String regex, String dspaceOperator) {
+        this.regex = Pattern.compile(regex);
+        this.dspaceOperator = dspaceOperator;
+    }
+
+    public String extractValue(String query) {
+        Matcher matcher = regex.matcher(query);
+        matcher.find();
+        return matcher.group(1);
+    }
+
+    public static RestSearchOperator forQuery(String query) {
+        for(RestSearchOperator op : RestSearchOperator.values()) {
+            if(op.getRegex().matcher(query).matches()) {
+                return op;
+            }
+        }
+        return null;
+    }
+
+    public Pattern getRegex() {
+        return regex;
+    }
+
+    public String getDspaceOperator() {
+        return dspaceOperator;
+    }
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/query/RestSearchOperator.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/query/RestSearchOperator.java
@@ -35,8 +35,8 @@ public enum RestSearchOperator {
     }
 
     public static RestSearchOperator forQuery(String query) {
-        for(RestSearchOperator op : RestSearchOperator.values()) {
-            if(op.getRegex().matcher(query).matches()) {
+        for (RestSearchOperator op : RestSearchOperator.values()) {
+            if (op.getRegex().matcher(query).matches()) {
                 return op;
             }
         }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
@@ -129,7 +129,7 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
         return discoverSearchSupportConverter.convert();
     }
 
-    public FacetResultsRest getFacetObjects(String facetName, String query, String dsoType, String dsoScope,
+    public FacetResultsRest getFacetObjects(String facetName, String prefix, String query, String dsoType, String dsoScope,
                                             List<SearchFilter> searchFilters, Pageable page)
         throws InvalidRequestException {
 
@@ -143,7 +143,7 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
         DiscoverQuery discoverQuery = null;
         try {
             discoverQuery = queryBuilder
-                .buildFacetQuery(context, scopeObject, configuration, query, searchFilters, dsoType, page, facetName);
+                .buildFacetQuery(context, scopeObject, configuration, prefix, query, searchFilters, dsoType, page, facetName);
             searchResult = searchService.search(context, scopeObject, discoverQuery);
 
         } catch (SearchServiceException e) {
@@ -152,7 +152,7 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
         }
 
         FacetResultsRest facetResultsRest = discoverFacetResultsConverter
-            .convert(context, facetName, query, dsoType, dsoScope, searchFilters, searchResult, configuration, page);
+            .convert(context, facetName, prefix, query, dsoType, dsoScope, searchFilters, searchResult, configuration, page);
         return facetResultsRest;
     }
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
@@ -83,7 +83,7 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
 
         DSpaceObject scopeObject = scopeResolver.resolveScope(context, dsoScope);
         DiscoveryConfiguration configuration = searchConfigurationService
-            .getDiscoveryConfigurationByNameOrDso(configurationName, scopeObject);
+                .getDiscoveryConfigurationByNameOrDso(configurationName, scopeObject);
 
         return discoverConfigurationConverter.convert(configuration);
     }
@@ -91,19 +91,19 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
     public SearchResultsRest getSearchObjects(final String query, final String dsoType, final String dsoScope,
                                               final String configurationName,
                                               final List<SearchFilter> searchFilters, final Pageable page)
-        throws InvalidRequestException {
+            throws InvalidRequestException {
         Context context = obtainContext();
 
         DSpaceObject scopeObject = scopeResolver.resolveScope(context, dsoScope);
         DiscoveryConfiguration configuration = searchConfigurationService
-            .getDiscoveryConfigurationByNameOrDso(configurationName, scopeObject);
+                .getDiscoveryConfigurationByNameOrDso(configurationName, scopeObject);
 
         DiscoverResult searchResult = null;
         DiscoverQuery discoverQuery = null;
 
         try {
             discoverQuery = queryBuilder
-                .buildQuery(context, scopeObject, configuration, query, searchFilters, dsoType, page);
+                    .buildQuery(context, scopeObject, configuration, query, searchFilters, dsoType, page);
             searchResult = searchService.search(context, scopeObject, discoverQuery);
 
         } catch (SearchServiceException e) {
@@ -111,8 +111,8 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
         }
 
         return discoverResultConverter
-            .convert(context, query, dsoType, configurationName, dsoScope, searchFilters, page, searchResult,
-                     configuration);
+                .convert(context, query, dsoType, configurationName, dsoScope, searchFilters, page, searchResult,
+                        configuration);
     }
 
     public FacetConfigurationRest getFacetsConfiguration(final String dsoScope, final String configurationName) {
@@ -120,7 +120,7 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
 
         DSpaceObject scopeObject = scopeResolver.resolveScope(context, dsoScope);
         DiscoveryConfiguration configuration = searchConfigurationService
-            .getDiscoveryConfigurationByNameOrDso(configurationName, scopeObject);
+                .getDiscoveryConfigurationByNameOrDso(configurationName, scopeObject);
 
         return discoverFacetConfigurationConverter.convert(configurationName, dsoScope, configuration);
     }
@@ -129,21 +129,22 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
         return discoverSearchSupportConverter.convert();
     }
 
-    public FacetResultsRest getFacetObjects(String facetName, String prefix, String query, String dsoType, String dsoScope,
-                                            List<SearchFilter> searchFilters, Pageable page)
-        throws InvalidRequestException {
+    public FacetResultsRest getFacetObjects(String facetName, String prefix, String query, String dsoType,
+                                            String dsoScope, List<SearchFilter> searchFilters, Pageable page)
+            throws InvalidRequestException {
 
         Context context = obtainContext();
 
         DSpaceObject scopeObject = scopeResolver.resolveScope(context, dsoScope);
         DiscoveryConfiguration configuration = searchConfigurationService
-            .getDiscoveryConfigurationByNameOrDso(facetName, scopeObject);
+                .getDiscoveryConfigurationByNameOrDso(facetName, scopeObject);
 
         DiscoverResult searchResult = null;
         DiscoverQuery discoverQuery = null;
         try {
             discoverQuery = queryBuilder
-                .buildFacetQuery(context, scopeObject, configuration, prefix, query, searchFilters, dsoType, page, facetName);
+                    .buildFacetQuery(context, scopeObject, configuration, prefix, query,
+                            searchFilters, dsoType, page, facetName);
             searchResult = searchService.search(context, scopeObject, discoverQuery);
 
         } catch (SearchServiceException e) {
@@ -152,7 +153,8 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
         }
 
         FacetResultsRest facetResultsRest = discoverFacetResultsConverter
-            .convert(context, facetName, prefix, query, dsoType, dsoScope, searchFilters, searchResult, configuration, page);
+                .convert(context, facetName, prefix, query, dsoType, dsoScope, searchFilters,
+                        searchResult, configuration, page);
         return facetResultsRest;
     }
 
@@ -163,14 +165,14 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
         Pageable page = new PageRequest(1, 1);
         DSpaceObject scopeObject = scopeResolver.resolveScope(context, dsoScope);
         DiscoveryConfiguration configuration = searchConfigurationService
-            .getDiscoveryConfigurationByNameOrDso(configurationName, scopeObject);
+                .getDiscoveryConfigurationByNameOrDso(configurationName, scopeObject);
 
         DiscoverResult searchResult = null;
         DiscoverQuery discoverQuery = null;
 
         try {
             discoverQuery = queryBuilder
-                .buildQuery(context, scopeObject, configuration, query, searchFilters, dsoType, page);
+                    .buildQuery(context, scopeObject, configuration, query, searchFilters, dsoType, page);
             searchResult = searchService.search(context, scopeObject, discoverQuery);
 
         } catch (SearchServiceException e) {
@@ -178,8 +180,8 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
         }
 
         SearchResultsRest searchResultsRest = discoverFacetsConverter
-            .convert(context, query, dsoType, configurationName, dsoScope, searchFilters, page, configuration,
-                     searchResult);
+                .convert(context, query, dsoType, configurationName, dsoScope, searchFilters, page, configuration,
+                        searchResult);
 
         return searchResultsRest;
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/DiscoverQueryBuilder.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/DiscoverQueryBuilder.java
@@ -101,7 +101,7 @@ public class DiscoverQueryBuilder implements InitializingBean {
 
     public DiscoverQuery buildFacetQuery(Context context, DSpaceObject scope,
                                          DiscoveryConfiguration discoveryConfiguration,
-                                         String query, List<SearchFilter> searchFilters,
+                                         String prefix, String query, List<SearchFilter> searchFilters,
                                          String dsoType, Pageable page, String facetName)
         throws InvalidRequestException {
 
@@ -109,7 +109,7 @@ public class DiscoverQueryBuilder implements InitializingBean {
                                                            dsoType);
 
         //When all search criteria are set, configure facet results
-        addFacetingForFacets(context, scope, queryArgs, discoveryConfiguration, facetName, page);
+        addFacetingForFacets(context, scope, prefix, queryArgs, discoveryConfiguration, facetName, page);
 
         //We don' want any search results, we only want facet values
         queryArgs.setMaxResults(0);
@@ -126,8 +126,8 @@ public class DiscoverQueryBuilder implements InitializingBean {
         }
     }
 
-    private DiscoverQuery addFacetingForFacets(Context context, DSpaceObject scope, DiscoverQuery queryArgs,
-                                               DiscoveryConfiguration discoveryConfiguration,
+    private DiscoverQuery addFacetingForFacets(Context context, DSpaceObject scope, String prefix,
+                                               DiscoverQuery queryArgs, DiscoveryConfiguration discoveryConfiguration,
                                                String facetName, Pageable page) throws InvalidSearchFacetException {
 
         DiscoverySearchFilterFacet facet = discoveryConfiguration.getSidebarFacet(facetName);
@@ -135,7 +135,7 @@ public class DiscoverQueryBuilder implements InitializingBean {
             queryArgs.setFacetMinCount(1);
             int pageSize = Math.min(pageSizeLimit, page.getPageSize());
 
-            fillFacetIntoQueryArgs(context, scope, queryArgs, facet, pageSize);
+            fillFacetIntoQueryArgs(context, scope, prefix, queryArgs, facet, pageSize);
 
         } else {
             throw new InvalidSearchFacetException(facetName + " is not a valid search facet");
@@ -144,7 +144,7 @@ public class DiscoverQueryBuilder implements InitializingBean {
         return queryArgs;
     }
 
-    private void fillFacetIntoQueryArgs(Context context, DSpaceObject scope, DiscoverQuery queryArgs,
+    private void fillFacetIntoQueryArgs(Context context, DSpaceObject scope, String prefix, DiscoverQuery queryArgs,
                                         DiscoverySearchFilterFacet facet, final int pageSize) {
         if (facet.getType().equals(DiscoveryConfigurationParameters.TYPE_DATE)) {
             try {
@@ -165,7 +165,7 @@ public class DiscoverQueryBuilder implements InitializingBean {
             int facetLimit = pageSize + 1;
             //This should take care of the sorting for us
             queryArgs.addFacetField(new DiscoverFacetField(facet.getIndexFieldName(), facet.getType(), facetLimit,
-                                                           facet.getSortOrderSidebar()));
+                    facet.getSortOrderSidebar(), StringUtils.trimToNull(prefix)));
         }
     }
 
@@ -321,7 +321,7 @@ public class DiscoverQueryBuilder implements InitializingBean {
 
             /** enable faceting of search results */
             for (DiscoverySearchFilterFacet facet : facets) {
-                fillFacetIntoQueryArgs(context, scope, queryArgs, facet, facet.getFacetLimit());
+                fillFacetIntoQueryArgs(context, scope, null, queryArgs, facet, facet.getFacetLimit());
             }
         }
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/DiscoverQueryBuilder.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/DiscoverQueryBuilder.java
@@ -15,6 +15,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
+import org.dspace.app.rest.converter.query.SearchQueryConverter;
 import org.dspace.app.rest.exception.InvalidDSpaceObjectTypeException;
 import org.dspace.app.rest.exception.InvalidRequestException;
 import org.dspace.app.rest.exception.InvalidSearchFacetException;
@@ -285,8 +286,10 @@ public class DiscoverQueryBuilder implements InitializingBean {
                                     List<SearchFilter> searchFilters) throws InvalidSearchFilterException {
         ArrayList<String> filterQueries = new ArrayList<>(CollectionUtils.size(searchFilters));
 
+        SearchQueryConverter searchQueryConverter = new SearchQueryConverter();
+        List<SearchFilter> transformedFilters = searchQueryConverter.convert(searchFilters);
         try {
-            for (SearchFilter searchFilter : CollectionUtils.emptyIfNull(searchFilters)) {
+            for (SearchFilter searchFilter : CollectionUtils.emptyIfNull(transformedFilters)) {
                 DiscoverySearchFilter filter = discoveryConfiguration.getSearchFilter(searchFilter.getName());
                 if (filter == null) {
                     throw new InvalidSearchFilterException(searchFilter.getName() + " is not a valid search filter");

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/DiscoverQueryBuilder.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/DiscoverQueryBuilder.java
@@ -180,7 +180,9 @@ public class DiscoverQueryBuilder implements InitializingBean {
 
         //Set search query
         if (StringUtils.isNotBlank(query)) {
-            queryArgs.setQuery(searchService.escapeQueryChars(query));
+            //Note that these quotes are needed incase we try to query OR for example.
+            //If the quotes aren't present, it'll crash.
+            queryArgs.setQuery("\"" + searchService.escapeQueryChars(query) + "\"");
         }
 
         //Limit results to DSO type

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -2494,7 +2494,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //An anonymous user browses this endpoint to find the the objects in the system
         //With the given search filter
         getClient().perform(get("/api/discover/search/objects")
-                .param("f.title", "-test,query"))
+                .param("f.title", "-Test,query"))
                 //** THEN **
                 //The status has to be 200 OK
                 .andExpect(status().isOk())
@@ -2505,7 +2505,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         PageMatcher.pageEntry(0,20)
                 )))
                 //The search results have to contain the items that match the searchFilter
-                .andExpect(jsonPath("$._embedded.objects", Matchers.allOf(
+                .andExpect(jsonPath("$._embedded.objects", Matchers.hasItems(
                         SearchResultMatcher.matchOnItemName("item","items", "Test 2"),
                         SearchResultMatcher.matchOnItemName("item", "items", "Public item 2")
                 )))

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -2096,6 +2096,144 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
 
     }
 
+    @Test
+    public void discoverSearchObjectsWithQueryOperatorContains() throws Exception{
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
+        //2. Three public items that are readable by Anonymous with different subjects
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                .withTitle("Test")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald")
+                .withSubject("ExtraEntry")
+                .build();
+
+        Item publicItem2 = ItemBuilder.createItem(context, col2)
+                .withTitle("Test 2")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
+
+        Item publicItem3 = ItemBuilder.createItem(context, col2)
+                .withTitle("Public item 2")
+                .withIssueDate("2010-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test").withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
+
+        UUID scope = col2.getID();
+        //** WHEN **
+        //An anonymous user browses this endpoint to find the the objects in the system
+        //With the given search filter
+        getClient().perform(get("/api/discover/search/objects")
+                .param("f.title", "test*,query"))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The page object needs to look like this
+                .andExpect(jsonPath("$.page", is(
+                        PageMatcher.pageEntry(0,20)
+                )))
+                //The search results have to contain the items that match the searchFilter
+                .andExpect(jsonPath("$._embedded.objects", Matchers.containsInAnyOrder(
+                        SearchResultMatcher.matchOnItemName("item","items", "Test"),
+                        SearchResultMatcher.matchOnItemName("item", "items", "Test 2")
+                )))
+                //These facets have to show up in the embedded.facets section as well with the given hasMore property because we don't exceed their default limit for a hasMore true (the default is 10)
+                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                        FacetEntryMatcher.authorFacet(false),
+                        FacetEntryMatcher.subjectFacet(false),
+                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                )))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+        ;
+
+    }
+
+    @Test
+    public void discoverSearchObjectsWithQueryOperatorNotContains() throws Exception{
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
+        //2. Three public items that are readable by Anonymous with different subjects
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                .withTitle("Test")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald")
+                .withSubject("ExtraEntry")
+                .build();
+
+        Item publicItem2 = ItemBuilder.createItem(context, col2)
+                .withTitle("Test 2")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
+
+        Item publicItem3 = ItemBuilder.createItem(context, col2)
+                .withTitle("Public item 2")
+                .withIssueDate("2010-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test").withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
+
+        UUID scope = col2.getID();
+        //** WHEN **
+        //An anonymous user browses this endpoint to find the the objects in the system
+        //With the given search filter
+        getClient().perform(get("/api/discover/search/objects")
+                .param("f.title", "-test*,query"))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The page object needs to look like this
+                .andExpect(jsonPath("$.page", is(
+                        PageMatcher.pageEntry(0,20)
+                )))
+                //The search results have to contain the items that match the searchFilter
+                .andExpect(jsonPath("$._embedded.objects", Matchers.hasItem(
+                        SearchResultMatcher.matchOnItemName("item","items", "Public item 2")
+                )))
+                //These facets have to show up in the embedded.facets section as well with the given hasMore property because we don't exceed their default limit for a hasMore true (the default is 10)
+                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                        FacetEntryMatcher.authorFacet(false),
+                        FacetEntryMatcher.subjectFacet(false),
+                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                )))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+        ;
+
+    }
 
     @Test
     public void discoverSearchObjectsTestForMinMaxValues() throws Exception {
@@ -2245,4 +2383,211 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
 
     }
 
+    @Test
+    public void discoverSearchObjectsWithQueryOperatorEquals() throws Exception {
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
+        //2. Three public items that are readable by Anonymous with different subjects
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                .withTitle("Test")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald")
+                .withSubject("ExtraEntry")
+                .build();
+
+        Item publicItem2 = ItemBuilder.createItem(context, col2)
+                .withTitle("Test 2")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
+
+        Item publicItem3 = ItemBuilder.createItem(context, col2)
+                .withTitle("Public item 2")
+                .withIssueDate("2010-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test").withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
+
+        UUID scope = col2.getID();
+        //** WHEN **
+        //An anonymous user browses this endpoint to find the the objects in the system
+        //With the given search filter
+        getClient().perform(get("/api/discover/search/objects")
+                .param("f.title", "Test,query"))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The page object needs to look like this
+                .andExpect(jsonPath("$.page", is(
+                        PageMatcher.pageEntry(0,20)
+                )))
+                //The search results have to contain the items that match the searchFilter
+                .andExpect(jsonPath("$._embedded.objects", Matchers.containsInAnyOrder(
+                        SearchResultMatcher.matchOnItemName("item","items", "Test")
+                )))
+                //These facets have to show up in the embedded.facets section as well with the given hasMore property because we don't exceed their default limit for a hasMore true (the default is 10)
+                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                        FacetEntryMatcher.authorFacet(false),
+                        FacetEntryMatcher.subjectFacet(false),
+                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                )))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+        ;
+
+    }
+
+    @Test
+    public void discoverSearchObjectsWithQueryOperatorNotEquals() throws Exception {
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
+        //2. Three public items that are readable by Anonymous with different subjects
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                .withTitle("Test")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald")
+                .withSubject("ExtraEntry")
+                .build();
+
+        Item publicItem2 = ItemBuilder.createItem(context, col2)
+                .withTitle("Test 2")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
+
+        Item publicItem3 = ItemBuilder.createItem(context, col2)
+                .withTitle("Public item 2")
+                .withIssueDate("2010-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test").withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
+
+        UUID scope = col2.getID();
+        //** WHEN **
+        //An anonymous user browses this endpoint to find the the objects in the system
+        //With the given search filter
+        getClient().perform(get("/api/discover/search/objects")
+                .param("f.title", "-test,query"))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The page object needs to look like this
+                .andExpect(jsonPath("$.page", is(
+                        PageMatcher.pageEntry(0,20)
+                )))
+                //The search results have to contain the items that match the searchFilter
+                .andExpect(jsonPath("$._embedded.objects", Matchers.allOf(
+                        SearchResultMatcher.matchOnItemName("item","items", "Test 2"),
+                        SearchResultMatcher.matchOnItemName("item", "items", "Public item 2")
+                )))
+                //These facets have to show up in the embedded.facets section as well with the given hasMore property because we don't exceed their default limit for a hasMore true (the default is 10)
+                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                        FacetEntryMatcher.authorFacet(false),
+                        FacetEntryMatcher.subjectFacet(false),
+                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                )))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+        ;
+
+    }
+
+    @Test
+    public void discoverSearchObjectsWithQueryOperatorNotAuthority() throws Exception {
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
+        //2. Three public items that are readable by Anonymous with different subjects
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                .withTitle("Test")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald")
+                .withSubject("ExtraEntry")
+                .build();
+
+        Item publicItem2 = ItemBuilder.createItem(context, col2)
+                .withTitle("Test 2")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
+
+        Item publicItem3 = ItemBuilder.createItem(context, col2)
+                .withTitle("Public item 2")
+                .withIssueDate("2010-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test").withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
+
+        UUID scope = col2.getID();
+        //** WHEN **
+        //An anonymous user browses this endpoint to find the the objects in the system
+        //With the given search filter
+        getClient().perform(get("/api/discover/search/objects")
+                .param("f.title", "-id:test,query"))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The page object needs to look like this
+                .andExpect(jsonPath("$.page", is(
+                        PageMatcher.pageEntry(0,20)
+                )))
+                //The search results have to contain the items that match the searchFilter
+                .andExpect(jsonPath("$._embedded.objects", Matchers.hasItem(
+                        SearchResultMatcher.matchOnItemName("item", "items", "Public item 2")
+                )))
+                //These facets have to show up in the embedded.facets section as well with the given hasMore property because we don't exceed their default limit for a hasMore true (the default is 10)
+                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                        FacetEntryMatcher.authorFacet(false),
+                        FacetEntryMatcher.subjectFacet(false),
+                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                )))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+        ;
+
+    }
 }

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -52,16 +52,16 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //When we call this endpoint
         getClient().perform(get("/api/discover"))
 
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //There needs to be a link to the facets endpoint
-                   .andExpect(jsonPath("$._links.facets.href", containsString("api/discover/facets")))
-                   //There needs to be a link to the search endpoint
-                   .andExpect(jsonPath("$._links.search.href", containsString("api/discover/search")))
-                   //There needs to be a self link
-                   .andExpect(jsonPath("$._links.self.href", containsString("api/discover")));
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //There needs to be a link to the facets endpoint
+                .andExpect(jsonPath("$._links.facets.href", containsString("api/discover/facets")))
+                //There needs to be a link to the search endpoint
+                .andExpect(jsonPath("$._links.search.href", containsString("api/discover/search")))
+                //There needs to be a self link
+                .andExpect(jsonPath("$._links.self.href", containsString("api/discover")));
     }
 
     @Test
@@ -70,19 +70,19 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //When we call this facets endpoint
         getClient().perform(get("/api/discover/facets"))
 
-                   //We expect a 200 OK status
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //There needs to be a self link to this endpoint
-                   .andExpect(jsonPath("$._links.self.href", containsString("api/discover/facets")))
-                   //We have 4 facets in the default configuration, they need to all be present in the embedded section
-                   .andExpect(jsonPath("$._embedded.facets", containsInAnyOrder(
-                       FacetEntryMatcher.authorFacet(false),
-                       FacetEntryMatcher.dateIssuedFacet(false),
-                       FacetEntryMatcher.subjectFacet(false),
-                       FacetEntryMatcher.hasContentInOriginalBundleFacet(false)))
-                   );
+                //We expect a 200 OK status
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //There needs to be a self link to this endpoint
+                .andExpect(jsonPath("$._links.self.href", containsString("api/discover/facets")))
+                //We have 4 facets in the default configuration, they need to all be present in the embedded section
+                .andExpect(jsonPath("$._embedded.facets", containsInAnyOrder(
+                        FacetEntryMatcher.authorFacet(false),
+                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.subjectFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)))
+                );
     }
 
     @Test
@@ -93,69 +93,69 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects and authors
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Public item 1")
-                                      .withIssueDate("2017-10-17")
-                                      .withAuthor("Smith, Donald").withAuthor("Doe, John")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                .withSubject("ExtraEntry")
+                .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2016-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2016-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
 
         //** WHEN **
         //An anonymous user browses this endpoint to find the objects in the system and enters a size of 2
         getClient().perform(get("/api/discover/facets/author")
-                                .param("size", "2"))
+                .param("size", "2"))
 
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type needs to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The name of the facet needs to be author, because that's what we called
-                   .andExpect(jsonPath("$.name", is("author")))
-                   //The facetType has to be 'text' because that's how the author facet is configured by default
-                   .andExpect(jsonPath("$.facetType", is("text")))
-                   //Because we've constructed such a structure so that we have more than 2 (size) authors, there
-                   // needs to be a next link
-                   .andExpect(jsonPath("$._links.next.href", containsString("api/discover/facets/author?page")))
-                   //There always needs to be a self link
-                   .andExpect(jsonPath("$._links.self.href", containsString("api/discover/facets/author")))
-                   //Because there are more authors than is represented (because of the size param), hasMore has to
-                   // be true
-                   //The page object needs to be present and just like specified in the matcher
-                   .andExpect(jsonPath("$.page",
-                                       is(PageMatcher.pageEntry(0, 2))))
-                   //These authors need to be in the response because it's sorted on how many times the author comes
-                   // up in different items
-                   //These authors are the most used ones. Only two show up because of the size.
-                   .andExpect(jsonPath("$._embedded.values", containsInAnyOrder(
-                       FacetValueMatcher.entryAuthor("Doe, Jane"),
-                       FacetValueMatcher.entryAuthor("Smith, Maria")
-                   )))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type needs to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The name of the facet needs to be author, because that's what we called
+                .andExpect(jsonPath("$.name", is("author")))
+                //The facetType has to be 'text' because that's how the author facet is configured by default
+                .andExpect(jsonPath("$.facetType", is("text")))
+                //Because we've constructed such a structure so that we have more than 2 (size) authors, there
+                // needs to be a next link
+                .andExpect(jsonPath("$._links.next.href", containsString("api/discover/facets/author?page")))
+                //There always needs to be a self link
+                .andExpect(jsonPath("$._links.self.href", containsString("api/discover/facets/author")))
+                //Because there are more authors than is represented (because of the size param), hasMore has to
+                // be true
+                //The page object needs to be present and just like specified in the matcher
+                .andExpect(jsonPath("$.page",
+                        is(PageMatcher.pageEntry(0, 2))))
+                //These authors need to be in the response because it's sorted on how many times the author comes
+                // up in different items
+                //These authors are the most used ones. Only two show up because of the size.
+                .andExpect(jsonPath("$._embedded.values", containsInAnyOrder(
+                        FacetValueMatcher.entryAuthor("Doe, Jane"),
+                        FacetValueMatcher.entryAuthor("Smith, Maria")
+                )))
         ;
     }
 
@@ -236,64 +236,64 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Public item 1")
-                                      .withIssueDate("2017-10-17")
-                                      .withAuthor("Smith, Donald").withAuthor("Doe, John")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                .withSubject("ExtraEntry")
+                .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2016-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2016-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
 
         //** WHEN **
         //An anonymous user browses this endpoint to find the authors by the facets and doesn't enter a size
         getClient().perform(get("/api/discover/facets/author"))
 
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The name has to be author, because that's the facet that we called upon
-                   .andExpect(jsonPath("$.name", is("author")))
-                   //The facetType has to be 'text' because that's the default configuration for this facet
-                   .andExpect(jsonPath("$.facetType", is("text")))
-                   //There always needs to be a self link present
-                   .andExpect(jsonPath("$._links.self.href", containsString("api/discover/facets/author")))
-                   //The page object needs to present and exactly like how it is specified here. 20 is entered as the
-                   // size because that's the default in the configuration if no size parameter has been given
-                   .andExpect(jsonPath("$.page",
-                                       is(PageMatcher.pageEntry(0, 20))))
-                   //The authors need to be embedded in the values, all 4 of them have to be present as the size
-                   // allows it
-                   .andExpect(jsonPath("$._embedded.values", containsInAnyOrder(
-                       FacetValueMatcher.entryAuthor("Doe, Jane"),
-                       FacetValueMatcher.entryAuthor("Smith, Maria"),
-                       FacetValueMatcher.entryAuthor("Doe, John"),
-                       FacetValueMatcher.entryAuthor("Smith, Donald")
-                   )))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The name has to be author, because that's the facet that we called upon
+                .andExpect(jsonPath("$.name", is("author")))
+                //The facetType has to be 'text' because that's the default configuration for this facet
+                .andExpect(jsonPath("$.facetType", is("text")))
+                //There always needs to be a self link present
+                .andExpect(jsonPath("$._links.self.href", containsString("api/discover/facets/author")))
+                //The page object needs to present and exactly like how it is specified here. 20 is entered as the
+                // size because that's the default in the configuration if no size parameter has been given
+                .andExpect(jsonPath("$.page",
+                        is(PageMatcher.pageEntry(0, 20))))
+                //The authors need to be embedded in the values, all 4 of them have to be present as the size
+                // allows it
+                .andExpect(jsonPath("$._embedded.values", containsInAnyOrder(
+                        FacetValueMatcher.entryAuthor("Doe, Jane"),
+                        FacetValueMatcher.entryAuthor("Smith, Maria"),
+                        FacetValueMatcher.entryAuthor("Doe, John"),
+                        FacetValueMatcher.entryAuthor("Smith, Donald")
+                )))
         ;
     }
 
@@ -306,69 +306,69 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Public item 1")
-                                      .withIssueDate("2017-10-17")
-                                      .withAuthor("Smith, Donald").withAuthor("Doe, John").withAuthor("Smith, Maria")
-                                      .withAuthor("Doe, Jane")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald").withAuthor("Doe, John").withAuthor("Smith, Maria")
+                .withAuthor("Doe, Jane")
+                .withSubject("ExtraEntry")
+                .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2016-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Doe, John")
-                                      .withAuthor("Smith, Donald")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Doe, John")
+                .withAuthor("Smith, Donald")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2016-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
 
         //** WHEN **
         //An anonymous user browses this endpoint to find the authors by the facet
         //The user enters a size of two and wants to see page 1, this is the second page.
         getClient().perform(get("/api/discover/facets/author")
-                                .param("size", "2")
-                                .param("page", "1"))
+                .param("size", "2")
+                .param("page", "1"))
 
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The name of the facet has to be author as that's the one we called
-                   .andExpect(jsonPath("$.name", is("author")))
-                   //The facetType has to be 'text' as this is the default configuration
-                   .andExpect(jsonPath("$.facetType", is("text")))
-                   //There needs to be a next link because there are more authors than the current size is allowed to
-                   // show. There are more pages after this one
-                   .andExpect(jsonPath("$._links.next.href", containsString("api/discover/facets/author?page")))
-                   //There always needs to be a self link
-                   .andExpect(jsonPath("$._links.self.href", containsString("api/discover/facets/author")))
-                   //The page object has to be like this because that's what we've asked in the parameters
-                   .andExpect(jsonPath("$.page",
-                                       is(PageMatcher.pageEntry(1, 2))))
-                   //These authors have to be present because of the current configuration
-                   .andExpect(jsonPath("$._embedded.values", containsInAnyOrder(
-                       FacetValueMatcher.entryAuthor("Doe, John"),
-                       FacetValueMatcher.entryAuthor("Smith, Donald")
-                   )))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The name of the facet has to be author as that's the one we called
+                .andExpect(jsonPath("$.name", is("author")))
+                //The facetType has to be 'text' as this is the default configuration
+                .andExpect(jsonPath("$.facetType", is("text")))
+                //There needs to be a next link because there are more authors than the current size is allowed to
+                // show. There are more pages after this one
+                .andExpect(jsonPath("$._links.next.href", containsString("api/discover/facets/author?page")))
+                //There always needs to be a self link
+                .andExpect(jsonPath("$._links.self.href", containsString("api/discover/facets/author")))
+                //The page object has to be like this because that's what we've asked in the parameters
+                .andExpect(jsonPath("$.page",
+                        is(PageMatcher.pageEntry(1, 2))))
+                //These authors have to be present because of the current configuration
+                .andExpect(jsonPath("$._embedded.values", containsInAnyOrder(
+                        FacetValueMatcher.entryAuthor("Doe, John"),
+                        FacetValueMatcher.entryAuthor("Smith, Donald")
+                )))
         ;
     }
 
@@ -381,76 +381,76 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Test")
-                                      .withIssueDate("2017-10-17")
-                                      .withAuthor("Smith, Donald").withAuthor("Testing, Works")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald").withAuthor("Testing, Works")
+                .withSubject("ExtraEntry")
+                .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2016-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2016-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
         //** WHEN **
         //An anonymous user browses this endpoint to find the authors by the facet
         //The user enters a small query, namely the title has to contain 'test'
         getClient().perform(get("/api/discover/facets/author")
-                                .param("f.title", "test,contains"))
+                .param("f.title", "test,contains"))
 
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The name has to be author as that's the facet that we've asked
-                   .andExpect(jsonPath("$.name", is("author")))
-                   //The facetType needs to be 'text' as that's the default configuration for the given facet
-                   .andExpect(jsonPath("$.facetType", is("text")))
-                   //There always needs to be a self link available
-                   .andExpect(jsonPath("$._links.self.href", containsString("api/discover/facets/author")))
-                   //The self link needs to contain the query that was specified in the parameters, this is how it
-                   // looks like
-                   .andExpect(jsonPath("$._links.self.href", containsString("f.title=test,contains")))
-                   //The applied filters have to be specified like this, applied filters are the parameters given
-                   // below starting with f.
-                   .andExpect(jsonPath("$.appliedFilters", contains(
-                       AppliedFilterMatcher.appliedFilterEntry("title", "contains", "test", "test")
-                   )))
-                   //This is how the page object must look like because it's the default
-                   .andExpect(jsonPath("$.page",
-                                       is(PageMatcher.pageEntry(0, 20))))
-                   //These authors need to be present in the result because these have made items that contain 'test'
-                   // in the title
-                   .andExpect(jsonPath("$._embedded.values", containsInAnyOrder(
-                       FacetValueMatcher.entryAuthor("Smith, Donald"),
-                       FacetValueMatcher.entryAuthor("Testing, Works")
-                   )))
-                   //These authors cannot be present because they've not produced an item with 'test' in the title
-                   .andExpect(jsonPath("$._embedded.values", not(containsInAnyOrder(
-                       FacetValueMatcher.entryAuthor("Smith, Maria"),
-                       FacetValueMatcher.entryAuthor("Doe, Jane")
-                   ))))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The name has to be author as that's the facet that we've asked
+                .andExpect(jsonPath("$.name", is("author")))
+                //The facetType needs to be 'text' as that's the default configuration for the given facet
+                .andExpect(jsonPath("$.facetType", is("text")))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("api/discover/facets/author")))
+                //The self link needs to contain the query that was specified in the parameters, this is how it
+                // looks like
+                .andExpect(jsonPath("$._links.self.href", containsString("f.title=test,contains")))
+                //The applied filters have to be specified like this, applied filters are the parameters given
+                // below starting with f.
+                .andExpect(jsonPath("$.appliedFilters", contains(
+                        AppliedFilterMatcher.appliedFilterEntry("title", "contains", "test", "test")
+                )))
+                //This is how the page object must look like because it's the default
+                .andExpect(jsonPath("$.page",
+                        is(PageMatcher.pageEntry(0, 20))))
+                //These authors need to be present in the result because these have made items that contain 'test'
+                // in the title
+                .andExpect(jsonPath("$._embedded.values", containsInAnyOrder(
+                        FacetValueMatcher.entryAuthor("Smith, Donald"),
+                        FacetValueMatcher.entryAuthor("Testing, Works")
+                )))
+                //These authors cannot be present because they've not produced an item with 'test' in the title
+                .andExpect(jsonPath("$._embedded.values", not(containsInAnyOrder(
+                        FacetValueMatcher.entryAuthor("Smith, Maria"),
+                        FacetValueMatcher.entryAuthor("Doe, Jane")
+                ))))
         ;
     }
 
@@ -462,62 +462,62 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Test")
-                                      .withIssueDate("2010-10-17")
-                                      .withAuthor("Smith, Donald").withAuthor("Testing, Works")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald").withAuthor("Testing, Works")
+                .withSubject("ExtraEntry")
+                .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("1990-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2000-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("2000-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
         //** WHEN **
         //An anonymous user browses this endpoint to find the dateIssued results by the facet
         getClient().perform(get("/api/discover/facets/dateIssued"))
 
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The name has to be 'dateIssued' as that's the facet that we've called
-                   .andExpect(jsonPath("$.name", is("dateIssued")))
-                   //The facetType has to be 'date' because that's the default configuration for this facet
-                   .andExpect(jsonPath("$.facetType", is("date")))
-                   //There always needs to be a self link available
-                   .andExpect(jsonPath("$._links.self.href", containsString("api/discover/facets/dateIssued")))
-                   //This is how the page object must look like because it's the default with size 20
-                   .andExpect(jsonPath("$.page",
-                                       is(PageMatcher.pageEntry(0, 20))))
-                   //The date values need to be as specified below
-                   .andExpect(jsonPath("$._embedded.values", containsInAnyOrder(
-                       //We'll always get atleast two intervals with the items specified above, so we ask to match
-                       // twice atleast
-                       FacetValueMatcher.entryDateIssued(),
-                       FacetValueMatcher.entryDateIssued()
-                   )))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The name has to be 'dateIssued' as that's the facet that we've called
+                .andExpect(jsonPath("$.name", is("dateIssued")))
+                //The facetType has to be 'date' because that's the default configuration for this facet
+                .andExpect(jsonPath("$.facetType", is("date")))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("api/discover/facets/dateIssued")))
+                //This is how the page object must look like because it's the default with size 20
+                .andExpect(jsonPath("$.page",
+                        is(PageMatcher.pageEntry(0, 20))))
+                //The date values need to be as specified below
+                .andExpect(jsonPath("$._embedded.values", containsInAnyOrder(
+                        //We'll always get atleast two intervals with the items specified above, so we ask to match
+                        // twice atleast
+                        FacetValueMatcher.entryDateIssued(),
+                        FacetValueMatcher.entryDateIssued()
+                )))
         ;
     }
 
@@ -530,90 +530,90 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Public item 1")
-                                      .withIssueDate("2017-10-17")
-                                      .withAuthor("Smith, Donald").withAuthor("Doe, John")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                .withSubject("ExtraEntry")
+                .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2016-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2016-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
 
         //** WHEN **
         //An anonymous user browses this endpoint to find the author results by the facet
         //With a certain scope
         getClient().perform(get("/api/discover/facets/author")
-                                .param("scope", "testScope"))
+                .param("scope", "testScope"))
 
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The name has to be author as that's the facet that we've called
-                   .andExpect(jsonPath("$.name", is("author")))
-                   //The facetType has to be 'text' as that's the default configuration for this facet
-                   .andExpect(jsonPath("$.facetType", is("text")))
-                   //The scope has to be the same as the one that we've given in the parameters
-                   .andExpect(jsonPath("$.scope", is("testScope")))
-                   //There always needs to be a self link available
-                   .andExpect(jsonPath("$._links.self.href", containsString("api/discover/facets/author")))
-                   //These are all the authors for the items that were created and thus they have to be present in
-                   // the embedded values section
-                   .andExpect(jsonPath("$._embedded.values", containsInAnyOrder(
-                       FacetValueMatcher.entryAuthor("Doe, Jane"),
-                       FacetValueMatcher.entryAuthor("Smith, Maria"),
-                       FacetValueMatcher.entryAuthor("Doe, John"),
-                       FacetValueMatcher.entryAuthor("Smith, Donald")
-                   )));
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The name has to be author as that's the facet that we've called
+                .andExpect(jsonPath("$.name", is("author")))
+                //The facetType has to be 'text' as that's the default configuration for this facet
+                .andExpect(jsonPath("$.facetType", is("text")))
+                //The scope has to be the same as the one that we've given in the parameters
+                .andExpect(jsonPath("$.scope", is("testScope")))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("api/discover/facets/author")))
+                //These are all the authors for the items that were created and thus they have to be present in
+                // the embedded values section
+                .andExpect(jsonPath("$._embedded.values", containsInAnyOrder(
+                        FacetValueMatcher.entryAuthor("Doe, Jane"),
+                        FacetValueMatcher.entryAuthor("Smith, Maria"),
+                        FacetValueMatcher.entryAuthor("Doe, John"),
+                        FacetValueMatcher.entryAuthor("Smith, Donald")
+                )));
         //** WHEN **
         //An anonymous user browses this endpoint to find the author results by the facet
         //With a certain scope
         //And a size of 2
         getClient().perform(get("/api/discover/facets/author")
-                                .param("scope", "testScope")
-                                .param("size", "2"))
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The name has to be 'author' as that's the facet that we called
-                   .andExpect(jsonPath("$.name", is("author")))
-                   //The facetType has to be 'text' as that's the default configuration for this facet
-                   .andExpect(jsonPath("$.facetType", is("text")))
-                   //The scope has to be same as the param that we've entered
-                   .andExpect(jsonPath("$.scope", is("testScope")))
-                   //There always needs to be a self link available
-                   .andExpect(jsonPath("$._links.self.href", containsString("api/discover/facets/author")))
-                   //These are the values that need to be present as it's ordered by count and these authors are the
-                   // most common ones in the items that we've created
-                   .andExpect(jsonPath("$._embedded.values", containsInAnyOrder(
-                       FacetValueMatcher.entryAuthor("Doe, Jane"),
-                       FacetValueMatcher.entryAuthor("Smith, Maria")
-                   )))
+                .param("scope", "testScope")
+                .param("size", "2"))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The name has to be 'author' as that's the facet that we called
+                .andExpect(jsonPath("$.name", is("author")))
+                //The facetType has to be 'text' as that's the default configuration for this facet
+                .andExpect(jsonPath("$.facetType", is("text")))
+                //The scope has to be same as the param that we've entered
+                .andExpect(jsonPath("$.scope", is("testScope")))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("api/discover/facets/author")))
+                //These are the values that need to be present as it's ordered by count and these authors are the
+                // most common ones in the items that we've created
+                .andExpect(jsonPath("$._embedded.values", containsInAnyOrder(
+                        FacetValueMatcher.entryAuthor("Doe, Jane"),
+                        FacetValueMatcher.entryAuthor("Smith, Maria")
+                )))
         ;
     }
 
@@ -625,105 +625,105 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. 7 public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Test")
-                                      .withIssueDate("2010-10-17")
-                                      .withAuthor("Smith, Donald").withAuthor("Testing, Works")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald").withAuthor("Testing, Works")
+                .withSubject("ExtraEntry")
+                .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("1990-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("1940-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("1940-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
 
         Item publicItem4 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("1950-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("1950-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
 
         Item publicItem5 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("1960-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("1960-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
 
         Item publicItem6 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("1970-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("1970-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
 
         Item publicItem7 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("1980-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("1980-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
 
         //** WHEN **
         //An anonymous user browses this endpoint to find the dateIssued results by the facet
         //And a size of 2
         getClient().perform(get("/api/discover/facets/dateIssued")
-                                .param("size", "2"))
+                .param("size", "2"))
 
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The name needs to be dateIssued as that's the facet that we've called
-                   .andExpect(jsonPath("$.name", is("dateIssued")))
-                   //the facetType needs to be 'date' as that's the default facetType for this facet in the
-                   // configuration
-                   .andExpect(jsonPath("$.facetType", is("date")))
-                   //There always needs to be a self link available
-                   .andExpect(jsonPath("$._links.self.href", containsString("api/discover/facets/dateIssued")))
-                   //Seeing as we've entered a size of two and there are more dates than just two, we'll need a next
-                   // link to go to the next page to see the rest of the dates
-                   .andExpect(jsonPath("$._links.next.href", containsString("api/discover/facets/dateIssued?page")))
-                   //The page object needs to look like this because we've entered a size of 2 and we didn't specify
-                   // a starting page so it defaults to 0
-                   .andExpect(jsonPath("$.page",
-                                       is(PageMatcher.pageEntry(0, 2))))
-                   //There needs to be two date results in the embedded values section because that's what we've
-                   // specified
-                   .andExpect(jsonPath("$._embedded.values", containsInAnyOrder(
-                       FacetValueMatcher.entryDateIssued(),
-                       FacetValueMatcher.entryDateIssued()
-                   )))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The name needs to be dateIssued as that's the facet that we've called
+                .andExpect(jsonPath("$.name", is("dateIssued")))
+                //the facetType needs to be 'date' as that's the default facetType for this facet in the
+                // configuration
+                .andExpect(jsonPath("$.facetType", is("date")))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("api/discover/facets/dateIssued")))
+                //Seeing as we've entered a size of two and there are more dates than just two, we'll need a next
+                // link to go to the next page to see the rest of the dates
+                .andExpect(jsonPath("$._links.next.href", containsString("api/discover/facets/dateIssued?page")))
+                //The page object needs to look like this because we've entered a size of 2 and we didn't specify
+                // a starting page so it defaults to 0
+                .andExpect(jsonPath("$.page",
+                        is(PageMatcher.pageEntry(0, 2))))
+                //There needs to be two date results in the embedded values section because that's what we've
+                // specified
+                .andExpect(jsonPath("$._embedded.values", containsInAnyOrder(
+                        FacetValueMatcher.entryDateIssued(),
+                        FacetValueMatcher.entryDateIssued()
+                )))
         ;
     }
 
@@ -737,71 +737,71 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Test")
-                                      .withIssueDate("2010-10-17")
-                                      .withAuthor("Smith, Donald").withAuthor("Testing, Works")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald").withAuthor("Testing, Works")
+                .withSubject("ExtraEntry")
+                .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Test 2")
-                                      .withIssueDate("1990-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test 2")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2010-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("2010-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
         //** WHEN **
         //An anonymous user browses this endpoint to find the dateIssued results by the facet
         //With a query stating that the title needs to contain 'test'
         //And a size of 2
         getClient().perform(get("/api/discover/facets/dateIssued")
-                                .param("f.title", "test,contains")
-                                .param("size", "2"))
+                .param("f.title", "test,contains")
+                .param("size", "2"))
 
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The name has to be dateIssued because that's the facet that we called
-                   .andExpect(jsonPath("$.name", is("dateIssued")))
-                   //The facetType needs to be 'date' as that's the default facetType for this facet in the
-                   // configuration
-                   .andExpect(jsonPath("$.facetType", is("date")))
-                   //There always needs to be a self link
-                   .andExpect(jsonPath("$._links.self.href", containsString("api/discover/facets/dateIssued")))
-                   //There needs to be an appliedFilters section that looks like this because we've specified a query
-                   // in the parameters
-                   .andExpect(jsonPath("$.appliedFilters", containsInAnyOrder(
-                       AppliedFilterMatcher.appliedFilterEntry("title", "contains", "test", "test")
-                   )))
-                   //The page object needs to look like this because we entered a size of 2 and we didn't specify a
-                   // starting page so it defaults to 0
-                   .andExpect(jsonPath("$.page",
-                                       is(PageMatcher.pageEntry(0, 2))))
-                   //There needs to be only two date intervals with a count of 1 because of the query we specified
-                   .andExpect(jsonPath("$._embedded.values", containsInAnyOrder(
-                       FacetValueMatcher.entryDateIssuedWithCountOne(),
-                       FacetValueMatcher.entryDateIssuedWithCountOne()
-                   )))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The name has to be dateIssued because that's the facet that we called
+                .andExpect(jsonPath("$.name", is("dateIssued")))
+                //The facetType needs to be 'date' as that's the default facetType for this facet in the
+                // configuration
+                .andExpect(jsonPath("$.facetType", is("date")))
+                //There always needs to be a self link
+                .andExpect(jsonPath("$._links.self.href", containsString("api/discover/facets/dateIssued")))
+                //There needs to be an appliedFilters section that looks like this because we've specified a query
+                // in the parameters
+                .andExpect(jsonPath("$.appliedFilters", containsInAnyOrder(
+                        AppliedFilterMatcher.appliedFilterEntry("title", "contains", "test", "test")
+                )))
+                //The page object needs to look like this because we entered a size of 2 and we didn't specify a
+                // starting page so it defaults to 0
+                .andExpect(jsonPath("$.page",
+                        is(PageMatcher.pageEntry(0, 2))))
+                //There needs to be only two date intervals with a count of 1 because of the query we specified
+                .andExpect(jsonPath("$._embedded.values", containsInAnyOrder(
+                        FacetValueMatcher.entryDateIssuedWithCountOne(),
+                        FacetValueMatcher.entryDateIssuedWithCountOne()
+                )))
         ;
     }
 
@@ -811,31 +811,31 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
 
         //When calling this root endpoint
         getClient().perform(get("/api/discover/search"))
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //There needs to be a link to the objects that contains a string as specified below
-                   .andExpect(jsonPath("$._links.objects.href", containsString("api/discover/search/objects")))
-                   //There always needs to be a self link available
-                   .andExpect(jsonPath("$._links.self.href", containsString("api/discover/search")))
-                   //There needs to be a section where these filters as specified as they're the default filters
-                   // given in the configuration
-                   .andExpect(jsonPath("$.filters", containsInAnyOrder(
-                       SearchFilterMatcher.titleFilter(),
-                       SearchFilterMatcher.authorFilter(),
-                       SearchFilterMatcher.subjectFilter(),
-                       SearchFilterMatcher.dateIssuedFilter(),
-                       SearchFilterMatcher.hasContentInOriginalBundleFilter()
-                   )))
-                   //These sortOptions need to be present as it's the default in the configuration
-                   .andExpect(jsonPath("$.sortOptions", containsInAnyOrder(
-                       SortOptionMatcher.titleSortOption(),
-                       SortOptionMatcher.dateIssuedSortOption(),
-                       SortOptionMatcher.dateAccessionedSortOption(),
-                       SortOptionMatcher.scoreSortOption()
-                   )));
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //There needs to be a link to the objects that contains a string as specified below
+                .andExpect(jsonPath("$._links.objects.href", containsString("api/discover/search/objects")))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("api/discover/search")))
+                //There needs to be a section where these filters as specified as they're the default filters
+                // given in the configuration
+                .andExpect(jsonPath("$.filters", containsInAnyOrder(
+                        SearchFilterMatcher.titleFilter(),
+                        SearchFilterMatcher.authorFilter(),
+                        SearchFilterMatcher.subjectFilter(),
+                        SearchFilterMatcher.dateIssuedFilter(),
+                        SearchFilterMatcher.hasContentInOriginalBundleFilter()
+                )))
+                //These sortOptions need to be present as it's the default in the configuration
+                .andExpect(jsonPath("$.sortOptions", containsInAnyOrder(
+                        SortOptionMatcher.titleSortOption(),
+                        SortOptionMatcher.dateIssuedSortOption(),
+                        SortOptionMatcher.dateAccessionedSortOption(),
+                        SortOptionMatcher.scoreSortOption()
+                )));
     }
 
     @Test
@@ -847,74 +847,74 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Test")
-                                      .withIssueDate("2010-10-17")
-                                      .withAuthor("Smith, Donald").withAuthor("Testing, Works")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald").withAuthor("Testing, Works")
+                .withSubject("ExtraEntry")
+                .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Test 2")
-                                      .withIssueDate("1990-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test 2")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2010-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("2010-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
 
         //** WHEN **
         //An anonymous user browses this endpoint to find the objects in the system
         getClient().perform(get("/api/discover/search/objects"))
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //There needs to be a page object that shows the total pages and total elements as well as the
-                   // size and the current page (number)
-                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
-                       PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 7)
-                   )))
-                   //These search results have to be shown in the embedded.objects section as these are the items
-                   // given in the structure defined above.
-                   //Seeing as everything fits onto one page, they have to all be present
-                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
-                       SearchResultMatcher.match("community", "communities"),
-                       SearchResultMatcher.match("community", "communities"),
-                       //This has to be like this because collections don't have anything else
-                       SearchResultMatcher.match(),
-                       SearchResultMatcher.match(),
-                       SearchResultMatcher.match("item", "items"),
-                       SearchResultMatcher.match("item", "items"),
-                       SearchResultMatcher.match("item", "items")
-                   )))
-                   //These facets have to show up in the embedded.facets section as well with the given hasMore
-                   // property because we don't exceed their default limit for a hasMore true (the default is 10)
-                   .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
-                       FacetEntryMatcher.authorFacet(false),
-                       FacetEntryMatcher.subjectFacet(false),
-                       FacetEntryMatcher.dateIssuedFacet(false),
-                       FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
-                   )))
-                   //There always needs to be a self link
-                   .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //There needs to be a page object that shows the total pages and total elements as well as the
+                // size and the current page (number)
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 7)
+                )))
+                //These search results have to be shown in the embedded.objects section as these are the items
+                // given in the structure defined above.
+                //Seeing as everything fits onto one page, they have to all be present
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                        SearchResultMatcher.match("community", "communities"),
+                        SearchResultMatcher.match("community", "communities"),
+                        //This has to be like this because collections don't have anything else
+                        SearchResultMatcher.match(),
+                        SearchResultMatcher.match(),
+                        SearchResultMatcher.match("item", "items"),
+                        SearchResultMatcher.match("item", "items"),
+                        SearchResultMatcher.match("item", "items")
+                )))
+                //These facets have to show up in the embedded.facets section as well with the given hasMore
+                // property because we don't exceed their default limit for a hasMore true (the default is 10)
+                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                        FacetEntryMatcher.authorFacet(false),
+                        FacetEntryMatcher.subjectFacet(false),
+                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                )))
+                //There always needs to be a self link
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
         ;
     }
 
@@ -926,79 +926,79 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Test")
-                                      .withIssueDate("2010-10-17")
-                                      .withAuthor("Smith, Donald").withAuthor("Testing, Works").withAuthor("a1, a1")
-                                      .withAuthor("b, b").withAuthor("c, c").withAuthor("d, d").withAuthor("e, e")
-                                      .withAuthor("f, f").withAuthor("g, g")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald").withAuthor("Testing, Works").withAuthor("a1, a1")
+                .withAuthor("b, b").withAuthor("c, c").withAuthor("d, d").withAuthor("e, e")
+                .withAuthor("f, f").withAuthor("g, g")
+                .withSubject("ExtraEntry")
+                .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Test 2")
-                                      .withIssueDate("1990-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test 2")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2010-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("2010-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
 
         //** WHEN **
         //An anonymous user browses this endpoint to find the objects in the system
         getClient().perform(get("/api/discover/search/objects"))
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The page object has to look like this because we've only made 7 elements, the default size is 20
-                   // and they all fit onto one page (20 > 7) so totalPages has to be 1. Number is 0 because
-                   //page 0 is the default page we view if not specified otherwise
-                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
-                       PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 7)
-                   )))
-                   //All elements have to be present in the embedded.objects section, these are the ones we made in
-                   // the structure defined above
-                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
-                       SearchResultMatcher.match("community", "communities"),
-                       SearchResultMatcher.match("community", "communities"),
-                       //Match without any parameters because collections don't have anything special to check in the
-                       // json
-                       SearchResultMatcher.match(),
-                       SearchResultMatcher.match(),
-                       SearchResultMatcher.match("item", "items"),
-                       SearchResultMatcher.match("item", "items"),
-                       SearchResultMatcher.match("item", "items")
-                   )))
-                   //These facets have to show up in the embedded.facets section as well with the given hasMore
-                   // property because we don't exceed their default limit for a hasMore true (the default is 10)
-                   //We do however exceed the limit for the authors, so this property has to be true for the author
-                   // facet
-                   .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
-                       FacetEntryMatcher.authorFacet(true),
-                       FacetEntryMatcher.subjectFacet(false),
-                       FacetEntryMatcher.dateIssuedFacet(false),
-                       FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
-                   )))
-                   //There always needs to be a self link available
-                   .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The page object has to look like this because we've only made 7 elements, the default size is 20
+                // and they all fit onto one page (20 > 7) so totalPages has to be 1. Number is 0 because
+                //page 0 is the default page we view if not specified otherwise
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 7)
+                )))
+                //All elements have to be present in the embedded.objects section, these are the ones we made in
+                // the structure defined above
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                        SearchResultMatcher.match("community", "communities"),
+                        SearchResultMatcher.match("community", "communities"),
+                        //Match without any parameters because collections don't have anything special to check in the
+                        // json
+                        SearchResultMatcher.match(),
+                        SearchResultMatcher.match(),
+                        SearchResultMatcher.match("item", "items"),
+                        SearchResultMatcher.match("item", "items"),
+                        SearchResultMatcher.match("item", "items")
+                )))
+                //These facets have to show up in the embedded.facets section as well with the given hasMore
+                // property because we don't exceed their default limit for a hasMore true (the default is 10)
+                //We do however exceed the limit for the authors, so this property has to be true for the author
+                // facet
+                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                        FacetEntryMatcher.authorFacet(true),
+                        FacetEntryMatcher.subjectFacet(false),
+                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                )))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
         ;
 
     }
@@ -1012,80 +1012,80 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Test")
-                                      .withIssueDate("2010-10-17")
-                                      .withAuthor("Smith, Donald").withAuthor("Testing, Works")
-                                      .withSubject("ExtraEntry").withSubject("a")
-                                      .withSubject("b").withSubject("c")
-                                      .withSubject("d").withSubject("e")
-                                      .withSubject("f").withSubject("g")
-                                      .withSubject("h").withSubject("i")
-                                      .withSubject("j").withSubject("k")
-                                      .build();
+                .withTitle("Test")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald").withAuthor("Testing, Works")
+                .withSubject("ExtraEntry").withSubject("a")
+                .withSubject("b").withSubject("c")
+                .withSubject("d").withSubject("e")
+                .withSubject("f").withSubject("g")
+                .withSubject("h").withSubject("i")
+                .withSubject("j").withSubject("k")
+                .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Test 2")
-                                      .withIssueDate("1990-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test 2")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2010-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("2010-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
 
         //** WHEN **
         //An anonymous user browses this endpoint to find the the objects in the system
         getClient().perform(get("/api/discover/search/objects"))
 
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The page object has to look like this because we've only made 7 items, they all fit onto 1 page
-                   // because the default size is 20 and the default starting page is 0.
-                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
-                       PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 7)
-                   )))
-                   //All the elements created in the structure above have to be present in the embedded.objects section
-                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
-                       SearchResultMatcher.match("community", "communities"),
-                       SearchResultMatcher.match("community", "communities"),
-                       //Collections are specified like this because they don't have any special properties
-                       SearchResultMatcher.match(),
-                       SearchResultMatcher.match(),
-                       SearchResultMatcher.match("item", "items"),
-                       SearchResultMatcher.match("item", "items"),
-                       SearchResultMatcher.match("item", "items")
-                   )))
-                   //These facets have to show up in the embedded.facets section as well with the given hasMore
-                   // property because we don't exceed their default limit for a hasMore true (the default is 10)
-                   //We do however exceed the limit for the subject, so this property has to be true for the subject
-                   // facet
-                   .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
-                       FacetEntryMatcher.authorFacet(false),
-                       FacetEntryMatcher.subjectFacet(true),
-                       FacetEntryMatcher.dateIssuedFacet(false),
-                       FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
-                   )))
-                   //There always needs to be a self link available
-                   .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The page object has to look like this because we've only made 7 items, they all fit onto 1 page
+                // because the default size is 20 and the default starting page is 0.
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 7)
+                )))
+                //All the elements created in the structure above have to be present in the embedded.objects section
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                        SearchResultMatcher.match("community", "communities"),
+                        SearchResultMatcher.match("community", "communities"),
+                        //Collections are specified like this because they don't have any special properties
+                        SearchResultMatcher.match(),
+                        SearchResultMatcher.match(),
+                        SearchResultMatcher.match("item", "items"),
+                        SearchResultMatcher.match("item", "items"),
+                        SearchResultMatcher.match("item", "items")
+                )))
+                //These facets have to show up in the embedded.facets section as well with the given hasMore
+                // property because we don't exceed their default limit for a hasMore true (the default is 10)
+                //We do however exceed the limit for the subject, so this property has to be true for the subject
+                // facet
+                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                        FacetEntryMatcher.authorFacet(false),
+                        FacetEntryMatcher.subjectFacet(true),
+                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                )))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
         ;
     }
 
@@ -1097,72 +1097,72 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Test")
-                                      .withIssueDate("2010-10-17")
-                                      .withAuthor("Smith, Donald").withAuthor("Testing, Works")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald").withAuthor("Testing, Works")
+                .withSubject("ExtraEntry")
+                .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Test 2")
-                                      .withIssueDate("1990-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test 2")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2010-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("2010-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .build();
 
         //** WHEN **
         //An anonymous user browses this endpoint to find the the objects in the system
         //With a query that says that the title has to contain 'test'
         getClient().perform(get("/api/discover/search/objects")
-                                .param("f.title", "test,contains"))
+                .param("f.title", "test,contains"))
 
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The page object has to look like this because of the query we specified, only two elements match
-                   // the query.
-                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
-                       PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 2)
-                   )))
-                   //Only the two item elements match the query, therefore those are the only ones that can be in the
-                   // embedded.objects section
-                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
-                       SearchResultMatcher.match("item", "items"),
-                       SearchResultMatcher.match("item", "items")
-                   )))
-                   //We need to display the appliedFilters object that contains the query that we've ran
-                   .andExpect(jsonPath("$.appliedFilters", contains(
-                       AppliedFilterMatcher.appliedFilterEntry("title", "contains", "test", "test")
-                   )))
-                   //These facets have to show up in the embedded.facets section as well with the given hasMore
-                   // property because we don't exceed their default limit for a hasMore true (the default is 10)
-                   .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
-                       FacetEntryMatcher.authorFacet(false),
-                       FacetEntryMatcher.subjectFacet(false),
-                       FacetEntryMatcher.dateIssuedFacet(false),
-                       FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
-                   )))
-                   //There always needs to be a self link available
-                   .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The page object has to look like this because of the query we specified, only two elements match
+                // the query.
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 2)
+                )))
+                //Only the two item elements match the query, therefore those are the only ones that can be in the
+                // embedded.objects section
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                        SearchResultMatcher.match("item", "items"),
+                        SearchResultMatcher.match("item", "items")
+                )))
+                //We need to display the appliedFilters object that contains the query that we've ran
+                .andExpect(jsonPath("$.appliedFilters", contains(
+                        AppliedFilterMatcher.appliedFilterEntry("title", "contains", "test", "test")
+                )))
+                //These facets have to show up in the embedded.facets section as well with the given hasMore
+                // property because we don't exceed their default limit for a hasMore true (the default is 10)
+                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                        FacetEntryMatcher.authorFacet(false),
+                        FacetEntryMatcher.subjectFacet(false),
+                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                )))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
         ;
     }
 
@@ -1175,75 +1175,75 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Test")
-                                      .withIssueDate("2010-10-17")
-                                      .withAuthor("Smith, Donald").withAuthor("Testing, Works")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald").withAuthor("Testing, Works")
+                .withSubject("ExtraEntry")
+                .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Test 2")
-                                      .withIssueDate("1990-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test 2")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2010-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("2010-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
         //** WHEN **
         //An anonymous user browses this endpoint to find the the objects in the system
         //With a scope 'test'
         getClient().perform(get("/api/discover/search/objects")
-                                .param("scope", "test"))
+                .param("scope", "test"))
 
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The page element has to look like this because it contains all the elements we've just created
-                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
-                       PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 7)
-                   )))
-                   //The scope property has to be set to the value we entered in the parameters
-                   .andExpect(jsonPath("$.scope", is("test")))
-                   //All the elements created in the structure above have to be present in the embedded.objects section
-                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
-                       SearchResultMatcher.match("community", "communities"),
-                       SearchResultMatcher.match("community", "communities"),
-                       //Collections are specified like this because they don't have any special properties
-                       SearchResultMatcher.match(),
-                       SearchResultMatcher.match(),
-                       SearchResultMatcher.match("item", "items"),
-                       SearchResultMatcher.match("item", "items"),
-                       SearchResultMatcher.match("item", "items")
-                   )))
-                   //These facets have to show up in the embedded.facets section as well with the given hasMore
-                   // property because we don't exceed their default limit for a hasMore true (the default is 10)
-                   .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
-                       FacetEntryMatcher.authorFacet(false),
-                       FacetEntryMatcher.subjectFacet(false),
-                       FacetEntryMatcher.dateIssuedFacet(false),
-                       FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
-                   )))
-                   //There always needs to be a self link available
-                   .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The page element has to look like this because it contains all the elements we've just created
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 7)
+                )))
+                //The scope property has to be set to the value we entered in the parameters
+                .andExpect(jsonPath("$.scope", is("test")))
+                //All the elements created in the structure above have to be present in the embedded.objects section
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                        SearchResultMatcher.match("community", "communities"),
+                        SearchResultMatcher.match("community", "communities"),
+                        //Collections are specified like this because they don't have any special properties
+                        SearchResultMatcher.match(),
+                        SearchResultMatcher.match(),
+                        SearchResultMatcher.match("item", "items"),
+                        SearchResultMatcher.match("item", "items"),
+                        SearchResultMatcher.match("item", "items")
+                )))
+                //These facets have to show up in the embedded.facets section as well with the given hasMore
+                // property because we don't exceed their default limit for a hasMore true (the default is 10)
+                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                        FacetEntryMatcher.authorFacet(false),
+                        FacetEntryMatcher.subjectFacet(false),
+                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                )))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
         ;
     }
 
@@ -1255,71 +1255,71 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Test")
-                                      .withIssueDate("2010-10-17")
-                                      .withAuthor("Smith, Donald").withAuthor("Testing, Works")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald").withAuthor("Testing, Works")
+                .withSubject("ExtraEntry")
+                .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Test 2")
-                                      .withIssueDate("1990-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test 2")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2010-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("2010-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
 
         //** WHEN **
         //An anonymous user browses this endpoint to find the the objects in the system
         //With a dsoType 'item'
         getClient().perform(get("/api/discover/search/objects")
-                                .param("dsoType", "item"))
+                .param("dsoType", "item"))
 
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The page element needs to look like this and only have three totalElements because we only want
-                   // the items (dsoType) and we only created three items
-                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
-                       PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 3)
-                   )))
-                   //Only the three items can be present in the embedded.objects section as that's what we specified
-                   // in the dsoType parameter
-                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
-                       SearchResultMatcher.match("item", "items"),
-                       SearchResultMatcher.match("item", "items"),
-                       SearchResultMatcher.match("item", "items")
-                   )))
-                   //These facets have to show up in the embedded.facets section as well with the given hasMore
-                   // property because we don't exceed their default limit for a hasMore true (the default is 10)
-                   .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
-                       FacetEntryMatcher.authorFacet(false),
-                       FacetEntryMatcher.subjectFacet(false),
-                       FacetEntryMatcher.dateIssuedFacet(false),
-                       FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
-                   )))
-                   //There always needs to be a self link available
-                   .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The page element needs to look like this and only have three totalElements because we only want
+                // the items (dsoType) and we only created three items
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 3)
+                )))
+                //Only the three items can be present in the embedded.objects section as that's what we specified
+                // in the dsoType parameter
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                        SearchResultMatcher.match("item", "items"),
+                        SearchResultMatcher.match("item", "items"),
+                        SearchResultMatcher.match("item", "items")
+                )))
+                //These facets have to show up in the embedded.facets section as well with the given hasMore
+                // property because we don't exceed their default limit for a hasMore true (the default is 10)
+                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                        FacetEntryMatcher.authorFacet(false),
+                        FacetEntryMatcher.subjectFacet(false),
+                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                )))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
         ;
     }
 
@@ -1330,85 +1330,85 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Test")
-                                      .withIssueDate("2010-10-17")
-                                      .withAuthor("Smith, Donald").withAuthor("Testing, Works")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald").withAuthor("Testing, Works")
+                .withSubject("ExtraEntry")
+                .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Testing")
-                                      .withIssueDate("1990-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Testing")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public")
-                                      .withIssueDate("2010-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public")
+                .withIssueDate("2010-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
 
         //** WHEN **
         //An anonymous user browses this endpoint to find the the objects in the system
         //With a dsoType 'item'
         //And a sort on the dc.title ascending
         getClient().perform(get("/api/discover/search/objects")
-                                .param("dsoType", "item")
-                                .param("sort", "dc.title,ASC"))
+                .param("dsoType", "item")
+                .param("sort", "dc.title,ASC"))
 
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The page object has to look like this and only contain three total elements because we only want
-                   // to get the items back
-                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
-                       PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 3)
-                   )))
-                   //Only the three items can be present in the embedded.objects section as that's what we specified
-                   // in the dsoType parameter
-                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
-                       SearchResultMatcher.match("item", "items"),
-                       SearchResultMatcher.match("item", "items"),
-                       SearchResultMatcher.match("item", "items")
-                   )))
-                   //Here we want to match on the item name in a certain specified order because we want to check the
-                   // sort properly
-                   //We check whether the items are sorted properly as we expected
-                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.contains(
-                       SearchResultMatcher.matchOnItemName("item", "items", "Public"),
-                       SearchResultMatcher.matchOnItemName("item", "items", "Test"),
-                       SearchResultMatcher.matchOnItemName("item", "items", "Testing")
-                   )))
-                   //These facets have to show up in the embedded.facets section as well with the given hasMore
-                   // property because we don't exceed their default limit for a hasMore true (the default is 10)
-                   .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
-                       FacetEntryMatcher.authorFacet(false),
-                       FacetEntryMatcher.subjectFacet(false),
-                       FacetEntryMatcher.dateIssuedFacet(false),
-                       FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
-                   )))
-                   //We want to get the sort that's been used as well in the response
-                   .andExpect(jsonPath("$.sort", is(
-                       SortOptionMatcher.sortByAndOrder("dc.title", "ASC")
-                   )))
-                   //There always needs to be a self link available
-                   .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The page object has to look like this and only contain three total elements because we only want
+                // to get the items back
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 3)
+                )))
+                //Only the three items can be present in the embedded.objects section as that's what we specified
+                // in the dsoType parameter
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                        SearchResultMatcher.match("item", "items"),
+                        SearchResultMatcher.match("item", "items"),
+                        SearchResultMatcher.match("item", "items")
+                )))
+                //Here we want to match on the item name in a certain specified order because we want to check the
+                // sort properly
+                //We check whether the items are sorted properly as we expected
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.contains(
+                        SearchResultMatcher.matchOnItemName("item", "items", "Public"),
+                        SearchResultMatcher.matchOnItemName("item", "items", "Test"),
+                        SearchResultMatcher.matchOnItemName("item", "items", "Testing")
+                )))
+                //These facets have to show up in the embedded.facets section as well with the given hasMore
+                // property because we don't exceed their default limit for a hasMore true (the default is 10)
+                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                        FacetEntryMatcher.authorFacet(false),
+                        FacetEntryMatcher.subjectFacet(false),
+                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                )))
+                //We want to get the sort that's been used as well in the response
+                .andExpect(jsonPath("$.sort", is(
+                        SortOptionMatcher.sortByAndOrder("dc.title", "ASC")
+                )))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
         ;
     }
 
@@ -1420,114 +1420,114 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. 9 public items that are readable by Anonymous with different subjects
         Item publicItem6 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public")
-                                      .withIssueDate("2017-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public")
+                .withIssueDate("2017-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
         Item publicItem7 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public")
-                                      .withIssueDate("2010-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public")
+                .withIssueDate("2010-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
         Item publicItem8 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public")
-                                      .withIssueDate("1990-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
         Item publicItem9 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public")
-                                      .withIssueDate("1970-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public")
+                .withIssueDate("1970-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
         Item publicItem10 = ItemBuilder.createItem(context, col2)
-                                       .withTitle("Public")
-                                       .withIssueDate("1950-02-13")
-                                       .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                       .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                       .withSubject("AnotherTest").withSubject("TestingForMore")
-                                       .withSubject("ExtraEntry")
-                                       .build();
+                .withTitle("Public")
+                .withIssueDate("1950-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
         Item publicItem11 = ItemBuilder.createItem(context, col2)
-                                       .withTitle("Public")
-                                       .withIssueDate("1930-02-13")
-                                       .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                       .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                       .withSubject("AnotherTest").withSubject("TestingForMore")
-                                       .withSubject("ExtraEntry")
-                                       .build();
+                .withTitle("Public")
+                .withIssueDate("1930-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
         Item publicItem12 = ItemBuilder.createItem(context, col2)
-                                       .withTitle("Public")
-                                       .withIssueDate("1910-02-13")
-                                       .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                       .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                       .withSubject("AnotherTest").withSubject("TestingForMore")
-                                       .withSubject("ExtraEntry")
-                                       .build();
+                .withTitle("Public")
+                .withIssueDate("1910-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
         Item publicItem13 = ItemBuilder.createItem(context, col2)
-                                       .withTitle("Public")
-                                       .withIssueDate("1890-02-13")
-                                       .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                       .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                       .withSubject("AnotherTest").withSubject("TestingForMore")
-                                       .withSubject("ExtraEntry")
-                                       .build();
+                .withTitle("Public")
+                .withIssueDate("1890-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
         Item publicItem14 = ItemBuilder.createItem(context, col2)
-                                       .withTitle("Public")
-                                       .withIssueDate("1866-02-13")
-                                       .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                       .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                       .withSubject("AnotherTest").withSubject("TestingForMore")
-                                       .withSubject("ExtraEntry")
-                                       .build();
+                .withTitle("Public")
+                .withIssueDate("1866-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
 
         //** WHEN **
         //An anonymous user browses this endpoint to find dateIssued facet values
         getClient().perform(get("/api/discover/facets/dateIssued"))
 
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The page object has to look like this because the default size is 20 and the default starting
-                   // page is 0
-                   .andExpect(jsonPath("$.page", is(
-                       PageMatcher.pageEntry(0, 20)
-                   )))
-                   //Then we expect these dateIssued values to be present with the labels as specified
-                   .andExpect(jsonPath("$._embedded.values", Matchers.containsInAnyOrder(
-                       FacetValueMatcher.entryDateIssuedWithLabel("2000 - 2017"),
-                       FacetValueMatcher.entryDateIssuedWithLabel("1980 - 1999"),
-                       FacetValueMatcher.entryDateIssuedWithLabel("1960 - 1979"),
-                       FacetValueMatcher.entryDateIssuedWithLabel("1940 - 1959"),
-                       FacetValueMatcher.entryDateIssuedWithLabel("1920 - 1939"),
-                       FacetValueMatcher.entryDateIssuedWithLabel("1880 - 1899"),
-                       FacetValueMatcher.entryDateIssuedWithLabel("1866 - 1879"),
-                       FacetValueMatcher.entryDateIssuedWithLabel("1900 - 1919")
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The page object has to look like this because the default size is 20 and the default starting
+                // page is 0
+                .andExpect(jsonPath("$.page", is(
+                        PageMatcher.pageEntry(0, 20)
+                )))
+                //Then we expect these dateIssued values to be present with the labels as specified
+                .andExpect(jsonPath("$._embedded.values", Matchers.containsInAnyOrder(
+                        FacetValueMatcher.entryDateIssuedWithLabel("2000 - 2017"),
+                        FacetValueMatcher.entryDateIssuedWithLabel("1980 - 1999"),
+                        FacetValueMatcher.entryDateIssuedWithLabel("1960 - 1979"),
+                        FacetValueMatcher.entryDateIssuedWithLabel("1940 - 1959"),
+                        FacetValueMatcher.entryDateIssuedWithLabel("1920 - 1939"),
+                        FacetValueMatcher.entryDateIssuedWithLabel("1880 - 1899"),
+                        FacetValueMatcher.entryDateIssuedWithLabel("1866 - 1879"),
+                        FacetValueMatcher.entryDateIssuedWithLabel("1900 - 1919")
 
-                   )))
+                )))
         ;
     }
 
@@ -1539,76 +1539,76 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Test")
-                                      .withIssueDate("2010-10-17")
-                                      .withAuthor("Smith, Donald").withAuthor("t, t").withAuthor("t, y")
-                                      .withAuthor("t, r").withAuthor("t, e").withAuthor("t, z").withAuthor("t, a")
-                                      .withAuthor("t, tq").withAuthor("t, ts").withAuthor("t, td").withAuthor("t, tf")
-                                      .withAuthor("t, tg").withAuthor("t, th").withAuthor("t, tj").withAuthor("t, tk")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald").withAuthor("t, t").withAuthor("t, y")
+                .withAuthor("t, r").withAuthor("t, e").withAuthor("t, z").withAuthor("t, a")
+                .withAuthor("t, tq").withAuthor("t, ts").withAuthor("t, td").withAuthor("t, tf")
+                .withAuthor("t, tg").withAuthor("t, th").withAuthor("t, tj").withAuthor("t, tk")
+                .withSubject("ExtraEntry")
+                .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Test 2")
-                                      .withIssueDate("1990-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test 2")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2010-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry").withSubject("a").withSubject("b").withSubject("c")
-                                      .withSubject("d").withSubject("e").withSubject("f").withSubject("g")
-                                      .withSubject("h").withSubject("i").withSubject("j")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("2010-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry").withSubject("a").withSubject("b").withSubject("c")
+                .withSubject("d").withSubject("e").withSubject("f").withSubject("g")
+                .withSubject("h").withSubject("i").withSubject("j")
+                .build();
 
         //** WHEN **
         //An anonymous user browses this endpoint to find the the objects in the system
         //With a size 2
         getClient().perform(get("/api/discover/search/objects")
-                                .param("size", "2")
-                                .param("page", "1"))
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The page object needs to look like this
-                   //Size of 2 because that's what we entered
-                   //Page number 1 because that's the param we entered
-                   //TotalPages 4 because size = 2 and total elements is 7 -> 4 pages
-                   //We made 7 elements -> 7 total elements
-                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
-                       PageMatcher.pageEntryWithTotalPagesAndElements(1, 2, 4, 7)
-                   )))
-                   //These are the  two elements that'll be shown (because page = 1, so the third and fourth element
-                   // in the list) and they'll be the only ones because the size is 2
-                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
-                       SearchResultMatcher.match(),
-                       SearchResultMatcher.match()
-                   )))
-                   .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
-                       FacetEntryMatcher.authorFacet(true),
-                       FacetEntryMatcher.subjectFacet(true),
-                       FacetEntryMatcher.dateIssuedFacet(false),
-                       FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
-                   )))
-                   //There always needs to be a self link available
-                   .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+                .param("size", "2")
+                .param("page", "1"))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The page object needs to look like this
+                //Size of 2 because that's what we entered
+                //Page number 1 because that's the param we entered
+                //TotalPages 4 because size = 2 and total elements is 7 -> 4 pages
+                //We made 7 elements -> 7 total elements
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntryWithTotalPagesAndElements(1, 2, 4, 7)
+                )))
+                //These are the  two elements that'll be shown (because page = 1, so the third and fourth element
+                // in the list) and they'll be the only ones because the size is 2
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                        SearchResultMatcher.match(),
+                        SearchResultMatcher.match()
+                )))
+                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                        FacetEntryMatcher.authorFacet(true),
+                        FacetEntryMatcher.subjectFacet(true),
+                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                )))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
         ;
 
     }
@@ -1622,45 +1622,45 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Test")
-                                      .withIssueDate("2010-10-17")
-                                      .withAuthor("Smith, Donald")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald")
+                .withSubject("ExtraEntry")
+                .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Test 2")
-                                      .withIssueDate("1990-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test 2")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2010-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("2010-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
         String bitstreamContent = "ThisIsSomeDummyText";
         //Add a bitstream to an item
         try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
             Bitstream bitstream = BitstreamBuilder.
-                                                      createBitstream(context, publicItem1, is)
-                                                  .withName("Bitstream")
-                                                  .withMimeType("text/plain")
-                                                  .build();
+                    createBitstream(context, publicItem1, is)
+                    .withName("Bitstream")
+                    .withMimeType("text/plain")
+                    .build();
         }
 
         //Run the filter media to make the text in the bitstream searchable through the query
@@ -1670,32 +1670,32 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //An anonymous user browses this endpoint to find the the objects in the system
         //With a query stating 'ThisIsSomeDummyText'
         getClient().perform(get("/api/discover/search/objects")
-                                .param("query", "ThisIsSomeDummyText"))
+                .param("query", "ThisIsSomeDummyText"))
 
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The page object needs to look like this
-                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
-                       PageMatcher.pageEntry(0, 20)
-                   )))
-                   //This is the only item that should be returned with the query given
-                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.contains(
-                       SearchResultMatcher.matchOnItemName("item", "items", "Test")
-                   )))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The page object needs to look like this
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntry(0, 20)
+                )))
+                //This is the only item that should be returned with the query given
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.contains(
+                        SearchResultMatcher.matchOnItemName("item", "items", "Test")
+                )))
 
-                   //These facets have to show up in the embedded.facets section as well with the given hasMore
-                   // property because we don't exceed their default limit for a hasMore true (the default is 10)
-                   .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
-                       FacetEntryMatcher.authorFacet(false),
-                       FacetEntryMatcher.subjectFacet(false),
-                       FacetEntryMatcher.dateIssuedFacet(false),
-                       FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
-                   )))
-                   //There always needs to be a self link available
-                   .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+                //These facets have to show up in the embedded.facets section as well with the given hasMore
+                // property because we don't exceed their default limit for a hasMore true (the default is 10)
+                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                        FacetEntryMatcher.authorFacet(false),
+                        FacetEntryMatcher.subjectFacet(false),
+                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                )))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
         ;
 
     }
@@ -1708,40 +1708,40 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Test")
-                                      .withIssueDate("2010-10-17")
-                                      .withAuthor("Smith, Donald")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald")
+                .withSubject("ExtraEntry")
+                .build();
 
         //Make this one public to make sure that it doesn't show up in the search
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Test 2")
-                                      .withIssueDate("1990-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .makePrivate()
-                                      .build();
+                .withTitle("Test 2")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .makePrivate()
+                .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2010-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .withEmbargoPeriod("12 months")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("2010-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .withEmbargoPeriod("12 months")
+                .build();
 
         //Turn on the authorization again
         context.restoreAuthSystemState();
@@ -1749,38 +1749,38 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //An anonymous user browses this endpoint to find the the objects in the system
         //
         getClient().perform(get("/api/discover/search/objects"))
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The page object needs to look like this
-                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
-                       PageMatcher.pageEntry(0, 20)
-                   )))
-                   //These are the items that aren't set to private
-                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
-                       SearchResultMatcher.match("community", "communities"),
-                       SearchResultMatcher.match("community", "communities"),
-                       //Collections are specified like this because they don't have any special properties
-                       SearchResultMatcher.match(),
-                       SearchResultMatcher.match(),
-                       SearchResultMatcher.matchOnItemName("item", "items", "Test"),
-                       SearchResultMatcher.matchOnItemName("item", "items", "Public item 2")
-                   )))
-                   //This is a private item, this shouldn't show up in the result
-                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects",
-                                       Matchers.not(SearchResultMatcher.matchOnItemName("item", "items", "Test 2"))))
-                   //These facets have to show up in the embedded.facets section as well with the given hasMore
-                   // property because we don't exceed their default limit for a hasMore true (the default is 10)
-                   .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
-                       FacetEntryMatcher.authorFacet(false),
-                       FacetEntryMatcher.subjectFacet(false),
-                       FacetEntryMatcher.dateIssuedFacet(false),
-                       FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
-                   )))
-                   //There always needs to be a self link available
-                   .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The page object needs to look like this
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntry(0, 20)
+                )))
+                //These are the items that aren't set to private
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                        SearchResultMatcher.match("community", "communities"),
+                        SearchResultMatcher.match("community", "communities"),
+                        //Collections are specified like this because they don't have any special properties
+                        SearchResultMatcher.match(),
+                        SearchResultMatcher.match(),
+                        SearchResultMatcher.matchOnItemName("item", "items", "Test"),
+                        SearchResultMatcher.matchOnItemName("item", "items", "Public item 2")
+                )))
+                //This is a private item, this shouldn't show up in the result
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects",
+                        Matchers.not(SearchResultMatcher.matchOnItemName("item", "items", "Test 2"))))
+                //These facets have to show up in the embedded.facets section as well with the given hasMore
+                // property because we don't exceed their default limit for a hasMore true (the default is 10)
+                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                        FacetEntryMatcher.authorFacet(false),
+                        FacetEntryMatcher.subjectFacet(false),
+                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                )))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
         ;
 
     }
@@ -1795,37 +1795,37 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
 
         //2. one public item that is readable by Anonymous
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Test")
-                                      .withIssueDate("2010-10-17")
-                                      .withAuthor("Smith, Donald")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald")
+                .withSubject("ExtraEntry")
+                .build();
 
         String bitstreamContent = "ThisIsSomeDummyText";
 
         //Make the group that anon doesn't have access to
         Group internalGroup = GroupBuilder.createGroup(context)
-                                          .withName("Internal Group")
-                                          .build();
+                .withName("Internal Group")
+                .build();
 
         //Add this bitstream with the internal group as the reader group
         try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
             Bitstream bitstream = BitstreamBuilder.
-                                                      createBitstream(context, publicItem1, is)
-                                                  .withName("Bitstream")
-                                                  .withDescription("Test Private Bitstream")
-                                                  .withMimeType("text/plain")
-                                                  .withReaderGroup(internalGroup)
-                                                  .build();
+                    createBitstream(context, publicItem1, is)
+                    .withName("Bitstream")
+                    .withDescription("Test Private Bitstream")
+                    .withMimeType("text/plain")
+                    .withReaderGroup(internalGroup)
+                    .build();
         }
 
 
@@ -1839,32 +1839,32 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //An anonymous user browses this endpoint to find the the objects in the system
         //With a size 2
         getClient().perform(get("/api/discover/search/objects")
-                                .param("query", "ThisIsSomeDummyText"))
+                .param("query", "ThisIsSomeDummyText"))
 
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The page object needs to look like this
-                   .andExpect(jsonPath("$.page", is(
-                       PageMatcher.pageEntry(0, 20)
-                   )))
-                   //Make sure that the item with the private bitstream doesn't show up
-                   .andExpect(jsonPath("$._embedded.object", Matchers.not(Matchers.contains(
-                       SearchResultMatcher.matchOnItemName("item", "items", "Test")
-                   ))))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The page object needs to look like this
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntry(0, 20)
+                )))
+                //Make sure that the item with the private bitstream doesn't show up
+                .andExpect(jsonPath("$._embedded.object", Matchers.not(Matchers.contains(
+                        SearchResultMatcher.matchOnItemName("item", "items", "Test")
+                ))))
 
-                   //These facets have to show up in the embedded.facets section as well with the given hasMore
-                   // property because we don't exceed their default limit for a hasMore true (the default is 10)
-                   .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
-                       FacetEntryMatcher.authorFacet(false),
-                       FacetEntryMatcher.subjectFacet(false),
-                       FacetEntryMatcher.dateIssuedFacet(false),
-                       FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
-                   )))
-                   //There always needs to be a self link available
-                   .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+                //These facets have to show up in the embedded.facets section as well with the given hasMore
+                // property because we don't exceed their default limit for a hasMore true (the default is 10)
+                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                        FacetEntryMatcher.authorFacet(false),
+                        FacetEntryMatcher.subjectFacet(false),
+                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                )))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
         ;
 
     }
@@ -1872,301 +1872,6 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
 
     @Test
     public void discoverSearchObjectsTestForScope() throws Exception {
-        //We turn off the authorization system in order to create the structure as defined below
-        context.turnOffAuthorisationSystem();
-
-        //** GIVEN **
-        //1. A community-collection structure with one parent community with sub-community and two collections.
-        parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
-        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
-        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
-        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
-        //2. Three public items that are readable by Anonymous with different subjects
-        Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Test")
-                                      .withIssueDate("2010-10-17")
-                                      .withAuthor("Smith, Donald")
-                                      .withSubject("ExtraEntry")
-                                      .build();
-
-        Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Test 2")
-                                      .withIssueDate("1990-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .build();
-
-        Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2010-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .build();
-
-        UUID scope = col2.getID();
-        //** WHEN **
-        //An anonymous user browses this endpoint to find the the objects in the system
-        //With the scope given
-        getClient().perform(get("/api/discover/search/objects")
-                                .param("scope", String.valueOf(scope)))
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The scope has to be equal to the one given in the parameters
-                   .andExpect(jsonPath("$.scope", is(String.valueOf(scope))))
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The page object needs to look like this
-                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
-                       PageMatcher.pageEntry(0, 20)
-                   )))
-                   //The search results have to contain the items belonging to the scope specified
-                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
-                       SearchResultMatcher.matchOnItemName("item", "items", "Test 2"),
-                       SearchResultMatcher.matchOnItemName("item", "items", "Public item 2")
-                   )))
-                   //These facets have to show up in the embedded.facets section as well with the given hasMore
-                   // property because we don't exceed their default limit for a hasMore true (the default is 10)
-                   .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
-                       FacetEntryMatcher.authorFacet(false),
-                       FacetEntryMatcher.subjectFacet(false),
-                       FacetEntryMatcher.dateIssuedFacet(false),
-                       FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
-                   )))
-                   //There always needs to be a self link available
-                   .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
-        ;
-
-    }
-
-    @Test
-    public void discoverSearchObjectsTestForScopeWithPrivateItem() throws Exception {
-        //We turn off the authorization system in order to create the structure as defined below
-        context.turnOffAuthorisationSystem();
-
-        //** GIVEN **
-        //1. A community-collection structure with one parent community with sub-community and two collections.
-        parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
-        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
-        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
-        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
-        //2. Two items that are readable by Anonymous with different subjects and one private item
-        Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Test")
-                                      .withIssueDate("2010-10-17")
-                                      .withAuthor("Smith, Donald")
-                                      .withSubject("ExtraEntry")
-                                      .build();
-
-        Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Test 2")
-                                      .withIssueDate("1990-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .build();
-
-        Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2010-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry")
-                                      .makePrivate()
-                                      .build();
-
-        UUID scope = col2.getID();
-        //** WHEN **
-        //An anonymous user browses this endpoint to find the the objects in the system
-        //With a size 2
-        getClient().perform(get("/api/discover/search/objects")
-                                .param("scope", String.valueOf(scope)))
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //Make sure that the scope is set to the scope given in the param
-                   .andExpect(jsonPath("$.scope", is(String.valueOf(scope))))
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The page object needs to look like this
-                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
-                       PageMatcher.pageEntry(0, 20)
-                   )))
-                   //Make sure that the search results contains the item with the correct scope
-                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.contains(
-                       SearchResultMatcher.matchOnItemName("item", "items", "Test 2")
-//                        SearchResultMatcher.matchOnItemName("item", "items", "Public item 2")
-                   )))
-                   //Make sure that the search result doesn't contain the item that's set to private but does have
-                   // the correct scope
-                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.not(Matchers.contains(
-                       SearchResultMatcher.matchOnItemName("item", "items", "Public item 2")
-                   ))))
-                   //These facets have to show up in the embedded.facets section as well with the given hasMore
-                   // property because we don't exceed their default limit for a hasMore true (the default is 10)
-                   .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
-                       FacetEntryMatcher.authorFacet(false),
-                       FacetEntryMatcher.subjectFacet(false),
-                       FacetEntryMatcher.dateIssuedFacet(false),
-                       FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
-                   )))
-                   //There always needs to be a self link available
-                   .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
-        ;
-
-    }
-
-    @Test
-    public void discoverSearchObjectsTestForHitHighlights() throws Exception {
-        //We turn off the authorization system in order to create the structure as defined below
-        context.turnOffAuthorisationSystem();
-
-        //** GIVEN **
-        //1. A community-collection structure with one parent community with sub-community and two collections.
-        parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
-        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
-        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
-        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
-        //2. Three public items that are readable by Anonymous with different subjects
-        Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Test")
-                                      .withIssueDate("2010-10-17")
-                                      .withAuthor("Smith, Donald")
-                                      .withSubject("ExtraEntry")
-                                      .build();
-
-        Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Test 2")
-                                      .withIssueDate("1990-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-                                      .withSubject("ExtraEntry")
-                                      .build();
-
-        Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2010-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-                                      .withSubject("AnotherTest").withSubject("ExtraEntry")
-                                      .build();
-
-
-        String query = "Public";
-        //** WHEN **
-        //An anonymous user browses this endpoint to find the the objects in the system
-        //With a query stating 'public'
-        getClient().perform(get("/api/discover/search/objects")
-                                .param("query", query))
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The page object needs to look like this
-                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
-                       PageMatcher.pageEntry(0, 20)
-                   )))
-                   //The search results has to contain the item with the query in the title and the hithighlight has
-                   // to be filled in with a string containing the query
-                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.contains(
-                       SearchResultMatcher
-                           .matchOnItemNameAndHitHighlight("item", "items", "Public item 2", query, "dc.title")
-                   )))
-                   //These facets have to show up in the embedded.facets section as well with the given hasMore
-                   // property because we don't exceed their default limit for a hasMore true (the default is 10)
-                   .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
-                       FacetEntryMatcher.authorFacet(false),
-                       FacetEntryMatcher.subjectFacet(false),
-                       FacetEntryMatcher.dateIssuedFacet(false),
-                       FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
-                   )))
-                   //There always needs to be a self link available
-                   .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
-        ;
-
-    }
-
-
-    @Test
-    public void discoverSearchObjectsTestForHitHighlightsWithPrivateItem() throws Exception {
-        //We turn off the authorization system in order to create the structure as defined below
-        context.turnOffAuthorisationSystem();
-
-        //** GIVEN **
-        //1. A community-collection structure with one parent community with sub-community and two collections.
-        parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
-        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
-        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
-        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
-        //2. Two public items that are readable by Anonymous with different subjects and one private item
-        Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Test")
-                                      .withIssueDate("2010-10-17")
-                                      .withAuthor("Smith, Donald")
-                                      .withSubject("ExtraEntry")
-                                      .build();
-
-        Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Test 2")
-                                      .withIssueDate("1990-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-                                      .withSubject("ExtraEntry")
-                                      .build();
-
-        Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2010-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-                                      .withSubject("AnotherTest").withSubject("ExtraEntry")
-                                      .makePrivate()
-                                      .build();
-
-
-        String query = "Public";
-        //** WHEN **
-        //An anonymous user browses this endpoint to find the the objects in the system
-        //With a query stating 'Public'
-        getClient().perform(get("/api/discover/search/objects")
-                                .param("query", query))
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The page object needs to look like this
-                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
-                       PageMatcher.pageEntry(0, 20)
-                   )))
-                   //The search results should not contain this
-                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.not(Matchers.contains(
-                       SearchResultMatcher
-                           .matchOnItemNameAndHitHighlight("item", "items", "Public item 2", query, "dc.title")
-                   ))))
-                   //There always needs to be a self link available
-                   .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
-        ;
-
-    }
-
-    @Test
-    public void discoverSearchObjectsWithQueryOperatorContains() throws Exception{
         //We turn off the authorization system in order to create the structure as defined below
         context.turnOffAuthorisationSystem();
 
@@ -2198,7 +1903,307 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         Item publicItem3 = ItemBuilder.createItem(context, col2)
                 .withTitle("Public item 2")
                 .withIssueDate("2010-02-13")
-                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test").withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .build();
+
+        UUID scope = col2.getID();
+        //** WHEN **
+        //An anonymous user browses this endpoint to find the the objects in the system
+        //With the scope given
+        getClient().perform(get("/api/discover/search/objects")
+                .param("scope", String.valueOf(scope)))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The scope has to be equal to the one given in the parameters
+                .andExpect(jsonPath("$.scope", is(String.valueOf(scope))))
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The page object needs to look like this
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntry(0, 20)
+                )))
+                //The search results have to contain the items belonging to the scope specified
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                        SearchResultMatcher.matchOnItemName("item", "items", "Test 2"),
+                        SearchResultMatcher.matchOnItemName("item", "items", "Public item 2")
+                )))
+                //These facets have to show up in the embedded.facets section as well with the given hasMore
+                // property because we don't exceed their default limit for a hasMore true (the default is 10)
+                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                        FacetEntryMatcher.authorFacet(false),
+                        FacetEntryMatcher.subjectFacet(false),
+                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                )))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+        ;
+
+    }
+
+    @Test
+    public void discoverSearchObjectsTestForScopeWithPrivateItem() throws Exception {
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
+        //2. Two items that are readable by Anonymous with different subjects and one private item
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                .withTitle("Test")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald")
+                .withSubject("ExtraEntry")
+                .build();
+
+        Item publicItem2 = ItemBuilder.createItem(context, col2)
+                .withTitle("Test 2")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
+
+        Item publicItem3 = ItemBuilder.createItem(context, col2)
+                .withTitle("Public item 2")
+                .withIssueDate("2010-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry")
+                .makePrivate()
+                .build();
+
+        UUID scope = col2.getID();
+        //** WHEN **
+        //An anonymous user browses this endpoint to find the the objects in the system
+        //With a size 2
+        getClient().perform(get("/api/discover/search/objects")
+                .param("scope", String.valueOf(scope)))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //Make sure that the scope is set to the scope given in the param
+                .andExpect(jsonPath("$.scope", is(String.valueOf(scope))))
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The page object needs to look like this
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntry(0, 20)
+                )))
+                //Make sure that the search results contains the item with the correct scope
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.contains(
+                        SearchResultMatcher.matchOnItemName("item", "items", "Test 2")
+//                        SearchResultMatcher.matchOnItemName("item", "items", "Public item 2")
+                )))
+                //Make sure that the search result doesn't contain the item that's set to private but does have
+                // the correct scope
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.not(
+                        Matchers.contains(
+                        SearchResultMatcher.matchOnItemName("item", "items", "Public item 2")
+                ))))
+                //These facets have to show up in the embedded.facets section as well with the given hasMore
+                // property because we don't exceed their default limit for a hasMore true (the default is 10)
+                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                        FacetEntryMatcher.authorFacet(false),
+                        FacetEntryMatcher.subjectFacet(false),
+                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                )))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+        ;
+
+    }
+
+    @Test
+    public void discoverSearchObjectsTestForHitHighlights() throws Exception {
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
+        //2. Three public items that are readable by Anonymous with different subjects
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                .withTitle("Test")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald")
+                .withSubject("ExtraEntry")
+                .build();
+
+        Item publicItem2 = ItemBuilder.createItem(context, col2)
+                .withTitle("Test 2")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                .withSubject("ExtraEntry")
+                .build();
+
+        Item publicItem3 = ItemBuilder.createItem(context, col2)
+                .withTitle("Public item 2")
+                .withIssueDate("2010-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                .withSubject("AnotherTest").withSubject("ExtraEntry")
+                .build();
+
+
+        String query = "Public";
+        //** WHEN **
+        //An anonymous user browses this endpoint to find the the objects in the system
+        //With a query stating 'public'
+        getClient().perform(get("/api/discover/search/objects")
+                .param("query", query))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The page object needs to look like this
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntry(0, 20)
+                )))
+                //The search results has to contain the item with the query in the title and the hithighlight has
+                // to be filled in with a string containing the query
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.contains(
+                        SearchResultMatcher
+                                .matchOnItemNameAndHitHighlight("item", "items",
+                                        "Public item 2", query, "dc.title")
+                )))
+                //These facets have to show up in the embedded.facets section as well with the given hasMore
+                // property because we don't exceed their default limit for a hasMore true (the default is 10)
+                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                        FacetEntryMatcher.authorFacet(false),
+                        FacetEntryMatcher.subjectFacet(false),
+                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                )))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+        ;
+
+    }
+
+
+    @Test
+    public void discoverSearchObjectsTestForHitHighlightsWithPrivateItem() throws Exception {
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
+        //2. Two public items that are readable by Anonymous with different subjects and one private item
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                .withTitle("Test")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald")
+                .withSubject("ExtraEntry")
+                .build();
+
+        Item publicItem2 = ItemBuilder.createItem(context, col2)
+                .withTitle("Test 2")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                .withSubject("ExtraEntry")
+                .build();
+
+        Item publicItem3 = ItemBuilder.createItem(context, col2)
+                .withTitle("Public item 2")
+                .withIssueDate("2010-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                .withSubject("AnotherTest").withSubject("ExtraEntry")
+                .makePrivate()
+                .build();
+
+
+        String query = "Public";
+        //** WHEN **
+        //An anonymous user browses this endpoint to find the the objects in the system
+        //With a query stating 'Public'
+        getClient().perform(get("/api/discover/search/objects")
+                .param("query", query))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The page object needs to look like this
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntry(0, 20)
+                )))
+                //The search results should not contain this
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.not(
+                        Matchers.contains(
+                        SearchResultMatcher
+                                .matchOnItemNameAndHitHighlight("item", "items",
+                                        "Public item 2", query, "dc.title")
+                ))))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+        ;
+
+    }
+
+    @Test
+    public void discoverSearchObjectsWithQueryOperatorContains() throws Exception {
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
+        //2. Three public items that are readable by Anonymous with different subjects
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                .withTitle("Test")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald")
+                .withSubject("ExtraEntry")
+                .build();
+
+        Item publicItem2 = ItemBuilder.createItem(context, col2)
+                .withTitle("Test 2")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
+
+        Item publicItem3 = ItemBuilder.createItem(context, col2)
+                .withTitle("Public item 2")
+                .withIssueDate("2010-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
                 .withSubject("AnotherTest").withSubject("TestingForMore").withSubject("ExtraEntry")
                 .build();
 
@@ -2214,15 +2219,16 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 //The type has to be 'discover'
                 .andExpect(jsonPath("$.type", is("discover")))
                 //The page object needs to look like this
-                .andExpect(jsonPath("$.page", is(
-                        PageMatcher.pageEntry(0,20)
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntry(0, 20)
                 )))
                 //The search results have to contain the items that match the searchFilter
-                .andExpect(jsonPath("$._embedded.objects", Matchers.containsInAnyOrder(
-                        SearchResultMatcher.matchOnItemName("item","items", "Test"),
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                        SearchResultMatcher.matchOnItemName("item", "items", "Test"),
                         SearchResultMatcher.matchOnItemName("item", "items", "Test 2")
                 )))
-                //These facets have to show up in the embedded.facets section as well with the given hasMore property because we don't exceed their default limit for a hasMore true (the default is 10)
+                //These facets have to show up in the embedded.facets section as well with the given hasMore property
+                // because we don't exceed their default limit for a hasMore true (the default is 10)
                 .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
@@ -2236,7 +2242,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
     }
 
     @Test
-    public void discoverSearchObjectsWithQueryOperatorNotContains() throws Exception{
+    public void discoverSearchObjectsWithQueryOperatorNotContains() throws Exception {
         //We turn off the authorization system in order to create the structure as defined below
         context.turnOffAuthorisationSystem();
 
@@ -2268,7 +2274,8 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         Item publicItem3 = ItemBuilder.createItem(context, col2)
                 .withTitle("Public item 2")
                 .withIssueDate("2010-02-13")
-                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test").withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
                 .withSubject("AnotherTest").withSubject("TestingForMore").withSubject("ExtraEntry")
                 .build();
 
@@ -2284,14 +2291,15 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 //The type has to be 'discover'
                 .andExpect(jsonPath("$.type", is("discover")))
                 //The page object needs to look like this
-                .andExpect(jsonPath("$.page", is(
-                        PageMatcher.pageEntry(0,20)
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntry(0, 20)
                 )))
                 //The search results have to contain the items that match the searchFilter
-                .andExpect(jsonPath("$._embedded.objects", Matchers.hasItem(
-                        SearchResultMatcher.matchOnItemName("item","items", "Public item 2")
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.hasItem(
+                        SearchResultMatcher.matchOnItemName("item", "items", "Public item 2")
                 )))
-                //These facets have to show up in the embedded.facets section as well with the given hasMore property because we don't exceed their default limit for a hasMore true (the default is 10)
+                //These facets have to show up in the embedded.facets section as well with the given hasMore property
+                // because we don't exceed their default limit for a hasMore true (the default is 10)
                 .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
@@ -2453,7 +2461,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
     }
 
     @Test
-    public void discoverSearchObjectsWithQueryOperatorEquals() throws Exception{
+    public void discoverSearchObjectsWithQueryOperatorEquals() throws Exception {
         //We turn off the authorization system in order to create the structure as defined below
         context.turnOffAuthorisationSystem();
 
@@ -2485,7 +2493,8 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         Item publicItem3 = ItemBuilder.createItem(context, col2)
                 .withTitle("Public item 2")
                 .withIssueDate("2010-02-13")
-                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test").withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
                 .withSubject("AnotherTest").withSubject("TestingForMore").withSubject("ExtraEntry")
                 .build();
 
@@ -2501,14 +2510,15 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 //The type has to be 'discover'
                 .andExpect(jsonPath("$.type", is("discover")))
                 //The page object needs to look like this
-                .andExpect(jsonPath("$.page", is(
-                        PageMatcher.pageEntry(0,20)
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntry(0, 20)
                 )))
                 //The search results have to contain the items that match the searchFilter
-                .andExpect(jsonPath("$._embedded.objects", Matchers.containsInAnyOrder(
-                        SearchResultMatcher.matchOnItemName("item","items", "Test")
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                        SearchResultMatcher.matchOnItemName("item", "items", "Test")
                 )))
-                //These facets have to show up in the embedded.facets section as well with the given hasMore property because we don't exceed their default limit for a hasMore true (the default is 10)
+                //These facets have to show up in the embedded.facets section as well with the given hasMore property
+                // because we don't exceed their default limit for a hasMore true (the default is 10)
                 .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
@@ -2522,7 +2532,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
     }
 
     @Test
-    public void discoverSearchObjectsWithQueryOperatorNotEquals() throws Exception{
+    public void discoverSearchObjectsWithQueryOperatorNotEquals() throws Exception {
         //We turn off the authorization system in order to create the structure as defined below
         context.turnOffAuthorisationSystem();
 
@@ -2554,7 +2564,8 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         Item publicItem3 = ItemBuilder.createItem(context, col2)
                 .withTitle("Public item 2")
                 .withIssueDate("2010-02-13")
-                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test").withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
                 .withSubject("AnotherTest").withSubject("TestingForMore").withSubject("ExtraEntry")
                 .build();
 
@@ -2570,15 +2581,16 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 //The type has to be 'discover'
                 .andExpect(jsonPath("$.type", is("discover")))
                 //The page object needs to look like this
-                .andExpect(jsonPath("$.page", is(
-                        PageMatcher.pageEntry(0,20)
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntry(0, 20)
                 )))
                 //The search results have to contain the items that match the searchFilter
-                .andExpect(jsonPath("$._embedded.objects", Matchers.hasItems(
-                        SearchResultMatcher.matchOnItemName("item","items", "Test 2"),
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.hasItems(
+                        SearchResultMatcher.matchOnItemName("item", "items", "Test 2"),
                         SearchResultMatcher.matchOnItemName("item", "items", "Public item 2")
                 )))
-                //These facets have to show up in the embedded.facets section as well with the given hasMore property because we don't exceed their default limit for a hasMore true (the default is 10)
+                //These facets have to show up in the embedded.facets section as well with the given hasMore property
+                // because we don't exceed their default limit for a hasMore true (the default is 10)
                 .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.subjectFacet(false),
@@ -2592,7 +2604,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
     }
 
     @Test
-    public void discoverSearchObjectsWithQueryOperatorNotAuthority() throws Exception{
+    public void discoverSearchObjectsWithQueryOperatorNotAuthority() throws Exception {
         //We turn off the authorization system in order to create the structure as defined below
         context.turnOffAuthorisationSystem();
 
@@ -2624,7 +2636,8 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         Item publicItem3 = ItemBuilder.createItem(context, col2)
                 .withTitle("Public item 2")
                 .withIssueDate("2010-02-13")
-                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test").withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
                 .withSubject("AnotherTest").withSubject("TestingForMore").withSubject("ExtraEntry")
                 .build();
 
@@ -2640,14 +2653,15 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 //The type has to be 'discover'
                 .andExpect(jsonPath("$.type", is("discover")))
                 //The page object needs to look like this
-                .andExpect(jsonPath("$.page", is(
-                        PageMatcher.pageEntry(0,20)
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntry(0, 20)
                 )))
                 //The search results have to contain the items that match the searchFilter
-                .andExpect(jsonPath("$._embedded.objects", Matchers.hasItem(
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.hasItem(
                         SearchResultMatcher.matchOnItemName("item", "items", "Public item 2")
                 )))
-                //These facets have to show up in the embedded.facets section as well with the given hasMore property because we don't exceed their default limit for a hasMore true (the default is 10)
+                //These facets have to show up in the embedded.facets section as well with the given hasMore property
+                // because we don't exceed their default limit for a hasMore true (the default is 10)
                 .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
                         FacetEntryMatcher.authorFacet(false),
                         FacetEntryMatcher.subjectFacet(false),

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -209,9 +209,8 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 .andExpect(jsonPath("$.name", is("author")))
                 //The facetType has to be 'text' because that's how the author facet is configured by default
                 .andExpect(jsonPath("$.facetType", is("text")))
-                //Because we've constructed such a structure so that we have more than 2 (size) authors, there
-                // needs to be a next link
-                .andExpect(jsonPath("$._links.next.href", containsString("api/discover/facets/author?prefix=smith&page")))
+                //We only request value starting with "smith", so we expect to only receive one page
+                .andExpect(jsonPath("$._links.next").doesNotExist())
                 //There always needs to be a self link
                 .andExpect(jsonPath("$._links.self.href", containsString("api/discover/facets/author?prefix=smith")))
                 //Because there are more authors than is represented (because of the size param), hasMore has to

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -764,6 +764,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                    .andExpect(jsonPath("$.sortOptions", containsInAnyOrder(
                        SortOptionMatcher.titleSortOption(),
                        SortOptionMatcher.dateIssuedSortOption(),
+                       SortOptionMatcher.dateAccessionedSortOption(),
                        SortOptionMatcher.scoreSortOption()
                    )));
     }

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -2243,76 +2243,76 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Test")
-                                      .withIssueDate("2010-10-17")
-                                      .withAuthor("Smith, Donald").withAuthor("t, t").withAuthor("t, y")
-                                      .withAuthor("t, r").withAuthor("t, e").withAuthor("t, z").withAuthor("t, a")
-                                      .withAuthor("t, tq").withAuthor("t, ts").withAuthor("t, td").withAuthor("t, tf")
-                                      .withAuthor("t, tg").withAuthor("t, th").withAuthor("t, tj").withAuthor("t, tk")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald").withAuthor("t, t").withAuthor("t, y")
+                .withAuthor("t, r").withAuthor("t, e").withAuthor("t, z").withAuthor("t, a")
+                .withAuthor("t, tq").withAuthor("t, ts").withAuthor("t, td").withAuthor("t, tf")
+                .withAuthor("t, tg").withAuthor("t, th").withAuthor("t, tj").withAuthor("t, tk")
+                .withSubject("ExtraEntry")
+                .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Test 2")
-                                      .withIssueDate("1990-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test 2")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2010-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry").withSubject("a").withSubject("b").withSubject("c")
-                                      .withSubject("d").withSubject("e").withSubject("f").withSubject("g")
-                                      .withSubject("h").withSubject("i").withSubject("j")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("2010-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry").withSubject("a").withSubject("b").withSubject("c")
+                .withSubject("d").withSubject("e").withSubject("f").withSubject("g")
+                .withSubject("h").withSubject("i").withSubject("j")
+                .build();
 
         //** WHEN **
         //An anonymous user browses this endpoint to find the the objects in the system
         //With a size 2
         getClient().perform(get("/api/discover/search/objects")
-                                .param("size", "2")
-                                .param("page", "1"))
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The page object needs to look like this
-                   //Size of 2 because that's what we entered
-                   //Page number 1 because that's the param we entered
-                   //TotalPages 4 because size = 2 and total elements is 7 -> 4 pages
-                   //We made 7 elements -> 7 total elements
-                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
-                       PageMatcher.pageEntryWithTotalPagesAndElements(1, 2, 4, 7)
-                   )))
-                   //These are the  two elements that'll be shown (because page = 1, so the third and fourth element
-                   // in the list) and they'll be the only ones because the size is 2
-                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
-                       SearchResultMatcher.match(),
-                       SearchResultMatcher.match()
-                   )))
-                   .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
-                       FacetEntryMatcher.authorFacetWithMinMax(true, "Doe, Jane", "Testing, Works"),
-                       FacetEntryMatcher.subjectFacet(true),
-                       FacetEntryMatcher.dateIssuedFacetWithMinMax(false, "1990-02-13", "2010-10-17"),
-                       FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
-                   )))
-                   //There always needs to be a self link available
-                   .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+                .param("size", "2")
+                .param("page", "1"))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                //The page object needs to look like this
+                //Size of 2 because that's what we entered
+                //Page number 1 because that's the param we entered
+                //TotalPages 4 because size = 2 and total elements is 7 -> 4 pages
+                //We made 7 elements -> 7 total elements
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntryWithTotalPagesAndElements(1, 2, 4, 7)
+                )))
+                //These are the  two elements that'll be shown (because page = 1, so the third and fourth element
+                // in the list) and they'll be the only ones because the size is 2
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                        SearchResultMatcher.match(),
+                        SearchResultMatcher.match()
+                )))
+                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                        FacetEntryMatcher.authorFacetWithMinMax(true, "Doe, Jane", "Testing, Works"),
+                        FacetEntryMatcher.subjectFacet(true),
+                        FacetEntryMatcher.dateIssuedFacetWithMinMax(false, "1990-02-13", "2010-10-17"),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                )))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
         ;
 
     }
@@ -2325,66 +2325,66 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         //** GIVEN **
         //1. A community-collection structure with one parent community with sub-community and two collections.
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Test")
-                                      .withIssueDate("2010-10-17")
-                                      .withAuthor("Smith, Donald").withAuthor("t, t").withAuthor("t, y")
-                                      .withAuthor("t, r").withAuthor("t, e").withAuthor("t, z").withAuthor("t, a")
-                                      .withAuthor("t, tq").withAuthor("t, ts").withAuthor("t, td").withAuthor("t, tf")
-                                      .withAuthor("t, tg").withAuthor("t, th").withAuthor("t, tj").withAuthor("t, tk")
-                                      .withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald").withAuthor("t, t").withAuthor("t, y")
+                .withAuthor("t, r").withAuthor("t, e").withAuthor("t, z").withAuthor("t, a")
+                .withAuthor("t, tq").withAuthor("t, ts").withAuthor("t, td").withAuthor("t, tf")
+                .withAuthor("t, tg").withAuthor("t, th").withAuthor("t, tj").withAuthor("t, tk")
+                .withSubject("ExtraEntry")
+                .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Test 2")
-                                      .withIssueDate("1990-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
-                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
-                                      .build();
+                .withTitle("Test 2")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                .withSubject("TestingForMore").withSubject("ExtraEntry")
+                .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Public item 2")
-                                      .withIssueDate("2010-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest").withSubject("TestingForMore")
-                                      .withSubject("ExtraEntry").withSubject("a").withSubject("b").withSubject("c")
-                                      .withSubject("d").withSubject("e").withSubject("f").withSubject("g")
-                                      .withSubject("h").withSubject("i").withSubject("j")
-                                      .build();
+                .withTitle("Public item 2")
+                .withIssueDate("2010-02-13")
+                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                .withSubject("AnotherTest").withSubject("TestingForMore")
+                .withSubject("ExtraEntry").withSubject("a").withSubject("b").withSubject("c")
+                .withSubject("d").withSubject("e").withSubject("f").withSubject("g")
+                .withSubject("h").withSubject("i").withSubject("j")
+                .build();
 
         //** WHEN **
         //An anonymous user browses this endpoint to find the the objects in the system
         //With a size 2
         getClient().perform(get("/api/discover/search/facets"))
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
-                       FacetEntryMatcher.authorFacetWithMinMax(true, "Doe, Jane", "Testing, Works"),
-                       FacetEntryMatcher.subjectFacet(true),
-                       FacetEntryMatcher.dateIssuedFacetWithMinMax(false, "1990-02-13", "2010-10-17"),
-                       FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
-                   )))
-                   //There always needs to be a self link available
-                   .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/facets")))
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                        FacetEntryMatcher.authorFacetWithMinMax(true, "Doe, Jane", "Testing, Works"),
+                        FacetEntryMatcher.subjectFacet(true),
+                        FacetEntryMatcher.dateIssuedFacetWithMinMax(false, "1990-02-13", "2010-10-17"),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                )))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/facets")))
         ;
 
     }
 
     @Test
-    public void discoverSearchObjectsWithQueryOperatorEquals() throws Exception {
+    public void discoverSearchObjectsWithQueryOperatorEquals() throws Exception{
         //We turn off the authorization system in order to create the structure as defined below
         context.turnOffAuthorisationSystem();
 
@@ -2453,7 +2453,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
     }
 
     @Test
-    public void discoverSearchObjectsWithQueryOperatorNotEquals() throws Exception {
+    public void discoverSearchObjectsWithQueryOperatorNotEquals() throws Exception{
         //We turn off the authorization system in order to create the structure as defined below
         context.turnOffAuthorisationSystem();
 
@@ -2523,7 +2523,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
     }
 
     @Test
-    public void discoverSearchObjectsWithQueryOperatorNotAuthority() throws Exception {
+    public void discoverSearchObjectsWithQueryOperatorNotAuthority() throws Exception{
         //We turn off the authorization system in order to create the structure as defined below
         context.turnOffAuthorisationSystem();
 

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -819,13 +819,13 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                    .andExpect(jsonPath("$.type", is("discover")))
                    //There needs to be a page object that shows the total pages and total elements as well as the
                    // size and the current page (number)
-                   .andExpect(jsonPath("$.page", is(
+                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
                        PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 7)
                    )))
                    //These search results have to be shown in the embedded.objects section as these are the items
                    // given in the structure defined above.
                    //Seeing as everything fits onto one page, they have to all be present
-                   .andExpect(jsonPath("$._embedded.objects", Matchers.containsInAnyOrder(
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
                        SearchResultMatcher.match("community", "communities"),
                        SearchResultMatcher.match("community", "communities"),
                        //This has to be like this because collections don't have anything else
@@ -901,12 +901,12 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                    //The page object has to look like this because we've only made 7 elements, the default size is 20
                    // and they all fit onto one page (20 > 7) so totalPages has to be 1. Number is 0 because
                    //page 0 is the default page we view if not specified otherwise
-                   .andExpect(jsonPath("$.page", is(
+                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
                        PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 7)
                    )))
                    //All elements have to be present in the embedded.objects section, these are the ones we made in
                    // the structure defined above
-                   .andExpect(jsonPath("$._embedded.objects", Matchers.containsInAnyOrder(
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
                        SearchResultMatcher.match("community", "communities"),
                        SearchResultMatcher.match("community", "communities"),
                        //Match without any parameters because collections don't have anything special to check in the
@@ -990,11 +990,11 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                    .andExpect(jsonPath("$.type", is("discover")))
                    //The page object has to look like this because we've only made 7 items, they all fit onto 1 page
                    // because the default size is 20 and the default starting page is 0.
-                   .andExpect(jsonPath("$.page", is(
+                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
                        PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 7)
                    )))
                    //All the elements created in the structure above have to be present in the embedded.objects section
-                   .andExpect(jsonPath("$._embedded.objects", Matchers.containsInAnyOrder(
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
                        SearchResultMatcher.match("community", "communities"),
                        SearchResultMatcher.match("community", "communities"),
                        //Collections are specified like this because they don't have any special properties
@@ -1070,12 +1070,12 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                    .andExpect(jsonPath("$.type", is("discover")))
                    //The page object has to look like this because of the query we specified, only two elements match
                    // the query.
-                   .andExpect(jsonPath("$.page", is(
+                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
                        PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 2)
                    )))
                    //Only the two item elements match the query, therefore those are the only ones that can be in the
                    // embedded.objects section
-                   .andExpect(jsonPath("$._embedded.objects", Matchers.containsInAnyOrder(
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
                        SearchResultMatcher.match("item", "items"),
                        SearchResultMatcher.match("item", "items")
                    )))
@@ -1148,13 +1148,13 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                    //The type has to be 'discover'
                    .andExpect(jsonPath("$.type", is("discover")))
                    //The page element has to look like this because it contains all the elements we've just created
-                   .andExpect(jsonPath("$.page", is(
+                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
                        PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 7)
                    )))
                    //The scope property has to be set to the value we entered in the parameters
                    .andExpect(jsonPath("$.scope", is("test")))
                    //All the elements created in the structure above have to be present in the embedded.objects section
-                   .andExpect(jsonPath("$._embedded.objects", Matchers.containsInAnyOrder(
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
                        SearchResultMatcher.match("community", "communities"),
                        SearchResultMatcher.match("community", "communities"),
                        //Collections are specified like this because they don't have any special properties
@@ -1230,12 +1230,12 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                    .andExpect(jsonPath("$.type", is("discover")))
                    //The page element needs to look like this and only have three totalElements because we only want
                    // the items (dsoType) and we only created three items
-                   .andExpect(jsonPath("$.page", is(
+                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
                        PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 3)
                    )))
                    //Only the three items can be present in the embedded.objects section as that's what we specified
                    // in the dsoType parameter
-                   .andExpect(jsonPath("$._embedded.objects", Matchers.containsInAnyOrder(
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
                        SearchResultMatcher.match("item", "items"),
                        SearchResultMatcher.match("item", "items"),
                        SearchResultMatcher.match("item", "items")
@@ -1307,12 +1307,12 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                    .andExpect(jsonPath("$.type", is("discover")))
                    //The page object has to look like this and only contain three total elements because we only want
                    // to get the items back
-                   .andExpect(jsonPath("$.page", is(
+                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
                        PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 3)
                    )))
                    //Only the three items can be present in the embedded.objects section as that's what we specified
                    // in the dsoType parameter
-                   .andExpect(jsonPath("$._embedded.objects", Matchers.containsInAnyOrder(
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
                        SearchResultMatcher.match("item", "items"),
                        SearchResultMatcher.match("item", "items"),
                        SearchResultMatcher.match("item", "items")
@@ -1320,7 +1320,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                    //Here we want to match on the item name in a certain specified order because we want to check the
                    // sort properly
                    //We check whether the items are sorted properly as we expected
-                   .andExpect(jsonPath("$._embedded.objects", Matchers.contains(
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.contains(
                        SearchResultMatcher.matchOnItemName("item", "items", "Public"),
                        SearchResultMatcher.matchOnItemName("item", "items", "Test"),
                        SearchResultMatcher.matchOnItemName("item", "items", "Testing")
@@ -1522,12 +1522,12 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                    //Page number 1 because that's the param we entered
                    //TotalPages 4 because size = 2 and total elements is 7 -> 4 pages
                    //We made 7 elements -> 7 total elements
-                   .andExpect(jsonPath("$.page", is(
+                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
                        PageMatcher.pageEntryWithTotalPagesAndElements(1, 2, 4, 7)
                    )))
                    //These are the  two elements that'll be shown (because page = 1, so the third and fourth element
                    // in the list) and they'll be the only ones because the size is 2
-                   .andExpect(jsonPath("$._embedded.objects", Matchers.containsInAnyOrder(
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
                        SearchResultMatcher.match(),
                        SearchResultMatcher.match()
                    )))
@@ -1608,11 +1608,11 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                    //The type has to be 'discover'
                    .andExpect(jsonPath("$.type", is("discover")))
                    //The page object needs to look like this
-                   .andExpect(jsonPath("$.page", is(
+                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
                        PageMatcher.pageEntry(0, 20)
                    )))
                    //This is the only item that should be returned with the query given
-                   .andExpect(jsonPath("$._embedded.objects", Matchers.contains(
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.contains(
                        SearchResultMatcher.matchOnItemName("item", "items", "Test")
                    )))
 
@@ -1685,11 +1685,11 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                    //The type has to be 'discover'
                    .andExpect(jsonPath("$.type", is("discover")))
                    //The page object needs to look like this
-                   .andExpect(jsonPath("$.page", is(
+                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
                        PageMatcher.pageEntry(0, 20)
                    )))
                    //These are the items that aren't set to private
-                   .andExpect(jsonPath("$._embedded.objects", Matchers.containsInAnyOrder(
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
                        SearchResultMatcher.match("community", "communities"),
                        SearchResultMatcher.match("community", "communities"),
                        //Collections are specified like this because they don't have any special properties
@@ -1699,7 +1699,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                        SearchResultMatcher.matchOnItemName("item", "items", "Public item 2")
                    )))
                    //This is a private item, this shouldn't show up in the result
-                   .andExpect(jsonPath("$._embedded.objects",
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects",
                                        Matchers.not(SearchResultMatcher.matchOnItemName("item", "items", "Test 2"))))
                    //These facets have to show up in the embedded.facets section as well with the given hasMore
                    // property because we don't exceed their default limit for a hasMore true (the default is 10)
@@ -1853,11 +1853,11 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                    //The type has to be 'discover'
                    .andExpect(jsonPath("$.type", is("discover")))
                    //The page object needs to look like this
-                   .andExpect(jsonPath("$.page", is(
+                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
                        PageMatcher.pageEntry(0, 20)
                    )))
                    //The search results have to contain the items belonging to the scope specified
-                   .andExpect(jsonPath("$._embedded.objects", Matchers.containsInAnyOrder(
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
                        SearchResultMatcher.matchOnItemName("item", "items", "Test 2"),
                        SearchResultMatcher.matchOnItemName("item", "items", "Public item 2")
                    )))
@@ -1929,17 +1929,17 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                    //The type has to be 'discover'
                    .andExpect(jsonPath("$.type", is("discover")))
                    //The page object needs to look like this
-                   .andExpect(jsonPath("$.page", is(
+                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
                        PageMatcher.pageEntry(0, 20)
                    )))
                    //Make sure that the search results contains the item with the correct scope
-                   .andExpect(jsonPath("$._embedded.objects", Matchers.contains(
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.contains(
                        SearchResultMatcher.matchOnItemName("item", "items", "Test 2")
 //                        SearchResultMatcher.matchOnItemName("item", "items", "Public item 2")
                    )))
                    //Make sure that the search result doesn't contain the item that's set to private but does have
                    // the correct scope
-                   .andExpect(jsonPath("$._embedded.objects", Matchers.not(Matchers.contains(
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.not(Matchers.contains(
                        SearchResultMatcher.matchOnItemName("item", "items", "Public item 2")
                    ))))
                    //These facets have to show up in the embedded.facets section as well with the given hasMore
@@ -2006,12 +2006,12 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                    //The type has to be 'discover'
                    .andExpect(jsonPath("$.type", is("discover")))
                    //The page object needs to look like this
-                   .andExpect(jsonPath("$.page", is(
+                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
                        PageMatcher.pageEntry(0, 20)
                    )))
                    //The search results has to contain the item with the query in the title and the hithighlight has
                    // to be filled in with a string containing the query
-                   .andExpect(jsonPath("$._embedded.objects", Matchers.contains(
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.contains(
                        SearchResultMatcher
                            .matchOnItemNameAndHitHighlight("item", "items", "Public item 2", query, "dc.title")
                    )))
@@ -2081,11 +2081,11 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                    //The type has to be 'discover'
                    .andExpect(jsonPath("$.type", is("discover")))
                    //The page object needs to look like this
-                   .andExpect(jsonPath("$.page", is(
+                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
                        PageMatcher.pageEntry(0, 20)
                    )))
                    //The search results should not contain this
-                   .andExpect(jsonPath("$._embedded.objects", Matchers.not(Matchers.contains(
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.not(Matchers.contains(
                        SearchResultMatcher
                            .matchOnItemNameAndHitHighlight("item", "items", "Public item 2", query, "dc.title")
                    ))))

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/converter/query/SearchQueryConverterTest.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/converter/query/SearchQueryConverterTest.java
@@ -7,14 +7,14 @@
  */
 package org.dspace.app.rest.converter.query;
 
-import org.dspace.app.rest.parameter.SearchFilter;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import org.dspace.app.rest.parameter.SearchFilter;
+import org.junit.Before;
+import org.junit.Test;
 
 public class SearchQueryConverterTest {
 
@@ -22,12 +22,12 @@ public class SearchQueryConverterTest {
 
 
     @Before
-    public void setUp() throws Exception{
+    public void setUp() throws Exception {
         searchQueryConverter = new SearchQueryConverter();
     }
 
     @Test
-    public void convertAuthorContainsSearchFilterTest(){
+    public void convertAuthorContainsSearchFilterTest() {
         SearchFilter searchFilter = new SearchFilter("author", "query", "test*");
         List<SearchFilter> list = new LinkedList<>();
         list.add(searchFilter);
@@ -42,7 +42,7 @@ public class SearchQueryConverterTest {
     }
 
     @Test
-    public void convertAuthorNotContainsSearchFilterTest(){
+    public void convertAuthorNotContainsSearchFilterTest() {
         SearchFilter searchFilter = new SearchFilter("author", "query", "-test*");
         List<SearchFilter> list = new LinkedList<>();
         list.add(searchFilter);
@@ -57,7 +57,7 @@ public class SearchQueryConverterTest {
     }
 
     @Test
-    public void convertAuthorEqualsSearchFilterTest(){
+    public void convertAuthorEqualsSearchFilterTest() {
         SearchFilter searchFilter = new SearchFilter("author", "query", "test");
         List<SearchFilter> list = new LinkedList<>();
         list.add(searchFilter);
@@ -72,7 +72,7 @@ public class SearchQueryConverterTest {
     }
 
     @Test
-    public void convertAuthorNotEqualsSearchFilterTest(){
+    public void convertAuthorNotEqualsSearchFilterTest() {
         SearchFilter searchFilter = new SearchFilter("author", "query", "-test");
         List<SearchFilter> list = new LinkedList<>();
         list.add(searchFilter);
@@ -87,7 +87,7 @@ public class SearchQueryConverterTest {
     }
 
     @Test
-    public void convertAuthorAuthoritySearchFilterTest(){
+    public void convertAuthorAuthoritySearchFilterTest() {
         SearchFilter searchFilter = new SearchFilter("author", "query", "id:test");
         List<SearchFilter> list = new LinkedList<>();
         list.add(searchFilter);
@@ -102,7 +102,7 @@ public class SearchQueryConverterTest {
     }
 
     @Test
-    public void convertAuthorNotAuthoritySearchFilterTest(){
+    public void convertAuthorNotAuthoritySearchFilterTest() {
         SearchFilter searchFilter = new SearchFilter("author", "query", "-id:test");
         List<SearchFilter> list = new LinkedList<>();
         list.add(searchFilter);

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/converter/query/SearchQueryConverterTest.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/converter/query/SearchQueryConverterTest.java
@@ -1,0 +1,111 @@
+package org.dspace.app.rest.converter.query;
+
+import org.dspace.app.rest.parameter.SearchFilter;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class SearchQueryConverterTest {
+
+    SearchQueryConverter searchQueryConverter;
+
+
+    @Before
+    public void setUp() throws Exception{
+        searchQueryConverter = new SearchQueryConverter();
+    }
+
+    @Test
+    public void convertAuthorContainsSearchFilterTest(){
+        SearchFilter searchFilter = new SearchFilter("author", "query", "test*");
+        List<SearchFilter> list = new LinkedList<>();
+        list.add(searchFilter);
+        List<SearchFilter> transformedList = searchQueryConverter.convert(list);
+
+        assertEquals(transformedList.get(0).getOperator(), "contains");
+        assertEquals(list.get(0).getOperator(), "query");
+        assertEquals(transformedList.get(0).getName(), "author");
+        assertEquals(list.get(0).getName(), "author");
+        assertEquals(transformedList.get(0).getValue(), "test");
+        assertEquals(list.get(0).getValue(), "test*");
+    }
+
+    @Test
+    public void convertAuthorNotContainsSearchFilterTest(){
+        SearchFilter searchFilter = new SearchFilter("author", "query", "-test*");
+        List<SearchFilter> list = new LinkedList<>();
+        list.add(searchFilter);
+        List<SearchFilter> transformedList = searchQueryConverter.convert(list);
+
+        assertEquals(transformedList.get(0).getOperator(), "notcontains");
+        assertEquals(list.get(0).getOperator(), "query");
+        assertEquals(transformedList.get(0).getName(), "author");
+        assertEquals(list.get(0).getName(), "author");
+        assertEquals(transformedList.get(0).getValue(), "test");
+        assertEquals(list.get(0).getValue(), "-test*");
+    }
+
+    @Test
+    public void convertAuthorEqualsSearchFilterTest(){
+        SearchFilter searchFilter = new SearchFilter("author", "query", "test");
+        List<SearchFilter> list = new LinkedList<>();
+        list.add(searchFilter);
+        List<SearchFilter> transformedList = searchQueryConverter.convert(list);
+
+        assertEquals(transformedList.get(0).getOperator(), "equals");
+        assertEquals(list.get(0).getOperator(), "query");
+        assertEquals(transformedList.get(0).getName(), "author");
+        assertEquals(list.get(0).getName(), "author");
+        assertEquals(transformedList.get(0).getValue(), "test");
+        assertEquals(list.get(0).getValue(), "test");
+    }
+
+    @Test
+    public void convertAuthorNotEqualsSearchFilterTest(){
+        SearchFilter searchFilter = new SearchFilter("author", "query", "-test");
+        List<SearchFilter> list = new LinkedList<>();
+        list.add(searchFilter);
+        List<SearchFilter> transformedList = searchQueryConverter.convert(list);
+
+        assertEquals(transformedList.get(0).getOperator(), "notequals");
+        assertEquals(list.get(0).getOperator(), "query");
+        assertEquals(transformedList.get(0).getName(), "author");
+        assertEquals(list.get(0).getName(), "author");
+        assertEquals(transformedList.get(0).getValue(), "test");
+        assertEquals(list.get(0).getValue(), "-test");
+    }
+
+    @Test
+    public void convertAuthorAuthoritySearchFilterTest(){
+        SearchFilter searchFilter = new SearchFilter("author", "query", "id:test");
+        List<SearchFilter> list = new LinkedList<>();
+        list.add(searchFilter);
+        List<SearchFilter> transformedList = searchQueryConverter.convert(list);
+
+        assertEquals(transformedList.get(0).getOperator(), "authority");
+        assertEquals(list.get(0).getOperator(), "query");
+        assertEquals(transformedList.get(0).getName(), "author");
+        assertEquals(list.get(0).getName(), "author");
+        assertEquals(transformedList.get(0).getValue(), "test");
+        assertEquals(list.get(0).getValue(), "id:test");
+    }
+
+    @Test
+    public void convertAuthorNotAuthoritySearchFilterTest(){
+        SearchFilter searchFilter = new SearchFilter("author", "query", "-id:test");
+        List<SearchFilter> list = new LinkedList<>();
+        list.add(searchFilter);
+        List<SearchFilter> transformedList = searchQueryConverter.convert(list);
+
+        assertEquals(transformedList.get(0).getOperator(), "notauthority");
+        assertEquals(list.get(0).getOperator(), "query");
+        assertEquals(transformedList.get(0).getName(), "author");
+        assertEquals(list.get(0).getName(), "author");
+        assertEquals(transformedList.get(0).getValue(), "test");
+        assertEquals(list.get(0).getValue(), "-id:test");
+    }
+}

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/converter/query/SearchQueryConverterTest.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/converter/query/SearchQueryConverterTest.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.app.rest.converter.query;
 
 import org.dspace.app.rest.parameter.SearchFilter;

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/CommunityMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/CommunityMatcher.java
@@ -56,7 +56,7 @@ public class CommunityMatcher {
                                                                             Collection col) {
         return allOf(
             matchProperties(name, uuid, handle),
-            hasJsonPath("$._embedded.collections._embedded[0]",
+            hasJsonPath("$._embedded.collections._embedded.collections[0]",
                         CollectionMatcher
                             .matchCollectionEntry(col.getName(), col.getID(), col.getHandle(), col.getLogo())),
             hasJsonPath("$._embedded.logo", Matchers.not(Matchers.empty())),

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/FacetEntryMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/FacetEntryMatcher.java
@@ -29,6 +29,18 @@ public class FacetEntryMatcher {
         );
     }
 
+    public static Matcher<? super Object> authorFacetWithMinMax(boolean hasNext, String min, String max) {
+        return allOf(
+            hasJsonPath("$.name", is("author")),
+            hasJsonPath("$.facetType", is("text")),
+            hasJsonPath("$.facetLimit", is(10)),
+            hasJsonPath("$.minValue", is(min)),
+            hasJsonPath("$.maxValue", is(max)),
+            hasJsonPath("$._links.self.href", containsString("api/discover/facets/author")),
+            hasJsonPath("$._links", matchNextLink(hasNext, "api/discover/facets/author"))
+        );
+    }
+
     public static Matcher<? super Object> subjectFacet(boolean hasNext) {
         return allOf(
             hasJsonPath("$.name", is("subject")),
@@ -45,6 +57,18 @@ public class FacetEntryMatcher {
             hasJsonPath("$.name", is("dateIssued")),
             hasJsonPath("$.facetType", is("date")),
             hasJsonPath("$.facetLimit", is(10)),
+            hasJsonPath("$._links.self.href", containsString("api/discover/facets/dateIssued")),
+            hasJsonPath("$._links", matchNextLink(hasNext, "api/discover/facets/dateIssued"))
+        );
+    }
+
+    public static Matcher<? super Object> dateIssuedFacetWithMinMax(boolean hasNext, String min, String max) {
+        return allOf(
+            hasJsonPath("$.name", is("dateIssued")),
+            hasJsonPath("$.facetType", is("date")),
+            hasJsonPath("$.facetLimit", is(10)),
+            hasJsonPath("$.minValue", is(min)),
+            hasJsonPath("$.maxValue", is(max)),
             hasJsonPath("$._links.self.href", containsString("api/discover/facets/dateIssued")),
             hasJsonPath("$._links", matchNextLink(hasNext, "api/discover/facets/dateIssued"))
         );

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/FacetEntryMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/FacetEntryMatcher.java
@@ -23,6 +23,7 @@ public class FacetEntryMatcher {
         return allOf(
             hasJsonPath("$.name", is("author")),
             hasJsonPath("$.facetType", is("text")),
+            hasJsonPath("$.facetLimit", is(10)),
             hasJsonPath("$._links.self.href", containsString("api/discover/facets/author")),
             hasJsonPath("$._links", matchNextLink(hasNext, "api/discover/facets/author"))
         );
@@ -32,6 +33,7 @@ public class FacetEntryMatcher {
         return allOf(
             hasJsonPath("$.name", is("subject")),
             hasJsonPath("$.facetType", is("hierarchical")),
+            hasJsonPath("$.facetLimit", is(10)),
             hasJsonPath("$._links.self.href", containsString("api/discover/facets/subject")),
             hasJsonPath("$._links", matchNextLink(hasNext, "api/discover/facets/subject"))
 
@@ -42,6 +44,7 @@ public class FacetEntryMatcher {
         return allOf(
             hasJsonPath("$.name", is("dateIssued")),
             hasJsonPath("$.facetType", is("date")),
+            hasJsonPath("$.facetLimit", is(10)),
             hasJsonPath("$._links.self.href", containsString("api/discover/facets/dateIssued")),
             hasJsonPath("$._links", matchNextLink(hasNext, "api/discover/facets/dateIssued"))
         );
@@ -51,6 +54,7 @@ public class FacetEntryMatcher {
         return allOf(
             hasJsonPath("$.name", is("has_content_in_original_bundle")),
             hasJsonPath("$.facetType", is("standard")),
+            hasJsonPath("$.facetLimit", is(2)),
             hasJsonPath("$._links.self.href", containsString("api/discover/facets/has_content_in_original_bundle")),
             hasJsonPath("$._links", matchNextLink(hasNext, "api/discover/facets/has_content_in_original_bundle"))
         );

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/SearchFilterMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/SearchFilterMatcher.java
@@ -20,40 +20,50 @@ public class SearchFilterMatcher {
 
     public static Matcher<? super Object> titleFilter() {
         return allOf(
-            hasJsonPath("$.filter", is("title")),
-            checkOperators()
+                hasJsonPath("$.filter", is("title")),
+                hasJsonPath("$.hasFacets", is(false)),
+                hasJsonPath("$.type", is("text")),
+                hasJsonPath("$.openByDefault", is(false)),checkOperators()
 
         );
     }
 
     public static Matcher<? super Object> authorFilter() {
         return allOf(
-            hasJsonPath("$.filter", is("author")),
-            checkOperators()
+                hasJsonPath("$.filter", is("author")),
+                hasJsonPath("$.hasFacets", is(true)),
+                hasJsonPath("$.type", is("text")),
+                hasJsonPath("$.openByDefault", is(true)),checkOperators()
 
         );
     }
 
     public static Matcher<? super Object> subjectFilter() {
         return allOf(
-            hasJsonPath("$.filter", is("subject")),
-            checkOperators()
+                hasJsonPath("$.filter", is("subject")),
+                hasJsonPath("$.hasFacets", is(true)),
+                hasJsonPath("$.type", is("hierarchical")),
+                hasJsonPath("$.openByDefault", is(false)),checkOperators()
 
         );
     }
 
     public static Matcher<? super Object> dateIssuedFilter() {
         return allOf(
-            hasJsonPath("$.filter", is("dateIssued")),
-            checkOperators()
+                hasJsonPath("$.filter", is("dateIssued")),
+                hasJsonPath("$.hasFacets", is(true)),
+                hasJsonPath("$.type", is("date")),
+                hasJsonPath("$.openByDefault", is(false)),checkOperators()
 
         );
     }
 
     public static Matcher<? super Object> hasContentInOriginalBundleFilter() {
         return allOf(
-            hasJsonPath("$.filter", is("has_content_in_original_bundle")),
-            checkOperators()
+                hasJsonPath("$.filter", is("has_content_in_original_bundle")),
+                hasJsonPath("$.hasFacets", is(true)),
+                hasJsonPath("$.type", is("standard")),
+                hasJsonPath("$.openByDefault", is(false)),checkOperators()
 
         );
     }

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/SearchFilterMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/SearchFilterMatcher.java
@@ -23,7 +23,8 @@ public class SearchFilterMatcher {
                 hasJsonPath("$.filter", is("title")),
                 hasJsonPath("$.hasFacets", is(false)),
                 hasJsonPath("$.type", is("text")),
-                hasJsonPath("$.openByDefault", is(false)),checkOperators()
+                hasJsonPath("$.openByDefault", is(true)),
+                checkOperators()
 
         );
     }
@@ -33,7 +34,8 @@ public class SearchFilterMatcher {
                 hasJsonPath("$.filter", is("author")),
                 hasJsonPath("$.hasFacets", is(true)),
                 hasJsonPath("$.type", is("text")),
-                hasJsonPath("$.openByDefault", is(true)),checkOperators()
+                hasJsonPath("$.openByDefault", is(true)),
+                checkOperators()
 
         );
     }
@@ -43,7 +45,8 @@ public class SearchFilterMatcher {
                 hasJsonPath("$.filter", is("subject")),
                 hasJsonPath("$.hasFacets", is(true)),
                 hasJsonPath("$.type", is("hierarchical")),
-                hasJsonPath("$.openByDefault", is(false)),checkOperators()
+                hasJsonPath("$.openByDefault", is(false)),
+                checkOperators()
 
         );
     }
@@ -53,7 +56,8 @@ public class SearchFilterMatcher {
                 hasJsonPath("$.filter", is("dateIssued")),
                 hasJsonPath("$.hasFacets", is(true)),
                 hasJsonPath("$.type", is("date")),
-                hasJsonPath("$.openByDefault", is(false)),checkOperators()
+                hasJsonPath("$.openByDefault", is(false)),
+                checkOperators()
 
         );
     }
@@ -63,21 +67,23 @@ public class SearchFilterMatcher {
                 hasJsonPath("$.filter", is("has_content_in_original_bundle")),
                 hasJsonPath("$.hasFacets", is(true)),
                 hasJsonPath("$.type", is("standard")),
-                hasJsonPath("$.openByDefault", is(false)),checkOperators()
+                hasJsonPath("$.openByDefault", is(false)),
+                checkOperators()
 
         );
     }
 
     public static Matcher<? super Object> checkOperators() {
         return allOf(
-            hasJsonPath("$.operators", containsInAnyOrder(
-                hasJsonPath("$.operator", is("equals")),
-                hasJsonPath("$.operator", is("notequals")),
-                hasJsonPath("$.operator", is("authority")),
-                hasJsonPath("$.operator", is("notauthority")),
-                hasJsonPath("$.operator", is("contains")),
-                hasJsonPath("$.operator", is("notcontains"))
-            ))
+                hasJsonPath("$.operators",  containsInAnyOrder(
+                        hasJsonPath("$.operator", is("equals")),
+                        hasJsonPath("$.operator", is("notequals")),
+                        hasJsonPath("$.operator", is("authority")),
+                        hasJsonPath("$.operator", is("notauthority")),
+                        hasJsonPath("$.operator", is("contains")),
+                        hasJsonPath("$.operator", is("notcontains")),
+                        hasJsonPath("$.operator", is("query"))
+                        ))
         );
     }
 }

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/SortOptionMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/SortOptionMatcher.java
@@ -29,6 +29,12 @@ public class SortOptionMatcher {
         );
     }
 
+    public static Matcher<? super Object> dateAccessionedSortOption() {
+        return allOf(
+                hasJsonPath("$.name", is("dc.date.accessioned"))
+        );
+    }
+
     public static Matcher<? super Object> scoreSortOption() {
         return allOf(
             hasJsonPath("$.name", is("score"))

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/test/AbstractControllerIntegrationTest.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/test/AbstractControllerIntegrationTest.java
@@ -95,7 +95,7 @@ public class AbstractControllerIntegrationTest extends AbstractIntegrationTestWi
 
         DefaultMockMvcBuilder mockMvcBuilder = webAppContextSetup(webApplicationContext)
             //Always log the response to debug
-            .alwaysDo(MockMvcResultHandlers.log())
+            .alwaysDo(MockMvcResultHandlers.print())
             //Add all filter implementations
             .addFilters(new ErrorPageFilter())
             .addFilters(requestFilters.toArray(new Filter[requestFilters.size()]));

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/utils/DiscoverQueryBuilderTest.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/utils/DiscoverQueryBuilderTest.java
@@ -287,7 +287,8 @@ public class DiscoverQueryBuilderTest {
 
     @Test
     public void testBuildFacetQuery() throws Exception {
-        DiscoverQuery discoverQuery = queryBuilder.buildFacetQuery(context, scope, discoveryConfiguration, query,
+        DiscoverQuery discoverQuery = queryBuilder.buildFacetQuery(context, scope, discoveryConfiguration,
+                                                            "prefix", query,
                                                                    Arrays.asList(searchFilter), "item", page,
                                                                    "subject");
 
@@ -302,13 +303,13 @@ public class DiscoverQueryBuilderTest {
         assertThat(discoverQuery.getFacetFields(), hasSize(1));
         assertThat(discoverQuery.getFacetFields(), contains(
             new ReflectionEquals(new DiscoverFacetField("subject", DiscoveryConfigurationParameters.TYPE_TEXT, 11,
-                                                        DiscoveryConfigurationParameters.SORT.COUNT))
+                                                        DiscoveryConfigurationParameters.SORT.COUNT, "prefix"))
         ));
     }
 
     @Test(expected = InvalidSearchFacetException.class)
     public void testInvalidSearchFacet() throws Exception {
-        queryBuilder.buildFacetQuery(context, scope, discoveryConfiguration, query,
+        queryBuilder.buildFacetQuery(context, scope, discoveryConfiguration, null, query,
                                      Arrays.asList(searchFilter), "item", page, "test");
     }
 

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/utils/DiscoverQueryBuilderTest.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/utils/DiscoverQueryBuilderTest.java
@@ -168,7 +168,7 @@ public class DiscoverQueryBuilderTest {
                                                               Arrays.asList(searchFilter), "item", page);
 
         assertThat(discoverQuery.getFilterQueries(), containsInAnyOrder("archived:true", "subject:\"Java\""));
-        assertThat(discoverQuery.getQuery(), is(query));
+        assertThat(discoverQuery.getQuery(), is("\"" + query + "\""));
         assertThat(discoverQuery.getDSpaceObjectFilter(), is(Constants.ITEM));
         assertThat(discoverQuery.getSortField(), is("dc.title_sort"));
         assertThat(discoverQuery.getSortOrder(), is(DiscoverQuery.SORT_ORDER.asc));
@@ -292,7 +292,7 @@ public class DiscoverQueryBuilderTest {
                                                                    "subject");
 
         assertThat(discoverQuery.getFilterQueries(), containsInAnyOrder("archived:true", "subject:\"Java\""));
-        assertThat(discoverQuery.getQuery(), is(query));
+        assertThat(discoverQuery.getQuery(), is("\"" + query + "\""));
         assertThat(discoverQuery.getDSpaceObjectFilter(), is(Constants.ITEM));
         assertThat(discoverQuery.getSortField(), isEmptyOrNullString());
         assertThat(discoverQuery.getMaxResults(), is(0));

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -381,7 +381,7 @@
         <property name="sortOrderFilterPage" value="COUNT"/>
         <property name="isOpenByDefault" value="true"/>
         <property name="pageSize" value="10"/>
-        <property name="exposeMinMax" value="true"/>
+        <property name="exposeMinAndMaxValue" value="true"/>
 
     </bean>
 
@@ -412,7 +412,7 @@
         <property name="sortOrderFilterPage" value="COUNT"/>
         <property name="isOpenByDefault" value="false"/>
         <property name="pageSize" value="10"/>
-        <property name="exposeMinMax" value="true"/>
+        <property name="exposeMinAndMaxValue" value="true"/>
 
     </bean>
     

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -378,6 +378,7 @@
         <property name="sortOrderSidebar" value="COUNT"/>
         <property name="sortOrderFilterPage" value="COUNT"/>
         <property name="isOpenByDefault" value="true"/>
+        <property name="exposeMinMax" value="true"/>
 
     </bean>
 
@@ -407,6 +408,7 @@
         <property name="sortOrderSidebar" value="COUNT"/>
         <property name="sortOrderFilterPage" value="COUNT"/>
         <property name="isOpenByDefault" value="false"/>
+        <property name="exposeMinMax" value="true"/>
 
     </bean>
     

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -375,6 +375,8 @@
         <property name="facetLimit" value="10"/>
         <property name="sortOrderSidebar" value="COUNT"/>
         <property name="sortOrderFilterPage" value="COUNT"/>
+        <property name="isOpenByDefault" value="true"/>
+
     </bean>
 
     <bean id="searchFilterSubject" class="org.dspace.discovery.configuration.HierarchicalSidebarFacetConfiguration">
@@ -388,6 +390,7 @@
         <property name="sortOrderSidebar" value="COUNT"/>
         <property name="sortOrderFilterPage" value="COUNT"/>
         <property name="splitter" value="::"/>
+
     </bean>
 
     <bean id="searchFilterIssued" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
@@ -400,6 +403,8 @@
         <property name="type" value="date"/>
         <property name="sortOrderSidebar" value="COUNT"/>
         <property name="sortOrderFilterPage" value="COUNT"/>
+        <property name="isOpenByDefault" value="false"/>
+
     </bean>
     
     <bean id="searchFilterContentInOriginalBundle" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
@@ -411,6 +416,8 @@
         <property name="type" value="standard"/>
         <property name="sortOrderSidebar" value="COUNT"/>
         <property name="sortOrderFilterPage" value="COUNT"/>
+        <property name="isOpenByDefault" value="false"/>
+
     </bean>
 
     <!--Sort properties-->

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -364,6 +364,8 @@
                 <value>dc.title</value>
             </list>
         </property>
+        <property name="isOpenByDefault" value="true"/>
+        <property name="pageSize" value="10"/>
     </bean>
 
     <bean id="searchFilterAuthor" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
@@ -378,6 +380,7 @@
         <property name="sortOrderSidebar" value="COUNT"/>
         <property name="sortOrderFilterPage" value="COUNT"/>
         <property name="isOpenByDefault" value="true"/>
+        <property name="pageSize" value="10"/>
         <property name="exposeMinMax" value="true"/>
 
     </bean>
@@ -408,6 +411,7 @@
         <property name="sortOrderSidebar" value="COUNT"/>
         <property name="sortOrderFilterPage" value="COUNT"/>
         <property name="isOpenByDefault" value="false"/>
+        <property name="pageSize" value="10"/>
         <property name="exposeMinMax" value="true"/>
 
     </bean>
@@ -422,6 +426,7 @@
         <property name="sortOrderSidebar" value="COUNT"/>
         <property name="sortOrderFilterPage" value="COUNT"/>
         <property name="isOpenByDefault" value="false"/>
+        <property name="pageSize" value="10"/>
 
     </bean>
 

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -113,6 +113,7 @@
                     <list>
                         <ref bean="sortTitle" />
                         <ref bean="sortDateIssued" />
+                        <ref bean="sortDateAccessioned"/>
                     </list>
                 </property>
             </bean>
@@ -220,6 +221,7 @@
                     <list>
                         <ref bean="sortTitle" />
                         <ref bean="sortDateIssued" />
+                        <ref bean="sortDateAccessioned" />
                     </list>
                 </property>
             </bean>
@@ -401,6 +403,7 @@
             </list>
         </property>
         <property name="type" value="date"/>
+        <property name="facetLimit" value="10"/>
         <property name="sortOrderSidebar" value="COUNT"/>
         <property name="sortOrderFilterPage" value="COUNT"/>
         <property name="isOpenByDefault" value="false"/>
@@ -429,5 +432,8 @@
         <property name="metadataField" value="dc.date.issued"/>
         <property name="type" value="date"/>
     </bean>
-    
+    <bean id="sortDateAccessioned" class="org.dspace.discovery.configuration.DiscoverySortFieldConfiguration">
+        <property name="metadataField" value="dc.date.accessioned"/>
+        <property name="type" value="date"/>
+    </bean>
 </beans>

--- a/dspace/solr/search/conf/schema.xml
+++ b/dspace/solr/search/conf/schema.xml
@@ -578,6 +578,8 @@
      <dynamicField name="*_hl" type="text" indexed="true" stored="true" multiValued="true" omitNorms="true"/>
      
      <dynamicField name="*_sort" type="lowerCaseSort" indexed="true" stored="true" multiValued="false" omitNorms="true"/>
+     <dynamicField name="*_min" type="text" indexed="true" stored="true" multiValued="false" omitNorms="true"/>
+     <dynamicField name="*_max" type="text" indexed="true" stored="true" multiValued="false" omitNorms="true"/>
 
      <!--Dynamic field used for related item searches-->
      <dynamicField name="*_mlt" type="text" indexed="true" stored="true" multiValued="true" omitNorms="true" termVectors="true" termPositions="true" termOffsets="true"/>


### PR DESCRIPTION
This PR builds on the work done in https://github.com/DSpace/DSpace/pull/2041 and add the following functionality required by the Search UI mockups:

* Support for a base-query language as described in https://wiki.duraspace.org/display/DSPACE/Search+Mockup#SearchMockup-Theequals,contains,not,ID,etcdropdownhasbeenremoved The API supports this using the `query` operator: 
   * `/api/discover/search/objects?f.subject=-Fedora,query`
* Support for filtering facets on a given prefix. This is required to support auto-complete functionality on filter values as described here https://wiki.duraspace.org/display/DSPACE/Search+Mockup#SearchMockup-Filterinputshaveautocomplete
   * `/api/discover/facets/author?prefix=sa`

