### PR TITLE
DS-4041: Update to Servlet Spec version 3.1.0 in all dependencies

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -366,10 +366,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>
         </dependency>
         <dependency>

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -395,7 +395,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/dspace-api/src/test/java/org/dspace/statistics/util/DummyHttpServletRequest.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/util/DummyHttpServletRequest.java
@@ -10,16 +10,25 @@ package org.dspace.statistics.util;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.security.Principal;
+import java.util.Collection;
 import java.util.Enumeration;
 import java.util.Locale;
 import java.util.Map;
+import javax.servlet.AsyncContext;
+import javax.servlet.DispatcherType;
 import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
 import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpUpgradeHandler;
+import javax.servlet.http.Part;
 
 /**
  * A mock request for testing.
@@ -43,6 +52,15 @@ class DummyHttpServletRequest implements HttpServletRequest {
 
     public void setRemoteHost(String host) {
         this.remoteHost = host;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.servlet.http.HttpServletRequest#changeSessionId
+     */
+    @Override
+    public String changeSessionId() {
+        // TODO Auto-generated method stub
+        return null;
     }
 
     /* (non-Javadoc)
@@ -79,6 +97,15 @@ class DummyHttpServletRequest implements HttpServletRequest {
     public long getDateHeader(String arg0) {
         // TODO Auto-generated method stub
         return 0;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.servlet.http.HttpServletRequest#getDispatcherType()
+     */
+    @Override
+    public DispatcherType getDispatcherType() {
+        // TODO Auto-generated method stub
+        return null;
     }
 
     /* (non-Javadoc)
@@ -256,6 +283,55 @@ class DummyHttpServletRequest implements HttpServletRequest {
     }
 
     /* (non-Javadoc)
+     * @see javax.servlet.http.HttpServletRequest#authenticate(javax.servlet.http.HttpServletResponse)
+     */
+    @Override
+    public boolean authenticate(HttpServletResponse httpServletResponse) {
+        return false;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.servlet.http.HttpServletRequest#login(java.lang.String,java.lang.String)
+     */
+    @Override
+    public void login(String s, String s1) {
+        return;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.servlet.http.HttpServletRequest#logout()
+     */
+    @Override
+    public void logout() {
+        return;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.servlet.http.HttpServletRequest#getPart(java.lang.String)
+     */
+    @Override
+    public Part getPart(String arg0) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.servlet.http.HttpServletRequest#getParts()
+     */
+    @Override
+    public Collection<Part> getParts() {
+        return null;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.servlet.http.HttpServletRequest#upgrade(java.lang.Class<T>)
+     */
+    @Override
+    public <T extends HttpUpgradeHandler> T upgrade(Class<T> aClass) throws IOException, ServletException {
+        return null;
+    }
+
+    /* (non-Javadoc)
      * @see javax.servlet.http.HttpServletRequest#isRequestedSessionIdValid()
      */
     @Override
@@ -306,6 +382,14 @@ class DummyHttpServletRequest implements HttpServletRequest {
     @Override
     public int getContentLength() {
         // TODO Auto-generated method stub
+        return 0;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.servlet.ServletRequest#getContentLengthLong()
+     */
+    @Override
+    public long getContentLengthLong() {
         return 0;
     }
 
@@ -490,8 +574,49 @@ class DummyHttpServletRequest implements HttpServletRequest {
      */
     @Override
     public void setCharacterEncoding(String arg0)
-        throws UnsupportedEncodingException {
+        throws UnsupportedOperationException {
         throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    /* (non-Javadoc)
+     * @see javax.servlet.ServletRequest#startAsync
+     */
+    @Override
+    public AsyncContext startAsync() throws IllegalStateException {
+        throw new IllegalStateException("Not supported yet.");
+    }
+
+    /* (non-Javadoc)
+     * @see javax.servlet.ServletRequest#startAsync(javax.servlet.ServletRequest,javax.servlet.ServletResponse)
+     */
+    @Override
+    public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse)
+        throws IllegalStateException {
+        throw new IllegalStateException("Not supported yet.");
+    }
+
+    /* (non-Javadoc)
+     * @see javax.servlet.ServletRequest#isAsyncStarted
+     */
+    @Override
+    public boolean isAsyncStarted() {
+        return false;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.servlet.ServletRequest#isAsyncSupported
+     */
+    @Override
+    public boolean isAsyncSupported() {
+        return false;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.servlet.ServletRequest#getAsyncContext
+     */
+    @Override
+    public AsyncContext getAsyncContext() {
+        return null;
     }
 
     @Override
@@ -512,6 +637,14 @@ class DummyHttpServletRequest implements HttpServletRequest {
     @Override
     public int getLocalPort() {
         throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    /* (non-Javadoc)
+     * @see javax.servlet.ServletRequest#getServletContext
+     */
+    @Override
+    public ServletContext getServletContext() {
+        return null;
     }
 
 }

--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -185,7 +185,7 @@
         <!-- Web API -->
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -16,7 +16,6 @@
     <properties>
         <!-- This is the path to the root [dspace-src] directory. -->
         <root.basedir>${basedir}/..</root.basedir>
-        <spring.version>3.2.5.RELEASE</spring.version>
         <xoai.version>3.2.10</xoai.version>
         <jtwig.version>2.0.1</jtwig.version>
     </properties>
@@ -145,10 +144,6 @@
             <version>${jtwig.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>org.ow2.asm</groupId>
-                    <artifactId>asm</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>com.google.guava</groupId>
                     <artifactId>guava</artifactId>
                 </exclusion>
@@ -228,10 +223,12 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Note: XOAI requires hamcrest both for testing and runtime -->
+        <!-- As our Parent POM sets this to 'test' scope, we must override it -->
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
-            <scope>test</scope>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -160,6 +160,10 @@
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-lang3</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/dspace-oai/src/main/webapp/WEB-INF/web.xml
+++ b/dspace-oai/src/main/webapp/WEB-INF/web.xml
@@ -8,9 +8,9 @@
     http://www.dspace.org/license/
 
 -->
-<web-app id="XOAILynCode" version="2.4" xmlns="http://java.sun.com/xml/ns/j2ee"
+<web-app id="DSpace-OAI" version="3.1" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
 
     <display-name>XOAI Data Provider</display-name>
 

--- a/dspace-rdf/pom.xml
+++ b/dspace-rdf/pom.xml
@@ -64,7 +64,7 @@
 
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/dspace-rdf/src/main/webapp/WEB-INF/web.xml
+++ b/dspace-rdf/src/main/webapp/WEB-INF/web.xml
@@ -8,10 +8,9 @@
     http://www.dspace.org/license/
 
 -->
-<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://java.sun.com/xml/ns/javaee"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
-         id="WebApp_ID" version="2.5">
+<web-app id="DSpace-RDF" version="3.1" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
 
     <display-name>RDF Data Provider</display-name>
 

--- a/dspace-rest/pom.xml
+++ b/dspace-rest/pom.xml
@@ -220,7 +220,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/dspace-rest/src/main/webapp/WEB-INF/web.xml
+++ b/dspace-rest/src/main/webapp/WEB-INF/web.xml
@@ -8,10 +8,9 @@
     http://www.dspace.org/license/
 
 -->
-<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://java.sun.com/xml/ns/javaee"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
-         id="WebApp_ID" version="2.5">
+<web-app id="DSpace-RESTv6" version="3.1" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
 
     <filter>
         <filter-name>dspace.request</filter-name>

--- a/dspace-services/pom.xml
+++ b/dspace-services/pom.xml
@@ -108,7 +108,7 @@
         <!-- for filters -->
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/dspace-solr/pom.xml
+++ b/dspace-solr/pom.xml
@@ -249,7 +249,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/dspace-sword/pom.xml
+++ b/dspace-sword/pom.xml
@@ -112,7 +112,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/dspace-sword/src/main/webapp/WEB-INF/web.xml
+++ b/dspace-sword/src/main/webapp/WEB-INF/web.xml
@@ -8,35 +8,29 @@
     http://www.dspace.org/license/
 
 -->
-<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-        "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app id="DSpace-SWORDv1" version="3.1" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
 
     <display-name>DSpace SWORD Server</display-name>
 
     <!-- ConfigurationService initialization for dspace.dir -->
     <context-param>
+        <description>The location of the DSpace home directory</description>
         <param-name>dspace.dir</param-name>
         <param-value>${dspace.dir}</param-value>
-        <description>
-            The location of the DSpace home directory
-        </description>
     </context-param>
 
     <context-param>
+        <description>The SWORDServer class name</description>
         <param-name>sword-server-class</param-name>
         <param-value>org.dspace.sword.DSpaceSWORDServer</param-value>
-        <description>
-            The SWORDServer class name
-        </description>
     </context-param>
 
     <context-param>
+        <description>The type of authentication used : [Basic|None]</description>
         <param-name>authentication-method</param-name>
         <param-value>Basic</param-value>
-        <description>
-            The type of authentication used : [Basic|None]
-        </description>
     </context-param>
 
     <!--

--- a/dspace-swordv2/pom.xml
+++ b/dspace-swordv2/pom.xml
@@ -81,7 +81,7 @@
     <dependencies>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/dspace-swordv2/pom.xml
+++ b/dspace-swordv2/pom.xml
@@ -95,6 +95,10 @@
                     <groupId>org.apache.abdera</groupId>
                     <artifactId>abdera-client</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/dspace-swordv2/src/main/webapp/WEB-INF/web.xml
+++ b/dspace-swordv2/src/main/webapp/WEB-INF/web.xml
@@ -8,89 +8,70 @@
     http://www.dspace.org/license/
 
 -->
-<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-        "http://java.sun.com/dtd/web-app_2_3.dtd">
-
-<web-app>
+<web-app id="DSpace-SWORDv2" version="3.1" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
 
     <display-name>DSpace SWORD 2.0 Server</display-name>
 
     <!-- ConfigurationService initialization for dspace.dir -->
     <context-param>
+        <description>The location of the DSpace home directory</description>
         <param-name>dspace.dir</param-name>
         <param-value>${dspace.dir}</param-value>
-        <description>
-            The location of the DSpace home directory
-        </description>
     </context-param>
 
     <!-- Configuration Information -->
 
     <context-param>
+        <description>The ServiceDocumentManager server implementation class name</description>
         <param-name>service-document-impl</param-name>
         <param-value>org.dspace.sword2.ServiceDocumentManagerDSpace</param-value>
-        <description>
-            The ServiceDocumentManager server implementation class name
-        </description>
     </context-param>
 
     <!-- this can be omitted if the server does not wish to support listing collection contents -->
     <context-param>
+        <description>The CollectionListManager server implementation class name</description>
         <param-name>collection-list-impl</param-name>
         <param-value>org.dspace.sword2.CollectionListManagerDSpace</param-value>
-        <description>
-            The CollectionListManager server implementation class name
-        </description>
     </context-param>
 
     <context-param>
+        <description>The CollectionDepositManager server implementation class name</description>
         <param-name>collection-deposit-impl</param-name>
         <param-value>org.dspace.sword2.CollectionDepositManagerDSpace</param-value>
-        <description>
-            The CollectionDepositManager server implementation class name
-        </description>
     </context-param>
 
     <context-param>
+        <description>The MediaResourceManager server implementation class name</description>
         <param-name>media-resource-impl</param-name>
         <param-value>org.dspace.sword2.MediaResourceManagerDSpace</param-value>
-        <description>
-            The MediaResourceManager server implementation class name
-        </description>
     </context-param>
 
     <context-param>
+        <description>The ContainerManager server implementation class name</description>
         <param-name>container-impl</param-name>
         <param-value>org.dspace.sword2.ContainerManagerDSpace</param-value>
-        <description>
-            The ContainerManager server implementation class name
-        </description>
     </context-param>
 
     <context-param>
+        <description>The StatementManager server implementation class name</description>
         <param-name>statement-impl</param-name>
         <param-value>org.dspace.sword2.StatementManagerDSpace</param-value>
-        <description>
-            The StatementManager server implementation class name
-        </description>
     </context-param>
 
     <!-- This option here is an actual implementation of the configuration class, which
             contains some default values -->
     <context-param>
+        <description>The SwordConfiguration server implementation class name</description>
         <param-name>config-impl</param-name>
         <param-value>org.dspace.sword2.SwordConfigurationDSpace</param-value>
-        <description>
-            The SwordConfiguration server implementation class name
-        </description>
     </context-param>
 
     <context-param>
+        <description>The type of authentication used : [Basic|None]</description>
         <param-name>authentication-method</param-name>
         <param-value>Basic</param-value>
-        <description>
-            The type of authentication used : [Basic|None]
-        </description>
     </context-param>
 
     <!--

--- a/dspace/modules/additions/pom.xml
+++ b/dspace/modules/additions/pom.xml
@@ -58,7 +58,7 @@
       </dependency>
       <dependency>
          <groupId>javax.servlet</groupId>
-         <artifactId>servlet-api</artifactId>
+         <artifactId>javax.servlet-api</artifactId>
          <scope>provided</scope>
       </dependency>
       <dependency>

--- a/dspace/modules/oai/pom.xml
+++ b/dspace/modules/oai/pom.xml
@@ -127,7 +127,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/dspace/modules/oai/pom.xml
+++ b/dspace/modules/oai/pom.xml
@@ -146,6 +146,14 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <!-- Note: XOAI requires hamcrest both for testing and runtime -->
+        <!-- As our Parent POM sets this to 'test' scope, we must override it -->
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <developers>

--- a/dspace/modules/rdf/pom.xml
+++ b/dspace/modules/rdf/pom.xml
@@ -104,7 +104,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/dspace/modules/rest/pom.xml
+++ b/dspace/modules/rest/pom.xml
@@ -143,7 +143,7 @@
 
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/dspace/modules/sword/pom.xml
+++ b/dspace/modules/sword/pom.xml
@@ -121,7 +121,7 @@
       </dependency>
       <dependency>
          <groupId>javax.servlet</groupId>
-         <artifactId>servlet-api</artifactId>
+         <artifactId>javax.servlet-api</artifactId>
          <scope>provided</scope>
       </dependency>
    </dependencies>

--- a/dspace/modules/swordv2/pom.xml
+++ b/dspace/modules/swordv2/pom.xml
@@ -135,7 +135,7 @@
 
       <dependency>
          <groupId>javax.servlet</groupId>
-         <artifactId>servlet-api</artifactId>
+         <artifactId>javax.servlet-api</artifactId>
          <scope>provided</scope>
       </dependency>
 

--- a/dspace/pom.xml
+++ b/dspace/pom.xml
@@ -321,7 +321,7 @@
              command. -->
     	<dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
     	</dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1236,8 +1236,8 @@
             </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>
-                <artifactId>servlet-api</artifactId>
-                <version>2.5</version>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>3.1.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-4041

This PR ensures we are using the same version of Servlet Spec across all our modules (currently Parent POM & dspace-api uses version 2.5).  Version 3.1.0 is required by both of our REST APIs, and this simply ensures we are using it in all dependencies.

Also includes a minor POM fix to dspace-api.  The `commons-collections4` was listed twice (in a row) which causes Maven warnings.

**NOTE:** With an update to Servlet Spec v3.1, Tomcat 8.0+ will be required for DSpace 7.  See http://tomcat.apache.org/whichversion.html

*UPDATE:* Today, I've been performing some thorough testing of our webapps using this PR and Tomcat v8.5.34. Here's what I've tested successfully so far:
- [x] SWORDv1 (tested servicedocument and new deposit)
- [x] SWORDv2 (tested servicedocument and new deposit and edit-metadata endpoint)
- [x] REST API v7 (tested authentication, clicked around various endpoints, all working)
- [x] REST API v6 (tested basic authentication, `/status`, and tried various other endpoints. All working)
- [x] OAI-PMH (tested various contexts with several verbs. All seems to be working)