### PR TITLE
[DS-4036] Delete EPersons even if they are referenced

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemAuthorExtractor.java
+++ b/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemAuthorExtractor.java
@@ -19,6 +19,15 @@ import org.dspace.core.Context;
  * @author Andrea Bollini
  */
 public interface RequestItemAuthorExtractor {
-    public RequestItemAuthor getRequestItemAuthor(Context context, Item item)
-        throws SQLException;
+
+    /**
+     * Retrieve the auhtor to contact for a request copy of the give item.
+     *
+     * @param context DSpace context object
+     * @param item item to request
+     * @return An object containing name an email address to send the request to
+     *         or null if no valid email address was found.
+     * @throws SQLException if database error
+     */
+    public RequestItemAuthor getRequestItemAuthor(Context context, Item item) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemHelpdeskStrategy.java
+++ b/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemHelpdeskStrategy.java
@@ -74,8 +74,7 @@ public class RequestItemHelpdeskStrategy extends RequestItemSubmitterStrategy {
             return new RequestItemAuthor(helpdeskEPerson);
         } else {
             String helpdeskName = I18nUtil.getMessage(
-                "org.dspace.app.requestitem.RequestItemHelpdeskStrategy.helpdeskname",
-                context);
+                "org.dspace.app.requestitem.helpdeskname", context);
             return new RequestItemAuthor(helpdeskName, helpDeskEmail);
         }
     }

--- a/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemMetadataStrategy.java
+++ b/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemMetadataStrategy.java
@@ -16,6 +16,7 @@ import org.dspace.content.MetadataValue;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
 import org.dspace.core.I18nUtil;
+import org.dspace.services.factory.DSpaceServicesFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -38,6 +39,7 @@ public class RequestItemMetadataStrategy extends RequestItemSubmitterStrategy {
     @Override
     public RequestItemAuthor getRequestItemAuthor(Context context, Item item)
         throws SQLException {
+        RequestItemAuthor author = null;
         if (emailMetadata != null) {
             List<MetadataValue> vals = itemService.getMetadataByMetadataString(item, emailMetadata);
             if (vals.size() > 0) {
@@ -49,19 +51,37 @@ public class RequestItemMetadataStrategy extends RequestItemSubmitterStrategy {
                         fullname = nameVals.iterator().next().getValue();
                     }
                 }
-
                 if (StringUtils.isBlank(fullname)) {
                     fullname = I18nUtil
-                        .getMessage(
-                            "org.dspace.app.requestitem.RequestItemMetadataStrategy.unnamed",
-                            context);
+                            .getMessage(
+                                    "org.dspace.app.requestitem.RequestItemMetadataStrategy.unnamed",
+                                    context);
                 }
-                RequestItemAuthor author = new RequestItemAuthor(
-                    fullname, email);
+                author = new RequestItemAuthor(fullname, email);
                 return author;
             }
+        } else {
+            // Uses the basic strategy to look for the original submitter
+            author = super.getRequestItemAuthor(context, item);
+            // Is the author or his email  null, so get the help desk or admin name and email
+            if (null == author || null == author.getEmail()) {
+                String email = null;
+                String name = null;
+                //First get help desk name and email
+                email = DSpaceServicesFactory.getInstance()
+                        .getConfigurationService().getProperty("mail.helpdesk");
+                name = I18nUtil.getMessage("org.dspace.app.requestitem.helpdeskname", context);
+                // If help desk mail is null get the mail and name of admin
+                if (email == null) {
+                    email = DSpaceServicesFactory.getInstance()
+                            .getConfigurationService().getProperty("mail.admin");
+                    name = DSpaceServicesFactory.getInstance()
+                            .getConfigurationService().getProperty("admin.name");
+                }
+                author = new RequestItemAuthor(name, email);
+            }
         }
-        return super.getRequestItemAuthor(context, item);
+        return author;
     }
 
     public void setEmailMetadata(String emailMetadata) {

--- a/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemSubmitterStrategy.java
+++ b/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemSubmitterStrategy.java
@@ -23,13 +23,22 @@ public class RequestItemSubmitterStrategy implements RequestItemAuthorExtractor 
     public RequestItemSubmitterStrategy() {
     }
 
+    /**
+     * Returns the submitter of an Item as RequestItemAuthor or null if the
+     * Submitter is deleted.
+     *
+     * @return The submitter of the item or null if the submitter is deleted
+     * @throws SQLException if database error
+     */
     @Override
     public RequestItemAuthor getRequestItemAuthor(Context context, Item item)
         throws SQLException {
         EPerson submitter = item.getSubmitter();
-        RequestItemAuthor author = new RequestItemAuthor(
-            submitter.getFullName(), submitter.getEmail());
+        RequestItemAuthor author = null;
+        if (null != submitter) {
+            author = new RequestItemAuthor(
+                    submitter.getFullName(), submitter.getEmail());
+        }
         return author;
     }
-
 }

--- a/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
@@ -607,6 +607,12 @@ public class AuthorizeServiceImpl implements AuthorizeService {
     }
 
     @Override
