### PR TITLE
Display LDAP error reason to user when logging in (XMLUI only)

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/LDAPLogin.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/LDAPLogin.java
@@ -32,233 +32,216 @@ import org.xml.sax.SAXException;
 
 /**
  * Query the user for their authentication credentials.
- * 
+ *
  * The parameter "return-url" may be passed to give a location where to redirect
  * the user to after successfully authenticating.
- * 
+ *
  * @author Jay Paz
  */
 public class LDAPLogin extends AbstractDSpaceTransformer implements
-		CacheableProcessingComponent {
-	/** language strings */
-	public static final Message T_title = message("xmlui.EPerson.LDAPLogin.title");
+        CacheableProcessingComponent {
 
-	public static final Message T_dspace_home = message("xmlui.general.dspace_home");
+    /**
+     * language strings
+     */
+    public static final Message T_title = message("xmlui.EPerson.LDAPLogin.title");
 
-	public static final Message T_trail = message("xmlui.EPerson.LDAPLogin.trail");
+    public static final Message T_dspace_home = message("xmlui.general.dspace_home");
 
-	public static final Message T_head1 = message("xmlui.EPerson.LDAPLogin.head1");
+    public static final Message T_trail = message("xmlui.EPerson.LDAPLogin.trail");
 
-	public static final Message T_userName = message("xmlui.EPerson.LDAPLogin.username");
+    public static final Message T_head1 = message("xmlui.EPerson.LDAPLogin.head1");
 
-	public static final Message T_error_bad_login = message("xmlui.EPerson.LDAPLogin.error_bad_login");
+    public static final Message T_userName = message("xmlui.EPerson.LDAPLogin.username");
 
-	public static final Message T_password = message("xmlui.EPerson.LDAPLogin.password");
+    public static final Message T_error_bad_login = message("xmlui.EPerson.LDAPLogin.error_bad_login");
 
-	public static final Message T_submit = message("xmlui.EPerson.LDAPLogin.submit");
-        
-  // LDAP
-  public static final Message T_error_login_530 = message("xmlui.EPerson.PasswordLogin.error_login_530");
+    public static final Message T_password = message("xmlui.EPerson.LDAPLogin.password");
 
-  public static final Message T_error_login_531 = message("xxmlui.EPerson.PasswordLogin.error_login_531");
+    public static final Message T_submit = message("xmlui.EPerson.LDAPLogin.submit");
 
-  public static final Message T_error_login_532 = message("xmlui.EPerson.PasswordLogin.error_login_532");
+    // LDAP
+    public static final Message T_error_login_530 = message("xmlui.EPerson.PasswordLogin.error_login_530");
 
-  public static final Message T_error_login_533 = message("xmlui.EPerson.PasswordLogin.error_login_533");
+    public static final Message T_error_login_531 = message("xxmlui.EPerson.PasswordLogin.error_login_531");
 
-  public static final Message T_error_login_701 = message("xmlui.EPerson.PasswordLogin.error_login_701");
+    public static final Message T_error_login_532 = message("xmlui.EPerson.PasswordLogin.error_login_532");
 
-  public static final Message T_error_login_773 = message("xmlui.EPerson.PasswordLogin.error_login_773");
+    public static final Message T_error_login_533 = message("xmlui.EPerson.PasswordLogin.error_login_533");
 
-  public static final Message T_error_login_775 = message("xmlui.EPerson.PasswordLogin.error_login_775");
+    public static final Message T_error_login_701 = message("xmlui.EPerson.PasswordLogin.error_login_701");
 
-	/**
-	 * Generate the unique caching key. This key must be unique inside the space
-	 * of this component.
-	 */
-	public Serializable getKey() {
-		Request request = ObjectModelHelper.getRequest(objectModel);
-		String previous_username = request.getParameter("username");
+    public static final Message T_error_login_773 = message("xmlui.EPerson.PasswordLogin.error_login_773");
 
-		// Get any message parameters
-		HttpSession session = request.getSession();
-		String header = (String) session
-				.getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_HEADER);
-		String message = (String) session
-				.getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_MESSAGE);
-		String characters = (String) session
-				.getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_CHARACTERS);
+    public static final Message T_error_login_775 = message("xmlui.EPerson.PasswordLogin.error_login_775");
 
-		// If there is a message or previous email attempt then the page is not
-		// cachable
-		if (header == null && message == null && characters == null
-				&& previous_username == null)
-        {
+    /**
+     * Generate the unique caching key. This key must be unique inside the space
+     * of this component.
+     */
+    public Serializable getKey() {
+        Request request = ObjectModelHelper.getRequest(objectModel);
+        String previous_username = request.getParameter("username");
+
+        // Get any message parameters
+        HttpSession session = request.getSession();
+        String header = (String) session
+                .getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_HEADER);
+        String message = (String) session
+                .getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_MESSAGE);
+        String characters = (String) session
+                .getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_CHARACTERS);
+
+        // If there is a message or previous email attempt then the page is not
+        // cachable
+        if (header == null && message == null && characters == null
+                && previous_username == null) {
             // cacheable
             return "1";
-        }
-		else
-        {
+        } else {
             // Uncachable
             return "0";
         }
