### PR TITLE
[DS-4010] Removed the escaping on the query parameter for the discove…

### DIFF
--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
@@ -10,7 +10,6 @@ package org.dspace.app.rest;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import javax.ws.rs.BadRequestException;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
@@ -35,8 +34,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.ResourceSupport;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -146,12 +143,8 @@ public class DiscoveryRestController implements InitializingBean {
 
         //Get the Search results in JSON format
         SearchResultsRest searchResultsRest = null;
-        try {
-            searchResultsRest = discoveryRestRepository
-                .getSearchObjects(query, dsoType, dsoScope, configurationName, searchFilters, page);
-        } catch (BadRequestException badRequestException) {
-            new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
+        searchResultsRest = discoveryRestRepository
+            .getSearchObjects(query, dsoType, dsoScope, configurationName, searchFilters, page);
 
         //Convert the Search JSON results to paginated HAL resources
         SearchResultsResource searchResultsResource = new SearchResultsResource(searchResultsRest, utils, page);

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
@@ -10,6 +10,7 @@ package org.dspace.app.rest;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import javax.ws.rs.BadRequestException;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
@@ -34,6 +35,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.ResourceSupport;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -142,8 +145,13 @@ public class DiscoveryRestController implements InitializingBean {
         }
 
         //Get the Search results in JSON format
-        SearchResultsRest searchResultsRest = discoveryRestRepository
-            .getSearchObjects(query, dsoType, dsoScope, configurationName, searchFilters, page);
+        SearchResultsRest searchResultsRest = null;
+        try {
+            searchResultsRest = discoveryRestRepository
+                .getSearchObjects(query, dsoType, dsoScope, configurationName, searchFilters, page);
+        } catch (BadRequestException badRequestException) {
+            new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
 
         //Convert the Search JSON results to paginated HAL resources
         SearchResultsResource searchResultsResource = new SearchResultsResource(searchResultsRest, utils, page);

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
@@ -10,6 +10,7 @@ package org.dspace.app.rest;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import javax.ws.rs.BadRequestException;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
@@ -34,6 +35,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.ResourceSupport;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -143,8 +146,12 @@ public class DiscoveryRestController implements InitializingBean {
 
         //Get the Search results in JSON format
         SearchResultsRest searchResultsRest = null;
-        searchResultsRest = discoveryRestRepository
-            .getSearchObjects(query, dsoType, dsoScope, configurationName, searchFilters, page);
+        try {
+            searchResultsRest = discoveryRestRepository
+                .getSearchObjects(query, dsoType, dsoScope, configurationName, searchFilters, page);
+        } catch (BadRequestException badRequestException) {
+            new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
 
         //Convert the Search JSON results to paginated HAL resources
         SearchResultsResource searchResultsResource = new SearchResultsResource(searchResultsRest, utils, page);

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -20,6 +20,7 @@ import org.dspace.authorize.AuthorizeException;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.repository.support.QueryMethodParameterConversionException;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -38,6 +39,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
  */
 @ControllerAdvice
 public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionHandler {
+
     @Autowired
     private RestAuthenticationService restAuthenticationService;
 
@@ -49,6 +51,12 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
         } else {
             sendErrorResponse(request, response, ex, ex.getMessage(), HttpServletResponse.SC_UNAUTHORIZED);
         }
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    protected void handleIllegalArgumentException(HttpServletRequest request, HttpServletResponse response,
+                                                  Exception ex) throws IOException {
+        sendErrorResponse(request, response, ex, ex.getMessage(), HttpServletResponse.SC_BAD_REQUEST);
     }
 
     @ExceptionHandler(SQLException.class)

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -20,7 +20,6 @@ import org.dspace.authorize.AuthorizeException;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.repository.support.QueryMethodParameterConversionException;
-import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -39,7 +38,6 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
  */
 @ControllerAdvice
 public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionHandler {
-
     @Autowired
     private RestAuthenticationService restAuthenticationService;
 
@@ -51,12 +49,6 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
         } else {
             sendErrorResponse(request, response, ex, ex.getMessage(), HttpServletResponse.SC_UNAUTHORIZED);
         }
-    }
-
-    @ExceptionHandler(IllegalArgumentException.class)
-    protected void handleIllegalArgumentException(HttpServletRequest request, HttpServletResponse response,
-                                                  Exception ex) throws IOException {
-        sendErrorResponse(request, response, ex, ex.getMessage(), HttpServletResponse.SC_BAD_REQUEST);
     }
 
     @ExceptionHandler(SQLException.class)

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -20,7 +20,6 @@ import org.dspace.authorize.AuthorizeException;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.repository.support.QueryMethodParameterConversionException;
-import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
@@ -110,7 +110,7 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
 
         } catch (SearchServiceException e) {
             log.error("Error while searching with Discovery", e);
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("Error while searching with Discovery: " + e.getMessage());
         }
 
         return discoverResultConverter

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
@@ -110,7 +110,7 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
 
         } catch (SearchServiceException e) {
             log.error("Error while searching with Discovery", e);
-            throw new IllegalArgumentException();
+            throw new BadRequestException();
         }
 
         return discoverResultConverter

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
@@ -9,6 +9,8 @@ package org.dspace.app.rest.repository;
 
 import java.util.List;
 
+import javax.ws.rs.BadRequestException;
+
 import org.apache.log4j.Logger;
 import org.dspace.app.rest.converter.DiscoverConfigurationConverter;
 import org.dspace.app.rest.converter.DiscoverFacetConfigurationConverter;
@@ -91,7 +93,7 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
     public SearchResultsRest getSearchObjects(final String query, final String dsoType, final String dsoScope,
                                               final String configurationName,
                                               final List<SearchFilter> searchFilters, final Pageable page)
-            throws InvalidRequestException {
+            throws InvalidRequestException, BadRequestException {
         Context context = obtainContext();
 
         DSpaceObject scopeObject = scopeResolver.resolveScope(context, dsoScope);
@@ -108,6 +110,7 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
 
         } catch (SearchServiceException e) {
             log.error("Error while searching with Discovery", e);
+            throw new BadRequestException();
         }
 
         return discoverResultConverter

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
@@ -110,7 +110,7 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
 
         } catch (SearchServiceException e) {
             log.error("Error while searching with Discovery", e);
-            throw new BadRequestException();
+            throw new IllegalArgumentException();
         }
 
         return discoverResultConverter

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/DiscoverQueryBuilder.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/DiscoverQueryBuilder.java
@@ -183,7 +183,7 @@ public class DiscoverQueryBuilder implements InitializingBean {
         if (StringUtils.isNotBlank(query)) {
             //Note that these quotes are needed incase we try to query OR for example.
             //If the quotes aren't present, it'll crash.
-            queryArgs.setQuery("\"" + searchService.escapeQueryChars(query) + "\"");
+            queryArgs.setQuery(query);
         }
 
         //Limit results to DSO type

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/DiscoverQueryBuilder.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/utils/DiscoverQueryBuilder.java
@@ -181,8 +181,6 @@ public class DiscoverQueryBuilder implements InitializingBean {
 
         //Set search query
         if (StringUtils.isNotBlank(query)) {
-            //Note that these quotes are needed incase we try to query OR for example.
-            //If the quotes aren't present, it'll crash.
             queryArgs.setQuery(query);
         }
 

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -2881,9 +2881,8 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                                       .withSubject("AnotherTest").withSubject("TestingForMore")
                                       .withSubject("ExtraEntry")
                                       .build();
-        //** WHEN **
         getClient().perform(get("/api/discover/search/objects")
-                                .param("query", "Faithful Infidel\\: Exploring Conformity \\(2nd edition\\)"))
+                                .param("query", "\"Faithful Infidel: Exploring Conformity (2nd edition)\""))
 
                    //** THEN **
                    //The status has to be 200 OK
@@ -2901,9 +2900,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                    )))
                    .andExpect(jsonPath("$._embedded.searchResult._embedded.objects",
                                        Matchers.not(Matchers.containsInAnyOrder(
-                       SearchResultMatcher.matchOnItemName("item", "items", "Test"),
-                       SearchResultMatcher.matchOnItemName("item", "items", "NotAProperTestTitle")
-                   ))))
+                                           SearchResultMatcher.matchOnItemName("item", "items", "Test"),
+                                           SearchResultMatcher.matchOnItemName("item", "items", "NotAProperTestTitle")
+                                       ))))
 
                    //There always needs to be a self link available
                    .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/utils/DiscoverQueryBuilderTest.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/utils/DiscoverQueryBuilderTest.java
