### PR TITLE
DS-3957 Curation email report

### DIFF
--- a/dspace-api/src/main/java/org/dspace/curate/AbstractCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/curate/AbstractCurationTask.java
@@ -211,7 +211,7 @@ public abstract class AbstractCurationTask implements CurationTask
      */
     protected void report(String message)
     {
-        curator.report(message);
+        curator.report(message, taskId);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/curate/CurationCli.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CurationCli.java
@@ -251,7 +251,12 @@ public class CurationCli
                     {
                         curator.addTask(task);
                     }
-                    curator.curate(c, entry.getObjectId());
+                    String epersonId = entry.getEpersonId();
+                    if(epersonId != null) {
+                        curator.curate(c, entry.getObjectId(), epersonId);
+                    } else {
+                        curator.curate(c, entry.getObjectId());
+                    }
                 }
                 else
                 {

--- a/dspace/config/emails/curation_report
+++ b/dspace/config/emails/curation_report
@@ -1,0 +1,21 @@
+# Curation report
+#
+# Parameters: {0} Curation Task Executed
+#             {1} Target Resource
+#             {2} Outcome
+#             {3} Report
+#
+# See org.dspace.core.Email for information on the format of this file.
+#
+Subject: DSpace - Curation report
+
+The following curation report has been completed:
+
+Curation Task Executed: {0}
+Target Resource: {1}
+Outcome: {2}
+Report:
+
+{3}
+
+The DSpace Team

--- a/dspace/config/modules/curate.cfg
+++ b/dspace/config/modules/curate.cfg
@@ -52,3 +52,12 @@ curate.ui.statusmessages = \
      2 = Skip, \
      other = Invalid Status
 
+# Send an email report after curation task completes. Reports are sent to the recipient configured below,
+# the Context object's current EPerson, and the EPerson passed to emailAlert function.
+curate.email.report = true
+
+# Send an email even if report is blank (does nothing if reports are disabled)
+curate.email.report.if-blank = false
+
+# Recipient for curation email reports
+curate.email.recipient = ${alert.recipient}


### PR DESCRIPTION
This functionality allows the Curation framework to send out an email report after completing.

The email report is sent to the Curation Context's current EPerson, the person configured by `curate.email.recipient`, and to the person passed to the `sendEmailAlert` function.

A single email is sent per curation task, regardless of run with a taskID, queue, or taskFile.