### PR TITLE
DS-3963 Allow expand all in community-list

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/scripts/community-list.js
+++ b/dspace-xmlui-mirage2/src/main/webapp/scripts/community-list.js
@@ -6,58 +6,84 @@
  * http://www.dspace.org/license/
  */
 (function($) {
+    var limitExpand = $('#aspect_artifactbrowser_CommunityBrowser_field_allowExpandAll').count == undefined;
     $(init_community_list);
+    if (!limitExpand) {
+        $(expand_collapse);
+    }
 
     function init_community_list() {
         $('.community-browser-row .toggler').click(function() {
             var parent_row, parent_toggler, parent_wrappers, other_wrappers, other_toggler_rows, all_rows, target, $this, target_id, open_icon, closed_icon;
             $this = $(this);
 
-            $('.current-community-browser-row').removeClass('current-community-browser-row')
-                                                .find('a strong').contents().unwrap();
+            if (limitExpand) {
+                $('.current-community-browser-row').removeClass('current-community-browser-row')
+                    .find('a strong').contents().unwrap();
+            }
 
             target_id = $this.data('target');
 
-            parent_wrappers = $this.parents('.sub-tree-wrapper');
-            other_wrappers = $('.sub-tree-wrapper:not(' + target_id + ')').not(parent_wrappers);
-            other_wrappers.addClass('hidden');
+            if (limitExpand) {
+                parent_wrappers = $this.parents('.sub-tree-wrapper');
+                other_wrappers = $('.sub-tree-wrapper:not(' + target_id + ')').not(parent_wrappers);
+                other_wrappers.addClass('hidden');
 
-            other_toggler_rows = $([]);
-            other_wrappers.each(function() {
-                other_toggler_rows = other_toggler_rows.add(get_toggler_from_wrapper($(this)).closest('.community-browser-row'));
-            });
-            other_toggler_rows.removeClass('open-community-browser-row').addClass('closed-community-browser-row');
+                other_toggler_rows = $([]);
+                other_wrappers.each(function () {
+                    other_toggler_rows = other_toggler_rows.add(get_toggler_from_wrapper($(this)).closest('.community-browser-row'));
+                });
+                other_toggler_rows.removeClass('open-community-browser-row').addClass('closed-community-browser-row');
+            }
 
             parent_row = $this.closest('.community-browser-row');
 
             open_icon = $this.find('.open-icon');
             closed_icon = $this.find('.closed-icon');
 
-            all_rows = $('.community-browser-row');
-            clear_relation_classes(all_rows);
+            if (limitExpand) {
+                all_rows = $('.community-browser-row');
+                clear_relation_classes(all_rows);
+            }
             target = $(target_id);
             if (target.is(':visible')) {
+                if (!limitExpand) {
+                    children_toggler = parent_row.next('.sub-tree-wrapper').find('.toggler');
+                    if (children_toggler.length > 0) {
+                        children_toggler.each(function () {
+                            if ($(this).is(':visible') && !$(this).find('i.glyphicon-minus').hasClass('hidden')) {
+                                $(this).click()
+                            }
+                        })
+                    }
+                }
                 target.addClass('hidden');
                 open_icon.addClass('hidden');
                 closed_icon.removeClass('hidden');
-                parent_row.removeClass('open-community-browser-row').addClass('closed-community-browser-row');
+                if (limitExpand) {
+                    parent_row.removeClass('open-community-browser-row').addClass('closed-community-browser-row');
+                }
                 target.find('.open-icon').addClass('hidden');
                 target.find('.closed-icon').removeClass('hidden');
-                parent_toggler = get_toggler_from_wrapper($this.closest('.sub-tree-wrapper'));
-                if (parent_toggler.length > 0) {
-                    parent_toggler.closest('.community-browser-row').addClass('current-community-browser-row').find('a').wrapInner( "<strong></strong>");
-                    set_relation_classes(all_rows, parent_toggler, $(parent_toggler.data('target')), parent_toggler.parents('.sub-tree-wrapper'));
+                if (limitExpand) {
+                    parent_toggler = get_toggler_from_wrapper($this.closest('.sub-tree-wrapper'));
+                    if (parent_toggler.length > 0) {
+                        parent_toggler.closest('.community-browser-row').addClass('current-community-browser-row').find('a').wrapInner("<strong></strong>");
+                        set_relation_classes(all_rows, parent_toggler, $(parent_toggler.data('target')), parent_toggler.parents('.sub-tree-wrapper'));
+                    }
                 }
             }
             else {
                 target.removeClass('hidden');
                 open_icon.removeClass('hidden');
                 closed_icon.addClass('hidden');
-                parent_row.removeClass('closed-community-browser-row')
+                if (limitExpand) {
+                    parent_row.removeClass('closed-community-browser-row')
                         .addClass('open-community-browser-row')
                         .addClass('current-community-browser-row')
-                        .find('a').wrapInner( "<strong></strong>");
-                set_relation_classes(all_rows, $this, target, parent_wrappers);
+                        .find('a').wrapInner("<strong></strong>");
+                    set_relation_classes(all_rows, $this, target, parent_wrappers);
+                }
             }
             set_odd_even_rows();
         }).bind('touchend', function () {
@@ -103,5 +129,31 @@
         visible_rows.filter(':odd').addClass('odd-community-browser-row');
     }
 
+    function expand_collapse() {
+        $('.community-browser-expand-all').click(function() {
+            $('.toggler').each(function() {
+                if ($(this).is(':visible') && !$(this).find('i.glyphicon-plus').hasClass('hidden')) {
+                    $this = $(this);
+
+                    target_id = $this.data('target');
+                    target = $(target_id);
+                    open_icon = $this.find('.open-icon');
+                    closed_icon = $this.find('.closed-icon');
+
+                    target.removeClass('hidden');
+                    open_icon.removeClass('hidden');
+                    closed_icon.addClass('hidden');
+                }
+            });
+        });
+
+        $('.community-browser-collapse-all').click(function() {
+            $('.community-browser-wrapper > .community-browser-row .toggler').each(function() {
+                if ($(this).is(':visible') && !$(this).find('i.glyphicon-minus').hasClass('hidden')) {
+                	$(this).click();
+                }
+            });
+        });
+    }
 
 })(jQuery);

--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/preprocess/communitylist.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/preprocess/communitylist.xsl
@@ -30,11 +30,19 @@
         xmlns:i18n="http://apache.org/cocoon/i18n/2.1"
         xmlns:mets="http://www.loc.gov/METS/"
         xmlns:dim="http://www.dspace.org/xmlns/dspace/dim"
-        exclude-result-prefixes="xsl dri dim mets i18n">
+        xmlns:confman="org.dspace.core.ConfigurationManager"
+        exclude-result-prefixes="xsl dri dim mets i18n confman">
 
     <xsl:output indent="yes"/>
 
     <xsl:template match="dri:referenceSet[@id='aspect.artifactbrowser.CommunityBrowser.referenceSet.community-browser']">
+        <xsl:if test="//dri:metadata[@qualifier='URI'] != '' and confman:getProperty('xmlui.community-list.expand.all') = 'true'">
+            <p>
+                <xref rend="community-browser-expand-all" target="javascript:void(0)">Expand All</xref>
+                <xsl:text> / </xsl:text>
+                <xref rend="community-browser-collapse-all" target="javascript:void(0)">Collapse All</xref>
+            </p>
+        </xsl:if>
         <div id="{@id}" rend="community-browser-wrapper">
             <xsl:apply-templates mode="community-browser"/>
         </div>

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/CommunityBrowser.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/CommunityBrowser.java
@@ -248,6 +248,10 @@ public class CommunityBrowser extends AbstractDSpaceTransformer implements Cache
         TreeNode treeRoot = buildTree(communityService.findAllTop(context));
 
         boolean full = DSpaceServicesFactory.getInstance().getConfigurationService().getBooleanProperty("xmlui.community-list.render.full", true);
+        boolean allowExpandAll = DSpaceServicesFactory.getInstance().getConfigurationService().getBooleanProperty("xmlui.community-list.expand.all", false);
+        if (allowExpandAll) {
+            division.addHidden("allowExpandAll");
+        }
 
         if (full)
         {

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1911,6 +1911,11 @@ mirage2.item-view.bitstream.href.label.2 = title
 # with turning this option off.
 #xmlui.community-list.render.full = false
 
+# On the community-list page should all communities/collection paths be able to expand.
+# This parameter defaults to false, which only allows a single path to be expanded at a time.
+# This option only applies to Mirage2.
+#xmlui.community-list.expand.all = true
+
 # Normally, Manakin will fully verify any cache pages before using a cache copy.
 # This means that when the community-list page is viewed the database is queried
 # for each community/collection to see if their metadata has been modified. This


### PR DESCRIPTION
Currently, in Mirage2, the community-list page only allows the user to expand a single path in the tree at a time, i.e. expanding a community and then expanding a sibling community will automatically collapse the previously open community. In addition, the currently expanded comm/coll's name is bolded.

It may be useful for users to be able to expand more than one path at a time. This feature introduces this configuration (defaulting to the current behavior) and implementation. Do note, with this mode enabled, comm/coll names are no longer bolded. This feature also adds links for Expand/Collapse All