-	}
+    }
 
-	/**
-	 * Generate the cache validity object.
-	 */
-	public SourceValidity getValidity() {
-		Request request = ObjectModelHelper.getRequest(objectModel);
-		String previous_username = request.getParameter("username");
+    /**
+     * Generate the cache validity object.
+     */
+    public SourceValidity getValidity() {
+        Request request = ObjectModelHelper.getRequest(objectModel);
+        String previous_username = request.getParameter("username");
 
-		// Get any message parameters
-		HttpSession session = request.getSession();
-		String header = (String) session
-				.getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_HEADER);
-		String message = (String) session
-				.getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_MESSAGE);
-		String characters = (String) session
-				.getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_CHARACTERS);
+        // Get any message parameters
+        HttpSession session = request.getSession();
+        String header = (String) session
+                .getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_HEADER);
+        String message = (String) session
+                .getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_MESSAGE);
+        String characters = (String) session
+                .getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_CHARACTERS);
 
-		// If there is a message or previous email attempt then the page is not
-		// cachable
-		if (header == null && message == null && characters == null
-				&& previous_username == null)
-        {
+        // If there is a message or previous email attempt then the page is not
+        // cachable
+        if (header == null && message == null && characters == null
+                && previous_username == null) {
             // Always valid
             return NOPValidity.SHARED_INSTANCE;
-        }
-		else
-        {
+        } else {
             // invalid
             return null;
         }
-	}
+    }
 
-	/**
-	 * Set the page title and trail.
-	 */
-	public void addPageMeta(PageMeta pageMeta) throws WingException {
-		pageMeta.addMetadata("title").addContent(T_title);
+    /**
+     * Set the page title and trail.
+     */
+    public void addPageMeta(PageMeta pageMeta) throws WingException {
+        pageMeta.addMetadata("title").addContent(T_title);
 
-		pageMeta.addTrailLink(contextPath + "/", T_dspace_home);
-		pageMeta.addTrail().addContent(T_trail);
-	}
+        pageMeta.addTrailLink(contextPath + "/", T_dspace_home);
+        pageMeta.addTrail().addContent(T_trail);
+    }
 
-	/**
-	 * Display the login form.
-	 */
-	public void addBody(Body body) throws SQLException, SAXException,
-			WingException {
-		// Check if the user has previously attempted to login.
-		Request request = ObjectModelHelper.getRequest(objectModel);
-		HttpSession session = request.getSession();
-		String previousUserName = request.getParameter("username");
+    /**
+     * Display the login form.
+     */
+    public void addBody(Body body) throws SQLException, SAXException,
+            WingException {
+        // Check if the user has previously attempted to login.
+        Request request = ObjectModelHelper.getRequest(objectModel);
+        HttpSession session = request.getSession();
+        String previousUserName = request.getParameter("username");
 
-		// Get any message parameters
-		String header = (String) session
-				.getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_HEADER);
-		String message = (String) session
-				.getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_MESSAGE);
-		String characters = (String) session
-				.getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_CHARACTERS);
+        // Get any message parameters
+        String header = (String) session
+                .getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_HEADER);
+        String message = (String) session
+                .getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_MESSAGE);
+        String characters = (String) session
+                .getAttribute(AuthenticationUtil.REQUEST_INTERRUPTED_CHARACTERS);
 
