### PR TITLE
DS-3975 Fix updateMissingBitstreams to use single database operation

### DIFF
--- a/dspace-api/src/main/java/org/dspace/checker/MostRecentChecksumServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/checker/MostRecentChecksumServiceImpl.java
@@ -97,64 +97,14 @@ public class MostRecentChecksumServiceImpl implements MostRecentChecksumService
     /**
      * Queries the bitstream table for bitstream IDs that are not yet in the
      * most_recent_checksum table, and inserts them into the
-     * most_recent_checksum and checksum_history tables.
+     * most_recent_checksum table.
      * @param context Context
      * @throws SQLException if database error
      */
     @Override
-    public void updateMissingBitstreams(Context context) throws SQLException {
-//                "insert into most_recent_checksum ( "
-//                + "bitstream_id, to_be_processed, expected_checksum, current_checksum, "
-//                + "last_process_start_date, last_process_end_date, "
-//                + "checksum_algorithm, matched_prev_checksum, result ) "
-//                + "select bitstream.bitstream_id, "
-//                + "CASE WHEN bitstream.deleted = false THEN true ELSE false END, "
-//                + "CASE WHEN bitstream.checksum IS NULL THEN '' ELSE bitstream.checksum END, "
-//                + "CASE WHEN bitstream.checksum IS NULL THEN '' ELSE bitstream.checksum END, "
-//                + "?, ?, CASE WHEN bitstream.checksum_algorithm IS NULL "
-//                + "THEN 'MD5' ELSE bitstream.checksum_algorithm END, true, "
-//                + "CASE WHEN bitstream.deleted = true THEN 'BITSTREAM_MARKED_DELETED' else 'CHECKSUM_MATCH' END "
-//                + "from bitstream where not exists( "
-//                + "select 'x' from most_recent_checksum "
-//                + "where most_recent_checksum.bitstream_id = bitstream.bitstream_id )";
-
-        List<Bitstream> unknownBitstreams = bitstreamService.findBitstreamsWithNoRecentChecksum(context);
-        for (Bitstream bitstream : unknownBitstreams)
-        {
-            log.info(bitstream + " " + bitstream.getID().toString() + " " + bitstream.getName());
-
-            MostRecentChecksum mostRecentChecksum = new MostRecentChecksum();
-            mostRecentChecksum.setBitstream(bitstream);
-            //Only process if our bitstream isn't deleted
-            mostRecentChecksum.setToBeProcessed(!bitstream.isDeleted());
-            if(bitstream.getChecksum() == null)
-            {
-                mostRecentChecksum.setCurrentChecksum("");
-                mostRecentChecksum.setExpectedChecksum("");
-            }else{
-                mostRecentChecksum.setCurrentChecksum(bitstream.getChecksum());
-                mostRecentChecksum.setExpectedChecksum(bitstream.getChecksum());
-            }
-            mostRecentChecksum.setProcessStartDate(new Date());
-            mostRecentChecksum.setProcessEndDate(new Date());
-            if(bitstream.getChecksumAlgorithm() == null)
-            {
-                mostRecentChecksum.setChecksumAlgorithm("MD5");
-            }else{
-                mostRecentChecksum.setChecksumAlgorithm(bitstream.getChecksumAlgorithm());
-            }
-            mostRecentChecksum.setMatchedPrevChecksum(true);
-            ChecksumResult checksumResult;
-            if(bitstream.isDeleted())
-            {
-                checksumResult = checksumResultService.findByCode(context, ChecksumResultCode.BITSTREAM_MARKED_DELETED);
-            } else {
-                checksumResult = checksumResultService.findByCode(context, ChecksumResultCode.CHECKSUM_MATCH);
-            }
-            mostRecentChecksum.setChecksumResult(checksumResult);
-            mostRecentChecksumDAO.create(context,  mostRecentChecksum);
-            mostRecentChecksumDAO.save(context, mostRecentChecksum);
-        }
+    public void updateMissingBitstreams(Context context) throws SQLException
+    {
+        mostRecentChecksumDAO.updateMissingBitstreams(context);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/checker/dao/MostRecentChecksumDAO.java
+++ b/dspace-api/src/main/java/org/dspace/checker/dao/MostRecentChecksumDAO.java
@@ -31,6 +31,8 @@ public interface MostRecentChecksumDAO extends GenericDAO<MostRecentChecksum>
 
     public List<MostRecentChecksum> findByResultTypeInDateRange(Context context, Date startDate, Date endDate, ChecksumResultCode resultCode) throws SQLException;
 
+    public void updateMissingBitstreams(Context context) throws SQLException;
+
     public void deleteByBitstream(Context context, Bitstream bitstream) throws SQLException;
 
     public MostRecentChecksum getOldestRecord(Context context) throws SQLException;

--- a/dspace-api/src/main/java/org/dspace/checker/dao/impl/MostRecentChecksumDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/checker/dao/impl/MostRecentChecksumDAOImpl.java
@@ -61,6 +61,21 @@ public class MostRecentChecksumDAOImpl extends AbstractHibernateDAO<MostRecentCh
         return list(criteria);
     }
 
+    public void updateMissingBitstreams(Context context) throws SQLException {
+        String hql = "INSERT INTO MostRecentChecksum(bitstream, toBeProcessed, expectedChecksum, currentChecksum, " +
+                "processStartDate, processEndDate, checksumAlgorithm, matchedPrevChecksum, checksumResult) " +
+                "SELECT b, " +
+                "CASE WHEN deleted = false THEN true ELSE false END, " +
+                "CASE WHEN checksum IS NULL THEN '' ELSE checksum END, " +
+                "CASE WHEN checksum IS NULL THEN '' ELSE checksum END, " +
+                "current_date(), current_date(), " +
+                "CASE WHEN checksumAlgorithm IS NULL THEN 'MD5' ELSE checksumAlgorithm END, " +
+                "CAST(1 AS boolean), " +
+                "(SELECT cr FROM ChecksumResult AS cr WHERE (resultCode='BITSTREAM_MARKED_DELETED' AND b.deleted = true) OR (resultCode='CHECKSUM_MATCH' AND b.deleted = false)) " +
+                "FROM Bitstream AS b WHERE NOT EXISTS(SELECT 'x' FROM MostRecentChecksum WHERE id=bitstream.id)";
+        Query query = createQuery(context, hql);
+        query.executeUpdate();
+    }
 
     @Override
     public MostRecentChecksum findByBitstream(Context context, Bitstream bitstream) throws SQLException {


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3975
Fixes #7322 

Currently, checksum checker fails to complete on large repositories. This is because of the large O-O operation done within `updateMissingBitstream` initializing objects just to insert into the database, instead of performing a single database operation.

While the HQL syntax was difficult to come up with, the query performed in this commit accomplishes the same thing as the Java code did previously (and the PSQL command before it).

Tested this on a large client repository and performance is exponentially improved.