### PR TITLE
DS-3735 DS-3924 DS-3737 Implement CREATE, DELETE and some search methods for the EPersons endpoint

### DIFF
--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/EPersonRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/EPersonRest.java
@@ -10,7 +10,10 @@ package org.dspace.app.rest.model;
 import java.util.Date;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import org.dspace.app.rest.RestResourceController;
+
 
 /**
  * The EPerson REST Resource
@@ -32,12 +35,16 @@ public class EPersonRest extends DSpaceObjectRest {
 
     private boolean selfRegistered = false;
 
+    @JsonProperty(access = Access.WRITE_ONLY)
+    private String password;
+
     // FIXME this should be annotated with @JsonIgnore but right now only simple
     // rest resource can be embedded not list, see
     // https://jira.duraspace.org/browse/DS-3483
     private List<GroupRest> groups;
 
     @Override
+    @JsonProperty(access = Access.READ_ONLY)
     public String getType() {
         return NAME;
     }
@@ -90,6 +97,14 @@ public class EPersonRest extends DSpaceObjectRest {
         this.selfRegistered = selfRegistered;
     }
 
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
     public List<GroupRest> getGroups() {
         return groups;
     }
@@ -107,4 +122,5 @@ public class EPersonRest extends DSpaceObjectRest {
     public Class getController() {
         return RestResourceController.class;
     }
+
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
@@ -77,14 +77,14 @@ public class EPersonRestRepository extends DSpaceRestRepository<EPersonRest, UUI
     }
 
     @SearchRestMethod(name = "byName")
-    public Page<EPersonRest> findByName(@Parameter(value = "q") String q,
+    public Page<EPersonRest> findByName(@Parameter(value = "q", required = true) String q,
             Pageable pageable) {
         return null;
     }
 
     @SearchRestMethod(name = "byEmail")
-    public EPersonRest findByEmail(@Parameter(value = "email") String email) {
-       return null;
+    public EPersonRest findByEmail(@Parameter(value = "email", required = true) String email) {
+        return null;
     }
 
     @Override

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
@@ -79,12 +79,32 @@ public class EPersonRestRepository extends DSpaceRestRepository<EPersonRest, UUI
     @SearchRestMethod(name = "byName")
     public Page<EPersonRest> findByName(@Parameter(value = "q", required = true) String q,
             Pageable pageable) {
-        return null;
+        List<EPerson> epersons = null;
+        int total = 0;
+        try {
+            Context context = obtainContext();
+            epersons = es.search(context, q, pageable.getOffset(), pageable.getOffset() + pageable.getPageSize());
+            total = es.searchResultCount(context, q);
+        } catch (SQLException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+        Page<EPersonRest> page = new PageImpl<EPerson>(epersons, pageable, total).map(converter);
+        return page;
     }
 
     @SearchRestMethod(name = "byEmail")
     public EPersonRest findByEmail(@Parameter(value = "email", required = true) String email) {
-        return null;
+        EPerson eperson = null;
+        try {
+            Context context = obtainContext();
+            eperson = es.findByEmail(context, email);
+        } catch (SQLException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+        if (eperson == null) {
+            return null;
+        }
+        return converter.fromModel(eperson);
     }
 
     @Override

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
@@ -12,8 +12,10 @@ import java.util.List;
 import java.util.UUID;
 
 import org.dspace.app.rest.converter.EPersonConverter;
+import org.dspace.app.rest.exception.RESTAuthorizationException;
 import org.dspace.app.rest.model.EPersonRest;
 import org.dspace.app.rest.model.hateoas.EPersonResource;
+import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.factory.EPersonServiceFactory;
@@ -33,6 +35,9 @@ import org.springframework.stereotype.Component;
 @Component(EPersonRest.CATEGORY + "." + EPersonRest.NAME)
 public class EPersonRestRepository extends DSpaceRestRepository<EPersonRest, UUID> {
     EPersonService es = EPersonServiceFactory.getInstance().getEPersonService();
+    
+    @Autowired
+    AuthorizeService authorizeService;
 
     @Autowired
     EPersonConverter converter;
@@ -56,6 +61,10 @@ public class EPersonRestRepository extends DSpaceRestRepository<EPersonRest, UUI
         List<EPerson> epersons = null;
         int total = 0;
         try {
+            if (!authorizeService.isAdmin(context)) {
+                throw new RESTAuthorizationException(
+                        "The EPerson collection endpoint is reserved to system administrators");
+            }
             total = es.countTotal(context);
             epersons = es.findAll(context, EPerson.ID, pageable.getPageSize(), pageable.getOffset());
         } catch (SQLException e) {

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
@@ -11,6 +11,8 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.UUID;
 
+import org.dspace.app.rest.Parameter;
+import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.converter.EPersonConverter;
 import org.dspace.app.rest.exception.RESTAuthorizationException;
 import org.dspace.app.rest.model.EPersonRest;
@@ -35,7 +37,7 @@ import org.springframework.stereotype.Component;
 @Component(EPersonRest.CATEGORY + "." + EPersonRest.NAME)
 public class EPersonRestRepository extends DSpaceRestRepository<EPersonRest, UUID> {
     EPersonService es = EPersonServiceFactory.getInstance().getEPersonService();
-    
+
     @Autowired
     AuthorizeService authorizeService;
 
@@ -72,6 +74,17 @@ public class EPersonRestRepository extends DSpaceRestRepository<EPersonRest, UUI
         }
         Page<EPersonRest> page = new PageImpl<EPerson>(epersons, pageable, total).map(converter);
         return page;
+    }
+
+    @SearchRestMethod(name = "byName")
+    public Page<EPersonRest> findByName(@Parameter(value = "q") String q,
+            Pageable pageable) {
+        return null;
+    }
+
+    @SearchRestMethod(name = "byEmail")
+    public EPersonRest findByEmail(@Parameter(value = "email") String email) {
+       return null;
     }
 
     @Override

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
@@ -20,7 +20,6 @@ import org.dspace.app.rest.Parameter;
 import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.converter.EPersonConverter;
 import org.dspace.app.rest.exception.RESTAuthorizationException;
-import org.dspace.app.rest.exception.RepositoryMethodNotImplementedException;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.EPersonRest;
 import org.dspace.app.rest.model.MetadataEntryRest;
@@ -57,12 +56,12 @@ public class EPersonRestRepository extends DSpaceRestRepository<EPersonRest, UUI
     @Override
     protected EPersonRest createAndReturn(Context context)
             throws AuthorizeException {
-        // this need to be revisited we should receive a mock EPersonRest as input
+        // this need to be revisited we should receive an EPersonRest as input
         HttpServletRequest req = getRequestService().getCurrentRequest().getHttpServletRequest();
         ObjectMapper mapper = new ObjectMapper();
-        EPersonRest mock = null;
+        EPersonRest epersonRest = null;
         try {
-            mock = mapper.readValue(req.getInputStream(), EPersonRest.class);
+            epersonRest = mapper.readValue(req.getInputStream(), EPersonRest.class);
         } catch (IOException e1) {
             throw new UnprocessableEntityException("error parsing the body... maybe this is not the right error code");
         }
@@ -72,16 +71,16 @@ public class EPersonRestRepository extends DSpaceRestRepository<EPersonRest, UUI
             eperson = es.create(context);
 
             // this should be probably moved to the converter (a merge method?)
-            eperson.setCanLogIn(mock.isCanLogIn());
-            eperson.setRequireCertificate(mock.isRequireCertificate());
-            eperson.setEmail(mock.getEmail());
-            eperson.setNetid(mock.getNetid());
-            if (mock.getPassword() != null) {
-                es.setPassword(eperson, mock.getPassword());
+            eperson.setCanLogIn(epersonRest.isCanLogIn());
+            eperson.setRequireCertificate(epersonRest.isRequireCertificate());
+            eperson.setEmail(epersonRest.getEmail());
+            eperson.setNetid(epersonRest.getNetid());
+            if (epersonRest.getPassword() != null) {
+                es.setPassword(eperson, epersonRest.getPassword());
             }
             es.update(context, eperson);
-            if (mock.getMetadata() != null) {
-                for (MetadataEntryRest mer : mock.getMetadata()) {
+            if (epersonRest.getMetadata() != null) {
+                for (MetadataEntryRest mer : epersonRest.getMetadata()) {
                     String[] metadatakey = mer.getKey().split("\\.");
                     es.addMetadata(context, eperson, metadatakey[0], metadatakey[1],
                             metadatakey.length == 3 ? metadatakey[2] : null, mer.getLanguage(), mer.getValue());
@@ -178,7 +177,7 @@ public class EPersonRestRepository extends DSpaceRestRepository<EPersonRest, UUI
     }
 
     @Override
-    protected void delete(Context context, UUID id) throws AuthorizeException, RepositoryMethodNotImplementedException {
+    protected void delete(Context context, UUID id) throws AuthorizeException {
         EPerson eperson = null;
         try {
             eperson = es.find(context, id);

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
@@ -126,6 +126,16 @@ public class EPersonRestRepository extends DSpaceRestRepository<EPersonRest, UUI
         return page;
     }
 
+    /**
+     * Find the epersons matching the query q parameter. The search is delegated to the
+     * {@link EPersonService#search(Context, String, int, int)} method
+     *
+     * @param q
+     *            is the *required* query string
+     * @param pageable
+     *            contains the pagination information
+     * @return a Page of EPersonRest instances matching the user query
+     */
     @SearchRestMethod(name = "byName")
     public Page<EPersonRest> findByName(@Parameter(value = "q", required = true) String q,
             Pageable pageable) {
@@ -142,6 +152,16 @@ public class EPersonRestRepository extends DSpaceRestRepository<EPersonRest, UUI
         return page;
     }
 
