### PR TITLE
DS-3962 Improve community list performance

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/preprocess/communitylist.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/preprocess/communitylist.xsl
@@ -34,7 +34,8 @@
 
     <xsl:output indent="yes"/>
 
-    <xsl:template match="dri:referenceSet[@id='aspect.artifactbrowser.CommunityBrowser.referenceSet.community-browser']">
+    <xsl:template match="dri:referenceSet[@id='aspect.artifactbrowser.CommunityBrowser.referenceSet.community-browser'] |
+                         dri:list[@id='aspect.artifactbrowser.CommunityBrowser.list.comunity-browser']">
         <div id="{@id}" rend="community-browser-wrapper">
             <xsl:apply-templates mode="community-browser"/>
         </div>
@@ -141,8 +142,165 @@
                 <xsl:value-of select="$description"/>
             </p>
         </xsl:if>
+    </xsl:template>
 
+    <xsl:template match="dri:list " mode="community-browser">
+        <xsl:variable name="list-position">
+            <xsl:value-of select="position()"/>
+        </xsl:variable>
+        <xsl:for-each select="dri:item">
+            <xsl:variable name="handle">
+                <xsl:choose>
+                    <xsl:when test="dri:hi/dri:xref/@target">
+                        <xsl:value-of select="dri:hi/dri:xref/@target"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="dri:xref/@target"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:variable>
+            <xsl:variable name="title">
+                <xsl:choose>
+                    <xsl:when test="dri:hi/dri:xref">
+                        <xsl:value-of select="dri:hi/dri:xref"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="dri:xref"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:variable>
+            <xsl:variable name="count">
+                <xsl:choose>
+                    <xsl:when test="dri:hi/dri:xref/@rend">
+                        <xsl:value-of select="dri:hi/dri:xref/@rend"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="dri:xref/@rend"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:variable>
+            <xsl:variable name="desc">
+                <xsl:choose>
+                    <xsl:when test="dri:hi/dri:xref/@n">
+                        <xsl:value-of select="dri:hi/dri:xref/@n"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="dri:xref/@n"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:variable>
 
+            <xsl:variable name="handle-class">
+                <xsl:call-template name="get-handle-class-from-handle">
+                    <xsl:with-param name="url">
+                        <xsl:value-of select="$handle"/>
+                    </xsl:with-param>
+                </xsl:call-template>
+            </xsl:variable>
+            <div>
+                <xsl:attribute name="rend">
+                    <xsl:text>row community-browser-row</xsl:text>
+                    <xsl:if test="parent::dri:list/ancestor::dri:list[1][@id='aspect.artifactbrowser.CommunityBrowser.list.comunity-browser'] and $list-position mod 2 = 0">
+                        <xsl:text> odd-community-browser-row</xsl:text>
+                    </xsl:if>
+                </xsl:attribute>
+                <xsl:variable name="depth" select="count(parent::dri:list/ancestor::dri:list)"/>
+                <xsl:variable name="nephews" select="count(parent::dri:list/following-sibling::dri:list/dri:item[following-sibling::dri:list]) + count(parent::dri:list/preceding-sibling::dri:list/dri:item[following-sibling::dri:list])"/>
+                <xsl:variable name="second_cousins" select="count(parent::dri:list/parent::dri:list/following-sibling::dri:list/dri:item/dri:list) + count(parent::dri:list/parent::dri:list/preceding-sibling::dri:list/dri:item/dri:list)"/>
+                <xsl:variable name="needs_one_less_indent"
+                              select="$depth > 0 and $nephews = 0 and $second_cousins = 0 and not(parent::dri:list/dri:list)"/>
+                <xsl:variable name="left-width">
+                    <xsl:choose>
+                        <xsl:when test="$depth = 1 and $needs_one_less_indent">
+                            <xsl:value-of select="$depth - 1"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="$depth"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:variable>
+                <xsl:choose>
+                    <xsl:when test="following-sibling::dri:list">
+                        <div>
+                            <xsl:attribute name="rend">
+                                <xsl:text>col-xs-2 col-sm-1</xsl:text>
+                                <xsl:if test="$left-width > 1">
+                                    <xsl:text> col-sm-offset-</xsl:text>
+                                    <xsl:value-of select="$left-width - 1"/>
+                                </xsl:if>
+                            </xsl:attribute>
+                            <field rend="community-browser-toggle-button" value="#collapse-{$handle-class}"/>
+                        </div>
+                        <div rend="col-xs-10 col-sm-{12 - $left-width}">
+                            <xref n="community-browser-link">
+                                <xsl:attribute name="target">
+                                    <xsl:value-of select="$handle"/>
+                                </xsl:attribute>
+                                <xsl:value-of select="$title"/>
+                            </xref>
+                            <!--Display community strengths (item counts) if they exist-->
+                            <xsl:if test="$count != ''">
+                                <span>
+                                    <xsl:text> [</xsl:text>
+                                    <xsl:value-of
+                                            select="$count"/>
+                                    <xsl:text>]</xsl:text>
+                                </span>
+                            </xsl:if>
+                            <xsl:if test="$desc != ''">
+                                <p rend="hidden-xs">
+                                    <xsl:value-of select="$desc"/>
+                                </p>
+                            </xsl:if>
+                        </div>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <div rend="col-xs-10 col-sm-{12 - $left-width} col-xs-offset-2 col-sm-offset-{$left-width}">
+                            <xsl:attribute name="rend">
+                                <xsl:text>col-xs-10 col-sm-</xsl:text><xsl:value-of select="12 - $left-width"/>
+                                <xsl:text> col-sm-offset-</xsl:text><xsl:value-of select="$left-width"/>
+                                <xsl:choose>
+                                    <xsl:when test="$depth = 1 and $needs_one_less_indent">
+                                        <xsl:text> list-mode</xsl:text>
+                                    </xsl:when>
+                                    <!--<xsl:when test="$depth > 1 and $needs_one_less_indent">-->
+                                    <!--<xsl:text> col-xs-offset-2  half-indented</xsl:text>-->
+                                    <!--</xsl:when>-->
+                                    <xsl:otherwise>
+                                        <xsl:text> col-xs-offset-2</xsl:text>
+                                    </xsl:otherwise>
+                                </xsl:choose>
+                            </xsl:attribute>
+                            <xref n="community-browser-link">
+                                <xsl:attribute name="target">
+                                    <xsl:value-of select="$handle"/>
+                                </xsl:attribute>
+                                <xsl:value-of select="$title"/>
+                            </xref>
+                            <!--Display community strengths (item counts) if they exist-->
+                            <xsl:if test="$count != ''">
+                                <span>
+                                    <xsl:text> [</xsl:text>
+                                    <xsl:value-of
+                                            select="$count"/>
+                                    <xsl:text>]</xsl:text>
+                                </span>
+                            </xsl:if>
+                            <xsl:if test="$desc != ''">
+                                <p rend="hidden-xs">
+                                    <xsl:value-of select="$desc"/>
+                                </p>
+                            </xsl:if>
+                        </div>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </div>
+            <xsl:if test="following-sibling::dri:list/dri:item">
+                <div id="collapse-{$handle-class}" rend="sub-tree-wrapper hidden">
+                    <xsl:apply-templates select="parent::dri:list/dri:list" mode="community-browser"/>
+                </div>
+            </xsl:if>
+        </xsl:for-each>
     </xsl:template>
     
     <xsl:template name="get-handle-class-from-url">
