### PR TITLE
DS-3976 Reduce itemCounter init

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/CommunityBrowser.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/CommunityBrowser.java
@@ -88,6 +88,10 @@ public class CommunityBrowser extends AbstractDSpaceTransformer implements Cache
     
     /** cached validity object */
     private SourceValidity validity;
+
+    /** Whether to display collection and community strengths (i.e. item counts) */
+    private boolean showCount;
+    private ItemCounter itemCounter = null;
     
     /**
      * Set the component up, pulling any configuration values from the sitemap
@@ -102,6 +106,14 @@ public class CommunityBrowser extends AbstractDSpaceTransformer implements Cache
         depth = parameters.getParameterAsInteger("depth", DEFAULT_DEPTH);
         excludeCollections = parameters.getParameterAsBoolean(
                 "exclude-collections", false);
+        showCount = ConfigurationManager.getBooleanProperty("webui.strengths.show");
+        if (showCount) {
+            try {
+                itemCounter = new ItemCounter(context);
+            } catch (ItemCountException e) {
+                log.error(e);
+            }
+        }
     }
 
     /**
@@ -139,13 +151,12 @@ public class CommunityBrowser extends AbstractDSpaceTransformer implements Cache
 	                validity.add(node.getDSO());
 	                
 	                // If we are configured to use collection strengths (i.e. item counts) then include that number in the validity.
-	                boolean showCount = ConfigurationManager.getBooleanProperty("webui.strengths.show");
 	                if (showCount)
 	        		{
 	                    try
 	                    {	//try to determine Collection size (i.e. # of items)
 	                    	
-	                    	int size = new ItemCounter(context).getCount(node.getDSO());
+	                    	int size = itemCounter.getCount(node.getDSO());
 	                    	validity.add("size:"+size);
 	                    }
 	                    catch(ItemCountException e) { /* ignore */ }


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3976
Fixes #7323

When `ItemCounter` is initialized and caching enabled, the first time a count is retrieved, a  a solr query is performed to count and cache the number of items in each community/collection. Because this cache is not static, each individual instance of `ItemCounter` must cache its own results.
`CommunityViewer` and `CommunityBrowser` each initialize this object once for every node, causing the same query to be executed again and again, greatly reducing performance.
Simply initializing one global `ItemCounter` and using it throughout the transformer fixes the issue.

This issue is only present when both `webui.strengths.show` and `webui.strengths.cache` are true. 

This fix also relates to [PR-2130](https://github.com/DSpace/DSpace/pull/2130)