### PR TITLE
DS-3945: XMLUI: filtering by "starts with" field twice on browsing pages doesn't work

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ConfigurableBrowse.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ConfigurableBrowse.java
@@ -412,7 +412,9 @@ public class ConfigurableBrowse extends AbstractDSpaceTransformer implements
         // Add all the query parameters as hidden fields on the form
         for (Map.Entry<String, String> param : queryParamsPOST.entrySet())
         {
-            jump.addHidden(param.getKey()).setValue(param.getValue());
+            if (!BrowseParams.STARTS_WITH.equals(param.getKey())) {
+                jump.addHidden(param.getKey()).setValue(param.getValue());
+            }
         }
 
         // If this is a date based browse, render the date navigation


### PR DESCRIPTION
Pull request for: https://jira.duraspace.org/browse/DS-3945

To reproduce this error:

1) Go to browse by title: http://demo.dspace.org/xmlui/browse?type=title

2) Filter by some text (by example: document)

3) Filter again by some other text (by example: test)

Result: With Mirage2 theme, the browse page goes to the browse by date because it lost the "type" parameter.

With Mirage theme, the user-submitted value "starts with" is ignored on the second search.