### PR TITLE
DS-3921 Now an item from workflow overview can be deleted

### DIFF
--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/service/XmlWorkflowService.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/service/XmlWorkflowService.java
@@ -65,4 +65,6 @@ public interface XmlWorkflowService extends WorkflowService<XmlWorkflowItem> {
     public void removeUserItemPolicies(Context context, Item item, EPerson e) throws SQLException, AuthorizeException;
 
     public String getEPersonName(EPerson ePerson);
+
+    public void sendWorkflowItemDelete(Context c, XmlWorkflowItem wi) throws AuthorizeException, SQLException, IOException;
 }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/xmlworkflow/admin/DeleteWorkflowItemsAction.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/xmlworkflow/admin/DeleteWorkflowItemsAction.java
@@ -25,6 +25,7 @@ import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Context;
 import org.dspace.xmlworkflow.XmlWorkflowServiceImpl;
 import org.dspace.xmlworkflow.factory.XmlWorkflowServiceFactory;
+import org.dspace.xmlworkflow.service.WorkflowRequirementsService;
 import org.dspace.xmlworkflow.service.XmlWorkflowService;
 import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 import org.dspace.xmlworkflow.storedcomponents.service.XmlWorkflowItemService;
@@ -56,13 +57,16 @@ public class DeleteWorkflowItemsAction extends AbstractAction {
         }
 
         int[] workflowIdentifiers = Util.getIntParameters(request, "workflow_id");
+        WorkflowRequirementsService workflowRequirementsService=XmlWorkflowServiceFactory.getInstance().getWorkflowRequirementsService();
+
         if(workflowIdentifiers != null){
             for (int workflowIdentifier : workflowIdentifiers) {
                 XmlWorkflowItem workflowItem = xmlWorkflowItemService.find(context, workflowIdentifier);
                 if (workflowItem != null) {
-                    WorkspaceItem workspaceItem = xmlWorkflowService.sendWorkflowItemBackSubmission(context, workflowItem, context.getCurrentUser(), "Item sent back to the submisson process by admin", null);
-                    //Delete the workspaceItem
-                    workspaceItemService.deleteAll(context, workspaceItem);
+                    //Remove references from 'cwf_in_progress_user'
+                    workflowRequirementsService.clearInProgressUsers(context, workflowItem);
+                    //Delete workflow item
+                    xmlWorkflowItemService.delete(context, workflowItem);
                 }
             }
         }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/xmlworkflow/admin/DeleteWorkflowItemsAction.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/xmlworkflow/admin/DeleteWorkflowItemsAction.java
@@ -45,7 +45,6 @@ public class DeleteWorkflowItemsAction extends AbstractAction {
     protected AuthorizeService authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();
     protected XmlWorkflowService xmlWorkflowService = XmlWorkflowServiceFactory.getInstance().getXmlWorkflowService();
     protected XmlWorkflowItemService xmlWorkflowItemService = XmlWorkflowServiceFactory.getInstance().getXmlWorkflowItemService();
-    protected WorkspaceItemService workspaceItemService = ContentServiceFactory.getInstance().getWorkspaceItemService();
 
 
     @Override
@@ -63,10 +62,7 @@ public class DeleteWorkflowItemsAction extends AbstractAction {
             for (int workflowIdentifier : workflowIdentifiers) {
                 XmlWorkflowItem workflowItem = xmlWorkflowItemService.find(context, workflowIdentifier);
                 if (workflowItem != null) {
-                    //Remove references from 'cwf_in_progress_user'
-                    workflowRequirementsService.clearInProgressUsers(context, workflowItem);
-                    //Delete workflow item
-                    xmlWorkflowItemService.delete(context, workflowItem);
+                    xmlWorkflowService.sendWorkflowItemDelete(context,workflowItem);
                 }
             }
         }

--- a/dspace/config/emails/submit_delete
+++ b/dspace/config/emails/submit_delete
@@ -1,0 +1,15 @@
+# Deletion email message
+#
+# {0}  Title of submission
+# {1}  Name of collection
+#
+Subject: DSpace: Submission Deleted
+
+You submitted: {0}
+
+To collection: {1}
+
+Your submission has been deleted by a system administrator
+
+
+DSpace


### PR DESCRIPTION
The problem was that sending back the item to the submitter and right after that delete the workspace item, generates an inconsistency
There was no need in sending the item back to submitter, as the item was going to be deleted anyway. Now the workflow item is directly removed

The whole issue is described here: https://jira.duraspace.org/browse/DS-3921

Fixes #7268