### PR TITLE
DS-3994 Authority ID & Confidence during CSV batch import not respected

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -1173,7 +1173,7 @@ public class MetadataImport
      */
     private static boolean isAuthorityControlledField(String md)
     {
-        String mdf = StringUtils.substringAfter(md, ":");
+        String mdf = md.contains(":") ? StringUtils.substringAfter(md, ":") : md;
         mdf = StringUtils.substringBefore(mdf, "[");
         return authorityControlled.contains(mdf);
     }


### PR DESCRIPTION
Fixes #7341 
JIRA Post:

Issue: Providing authority ID and confidence during CSV batch import was not being respected.

Given CSV input: [https://pastebin.com/z4hnGWBC](https://pastebin.com/z4hnGWBC)

We can create cases where authority ID and confidence are not being respected.

See:

[https://github.com/DSpace/DSpace/blob/master/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java#L1041](https://github.com/DSpace/DSpace/blob/master/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java#L1041
)
Should be replaced with something more like:

`String mdf = md.contains(":") ? StringUtils.substringAfter(md, ":") : md;
`
(Credit: to Chris Herron)