### PR TITLE
DS-3905 Implement a generic uuid lookup endpoint (DSpaceObjectService based)

### DIFF
--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/UUIDLookupRestController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/UUIDLookupRestController.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.UUID;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -24,10 +25,10 @@ import org.dspace.app.rest.model.DSpaceObjectRest;
 import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.content.DSpaceObject;
 import org.dspace.core.Context;
-import org.dspace.identifier.IdentifierNotFoundException;
-import org.dspace.identifier.IdentifierNotResolvableException;
-import org.dspace.identifier.factory.IdentifierServiceFactory;
-import org.dspace.identifier.service.IdentifierService;
+import org.dspace.discovery.DiscoverQuery;
+import org.dspace.discovery.DiscoverResult;
+import org.dspace.discovery.SearchService;
+import org.dspace.discovery.SearchServiceException;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.Link;
@@ -40,23 +41,33 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * This is an utility endpoint to lookup a generic DSpaceObject using the uuid in SOLR. If found the controller will
+ * respond with a redirection to the canonical endpoint for the actual object. Please note that currently it is limited
+ * to Community, Collection and Item as the other DSpaceObject are not yet indexed in SOLR
+ *
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ */
 @RestController
-@RequestMapping("/api/" + IdentifierRestController.CATEGORY)
-public class IdentifierRestController implements InitializingBean {
-    public static final String CATEGORY = "pid";
+@RequestMapping("/api/" + UUIDLookupRestController.CATEGORY)
+public class UUIDLookupRestController implements InitializingBean {
+    public static final String CATEGORY = "dso";
 
     public static final String ACTION = "find";
 
-    public static final String PARAM = "id";
+    public static final String PARAM = "uuid";
 
     private static final Logger log =
-            Logger.getLogger(IdentifierRestController.class);
-
-    @Autowired
-    private GenericDSpaceObjectConverter converter;
+            Logger.getLogger(UUIDLookupRestController.class);
 
     @Autowired
     private DiscoverableEndpointsService discoverableEndpointsService;
+
+    @Autowired
+    private SearchService searchService;
+
+    @Autowired
+    private GenericDSpaceObjectConverter converter;
 
     @Override
     public void afterPropertiesSet() throws Exception {
@@ -74,32 +85,32 @@ public class IdentifierRestController implements InitializingBean {
     @SuppressWarnings("unchecked")
     public void getDSObyIdentifier(HttpServletRequest request,
                                    HttpServletResponse response,
-                                   @RequestParam(PARAM) String id)
-            throws IOException, SQLException {
+                                   @RequestParam(PARAM) UUID id)
+            throws IOException, SQLException, SearchServiceException {
 
-        DSpaceObject dso = null;
-        Context context = ContextUtil.obtainContext(request);
-        IdentifierService identifierService = IdentifierServiceFactory
-                .getInstance().getIdentifierService();
+        Context context = null;
         try {
-            dso = identifierService.resolve(context, id);
-            if (dso != null) {
-                DSpaceObjectRest dsor = converter.convert(dso);
-                URI link = linkTo(dsor.getController(), dsor.getCategory(),
-                        English.plural(dsor.getType()))
-                        .slash(dsor.getId()).toUri();
-                response.setStatus(HttpServletResponse.SC_FOUND);
-                response.sendRedirect(link.toString());
+            DSpaceObject dso = null;
+            context = ContextUtil.obtainContext(request);
+            DiscoverQuery query = new DiscoverQuery();
+            query.setQuery("search.resourceid:\"" + id.toString() + "\"");
+            DiscoverResult result = searchService.search(context, query);
+            if (result.getTotalSearchResults() == 1) {
+                dso = result.getDspaceObjects().get(0);
+                if (dso != null) {
+                    DSpaceObjectRest dsor = converter.convert(dso);
+                    URI link = linkTo(dsor.getController(), dsor.getCategory(), English.plural(dsor.getType()))
+                            .slash(dsor.getId()).toUri();
+                    response.setStatus(HttpServletResponse.SC_FOUND);
+                    response.sendRedirect(link.toString());
+                } else {
+                    response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                }
             } else {
                 response.setStatus(HttpServletResponse.SC_NOT_FOUND);
             }
-        } catch (IdentifierNotFoundException e) {
-            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-        } catch (IdentifierNotResolvableException e) {
-            response.setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
         } finally {
             context.abort();
         }
     }
-
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/UUIDLookupRestController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/UUIDLookupRestController.java
@@ -19,7 +19,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.log4j.Logger;
-import org.atteo.evo.inflector.English;
 import org.dspace.app.rest.converter.GenericDSpaceObjectConverter;
 import org.dspace.app.rest.model.DSpaceObjectRest;
 import org.dspace.app.rest.utils.ContextUtil;
@@ -93,7 +92,7 @@ public class UUIDLookupRestController implements InitializingBean {
                 DSpaceObject dso = dSpaceObjectService.find(context, uuid);
                 if (dso != null) {
                     DSpaceObjectRest dsor = converter.convert(dso);
-                    URI link = linkTo(dsor.getController(), dsor.getCategory(), English.plural(dsor.getType()))
+                    URI link = linkTo(dsor.getController(), dsor.getCategory(), dsor.getTypePlural())
                             .slash(dsor.getId()).toUri();
                     response.setStatus(HttpServletResponse.SC_FOUND);
                     response.sendRedirect(link.toString());

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/GenericDSpaceObjectConverter.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/converter/GenericDSpaceObjectConverter.java
@@ -1,0 +1,61 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.converter;
+
+import java.util.List;
+
+import org.apache.log4j.Logger;
+import org.dspace.app.rest.model.DSpaceObjectRest;
+import org.dspace.content.DSpaceObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * This is the converter from/to an unknown DSpaceObject in the DSpace API data model and the
+ * REST data model
+ *
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ */
+@Component
+public class GenericDSpaceObjectConverter
+        extends DSpaceObjectConverter<org.dspace.content.DSpaceObject, org.dspace.app.rest.model.DSpaceObjectRest> {
+
+    @Autowired
+    private List<DSpaceObjectConverter> converters;
+
+    private static final Logger log = Logger.getLogger(GenericDSpaceObjectConverter.class);
+
+    /**
+     * Convert a DSpaceObject in its REST representation using a suitable converter
+     */
+    @Override
+    public DSpaceObjectRest fromModel(org.dspace.content.DSpaceObject dspaceObject) {
+        for (DSpaceObjectConverter converter : converters) {
+            if (converter.supportsModel(dspaceObject)) {
+                return converter.fromModel(dspaceObject);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public org.dspace.content.DSpaceObject toModel(DSpaceObjectRest obj) {
+        return null;
+    }
+
+    @Override
+    protected DSpaceObjectRest newInstance() {
+        return null;
+    }
+
+    @Override
+    protected Class<DSpaceObject> getModelClass() {
+        return DSpaceObject.class;
+    }
+
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -11,16 +11,22 @@ import static org.springframework.web.servlet.DispatcherServlet.EXCEPTION_ATTRIB
 
 import java.io.IOException;
 import java.sql.SQLException;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.dspace.app.rest.security.RestAuthenticationService;
 import org.dspace.authorize.AuthorizeException;
+import org.springframework.beans.TypeMismatchException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.repository.support.QueryMethodParameterConversionException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 /**
@@ -60,8 +66,8 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
                           HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
     }
 
-    @ExceptionHandler(MissingParameterException.class)
-    protected void MissingParameterException(HttpServletRequest request, HttpServletResponse response, Exception ex)
+    @ExceptionHandler({MissingParameterException.class, QueryMethodParameterConversionException.class})
+    protected void ParameterConversionException(HttpServletRequest request, HttpServletResponse response, Exception ex)
         throws IOException {
 
         //422 is not defined in HttpServletResponse.  Its meaning is "Unprocessable Entity".
@@ -72,16 +78,21 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
                           HttpStatus.UNPROCESSABLE_ENTITY.value());
     }
 
-    @ExceptionHandler(QueryMethodParameterConversionException.class)
-    protected void ParameterConversionException(HttpServletRequest request, HttpServletResponse response, Exception ex)
-        throws IOException {
+    @Override
+    protected ResponseEntity<Object> handleMissingServletRequestParameter(MissingServletRequestParameterException ex,
+            HttpHeaders headers, HttpStatus status, WebRequest request) {
+        // we want the 422 status for missing parameter as it seems to be the common behavior for REST application, see
+        // https://stackoverflow.com/questions/3050518/what-http-status-response-code-should-i-use-if-the-request-is-missing-a-required
+        return super.handleMissingServletRequestParameter(ex, headers, HttpStatus.UNPROCESSABLE_ENTITY, request);
+    }
 
-        //422 is not defined in HttpServletResponse.  Its meaning is "Unprocessable Entity".
-        //Using the value from HttpStatus.
-        //Since this is a handled exception case, the stack trace will not be returned.
-        sendErrorResponse(request, response, null,
-                          ex.getMessage(),
-                          HttpStatus.UNPROCESSABLE_ENTITY.value());
+    @Override
+    protected ResponseEntity<Object> handleTypeMismatch(TypeMismatchException ex, HttpHeaders headers,
+            HttpStatus status, WebRequest request) {
+        // we want the 422 status for type mismatch on parameters as it seems to be the common behavior for REST
+        // application, see
+        // https://stackoverflow.com/questions/3050518/what-http-status-response-code-should-i-use-if-the-request-is-missing-a-required
+        return super.handleTypeMismatch(ex, headers, HttpStatus.UNPROCESSABLE_ENTITY, request);
     }
 
     private void sendErrorResponse(final HttpServletRequest request, final HttpServletResponse response,

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/IdentifierRestControllerIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/IdentifierRestControllerIT.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.dspace.app.rest.builder.CommunityBuilder;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -51,8 +52,20 @@ public class IdentifierRestControllerIT extends AbstractControllerIntegrationTes
 
     @Test
     public void testUnexistentIdentifier() throws Exception {
-        getClient().perform(get("/api/pid/find?{id}","fakeIdentifier"))
+        getClient().perform(get("/api/pid/find?id={id}","fakeIdentifier"))
                         .andExpect(status().isNotFound());
     }
 
+    @Test
+    @Ignore
+    /**
+     * This test will check the return status code when no id is supplied. It currently fails as our
+     * RestResourceController take the precedence over the pid controller returning a 404 Repository not found
+     *
+     * @throws Exception
+     */
+    public void testMissingIdentifierParameter() throws Exception {
+        getClient().perform(get("/api/pid/find"))
+                        .andExpect(status().isUnprocessableEntity());
+    }
 }

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/UUIDLookupRestControllerIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/UUIDLookupRestControllerIT.java
@@ -1,0 +1,158 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+
+import org.dspace.app.rest.builder.CollectionBuilder;
+import org.dspace.app.rest.builder.CommunityBuilder;
+import org.dspace.app.rest.builder.ItemBuilder;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Integration test for the UUIDLookup endpoint
+ *
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ */
+public class UUIDLookupRestControllerIT extends AbstractControllerIntegrationTest {
+
+    @Test
+    /**
+     * Test the proper redirection of an community's uuid
+     * 
+     * @throws Exception
+     */
+    public void testCommunityUUID() throws Exception {
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        // We create a community to get the uuid to lookup
+        Community community = CommunityBuilder.createCommunity(context)
+                                          .withName("A Community")
+                                          .build();
+
+        context.restoreAuthSystemState();
+
+        String uuid = community.getID().toString();
+        String communityDetail = REST_SERVER_URL + "core/communities/" + uuid;
+
+        getClient().perform(get("/api/dso/find?uuid={uuid}",uuid))
+                        .andExpect(status().isFound())
+                        //We expect a Location header to redirect to the community details
+                        .andExpect(header().string("Location", communityDetail));
+    }
+
+    @Test
+    /**
+     * Test the proper redirection of an collection's uuid
+     *
+     * @throws Exception
+     */
+    public void testCollectionUUID() throws Exception {
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        // We create a community and a collection to get the uuid to lookup
+        Community community = CommunityBuilder.createCommunity(context)
+                                          .withName("A Community")
+                                          .build();
+
+        Collection collection = CollectionBuilder.createCollection(context, community)
+                                            .withName("A Collection")
+                                            .build();
+
+        context.restoreAuthSystemState();
+
+        String uuid = collection.getID().toString();
+        String collectionDetail = REST_SERVER_URL + "core/collections/" + uuid;
+
+        getClient().perform(get("/api/dso/find?uuid={uuid}",uuid))
+                        .andExpect(status().isFound())
+                        //We expect a Location header to redirect to the community details
+                        .andExpect(header().string("Location", collectionDetail));
+    }
+
+    @Test
+    /**
+     * Test the proper redirection of an item's uuid
+     *
+     * @throws Exception
+     */
+    public void testItemUUID() throws Exception {
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        // We create a community and a collection to get the uuid to lookup
+        Community community = CommunityBuilder.createCommunity(context)
+                                          .withName("A Community")
+                                          .build();
+
+        Collection collection = CollectionBuilder.createCollection(context, community)
+                                            .withName("A Collection")
+                                            .build();
+
+        Item item = ItemBuilder.createItem(context, collection)
+                            .withTitle("An Item")
+                            .build();
+
+        context.restoreAuthSystemState();
+
+        String uuid = item.getID().toString();
+        String itemDetail = REST_SERVER_URL + "core/items/" + uuid;
+
+        getClient().perform(get("/api/dso/find?uuid={uuid}",uuid))
+                        .andExpect(status().isFound())
+                        //We expect a Location header to redirect to the community details
+                        .andExpect(header().string("Location", itemDetail));
+    }
+
+    @Test
+    /**
+     * Test that a request with a valid, not existent, uuid parameter return a 404 Not Found status
+     *
+     * @throws Exception
+     */
+    public void testUnexistentUUID() throws Exception {
+        getClient().perform(get("/api/dso/find?uuid={uuid}",UUID.randomUUID().toString()))
+                        .andExpect(status().isNotFound());
+    }
+
+    @Test
+    /**
+     * Test that a request with an uuid parameter that is not an actual UUID return a 422 Unprocessable Entity status
+     *
+     * @throws Exception
+     */
+    public void testInvalidUUID() throws Exception {
+        getClient().perform(get("/api/dso/find?uuid={uuid}","invalidUUID"))
+                        .andExpect(status().isUnprocessableEntity());
+    }
+
+    @Test
+    @Ignore
+    /**
+     * This test will check the return status code when no uuid is supplied. It currently fails as our
+     * RestResourceController take the precedence over the UUIDLookupController returning a 404 Repository not found
+     *
+     * @throws Exception
+     */
+    public void testMissingIdentifierParameter() throws Exception {
+        getClient().perform(get("/api/dso/find"))
+                        .andExpect(status().isUnprocessableEntity());
+    }
+
+}

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/UUIDLookupRestControllerIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/UUIDLookupRestControllerIT.java
@@ -11,15 +11,24 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.io.InputStream;
 import java.util.UUID;
 
+import org.apache.commons.codec.CharEncoding;
+import org.apache.commons.io.IOUtils;
+import org.dspace.app.rest.builder.BitstreamBuilder;
 import org.dspace.app.rest.builder.CollectionBuilder;
 import org.dspace.app.rest.builder.CommunityBuilder;
+import org.dspace.app.rest.builder.GroupBuilder;
 import org.dspace.app.rest.builder.ItemBuilder;
+import org.dspace.app.rest.builder.SiteBuilder;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.content.Bitstream;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.Item;
+import org.dspace.content.Site;
+import org.dspace.eperson.Group;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -29,6 +38,30 @@ import org.junit.Test;
  * @author Andrea Bollini (andrea.bollini at 4science.it)
  */
 public class UUIDLookupRestControllerIT extends AbstractControllerIntegrationTest {
+
+    @Test
+    /**
+     * Test the proper redirection of a site's uuid
+     *
+     * @throws Exception
+     */
+    public void testSiteUUID() throws Exception {
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        // We create a site to get the uuid to lookup
+        Site site = SiteBuilder.createSite(context).build();
+
+        context.restoreAuthSystemState();
+
+        String uuid = site.getID().toString();
+        String siteDetail = REST_SERVER_URL + "core/sites/" + uuid;
+
+        getClient().perform(get("/api/dso/find?uuid={uuid}",uuid))
+                        .andExpect(status().isFound())
+                        //We expect a Location header to redirect to the site details
+                        .andExpect(header().string("Location", siteDetail));
+    }
 
     @Test
     /**
@@ -118,6 +151,121 @@ public class UUIDLookupRestControllerIT extends AbstractControllerIntegrationTes
                         .andExpect(status().isFound())
                         //We expect a Location header to redirect to the community details
                         .andExpect(header().string("Location", itemDetail));
+    }
+
+    @Test
+    @Ignore
+    /**
+     * Test the proper redirection of a bundle's uuid
+     *
+     * @throws Exception
+     */
+    public void testBundleUUID() throws Exception {
+        // Currently, there is no bundle endpoint
+    }
+
+    @Test
+    /**
+     * Test the proper redirection of uuids of different kinds of bitstreams (standard, collection and community logo)
+     *
+     * @throws Exception
+     */
+    public void testBitstreamUUID() throws Exception {
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        // We create a community and a collection to get the uuid to lookup
+        Community community = CommunityBuilder.createCommunity(context)
+                                          .withName("A Community")
+                                          .withLogo("Community Logo")
+                                          .build();
+
+        Collection collection = CollectionBuilder.createCollection(context, community)
+                                            .withName("A Collection")
+                                            .withLogo("Collection Logo")
+                                            .build();
+
+        Item item = ItemBuilder.createItem(context, collection)
+                            .withTitle("An Item")
+                            .build();
+
+        Bitstream bitstream = null;
+        try (InputStream is = IOUtils.toInputStream("bitstreamContent", CharEncoding.UTF_8)) {
+            bitstream = BitstreamBuilder.createBitstream(context, item, is)
+                                        .withName("Bitstream")
+                                        .withDescription("description")
+                                        .withMimeType("text/plain")
+                                        .build();
+        }
+
+        context.restoreAuthSystemState();
+
+        String uuid = bitstream.getID().toString();
+        String colLogoUuid = community.getLogo().getID().toString();
+        String comLogoUuid = collection.getLogo().getID().toString();
+        String bitstreamDetail = REST_SERVER_URL + "core/bitstreams/" + uuid;
+        String colLogoDetail = REST_SERVER_URL + "core/bitstreams/" + colLogoUuid;
+        String comLogoDetail = REST_SERVER_URL + "core/bitstreams/" + comLogoUuid;
+
+        // test the resolution of a standard bitstream
+        getClient().perform(get("/api/dso/find?uuid={uuid}",uuid))
+                        .andExpect(status().isFound())
+                        //We expect a Location header to redirect to the community details
+                        .andExpect(header().string("Location", bitstreamDetail));
+
+        // test the resolution of a community's logo bitstream
+        getClient().perform(get("/api/dso/find?uuid={uuid}", comLogoUuid))
+                        .andExpect(status().isFound())
+                        //We expect a Location header to redirect to the community details
+                        .andExpect(header().string("Location", comLogoDetail));
+
+        // test the resolution of a collection's logo bitstream
+        getClient().perform(get("/api/dso/find?uuid={uuid}", colLogoUuid))
+                        .andExpect(status().isFound())
+                        //We expect a Location header to redirect to the community details
+                        .andExpect(header().string("Location", colLogoDetail));
+
+    }
+
+    @Test
+    /**
+     * Test the proper redirection of an eperson's uuid
+     *
+     * @throws Exception
+     */
+    public void testEPersonUUID() throws Exception {
+        String uuid = eperson.getID().toString();
+        String epersonDetail = REST_SERVER_URL + "eperson/epersons/" + uuid;
+
+        getClient().perform(get("/api/dso/find?uuid={uuid}",uuid))
+                        .andExpect(status().isFound())
+                        //We expect a Location header to redirect to the eperson details
+                        .andExpect(header().string("Location", epersonDetail));
+    }
+
+    @Test
+    /**
+     * Test the proper redirection of an eperson's uuid
+     *
+     * @throws Exception
+     */
+    public void testGroupUUID() throws Exception {
+        // We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        Group group = GroupBuilder.createGroup(context)
+                .withName("Test Group")
+                .build();
+
+        context.restoreAuthSystemState();
+
+        String uuid = group.getID().toString();
+        String groupDetail = REST_SERVER_URL + "eperson/groups/" + uuid;
+
+        getClient().perform(get("/api/dso/find?uuid={uuid}",uuid))
+                        .andExpect(status().isFound())
+                        //We expect a Location header to redirect to the group details
+                        .andExpect(header().string("Location", groupDetail));
     }
 
     @Test


### PR DESCRIPTION
This is a revision of #2176 to use a DSpaceObjectService to lookup for the UUID instead than SOLR merging the approach of #2176 with the original one in #2125 