-		if (header != null || message != null || characters != null) {
-			Division reason = body.addDivision("login-reason");
+        if (header != null || message != null || characters != null) {
+            Division reason = body.addDivision("login-reason");
 
-			if (header != null)
-            {
+            if (header != null) {
                 reason.setHead(message(header));
-            }
-			else
-            {
+            } else {
                 // Always have a head.
                 reason.setHead("Authentication Required");
             }
 
-			if (message != null)
-            {
+            if (message != null) {
                 reason.addPara(message(message));
             }
 
-			if (characters != null)
-            {
+            if (characters != null) {
                 reason.addPara(characters);
             }
-		}
+        }
 
-		Division login = body.addInteractiveDivision("login", contextPath
-				+ "/ldap-login", Division.METHOD_POST, "primary");
-		login.setHead(T_head1);
+        Division login = body.addInteractiveDivision("login", contextPath
+                + "/ldap-login", Division.METHOD_POST, "primary");
+        login.setHead(T_head1);
 
-		List list = login.addList("ldap-login", List.TYPE_FORM);
+        List list = login.addList("ldap-login", List.TYPE_FORM);
 
-		Text email = list.addItem().addText("username");
-		email.setRequired();
+        Text email = list.addItem().addText("username");
+        email.setRequired();
         email.setAutofocus("autofocus");
-		email.setLabel(T_userName);
-                
-    // Get stored login code
-    int loginCode = 0;
+        email.setLabel(T_userName);
 
-    if (request.getAttribute("login_code") != null) {
-        loginCode = (int) request.getAttribute("login_code");
+        // Get stored login code
+        int loginCode = 0;
+
+        if (request.getAttribute("login_code") != null) {
+            loginCode = (int) request.getAttribute("login_code");
+        }
+
+        // Add error reason
+        if (loginCode != 0) {
+            email.setValue(previousUserName);
+
+            if (loginCode > 1 && loginCode <= 4) {
+                // DSpace
+                email.addError(T_error_bad_login);
+            } else if (loginCode == -1326) {
+                // LDAP: Bad credentials
+                email.addError(T_error_bad_login);
+            } else if (loginCode == -1328) {
+                // LDAP: Login not permitted at this time
+                email.addError(T_error_login_530);
+            } else if (loginCode == -1329) {
+                // LDAP: Login not permitted from this workstation
+                email.addError(T_error_login_531);
+            } else if (loginCode == -1330) {
+                // LDAP: Password has expired
+                email.addError(T_error_login_532);
+            } else if (loginCode == -1331) {
+                // LDAP: Account disabled
+                email.addError(T_error_login_533);
+            } else if (loginCode == -1793) {
+                // LDAP: Account expired
+                email.addError(T_error_login_701);
+            } else if (loginCode == -1907) {
+                // LDAP: Password must be changed
+                email.addError(T_error_login_773);
+            } else if (loginCode == -1909) {
+                // LDAP: Account locked
+                email.addError(T_error_login_775);
+            } else {
+                // LDAP: Other error
+                email.addError(T_error_bad_login);
+            }
+        }
+
+        Item item = list.addItem();
+        Password password = item.addPassword("ldap_password");
+        password.setRequired();
+        password.setLabel(T_password);
+
+        list.addLabel();
+        Item submit = list.addItem("login-in", null);
+        submit.addButton("submit").setValue(T_submit);
+
     }
-    
-    // Add error reason
-    if (loginCode != 0) {
-        email.setValue(previousUserName);
-
-        if (loginCode > 1 && loginCode <= 4) {
-            // DSpace
-            email.addError(T_error_bad_login);
-        }
-        else if (loginCode == -1326) {
-            // LDAP: Bad credentials
-            email.addError(T_error_bad_login);
-        }
-        else if (loginCode == -1328) {
-            // LDAP: Login not permitted at this time
-            email.addError(T_error_login_530);
-        }
-        else if (loginCode == -1329) {
-            // LDAP: Login not permitted from this workstation
-            email.addError(T_error_login_531);
-        }
-        else if (loginCode == -1330) {
-            // LDAP: Password has expired
-            email.addError(T_error_login_532);
-        }
-        else if (loginCode == -1331) {
-            // LDAP: Account disabled
-            email.addError(T_error_login_533);
-        }
-        else if (loginCode == -1793) {
-            // LDAP: Account expired
-            email.addError(T_error_login_701);
-        }
-        else if (loginCode == -1907) {
-            // LDAP: Password must be changed
-            email.addError(T_error_login_773);
-        }
-        else if (loginCode == -1909) {
-            // LDAP: Account locked
-            email.addError(T_error_login_775);
-        }
-        else {
-            // LDAP: Other error
-            email.addError(T_error_bad_login);
-        }
-    }
-
-		Item item = list.addItem();
-		Password password = item.addPassword("ldap_password");
-		password.setRequired();
-		password.setLabel(T_password);
-
-		list.addLabel();
-		Item submit = list.addItem("login-in", null);
-		submit.addButton("submit").setValue(T_submit);
-
-	}
 }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/LDAPLogin.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/eperson/LDAPLogin.java
@@ -56,6 +56,21 @@ public class LDAPLogin extends AbstractDSpaceTransformer implements
 	public static final Message T_password = message("xmlui.EPerson.LDAPLogin.password");
 
 	public static final Message T_submit = message("xmlui.EPerson.LDAPLogin.submit");
+        
+  // LDAP
+  public static final Message T_error_login_530 = message("xmlui.EPerson.PasswordLogin.error_login_530");
+
+  public static final Message T_error_login_531 = message("xxmlui.EPerson.PasswordLogin.error_login_531");
+
+  public static final Message T_error_login_532 = message("xmlui.EPerson.PasswordLogin.error_login_532");
+
+  public static final Message T_error_login_533 = message("xmlui.EPerson.PasswordLogin.error_login_533");
+
+  public static final Message T_error_login_701 = message("xmlui.EPerson.PasswordLogin.error_login_701");
+
+  public static final Message T_error_login_773 = message("xmlui.EPerson.PasswordLogin.error_login_773");
+
+  public static final Message T_error_login_775 = message("xmlui.EPerson.PasswordLogin.error_login_775");
 
 	/**
 	 * Generate the unique caching key. This key must be unique inside the space
@@ -182,10 +197,59 @@ public class LDAPLogin extends AbstractDSpaceTransformer implements
 		email.setRequired();
         email.setAutofocus("autofocus");
 		email.setLabel(T_userName);
-		if (previousUserName != null) {
-			email.setValue(previousUserName);
-			email.addError(T_error_bad_login);
-		}
+                
+    // Get stored login code
+    int loginCode = 0;
+
+    if (request.getAttribute("login_code") != null) {
+        loginCode = (int) request.getAttribute("login_code");
+    }
+    
+    // Add error reason
+    if (loginCode != 0) {
+        email.setValue(previousUserName);
+
+        if (loginCode > 1 && loginCode <= 4) {
+            // DSpace
+            email.addError(T_error_bad_login);
+        }
+        else if (loginCode == -1326) {
+            // LDAP: Bad credentials
+            email.addError(T_error_bad_login);
+        }
+        else if (loginCode == -1328) {
+            // LDAP: Login not permitted at this time
+            email.addError(T_error_login_530);
+        }
+        else if (loginCode == -1329) {
+            // LDAP: Login not permitted from this workstation
+            email.addError(T_error_login_531);
+        }
+        else if (loginCode == -1330) {
+            // LDAP: Password has expired
+            email.addError(T_error_login_532);
+        }
+        else if (loginCode == -1331) {
+            // LDAP: Account disabled
+            email.addError(T_error_login_533);
+        }
+        else if (loginCode == -1793) {
+            // LDAP: Account expired
+            email.addError(T_error_login_701);
+        }
+        else if (loginCode == -1907) {
+            // LDAP: Password must be changed
+            email.addError(T_error_login_773);
+        }
+        else if (loginCode == -1909) {
+            // LDAP: Account locked
+            email.addError(T_error_login_775);
+        }
+        else {
+            // LDAP: Other error
+            email.addError(T_error_bad_login);
+        }
+    }
 
 		Item item = list.addItem();
 		Password password = item.addPassword("ldap_password");

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/AuthenticationUtil.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/AuthenticationUtil.java
@@ -94,6 +94,10 @@ public class AuthenticationUtil
 
         int implicitStatus = AuthenticationManager.authenticateImplicit(
                 context, null, null, null, request);
+        
+        // Store login code
+        // as a request attribute
+        request.setAttribute("login_code", implicitStatus);
 
         if (implicitStatus == AuthenticationMethod.SUCCESS)
         {
@@ -106,6 +110,10 @@ public class AuthenticationUtil
 
             int explicitStatus = AuthenticationManager.authenticate(context,
                     email, password, realm, request);
+
+            // Store login code
+            // as a request attribute
+            request.setAttribute("login_code", explicitStatus);
 
             if (explicitStatus == AuthenticationMethod.SUCCESS)
             {

--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -536,6 +536,15 @@
 	<message key="xmlui.EPerson.LDAPLogin.error_bad_login">The user name and/or password supplied were not valid.</message>
 	<message key="xmlui.EPerson.LDAPLogin.password">Password</message>
 	<message key="xmlui.EPerson.LDAPLogin.submit">Sign in</message>
+  
+  <!-- LDAP error messages -->
+  <message key="xmlui.EPerson.PasswordLogin.error_login_530">Login not permitted at this time.</message>
+  <message key="xmlui.EPerson.PasswordLogin.error_login_531">Login not permitted from this workstation.</message>
+  <message key="xmlui.EPerson.PasswordLogin.error_login_532">Password has expired.</message>
+  <message key="xmlui.EPerson.PasswordLogin.error_login_533">Account disabled.</message>
+  <message key="xmlui.EPerson.PasswordLogin.error_login_701">Account expired.</message>
+  <message key="xmlui.EPerson.PasswordLogin.error_login_773">Password must be changed.</message>
+  <message key="xmlui.EPerson.PasswordLogin.error_login_775">Account locked.</message>
 
 	<!-- org.dspace.app.xmlui.eperson.LoginChooser.java -->
 	<message key="xmlui.EPerson.LoginChooser.title">Choose a Login Method</message>


### PR DESCRIPTION
Some changes in order to display the error reason after a failed login using LDAP on the XMLUI interface. 

Only covers these common errors:

- Login not permitted at this time.
- Login not permitted from this workstation.
- Password has expired.
- Account disabled.
- Account expired.
- Password must be changed.
- Account locked.

**Note:** tested on the 5.8 version but could work with earlier releases from the 5.X branch.