### PR TITLE
checksum checker: with selective check option, checksum printer: with…

### DIFF
--- a/dspace-api/src/main/java/org/dspace/checker/CheckBitstreamIterator.java
+++ b/dspace-api/src/main/java/org/dspace/checker/CheckBitstreamIterator.java
@@ -1,0 +1,174 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.checker;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.Date;
+import org.apache.log4j.Logger;
+import org.dspace.content.DSpaceObject;
+import org.dspace.core.Context;
+
+/**
+ * <p>
+ * Use to iterate over bitstreams selected based on information stored in MOST_RECENT_CHECKSUM
+ * </p>
+ *
+ * @author Monika Mevenkamp
+ */
+public final class CheckBitstreamIterator extends QueryBuilder
+{
+    private static final Logger LOG = Logger.getLogger(CheckBitstreamIterator.class);
+
+    private Date before = null, after = null;
+    private PreparedStatement sqlStmt = null;
+    private ResultSet rs = null;
+
+    public CheckBitstreamIterator(Context ctxt,
+                                   String has_result, String[] has_not_results,
+                                   Date before_date, Date after_date,
+                                   DSpaceObject inside)
+    {
+        super(ctxt, has_result, has_not_results, inside);
+        after = after_date;
+        before = before_date;
+        rs = null;
+    }
+
+    // TODO return BitstreamInfo instance or null
+    public boolean next() throws SQLException
+    {
+        if (rs == null)
+        {
+            String stmt = "SELECT MRC.bitstream_id, MRC.result, MRC.last_process_end_date, MRC.current_checksum, \n" +
+                    "BITSTREAM.DELETED, BITSTREAM.internal_id, BITSTREAM.checksum_algorithm, BITSTREAM.checksum \n" +
+                    "FROM MOST_RECENT_CHECKSUM MRC JOIN BITSTREAM ON BITSTREAM.BITSTREAM_ID = MRC.BITSTREAM_ID ";
+            sqlStmt = prepare(stmt);
+            rs = sqlStmt.executeQuery();
+        }
+        boolean nxt = rs.next();
+        if (! nxt)
+        {
+            sqlStmt.close();
+        }
+        return nxt;
+    }
+
+    public void close() throws SQLException
+    {
+        if (sqlStmt != null) {
+            sqlStmt.close();
+        }
+    }
+
+    public int bitstream_id() throws SQLException
+    {
+        return rs.getInt(1);
+    }
+
+    public String result() throws SQLException
+    {
+        return rs.getString(2);
+    }
+
+    public Timestamp last_process_end_date() throws SQLException
+    {
+        return rs.getTimestamp(3);
+    }
+
+    public String checksum() throws SQLException
+    {
+        return rs.getString(4);
+    }
+
+    public boolean deleted() throws SQLException
+    {
+        return rs.getBoolean(5);
+    }
+
+    public String internalId() throws SQLException
+    {
+        return rs.getString(6);
+    }
+
+    public String checksumAlgo() throws SQLException
+    {
+        return rs.getString(7);
+    }
+
+    public String storedChecksum() throws SQLException
+    {
+        return rs.getString(8);
+    }
+
+
+
+    public int count() throws SQLException
+    {
+        String stmt = "SELECT COUNT(*) AS N FROM MOST_RECENT_CHECKSUM MRC ";
+        LOG.debug(stmt);
+        ResultSet rs = prepare(stmt).executeQuery();
+        rs.next();
+        return rs.getInt(1);
+    }
+
+    private PreparedStatement prepare(String stmt) throws SQLException {
+        String operator = " WHERE ";
+        if (before != null)
+        {
+            stmt = stmt + operator + " MRC.LAST_PROCESS_END_DATE < ? ";
+            operator = " AND ";
+        }
+        if (after != null)
+        {
+            stmt = stmt + operator + " MRC.LAST_PROCESS_END_DATE >= ?";
+            operator = " AND ";
+        }
+        stmt = stmt + where_clause(operator, "MRC");
+        stmt = stmt + " ORDER BY LAST_PROCESS_END_DATE";
+
+        PreparedStatement sqlStmt = prepareStatement(stmt);
+        int pos = 1;
+        if (before != null)
+        {
+            sqlStmt.setTimestamp(pos, new Timestamp(before.getTime()));
+            if (LOG.isDebugEnabled())
+                LOG.debug("pos " + pos + " " + before);
+            pos++;
+        }
+        if (after != null)
+        {
+            sqlStmt.setTimestamp(pos, new Timestamp(after.getTime()));
+            if (LOG.isDebugEnabled())
+                LOG.debug("pos " + pos + " " + after);
+            pos++;
+        }
+        return  prepare(pos, sqlStmt);
+    }
+
+    public String toString()
+    {
+        return getClass().getCanonicalName() + "(" + propertyString(", ") + ")";
+    }
+
+    public String propertyString(String sep)
+    {
+        String me = super.propertyString(sep);
+        String  s = (me.isEmpty()) ? "" : sep;
+        if (after != null) {
+            me = me + s + "after=" + after.toString();
+            s = sep;
+        }
+        if (before != null) {
+            me = me + s + "before=" + before.toString();
+        }
+        return me;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/checker/CheckerCommand.java
+++ b/dspace-api/src/main/java/org/dspace/checker/CheckerCommand.java
@@ -43,7 +43,7 @@ public final class CheckerCommand
     private static final String DEFAULT_DIGEST_ALGORITHM = "MD5";
 
     /** 4 Meg byte array for reading file. */
-    private int BYTE_ARRAY_SIZE = 4 * 1024;
+    private static final int BYTE_ARRAY_SIZE = 4 * 1024;
 
     /** BitstreamInfoDAO dependency. */
     private BitstreamInfoDAO bitstreamInfoDAO = null;
@@ -190,7 +190,7 @@ public final class CheckerCommand
      * @throws java.io.IOException
      *             If an exception arises whilst reading the stream
      */
-    private String digestStream(InputStream stream, String algorithm)
+    public static String digestStream(InputStream stream, String algorithm)
             throws java.security.NoSuchAlgorithmException, java.io.IOException
     {
         // create the digest stream
@@ -218,7 +218,7 @@ public final class CheckerCommand
      * 
      * @return a result code (constants defined in Util)
      */
-    private String compareChecksums(String checksumA, String checksumB)
+    public static String compareChecksums(String checksumA, String checksumB)
     {
         String result = ChecksumCheckResults.CHECKSUM_NO_MATCH;
 

--- a/dspace-api/src/main/java/org/dspace/checker/ChecksumCheckResults.java
+++ b/dspace-api/src/main/java/org/dspace/checker/ChecksumCheckResults.java
@@ -59,4 +59,10 @@ public class ChecksumCheckResults
      * No match between requested algorithm and previously used algorithm.
      */
     public static final String CHECKSUM_ALGORITHM_INVALID = "CHECKSUM_ALGORITHM_INVALID";
+
+    /**
+     * List of available Checksum Result Strings
+     */
+    public static final String[] RESULTS_LIST = {BITSTREAM_NOT_FOUND, BITSTREAM_INFO_NOT_FOUND, BITSTREAM_NOT_PROCESSED, BITSTREAM_MARKED_DELETED, CHECKSUM_MATCH, CHECKSUM_NO_MATCH, CHECKSUM_ALGORITHM_INVALID};
+
 }

--- a/dspace-api/src/main/java/org/dspace/checker/ChecksumHistoryIterator.java
+++ b/dspace-api/src/main/java/org/dspace/checker/ChecksumHistoryIterator.java
@@ -1,0 +1,207 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.checker;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.Date;
+import org.apache.log4j.Logger;
+import org.dspace.content.DSpaceObject;
+import org.dspace.core.Context;
+
+/**
+ * <p>
+ * Use to iterate over bitstreams selected based on information stored in MOST_RECENT_CHECKSUM
+ * </p>
+ *
+ * @author Monika Mevenkamp
+ */
+public final class ChecksumHistoryIterator
+{
+    private static final Logger LOG = Logger.getLogger(ChecksumHistoryIterator.class);
+
+    private static final String SELECT_HISTORY = "select CSH.bitstream_id, CSH.process_start_date, "
+            + " CSH.process_end_date, CSH.checksum_expected, CSH.checksum_calculated, CSH.result  "
+            + " from checksum_history CSH ";
+
+    private static final String COUNT_HISTORY = "select COUNT(*)  from checksum_history CSH ";
+    private static final String DELETE_HISTORY = "delete from checksum_history CSH ";
+
+    private static final String BITSTREAM_WHERE = " where CSH.bitstream_id = ? ";
+    private static final String ORDER_BY = " order by CSH.process_end_date desc ";
+
+    private static final int UNDEFINED = -1;
+    private Context context = null;
+    private int bitstream_id = UNDEFINED;
+    private Date after = null, before = null;
+    private QueryBuilder builder;
+    private PreparedStatement sqlStmt = null;
+    private ResultSet rs = null;
+
+    /**
+     * create iterator to loop over checksum_history entries for given bitstream
+     *
+     * @param ctxt
+     * @param bitstream_id
+     */
+    public ChecksumHistoryIterator(Context ctxt, int bitstream_id)
+    {
+        context = ctxt;
+        this.bitstream_id = bitstream_id;
+    }
+
+    public ChecksumHistoryIterator(Context ctxt,
+                                   String has_result, String[] has_not_results,
+                                   Date before_date, Date after_date,
+                                   DSpaceObject inside)
+    {
+        context = ctxt;
+        bitstream_id = UNDEFINED;
+        builder = new QueryBuilder(ctxt, has_result, has_not_results, inside);
+        after = after_date;
+        before = before_date;
+    }
+
+    /**
+     * return the number of checksum_history entries in this iterator
+     */
+    public int count() throws SQLException
+    {
+        buildQuery(COUNT_HISTORY, "");
+        rs = sqlStmt.executeQuery();
+        rs.next();
+        int n =  rs.getInt(1);
+        sqlStmt.close();
+        return n;
+    }
+
+
+    /**
+     * delete checksum_history entries in this iterator
+     */
+    public void delete() throws SQLException
+    {
+        buildQuery(DELETE_HISTORY, "");
+        sqlStmt.executeUpdate();
+        LOG.debug("commit");
+        context.getDBConnection().commit();
+        sqlStmt.close();
+    }
+
+    /**
+     * return null or next checksum_history entry
+     */
+    public ChecksumHistory next() throws SQLException
+    {
+        if (rs == null)
+        {
+            buildQuery(SELECT_HISTORY, ORDER_BY);
+            rs = sqlStmt.executeQuery();
+        }
+        ChecksumHistory hist = null;
+        if (rs.next())
+        {
+            int bitId = rs.getInt(1);
+            Date startDate = rs.getDate(2);
+            Date endDate = rs.getDate(3);
+            String expected = rs.getString(4);
+            String computed = rs.getString(5);
+            String resultCode = rs.getString(6);
+            hist = new ChecksumHistory(bitId, startDate, endDate, expected, computed, resultCode);
+        } else
+        {
+            sqlStmt.close();
+        }
+        return hist;
+    }
+
+    public void close() throws SQLException
+    {
+        if (sqlStmt != null)
+            sqlStmt.close();
+    }
+
+    private void  buildQuery(String stmt, String order) throws SQLException
+    {
+        if (bitstream_id != UNDEFINED)
+        {
+            stmt = stmt + BITSTREAM_WHERE + ORDER_BY;
+            LOG.debug(stmt);
+            sqlStmt = context.getDBConnection().prepareStatement(stmt);
+            sqlStmt.setInt(1, bitstream_id);
+        } else
+        {
+            String operator = " WHERE ";
+            if (before != null)
+            {
+                stmt = stmt + operator + " CSH.PROCESS_END_DATE < ? ";
+                operator = " AND ";
+            }
+            if (after != null)
+            {
+                stmt = stmt + operator + " CSH.PROCESS_END_DATE >= ?";
+                operator = " AND ";
+            }
+            stmt = stmt + builder.where_clause(operator, "CSH");
+            stmt = stmt + order;
+
+            sqlStmt = builder.prepareStatement(stmt);
+            int pos = 1;
+            if (before != null)
+            {
+                sqlStmt.setTimestamp(pos, new Timestamp(before.getTime()));
+                if (LOG.isDebugEnabled())
+                {
+                    LOG.debug("pos " + pos + " " + before);
+                }
+                pos++;
+            }
+            if (after != null)
+            {
+                sqlStmt.setTimestamp(pos, new Timestamp(after.getTime()));
+                if (LOG.isDebugEnabled())
+                {
+                    LOG.debug("pos " + pos + " " + after);
+                }
+                pos++;
+            }
+            sqlStmt = builder.prepare(pos, sqlStmt);
+        }
+    }
+
+    public String propertyString(String sep)
+    {
+        if (bitstream_id != UNDEFINED)
+        {
+            return "bitstrame_id=" + bitstream_id;
+        } else
+        {
+            String me = builder.propertyString(sep);
+
+            String s = (me.isEmpty()) ? "" : sep;
+            if (after != null)
+            {
+                me = me + s + "after=" + after.toString();
+                s = sep;
+            }
+            if (before != null)
+            {
+                me = me + s + "before=" + before.toString();
+            }
+            return me;
+        }
+    }
+
+    public String toString()
+    {
+        return getClass().getCanonicalName() + "(" + propertyString(", ") + ")";
+    }
+
+}

--- a/dspace-api/src/main/java/org/dspace/checker/QueryBuilder.java
+++ b/dspace-api/src/main/java/org/dspace/checker/QueryBuilder.java
@@ -1,0 +1,166 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.checker;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.dspace.content.DSpaceObject;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+
+/**
+ * <p>
+ * Use to iterate over bitstreams selected based on information stored in MOST_RECENT_CHECKSUM
+ * </p>
+ *
+ * @author Monika Mevenkamp
+ */
+public class QueryBuilder
+{
+    private static final Logger LOG = Logger.getLogger(QueryBuilder.class);
+
+    static final String THIS_BITSTREAM = "BITSTREAM_ID = ?";
+
+    static final String BITSTREAMS_IN_ITEM = "BITSTREAM_ID in \n" +
+            "(SELECT BITSTREAM_ID FROM BUNDLE2BITSTREAM WHERE BUNDLE_ID in\n" +
+            "   (SELECT BUNDLE_ID FROM ITEM2BUNDLE WHERE ITEM_ID = ?))";
+
+    static final String BITSTREAMS_IN_COLLECTION = "BITSTREAM_ID in \n" +
+            "(SELECT BITSTREAM_ID FROM BUNDLE2BITSTREAM WHERE BUNDLE_ID in\n" +
+            "  (SELECT BUNDLE_ID FROM ITEM2BUNDLE WHERE ITEM_ID  in\n" +
+            "     (SELECT ITEM_ID FROM COLLECTION2ITEM WHERE COLLECTION_ID = ?)))";
+
+    static final String BITSTREAMS_IN_COMMUNITY = "BITSTREAM_ID in \n" +
+            "(SELECT BITSTREAM_ID FROM BUNDLE2BITSTREAM WHERE BUNDLE_ID in\n" +
+            "   (SELECT BUNDLE_ID FROM ITEM2BUNDLE WHERE ITEM_ID  in\n" +
+            "      (SELECT ITEM_ID  FROM COLLECTION2ITEM WHERE COLLECTION_ID in \n" +
+            "         (SELECT COLLECTION_ID FROM COMMUNITY2COLLECTION WHERE COMMUNITY_ID =  ?))))";
+
+
+    private Context context;
+    private String with_result;
+    private String[] without_result;
+    private DSpaceObject root;
+    private ResultSet rs;
+
+    protected QueryBuilder(Context ctxt,
+                        String has_result, String[] has_not_results,
+                        DSpaceObject inside)
+    {
+        context = ctxt;
+        root = inside;
+        with_result = has_result;
+        without_result = has_not_results;
+        rs = null;
+    }
+
+    protected String where_clause(String operator, String tableName) {
+        String stmt = " ";
+        if (with_result != null)
+        {
+            stmt = stmt + operator + " " + tableName + ".RESULT = ?";
+            operator = " AND ";
+        }
+        if (without_result != null)
+        {
+            for (int i = 0; i < without_result.length; i++)
+            {
+                stmt = stmt + operator + " " + tableName + ".RESULT != ?";
+                operator = " AND ";
+            }
+        }
+        if (root != null)
+        {
+            String bitstream_ids = "";
+            switch (root.getType())
+            {
+                case Constants.ITEM:
+                    bitstream_ids = tableName + "." + BITSTREAMS_IN_ITEM;
+                    break;
+                case Constants.COLLECTION:
+                    bitstream_ids = tableName + "." + BITSTREAMS_IN_COLLECTION;
+                    break;
+                case Constants.COMMUNITY:
+                    bitstream_ids = tableName + "." + BITSTREAMS_IN_COMMUNITY;
+                    break;
+                case Constants.BITSTREAM:
+                    bitstream_ids = tableName + "." + THIS_BITSTREAM;
+                    break;
+                default:
+                    throw new RuntimeException(root.toString() + " does not contains Bitstreams");
+            }
+            stmt = stmt + operator + bitstream_ids;
+        }
+        return stmt;
+    }
+
+    protected PreparedStatement prepare(int pos, PreparedStatement sqlStmt) throws SQLException
+    {
+        if (with_result != null)
+        {
+            sqlStmt.setString(pos, with_result);
+            if (LOG.isDebugEnabled())
+                LOG.debug("pos " + pos + " " + with_result);
+            pos++;
+        }
+        if (without_result != null)
+        {
+            for (int i = 0; i < without_result.length; i++)
+            {
+                sqlStmt.setString(pos, without_result[i]);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("pos " + pos +  without_result[i]);
+                pos++;
+            }
+        }
+        if (root != null)
+        {
+            sqlStmt.setInt(pos, root.getID());
+            if (LOG.isDebugEnabled())
+                LOG.debug("pos " + pos + " " + root);
+            pos++;
+        }
+        return  sqlStmt;
+    }
+
+    public String toString()
+    {
+        return getClass().getCanonicalName() + "(" + propertyString(", ") + ")";
+    }
+
+    public String propertyString(String sep)
+    {
+        String me = "";
+        if (root != null) {
+            me = me + sep + "root=" + root;
+        }
+        if (with_result != null) {
+            me = me + sep + "with_result=" + with_result;
+        }
+        if (without_result != null) {
+            me = me + sep + "without_result=[" + StringUtils.join(without_result, ',') + "]";
+        }
+        if (! me.isEmpty())
+            me = me.substring(sep.length());
+        return me;
+    }
+
+    protected PreparedStatement prepareStatement(String stmt) throws SQLException
+    {
+        if (LOG.isDebugEnabled())
+        {
+            String prt = stmt.replaceAll("\n", " ").toLowerCase().replaceAll("\\([^*]", "(\n\t").replaceAll("\\)", ")\n\t");
+            LOG.debug(prt);
+        }
+        return context.getDBConnection().prepareStatement(stmt);
+    }
+
+}

--- a/dspace/config/launcher.xml
+++ b/dspace/config/launcher.xml
@@ -8,6 +8,20 @@
         </step>
     </command>
     <command>
+        <name>checkhistory</name>
+        <description>Print, count, or delete historic checksum results</description>
+        <step>
+            <class>org.dspace.app.checker.ChecksumHistoryWorker</class>
+        </step>
+    </command>
+    <command>
+        <name>checksum</name>
+        <description>Run checksum checker or print/count last checksum results </description>
+        <step>
+            <class>org.dspace.app.checker.ChecksumWorker</class>
+        </step>
+    </command>
+    <command>
         <name>checker-emailer</name>
         <description>Send emails related to the checksum checker</description>
         <step>
@@ -252,6 +266,8 @@
             <class>org.dspace.util.SolrImportExport</class>
 	    <argument>-a</argument>
 	    <argument>export</argument>
+	    <argument>-i</argument>
+	    <argument>statistics</argument>
         </step>
     </command>
     <command>
@@ -261,6 +277,8 @@
             <class>org.dspace.util.SolrImportExport</class>
 	    <argument>-a</argument>
 	    <argument>import</argument>
+	    <argument>-i</argument>
+	    <argument>statistics</argument>
         </step>
     </command>
     <command>
@@ -270,6 +288,8 @@
             <class>org.dspace.util.SolrImportExport</class>
 	    <argument>-a</argument>
 	    <argument>reindex</argument>
+	    <argument>-i</argument>
+	    <argument>statistics</argument>
         </step>
     </command>
     <command>


### PR DESCRIPTION
more powerful checksum-checker code - two CLI utilities: 

checker  - Update checksum of selected bitstreams 
checkhistory - Print, count, or delete historic checksum results

--------
usage: Checksum Checker
                
 -a,--handle <arg>     Specify a handle to check
 -b <bitstream-ids>    Space separated list of bitstream ids
 -c,--count <arg>      Check count
 -d,--duration <arg>   Checking duration
 -h,--help             Help
 -l,--looping          Loop once through bitstreams
 -L,--continuous       Loop continuously through bitstreams
 -p <prune>            Prune old results (optionally using specified
                       properties file for configuration)
 -v,--verbose          Report all processing

Specify a duration for checker process, using s(seconds),m(minutes), or h(hours): ChecksumChecker -d 30s OR ChecksumChecker -d 30m OR ChecksumChecker -d 2h

Specify bitstream IDs: ChecksumChecker -b 13 15 17 20

Loop once through all bitstreams: ChecksumChecker -l

Loop continuously through all bitstreams: ChecksumChecker -L

Check a defined number of bitstreams: ChecksumChecker -c 10

Report all processing (verbose)(default reports only errors): ChecksumChecker -v

Default (no arguments) is equivalent to '-c 1'



--------
usage: ChecksumHistoryWorker:
       
 -a,--after <arg>            Work on bitstreams last checked after
                             (current time minus given duration)
 -b,--before <arg>           Work on bitstreams last checked before
                             (current time minus given duration)
 -d,--do <arg>               action to apply to bitstreams
 -h,--help                   Print this help
 -i,--include_result <arg>   Work on bitstreams whose last result matches
                             the given result
 -r,--root <arg>             Work on bitstream in given Community,
                             Collection, Item, or on the given Bitstream,
                             give root as handle or TYPE.ID)
 -x,--exclude_result <arg>   Work on bitstreams whose last result is not
                             one of the given results (use a comma
                             separated list)

Available do actions that may be applied to selected bitstreams:
        delete, print, count
        default action: count
        print   prints selected checksum history entries
        count   counts how may checksum history entries match with the given parameters
        delete  deletes selected checksum history entries"

Available checksum results: 
        BITSTREAM_NOT_FOUND
        BITSTREAM_INFO_NOT_FOUND
        BITSTREAM_NOT_PROCESSED
        BITSTREAM_MARKED_DELETED
        CHECKSUM_MATCH
        CHECKSUM_NO_MATCH
        CHECKSUM_ALGORITHM_INVALID

Give duration using y(year) w(week), d(days), h(hours) m(minutes):
        4w for 4 weeks, 30d for 30 days, or 15m for 15 minutes
