### PR TITLE
[DS-3997] Set encoding of ORCID search path to UTF-8

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authority/orcid/Orcidv2.java
+++ b/dspace-api/src/main/java/org/dspace/authority/orcid/Orcidv2.java
@@ -156,13 +156,17 @@ public class Orcidv2 implements SolrAuthorityInterface {
         if (rows > 100) {
             throw new IllegalArgumentException("The maximum number of results to retrieve cannot exceed 100.");
         }
-
-        String searchPath = "search?q=" + URLEncoder.encode(text, "UTF-8") + "&start=" + start + "&rows=" + rows;
-        log.debug("queryBio searchPath=" + searchPath + " accessToken=" + accessToken);
-        InputStream bioDocument = restConnector.get(searchPath, accessToken);
-        XMLtoBio converter = new XMLtoBio();
-        List<Person> bios = converter.convert(bioDocument);
-        return bios;
+        try {
+            String searchPath = "search?q=" + URLEncoder.encode(text, "UTF-8") + "&start=" + start + "&rows=" + rows;
+            log.debug("queryBio searchPath=" + searchPath + " accessToken=" + accessToken);
+            InputStream bioDocument = restConnector.get(searchPath, accessToken);
+            XMLtoBio converter = new XMLtoBio();
+            List<Person> bios = converter.convert(bioDocument);
+            return bios;
+        } catch (UnsupportedEncodingException e) {
+			log.error(e.getMessage());
+		}
+		return null;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/authority/orcid/Orcidv2.java
+++ b/dspace-api/src/main/java/org/dspace/authority/orcid/Orcidv2.java
@@ -157,7 +157,7 @@ public class Orcidv2 implements SolrAuthorityInterface {
             throw new IllegalArgumentException("The maximum number of results to retrieve cannot exceed 100.");
         }
 
-        String searchPath = "search?q=" + URLEncoder.encode(text) + "&start=" + start + "&rows=" + rows;
+        String searchPath = "search?q=" + URLEncoder.encode(text, "UTF-8") + "&start=" + start + "&rows=" + rows;
         log.debug("queryBio searchPath=" + searchPath + " accessToken=" + accessToken);
         InputStream bioDocument = restConnector.get(searchPath, accessToken);
         XMLtoBio converter = new XMLtoBio();

--- a/dspace-api/src/main/java/org/dspace/authority/orcid/Orcidv2.java
+++ b/dspace-api/src/main/java/org/dspace/authority/orcid/Orcidv2.java
@@ -24,6 +24,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
Problem described in DS-3997. The search path for ORCID should use UTF-8 encoding.

https://jira.duraspace.org/browse/DS-3997

Fixes #7344