### PR TITLE
[DS-3971] BitstreamStorageServiceImpl: Do not call update

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
@@ -351,7 +351,6 @@ public class BitstreamStorageServiceImpl implements BitstreamStorageService, Ini
         {
             bitstreamService.addMetadata(context, clonedBitstream, metadataValue.getMetadataField(), metadataValue.getLanguage(), metadataValue.getValue(), metadataValue.getAuthority(), metadataValue.getConfidence());
         }
-        bitstreamService.update(context, clonedBitstream);
         return clonedBitstream;
 
     }

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/service/BitstreamStorageService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/service/BitstreamStorageService.java
@@ -151,6 +151,14 @@ public interface BitstreamStorageService {
     /**
      * Clone the given bitstream to a new bitstream with a new ID. 
      * Metadata of the given bitstream are also copied to the new bitstream.
+     *
+     * <p>
+     * This method does not persist the modifications to the new bitstream.
+     * This would lead to authorization failures, because the new bitstream
+     * does not belong to any Item yet. The caller have to ensure to call
+     * {@link org.dspace.content.service.BitstreamService#update} on the
+     * returned bitstream after adding it to an Item.
+     * </p>
      * 
      * @param context
      *            DSpace context object


### PR DESCRIPTION
If the BitstreamStorageService calls update on the just cloned bitstream, this
bitstream will not belong to any Item and the user may get authorization
failures.

The update call can be removed here, because the clone method is only used by
the AbstractVersionProvider and it will call update on the bitstream later by
itself.

https://jira.duraspace.org/browse/DS-3971