### PR TITLE
DS-3979 Automatic bitstream policies should default to DEFAULT_BITSTREAM_READ

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
@@ -736,8 +736,11 @@ public class AuthorizeServiceImpl implements AuthorizeService
 
         if (embargoDate != null || (embargoDate == null && dso instanceof Bitstream))
         {
-
-            List<Group> authorizedGroups = getAuthorizedGroups(context, owningCollection, Constants.DEFAULT_ITEM_READ);
+            int actionID = Constants.DEFAULT_ITEM_READ;
+            if (dso instanceof Bitstream) {
+                actionID = Constants.DEFAULT_BITSTREAM_READ;
+            }
+            List<Group> authorizedGroups = getAuthorizedGroups(context, owningCollection, actionID);
 
             removeAllPoliciesByDSOAndType(context, dso, ResourcePolicy.TYPE_CUSTOM);
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3979
Fixes #7326 

The automatic policies created by `AuthorizeService.generateAutomaticPolicies` always default to `DEFAULT_ITEM_READ`. While this is usually appropriate (in the default Edit Collection form, it is not possible to have different `DEFAULT_ITEM_READ` and `DEFAULT_BITSTREAM_READ` groups), it still is possible for these groups to default within the Administrative Authorizations form.

Therefore, the policy should still default to `DEFAULT_BITSTREAM_READ` in the case the dso is a bitstream.

Without this in place, if `DEFAULT_ITEM_READ` is `Anonymous` and `DEFAULT_BITSTREAM_READ` is `Administrator`, then any edit to a bitstream will add an `Anonymous` `READ` policy, making the bitstream public again.