### PR TITLE
DS-3981 Improve IndexClient usage & options

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
@@ -50,7 +50,7 @@ public class IndexClient {
         Context context = new Context(Context.Mode.READ_ONLY);
         context.turnOffAuthorisationSystem();
 
-        String usage = "org.dspace.discovery.IndexClient [-cbhf] | [-r <handle>] | [-i <handle>] or nothing to update/clean an existing index.";
+        String usage = "org.dspace.discovery.IndexClient [-h | -d | -c | -r <handle> | -b | -i <handle> | -f] [-os] or nothing to update an existing index.";
         Options options = new Options();
         HelpFormatter formatter = new HelpFormatter();
         CommandLine line = null;
@@ -77,6 +77,13 @@ public class IndexClient {
                         .withDescription(
                                 "clean existing index removing any documents that no longer exist in the db")
                         .create("c"));
+
+        options
+                .addOption(OptionBuilder
+                        .isRequired(false)
+                        .withDescription(
+                                "delete existing index removing all documents")
+                        .create("d"));
 
         options.addOption(OptionBuilder.isRequired(false).withDescription(
                 "(re)build index, wiping out current one if it exists").create(
@@ -120,22 +127,20 @@ public class IndexClient {
 
         IndexingService indexer = DSpaceServicesFactory.getInstance().getServiceManager().getServiceByName(IndexingService.class.getName(),IndexingService.class);
 
-        if (line.hasOption("r")) {
+        if (line.hasOption("d")) { // Delete
+            log.info("Deleting Index");
+            indexer.cleanIndex(true);
+        } else if (line.hasOption("c")) { // Clean
+            log.info("Cleaning Index");
+            indexer.cleanIndex(false);
+        } else if (line.hasOption("r")) { // Remove
             log.info("Removing " + line.getOptionValue("r") + " from Index");
             indexer.unIndexContent(context, line.getOptionValue("r"));
-        } else if (line.hasOption("c")) {
-            log.info("Cleaning Index");
-            indexer.cleanIndex(line.hasOption("f"));
-        } else if (line.hasOption("b")) {
+        } else if (line.hasOption("b")) { // Build
             log.info("(Re)building index from scratch.");
+            indexer.cleanIndex(true);
             indexer.createIndex(context);
-            checkRebuildSpellCheck(line, indexer);
-        } else if (line.hasOption("o")) {
-            log.info("Optimizing search core.");
-            indexer.optimize();
-        } else if(line.hasOption('s')) {
-            checkRebuildSpellCheck(line, indexer);
-        } else if(line.hasOption('i')) {
+        } else if (line.hasOption('i')) { // Index
             final String handle = line.getOptionValue('i');
             final DSpaceObject dso = HandleServiceFactory.getInstance().getHandleService().resolveToObject(context, handle);
             if (dso == null) {
@@ -143,14 +148,20 @@ public class IndexClient {
             }
             log.info("Forcibly Indexing " + handle);
             final long startTimeMillis = System.currentTimeMillis();
-            final long count = indexAll(indexer,  ContentServiceFactory.getInstance().getItemService(), context, dso);
-            final long seconds = (System.currentTimeMillis() - startTimeMillis ) / 1000;
+            final long count = indexAll(indexer, ContentServiceFactory.getInstance().getItemService(), context, dso);
+            final long seconds = (System.currentTimeMillis() - startTimeMillis) / 1000;
             log.info("Indexed " + count + " DSpace object" + (count > 1 ? "s" : "") + " in " + seconds + " seconds");
-        } else {
+        } else { // No Option (or Force)
             log.info("Updating and Cleaning Index");
-            indexer.cleanIndex(line.hasOption("f"));
             indexer.updateIndex(context, line.hasOption("f"));
-            checkRebuildSpellCheck(line, indexer);
+        }
+        if (line.hasOption('s')) { // Spell-checker
+            log.info("Rebuilding spell checker.");
+            indexer.buildSpellCheck();
+        }
+        if (line.hasOption("o")) { // Optimize
+            log.info("Optimizing search core.");
+            indexer.optimize();
         }
 
         log.info("Done with indexing");
@@ -210,18 +221,5 @@ public class IndexClient {
         indexingService.commit();
 
         return count;
-    }
-
-    /**
-     * Check the command line options and rebuild the spell check if active.
-     * @param line the command line options
-     * @param indexer the solr indexer
-     * @throws SearchServiceException in case of a solr exception
-     */
-    protected static void checkRebuildSpellCheck(CommandLine line, IndexingService indexer) throws SearchServiceException {
-        if (line.hasOption("s")) {
-            log.info("Rebuilding spell checker.");
-            indexer.buildSpellCheck();
-        }
     }
 }


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3981
Fixes #7328 (for 6.x). See also #2172 for main version

### Issue
Currently, the way the `IndexClient` CLI works is rather un-intuitive to new users. Below are just a few examples:

Given the current usage statement, one might assume running `-cf` would clean the index and then force-update the index. Instead, this is _actually_ synonymous with deleting the entire search core.

One might assume `-f` would simply force-update all existing records. Instead, this would _actually_ result in the entire core being deleted, then all the items re-indexed.

The `-b` option states it is "(Re)building index from scratch" but never _actually_ deletes the index. (This was accomplished by `-f`)

Lastly, the usage statement shows each of these as options usable together, when the Java code _actually_ treats them as mutually exclusive.

It is my opinion that these options _should_ be mutually exclusive, and separated in the usage statement as such. In addition, the behavior of these options should be more clearly defined as to reduce confusion for site administrators.

### Solution
This commit separates `IndexClient` usage into the following mutually-exclusive components:
* `-h` - Prints help message
* `-d` - "Deletes" all documents from the search core
* `-c` - "Cleans" the search core, removing documents whose handle is no longer present in the database
* `-r <handle>` - "Removes" a single object from the search core
* `-b` - "Builds" the search core from scratch, first deleting all documents, then indexing all objects
* `-i <handle>` - "Indexes" or updates a a single object in the search core
* `-f` - "Force" updates the index (indexes all objects regardless of `getLastModified()`)
* `no-op` - Update the index (indexes objects _not_ in the index or which have been modified since the last index)

In addition, the `optimize` and `spellcheck` functions have been de-coupled and can be ran with any of these options.

The updated usage looks like this:
```
org.dspace.discovery.IndexClient [-h | -d | -c | -r <handle> | -b | -i <handle> | -f] [-os] 
                                 or nothing to update/clean an existing index.
```