### PR TITLE
[DS-3991] made sure that the halbrowser now correctly downloads files

### DIFF
--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/BitstreamContentRestController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/BitstreamContentRestController.java
@@ -27,6 +27,7 @@ import org.dspace.content.BitstreamFormat;
 import org.dspace.content.service.BitstreamService;
 import org.dspace.core.Context;
 import org.dspace.disseminate.service.CitationDocumentService;
+import org.dspace.services.ConfigurationService;
 import org.dspace.services.EventService;
 import org.dspace.usage.UsageEvent;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -70,6 +71,9 @@ public class BitstreamContentRestController {
     @Autowired
     private CitationDocumentService citationDocumentService;
 
+    @Autowired
+    private ConfigurationService configurationService;
+
     @PreAuthorize("hasPermission(#uuid, 'BITSTREAM', 'READ')")
     @RequestMapping(method = {RequestMethod.GET, RequestMethod.HEAD})
     public void retrieve(@PathVariable UUID uuid, HttpServletResponse response,
@@ -103,6 +107,12 @@ public class BitstreamContentRestController {
                     .withLastModified(lastModified)
                     .with(request)
                     .with(response);
+
+            //Determine if we need to send the file as a download or if the browser can open it inline
+            long dispositionThreshold = configurationService.getLongProperty("webui.content_disposition_threshold");
+            if (dispositionThreshold >= 0 && bitstreamTuple.getRight() > dispositionThreshold) {
+                sender.withDisposition(MultipartFileSender.CONTENT_DISPOSITION_ATTACHMENT);
+            }
 
             if (sender.isNoRangeRequest() && isNotAnErrorResponse(response)) {
                 //We only log a download request when serving a request without Range header. This is because

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/MultipartFileSender.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/MultipartFileSender.java
@@ -193,6 +193,9 @@ public class MultipartFileSender {
                 log.debug("Return full file");
                 response.setContentType(contentType);
                 response.setHeader(CONTENT_LENGTH, String.valueOf(length));
+                if (length > 10000) {
+                    response.setHeader(CONTENT_DISPOSITION, String.format(CONTENT_DISPOSITION_FORMAT, CONTENT_DISPOSITION_ATTACHMENT, fileName));
+                }
                 Range.copy(inputStream, output, length, 0, length, bufferSize);
 
             } else if (ranges.size() == 1) {

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/MultipartFileSender.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/MultipartFileSender.java
@@ -41,8 +41,8 @@ public class MultipartFileSender {
     private static final String MULTIPART_BOUNDARY = "MULTIPART_BYTERANGES";
     private static final String CONTENT_TYPE_MULTITYPE_WITH_BOUNDARY = "multipart/byteranges; boundary=" +
         MULTIPART_BOUNDARY;
-    private static final String CONTENT_DISPOSITION_INLINE = "inline";
-    private static final String CONTENT_DISPOSITION_ATTACHMENT = "attachment";
+    public static final String CONTENT_DISPOSITION_INLINE = "inline";
+    public static final String CONTENT_DISPOSITION_ATTACHMENT = "attachment";
     private static final String IF_NONE_MATCH = "If-None-Match";
     private static final String IF_MODIFIED_SINCE = "If-Modified-Since";
     private static final String ETAG = "ETag";
@@ -134,6 +134,10 @@ public class MultipartFileSender {
         }
         return this;
     }
+    public MultipartFileSender withDisposition(String contentDisposition) {
+        this.disposition = contentDisposition;
+        return this;
+    }
 
     public void serveResource() throws IOException {
 
@@ -172,9 +176,9 @@ public class MultipartFileSender {
                     CONTENT_DISPOSITION_ATTACHMENT;
             }
 
-            response.setHeader(CONTENT_DISPOSITION, String.format(CONTENT_DISPOSITION_FORMAT, disposition, fileName));
-            log.debug("Content-Disposition : {}", disposition);
         }
+        response.setHeader(CONTENT_DISPOSITION, String.format(CONTENT_DISPOSITION_FORMAT, disposition, fileName));
+        log.debug("Content-Disposition : {}", disposition);
 
         // Content phase
         if (METHOD_HEAD.equals(request.getMethod())) {
@@ -193,9 +197,6 @@ public class MultipartFileSender {
                 log.debug("Return full file");
                 response.setContentType(contentType);
                 response.setHeader(CONTENT_LENGTH, String.valueOf(length));
-                if (length > 10000) {
-                    response.setHeader(CONTENT_DISPOSITION, String.format(CONTENT_DISPOSITION_FORMAT, CONTENT_DISPOSITION_ATTACHMENT, fileName));
-                }
                 Range.copy(inputStream, output, length, 0, length, bufferSize);
 
             } else if (ranges.size() == 1) {

--- a/dspace-spring-rest/src/main/webapp/js/hal/http/client.js
+++ b/dspace-spring-rest/src/main/webapp/js/hal/http/client.js
@@ -36,7 +36,7 @@ function downloadFile(url) {
             // Try to find out the filename from the content disposition `filename` value
             var disposition = request.getResponseHeader('content-disposition');
             var matches = /"([^"]*)"/.exec(disposition);
-            var filename = (matches != null && matches[1] ? matches[1] : 'file.pdf');
+            var filename = (matches != null && matches[1] ? matches[1] : 'content');
             // The actual download
             var contentTypeHeader = request.getResponseHeader("content-type");
             if (contentTypeHeader === undefined || contentTypeHeader === "") {

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1368,7 +1368,6 @@ websvc.opensearch.formats = html,atom,rss
 # The 'webui.*' setting is for the JSPUI, and
 # the 'xmlui.*' setting is for the XMLUI
 webui.content_disposition_threshold = 8388608
-xmlui.content_disposition_threshold = 8388608
 
 
 #### Multi-file HTML document/site settings #####


### PR DESCRIPTION
Implemented a fix that allows the HAL browser to properly download files when trying to access the content of a bitstream through the BitstreamContentRestController.

Related jira ticket: https://jira.duraspace.org/browse/DS-3991