### PR TITLE
DS-3996 The "first few letters" search was fixed

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ConfigurableBrowse.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ConfigurableBrowse.java
@@ -412,7 +412,9 @@ public class ConfigurableBrowse extends AbstractDSpaceTransformer implements
         // Add all the query parameters as hidden fields on the form
         for (Map.Entry<String, String> param : queryParamsPOST.entrySet())
         {
-            jump.addHidden(param.getKey()).setValue(param.getValue());
+            //Not necessary to hide the start-with param because it's added later
+            if (param.getKey() != BrowseParams.STARTS_WITH)
+                jump.addHidden(param.getKey()).setValue(param.getValue());
         }
 
         // If this is a date based browse, render the date navigation


### PR DESCRIPTION
The problem was that a hidden parameter was added to the browse in order to fix another bug (DS-2675).
That parameter has the same name of the one used in the "first few letters" search input, so the form has the same field name twice which generates an inconsistency.

The whole issue is described here: https://jira.duraspace.org/browse/DS-3996