### PR TITLE
DS-1046 In MetadataExportReader at the moment of asking for authoriza…

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/MetadataExportReader.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/MetadataExportReader.java
@@ -113,9 +113,6 @@ public class MetadataExportReader extends AbstractReader implements Recyclable
             this.response = ObjectModelHelper.getResponse(objectModel);
             Context context = ContextUtil.obtainContext(objectModel);
 
-            if(authorizeService.isAdmin(context))
-            {
-
             /* Get our parameters that identify the item, collection
              * or community to be exported
              *
@@ -123,6 +120,9 @@ public class MetadataExportReader extends AbstractReader implements Recyclable
 
             String handle = par.getParameter("handle");
             DSpaceObject dso = handleService.resolveToObject(context, handle);
+
+            if(authorizeService.isAdmin(context,dso))
+            {
             
             java.util.List<Item> itemmd = new ArrayList<>();
             if(dso.getType() == Constants.ITEM)


### PR DESCRIPTION
…tion instead of using isAdmin(context) method now isAdmin(context,dso) is used

isAdmin(context,dso) checks for eperson authorization over the object and it's parents, allowing a Community/Collection Administrator exporting metadata from that community/collection or any of it's subcommunities/collections/items