### PR TITLE
DS-3981 Improve IndexClient usage & options

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
@@ -61,13 +61,14 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
             indexer.unIndexContent(context, commandLine.getOptionValue("r"));
         } else if (indexClientOptions == IndexClientOptions.CLEAN) {
             handler.logInfo("Cleaning Index");
-            indexer.cleanIndex(false);
-        } else if (indexClientOptions == IndexClientOptions.FORCECLEAN) {
-            handler.logInfo("Cleaning Index");
-            indexer.cleanIndex(true);
+            indexer.cleanIndex();
+        } else if (indexClientOptions == IndexClientOptions.DELETE) {
+            handler.logInfo("Deleting Index");
+            indexer.deleteIndex();
         } else if (indexClientOptions == IndexClientOptions.BUILD ||
             indexClientOptions == IndexClientOptions.BUILDANDSPELLCHECK) {
             handler.logInfo("(Re)building index from scratch.");
+            indexer.deleteIndex();
             indexer.createIndex(context);
             if (indexClientOptions == IndexClientOptions.BUILDANDSPELLCHECK) {
                 checkRebuildSpellCheck(commandLine, indexer);
@@ -125,16 +126,14 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
             handler.logInfo("Indexed " + count + " object" + (count > 1 ? "s" : "") + " in " + seconds + " seconds");
         } else if (indexClientOptions == IndexClientOptions.UPDATE ||
             indexClientOptions == IndexClientOptions.UPDATEANDSPELLCHECK) {
-            handler.logInfo("Updating and Cleaning Index");
-            indexer.cleanIndex(false);
+            handler.logInfo("Updating Index");
             indexer.updateIndex(context, false);
             if (indexClientOptions == IndexClientOptions.UPDATEANDSPELLCHECK) {
                 checkRebuildSpellCheck(commandLine, indexer);
             }
         } else if (indexClientOptions == IndexClientOptions.FORCEUPDATE ||
             indexClientOptions == IndexClientOptions.FORCEUPDATEANDSPELLCHECK) {
-            handler.logInfo("Updating and Cleaning Index");
-            indexer.cleanIndex(true);
+            handler.logInfo("Updating Index");
             indexer.updateIndex(context, true);
             if (indexClientOptions == IndexClientOptions.FORCEUPDATEANDSPELLCHECK) {
                 checkRebuildSpellCheck(commandLine, indexer);

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClientOptions.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClientOptions.java
@@ -17,7 +17,7 @@ import org.apache.commons.cli.Options;
 public enum IndexClientOptions {
     REMOVE,
     CLEAN,
-    FORCECLEAN,
+    DELETE,
     BUILD,
     BUILDANDSPELLCHECK,
     OPTIMIZE,
@@ -41,11 +41,9 @@ public enum IndexClientOptions {
         } else if (commandLine.hasOption("r")) {
             return IndexClientOptions.REMOVE;
         } else if (commandLine.hasOption("c")) {
-            if (commandLine.hasOption("f")) {
-                return IndexClientOptions.FORCECLEAN;
-            } else {
-                return IndexClientOptions.CLEAN;
-            }
+            return IndexClientOptions.CLEAN;
+        } else if (commandLine.hasOption("d")) {
+            return IndexClientOptions.DELETE;
         } else if (commandLine.hasOption("b")) {
             if (commandLine.hasOption("s")) {
                 return IndexClientOptions.BUILDANDSPELLCHECK;
@@ -83,6 +81,9 @@ public enum IndexClientOptions {
         options.addOption("c", "clean", false,
                           "clean existing index removing any documents that no longer exist in the db");
         options.getOption("c").setType(boolean.class);
+        options.addOption("d", "delete", false,
+                "delete all records from existing index");
+        options.getOption("d").setType(boolean.class);
         options.addOption("b", "build", false, "(re)build index, wiping out current one if it exists");
         options.getOption("b").setType(boolean.class);
         options.addOption("s", "spellchecker", false, "Rebuild the spellchecker, can be combined with -b and -f.");

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexingService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexingService.java
@@ -53,8 +53,9 @@ public interface IndexingService {
 
     void updateIndex(Context context, boolean force, String type);
 
-    void cleanIndex(boolean force) throws IOException,
-        SQLException, SearchServiceException;
+    void cleanIndex() throws IOException, SQLException, SearchServiceException;
+
+    void deleteIndex();
 
     void commit() throws SearchServiceException;
 

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -1327,7 +1327,7 @@ public class DatabaseUtils {
 
                         // Reindex Discovery completely
                         // Force clean all content
-                        this.indexer.cleanIndex(true);
+                        this.indexer.deleteIndex();
                         // Recreate the entire index (overwriting existing one)
                         this.indexer.createIndex(context);
                         // Rebuild spell checker (which is based on index)


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3981
Fixes #7328
### Issue
Currently, the way the `IndexClient` CLI works is rather un-intuitive to new users. Below are just a few examples:

Given the current usage statement, one might assume running `-cf` would clean the index and then force-update the index. Instead, this is _actually_ synonymous with deleting the entire search core.

One might assume `-f` would simply force-update all existing records. Instead, this would _actually_ result in the entire core being deleted, then all the items re-indexed.

The `-b` option states it is "(Re)building index from scratch" but never _actually_ deletes the index. (This was accomplished by `-f`)

Lastly, the usage statement shows each of these as options usable together, when the Java code _actually_ treats them as mutually exclusive.

It is my opinion that these options _should_ be mutually exclusive, and separated in the usage statement as such. In addition, the behavior of these options should be more clearly defined as to reduce confusion for site administrators.

### Solution
This commit separates `IndexClient` usage into the following mutually-exclusive components:
* `-h` - Prints help message
* `-d` - "Deletes" all documents from the search core
* `-c` - "Cleans" the search core, removing documents whose handle is no longer present in the database
* `-r <handle>` - "Removes" a single object from the search core
* `-b` - "Builds" the search core from scratch, first deleting all documents, then indexing all objects
* `-i <handle>` - "Indexes" or updates a a single object in the search core
* `-f` - "Force" updates the index (indexes all objects regardless of `getLastModified()`)
* `no-op` - Update the index (indexes objects _not_ in the index or which have been modified since the last index)

In addition, the `optimize` and `spellcheck` functions have been de-coupled and can be ran with any of these options.

The updated usage looks like this:
```
org.dspace.discovery.IndexClient [-h | -d | -c | -r <handle> | -b | -i <handle> | -f] [-os] 
                                 or nothing to update/clean an existing index.
```