### PR TITLE
[DS-3664] ImageMagick: Only execute "identify" on first page

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
@@ -140,7 +140,7 @@ public abstract class ImageMagickThumbnailFilter extends MediaFilter {
                 // PDFs using the CMYK color system can be handled specially if
                 // profiles are defined
                 if (cmyk_profile != null && srgb_profile != null) {
-                        Info imageInfo = new Info(f.getAbsolutePath(), true);
+                        Info imageInfo = new Info(f.getAbsolutePath() + s, true);
                         String imageClass = imageInfo.getImageClass();
                         if (imageClass.contains("CMYK")) {
                                 op.profile(cmyk_profile);


### PR DESCRIPTION
The Info object used to get the color format runs "identify" on the supplied
input file. If the file has many pages, this process might require some time.
"identify" supports the same syntax for the input file like the other
ImageMagick tools and we can simply restrict the pages by changing the input
file name.

This fixes DS-3664. This is the dspace-5_x port of #2201.