@@ -168,7 +168,7 @@ public class DiscoverQueryBuilderTest {
                                                               Arrays.asList(searchFilter), "item", page);
 
         assertThat(discoverQuery.getFilterQueries(), containsInAnyOrder("archived:true", "subject:\"Java\""));
-        assertThat(discoverQuery.getQuery(), is("\"" + query + "\""));
+        assertThat(discoverQuery.getQuery(), is(query));
         assertThat(discoverQuery.getDSpaceObjectFilter(), is(Constants.ITEM));
         assertThat(discoverQuery.getSortField(), is("dc.title_sort"));
         assertThat(discoverQuery.getSortOrder(), is(DiscoverQuery.SORT_ORDER.asc));
@@ -293,7 +293,7 @@ public class DiscoverQueryBuilderTest {
                                                                    "subject");
 
         assertThat(discoverQuery.getFilterQueries(), containsInAnyOrder("archived:true", "subject:\"Java\""));
-        assertThat(discoverQuery.getQuery(), is("\"" + query + "\""));
+        assertThat(discoverQuery.getQuery(), is(query));
         assertThat(discoverQuery.getDSpaceObjectFilter(), is(Constants.ITEM));
         assertThat(discoverQuery.getSortField(), isEmptyOrNullString());
         assertThat(discoverQuery.getMaxResults(), is(0));


### PR DESCRIPTION
This PR removes the escaping that is done on the input from the query parameter in the discover endpoints to pull this functionality equal to previous versions of DSpace which didn't take this into account either. This fixes simple issues like not being able to query on the dc.date.issued metadata field through a query paremeter.

Related Jira ticket: https://jira.duraspace.org/browse/DS-4010