### PR TITLE
DS-3658 Configure ReindexerThread disable reindex

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -1244,14 +1244,13 @@ public class DatabaseUtils
      * <P>
      * Because the DB migration may be initialized by commandline or any one of
      * the many DSpace webapps, this checks for the existence of a temporary
-     * file to know when Discovery/Solr needs reindexing.
-     * @return whether reindex flag is true/false
+     * file, and the discovery.autoReindex setting to know when Discovery/Solr needs reindexing.
+     * @return whether reindexing should happen.
      */
     public static boolean getReindexDiscovery()
     {
-        // Simply check if the flag file exists
-        File reindexFlag = new File(reindexDiscoveryFilePath);
-        return reindexFlag.exists();
+        boolean autoReindex = DSpaceServicesFactory.getInstance().getConfigurationService().getBooleanProperty("discovery.autoReindex", true);
+        return (autoReindex && new File(reindexDiscoveryFilePath).exists());
     }
 
     /**

--- a/dspace/config/modules/discovery.cfg
+++ b/dspace/config/modules/discovery.cfg
@@ -22,3 +22,5 @@ discovery.index.projection=dc.title,dc.contributor.*,dc.date.issued
 # 1) you need to set the DiscoverySearchRequestProcessor in the dspace.cfg 
 # 2) to show facet on Site/Community/etc. you need to add a Site/Community/Collection
 #	 Processors plugin in the dspace.cfg
+
+#discovery.autoReindex = false

--- a/dspace/config/modules/discovery.cfg
+++ b/dspace/config/modules/discovery.cfg
@@ -23,4 +23,6 @@ discovery.index.projection=dc.title,dc.contributor.*,dc.date.issued
 # 2) to show facet on Site/Community/etc. you need to add a Site/Community/Collection
 #	 Processors plugin in the dspace.cfg
 
-#discovery.autoReindex = false
+#Allow auto-reindexing
+#Defaults to true: auto-reindexing is enabled
+#discovery.autoReindex = true

--- a/dspace/config/modules/discovery.cfg
+++ b/dspace/config/modules/discovery.cfg
@@ -23,6 +23,9 @@ discovery.index.projection=dc.title,dc.contributor.*,dc.date.issued
 # 2) to show facet on Site/Community/etc. you need to add a Site/Community/Collection
 #	 Processors plugin in the dspace.cfg
 
-#Allow auto-reindexing
-#Defaults to true: auto-reindexing is enabled
+# Allow auto-reindexing
+# When enabled, if any database migrations are applied to your database (via Flyway), then a reindex flag 
+# is written to [dspace]/solr/search/conf/reindex.flag. Whenever the DSpace webapp is (re)started, it checks
+# for the existence of that file. If found, a background reindex of all content is triggered in Discovery.
+# Defaults to true: auto-reindexing is enabled.
 #discovery.autoReindex = true


### PR DESCRIPTION
In response to: https://jira.duraspace.org/browse/DS-3658

This contribution wraps the automatic invocation of the ReindexerThread with a configurable property. Effectively allowing the user to configure the automatic triggering of the ReindexerThread.