### PR TITLE
 DS-3914: Fix community defiliation

### DIFF
--- a/dspace-api/src/main/java/org/dspace/administer/CommunityFiliator.java
+++ b/dspace-api/src/main/java/org/dspace/administer/CommunityFiliator.java
@@ -261,8 +261,8 @@ public class CommunityFiliator
 
         // OK remove the mappings - but leave the community, which will become
         // top-level
-        child.getParentCommunities().remove(parent);
-        parent.getSubcommunities().remove(child);
+        child.removeParentCommunity(parent);
+        parent.removeSubCommunity(child);
         communityService.update(c, child);
         communityService.update(c, parent);
 

--- a/dspace-api/src/main/java/org/dspace/administer/CommunityFiliator.java
+++ b/dspace-api/src/main/java/org/dspace/administer/CommunityFiliator.java
@@ -206,15 +206,11 @@ public class CommunityFiliator
         // second test - circularity: parent's parents can't include proposed
         // child
         List<Community> parentDads = parent.getParentCommunities();
-
-        for (int i = 0; i < parentDads.size(); i++)
+        if (parentDads.contains(child))
         {
-            if (parentDads.get(i).getID().equals(child.getID()))
-            {
-                System.out
-                        .println("Error, circular parentage - child is parent of parent");
-                System.exit(1);
-            }
+            System.out.println(
+                    "Error, circular parentage - child is parent of parent");
+            System.exit(1);
         }
 
         // everthing's OK
@@ -240,19 +236,7 @@ public class CommunityFiliator
     {
         // verify that child is indeed a child of parent
         List<Community> parentKids = parent.getSubcommunities();
-        boolean isChild = false;
-
-        for (int i = 0; i < parentKids.size(); i++)
-        {
-            if (parentKids.get(i).getID().equals(child.getID()))
-            {
-                isChild = true;
-
-                break;
-            }
-        }
-
-        if (!isChild)
+        if (!parentKids.contains(child))
         {
             System.out
                     .println("Error, child community not a child of parent community");

--- a/dspace-api/src/main/java/org/dspace/content/Community.java
+++ b/dspace-api/src/main/java/org/dspace/content/Community.java
@@ -93,7 +93,7 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
         setModified();
     }
 
-    void removeSubCommunity(Community subCommunity)
+    public void removeSubCommunity(Community subCommunity)
     {
         subCommunities.remove(subCommunity);
         setModified();


### PR DESCRIPTION
This is an alternative for #2063 without changing the `CommunityService.removeSubcommunity()` method.

This fixes in issue in the defiliate method of the community filiator. The
child and parent relations should be managed using the provided methods of the
Community.

This changes the visibility of `Community.removeSubCommunity()` to *public*, but
`Community.removeParentCommunity()` was public before already. So this should
not be a problem.

The second commit is just a bit cleanup of manual loops.