### PR TITLE
/api/config/submissiondefinitions/traditional/collections should return empty list rather than 204 [was#2189]

### DIFF
--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -757,10 +757,12 @@ public class RestResourceController implements InitializingBean {
 
         } else {
             if (resource.getEmbeddedResources().get(rel) == null) {
-                response.setStatus(HttpServletResponse.SC_NO_CONTENT);
+	    PageImpl<Resource>emptyPage = new PageImpl(new ArrayList<Resource>(), page, 0);
+	    return assembler.toResource ( emptyPage );
             }
-
-            return (ResourceSupport) resource.getEmbeddedResources().get(rel);
+	    else {
+		return (ResourceSupport) resource.getEmbeddedResources().get(rel);
+	    }
         }
 
     }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -757,12 +757,11 @@ public class RestResourceController implements InitializingBean {
 
         } else {
             if (resource.getEmbeddedResources().get(rel) == null) {
-	    PageImpl<Resource>emptyPage = new PageImpl(new ArrayList<Resource>(), page, 0);
-	    return assembler.toResource ( emptyPage );
+                PageImpl<Resource> emptyPage = new PageImpl(new ArrayList<Resource>(), page, 0);
+                return assembler.toResource(emptyPage);
+            } else {
+                return (ResourceSupport) resource.getEmbeddedResources().get(rel);
             }
-	    else {
-		return (ResourceSupport) resource.getEmbeddedResources().get(rel);
-	    }
         }
 
     }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -736,8 +736,9 @@ public class RestResourceController implements InitializingBean {
             EmbeddedPage ep = (EmbeddedPage) resource.getEmbeddedResources().get(rel);
             List<? extends RestAddressableModel> fullList = ep.getFullList();
             if (fullList == null || fullList.size() == 0) {
-                response.setStatus(HttpServletResponse.SC_NO_CONTENT);
-                return null;
+                PageImpl<RestAddressableModel> pageResult = new PageImpl(fullList, page, 0);
+                result = assembler.toResource(pageResult);
+                return result;
             }
             int start = page.getOffset();
             int end = (start + page.getPageSize()) > fullList.size() ? fullList.size() : (start + page.getPageSize());
@@ -757,11 +758,9 @@ public class RestResourceController implements InitializingBean {
 
         } else {
             if (resource.getEmbeddedResources().get(rel) == null) {
-                PageImpl<Resource> emptyPage = new PageImpl(new ArrayList<Resource>(), page, 0);
-                return assembler.toResource(emptyPage);
-            } else {
-                return (ResourceSupport) resource.getEmbeddedResources().get(rel);
+                response.setStatus(HttpServletResponse.SC_NO_CONTENT);
             }
+            return (ResourceSupport) resource.getEmbeddedResources().get(rel);
         }
 
     }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/DSpaceResource.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/hateoas/DSpaceResource.java
@@ -129,7 +129,9 @@ public abstract class DSpaceResource<T extends RestAddressableModel> extends HAL
                                                                           page.map(resourceRepository::wrapResource),
                                                                           linkedRMList, name);
                                         } else {
-                                            wrapObject = null;
+                                            PageImpl<RestAddressableModel> page = new PageImpl(linkedRMList);
+                                            wrapObject = new EmbeddedPage(linkToSubResource.getHref(), page,
+                                                    linkedRMList, name);
                                         }
                                     }
                                 }

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -187,11 +187,13 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                    .andExpect(content().contentType(contentType));
 
         getClient().perform(get("/api/core/communities/" + child1.getID().toString() + "/logo"))
-                   .andExpect(status().isNoContent());
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         //Main community has no collections, therefore contentType is not set
         getClient().perform(get("/api/core/communities/" + parentCommunity.getID().toString() + "/collections"))
-                   .andExpect(status().isNoContent());
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         getClient().perform(get("/api/core/communities/" + child1.getID().toString() + "/collections"))
                    .andExpect(status().isOk())
@@ -203,7 +205,8 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
 
         //child1 subcommunity has no subcommunities, therefore contentType is not set
         getClient().perform(get("/api/core/communities/" + child1.getID().toString() + "/subcommunities"))
-                   .andExpect(status().isNoContent());
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 
 

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -187,8 +187,7 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                    .andExpect(content().contentType(contentType));
 
         getClient().perform(get("/api/core/communities/" + child1.getID().toString() + "/logo"))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$.page.totalElements", is(0)));
+                   .andExpect(status().isNoContent());
 
         //Main community has no collections, therefore contentType is not set
         getClient().perform(get("/api/core/communities/" + parentCommunity.getID().toString() + "/collections"))

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -301,7 +301,8 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         ;
 
         getClient().perform(get("/api/core/items/" + publicItem1.getID() + "/templateItemOf"))
-                   .andExpect(status().isNoContent())
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.page.totalElements", is(0)));
         ;
     }
 

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -301,8 +301,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         ;
 
         getClient().perform(get("/api/core/items/" + publicItem1.getID() + "/templateItemOf"))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$.page.totalElements", is(0)));
+                   .andExpect(status().isNoContent());
         ;
     }
 

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
@@ -129,11 +129,8 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
 
         //Match only that a section exists with a submission configuration behind
         getClient(token).perform(get("/api/config/submissiondefinitions/traditional/collections"))
-                   //TODO - this method should return an empty page
-                   .andExpect(status().isNoContent());
-                   //this is the expected result
-                   //.andExpect(status().isOk())
-                   //.andExpect(jsonPath("$.page.totalElements", is(0)));
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 
     @Test


### PR DESCRIPTION
Here is an initial attempt following the initial simper suggestion as a solution.