### PR TITLE
DS-3873 Limit the usage of PDFBoxThumbnail to PDFs

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFBoxThumbnail.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFBoxThumbnail.java
@@ -9,15 +9,9 @@ package org.dspace.app.mediafilter;
 
 import java.awt.image.*;
 import java.io.InputStream;
-
-import javax.imageio.ImageIO;
-
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.rendering.PDFRenderer;
-
 import org.dspace.content.Item;
-
-import org.dspace.app.mediafilter.JPEGFilter;
 
 /**
  * Create JPEG thumbnails from PDF cover page using PDFBox.
@@ -29,7 +23,7 @@ import org.dspace.app.mediafilter.JPEGFilter;
  * @author Ivan Masár helix84@centrum.sk
  * @author Jason Sherman jsherman@usao.edu
  */
-public class PDFBoxThumbnail extends MediaFilter implements SelfRegisterInputFormats
+public class PDFBoxThumbnail extends MediaFilter
 {
     @Override
     public String getFilteredName(String oldFilename)
@@ -85,25 +79,5 @@ public class PDFBoxThumbnail extends MediaFilter implements SelfRegisterInputFor
 
         JPEGFilter jpegFilter = new JPEGFilter();
         return jpegFilter.getThumb(currentItem, buf, verbose);
-    }
-
-    @Override
-    public String[] getInputMIMETypes()
-    {
-        return ImageIO.getReaderMIMETypes();
-    }
-
-    @Override
-    public String[] getInputDescriptions()
-    {
-        return null;
-    }
-
-    @Override
-    public String[] getInputExtensions()
-    {
-        // Temporarily disabled as JDK 1.6 only
-        // return ImageIO.getReaderFileSuffixes();
-        return null;
     }
 }


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3873

`PDFBoxThumbnail` media filter is currently configured to run on more than just PDFs. This consistently results in an error in the logs:

```ERROR filtering, skipping bitstream #7f142dd0-fca6-4533-b966-19b1354e9a9d java.io.IOException: Error: Header doesn't contain versioninfo
java.io.IOException: Error: Header doesn't contain versioninfo
        at org.apache.pdfbox.pdfparser.PDFParser.parse(PDFParser.java:244)
        at org.apache.pdfbox.pdmodel.PDDocument.load(PDDocument.java:966)
        at org.apache.pdfbox.pdmodel.PDDocument.load(PDDocument.java:868)
        at org.dspace.app.mediafilter.PDFBoxThumbnail.getDestinationStream(PDFBoxThumbnail.java:80)
        at org.dspace.app.mediafilter.MediaFilterServiceImpl.processBitstream(MediaFilterServiceImpl.java:358)
        at org.dspace.app.mediafilter.MediaFilterServiceImpl.filterBitstream(MediaFilterServiceImpl.java:286)
        at org.dspace.app.mediafilter.MediaFilterServiceImpl.filterItem(MediaFilterServiceImpl.java:180)
        at org.dspace.app.mediafilter.MediaFilterServiceImpl.applyFiltersItem(MediaFilterServiceImpl.java:158)
        at org.dspace.app.mediafilter.MediaFilterCLITool.main(MediaFilterCLITool.java:315)
```

This can be fixed by removing `implements SelfRegisteredInputFormats`, as the inherited methods aren't being used and most other filters don't implement this.