### PR TITLE
DS-3956 Remove handle query cache

### DIFF
--- a/dspace-api/src/main/java/org/dspace/handle/dao/impl/HandleDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/handle/dao/impl/HandleDAOImpl.java
@@ -72,7 +72,6 @@ public class HandleDAOImpl extends AbstractHibernateDAO<Handle> implements Handl
 
         query.setParameter("handle", handle);
 
-        query.setCacheable(true);
         return uniqueResult(query);
     }
 


### PR DESCRIPTION
Fixes #7303 

This fix prevents the result of `findByHandle` from being cached. The caching causes a problem with the handle survey resolving URLs for newly submitted Items.

Alternatively, this could be configurable, or only cached if queried through DSpace, and _not_ through the Handle server.