### PR TITLE
fix for DS-3986 -- 'View' statistics are not logged to solr in dspace 5.9

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLogger.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLogger.java
@@ -170,7 +170,7 @@ public class SolrLogger
 
         DatabaseReader service = null;
         // Get the db file for the location
-        String dbPath = ConfigurationManager.getProperty("usage-statistics.dbfile");
+        String dbPath = ConfigurationManager.getProperty("usage-statistics", "dbfile");
         if (dbPath != null) {
             try {
                 File dbFile = new File(dbPath);


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3986