### PR TITLE
Update SpiderDetectorServiceImpl.java to omit "*.old" config files

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/util/NoDotOldFilter.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/NoDotOldFilter.java
@@ -1,0 +1,31 @@
+/**
+ * 
+ */
+package org.dspace.statistics.util;
+
+import java.io.File;
+import java.io.FileFilter;
+
+/**
+ * @author Ulrich Hahn
+ *
+ */
+public class NoDotOldFilter implements FileFilter {
+
+	/**
+	 * All files with ending .old are fitered out.
+	 * Motivation: each "ant update" run backs up changed config files with .old extensions.
+	 * These files were read unexpectedly in addition to the current config files.
+	 */
+
+	/* (non-Javadoc)
+	 * @see java.io.FileFilter#accept(java.io.File)
+	 */
+	@Override
+	public boolean accept(File inFile) {
+		if(inFile.getName().matches(".+\\.old$"))
+			return false;
+		return true;
+	}
+
+}

--- a/dspace-api/src/main/java/org/dspace/statistics/util/NoDotOldFilter.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/NoDotOldFilter.java
@@ -1,0 +1,31 @@
+/**
+ * 
+ */
+package org.dspace.statistics.util;
+
+import java.io.File;
+import java.io.FileFilter;
+
+/**
+ * @author uhahn
+ *
+ */
+public class NoDotOldFilter implements FileFilter {
+
+	/**
+	 * all files with ending .old are fitered out
+	 * motivation: each "ant update" run backs up changed config files with .old extensions
+	 * these files were read unexpectedly in addition to the current config files 
+	 */
+
+	/* (non-Javadoc)
+	 * @see java.io.FileFilter#accept(java.io.File)
+	 */
+	@Override
+	public boolean accept(File inFile) {
+		if(inFile.getName().matches(".*\\.old$"))
+			return false;
+		return true;
+	}
+
+}

--- a/dspace-api/src/main/java/org/dspace/statistics/util/NoDotOldFilter.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/NoDotOldFilter.java
@@ -16,20 +16,18 @@ import java.io.FileFilter;
  */
 public class NoDotOldFilter implements FileFilter {
 
-	/**
-	 * All files with ending .old are fitered out.
-	 * Motivation: each "ant update" run backs up changed config files with .old extensions.
-	 * These files were read unexpectedly in addition to the current config files.
-	 */
-
-	/* (non-Javadoc)
-	 * @see java.io.FileFilter#accept(java.io.File)
-	 */
-	@Override
-	public boolean accept(File inFile) {
-		if(inFile.getName().matches(".+\\.old$"))
-			return false;
-		return true;
-	}
+    /**
+     * All files with ending .old are fitered out.
+     * Motivation: each "ant update" run backs up changed config files with .old extensions.
+     * These files were read unexpectedly in addition to the current config files.
+     * @see java.io.FileFilter#accept(java.io.File)
+     */
+    @Override
+    public boolean accept(File inFile) {
+        if(inFile.getName().matches(".+\\.old$")) {    
+            return false;
+        }
+        return true;
+    }
 
 }

--- a/dspace-api/src/main/java/org/dspace/statistics/util/NoDotOldFilter.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/NoDotOldFilter.java
@@ -1,4 +1,11 @@
 /**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+/**
  * 
  */
 package org.dspace.statistics.util;
