### PR TITLE
DS-4000: REST API (v5.9) does not run

### DIFF
--- a/dspace-rest/pom.xml
+++ b/dspace-rest/pom.xml
@@ -103,6 +103,12 @@
         <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>dspace-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>jersey-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Connecting to DSpace datasource sets a dependency on Postgres DB-->

--- a/dspace/modules/rest/pom.xml
+++ b/dspace/modules/rest/pom.xml
@@ -88,6 +88,12 @@
         <dependency>
             <groupId>org.dspace.modules</groupId>
             <artifactId>additions</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>jersey-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- DSpace REST Webapp -->


### PR DESCRIPTION
This is a pull request for issue https://jira.duraspace.org/browse/DS-4000.

This issue seems to be caused by a conflict in Jersey versions in the DSpace-rest module. 

The DSpace-api module has a dependency on Jersey 2.22.1: 
https://github.com/DSpace/DSpace/blob/dspace-5_x/dspace-api/pom.xml#L659

While the DSpace-rest module has a dependency on Jersey 1.19:
https://github.com/DSpace/DSpace/blob/dspace-5_x/dspace-rest/pom.xml#L39

Since the DSpace-rest module is dependant on the DSpace-api module, both Jersey versions end up in the DSpace-rest module. The solution I suggest here is to exclude the Jersey 2 dependency from the DSpace-rest module. 