### PR TITLE
[DS-4014] added a catch in the DSpaceApiExceptionControllerAdvice for…

### DIFF
--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -102,6 +102,13 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
         return super.handleTypeMismatch(ex, headers, HttpStatus.UNPROCESSABLE_ENTITY, request);
     }
 
+    @ExceptionHandler(Exception.class)
+    protected void handleGenericException(HttpServletRequest request, HttpServletResponse response, Exception ex)
+        throws IOException {
+        sendErrorResponse(request, response, ex, "An Exception has occured",
+                          HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
     private void sendErrorResponse(final HttpServletRequest request, final HttpServletResponse response,
                                    final Exception ex, final String message, final int statusCode) throws IOException {
         //Make sure Spring picks up this exception

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -11,18 +11,21 @@ import static org.springframework.web.servlet.DispatcherServlet.EXCEPTION_ATTRIB
 
 import java.io.IOException;
 import java.sql.SQLException;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.ForbiddenException;
 
 import org.dspace.app.rest.security.RestAuthenticationService;
 import org.dspace.authorize.AuthorizeException;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.repository.support.QueryMethodParameterConversionException;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -42,7 +45,7 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
     @Autowired
     private RestAuthenticationService restAuthenticationService;
 
-    @ExceptionHandler({AuthorizeException.class, RESTAuthorizationException.class})
+    @ExceptionHandler( {AuthorizeException.class, RESTAuthorizationException.class})
     protected void handleAuthorizeException(HttpServletRequest request, HttpServletResponse response, Exception ex)
         throws IOException {
         if (restAuthenticationService.hasAuthenticationData(request)) {
@@ -73,7 +76,7 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
                           HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
     }
 
-    @ExceptionHandler({MissingParameterException.class, QueryMethodParameterConversionException.class})
+    @ExceptionHandler( {MissingParameterException.class, QueryMethodParameterConversionException.class})
     protected void ParameterConversionException(HttpServletRequest request, HttpServletResponse response, Exception ex)
         throws IOException {
 
@@ -87,18 +90,21 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
 
     @Override
     protected ResponseEntity<Object> handleMissingServletRequestParameter(MissingServletRequestParameterException ex,
-            HttpHeaders headers, HttpStatus status, WebRequest request) {
+                                                                          HttpHeaders headers, HttpStatus status,
+                                                                          WebRequest request) {
         // we want the 422 status for missing parameter as it seems to be the common behavior for REST application, see
-        // https://stackoverflow.com/questions/3050518/what-http-status-response-code-should-i-use-if-the-request-is-missing-a-required
+        // https://stackoverflow.com/questions/3050518/what-http-status-response-code-should-i-use-if-the-request-is
+        // -missing-a-required
         return super.handleMissingServletRequestParameter(ex, headers, HttpStatus.UNPROCESSABLE_ENTITY, request);
     }
 
     @Override
     protected ResponseEntity<Object> handleTypeMismatch(TypeMismatchException ex, HttpHeaders headers,
-            HttpStatus status, WebRequest request) {
+                                                        HttpStatus status, WebRequest request) {
         // we want the 422 status for type mismatch on parameters as it seems to be the common behavior for REST
         // application, see
-        // https://stackoverflow.com/questions/3050518/what-http-status-response-code-should-i-use-if-the-request-is-missing-a-required
+        // https://stackoverflow.com/questions/3050518/what-http-status-response-code-should-i-use-if-the-request-is
+        // -missing-a-required
         return super.handleTypeMismatch(ex, headers, HttpStatus.UNPROCESSABLE_ENTITY, request);
     }
 
@@ -107,6 +113,45 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
         throws IOException {
         sendErrorResponse(request, response, ex, "An Exception has occured",
                           HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler( {ResourceNotFoundException.class, RepositoryNotFoundException.class})
+    protected void handleResourceNotFoundException(HttpServletRequest request, HttpServletResponse response,
+                                                   Exception ex)
+        throws IOException {
+        sendErrorResponse(request, response, ex, "A ResourceNotFoundException has occured",
+                          HttpServletResponse.SC_NOT_FOUND);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    protected void handleAccessDeniedException(HttpServletRequest request, HttpServletResponse response,
+                                               Exception ex)
+        throws IOException {
+        sendErrorResponse(request, response, ex, "A ResourceNotFoundException has occured",
+                          HttpServletResponse.SC_UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(UnprocessableEntityException.class)
+    protected void handleUnprocessableEntityException(HttpServletRequest request, HttpServletResponse response,
+                                                      Exception ex)
+        throws IOException {
+        sendErrorResponse(request, response, ex, "An UnprocessableEntityException has occured", 422);
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    protected void handleForbiddenException(HttpServletRequest request, HttpServletResponse response,
+                                            Exception ex)
+        throws IOException {
+        sendErrorResponse(request, response, ex, "A ForbiddenException has occured", HttpServletResponse.SC_FORBIDDEN);
+    }
+
+
+    @ExceptionHandler(BadRequestException.class)
+    protected void handleBadRequestExceptionn(HttpServletRequest request, HttpServletResponse response,
+                                              Exception ex)
+        throws IOException {
+        sendErrorResponse(request, response, ex, "A BadRequestException has occured",
+                          HttpServletResponse.SC_BAD_REQUEST);
     }
 
     private void sendErrorResponse(final HttpServletRequest request, final HttpServletResponse response,

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -44,7 +44,7 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
     @Autowired
     private RestAuthenticationService restAuthenticationService;
 
-    @ExceptionHandler( {AuthorizeException.class, RESTAuthorizationException.class})
+    @ExceptionHandler({AuthorizeException.class, RESTAuthorizationException.class, AccessDeniedException.class})
     protected void handleAuthorizeException(HttpServletRequest request, HttpServletResponse response, Exception ex)
         throws IOException {
         if (restAuthenticationService.hasAuthenticationData(request)) {
@@ -118,14 +118,6 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
         }
         sendErrorResponse(request, response, ex, "An Exception has occured", returnCode);
 
-    }
-
-    @ExceptionHandler(AccessDeniedException.class)
-    protected void handleAccessDeniedException(HttpServletRequest request, HttpServletResponse response,
-                                               Exception ex)
-        throws IOException {
-        sendErrorResponse(request, response, ex, "An AccessDenied Exception has occured",
-                          HttpServletResponse.SC_UNAUTHORIZED);
     }
 
 

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
@@ -126,7 +126,7 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         String authToken = getAuthToken(eperson.getEmail(), password);
         // Access endpoint logged in as an unprivileged user
         getClient(authToken).perform(get("/api/eperson/eperson"))
-                            .andExpect(status().isForbidden());
+                            .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -242,7 +242,7 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         // Verify an unprivileged user cannot access information about a *different* user
         String epersonToken = getAuthToken(eperson.getEmail(), password);
         getClient(epersonToken).perform(get("/api/eperson/epersons/" + ePerson2.getID()))
-                               .andExpect(status().isForbidden());
+                               .andExpect(status().isUnauthorized());
 
         // Verify an unprivilegd user can access information about himself/herself
         getClient(epersonToken).perform(get("/api/eperson/epersons/" + eperson.getID()))

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
@@ -473,7 +473,6 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
                 .andExpect(status().isOk());
     }
 
-    @Ignore
     @Test
     public void deleteViolatingConstraints() throws Exception {
         // We turn off the authorization system in order to create the structure as defined below

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
@@ -42,7 +42,6 @@ import org.dspace.content.Collection;
 import org.dspace.content.Item;
 import org.dspace.eperson.EPerson;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
 
 

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
@@ -126,7 +126,7 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         String authToken = getAuthToken(eperson.getEmail(), password);
         // Access endpoint logged in as an unprivileged user
         getClient(authToken).perform(get("/api/eperson/eperson"))
-                            .andExpect(status().isUnauthorized());
+                            .andExpect(status().isForbidden());
     }
 
     @Test
@@ -242,7 +242,7 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         // Verify an unprivileged user cannot access information about a *different* user
         String epersonToken = getAuthToken(eperson.getEmail(), password);
         getClient(epersonToken).perform(get("/api/eperson/epersons/" + ePerson2.getID()))
-                               .andExpect(status().isUnauthorized());
+                               .andExpect(status().isForbidden());
 
         // Verify an unprivilegd user can access information about himself/herself
         getClient(epersonToken).perform(get("/api/eperson/epersons/" + eperson.getID()))

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/builder/EPersonBuilder.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/builder/EPersonBuilder.java
@@ -32,6 +32,11 @@ public class EPersonBuilder extends AbstractDSpaceObjectBuilder<EPerson> {
         return ePersonService;
     }
 
+    @Override
+    protected int getPriority() {
+        return 100;
+    }
+
     public EPerson build() {
         try {
             ePersonService.update(context, ePerson);


### PR DESCRIPTION
When a generic exception is thrown anywhere in the REST API backend code, the server will simply generate an error back to the user but it wouldn't contain any CORS information or extra headers.
This PR resolves this issue by adding a generic catch for an Exception in the DSpaceApiExceptionControllerAdvice class and throwing an internal server error whilst adding the CORS headers and other headers to the response so that the user still gets that information.