### PR TITLE
DS-3916 /api/config/submissiondefinitions/traditional/collections should return empty list rather than 204

### DIFF
--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -742,9 +742,9 @@ public class RestResourceController implements InitializingBean {
             int start = page.getOffset();
             int end = (start + page.getPageSize()) > fullList.size() ? fullList.size() : (start + page.getPageSize());
             DSpaceRestRepository<RestAddressableModel, ?> resourceRepository = utils
-                .getResourceRepository(fullList.get(0).getCategory(), fullList.get(0).getType());
+                    .getResourceRepository(fullList.get(0).getCategory(), fullList.get(0).getType());
             PageImpl<RestAddressableModel> pageResult = new PageImpl(fullList.subList(start, end), page,
-                                                                     fullList.size());
+                    fullList.size());
             result = assembler.toResource(pageResult.map(resourceRepository::wrapResource));
 
             for (Resource subObj : result) {
@@ -757,14 +757,18 @@ public class RestResourceController implements InitializingBean {
 
         } else {
             if (resource.getEmbeddedResources().get(rel) == null) {
-                response.setStatus(HttpServletResponse.SC_OK);
-                return new ResourceSupport();
-            } else {
-                return (ResourceSupport) resource.getEmbeddedResources().get(rel);
+                if (model.equals("submissiondefinitions")) {
+                    response.setStatus(HttpServletResponse.SC_OK);
+                    return new ResourceSupport();
+                } else {
+                    response.setStatus(HttpServletResponse.SC_NO_CONTENT);
+                }
             }
         }
-
+        
+        return (ResourceSupport) resource.getEmbeddedResources().get(rel);
     }
+
 
     /**
      * Find all

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -757,10 +757,11 @@ public class RestResourceController implements InitializingBean {
 
         } else {
             if (resource.getEmbeddedResources().get(rel) == null) {
-                response.setStatus(HttpServletResponse.SC_NO_CONTENT);
+                response.setStatus(HttpServletResponse.SC_OK);
+                return new ResourceSupport();
+            } else {
+                return (ResourceSupport) resource.getEmbeddedResources().get(rel);
             }
-
-            return (ResourceSupport) resource.getEmbeddedResources().get(rel);
         }
 
     }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -765,7 +765,6 @@ public class RestResourceController implements InitializingBean {
                 }
             }
         }
-        
         return (ResourceSupport) resource.getEmbeddedResources().get(rel);
     }
 

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
@@ -130,9 +130,9 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
         //Match only that a section exists with a submission configuration behind
         getClient(token).perform(get("/api/config/submissiondefinitions/traditional/collections"))
                    //TODO - this method should return an empty page
-                   .andExpect(status().isNoContent());
+                   //.andExpect(status().isNoContent());
                    //this is the expected result
-                   //.andExpect(status().isOk())
+                   .andExpect(status().isOk());
                    //.andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3916
/api/config/submissiondefinitions/traditional/collections returns 200/empty list instead of 204/null.

I'm not sure if this is where you were going with your comment, but hopefully we can start a discussion with this proposed solution.