### PR TITLE
[DS-4044] DataCiteConnector assumes schema version 2.2

### DIFF
--- a/dspace-api/src/main/java/org/dspace/identifier/doi/DataCiteConnector.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/DataCiteConnector.java
@@ -1036,7 +1036,7 @@ implements DOIConnector
         {
             return root;
         }
-        Element identifier = new Element("identifier", "http://datacite.org/schema/kernel-2.2");
+        Element identifier = new Element("identifier", root.getNamespaceURI());
         identifier.setAttribute("identifierType", "DOI");
         identifier.addContent(doi.substring(DOI.SCHEME.length()));
         return root.addContent(0, identifier);


### PR DESCRIPTION
Fixes #7391
https://jira.duraspace.org/browse/DS-4044
This was already fixed in 6.0, but still exists in 5_x.