@@ -174,6 +332,23 @@
         <xsl:call-template name="string-replace-all">
             <xsl:with-param name="text" select="$handle"/>
             <xsl:with-param name="replace" select="'.'"/>
+            <xsl:with-param name="by" select="'_'"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <xsl:template name="get-handle-class-from-handle">
+        <xsl:param name="url"/>
+        <xsl:variable name="handle_pre">
+            <xsl:call-template name="string-replace-all">
+                <xsl:with-param name="text" select="$url"/>
+                <xsl:with-param name="replace" select="'/handle/'"/>
+                <xsl:with-param name="by" select="''"/>
+            </xsl:call-template>
+        </xsl:variable>
+
+        <xsl:call-template name="string-replace-all">
+            <xsl:with-param name="text" select="$handle_pre"/>
+            <xsl:with-param name="replace" select="'/'"/>
             <xsl:with-param name="by" select="'_'"/>
         </xsl:call-template>
     </xsl:template>

--- a/dspace-xmlui/src/main/webapp/themes/dri2xhtml-alt/core/elements.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/dri2xhtml-alt/core/elements.xsl
@@ -445,7 +445,15 @@
                 </xsl:call-template>
                 <xsl:apply-templates select="dri:item" mode="nested"/>
             </ul>
+            <xsl:if test="not(ancestor::dri:list)">
+                <xsl:apply-templates select="dri:list" mode="nested-list"/>
+            </xsl:if>
         </xsl:if>
+    </xsl:template>
+
+    <xsl:template match="dri:list[not(@type)]" priority="2" mode="nested-list">
+        <xsl:apply-templates select="dri:head"/>
+        <xsl:apply-templates select="dri:item" mode="nested"/>
     </xsl:template>
 
     <xsl:template match="dri:list[not(@type)]/dri:item" priority="2" mode="labeled">
@@ -526,6 +534,10 @@
         <li>
             <xsl:apply-templates select="."/>
         </li>
+    </xsl:template>
+
+    <xsl:template match="dri:list/dri:list" priority="1" mode="nested-list">
+        <xsl:apply-templates select="." mode="nested-list"/>
     </xsl:template>
 
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3962
Fixes #7309

Currently, DSpace's "full" community-list rendering uses `referenceSet` objects. These, in turn, result in individual METS document generation calls, which can cause a very slow page load for larger repositories. In order to improve load times, while maintaining the "full" list style, the necessary information can be pre-loaded into DRI elements instead of `referenceSet` objects.

As is done in full-view this new view, this improvement provides the item count (if configured) and comm/coll description in the DRI. In addition, for Mirage2, it brings the collapsable structure to the non-"full" view. Original Mirage style has been left unchanged (but XSL has been updated to render new DRI structure).

May want to consider defaulting `xmlui.community-list.render.full` to `false`. If developers desire additional `DIM` or `METS` metadata, they can toggle to true. This should improve performance overall (not making N METS calls), while not degrading most systems with "full" view currently enabled.