### PR TITLE
[DS-3941] changes the role to roleId in the query found in workflowIt…

### DIFF
--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/dao/impl/WorkflowItemRoleDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/dao/impl/WorkflowItemRoleDAOImpl.java
@@ -38,7 +38,7 @@ public class WorkflowItemRoleDAOImpl extends AbstractHibernateDAO<WorkflowItemRo
         Criteria criteria = createCriteria(context, WorkflowItemRole.class);
         criteria.add(Restrictions.and(
                         Restrictions.eq("workflowItem", workflowItem),
-                        Restrictions.eq("role", role)
+                        Restrictions.eq("roleId", role)
                 )
         );
 


### PR DESCRIPTION
Changed the "role" to "roleId" for it to properly match on the WorkflowItemRoleDAOImpl roleId attribute and not throw an error when called.