+    public void removeAllEPersonPolicies(Context c, EPerson e)
+        throws SQLException, AuthorizeException {
+        resourcePolicyService.removeAllEPersonPolicies(c, e);
+    }
+
+    @Override
     public List<Group> getAuthorizedGroups(Context c, DSpaceObject o,
                                            int actionID) throws java.sql.SQLException {
         List<ResourcePolicy> policies = getPoliciesActionFilter(c, o, actionID);

--- a/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
@@ -110,6 +110,11 @@ public class ResourcePolicyServiceImpl implements ResourcePolicyService {
     }
 
     @Override
+    public List<ResourcePolicy> find(Context context, EPerson ePerson) throws SQLException {
+        return resourcePolicyDAO.findByEPerson(context, ePerson);
+    }
+
+    @Override
     public List<ResourcePolicy> findByTypeGroupActionExceptId(Context context, DSpaceObject dso, Group group,
                                                               int action, int notPolicyID)
         throws SQLException {
@@ -239,6 +244,11 @@ public class ResourcePolicyServiceImpl implements ResourcePolicyService {
         contentServiceFactory.getDSpaceObjectService(dso).updateLastModified(context, dso);
         context.restoreAuthSystemState();
 
+    }
+
+    @Override
+    public void removeAllEPersonPolicies(Context context, EPerson ePerson) throws SQLException, AuthorizeException {
+        resourcePolicyDAO.deleteAllEPersonPolicies(context, ePerson);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
@@ -32,6 +32,8 @@ public interface ResourcePolicyDAO extends GenericDAO<ResourcePolicy> {
     public List<ResourcePolicy> findByDsoAndType(Context context, DSpaceObject dSpaceObject, String type)
         throws SQLException;
 
+    public List<ResourcePolicy> findByEPerson(Context context, EPerson ePerson) throws SQLException;
+
     public List<ResourcePolicy> findByGroup(Context context, Group group) throws SQLException;
 
     public List<ResourcePolicy> findByDSoAndAction(Context context, DSpaceObject dso, int actionId) throws SQLException;
@@ -64,6 +66,8 @@ public interface ResourcePolicyDAO extends GenericDAO<ResourcePolicy> {
     public void deleteByDsoGroupPolicies(Context context, DSpaceObject dso, Group group) throws SQLException;
 
     public void deleteByDsoEPersonPolicies(Context context, DSpaceObject dso, EPerson ePerson) throws SQLException;
+
+    public void deleteAllEPersonPolicies(Context context, EPerson ePerson) throws SQLException;
 
     public void deleteByDsoAndTypeNotEqualsTo(Context c, DSpaceObject o, String type) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
@@ -61,6 +61,16 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
     }
 
     @Override
+    public List<ResourcePolicy> findByEPerson(Context context, EPerson ePerson) throws SQLException {
+        CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
+        CriteriaQuery criteriaQuery = getCriteriaQuery(criteriaBuilder, ResourcePolicy.class);
+        Root<ResourcePolicy> resourcePolicyRoot = criteriaQuery.from(ResourcePolicy.class);
+        criteriaQuery.select(resourcePolicyRoot);
+        criteriaQuery.where(criteriaBuilder.equal(resourcePolicyRoot.get(ResourcePolicy_.eperson), ePerson));
+        return list(context, criteriaQuery, false, ResourcePolicy.class, -1, -1);
+    }
+
+    @Override
     public List<ResourcePolicy> findByGroup(Context context, Group group) throws SQLException {
         CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
         CriteriaQuery criteriaQuery = getCriteriaQuery(criteriaBuilder, ResourcePolicy.class);
@@ -187,6 +197,15 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
         String queryString = "delete from ResourcePolicy where dSpaceObject= :dso AND eperson= :eperson";
         Query query = createQuery(context, queryString);
         query.setParameter("dso", dso);
+        query.setParameter("eperson", ePerson);
+        query.executeUpdate();
+
+    }
+
+    @Override
+    public void deleteAllEPersonPolicies(Context context, EPerson ePerson) throws SQLException {
+        String queryString = "delete from ResourcePolicy where eperson= :eperson";
+        Query query = createQuery(context, queryString);
         query.setParameter("eperson", ePerson);
         query.executeUpdate();
 

--- a/dspace-api/src/main/java/org/dspace/authorize/service/AuthorizeService.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/service/AuthorizeService.java
@@ -418,6 +418,16 @@ public interface AuthorizeService {
     public void removeEPersonPolicies(Context c, DSpaceObject o, EPerson e) throws SQLException, AuthorizeException;
 
     /**
+     * Removes all policies from an eperson that belong to an EPerson.
+     *
+     * @param c current context
+     * @param e the eperson
+     * @throws SQLException if there's a database problem
+     * @throws AuthorizeException if authorization error
+     */
+    public void removeAllEPersonPolicies(Context c, EPerson e) throws SQLException, AuthorizeException;
+
+    /**
      * Returns all groups authorized to perform an action on an object. Returns
      * empty array if no matches.
      *

--- a/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
@@ -38,6 +38,8 @@ public interface ResourcePolicyService extends DSpaceCRUDService<ResourcePolicy>
 
     public List<ResourcePolicy> find(Context context, Group group) throws SQLException;
 
+    public List<ResourcePolicy> find(Context c, EPerson ePerson) throws SQLException;
+
     public List<ResourcePolicy> find(Context c, EPerson e, List<Group> groups, int action, int type_id)
         throws SQLException;
 
@@ -70,6 +72,8 @@ public interface ResourcePolicyService extends DSpaceCRUDService<ResourcePolicy>
 
     public void removeDsoEPersonPolicies(Context context, DSpaceObject dso, EPerson ePerson)
         throws SQLException, AuthorizeException;
+
+    public void removeAllEPersonPolicies(Context context, EPerson ePerson) throws SQLException, AuthorizeException;
 
     public void removeGroupPolicies(Context c, Group group) throws SQLException;
 

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -215,6 +215,12 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
     }
 
     @Override
+    public Iterator<Item> findBySubmitter(Context context, EPerson eperson, boolean retrieveAllItems)
+        throws SQLException {
+        return itemDAO.findBySubmitter(context, eperson, retrieveAllItems);
+    }
+
+    @Override
     public Iterator<Item> findBySubmitterDateSorted(Context context, EPerson eperson, Integer limit)
         throws SQLException {
 

--- a/dspace-api/src/main/java/org/dspace/content/WorkspaceItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/WorkspaceItemServiceImpl.java
@@ -208,9 +208,8 @@ public class WorkspaceItemServiceImpl implements WorkspaceItemService {
          */
         Item item = workspaceItem.getItem();
         if (!authorizeService.isAdmin(context)
-            && ((context.getCurrentUser() == null) || (context
-            .getCurrentUser().getID() != item.getSubmitter()
-                                             .getID()))) {
+            && (item.getSubmitter() == null || (context.getCurrentUser() == null)
+                || (context.getCurrentUser().getID() != item.getSubmitter().getID()))) {
             // Not an admit, not the submitter
             throw new AuthorizeException("Must be an administrator or the "
                                              + "original submitter to delete a workspace item");

--- a/dspace-api/src/main/java/org/dspace/content/dao/ItemDAO.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/ItemDAO.java
@@ -46,6 +46,9 @@ public interface ItemDAO extends DSpaceObjectLegacySupportDAO<Item> {
 
     public Iterator<Item> findBySubmitter(Context context, EPerson eperson) throws SQLException;
 
+    public Iterator<Item> findBySubmitter(Context context, EPerson eperson, boolean retrieveAllItems)
+        throws SQLException;
+
     public Iterator<Item> findBySubmitter(Context context, EPerson eperson, MetadataField metadataField, int limit)
         throws SQLException;
 

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
@@ -105,6 +105,17 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
     }
 
     @Override
+    public Iterator<Item> findBySubmitter(Context context, EPerson eperson, boolean retrieveAllItems)
+        throws SQLException {
+        Query query = createQuery(context, "FROM Item WHERE submitter= :submitter");
+        if (!retrieveAllItems) {
+            return findBySubmitter(context, eperson);
+        }
+        query.setParameter("submitter", eperson);
+        return iterate(query);
+    }
+
+    @Override
     public Iterator<Item> findBySubmitter(Context context, EPerson eperson, MetadataField metadataField, int limit)
         throws SQLException {
         StringBuilder query = new StringBuilder();

--- a/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
@@ -111,6 +111,19 @@ public interface ItemService extends DSpaceObjectService<Item>, DSpaceObjectLega
         throws SQLException;
 
     /**
+     * Find all the items by a given submitter. The order is
+     * indeterminate. All items are included.
+     *
+     * @param context DSpace context object
+     * @param eperson the submitter
+     * @param retrieveAllItems flag to determine if only archive should be returned
+     * @return an iterator over the items submitted by eperson
+     * @throws SQLException if database error
+     */
+    public Iterator<Item> findBySubmitter(Context context, EPerson eperson, boolean retrieveAllItems)
+            throws SQLException;
+
+    /**
      * Retrieve the list of items submitted by eperson, ordered by recently submitted, optionally limitable
      *
      * @param context DSpace context object

--- a/dspace-api/src/main/java/org/dspace/eperson/EPersonDeletionException.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPersonDeletionException.java
@@ -9,6 +9,8 @@ package org.dspace.eperson;
 
 import java.util.List;
 
+import org.apache.commons.lang.ArrayUtils;
+
 /**
  * Exception indicating that an EPerson may not be deleted due to the presence
  * of the EPerson's ID in certain tables
@@ -33,7 +35,10 @@ public class EPersonDeletionException extends Exception {
      *                  deleted if it exists in these tables.
      */
     public EPersonDeletionException(List<String> tableList) {
-        super();
+        // this may not be the most beautiful way to print the tablenames as part or the error message.
+        // but it has to be a one liner, as the super() call must be the first statement in the constructor.
+        super("Cannot delete EPerson as it is referenced by the following database tables: "
+                + ArrayUtils.toString(tableList.toArray()));
         myTableList = tableList;
     }
 

--- a/dspace-api/src/main/java/org/dspace/eperson/EPersonDeletionException.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPersonDeletionException.java
@@ -9,7 +9,7 @@ package org.dspace.eperson;
 
 import java.util.List;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 
 /**
  * Exception indicating that an EPerson may not be deleted due to the presence

--- a/dspace-api/src/main/java/org/dspace/workflow/WorkflowService.java
+++ b/dspace-api/src/main/java/org/dspace/workflow/WorkflowService.java
@@ -80,6 +80,20 @@ public interface WorkflowService<T extends WorkflowItem> {
      */
     public WorkspaceItem abort(Context c, T wi, EPerson e) throws SQLException, AuthorizeException, IOException;
 
+    /**
+     * Deletes workflow task item in correct order.
+     *
+     * @param c  The relevant DSpace Context.
+     * @param wi The WorkflowItem that shall be deleted.
+     * @param e  Admin that deletes this workflow task and item (for logging
+     * @throws SQLException       An exception that provides information on a database access error or other errors.
+     * @throws AuthorizeException Exception indicating the current user of the context does not have permission
+     *                            to perform a particular action.
+     * @throws IOException        A general class of exceptions produced by failed or interrupted I/O operations.
+     */
+    public void deleteWorkflowByWorkflowItem(Context c, T wi, EPerson e)
+        throws SQLException, AuthorizeException, IOException;
+
     public WorkspaceItem sendWorkflowItemBackSubmission(Context c, T workflowItem, EPerson e, String provenance,
                                                         String rejection_message)
         throws SQLException, AuthorizeException, IOException;

--- a/dspace-api/src/main/java/org/dspace/workflowbasic/BasicWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/workflowbasic/BasicWorkflowServiceImpl.java
@@ -798,33 +798,38 @@ public class BasicWorkflowServiceImpl implements BasicWorkflowService {
         try {
             // Get submitter
             EPerson ep = item.getSubmitter();
-            // Get the Locale
-            Locale supportedLocale = I18nUtil.getEPersonLocale(ep);
-            Email email = Email.getEmail(I18nUtil.getEmailFilename(supportedLocale, "submit_archive"));
 
-            // Get the item handle to email to user
-            String handle = handleService.findHandle(context, item);
+            // send the notification only if the person was not deleted in the
+            // meantime between submission and archiving.
+            if (ep != null) {
+                // Get the Locale
+                Locale supportedLocale = I18nUtil.getEPersonLocale(ep);
+                Email email = Email.getEmail(I18nUtil.getEmailFilename(supportedLocale, "submit_archive"));
 
-            // Get title
-            String title = item.getName();
-            if (StringUtils.isBlank(title)) {
-                try {
-                    title = I18nUtil.getMessage("org.dspace.workflow.WorkflowManager.untitled");
-                } catch (MissingResourceException e) {
-                    title = "Untitled";
+                // Get the item handle to email to user
+                String handle = handleService.findHandle(context, item);
+
+                // Get title
+                String title = item.getName();
+                if (StringUtils.isBlank(title)) {
+                    try {
+                        title = I18nUtil.getMessage("org.dspace.workflow.WorkflowManager.untitled");
+                    } catch (MissingResourceException e) {
+                        title = "Untitled";
+                    }
                 }
+
+                email.addRecipient(ep.getEmail());
+                email.addArgument(title);
+                email.addArgument(coll.getName());
+                email.addArgument(handleService.getCanonicalForm(handle));
+
+                email.send();
             }
-
-            email.addRecipient(ep.getEmail());
-            email.addArgument(title);
-            email.addArgument(coll.getName());
-            email.addArgument(handleService.getCanonicalForm(handle));
-
-            email.send();
         } catch (MessagingException e) {
             log.warn(LogManager.getHeader(context, "notifyOfArchive",
-                                          "cannot email user; item_id=" + item.getID()
-                                              + ":  " + e.getMessage()));
+                    "cannot email user; item_id=" + item.getID()
+                    + ":  " + e.getMessage()));
         }
     }
 
@@ -866,6 +871,24 @@ public class BasicWorkflowServiceImpl implements BasicWorkflowService {
         return workspaceItem;
     }
 
+    @Override
+    public void deleteWorkflowByWorkflowItem(Context context, BasicWorkflowItem wi, EPerson e)
+        throws SQLException, AuthorizeException, IOException {
+        Item myitem = wi.getItem();
+        UUID itemID = myitem.getID();
+        Integer workflowID = wi.getID();
+        UUID collID = wi.getCollection().getID();
+        // stop workflow
+        taskListItemService.deleteByWorkflowItem(context, wi);
+        // Now remove the workflow object manually from the database
+        workflowItemService.deleteWrapper(context, wi);
+        // Now delete the item
+        itemService.delete(context, myitem);
+        log.info(LogManager.getHeader(context, "delete_workflow", "workflow_item_id="
+                + workflowID + "item_id=" + itemID
+                + "collection_id=" + collID + "eperson_id="
+                + e.getID()));
+    }
 
     @Override
     public WorkspaceItem sendWorkflowItemBackSubmission(Context context, BasicWorkflowItem workflowItem,
@@ -1047,25 +1070,30 @@ public class BasicWorkflowServiceImpl implements BasicWorkflowService {
     protected void notifyOfReject(Context context, BasicWorkflowItem workflowItem, EPerson e,
                                   String reason) {
         try {
-            // Get the item title
-            String title = getItemTitle(workflowItem);
+            // Get submitter
+            EPerson ep = workflowItem.getSubmitter();
+            // send the notification only if the person was not deleted in the meantime
+            if (ep != null) {
+                // Get the item title
+                String title = getItemTitle(workflowItem);
 
-            // Get the collection
-            Collection coll = workflowItem.getCollection();
+                // Get the collection
+                Collection coll = workflowItem.getCollection();
 
-            // Get rejector's name
-            String rejector = getEPersonName(e);
-            Locale supportedLocale = I18nUtil.getEPersonLocale(e);
-            Email email = Email.getEmail(I18nUtil.getEmailFilename(supportedLocale, "submit_reject"));
+                // Get rejector's name
+                String rejector = getEPersonName(e);
+                Locale supportedLocale = I18nUtil.getEPersonLocale(e);
+                Email email = Email.getEmail(I18nUtil.getEmailFilename(supportedLocale, "submit_reject"));
 
-            email.addRecipient(workflowItem.getSubmitter().getEmail());
-            email.addArgument(title);
-            email.addArgument(coll.getName());
-            email.addArgument(rejector);
-            email.addArgument(reason);
-            email.addArgument(getMyDSpaceLink());
+                email.addRecipient(ep.getEmail());
+                email.addArgument(title);
+                email.addArgument(coll.getName());
+                email.addArgument(rejector);
+                email.addArgument(reason);
+                email.addArgument(getMyDSpaceLink());
 
-            email.send();
+                email.send();
+            }
         } catch (RuntimeException re) {
             // log this email error
             log.warn(LogManager.getHeader(context, "notify_of_reject",
@@ -1101,7 +1129,9 @@ public class BasicWorkflowServiceImpl implements BasicWorkflowService {
     @Override
     public String getSubmitterName(BasicWorkflowItem wi) throws SQLException {
         EPerson e = wi.getSubmitter();
-
+        if (e == null) {
+            return null;
+        }
         return getEPersonName(e);
     }
 

--- a/dspace-api/src/main/java/org/dspace/workflowbasic/BasicWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/workflowbasic/BasicWorkflowServiceImpl.java
@@ -799,8 +799,7 @@ public class BasicWorkflowServiceImpl implements BasicWorkflowService {
             // Get submitter
             EPerson ep = item.getSubmitter();
 
-            // send the notification only if the person was not deleted in the
-            // meantime between submission and archiving.
+            // send the notification to the submitter unless the submitter eperson has been deleted
             if (ep != null) {
                 // Get the Locale
                 Locale supportedLocale = I18nUtil.getEPersonLocale(ep);
@@ -884,10 +883,8 @@ public class BasicWorkflowServiceImpl implements BasicWorkflowService {
         workflowItemService.deleteWrapper(context, wi);
         // Now delete the item
         itemService.delete(context, myitem);
-        log.info(LogManager.getHeader(context, "delete_workflow", "workflow_item_id="
-                + workflowID + "item_id=" + itemID
-                + "collection_id=" + collID + "eperson_id="
-                + e.getID()));
+        log.info(LogManager.getHeader(context, "delete_workflow", String.format("workflow_item_id=%s " +
+                        "item_id=%s collection_id=%s eperson_id=%s", workflowID, itemID, collID, e.getID())));
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/workflowbasic/TaskListItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/workflowbasic/TaskListItemServiceImpl.java
@@ -47,6 +47,17 @@ public class TaskListItemServiceImpl implements TaskListItemService {
     }
 
     @Override
+    public void deleteByWorkflowItemAndEPerson(Context context, BasicWorkflowItem workflowItem, EPerson ePerson)
+        throws SQLException {
+        taskListItemDAO.deleteByWorkflowItemAndEPerson(context, workflowItem, ePerson);
+    }
+
+    @Override
+    public void deleteByEPerson(Context context, EPerson ePerson) throws SQLException {
+        taskListItemDAO.deleteByEPerson(context, ePerson);
+    }
+
+    @Override
     public void update(Context context, TaskListItem taskListItem) throws SQLException {
         taskListItemDAO.save(context, taskListItem);
     }

--- a/dspace-api/src/main/java/org/dspace/workflowbasic/dao/TaskListItemDAO.java
+++ b/dspace-api/src/main/java/org/dspace/workflowbasic/dao/TaskListItemDAO.java
@@ -28,5 +28,10 @@ public interface TaskListItemDAO extends GenericDAO<TaskListItem> {
 
     public void deleteByWorkflowItem(Context context, BasicWorkflowItem workflowItem) throws SQLException;
 
+    public void deleteByWorkflowItemAndEPerson(Context context, BasicWorkflowItem workflowItem, EPerson ePerson)
+        throws SQLException;
+
+    public void deleteByEPerson(Context context, EPerson ePerson) throws SQLException;
+
     public List<TaskListItem> findByEPerson(Context context, EPerson ePerson) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/workflowbasic/dao/impl/TaskListItemDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/workflowbasic/dao/impl/TaskListItemDAOImpl.java
@@ -43,6 +43,24 @@ public class TaskListItemDAOImpl extends AbstractHibernateDAO<TaskListItem> impl
     }
 
     @Override
+    public void deleteByWorkflowItemAndEPerson(Context context, BasicWorkflowItem workflowItem, EPerson ePerson)
+        throws SQLException {
+        String queryString = "delete from TaskListItem where workflowItem = :workflowItem AND ePerson = :ePerson";
+        Query query = createQuery(context, queryString);
+        query.setParameter("workflowItem", workflowItem);
+        query.setParameter("ePerson", ePerson);
+        query.executeUpdate();
+    }
+
+    @Override
+    public void deleteByEPerson(Context context, EPerson ePerson) throws SQLException {
+        String queryString = "delete from TaskListItem where ePerson = :ePerson";
+        Query query = createQuery(context, queryString);
+        query.setParameter("ePerson", ePerson);
+        query.executeUpdate();
+    }
+
+    @Override
     public List<TaskListItem> findByEPerson(Context context, EPerson ePerson) throws SQLException {
         CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
         CriteriaQuery criteriaQuery = getCriteriaQuery(criteriaBuilder, TaskListItem.class);

--- a/dspace-api/src/main/java/org/dspace/workflowbasic/service/TaskListItemService.java
+++ b/dspace-api/src/main/java/org/dspace/workflowbasic/service/TaskListItemService.java
@@ -28,6 +28,11 @@ public interface TaskListItemService {
 
     public void deleteByWorkflowItem(Context context, BasicWorkflowItem workflowItem) throws SQLException;
 
+    public void deleteByWorkflowItemAndEPerson(Context context, BasicWorkflowItem workflowItem, EPerson ePerson)
+        throws SQLException;
+
+    public void deleteByEPerson(Context context, EPerson ePerson) throws SQLException;
+
     public void update(Context context, TaskListItem taskListItem) throws SQLException;
 
     public List<TaskListItem> findByEPerson(Context context, EPerson ePerson) throws SQLException;

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
@@ -251,19 +251,21 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
     }
 
     protected void grantSubmitterReadPolicies(Context context, Item item) throws SQLException, AuthorizeException {
-        //A list of policies the user has for this item
-        List<Integer> userHasPolicies = new ArrayList<Integer>();
-        List<ResourcePolicy> itempols = authorizeService.getPolicies(context, item);
         EPerson submitter = item.getSubmitter();
-        for (ResourcePolicy resourcePolicy : itempols) {
-            if (submitter.equals(resourcePolicy.getEPerson())) {
-                //The user has already got this policy so add it to the list
-                userHasPolicies.add(resourcePolicy.getAction());
+        if (null != submitter) {
+            //A list of policies the user has for this item
+            List<Integer> userHasPolicies = new ArrayList<>();
+            List<ResourcePolicy> itempols = authorizeService.getPolicies(context, item);
+            for (ResourcePolicy resourcePolicy : itempols) {
+                if (submitter.equals(resourcePolicy.getEPerson())) {
+                    //The user has already got this policy so add it to the list
+                    userHasPolicies.add(resourcePolicy.getAction());
+                }
             }
-        }
-        //Make sure we don't add duplicate policies
-        if (!userHasPolicies.contains(Constants.READ)) {
-            addPolicyToItem(context, item, Constants.READ, submitter, ResourcePolicy.TYPE_SUBMISSION);
+            //Make sure we don't add duplicate policies
+            if (!userHasPolicies.contains(Constants.READ)) {
+                addPolicyToItem(context, item, Constants.READ, submitter, ResourcePolicy.TYPE_SUBMISSION);
+            }
         }
     }
 
@@ -564,35 +566,39 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
         try {
             // Get submitter
             EPerson ep = item.getSubmitter();
-            // Get the Locale
-            Locale supportedLocale = I18nUtil.getEPersonLocale(ep);
-            Email email = Email.getEmail(I18nUtil.getEmailFilename(supportedLocale, "submit_archive"));
+            // send the notification only if the person was not deleted in the
+            // meantime between submission and archiving.
+            if (null != ep) {
+                // Get the Locale
+                Locale supportedLocale = I18nUtil.getEPersonLocale(ep);
+                Email email = Email.getEmail(I18nUtil.getEmailFilename(supportedLocale, "submit_archive"));
 
-            // Get the item handle to email to user
-            String handle = handleService.findHandle(context, item);
+                // Get the item handle to email to user
+                String handle = handleService.findHandle(context, item);
 
-            // Get title
-            List<MetadataValue> titles = itemService
-                .getMetadata(item, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
-            String title = "";
-            try {
-                title = I18nUtil.getMessage("org.dspace.workflow.WorkflowManager.untitled");
-            } catch (MissingResourceException e) {
-                title = "Untitled";
+                // Get title
+                List<MetadataValue> titles = itemService
+                    .getMetadata(item, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
+                String title = "";
+                try {
+                    title = I18nUtil.getMessage("org.dspace.workflow.WorkflowManager.untitled");
+                } catch (MissingResourceException e) {
+                    title = "Untitled";
+                }
+                if (titles.size() > 0) {
+                    title = titles.iterator().next().getValue();
+                }
+
+                email.addRecipient(ep.getEmail());
+                email.addArgument(title);
+                email.addArgument(coll.getName());
+                email.addArgument(handleService.getCanonicalForm(handle));
+
+                email.send();
             }
-            if (titles.size() > 0) {
-                title = titles.iterator().next().getValue();
-            }
-
-            email.addRecipient(ep.getEmail());
-            email.addArgument(title);
-            email.addArgument(coll.getName());
-            email.addArgument(handleService.getCanonicalForm(handle));
-
-            email.send();
         } catch (MessagingException e) {
             log.warn(LogManager.getHeader(context, "notifyOfArchive",
-                                          "cannot email user" + " item_id=" + item.getID()));
+                    "cannot email user" + " item_id=" + item.getID()));
         }
     }
 
@@ -803,7 +809,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
     }
 
     public void removeUserItemPolicies(Context context, Item item, EPerson e) throws SQLException, AuthorizeException {
-        if (e != null) {
+        if (e != null && item.getSubmitter() != null) {
             //Also remove any lingering authorizations from this user
             authorizeService.removeEPersonPolicies(context, item, e);
             //Remove the bundle rights
@@ -825,7 +831,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
 
     protected void removeGroupItemPolicies(Context context, Item item, Group e)
         throws SQLException, AuthorizeException {
-        if (e != null) {
+        if (e != null && item.getSubmitter() != null) {
             //Also remove any lingering authorizations from this user
             authorizeService.removeGroupPolicies(context, item, e);
             //Remove the bundle rights
@@ -841,7 +847,32 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
     }
 
     @Override
-    public WorkspaceItem sendWorkflowItemBackSubmission(Context context, XmlWorkflowItem wi, EPerson e,
+    public void deleteWorkflowByWorkflowItem(Context context, XmlWorkflowItem wi, EPerson e)
+            throws SQLException, AuthorizeException, IOException {
+        Item myitem = wi.getItem();
+        UUID itemID = myitem.getID();
+        Integer workflowID = wi.getID();
+        UUID collID = wi.getCollection().getID();
+        // stop workflow
+        deleteAllTasks(context, wi);
+        context.turnOffAuthorisationSystem();
+        //Also clear all info for this step
+        workflowRequirementsService.clearInProgressUsers(context, wi);
+        // Remove (if any) the workflowItemroles for this item
+        workflowItemRoleService.deleteForWorkflowItem(context, wi);
+        // Now remove the workflow object manually from the database
+        xmlWorkflowItemService.deleteWrapper(context, wi);
+        // Now delete the item
+        itemService.delete(context, myitem);
+        log.info(LogManager.getHeader(context, "delete_workflow", "workflow_item_id="
+                + workflowID + "item_id=" + itemID
+                + "collection_id=" + collID + "eperson_id="
+                + e.getID()));
+        context.restoreAuthSystemState();
+    }
+
+    @Override
+   public WorkspaceItem sendWorkflowItemBackSubmission(Context context, XmlWorkflowItem wi, EPerson e,
                                                         String provenance,
                                                         String rejection_message)
         throws SQLException, AuthorizeException,
@@ -1009,31 +1040,38 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
     protected void notifyOfReject(Context c, XmlWorkflowItem wi, EPerson e,
                                   String reason) {
         try {
-            // Get the item title
-            String title = wi.getItem().getName();
+            // send the notification only if the person was not deleted in the
+            // meantime between submission and archiving.
+            EPerson eperson = wi.getSubmitter();
+            if (eperson != null) {
+                // Get the item title
+                String title = wi.getItem().getName();
 
-            // Get the collection
-            Collection coll = wi.getCollection();
+                // Get the collection
+                Collection coll = wi.getCollection();
 
-            // Get rejector's name
-            String rejector = getEPersonName(e);
-            Locale supportedLocale = I18nUtil.getEPersonLocale(e);
-            Email email = Email.getEmail(I18nUtil.getEmailFilename(supportedLocale, "submit_reject"));
+                // Get rejector's name
+                String rejector = getEPersonName(e);
+                Locale supportedLocale = I18nUtil.getEPersonLocale(e);
+                Email email = Email.getEmail(I18nUtil.getEmailFilename(supportedLocale, "submit_reject"));
 
-            email.addRecipient(wi.getSubmitter().getEmail());
-            email.addArgument(title);
-            email.addArgument(coll.getName());
-            email.addArgument(rejector);
-            email.addArgument(reason);
-            email.addArgument(ConfigurationManager.getProperty("dspace.url") + "/mydspace");
+                email.addRecipient(eperson.getEmail());
+                email.addArgument(title);
+                email.addArgument(coll.getName());
+                email.addArgument(rejector);
+                email.addArgument(reason);
+                email.addArgument(ConfigurationManager.getProperty("dspace.url") + "/mydspace");
 
-            email.send();
+                email.send();
+            } else {
+                // DO nothing
+            }
         } catch (Exception ex) {
             // log this email error
             log.warn(LogManager.getHeader(c, "notify_of_reject",
-                                          "cannot email user" + " eperson_id" + e.getID()
-                                              + " eperson_email" + e.getEmail()
-                                              + " workflow_item_id" + wi.getID()));
+                    "cannot email user" + " eperson_id" + e.getID()
+                    + " eperson_email" + e.getEmail()
+                    + " workflow_item_id" + wi.getID()));
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
@@ -566,8 +566,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
         try {
             // Get submitter
             EPerson ep = item.getSubmitter();
-            // send the notification only if the person was not deleted in the
-            // meantime between submission and archiving.
+            // send the notification to the submitter unless the submitter eperson has been deleted
             if (null != ep) {
                 // Get the Locale
                 Locale supportedLocale = I18nUtil.getEPersonLocale(ep);

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/AcceptEditRejectAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/AcceptEditRejectAction.java
@@ -69,7 +69,11 @@ public class AcceptEditRejectAction extends ProcessingAction {
             return new ActionResult(ActionResult.TYPE.TYPE_OUTCOME, ActionResult.OUTCOME_COMPLETE);
         } else if (request.getParameter("submit_reject") != null) {
             // Make sure we indicate which page we want to process
-            request.setAttribute("page", REJECT_PAGE);
+            if (wfi.getSubmitter() == null) {
+                request.setAttribute("page", SUBMITTER_IS_DELETED_PAGE);
+            } else {
+                request.setAttribute("page", REJECT_PAGE);
+            }
             // We have pressed reject item, so take the user to a page where he can reject
             return new ActionResult(ActionResult.TYPE.TYPE_PAGE);
         } else {

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/AcceptEditRejectAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/AcceptEditRejectAction.java
@@ -34,6 +34,7 @@ public class AcceptEditRejectAction extends ProcessingAction {
 
     public static final int MAIN_PAGE = 0;
     public static final int REJECT_PAGE = 1;
+    public static final int SUBMITTER_IS_DELETED_PAGE = 2;
 
     //TODO: rename to AcceptAndEditMetadataAction
 
@@ -52,6 +53,8 @@ public class AcceptEditRejectAction extends ProcessingAction {
                 return processMainPage(c, wfi, step, request);
             case REJECT_PAGE:
                 return processRejectPage(c, wfi, step, request);
+            case SUBMITTER_IS_DELETED_PAGE:
+                return processSubmitterIsDeletedPage(c, wfi, request);
             default:
                 return new ActionResult(ActionResult.TYPE.TYPE_CANCEL);
         }
@@ -96,6 +99,23 @@ public class AcceptEditRejectAction extends ProcessingAction {
             //Cancel, go back to the main task page
             request.setAttribute("page", MAIN_PAGE);
 
+            return new ActionResult(ActionResult.TYPE.TYPE_PAGE);
+        }
+    }
+
+    public ActionResult processSubmitterIsDeletedPage(Context c, XmlWorkflowItem wfi, HttpServletRequest request)
+        throws SQLException, AuthorizeException, IOException {
+        if (request.getParameter("submit_delete") != null) {
+            XmlWorkflowServiceFactory.getInstance().getXmlWorkflowService()
+                    .deleteWorkflowByWorkflowItem(c, wfi, c.getCurrentUser());
+            // Delete and send user back to myDspace page
+            return new ActionResult(ActionResult.TYPE.TYPE_SUBMISSION_PAGE);
+        } else if (request.getParameter("submit_keep_it") != null) {
+            // Do nothing, just send it back to myDspace page
+            return new ActionResult(ActionResult.TYPE.TYPE_SUBMISSION_PAGE);
+        } else {
+            //Cancel, go back to the main task page
+            request.setAttribute("page", MAIN_PAGE);
             return new ActionResult(ActionResult.TYPE.TYPE_PAGE);
         }
     }

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/ReviewAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/ReviewAction.java
@@ -67,7 +67,11 @@ public class ReviewAction extends ProcessingAction {
             return new ActionResult(ActionResult.TYPE.TYPE_OUTCOME, ActionResult.OUTCOME_COMPLETE);
         } else if (request.getParameter("submit_reject") != null) {
             // Make sure we indicate which page we want to process
-            request.setAttribute("page", REJECT_PAGE);
+            if (wfi.getSubmitter() == null) {
+                request.setAttribute("page", SUBMITTER_IS_DELETED_PAGE);
+            } else {
+                request.setAttribute("page", REJECT_PAGE);
+            }
             // We have pressed reject item, so take the user to a page where he can reject
             return new ActionResult(ActionResult.TYPE.TYPE_PAGE);
         } else {

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/ReviewAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/ReviewAction.java
@@ -33,6 +33,7 @@ public class ReviewAction extends ProcessingAction {
 
     public static final int MAIN_PAGE = 0;
     public static final int REJECT_PAGE = 1;
+    public static final int SUBMITTER_IS_DELETED_PAGE = 2;
 
 
     @Override
@@ -50,6 +51,8 @@ public class ReviewAction extends ProcessingAction {
                 return processMainPage(c, wfi, step, request);
             case REJECT_PAGE:
                 return processRejectPage(c, wfi, step, request);
+            case SUBMITTER_IS_DELETED_PAGE:
+                return processSubmitterIsDeletedPage(c, wfi, request);
             default:
                 return new ActionResult(ActionResult.TYPE.TYPE_CANCEL);
         }
@@ -111,6 +114,23 @@ public class ReviewAction extends ProcessingAction {
             //Cancel, go back to the main task page
             request.setAttribute("page", MAIN_PAGE);
 
+            return new ActionResult(ActionResult.TYPE.TYPE_PAGE);
+        }
+    }
+
+    public ActionResult processSubmitterIsDeletedPage(Context c, XmlWorkflowItem wfi, HttpServletRequest request)
+        throws SQLException, AuthorizeException, IOException {
+        if (request.getParameter("submit_delete") != null) {
+            XmlWorkflowServiceFactory.getInstance().getXmlWorkflowService()
+                    .deleteWorkflowByWorkflowItem(c, wfi, c.getCurrentUser());
+            // Delete and send user back to myDspace page
+            return new ActionResult(ActionResult.TYPE.TYPE_SUBMISSION_PAGE);
+        } else if (request.getParameter("submit_keep_it") != null) {
+            // Do nothing, just send it back to myDspace page
+            return new ActionResult(ActionResult.TYPE.TYPE_SUBMISSION_PAGE);
+        } else {
+            //Cancel, go back to the main task page
+            request.setAttribute("page", MAIN_PAGE);
             return new ActionResult(ActionResult.TYPE.TYPE_PAGE);
         }
     }

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/SingleUserReviewAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/SingleUserReviewAction.java
@@ -70,7 +70,11 @@ public class SingleUserReviewAction extends ProcessingAction {
             return new ActionResult(ActionResult.TYPE.TYPE_OUTCOME, ActionResult.OUTCOME_COMPLETE);
         } else if (request.getParameter("submit_reject") != null) {
             // Make sure we indicate which page we want to process
-            request.setAttribute("page", REJECT_PAGE);
+            if (wfi.getSubmitter() == null) {
+                request.setAttribute("page", SUBMITTER_IS_DELETED_PAGE);
+            } else {
+                request.setAttribute("page", REJECT_PAGE);
+            }
             // We have pressed reject item, so take the user to a page where he can reject
             return new ActionResult(ActionResult.TYPE.TYPE_PAGE);
         } else if (request.getParameter("submit_decline_task") != null) {

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/SingleUserReviewAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/SingleUserReviewAction.java
@@ -35,6 +35,7 @@ public class SingleUserReviewAction extends ProcessingAction {
 
     public static final int MAIN_PAGE = 0;
     public static final int REJECT_PAGE = 1;
+    public static final int SUBMITTER_IS_DELETED_PAGE = 2;
 
     public static final int OUTCOME_REJECT = 1;
 
@@ -53,6 +54,8 @@ public class SingleUserReviewAction extends ProcessingAction {
                 return processMainPage(c, wfi, step, request);
             case REJECT_PAGE:
                 return processRejectPage(c, wfi, step, request);
+            case SUBMITTER_IS_DELETED_PAGE:
+                return processSubmitterIsDeletedPage(c, wfi, request);
             default:
                 return new ActionResult(ActionResult.TYPE.TYPE_CANCEL);
         }
@@ -117,6 +120,23 @@ public class SingleUserReviewAction extends ProcessingAction {
             //Cancel, go back to the main task page
             request.setAttribute("page", MAIN_PAGE);
 
+            return new ActionResult(ActionResult.TYPE.TYPE_PAGE);
+        }
+    }
+
+    public ActionResult processSubmitterIsDeletedPage(Context c, XmlWorkflowItem wfi, HttpServletRequest request)
+        throws SQLException, AuthorizeException, IOException {
+        if (request.getParameter("submit_delete") != null) {
+            XmlWorkflowServiceFactory.getInstance().getXmlWorkflowService()
+                    .deleteWorkflowByWorkflowItem(c, wfi, c.getCurrentUser());
+            // Delete and send user back to myDspace page
+            return new ActionResult(ActionResult.TYPE.TYPE_SUBMISSION_PAGE);
+        } else if (request.getParameter("submit_keep_it") != null) {
+            // Do nothing, just send it back to myDspace page
+            return new ActionResult(ActionResult.TYPE.TYPE_SUBMISSION_PAGE);
+        } else {
+            //Cancel, go back to the main task page
+            request.setAttribute("page", MAIN_PAGE);
             return new ActionResult(ActionResult.TYPE.TYPE_PAGE);
         }
     }

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/userassignment/AssignOriginalSubmitterAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/userassignment/AssignOriginalSubmitterAction.java
@@ -72,20 +72,22 @@ public class AssignOriginalSubmitterAction extends UserSelectionAction {
     @Override
     public void alertUsersOnActivation(Context c, XmlWorkflowItem wfi, RoleMembers roleMembers)
         throws IOException, SQLException {
-        try {
-            XmlWorkflowService xmlWorkflowService = XmlWorkflowServiceFactory.getInstance().getXmlWorkflowService();
-            xmlWorkflowService.alertUsersOnTaskActivation(c, wfi, "submit_task", Arrays.asList(wfi.getSubmitter()),
-                                                          //The arguments
-                                                          wfi.getItem().getName(),
-                                                          wfi.getCollection().getName(),
-                                                          wfi.getSubmitter().getFullName(),
-                                                          //TODO: message
-                                                          "New task available.",
-                                                          xmlWorkflowService.getMyDSpaceLink()
-            );
-        } catch (MessagingException e) {
-            log.info(LogManager.getHeader(c, "error emailing user(s) for claimed task",
+        if (wfi.getSubmitter() != null) {
+            try {
+                XmlWorkflowService xmlWorkflowService = XmlWorkflowServiceFactory.getInstance().getXmlWorkflowService();
+                xmlWorkflowService.alertUsersOnTaskActivation(c, wfi, "submit_task", Arrays.asList(wfi.getSubmitter()),
+                        //The arguments
+                        wfi.getItem().getName(),
+                        wfi.getCollection().getName(),
+                        wfi.getSubmitter().getFullName(),
+                        //TODO: message
+                        "New task available.",
+                        xmlWorkflowService.getMyDSpaceLink()
+                );
+            } catch (MessagingException e) {
+                log.info(LogManager.getHeader(c, "error emailing user(s) for claimed task",
                                           "step: " + getParent().getStep().getId() + " workflowitem: " + wfi.getID()));
+            }
         }
     }
 
@@ -105,9 +107,9 @@ public class AssignOriginalSubmitterAction extends UserSelectionAction {
                 .getId() + " to assign a submitter to. Aborting the action.");
             throw new IllegalStateException();
         }
-
-        createTaskForEPerson(c, wfi, step, nextAction, submitter);
-
+        if (submitter != null) {
+            createTaskForEPerson(c, wfi, step, nextAction, submitter);
+        }
         //It is important that we return to the submission page since we will continue our actions with the submitter
         return new ActionResult(ActionResult.TYPE.TYPE_OUTCOME, ActionResult.OUTCOME_COMPLETE);
     }

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/userassignment/ClaimAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/userassignment/ClaimAction.java
@@ -77,22 +77,25 @@ public class ClaimAction extends UserSelectionAction {
     public void alertUsersOnActivation(Context c, XmlWorkflowItem wfi, RoleMembers roleMembers)
         throws IOException, SQLException {
         try {
+            EPerson ep = wfi.getSubmitter();
+            String submitterName = null;
+            if (ep != null) {
+                submitterName = ep.getFullName();
+            }
             XmlWorkflowService xmlWorkflowService = XmlWorkflowServiceFactory.getInstance().getXmlWorkflowService();
             xmlWorkflowService.alertUsersOnTaskActivation(c, wfi, "submit_task", roleMembers.getAllUniqueMembers(c),
-                                                          //The arguments
-                                                          wfi.getItem().getName(),
-                                                          wfi.getCollection().getName(),
-                                                          wfi.getSubmitter().getFullName(),
-                                                          //TODO: message
-                                                          "New task available.",
-                                                          xmlWorkflowService.getMyDSpaceLink()
+                    //The arguments
+                    wfi.getItem().getName(),
+                    wfi.getCollection().getName(),
+                    submitterName,
+                    //TODO: message
+                    "New task available.",
+                    xmlWorkflowService.getMyDSpaceLink()
             );
         } catch (MessagingException e) {
             log.info(LogManager.getHeader(c, "error emailing user(s) for claimed task",
-                                          "step: " + getParent().getStep().getId() + " workflowitem: " + wfi.getID()));
+                    "step: " + getParent().getStep().getId() + " workflowitem: " + wfi.getID()));
         }
-
-
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/PoolTaskServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/PoolTaskServiceImpl.java
@@ -121,6 +121,19 @@ public class PoolTaskServiceImpl implements PoolTaskService {
     }
 
     @Override
+    public void deleteByEperson(Context context, EPerson ePerson)
+        throws SQLException, AuthorizeException, IOException {
+        List<PoolTask> tasks = findByEperson(context, ePerson);
+        //Use an iterator to remove the tasks !
+        Iterator<PoolTask> iterator = tasks.iterator();
+        while (iterator.hasNext()) {
+            PoolTask poolTask = iterator.next();
+            iterator.remove();
+            delete(context, poolTask);
+        }
+    }
+
+    @Override
     public List<PoolTask> findByEPerson(Context context, EPerson ePerson) throws SQLException {
         return poolTaskDAO.findByEPerson(context, ePerson);
     }

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/WorkflowItemRoleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/WorkflowItemRoleServiceImpl.java
@@ -59,6 +59,16 @@ public class WorkflowItemRoleServiceImpl implements WorkflowItemRoleService {
     }
 
     @Override
+    public void deleteByEPerson(Context context, EPerson ePerson) throws SQLException, AuthorizeException {
+        Iterator<WorkflowItemRole> workflowItemRoles = findByEPerson(context, ePerson).iterator();
+        while (workflowItemRoles.hasNext()) {
+            WorkflowItemRole workflowItemRole = workflowItemRoles.next();
+            workflowItemRoles.remove();
+            delete(context, workflowItemRole);
+        }
+    }
+
+    @Override
     public List<WorkflowItemRole> findByEPerson(Context context, EPerson ePerson) throws SQLException {
         return workflowItemRoleDAO.findByEPerson(context, ePerson);
     }

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/service/PoolTaskService.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/service/PoolTaskService.java
@@ -37,5 +37,7 @@ public interface PoolTaskService extends DSpaceCRUDService<PoolTask> {
     public void deleteByWorkflowItem(Context context, XmlWorkflowItem xmlWorkflowItem)
         throws SQLException, AuthorizeException;
 
+    public void deleteByEperson(Context context, EPerson ePerson) throws SQLException, AuthorizeException, IOException;
+
     public List<PoolTask> findByEPerson(Context context, EPerson ePerson) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/service/WorkflowItemRoleService.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/service/WorkflowItemRoleService.java
@@ -33,5 +33,7 @@ public interface WorkflowItemRoleService extends DSpaceCRUDService<WorkflowItemR
 
     public void deleteForWorkflowItem(Context context, XmlWorkflowItem wfi) throws SQLException, AuthorizeException;
 
+    public void deleteByEPerson(Context context, EPerson ePerson) throws SQLException, AuthorizeException;
+
     public List<WorkflowItemRole> findByEPerson(Context context, EPerson ePerson) throws SQLException;
 }

--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -6,6 +6,8 @@
 # http://www.dspace.org/license/
 #
 
+admin.name = DSpace Administrator
+
 browse.page-title = Browsing DSpace
 browse.et-al = et al
 
@@ -252,6 +254,12 @@ jsp.dspace-admin.eperson-browse.phone                           = Telephone
 jsp.dspace-admin.eperson-browse.self                            = Self Registered
 jsp.dspace-admin.eperson-browse.title                           = E-People
 jsp.dspace-admin.eperson-confirm-delete.confirm                 = Are you sure this e-person should be deleted?
+jsp.dspace-admin.eperson-confirm-delete.confirm.constraint      = This EPerson
+jsp.dspace-admin.eperson-confirm-delete.confirm.item            = has submitted one or more items which will be kept
+jsp.dspace-admin.eperson-confirm-delete.confirm.workspaceitem   = has unsubmitted workspace items which will be deleted
+jsp.dspace-admin.eperson-confirm-delete.confirm.workflowitem    = has an active submission workflow which will be put back into the pool
+jsp.dspace-admin.eperson-confirm-delete.confirm.resourcepolicy  = has resource policies associated with him which will be deleted
+jsp.dspace-admin.eperson-confirm-delete.confirm.tasklistitem    = has a workflow task awaiting their attention
 jsp.dspace-admin.eperson-confirm-delete.heading                 = Delete e-person: {0} ({1})
 jsp.dspace-admin.eperson-confirm-delete.title                   = Delete E-Person
 jsp.dspace-admin.eperson-deletion-error.errormsg                = The EPerson {0} cannot be deleted because a reference to it exists in the following table(s):
@@ -576,7 +584,6 @@ jsp.general.without-contributor                                                 
 jsp.general.without-date                                                                                = No date given
 jsp.help                                                        = <span class="glyphicon glyphicon-question-sign"></span>
 jsp.help.formats.contact1                                       = Please contact your
-jsp.help.formats.contact2                                       = DSpace Administrator
 jsp.help.formats.contact3                                       = if you have questions about a particular format.
 jsp.help.formats.extensions                                     = Extensions
 jsp.help.formats.here                                           = (Your Site's Format Support Policy Here)
@@ -741,6 +748,12 @@ jsp.mydspace.reject-reason.cancel.button                        = Cancel Rejecti
 jsp.mydspace.reject-reason.reject.button                        = Reject Item
 jsp.mydspace.reject-reason.text1                                = Please enter the reason you are rejecting the submission into the box below.  Please indicate in your message whether the submitter should fix a problem and resubmit.
 jsp.mydspace.reject-reason.title                                = Enter Reason for Rejection
+jsp.mydspace.reject-deleted-submitter.title                     = The Submitter of this item has been deleted
+jsp.mydspace.reject-deleted-submitter.message                   = Do you want to delete the document, keep it as a task and work on it later or cancel the rejection process?
+jsp.mydspace.reject-deleted-submitter-keep-it.button            = Keep it I will work on it later
+jsp.mydspace.reject-deleted-submitter-delete.button             = Delete Item
+jsp.mydspace.reject-deleted-submitter-delete.title              = Delete successfully
+jsp.mydspace.reject-deleted-submitter-delete.info               = Reviewing task is done, the submitted item has been successfully removed from the system.
 jsp.mydspace.remove-item.cancel.button                          = Cancel Removal
 jsp.mydspace.remove-item.confirmation                           = Are you sure you want to remove the following incomplete item?
 jsp.mydspace.remove-item.remove.button                          = Remove the Item
@@ -1643,6 +1656,7 @@ org.dspace.workflow.WorkflowManager.step1                                       
 org.dspace.workflow.WorkflowManager.step2                                       = The submission must be checked before inclusion in the archive.
 org.dspace.workflow.WorkflowManager.step3                                       = The metadata needs to be checked to ensure compliance with the collection's standards, and edited if necessary.
 org.dspace.workflow.WorkflowManager.untitled                                    = Untitled
+org.dspace.workflow.WorkflowManager.deleted-submitter                           = Unknown (deleted submitter)
 
 search.order.asc                                                                = Ascending
 search.order.desc                                                               = Descending
@@ -1824,6 +1838,11 @@ In response to your request I have the pleasure to send you in attachment a copy
 Best regards,\n\
 {3} <{4}>
 
+itemRequest.admin.response.body.approve = Dear {0},\n\
+In response to your request I have the pleasure to send you in attachment a copy of the file(s) concerning the document: "{2}" ({1}).\n\n\
+Best regards,\n\
+{3}
+
 itemRequest.response.subject.reject = Request copy of document
 itemRequest.response.body.reject = Dear {0},\n\
 In response to your request I regret to inform you that it''s not possible to send you a copy of the file(s) you have requested, concerning the document: "{2}" ({1}), of which I am author (or co-author).\n\n\
@@ -1845,6 +1864,12 @@ itemRequest.response.body.contactRequester = Dear {0},\n\n\
 Thanks for your interest! Since the author owns the copyright for this work, I will contact the author and ask permission to send you a copy. I''ll let you know as soon as I hear from the author.\n\n\
 Thanks!\n\
 {1} <{2}>
+
+itemRequest.admin.response.body.reject = Dear {0},\n\
+In response to your request I regret to inform you that it''s not possible to send you a copy of the file(s) you have requested, concerning the document: "{2}" ({1}).\n\n\
+Best regards,\n\
+{3}
+
 jsp.request.item.request-form.info2 = Request a document copy: {0}
 jsp.request.item.request-form.problem = You must fill all the missing fields.
 jsp.request.item.request-form.reqname = Requester name:
@@ -1886,7 +1911,8 @@ jsp.request.item.request-free-acess.free = Change to Open Access
 jsp.request.item.request-free-acess.name = Name:
 jsp.request.item.request-free-acess.email = E-mail:
 org.dspace.app.requestitem.RequestItemMetadataStrategy.unnamed = Corresponding Author
-org.dspace.app.requestitem.RequestItemHelpdeskStrategy.helpdeskname = Help Desk
+org.dspace.app.requestitem.helpdeskname = Help Desk
+org.dspace.app.requestitem.default-author-name = DSpace User
 org.dspace.app.webui.jsptag.ItemTag.restrict = Request a copy
 
 jsp.layout.navbar-admin.batchimport = Batch import

--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -1839,7 +1839,7 @@ Best regards,\n\
 {3} <{4}>
 
 itemRequest.admin.response.body.approve = Dear {0},\n\
-In response to your request I have the pleasure to send you in attachment a copy of the file(s) concerning the document: "{2}" ({1}).\n\n\
+In response to your request please see the attached copy of the file(s) related to the document: "{2}" ({1}).\n\n\
 Best regards,\n\
 {3}
 

--- a/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
@@ -5,21 +5,46 @@
  *
  * http://www.dspace.org/license/
  */
-
 package org.dspace.eperson;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
+import java.io.IOException;
 import java.sql.SQLException;
+import java.util.Iterator;
+import java.util.List;
+import javax.mail.MessagingException;
 
 import org.apache.commons.codec.DecoderException;
 import org.apache.logging.log4j.Logger;
+import org.apache.commons.lang.StringUtils;
 import org.dspace.AbstractUnitTest;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.content.WorkspaceItem;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.CollectionService;
+import org.dspace.content.service.CommunityService;
+import org.dspace.content.service.InstallItemService;
+import org.dspace.content.service.ItemService;
+import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Constants;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
+import org.dspace.eperson.service.GroupService;
+import org.dspace.workflow.WorkflowException;
+import org.dspace.workflow.WorkflowItem;
+import org.dspace.workflow.WorkflowItemService;
+import org.dspace.workflow.WorkflowService;
+import org.dspace.workflow.factory.WorkflowServiceFactory;
+import org.dspace.workflowbasic.BasicWorkflowItem;
+import org.dspace.workflowbasic.factory.BasicWorkflowServiceFactory;
+import org.dspace.workflowbasic.service.BasicWorkflowService;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -27,9 +52,31 @@ import org.junit.Test;
  * @author mwood
  */
 public class EPersonTest extends AbstractUnitTest {
-    protected EPersonService ePersonService = EPersonServiceFactory.getInstance().getEPersonService();
-    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(EPersonTest.class);
 
+    protected EPersonService ePersonService = EPersonServiceFactory.getInstance().getEPersonService();
+    protected GroupService groupService = EPersonServiceFactory.getInstance().getGroupService();
+    protected CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
+    protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
+    protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();
+    protected InstallItemService installItemService = ContentServiceFactory.getInstance().getInstallItemService();
+    protected BasicWorkflowService basicWorkflowService = BasicWorkflowServiceFactory.getInstance()
+                                                          .getBasicWorkflowService();
+    protected WorkflowItemService workflowItemService = WorkflowServiceFactory.getInstance().getWorkflowItemService();
+    protected WorkflowService workflowService = WorkflowServiceFactory.getInstance().getWorkflowService();
+    protected WorkspaceItemService workspaceItemService = ContentServiceFactory.getInstance()
+                                                          .getWorkspaceItemService();
+
+    private Community community = null;
+    private Collection collection = null;
+    private Item item = null;
+
+    private static final String EMAIL = "kevin@dspace.org";
+    private static final String FIRSTNAME = "Kevin";
+    private static final String LASTNAME = "Van de Velde";
+    private static final String NETID = "1985";
+    private static final String PASSWORD = "test";
+
+    private static final Logger log = Logger.getLogger(EPersonTest.class);
 
     public EPersonTest() {
     }
@@ -38,8 +85,8 @@ public class EPersonTest extends AbstractUnitTest {
      * This method will be run before every test as per @Before. It will
      * initialize resources required for the tests.
      *
-     * Other methods can be annotated with @Before here or in subclasses
-     * but no execution order is guaranteed
+     * Other methods can be annotated with @Before here or in subclasses but no
+     * execution order is guaranteed
      */
     @Before
     @Override
@@ -49,12 +96,14 @@ public class EPersonTest extends AbstractUnitTest {
         context.turnOffAuthorisationSystem();
         try {
             EPerson eperson = ePersonService.create(context);
-            eperson.setEmail("kevin@dspace.org");
-            eperson.setFirstName(context, "Kevin");
-            eperson.setLastName(context, "Van de Velde");
-            eperson.setNetid("1985");
-            eperson.setPassword("test");
+            eperson.setEmail(EMAIL);
+            eperson.setFirstName(context, FIRSTNAME);
+            eperson.setLastName(context, LASTNAME);
+            eperson.setNetid(NETID);
+            eperson.setPassword(PASSWORD);
             ePersonService.update(context, eperson);
+            this.community = communityService.create(null, context);
+            this.collection = collectionService.create(context, this.community);
         } catch (SQLException | AuthorizeException ex) {
             log.error("Error in init", ex);
             fail("Error in init: " + ex.getMessage());
@@ -71,649 +120,65 @@ public class EPersonTest extends AbstractUnitTest {
             if (testPerson != null) {
                 ePersonService.delete(context, testPerson);
             }
-        } catch (Exception ex) {
+        } catch (IOException | SQLException | AuthorizeException ex) {
             log.error("Error in destroy", ex);
             fail("Error in destroy: " + ex.getMessage());
         }
+        if (item != null) {
+            try {
+                item = itemService.find(context, item.getID());
+                itemService.delete(context, item);
+            } catch (SQLException | AuthorizeException | IOException ex) {
+                log.error("Error in destroy", ex);
+                fail("Error in destroy: " + ex.getMessage());
+            }
+        }
+        if (this.collection != null) {
+            try {
+                this.collection = collectionService.find(context, this.collection.getID());
+                collectionService.delete(context, this.collection);
+            } catch (SQLException | AuthorizeException | IOException ex) {
+                log.error("Error in destroy", ex);
+                fail("Error in destroy: " + ex.getMessage());
+            }
+        }
+        if (this.community != null) {
+            try {
+                this.community = communityService.find(context, this.community.getID());
+                communityService.delete(context, this.community);
+            } catch (SQLException | AuthorizeException | IOException ex) {
+                log.error("Error in destroy", ex);
+                fail("Error in destroy: " + ex.getMessage());
+            }
+        }
+        context.restoreAuthSystemState();
+        item = null;
+        this.collection = null;
+        this.community = null;
         super.destroy();
     }
 
-
-    /**
-     * Test of equals method, of class EPerson.
-     */
-/*
-    @Test
-    public void testEquals()
-    {
-        System.out.println("equals");
-        Object obj = null;
-        EPerson instance = null;
-        boolean expResult = false;
-        boolean result = instance.equals(obj);
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of hashCode method, of class EPerson.
-     */
-/*
-    @Test
-    public void testHashCode()
-    {
-        System.out.println("hashCode");
-        EPerson instance = null;
-        int expResult = 0;
-        int result = instance.hashCode();
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of find method, of class EPerson.
-     */
-/*
-    @Test
-    public void testFind()
-            throws Exception
-    {
-        System.out.println("find");
-        Context context = null;
-        int id = 0;
-        EPerson expResult = null;
-        EPerson result = EPerson.find(context, id);
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of findByEmail method, of class EPerson.
-     */
-/*
-    @Test
-    public void testFindByEmail()
-            throws Exception
-    {
-        System.out.println("findByEmail");
-        Context context = null;
-        String email = "";
-        EPerson expResult = null;
-        EPerson result = EPerson.findByEmail(context, email);
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of findByNetid method, of class EPerson.
-     */
-/*
-    @Test
-    public void testFindByNetid()
-            throws Exception
-    {
-        System.out.println("findByNetid");
-        Context context = null;
-        String netid = "";
-        EPerson expResult = null;
-        EPerson result = EPerson.findByNetid(context, netid);
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of search method, of class EPerson.
-     */
-/*
-    @Test
-    public void testSearch_Context_String()
-            throws Exception
-    {
-        System.out.println("search");
-        Context context = null;
-        String query = "";
-        EPerson[] expResult = null;
-        EPerson[] result = EPerson.search(context, query);
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of search method, of class EPerson.
-     */
-/*
-    @Test
-    public void testSearch_4args()
-            throws Exception
-    {
-        System.out.println("search");
-        Context context = null;
-        String query = "";
-        int offset = 0;
-        int limit = 0;
-        EPerson[] expResult = null;
-        EPerson[] result = EPerson.search(context, query, offset, limit);
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of searchResultCount method, of class EPerson.
-     */
-/*
-    @Test
-    public void testSearchResultCount()
-            throws Exception
-    {
-        System.out.println("searchResultCount");
-        Context context = null;
-        String query = "";
-        int expResult = 0;
-        int result = EPerson.searchResultCount(context, query);
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of findAll method, of class EPerson.
-     */
-/*
-    @Test
-    public void testFindAll()
-            throws Exception
-    {
-        System.out.println("findAll");
-        Context context = null;
-        int sortField = 0;
-        EPerson[] expResult = null;
-        EPerson[] result = EPerson.findAll(context, sortField);
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of create method, of class EPerson.
-     */
-/*
-    @Test
-    public void testCreate()
-            throws Exception
-    {
-        System.out.println("create");
-        Context context = null;
-        EPerson expResult = null;
-        EPerson result = EPerson.create(context);
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of delete method, of class EPerson.
-     */
-/*
-    @Test
-    public void testDelete()
-            throws Exception
-    {
-        System.out.println("delete");
-        EPerson instance = null;
-        instance.delete();
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of getID method, of class EPerson.
-     */
-/*
-    @Test
-    public void testGetID()
-    {
-        System.out.println("getID");
-        EPerson instance = null;
-        int expResult = 0;
-        int result = instance.getID();
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of getLanguage method, of class EPerson.
-     */
-/*
-    @Test
-    public void testGetLanguage()
-    {
-        System.out.println("getLanguage");
-        EPerson instance = null;
-        String expResult = "";
-        String result = instance.getLanguage();
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of setLanguage method, of class EPerson.
-     */
-/*
-    @Test
-    public void testSetLanguage()
-    {
-        System.out.println("setLanguage");
-        String language = "";
-        EPerson instance = null;
-        instance.setLanguage(language);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of getHandle method, of class EPerson.
-     */
-/*
-    @Test
-    public void testGetHandle()
-    {
-        System.out.println("getHandle");
-        EPerson instance = null;
-        String expResult = "";
-        String result = instance.getHandle();
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of getEmail method, of class EPerson.
-     */
-/*
-    @Test
-    public void testGetEmail()
-    {
-        System.out.println("getEmail");
-        EPerson instance = null;
-        String expResult = "";
-        String result = instance.getEmail();
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of setEmail method, of class EPerson.
-     */
-/*
-    @Test
-    public void testSetEmail()
-    {
-        System.out.println("setEmail");
-        String s = "";
-        EPerson instance = null;
-        instance.setEmail(s);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of getNetid method, of class EPerson.
-     */
-/*
-    @Test
-    public void testGetNetid()
-    {
-        System.out.println("getNetid");
-        EPerson instance = null;
-        String expResult = "";
-        String result = instance.getNetid();
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of setNetid method, of class EPerson.
-     */
-/*
-    @Test
-    public void testSetNetid()
-    {
-        System.out.println("setNetid");
-        String s = "";
-        EPerson instance = null;
-        instance.setNetid(s);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of getFullName method, of class EPerson.
-     */
-/*
-    @Test
-    public void testGetFullName()
-    {
-        System.out.println("getFullName");
-        EPerson instance = null;
-        String expResult = "";
-        String result = instance.getFullName();
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of getFirstName method, of class EPerson.
-     */
-/*
-    @Test
-    public void testGetFirstName()
-    {
-        System.out.println("getFirstName");
-        EPerson instance = null;
-        String expResult = "";
-        String result = instance.getFirstName();
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of setFirstName method, of class EPerson.
-     */
-/*
-    @Test
-    public void testSetFirstName()
-    {
-        System.out.println("setFirstName");
-        String firstname = "";
-        EPerson instance = null;
-        instance.setFirstName(firstname);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of getLastName method, of class EPerson.
-     */
-/*
-    @Test
-    public void testGetLastName()
-    {
-        System.out.println("getLastName");
-        EPerson instance = null;
-        String expResult = "";
-        String result = instance.getLastName();
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of setLastName method, of class EPerson.
-     */
-/*
-    @Test
-    public void testSetLastName()
-    {
-        System.out.println("setLastName");
-        String lastname = "";
-        EPerson instance = null;
-        instance.setLastName(lastname);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of setCanLogIn method, of class EPerson.
-     */
-/*
-    @Test
-    public void testSetCanLogIn()
-    {
-        System.out.println("setCanLogIn");
-        boolean login = false;
-        EPerson instance = null;
-        instance.setCanLogIn(login);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of canLogIn method, of class EPerson.
-     */
-/*
-    @Test
-    public void testCanLogIn()
-    {
-        System.out.println("canLogIn");
-        EPerson instance = null;
-        boolean expResult = false;
-        boolean result = instance.canLogIn();
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of setRequireCertificate method, of class EPerson.
-     */
-/*
-    @Test
-    public void testSetRequireCertificate()
-    {
-        System.out.println("setRequireCertificate");
-        boolean isrequired = false;
-        EPerson instance = null;
-        instance.setRequireCertificate(isrequired);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of getRequireCertificate method, of class EPerson.
-     */
-/*
-    @Test
-    public void testGetRequireCertificate()
-    {
-        System.out.println("getRequireCertificate");
-        EPerson instance = null;
-        boolean expResult = false;
-        boolean result = instance.getRequireCertificate();
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of setSelfRegistered method, of class EPerson.
-     */
-/*
-    @Test
-    public void testSetSelfRegistered()
-    {
-        System.out.println("setSelfRegistered");
-        boolean sr = false;
-        EPerson instance = null;
-        instance.setSelfRegistered(sr);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of getSelfRegistered method, of class EPerson.
-     */
-/*
-    @Test
-    public void testGetSelfRegistered()
-    {
-        System.out.println("getSelfRegistered");
-        EPerson instance = null;
-        boolean expResult = false;
-        boolean result = instance.getSelfRegistered();
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of getMetadata method, of class EPerson.
-     */
-/*
-    @Test
-    public void testGetMetadata()
-    {
-        System.out.println("getMetadata");
-        String field = "";
-        EPerson instance = null;
-        String expResult = "";
-        String result = instance.getMetadata(field);
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of setMetadata method, of class EPerson.
-     */
-/*
-    @Test
-    public void testSetMetadata()
-    {
-        System.out.println("setMetadata");
-        String field = "";
-        String value = "";
-        EPerson instance = null;
-        instance.setMetadata(field, value);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of setPassword method, of class EPerson.
-     */
-/*
-    @Test
-    public void testSetPassword()
-    {
-        System.out.println("setPassword");
-        String s = "";
-        EPerson instance = null;
-        instance.setPassword(s);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of setPasswordHash method, of class EPerson.
-     */
-/*
-    @Test
-    public void testSetPasswordHash()
-    {
-        System.out.println("setPasswordHash");
-        PasswordHash password = null;
-        EPerson instance = null;
-        instance.setPasswordHash(password);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
-    /**
-     * Test of getPasswordHash method, of class EPerson.
-     */
-/*
-    @Test
-    public void testGetPasswordHash()
-    {
-        System.out.println("getPasswordHash");
-        EPerson instance = null;
-        PasswordHash expResult = null;
-        PasswordHash result = instance.getPasswordHash();
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
-
     /**
      * Test of checkPassword method, of class EPerson.
+     *
+     * @throws SQLException
+     * @throws DecoderException
      */
     @Test
     public void testCheckPassword()
-        throws SQLException, DecoderException {
-        EPerson eperson = ePersonService.findByEmail(context, "kevin@dspace.org");
-        ePersonService.checkPassword(context, eperson, "test");
+            throws SQLException, DecoderException {
+        EPerson eperson = ePersonService.findByEmail(context, EMAIL);
+        ePersonService.checkPassword(context, eperson, PASSWORD);
     }
-
-    /**
-     * Test of update method, of class EPerson.
-     */
-/*
-    @Test
-    public void testUpdate()
-            throws Exception
-    {
-        System.out.println("update");
-        EPerson instance = null;
-        instance.update();
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
-*/
 
     /**
      * Test of getType method, of class EPerson.
+     *
+     * @throws SQLException
      */
     @Test
     public void testGetType()
-        throws SQLException {
+            throws SQLException {
         System.out.println("getType");
         int expResult = Constants.EPERSON;
         int result = eperson.getType();
@@ -721,37 +186,350 @@ public class EPersonTest extends AbstractUnitTest {
     }
 
     /**
-     * Test of getDeleteConstraints method, of class EPerson.
+     * Simple test if deletion of an EPerson throws any exceptions.
+     *
+     * @throws SQLException
+     * @throws AuthorizeException
      */
-/*
     @Test
-    public void testGetDeleteConstraints()
-            throws Exception
-    {
-        System.out.println("getDeleteConstraints");
-        EPerson instance = null;
-        List expResult = null;
-        List result = instance.getDeleteConstraints();
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
+    public void testDeleteEPerson() throws SQLException, AuthorizeException {
+        EPerson deleteEperson = ePersonService.findByEmail(context, EMAIL);
+        context.turnOffAuthorisationSystem();
+
+        try {
+            ePersonService.delete(context, deleteEperson);
+        } catch (AuthorizeException | IOException ex) {
+            log.error("Cannot delete EPersion, caught " + ex.getClass().getName() + ":", ex);
+            fail("Caught an Exception while deleting an EPerson. " + ex.getClass().getName() +
+                 ": " + ex.getMessage());
+        }
+        context.restoreAuthSystemState();
+        context.commit();
+        EPerson fundDeletedEperson = ePersonService.findByEmail(context, EMAIL);
+        assertNull("EPerson has not been deleted correctly!", fundDeletedEperson);
     }
-*/
 
     /**
-     * Test of getName method, of class EPerson.
+     * Test that an EPerson has a delete constraint if it submitted an Item.
+     *
+     * @throws SQLException
      */
-/*
     @Test
-    public void testGetName()
-    {
-        System.out.println("getName");
-        EPerson instance = null;
-        String expResult = "";
-        String result = instance.getName();
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
+    public void testDeletionConstraintOfSubmitter()
+            throws SQLException {
+        EPerson ep = ePersonService.findByEmail(context, EMAIL);
+        try {
+            item = prepareItem(ep);
+        } catch (SQLException | AuthorizeException | IOException ex) {
+            log.error("Caught an Exception while initializing an Item. " + ex.getClass().getName() + ": ", ex);
+            fail("Caught an Exception while initializing an Item. " + ex.getClass().getName() +
+                 ": " + ex.getMessage());
+        }
+
+        context.turnOffAuthorisationSystem();
+
+        List<String> tableList = ePersonService.getDeleteConstraints(context, ep);
+        Iterator<String> iterator = tableList.iterator();
+        while (iterator.hasNext()) {
+            String tableName = iterator.next();
+            if (StringUtils.equalsIgnoreCase(tableName, "item")) {
+                return;
+            }
+        }
+        // if we did not get and EPersonDeletionException or it did not contain the item table, we should fail
+        // because it was not recognized that the EPerson is used as submitter.
+        fail("It was not recognized that a EPerson is referenced in the item table.");
     }
-*/
+
+    /**
+     * Test that the submitter is set to null if the specified EPerson was
+     * deleted using cascading.
+     *
+     * @throws SQLException
+     * @throws AuthorizeException
+     */
+    @Test
+    public void testDeletionOfSubmitterWithAnItem()
+            throws SQLException, AuthorizeException {
+        EPerson ep = ePersonService.findByEmail(context, EMAIL);
+        try {
+            item = prepareItem(ep);
+        } catch (SQLException | AuthorizeException | IOException ex) {
+            log.error("Caught an Exception while initializing an Item. " + ex.getClass().getName() + ": ", ex);
+            fail("Caught an Exception while initializing an Item. " + ex.getClass().getName() +
+                 ": " + ex.getMessage());
+        }
+        assertNotNull(item);
+        context.turnOffAuthorisationSystem();
+        try {
+            ePersonService.delete(context, ep);
+        } catch (SQLException | IOException | AuthorizeException ex) {
+            if (ex.getCause() instanceof EPersonDeletionException) {
+                fail("Caught an EPersonDeletionException while trying to cascading delete an EPerson: " +
+                      ex.getMessage());
+            } else {
+                log.error("Caught an Exception while deleting an EPerson. " + ex.getClass().getName() + ": ", ex);
+                fail("Caught an Exception while deleting an EPerson. " + ex.getClass().getName() +
+                     ": " + ex.getMessage());
+            }
+        }
+        item = itemService.find(context, item.getID());
+        assertNotNull("Could not load item after cascading deletion of the submitter.", item);
+        assertNull("Cascading deletion of an EPerson did not set the submitter of an submitted item null.",
+                item.getSubmitter());
+    }
+
+    /**
+     * Test that an unsubmitted workspace items get deleted when an EPerson gets
+     * deleted.
+     *
+     * @throws SQLException
+     * @throws IOException
+     * @throws AuthorizeException
+     */
+    @Test
+    public void testCascadingDeletionOfUnsubmittedWorkspaceItem()
+            throws SQLException, AuthorizeException, IOException {
+        EPerson ep = ePersonService.findByEmail(context, EMAIL);
+
+        context.turnOffAuthorisationSystem();
+        WorkspaceItem wsi = prepareWorkspaceItem(ep);
+        Item item = wsi.getItem();
+        itemService.addMetadata(context, item, "dc", "title", null, "en", "Testdocument 1");
+        itemService.update(context, item);
+        context.restoreAuthSystemState();
+        context.commit();
+        context.turnOffAuthorisationSystem();
+
+        try {
+            ePersonService.delete(context, ep);
+        } catch (SQLException | IOException | AuthorizeException ex) {
+            if (ex.getCause() instanceof EPersonDeletionException) {
+                fail("Caught an EPersonDeletionException while trying to cascading delete an EPerson: " +
+                     ex.getMessage());
+            } else {
+                log.error("Caught an Exception while deleting an EPerson. " + ex.getClass().getName() +
+                          ": ", ex);
+                fail("Caught an Exception while deleting an EPerson. " + ex.getClass().getName() +
+                     ": " + ex.getMessage());
+            }
+        }
+
+        context.restoreAuthSystemState();
+        context.commit();
+
+        try {
+            WorkspaceItem restoredWsi = workspaceItemService.find(context, wsi.getID());
+            Item restoredItem = itemService.find(context, item.getID());
+            assertNull("An unsubmited WorkspaceItem wasn't deleted while cascading deleting the submitter.",
+                       restoredWsi);
+            assertNull("An unsubmited Item wasn't deleted while cascading deleting the submitter.", restoredItem);
+        } catch (SQLException ex) {
+            log.error("SQLException while trying to load previously stored. " + ex);
+        }
+    }
+
+    /**
+     * Test that submitted but not yet archived items do not get delete while
+     * cascading deletion of an EPerson.
+     *
+     * @throws SQLException
+     * @throws AuthorizeException
+     * @throws IOException
+     * @throws MessagingException
+     * @throws WorkflowException
+     */
+    @Test
+    public void testCascadingDeleteSubmitterPreservesWorkflowItems()
+            throws SQLException, AuthorizeException, IOException, MessagingException, WorkflowException {
+        EPerson ep = ePersonService.findByEmail(context, EMAIL);
+        WorkspaceItem wsi = null;
+
+        try {
+            wsi = prepareWorkspaceItem(ep);
+        } catch (SQLException | AuthorizeException | IOException ex) {
+            log.error("Caught an Exception while initializing an WorkspaceItem. " + ex.getClass().getName() +
+                      ": ", ex);
+            fail("Caught an Exception while initializing an WorkspaceItem. " + ex.getClass().getName() +
+                 ": " + ex.getMessage());
+        }
+        assertNotNull(wsi);
+        context.turnOffAuthorisationSystem();
+
+        // for this test we need an workflow item that is not yet submitted. Currently the Workflow advance
+        // automatically if nobody is defined to perform a step (see comments of DS-1941).
+        // We need to configure a collection to have a workflow step and set a person to perform this step. Then we can
+        // create an item, start the workflow and delete the item's submitter.
+        Group wfGroup = collectionService.createWorkflowGroup(context, wsi.getCollection(), 1);
+        collectionService.update(context, wsi.getCollection());
+        EPerson groupMember = ePersonService.create(context);
+        groupMember.setEmail("testCascadingDeleteSubmitterPreservesWorkflowItems2@example.org");
+        ePersonService.update(context, groupMember);
+        wfGroup.addMember(groupMember);
+        groupService.update(context, wfGroup);
+
+        // DSpace currently contains two workflow systems. The newer XMLWorfklow needs additional tables that are not
+        // part of the test database yet. While it is expected that it becomes the default workflow system (DS-2059)
+        // one day, this won't happen before it its backported to JSPUI (DS-2121).
+        // TODO: add tests using the configurable workflowsystem
+        int wfiID = workflowService.startWithoutNotify(context, wsi).getID();
+        context.restoreAuthSystemState();
+        context.commit();
+        context.turnOffAuthorisationSystem();
+
+        // check that the workflow item exists.
+        assertNotNull("Cannot find currently created WorkflowItem!", workflowItemService.find(context, wfiID));
+
+        // delete the submitter
+        try {
+            ePersonService.delete(context, ep);
+        } catch (SQLException | IOException | AuthorizeException ex) {
+            if (ex.getCause() instanceof EPersonDeletionException) {
+                fail("Caught an EPersonDeletionException while trying to cascading delete an EPerson: " +
+                     ex.getMessage());
+            } else {
+                log.error("Caught an Exception while deleting an EPerson. " + ex.getClass().getName() +
+                          ": ", ex);
+                fail("Caught an Exception while deleting an EPerson. " + ex.getClass().getName() +
+                     ": " + ex.getMessage());
+            }
+        }
+
+        context.restoreAuthSystemState();
+        context.commit();
+        context.turnOffAuthorisationSystem();
+
+        // check whether the workflow item still exists.
+        WorkflowItem wfi = workflowItemService.find(context, wfiID);
+        assertNotNull("Could not load WorkflowItem after cascading deletion of the submitter.", wfi);
+        assertNull("Cascading deletion of an EPerson did not set the submitter of an submitted WorkflowItem null.",
+                wfi.getSubmitter());
+    }
+
+    /**
+     * Test that deleting a Person that claimed a task, repools the task.
+     *
+     * @throws SQLException
+     * @throws AuthorizeException
+     * @throws MessagingException
+     * @throws IOException
+     * @throws WorkflowException
+     */
+    @Test
+    public void testDeletingAnTaskHolderUnclaimsTask()
+        throws SQLException, AuthorizeException, MessagingException, IOException, WorkflowException {
+        EPerson ep = ePersonService.findByEmail(context, EMAIL);
+        WorkspaceItem wsi = null;
+
+        try {
+            wsi = prepareWorkspaceItem(ep);
+        } catch (SQLException | AuthorizeException | IOException ex) {
+            log.error("Caught an Exception while initializing an WorkspaceItem. " + ex.getClass().getName() +
+                      ": ", ex);
+            fail("Caught an Exception while initializing an WorkspaceItem. " + ex.getClass().getName() +
+                 ": " + ex.getMessage());
+        }
+        assertNotNull(wsi);
+        context.turnOffAuthorisationSystem();
+
+        // for this test we need an workflow item that is not yet submitted. Currently the Workflow advance
+        // automatically if nobody is defined to perform a step (see comments of DS-1941).
+        // We need to configure a collection to have a workflow step and set at least two persons to perform this step.
+        // Then we can create an item, start the workflow, claim the task and delete the person who claimed it.
+        Group wfGroup = collectionService.createWorkflowGroup(context, wsi.getCollection(), 1);
+        collectionService.update(context, wsi.getCollection());
+        EPerson worker = ePersonService.create(context);
+        worker.setEmail("testDeletingAnTaskHolderUnclaimsTask2@example.org");
+        ePersonService.update(context, worker);
+        wfGroup.addMember(worker);
+        EPerson coWorker = ePersonService.create(context);
+        coWorker.setEmail("testDeletingAnTaskHolderUnclamisTask3example.org");
+        ePersonService.update(context, coWorker);
+        wfGroup.addMember(coWorker);
+        groupService.update(context, wfGroup);
+        context.restoreAuthSystemState();
+        context.commit();
+        context.turnOffAuthorisationSystem();
+        // DSpace currently contains two workflow systems. The newer XMLWorfklow needs additional tables that are not
+        // part of the test database yet. While it is expected that it becomes the default workflow system (DS-2059)
+        // one day, this won't happen before it its backported to JSPUI (DS-2121).
+        // TODO: add tests using the configurable xmlworkflow system
+        BasicWorkflowItem wfi = basicWorkflowService.startWithoutNotify(context, workspaceItemService
+                                                                                 .find(context, wsi.getID()));
+        context.commit();
+
+        basicWorkflowService.claim(context, wfi, worker);
+        context.restoreAuthSystemState();
+        context.commit();
+        context.turnOffAuthorisationSystem();
+
+        // delete the task owner
+        try {
+            ePersonService.delete(context, ePersonService.find(context, worker.getID()));
+        } catch (SQLException | IOException | AuthorizeException ex) {
+            if (ex.getCause() instanceof EPersonDeletionException) {
+                fail("Caught an EPersonDeletionException while trying to cascading delete an EPerson: " +
+                     ex.getMessage());
+            } else {
+                log.error("Caught an Exception while deleting an EPerson. " + ex.getClass().getName() + ": ", ex);
+                fail("Caught an Exception while deleting an EPerson. " + ex.getClass().getName() +
+                     ": " + ex.getMessage());
+            }
+        }
+        context.restoreAuthSystemState();
+        context.commit();
+        context.turnOffAuthorisationSystem();
+        // check whether the workflow item still exists and is unclaimed.
+        BasicWorkflowItem bwfi = BasicWorkflowServiceFactory.getInstance().getBasicWorkflowItemService()
+                                                                          .find(context, wfi.getID());
+        assertNotNull("Could not load WorkflowItem after cascading deletion of its owner.", wfi);
+        assertNull("Cascading deletion of an EPerson did not repooled a claimed task.", bwfi.getOwner());
+    }
+
+    /**
+     * Creates an item, sets the specified submitter.
+     *
+     * This method is just an shortcut, so we must not use all the code again
+     * and again.
+     *
+     * @param submitter
+     * @return the created item.
+     * @throws SQLException
+     * @throws AuthorizeException
+     * @throws IOException
+     */
+    private Item prepareItem(EPerson submitter)
+        throws SQLException, AuthorizeException, IOException {
+        context.turnOffAuthorisationSystem();
+        WorkspaceItem wsi = prepareWorkspaceItem(submitter);
+        item = installItemService.installItem(context, wsi);
+        //we need to commit the changes so we don't block the table for testing
+        context.restoreAuthSystemState();
+        return item;
+    }
+
+    /**
+     * Creates a WorkspaceItem and sets the specified submitter.
+     *
+     * This method is just an shortcut, so we must not use all the code again
+     * and again.
+     *
+     * @param submitter
+     * @return the created WorkspaceItem.
+     * @throws SQLException
+     * @throws AuthorizeException
+     * @throws IOException
+     */
+    private WorkspaceItem prepareWorkspaceItem(EPerson submitter)
+        throws SQLException, AuthorizeException, IOException {
+        context.turnOffAuthorisationSystem();
+        // create a community, a collection and a WorkspaceItem
+
+        WorkspaceItem wsi = workspaceItemService.create(context, this.collection, false);
+        // set the submitter
+        wsi.getItem().setSubmitter(submitter);
+        workspaceItemService.update(context, wsi);
+        context.restoreAuthSystemState();
+        return wsi;
+    }
 }

--- a/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
@@ -70,7 +70,7 @@ public class EPersonTest extends AbstractUnitTest {
     private Collection collection = null;
     private Item item = null;
 
-    private static final String EMAIL = "kevin@dspace.org";
+    private static final String EMAIL = "test@example.com";
     private static final String FIRSTNAME = "Kevin";
     private static final String LASTNAME = "Van de Velde";
     private static final String NETID = "1985";
@@ -116,7 +116,7 @@ public class EPersonTest extends AbstractUnitTest {
     public void destroy() {
         context.turnOffAuthorisationSystem();
         try {
-            EPerson testPerson = ePersonService.findByEmail(context, "kevin@dspace.org");
+            EPerson testPerson = ePersonService.findByEmail(context, EMAIL);
             if (testPerson != null) {
                 ePersonService.delete(context, testPerson);
             }
@@ -205,8 +205,8 @@ public class EPersonTest extends AbstractUnitTest {
         }
         context.restoreAuthSystemState();
         context.commit();
-        EPerson fundDeletedEperson = ePersonService.findByEmail(context, EMAIL);
-        assertNull("EPerson has not been deleted correctly!", fundDeletedEperson);
+        EPerson findDeletedEperson = ePersonService.findByEmail(context, EMAIL);
+        assertNull("EPerson has not been deleted correctly!", findDeletedEperson);
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
@@ -19,8 +19,8 @@ import java.util.List;
 import javax.mail.MessagingException;
 
 import org.apache.commons.codec.DecoderException;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
-import org.apache.commons.lang.StringUtils;
 import org.dspace.AbstractUnitTest;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Collection;
@@ -76,7 +76,7 @@ public class EPersonTest extends AbstractUnitTest {
     private static final String NETID = "1985";
     private static final String PASSWORD = "test";
 
-    private static final Logger log = Logger.getLogger(EPersonTest.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(EPersonTest.class);
 
     public EPersonTest() {
     }

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/helpers/stubs/ItemRepositoryBuilder.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/helpers/stubs/ItemRepositoryBuilder.java
@@ -51,7 +51,9 @@ public class ItemRepositoryBuilder {
         doc.addField("item.id", item.getId());
         doc.addField("item.public", item.isPublic());
         doc.addField("item.lastmodified", item.getLastModifiedDate());
-        doc.addField("item.submitter", item.getSubmitter());
+        if (item.getSubmitter() != null) {
+            doc.addField("item.submitter", item.getSubmitter());
+        }
         doc.addField("item.handle", item.getHandle());
         doc.addField("item.deleted", item.isDeleted());
 

--- a/dspace/config/emails/request_item.to_admin
+++ b/dspace/config/emails/request_item.to_admin
@@ -1,0 +1,13 @@
+Subject: Request copy of document
+
+Dear Administrator,
+
+A user of {7}, named {0} and using the email {1}, requested a copy of the file(s) associated with the document: "{4}" ({3}).
+
+This request came along with the following message:
+
+"{5}"
+
+To answer, click {6}. 
+
+PLEASE REDIRECT THIS MESSAGE TO THE AUTHOR(S).


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-4036
Fixes https://github.com/DSpace/DSpace/issues/2803

DSpace references EPersons in different database tables like the
submitter of an item or like the EPerson that gets special rights
granted in the resourcepolicy table. This PR changes DSpace so it can
handle references that are set null instead of referencing an actual
EPerson. This is important to be able to delete EPersons which is
demanded by several data protection laws like GDPR in the European
Union.