### PR TITLE
[DS-3980] Defend against bad MIME type in Email.addAttachment

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Email.java
+++ b/dspace-api/src/main/java/org/dspace/core/Email.java
@@ -32,10 +32,12 @@ import javax.mail.MessagingException;
 import javax.mail.Multipart;
 import javax.mail.Session;
 import javax.mail.Transport;
+import javax.mail.internet.ContentType;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
+import javax.mail.internet.ParseException;
 
 import org.apache.log4j.Logger;
 import org.dspace.services.ConfigurationService;
@@ -103,7 +105,6 @@ import org.dspace.services.factory.DSpaceServicesFactory;
  * @author Robert Tansley
  * @author Jim Downing - added attachment handling code
  * @author Adan Roman Ruiz at arvo.es - added inputstream attachment handling code
- * @version $Revision: 5844 $
  */
 public class Email {
     /**
@@ -207,7 +208,24 @@ public class Email {
         attachments.add(new FileAttachment(f, name));
     }
 
+    /** When given a bad MIME type for an attachment, use this instead. */
+    private static final String DEFAULT_ATTACHMENT_TYPE = "application/octet-stream";
+
     public void addAttachment(InputStream is, String name, String mimetype) {
+        if (null == mimetype) {
+            log.error("Null MIME type replaced with '" + DEFAULT_ATTACHMENT_TYPE
+                    + "' for attachment '" + name + "'");
+            mimetype = DEFAULT_ATTACHMENT_TYPE;
+        } else {
+            try { new ContentType(mimetype); } // Just try to parse it.
+            catch (ParseException ex) {
+                log.error("Bad MIME type '" + mimetype
+                        + "' replaced with '" + DEFAULT_ATTACHMENT_TYPE
+                        + "' for attachment '" + name + "'", ex);
+                mimetype = DEFAULT_ATTACHMENT_TYPE;
+            }
+        }
+
         moreAttachments.add(new InputStreamAttachment(is, name, mimetype));
     }
 

--- a/dspace-api/src/main/java/org/dspace/core/Email.java
+++ b/dspace-api/src/main/java/org/dspace/core/Email.java
@@ -217,8 +217,9 @@ public class Email {
                     + "' for attachment '" + name + "'");
             mimetype = DEFAULT_ATTACHMENT_TYPE;
         } else {
-            try { new ContentType(mimetype); } // Just try to parse it.
-            catch (ParseException ex) {
+            try {
+                new ContentType(mimetype); // Just try to parse it.
+            } catch (ParseException ex) {
                 log.error("Bad MIME type '" + mimetype
                         + "' replaced with '" + DEFAULT_ATTACHMENT_TYPE
                         + "' for attachment '" + name + "'", ex);


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3980
Something is passing unparseable MIME types.  This will log it and evade the problem by using the 'application/octet-stream' type instead.
This patch is untested.  An essentially identical version has been tested on 5_x.  If anyone has figured out how to reproduce the problem at will, please note it in the Jira ticket linked above.