### PR TITLE
DS-4008: fix indexing problems with solr

### DIFF
--- a/dspace/solr/search/conf/schema.xml
+++ b/dspace/solr/search/conf/schema.xml
@@ -451,6 +451,10 @@
             <!--Treats the entire field as a single token, regardless of its content-->
             <tokenizer class="solr.KeywordTokenizerFactory"/>
 
+            <!-- Underlying lucene index has a 32kb hard limit, so truncate long fields, so item will not be left unindexed -->
+            <!-- issue: https://issues.apache.org/jira/browse/LUCENE-5472 -->
+            <filter class="solr.LengthFilterFactory" min="0" max="7000"/>
+
             <!--<filter class="solr.LowerCaseFilterFactory" />-->
             <filter class="solr.TrimFilterFactory" />
         </analyzer>

--- a/dspace/solr/search/conf/solrconfig.xml
+++ b/dspace/solr/search/conf/solrconfig.xml
@@ -1016,11 +1016,11 @@
          updateRequestProcessorChains that can be used by name 
          on each Update Request
       -->
-    <!--
-       <lst name="defaults">
-         <str name="update.chain">dedupe</str>
-       </lst>
-       -->
+      <lst name="defaults">
+        <!-- Underlying lucene index has a 32kb hard limit, so truncate long fields, so item will not be left unindexed -->
+        <!-- issue: https://issues.apache.org/jira/browse/LUCENE-5472 -->
+        <str name="update.chain">truncateChain</str>
+      </lst>
   </requestHandler>
 
   <!-- for back compat with clients using /update/json and /update/csv -->  
@@ -1829,6 +1829,16 @@
       <processor class="solr.RunUpdateProcessorFactory" />
     </updateRequestProcessorChain>
   -->
+
+  <!-- Truncate a field if it exceeds 7k chars -->
+  <updateRequestProcessorChain name="truncateChain">
+    <processor class="solr.TruncateFieldUpdateProcessorFactory">
+      <str name="typeClass">solr.TextField</str>
+      <int name="maxLength">7000</int>
+    </processor>
+    <processor class="solr.LogUpdateProcessorFactory"/>
+    <processor class="solr.RunUpdateProcessorFactory"/>
+  </updateRequestProcessorChain>
  
   <!-- Response Writers
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-4008
Fixes #7355

Solr's underlying Lucene index has hardcoded 32kb limit to terms ([LUCENE-5472](https://issues.apache.org/jira/browse/LUCENE-5472)), and if it is exceeded solr produces following exceptions:` ERROR org.apache.solr.core.SolrCore @ org.apache.solr.common.SolrException: Exception writing document id <id> to the index; possible analysis error.`

`Caused by: java.lang.IllegalArgumentException: Document contains at least one immense term in field="abstract_and_notification_and_subject_ac" (whose UTF8 encoding is longer than the max length 32766), all of which were skipped.  Please correct the analyzer to not produce such terms.  The prefix of the first immense term is: '[...]...', original message: bytes can be at most 32766 in length; got 38285`

This leaves the item unindexed from solr. 

This commit adds truncateChain and added lengthfilter to the keywordfilter analyzer, with this the item will be indexed and discoverable, but fields will only be indexed up to 7000 characters.
