### PR TITLE
[DS-3999] save orcid info into item metadata

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authority/orcid/Orcidv2AuthorityValue.java
+++ b/dspace-api/src/main/java/org/dspace/authority/orcid/Orcidv2AuthorityValue.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.authority.orcid;
 
+import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrInputDocument;
@@ -149,6 +150,25 @@ public class Orcidv2AuthorityValue extends PersonAuthorityValue {
 
     }
 
+    /**
+     * set value including orcid information in metadata from solr document 
+     */
+    @Override
+    public void setValues(SolrDocument document) {
+        super.setValues(document);
+        this.setOrcid_id(ObjectUtils.toString(document.getFieldValue("orcid_id")));
+		for (String fieldName : document.getFieldNames()) {
+			String labelPrefix = "label_";
+			if (fieldName.startsWith(labelPrefix)) {
+				String label = fieldName.substring(labelPrefix.length());
+				Collection<Object> fieldValues = document.getFieldValues(fieldName);
+				for (Object o : fieldValues) {
+					addOtherMetadata(label,String.valueOf(o));
+				}
+			}
+		}
+    }
+    
     /**
      * Makes an instance of the AuthorityValue with the given information.
      * @param info string info


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3999

After running script index-authority, authority index is overwritten and all orcid relevant information is missing. The reason is that the orcid info (for example orcid_id, label_*) don't save in item metadata at moment. 
It can also explain why I don't find the author with orcid (non-italic) in solr section of lookup list every time, althrough I already choosed it last time.