### PR TITLE
DS-3961 Preserve UUIDs during METS export/import

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/Bitstream.java
+++ b/dspace-api/src/main/java/org/dspace/content/Bitstream.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.BitstreamService;
@@ -83,6 +84,10 @@ public class Bitstream extends DSpaceObject implements DSpaceObjectLegacySupport
      */
     protected Bitstream()
     {
+    }
+    protected Bitstream(UUID uuid)
+    {
+        this.predefinedUUID = uuid;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/Collection.java
+++ b/dspace-api/src/main/java/org/dspace/content/Collection.java
@@ -115,6 +115,10 @@ public class Collection extends DSpaceObject implements DSpaceObjectLegacySuppor
     {
 
     }
+    protected Collection(UUID uuid)
+    {
+        this.predefinedUUID = uuid;
+    }
 
     @Override
     public String getName()

--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -84,12 +84,22 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
 
     @Override
     public Collection create(Context context, Community community, String handle) throws SQLException, AuthorizeException {
+        return create(context, community, handle, null);
+    }
+
+    @Override
+    public Collection create(Context context, Community community, String handle, UUID uuid) throws SQLException, AuthorizeException {
         if(community == null)
         {
             throw new IllegalArgumentException("Community cannot be null when creating a new collection.");
         }
 
-        Collection newCollection = collectionDAO.create(context, new Collection());
+        Collection newCollection;
+        if (uuid != null) {
+            newCollection = collectionDAO.create(context, new Collection(uuid));
+        }  else {
+            newCollection = collectionDAO.create(context, new Collection());
+        }
         //Add our newly created collection to our community, authorization checks occur in THIS method
         communityService.addCollection(context, community, newCollection);
 

--- a/dspace-api/src/main/java/org/dspace/content/Community.java
+++ b/dspace-api/src/main/java/org/dspace/content/Community.java
@@ -86,6 +86,10 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
     {
 
     }
+    protected Community(UUID uuid)
+    {
+        this.predefinedUUID = uuid;
+    }
 
     void addSubCommunity(Community subCommunity)
     {

--- a/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
@@ -73,6 +73,11 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
 
     @Override
     public Community create(Community parent, Context context, String handle) throws SQLException, AuthorizeException {
+        return create(parent, context, handle, null);
+    }
+
+    @Override
+    public Community create(Community parent, Context context, String handle, UUID uuid) throws SQLException, AuthorizeException {
         if (!(authorizeService.isAdmin(context) ||
               (parent != null && authorizeService.authorizeActionBoolean(context, parent, Constants.ADD))))
         {
@@ -80,7 +85,12 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
                     "Only administrators can create communities");
         }
 
-        Community newCommunity = communityDAO.create(context, new Community());
+        Community newCommunity;
+        if (uuid != null) {
+            newCommunity = communityDAO.create(context, new Community(uuid));
+        } else {
+            newCommunity = communityDAO.create(context, new Community());
+        }
 
         try
         {
@@ -394,10 +404,20 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
 
     @Override
     public Community createSubcommunity(Context context, Community parentCommunity, String handle) throws SQLException, AuthorizeException {
+        return createSubcommunity(context, parentCommunity, handle, null);
+    }
+
+    @Override
+    public Community createSubcommunity(Context context, Community parentCommunity, String handle, UUID uuid) throws SQLException, AuthorizeException {
                 // Check authorisation
         authorizeService.authorizeAction(context, parentCommunity, Constants.ADD);
 
-        Community c = create(parentCommunity, context, handle);
+        Community c;
+        if (uuid != null) {
+            c = create(parentCommunity, context, handle, uuid);
+        } else {
+            c = create(parentCommunity, context, handle);
+        }
         addSubcommunity(context, parentCommunity, c);
 
         return c;

--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
@@ -8,8 +8,6 @@
 package org.dspace.content;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.dspace.authorize.ResourcePolicy;
 import org.dspace.core.ReloadableEntity;
 import org.dspace.handle.Handle;
@@ -29,8 +27,8 @@ import javax.persistence.*;
 public abstract class DSpaceObject implements Serializable, ReloadableEntity<java.util.UUID>
 {
     @Id
-    @GeneratedValue(generator = "system-uuid")
-    @GenericGenerator(name = "system-uuid", strategy = "uuid2")
+    @GeneratedValue(generator = "check-existing-uuid")
+    @GenericGenerator(name = "check-existing-uuid", strategy = "org.dspace.storage.rdbms.hibernate.CheckExistingUUIDGenerator")
     @Column(name = "uuid", unique = true, nullable = false, insertable = true, updatable = false)
     protected java.util.UUID id;
 
@@ -63,6 +61,12 @@ public abstract class DSpaceObject implements Serializable, ReloadableEntity<jav
     /** Flag set when data is modified, for events */
     @Transient
     private boolean modified = false;
+
+    @Transient
+    protected UUID predefinedUUID;
+    public UUID getPredefinedUUID() {
+        return predefinedUUID;
+    }
 
     protected DSpaceObject()
     {

--- a/dspace-api/src/main/java/org/dspace/content/Item.java
+++ b/dspace-api/src/main/java/org/dspace/content/Item.java
@@ -97,6 +97,11 @@ public class Item extends DSpaceObject implements DSpaceObjectLegacySupport
 
     }
 
+    protected Item(UUID uuid)
+    {
+        this.predefinedUUID = uuid;
+    }
+
     /**
      * Find out if the item is part of the main archive
      *

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -157,12 +157,16 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         return item;
     }
 
-    @Override
     public Item create(Context context, WorkspaceItem workspaceItem) throws SQLException, AuthorizeException {
+        return create(context, workspaceItem, null);
+    }
+
+    @Override
+    public Item create(Context context, WorkspaceItem workspaceItem, UUID uuid) throws SQLException, AuthorizeException {
         if (workspaceItem.getItem() != null) {
             throw new IllegalArgumentException("Attempting to create an item for a workspace item that already contains an item");
         }
-        Item item = createItem(context);
+        Item item = createItem(context, uuid);
         workspaceItem.setItem(item);
 
 
@@ -181,7 +185,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         AuthorizeUtil.authorizeManageTemplateItem(context, collection);
 
         if (collection.getTemplateItem() == null) {
-            Item template = createItem(context);
+            Item template = createItem(context, null);
             collection.setTemplateItem(template);
             template.setTemplateItemOf(collection);
 
@@ -374,8 +378,13 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         return bitstreamList;
     }
 
-    protected Item createItem(Context context) throws SQLException, AuthorizeException {
-        Item item = itemDAO.create(context, new Item());
+    protected Item createItem(Context context, UUID uuid) throws SQLException, AuthorizeException {
+        Item item;
+        if (uuid != null) {
+            item = itemDAO.create(context, new Item(uuid));
+        } else {
+            item = itemDAO.create(context, new Item());
+        }
         // set discoverable to true (default)
         item.setDiscoverable(true);
 

--- a/dspace-api/src/main/java/org/dspace/content/WorkspaceItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/WorkspaceItemServiceImpl.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Service implementation for the WorkspaceItem object.
@@ -82,6 +83,11 @@ public class WorkspaceItemServiceImpl implements WorkspaceItemService {
 
     @Override
     public WorkspaceItem create(Context context, Collection collection, boolean template) throws AuthorizeException, SQLException {
+        return create(context, collection, null, template);
+    }
+
+    @Override
+    public WorkspaceItem create(Context context, Collection collection, UUID uuid, boolean template) throws AuthorizeException, SQLException {
         // Check the user has permission to ADD to the collection
         authorizeService.authorizeAction(context, collection, Constants.ADD);
 
@@ -90,7 +96,7 @@ public class WorkspaceItemServiceImpl implements WorkspaceItemService {
 
 
         // Create an item
-        Item item = itemService.create(context, workspaceItem);
+        Item item = itemService.create(context, workspaceItem, uuid);
         item.setSubmitter(context.getCurrentUser());
 
         // Now create the policies for the submitter to modify item and contents

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/PREMISCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/PREMISCrosswalk.java
@@ -230,11 +230,21 @@ public class PREMISCrosswalk
         premis.addContent(object);
 
         // objectIdentifier is required
+        // Store the internal and external addresses
         Element oid = new Element("objectIdentifier", PREMIS_NS);
         Element oit = new Element("objectIdentifierType", PREMIS_NS);
-        oit.setText("URL");
+        oit.setText("INTERNAL");
         oid.addContent(oit);
         Element oiv = new Element("objectIdentifierValue", PREMIS_NS);
+        oiv.setText(bitstream.getStoreNumber() + ":" + bitstream.getInternalId());
+        oid.addContent(oiv);
+        object.addContent(oid);
+
+        oid = new Element("objectIdentifier", PREMIS_NS);
+        oit = new Element("objectIdentifierType", PREMIS_NS);
+        oit.setText("URL");
+        oid.addContent(oit);
+        oiv = new Element("objectIdentifierValue", PREMIS_NS);
 
         // objectIdentifier value: by preference, if available:
         //  a. DSpace "persistent" URL to bitstream, if components available.
@@ -264,7 +274,7 @@ public class PREMISCrosswalk
         {
             oiv.setText(baseUrl
                     + "/bitstream/"
-                    + URLEncoder.encode(handle, "UTF-8")
+                    + handle
                     + "/"
                     + sid
                     + "/"

--- a/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSDisseminator.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSDisseminator.java
@@ -818,11 +818,7 @@ public abstract class AbstractMETSDisseminator
         Mets mets = new Mets();
         
         String identifier = "DB-ID-" + dso.getID();
-        if(dso.getHandle()!=null)
-        {
-            identifier = dso.getHandle().replace('/', '-');
-        }
-        
+
         // this ID should be globally unique (format: DSpace_[objType]_[handle with slash replaced with a dash])
         mets.setID("DSpace_" + Constants.typeText[dso.getType()] + "_" + identifier);
 

--- a/dspace-api/src/main/java/org/dspace/content/packager/PackageUtils.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/PackageUtils.java
@@ -457,7 +457,7 @@ public class PackageUtils
      * @throws SQLException if database error
      * @throws IOException if IO error
      */
-    public static DSpaceObject createDSpaceObject(Context context, DSpaceObject parent, int type, String handle, PackageParameters params)
+    public static DSpaceObject createDSpaceObject(Context context, DSpaceObject parent, int type, String handle, UUID uuid, PackageParameters params)
         throws AuthorizeException, SQLException, IOException
     {
         DSpaceObject dso = null;
@@ -465,25 +465,25 @@ public class PackageUtils
         switch (type)
         {
             case Constants.COLLECTION:
-                dso = collectionService.create(context, (Community) parent, handle);
+                dso = collectionService.create(context, (Community) parent, handle, uuid);
                 return dso;
 
             case Constants.COMMUNITY:
                 // top-level community?
                 if (parent == null || parent.getType() == Constants.SITE)
                 {
-                    dso = communityService.create(null, context, handle);
+                    dso = communityService.create(null, context, handle, uuid);
                 }
                 else
                 {
-                    dso = communityService.createSubcommunity(context, ((Community) parent), handle);
+                    dso = communityService.createSubcommunity(context, ((Community) parent), handle, uuid);
                 }
                 return dso;
 
             case Constants.ITEM:
                 //Initialize a WorkspaceItem
                 //(Note: Handle is not set until item is finished)
-                WorkspaceItem wsi = workspaceItemService.create(context, (Collection)parent, params.useCollectionTemplate());
+                WorkspaceItem wsi = workspaceItemService.create(context, (Collection)parent, uuid, params.useCollectionTemplate());
 
                 // Please note that we are returning an Item which is *NOT* yet in the Archive,
                 // and doesn't yet have a handle assigned.

--- a/dspace-api/src/main/java/org/dspace/content/service/BitstreamService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/BitstreamService.java
@@ -16,6 +16,7 @@ import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Service interface class for the Bitstream object.
@@ -58,6 +59,7 @@ public interface BitstreamService extends DSpaceObjectService<Bitstream>, DSpace
      * @throws SQLException if database error
      */
     public Bitstream create(Context context, InputStream is) throws IOException, SQLException;
+    public Bitstream create(Context context, InputStream is, UUID uuid) throws IOException, SQLException;
 
     /**
      * Create a new bitstream, with a new ID. The checksum and file size are
@@ -78,7 +80,8 @@ public interface BitstreamService extends DSpaceObjectService<Bitstream>, DSpace
      * @throws AuthorizeException if authorization error
      */
     public Bitstream create(Context context, Bundle bundle, InputStream is) throws IOException, SQLException, AuthorizeException;
- 
+    public Bitstream create(Context context, Bundle bundle, InputStream is, UUID uuid) throws IOException, SQLException, AuthorizeException;
+
     /**
      * Register a new bitstream, with a new ID.  The checksum and file size
      * are calculated. The newly created bitstream has the "unknown"

--- a/dspace-api/src/main/java/org/dspace/content/service/CollectionService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/CollectionService.java
@@ -21,6 +21,7 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.MissingResourceException;
+import java.util.UUID;
 
 /**
  * Service interface class for the Collection object.
@@ -60,6 +61,21 @@ public interface CollectionService extends DSpaceObjectService<Collection>, DSpa
      * @throws AuthorizeException if authorization error
      */
     public Collection create(Context context, Community community, String handle) throws SQLException,
+            AuthorizeException;
+
+    /**
+     * Create a new collection with the supplied handle and ID.
+     * Once created the collection is added to the given community
+     *
+     * @param context DSpace context object
+     * @param community DSpace Community (parent)
+     * @param handle the pre-determined Handle to assign to the new collection
+     * @param uuid the pre-determined UUID to assign to the new collection
+     * @return the newly created collection
+     * @throws SQLException if database error
+     * @throws AuthorizeException if authorization error
+     */
+    public Collection create(Context context, Community community, String handle, UUID uuid) throws SQLException,
             AuthorizeException;
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/service/CommunityService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/CommunityService.java
@@ -19,6 +19,7 @@ import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.MissingResourceException;
+import java.util.UUID;
 
 /**
  * Service interface class for the Community object.
@@ -57,6 +58,20 @@ public interface CommunityService extends DSpaceObjectService<Community>, DSpace
      * @throws AuthorizeException if authorization error
      */
     public Community create(Community parent, Context context, String handle)
+            throws SQLException, AuthorizeException;
+
+    /**
+     * Create a new top-level community, with a new ID.
+     *
+     * @param parent parent community
+     * @param context DSpace context object
+     * @param handle the pre-determined Handle to assign to the new community
+     * @poram uuid the pre-determined UUID to assign to the new community
+     * @return the newly created community
+     * @throws SQLException if database error
+     * @throws AuthorizeException if authorization error
+     */
+    public Community create(Community parent, Context context, String handle, UUID uuid)
             throws SQLException, AuthorizeException;
 
 
@@ -243,6 +258,20 @@ public interface CommunityService extends DSpaceObjectService<Community>, DSpace
      * @throws AuthorizeException if authorization error
      */
     public Community createSubcommunity(Context context, Community parentCommunity, String handle)
+            throws SQLException, AuthorizeException;
+
+    /**
+     * Create a new sub-community within this community.
+     *
+     * @param context context
+     * @param handle the pre-determined Handle to assign to the new community
+     * @param parentCommunity parent community
+     * @param uuid the pre-determined UUID to assign to the new community
+     * @return the new community
+     * @throws SQLException if database error
+     * @throws AuthorizeException if authorization error
+     */
+    public Community createSubcommunity(Context context, Community parentCommunity, String handle, UUID uuid)
             throws SQLException, AuthorizeException;
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
@@ -46,6 +46,20 @@ public interface ItemService extends DSpaceObjectService<Item>, DSpaceObjectLega
     public Item create(Context context, WorkspaceItem workspaceItem) throws SQLException, AuthorizeException;
 
     /**
+     * Create a new item, with a provided ID. This method is not public,
+     * since items need to be created as workspace items. Authorisation is the
+     * responsibility of the caller.
+     *
+     * @param context DSpace context object
+     * @param workspaceItem in progress workspace item
+     * @param uuid the pre-determined UUID to assign to the new item
+     * @return the newly created item
+     * @throws SQLException if database error
+     * @throws AuthorizeException if authorization error
+     */
+    public Item create(Context context, WorkspaceItem workspaceItem, UUID uuid) throws SQLException, AuthorizeException;
+
+    /**
      * Create an empty template item for this collection. If one already exists,
      * no action is taken. Caution: Make sure you call <code>update</code> on
      * the collection after doing this, or the item will have been created but

--- a/dspace-api/src/main/java/org/dspace/content/service/WorkspaceItemService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/WorkspaceItemService.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Service interface class for the WorkspaceItem object.
@@ -60,6 +61,9 @@ public interface WorkspaceItemService extends InProgressSubmissionService<Worksp
      * @throws AuthorizeException if authorization error
      */
     public WorkspaceItem create(Context context, Collection collection,  boolean template)
+            throws AuthorizeException, SQLException;
+
+    public WorkspaceItem create(Context context, Collection collection, UUID uuid, boolean template)
             throws AuthorizeException, SQLException;
 
     public WorkspaceItem create(Context c, WorkflowItem wfi) throws SQLException, AuthorizeException;

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/hibernate/CheckExistingUUIDGenerator.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/hibernate/CheckExistingUUIDGenerator.java
@@ -1,0 +1,34 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.storage.rdbms.hibernate;
+
+import org.dspace.content.DSpaceObject;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.id.UUIDGenerator;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+/**
+ * Allows DSpaceObjects to provide a pre-determined UUID
+ *
+ * @author Chris Herron
+ */
+public class CheckExistingUUIDGenerator extends UUIDGenerator {
+
+    @Override
+    public Serializable generate(SessionImplementor session, Object object) {
+        if (object instanceof DSpaceObject) {
+            UUID uuid = ((DSpaceObject) object).getPredefinedUUID();
+            if (uuid != null) {
+                return uuid;
+            }
+        }
+        return super.generate(session, object);
+    }
+}


### PR DESCRIPTION
Currently, the DSpace framework does not support creating objects with a pre-defined UUID. This can be an annoyance when moving objects between repositories and wanting to keep previous statistics records.

This commit introduces a custom `UUIDGenerator` and associated `predefinedUUID` field for creating objects with pre-defined UUIDs. In addition, it provides the export/import functionality for packaging and restoring this information. Moreover, bitstream records have been extended with `bitstore` and `internal_id` to improve restore capabilities (restore will attempt to find file on bitstore while restoring).

This fix may also apply to 7.x