### PR TITLE
DS-3796 Fix missing bitstream detection and reporting for Checksum Checker

### DIFF
--- a/dspace-api/src/main/java/org/dspace/checker/CheckerCommand.java
+++ b/dspace-api/src/main/java/org/dspace/checker/CheckerCommand.java
@@ -270,10 +270,15 @@ public final class CheckerCommand
                 if(checksumMap.containsKey("checksum_algorithm")) {
                     info.setChecksumAlgorithm(checksumMap.get("checksum_algorithm").toString());
                 }
-            }
 
-            // compare new checksum to previous checksum
-            info.setChecksumResult(compareChecksums(info.getExpectedChecksum(), info.getCurrentChecksum()));
+                // compare new checksum to previous checksum
+                info.setChecksumResult(compareChecksums(info.getExpectedChecksum(), info.getCurrentChecksum()));
+            } else {
+                info.setCurrentChecksum("");
+                // bitstream located, but file missing from asset store
+                info.setChecksumResult(getChecksumResultByCode(ChecksumResultCode.BITSTREAM_NOT_FOUND));
+                info.setToBeProcessed(false);
+            }
         }
         catch (IOException e)
         {

--- a/dspace-api/src/main/java/org/dspace/checker/dao/impl/MostRecentChecksumDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/checker/dao/impl/MostRecentChecksumDAOImpl.java
@@ -53,8 +53,8 @@ public class MostRecentChecksumDAOImpl extends AbstractHibernateDAO<MostRecentCh
         criteria.add(
                 Restrictions.and(
                         Restrictions.eq("toBeProcessed", false),
-                        Restrictions.le("processStartDate", startDate),
-                        Restrictions.gt("processStartDate", endDate)
+                        Restrictions.le("processStartDate", endDate),
+                        Restrictions.gt("processStartDate", startDate)
                 )
         );
         criteria.addOrder(Order.asc("bitstream.id"));
@@ -84,8 +84,8 @@ public class MostRecentChecksumDAOImpl extends AbstractHibernateDAO<MostRecentCh
         criteria.add(
                 Restrictions.and(
                         Restrictions.eq("checksumResult.resultCode", resultCode),
-                        Restrictions.le("processStartDate", startDate),
-                        Restrictions.gt("processStartDate", endDate)
+                        Restrictions.le("processStartDate", endDate),
+                        Restrictions.gt("processStartDate", startDate)
                 )
         );
         criteria.addOrder(Order.asc("bitstream.id"));


### PR DESCRIPTION
Currently, Checksum Checker fails to correctly process missing bitstreams. If the bitstream is not found, it just uses the historical checksum for comparison instead of marking the bitstream as missing. In addition, the MostRecentChecksumDAOImpl date queries had start and end date parameters reversed.

https://jira.duraspace.org/browse/DS-3796

Fixes #7143