@@ -7,15 +14,15 @@ import java.io.File;
 import java.io.FileFilter;
 
 /**
- * @author uhahn
+ * @author Ulrich Hahn
  *
  */
 public class NoDotOldFilter implements FileFilter {
 
 	/**
-	 * all files with ending .old are fitered out
-	 * motivation: each "ant update" run backs up changed config files with .old extensions
-	 * these files were read unexpectedly in addition to the current config files 
+	 * All files with ending .old are fitered out.
+	 * Motivation: each "ant update" run backs up changed config files with .old extensions.
+	 * These files were read unexpectedly in addition to the current config files.
 	 */
 
 	/* (non-Javadoc)
@@ -23,7 +30,7 @@ public class NoDotOldFilter implements FileFilter {
 	 */
 	@Override
 	public boolean accept(File inFile) {
-		if(inFile.getName().matches(".*\\.old$"))
+		if(inFile.getName().matches(".+\\.old$"))
 			return false;
 		return true;
 	}

--- a/dspace-api/src/main/java/org/dspace/statistics/util/NoDotOldFilter.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/NoDotOldFilter.java
@@ -24,7 +24,7 @@ public class NoDotOldFilter implements FileFilter {
      */
     @Override
     public boolean accept(File inFile) {
-        if(inFile.getName().matches(".+\\.old$")) {    
+        if (inFile.getName().matches(".+\\.old$")) {
             return false;
         }
         return true;

--- a/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetectorServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetectorServiceImpl.java
@@ -186,7 +186,7 @@ public class SpiderDetectorServiceImpl implements SpiderDetectorService {
         if (patternsDir.exists() && patternsDir.isDirectory()) {
             for (File file : patternsDir.listFiles()) {
                 if (file.isFile()
-                    && !file.getName().matches(".+old$")) { // UH omit .old files from previous update runs
+                    && !file.getName().matches(".+old$")) { // omit .old files from previous update runs
                     Set<String> patterns;
                     try {
                         patterns = readPatterns(file);
@@ -263,7 +263,7 @@ public class SpiderDetectorServiceImpl implements SpiderDetectorService {
                 if (spidersDir.exists() && spidersDir.isDirectory()) {
                     for (File file : spidersDir.listFiles()) {
                         if (file.isFile()
-                            && !file.getName().matches(".+old$")) { // UH omit .old files from previous update runs
+                            && !file.getName().matches(".+old$")) { // omit .old files from previous update runs
                             for (String ip : readPatterns(file)) {
                                 log.debug("Loading {}", ip);
                                 if (!Character.isDigit(ip.charAt(0))) {

--- a/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetectorServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetectorServiceImpl.java
@@ -263,7 +263,7 @@ public class SpiderDetectorServiceImpl implements SpiderDetectorService {
                 if (spidersDir.exists() && spidersDir.isDirectory()) {
                     for (File file : spidersDir.listFiles()) {
                         if (file.isFile()
-                           	&& !file.getName().matches(".+old$")) { // UH omit .old files from previous update runs
+                            && !file.getName().matches(".+old$")) { // UH omit .old files from previous update runs
                             for (String ip : readPatterns(file)) {
                                 log.debug("Loading {}", ip);
                                 if (!Character.isDigit(ip.charAt(0))) {

--- a/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetectorServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetectorServiceImpl.java
@@ -201,7 +201,7 @@ public class SpiderDetectorServiceImpl implements SpiderDetectorService {
                     patternList.add(Pattern.compile(pattern));
                 }
 
-                    log.info("Loaded pattern file:  {}", file.getPath());
+                log.info("Loaded pattern file:  {}", file.getPath());
             }
         } else {
             log.info("No patterns loaded from {}", patternsDir.getPath());

--- a/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetectorServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetectorServiceImpl.java
@@ -185,6 +185,9 @@ public class SpiderDetectorServiceImpl implements SpiderDetectorService {
         File patternsDir = new File(spidersDir, directory);
         if (patternsDir.exists() && patternsDir.isDirectory()) {
             for (File file : patternsDir.listFiles()) {
+                if (file.isFile()
+                    	&& !file.getName().matches(".+old$")) // UH omit .old files from previous update runs
+                {
                 Set<String> patterns;
                 try {
                     patterns = readPatterns(file);
@@ -203,6 +206,7 @@ public class SpiderDetectorServiceImpl implements SpiderDetectorService {
 
 
                 log.info("Loaded pattern file:  {}", file.getPath());
+                }
             }
         } else {
             log.info("No patterns loaded from {}", patternsDir.getPath());
@@ -259,7 +263,9 @@ public class SpiderDetectorServiceImpl implements SpiderDetectorService {
 
                 if (spidersDir.exists() && spidersDir.isDirectory()) {
                     for (File file : spidersDir.listFiles()) {
-                        if (file.isFile()) {
+                        if (file.isFile()
+                           	&& !file.getName().matches(".+old$")) // UH omit .old files from previous update runs
+                        {
                             for (String ip : readPatterns(file)) {
                                 log.debug("Loading {}", ip);
                                 if (!Character.isDigit(ip.charAt(0))) {

--- a/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetectorServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetectorServiceImpl.java
@@ -186,26 +186,25 @@ public class SpiderDetectorServiceImpl implements SpiderDetectorService {
         if (patternsDir.exists() && patternsDir.isDirectory()) {
             for (File file : patternsDir.listFiles()) {
                 if (file.isFile()
-                    	&& !file.getName().matches(".+old$")) // UH omit .old files from previous update runs
-                {
-                Set<String> patterns;
-                try {
-                    patterns = readPatterns(file);
-                } catch (IOException ex) {
-                    log.error("Patterns not read from {}:  {}",
-                              file.getPath(), ex.getMessage());
-                    continue;
-                }
-                //If case insensitive matching is enabled, lowercase the patterns so they can be lowercase matched
-                for (String pattern : patterns) {
-                    if (isUseCaseInsensitiveMatching()) {
-                        pattern = StringUtils.lowerCase(pattern);
+                    && !file.getName().matches(".+old$")) { // UH omit .old files from previous update runs
+                    Set<String> patterns;
+                    try {
+                        patterns = readPatterns(file);
+                    } catch (IOException ex) {
+                        log.error("Patterns not read from {}:  {}",
+                                  file.getPath(), ex.getMessage());
+                        continue;
                     }
-                    patternList.add(Pattern.compile(pattern));
-                }
+                    //If case insensitive matching is enabled, lowercase the patterns so they can be lowercase matched
+                    for (String pattern : patterns) {
+                        if (isUseCaseInsensitiveMatching()) {
+                            pattern = StringUtils.lowerCase(pattern);
+                        }
+                        patternList.add(Pattern.compile(pattern));
+                    }
 
 
-                log.info("Loaded pattern file:  {}", file.getPath());
+                    log.info("Loaded pattern file:  {}", file.getPath());
                 }
             }
         } else {
@@ -264,8 +263,7 @@ public class SpiderDetectorServiceImpl implements SpiderDetectorService {
                 if (spidersDir.exists() && spidersDir.isDirectory()) {
                     for (File file : spidersDir.listFiles()) {
                         if (file.isFile()
-                           	&& !file.getName().matches(".+old$")) // UH omit .old files from previous update runs
-                        {
+                           	&& !file.getName().matches(".+old$")) { // UH omit .old files from previous update runs
                             for (String ip : readPatterns(file)) {
                                 log.debug("Loading {}", ip);
                                 if (!Character.isDigit(ip.charAt(0))) {

--- a/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetectorServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetectorServiceImpl.java
@@ -184,9 +184,8 @@ public class SpiderDetectorServiceImpl implements SpiderDetectorService {
         File spidersDir = new File(dspaceHome, "config/spiders");
         File patternsDir = new File(spidersDir, directory);
         if (patternsDir.exists() && patternsDir.isDirectory()) {
-            for (File file : patternsDir.listFiles()) {
-                if (file.isFile()
-                    && !file.getName().matches(".+old$")) { // omit .old files from previous update runs
+            for (File file : patternsDir.listFiles(new NoDotOldFilter())) {
+                if (file.isFile()) {
                     Set<String> patterns;
                     try {
                         patterns = readPatterns(file);
@@ -261,9 +260,8 @@ public class SpiderDetectorServiceImpl implements SpiderDetectorService {
                 File spidersDir = new File(filePath, "config/spiders");
 
                 if (spidersDir.exists() && spidersDir.isDirectory()) {
-                    for (File file : spidersDir.listFiles()) {
-                        if (file.isFile()
-                            && !file.getName().matches(".+old$")) { // omit .old files from previous update runs
+                    for (File file : spidersDir.listFiles(new NoDotOldFilter())) {
+                        if (file.isFile()) {
                             for (String ip : readPatterns(file)) {
                                 log.debug("Loading {}", ip);
                                 if (!Character.isDigit(ip.charAt(0))) {

--- a/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetectorServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetectorServiceImpl.java
@@ -184,7 +184,7 @@ public class SpiderDetectorServiceImpl implements SpiderDetectorService {
         File spidersDir = new File(dspaceHome, "config/spiders");
         File patternsDir = new File(spidersDir, directory);
         if (patternsDir.exists() && patternsDir.isDirectory()) {
-            for (File file : patternsDir.listFiles()) {
+            for (File file : patternsDir.listFiles(new NoDotOldFilter())) {
                 Set<String> patterns;
                 try {
                     patterns = readPatterns(file);
@@ -258,7 +258,7 @@ public class SpiderDetectorServiceImpl implements SpiderDetectorService {
                 File spidersDir = new File(filePath, "config/spiders");
 
                 if (spidersDir.exists() && spidersDir.isDirectory()) {
-                    for (File file : spidersDir.listFiles()) {
+                    for (File file : spidersDir.listFiles(new NoDotOldFilter())) {
                         if (file.isFile()) {
                             for (String ip : readPatterns(file)) {
                                 log.debug("Loading {}", ip);


### PR DESCRIPTION
Each "ant update" run preserves previous configuration changes in files ending with ".old", leaving them beside the current config.
The current loadPatterns() and loadSpider() will eat up each of them in addition to the current config files. This is unwanted as deletion of patterns/ip ranges will fail silently. 
This patch helps in skipping all files ending in ".old".