+    /**
+     * Find the eperson with the provided email address if any. The search is delegated to the
+     * {@link EPersonService#findByEmail(Context, String)} method
+     *
+     * @param email
+     *            is the *required* email address
+     * @param pageable
+     *            contains the pagination information
+     * @return a Page of EPersonRest instances matching the user query
+     */
     @SearchRestMethod(name = "byEmail")
     public EPersonRest findByEmail(@Parameter(value = "email", required = true) String email) {
         EPerson eperson = null;

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
@@ -33,7 +33,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
                                         .withEmail("Johndoe@gmail.com")
                                         .build();
 
-        getClient().perform(get("/api/eperson/eperson"))
+        String authToken = getAuthToken(admin.getEmail(), password);
+        getClient(authToken).perform(get("/api/eperson/eperson"))
                    .andExpect(status().isOk())
                    .andExpect(content().contentType(contentType))
                    .andExpect(jsonPath("$._embedded.epersons", Matchers.containsInAnyOrder(
@@ -47,6 +48,33 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
     }
 
     @Test
+    public void findAllUnauthorizedTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        EPerson newUser = EPersonBuilder.createEPerson(context)
+                                        .withNameInMetadata("John", "Doe")
+                                        .withEmail("Johndoe@gmail.com")
+                                        .build();
+
+        getClient().perform(get("/api/eperson/eperson"))
+                   .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void findAllForbiddenTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        EPerson newUser = EPersonBuilder.createEPerson(context)
+                                        .withNameInMetadata("John", "Doe")
+                                        .withEmail("Johndoe@gmail.com")
+                                        .build();
+
+        String authToken = getAuthToken(eperson.getEmail(), password);
+        getClient(authToken).perform(get("/api/eperson/eperson"))
+                            .andExpect(status().isForbidden());
+    }
+
+    @Test
     public void findAllPaginationTest() throws Exception {
         context.turnOffAuthorisationSystem();
 
@@ -55,8 +83,9 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
                                         .withEmail("Johndoe@gmail.com")
                                         .build();
 
+        String authToken = getAuthToken(admin.getEmail(), password);
         // using size = 2 the first page will contains our test user and admin
-        getClient().perform(get("/api/eperson/eperson")
+        getClient(authToken).perform(get("/api/eperson/eperson")
                                 .param("size", "2"))
                    .andExpect(status().isOk())
                    .andExpect(content().contentType(contentType))
@@ -74,7 +103,7 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         ;
 
         // using size = 2 the first page will contains our test user and admin
-        getClient().perform(get("/api/eperson/eperson")
+        getClient(authToken).perform(get("/api/eperson/eperson")
                                 .param("size", "2")
                                 .param("page", "1"))
                    .andExpect(status().isOk())
@@ -102,7 +131,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
                                          .withEmail("janesmith@gmail.com")
                                          .build();
 
-        getClient().perform(get("/api/eperson/epersons/" + ePerson2.getID()))
+        String authToken = getAuthToken(admin.getEmail(), password);
+        getClient(authToken).perform(get("/api/eperson/epersons/" + ePerson2.getID()))
                    .andExpect(status().isOk())
                    .andExpect(content().contentType(contentType))
                    .andExpect(jsonPath("$", is(
@@ -130,7 +160,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
                                          .withEmail("janesmith@gmail.com")
                                          .build();
 
-        getClient().perform(get("/api/eperson/epersons/" + ePerson2.getID()))
+        String authToken = getAuthToken(admin.getEmail(), password);
+        getClient(authToken).perform(get("/api/eperson/epersons/" + ePerson2.getID()))
                    .andExpect(status().isOk())
                    .andExpect(content().contentType(contentType))
                    .andExpect(jsonPath("$", is(
@@ -160,7 +191,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
                                          .withEmail("janesmith@gmail.com")
                                          .build();
 
-        getClient().perform(get("/api/eperson/epersons/" + UUID.randomUUID()))
+        String authToken = getAuthToken(admin.getEmail(), password);
+        getClient(authToken).perform(get("/api/eperson/epersons/" + UUID.randomUUID()))
                    .andExpect(status().isNotFound());
 
     }

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/builder/AbstractDSpaceObjectBuilder.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/builder/AbstractDSpaceObjectBuilder.java
@@ -16,6 +16,7 @@ import org.dspace.content.Item;
 import org.dspace.content.service.DSpaceObjectService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -98,6 +99,60 @@ public abstract class AbstractDSpaceObjectBuilder<T extends DSpaceObject>
                                                                       null, startDate, Constants.READ,
                                                                       "Integration Test", dso);
             if (rp != null) {
+                resourcePolicyService.update(context, rp);
+            }
+        } catch (Exception e) {
+            return handleException(e);
+        }
+        return (B) this;
+    }
+
+    protected <B extends AbstractDSpaceObjectBuilder<T>> B setRemovePermissionForEperson(DSpaceObject dso,
+                                                                                         EPerson eperson,
+                                                                                         Date startDate) {
+        try {
+
+            ResourcePolicy rp = authorizeService.createOrModifyPolicy(null, context, null, null,
+                eperson, startDate, Constants.REMOVE,
+                "Integration Test", dso);
+            if (rp != null) {
+                log.info("Updating resource policy with REMOVE for eperson: " + eperson.getEmail());
+                resourcePolicyService.update(context, rp);
+            }
+        } catch (Exception e) {
+            return handleException(e);
+        }
+        return (B) this;
+    }
+
+    protected <B extends AbstractDSpaceObjectBuilder<T>> B setAddPermissionForEperson(DSpaceObject dso,
+                                                                                      EPerson eperson,
+                                                                                      Date startDate) {
+        try {
+
+            ResourcePolicy rp = authorizeService.createOrModifyPolicy(null, context, null, null,
+                eperson, startDate, Constants.ADD,
+                "Integration Test", dso);
+            if (rp != null) {
+                log.info("Updating resource policy with ADD for eperson: " + eperson.getEmail());
+                resourcePolicyService.update(context, rp);
+            }
+        } catch (Exception e) {
+            return handleException(e);
+        }
+        return (B) this;
+    }
+
+    protected <B extends AbstractDSpaceObjectBuilder<T>> B setWritePermissionForEperson(DSpaceObject dso,
+                                                                                        EPerson eperson,
+                                                                                        Date startDate) {
+        try {
+
+            ResourcePolicy rp = authorizeService.createOrModifyPolicy(null, context, null, null,
+                eperson, startDate, Constants.WRITE,
+                "Integration Test", dso);
+            if (rp != null) {
+                log.info("Updating resource policy with WRITE for eperson: " + eperson.getEmail());
                 resourcePolicyService.update(context, rp);
             }
         } catch (Exception e) {

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/builder/AbstractDSpaceObjectBuilder.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/builder/AbstractDSpaceObjectBuilder.java
@@ -22,6 +22,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.MutablePeriod;
 import org.joda.time.format.PeriodFormat;
+import org.joda.time.format.PeriodFormatter;
 
 /**
  * Abstract builder to construct DSpace Objects
@@ -77,6 +78,17 @@ public abstract class AbstractDSpaceObjectBuilder<T extends DSpaceObject>
         return (B) this;
     }
 
+    /**
+     * Support method to grant the {@link Constants#READ} permission over an object only to the {@link Group#ANONYMOUS}
+     * after the specified embargoPeriod. Any other READ permissions will be removed
+     *
+     * @param embargoPeriod
+     *            the embargo period after which the READ permission will be active. It is parsed using the
+     *            {@link PeriodFormatter#parseMutablePeriod(String)} method of the joda library
+     * @param dso
+     *            the DSpaceObject on which grant the permission
+     * @return the builder properly configured to retain read permission on the object only for the specified group
+     */
     protected <B extends AbstractDSpaceObjectBuilder<T>> B setEmbargo(String embargoPeriod, DSpaceObject dso) {
         // add policy just for anonymous
         try {
@@ -89,6 +101,16 @@ public abstract class AbstractDSpaceObjectBuilder<T extends DSpaceObject>
         }
     }
 
+    /**
+     * Support method to grant the {@link Constants#READ} permission over an object only to a specific group. Any other
+     * READ permissions will be removed
+     *
+     * @param dso
+     *            the DSpaceObject on which grant the permission
+     * @param group
+     *            the EPersonGroup that will be granted of the permission
+     * @return the builder properly configured to retain read permission on the object only for the specified group
+     */
     protected <B extends AbstractDSpaceObjectBuilder<T>> B setOnlyReadPermission(DSpaceObject dso, Group group,
                                                                                  Date startDate) {
         // add policy just for anonymous
@@ -107,6 +129,17 @@ public abstract class AbstractDSpaceObjectBuilder<T extends DSpaceObject>
         return (B) this;
     }
 
+    /**
+     * Support method to grant {@link Constants#REMOVE} permission to a specific eperson
+     *
+     * @param dso
+     *            the DSpaceObject on which grant the permission
+     * @param eperson
+     *            the eperson that will be granted of the permission
+     * @param startDate
+     *            the optional start date from which the permission will be grant, can be <code>null</code>
+     * @return the builder properly configured to build the object with the additional remove permission
+     */
     protected <B extends AbstractDSpaceObjectBuilder<T>> B setRemovePermissionForEperson(DSpaceObject dso,
                                                                                          EPerson eperson,
                                                                                          Date startDate) {
@@ -125,6 +158,17 @@ public abstract class AbstractDSpaceObjectBuilder<T extends DSpaceObject>
         return (B) this;
     }
 
+    /**
+     * Support method to grant {@link Constants#ADD} permission to a specific eperson
+     *
+     * @param dso
+     *            the DSpaceObject on which grant the permission
+     * @param eperson
+     *            the eperson that will be granted of the permission
+     * @param startDate
+     *            the optional start date from which the permission will be grant, can be <code>null</code>
+     * @return the builder properly configured to build the object with the additional add permission
+     */
     protected <B extends AbstractDSpaceObjectBuilder<T>> B setAddPermissionForEperson(DSpaceObject dso,
                                                                                       EPerson eperson,
                                                                                       Date startDate) {
@@ -143,6 +187,17 @@ public abstract class AbstractDSpaceObjectBuilder<T extends DSpaceObject>
         return (B) this;
     }
 
+    /**
+     * Support method to grant {@link Constants#WRITE} permission to a specific eperson
+     *
+     * @param dso
+     *            the DSpaceObject on which grant the permission
+     * @param eperson
+     *            the eperson that will be granted of the permission
+     * @param startDate
+     *            the optional start date from which the permission will be grant, can be <code>null</code>
+     * @return the builder properly configured to build the object with the additional write permission
+     */
     protected <B extends AbstractDSpaceObjectBuilder<T>> B setWritePermissionForEperson(DSpaceObject dso,
                                                                                         EPerson eperson,
                                                                                         Date startDate) {


### PR DESCRIPTION
This PR is the porting to the master of (most of) the code developed for the OR2018 REST tutorial.
It solves the following jira tickets
- [DS-3735 Create eperson endpoint (POST)](https://jira.duraspace.org/browse/DS-3735)
- [DS-3924 EPerson endpoint should be accessible for logged in users only](https://jira.duraspace.org/browse/DS-3924)
and limited to the EPerson [DS-3737 Implement the DELETE operation in the REST repository](https://jira.duraspace.org/browse/DS-3737)

A broad range of ITs are provided.

The PATCH operation will be provided as a separate PR.