### PR TITLE
add empty ResourceSupport object to SubmissionDefinitionResource.

### DIFF
--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/SubmissionDefinitionResource.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/SubmissionDefinitionResource.java
@@ -10,6 +10,7 @@ package org.dspace.app.rest.model.hateoas;
 import org.dspace.app.rest.model.SubmissionDefinitionRest;
 import org.dspace.app.rest.model.hateoas.annotations.RelNameDSpaceResource;
 import org.dspace.app.rest.utils.Utils;
+import org.springframework.hateoas.ResourceSupport;
 
 /**
  * SubmissionDefinition Rest HAL Resource. The HAL Resource wraps the REST Resource
@@ -21,5 +22,6 @@ import org.dspace.app.rest.utils.Utils;
 public class SubmissionDefinitionResource extends DSpaceResource<SubmissionDefinitionRest> {
     public SubmissionDefinitionResource(SubmissionDefinitionRest sd, Utils utils, String... rels) {
         super(sd, utils, rels);
+        embedded.put("collections", new ResourceSupport());
     }
 }

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
@@ -95,11 +95,11 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
     public void findCollections() throws Exception {
         //Match only that a section exists with a submission configuration behind
         getClient().perform(get("/api/config/submissiondefinitions/traditional/collections"))
-                   //TODO - this method should return an empty page
-                   .andExpect(status().isNoContent());
-                   //this is the expected result
-                   //.andExpect(status().isOk())
-                   //.andExpect(jsonPath("$.page.totalElements", is(0)));
+                //TODO - this method should return an empty page
+                //.andExpect(status().isNoContent());
+                //this is the expected result
+                .andExpect(status().isOk());
+        //.andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 
     @Test


### PR DESCRIPTION
to address issue DS-3916.  This is sort of a hack, but it seems to work.  A better solution if this approach is feasible would be to add a method in HALResource.java with a signature like so:

   public void embedResource(String relationship, ResourceSupport resource) {
        embedded.put(relationship, resource);
    }

in addition to what is there.