### PR TITLE
DS-3995 Add option to IndexClient to disable indexing of Fulltext

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -1418,7 +1418,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
         // write the index and close the inputstreamreaders
         try {
-            writeDocument(doc, new FullTextContentStreams(context, item));
+            writeDocument(doc, IndexClient.FULLTEXT ? new FullTextContentStreams(context, item) : null);
             log.info("Wrote Item: " + handle + " to Index");
         } catch (RuntimeException e)
         {


### PR DESCRIPTION
From JIRA: https://jira.duraspace.org/browse/DS-3995
Fixes #7342

Indexing an item's Fulltext can be an expensive process when iterating over a large number of items. This contribution simply allows the user to not index the Fulltext portion.