### PR TITLE
Remove unused jackson dependencies from DSpace 5.x OAI

### DIFF
--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -196,27 +196,6 @@
             <version>${spring.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-mock</artifactId>
-            <version>2.0.8</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>2.3.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.3.3</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.3.3</version>
-        </dependency>
-        <dependency>
             <groupId>org.xmlmatchers</groupId>
             <artifactId>xml-matchers</artifactId>
             <version>0.10</version>


### PR DESCRIPTION
DSpace 5.x OAI-PMH has some unused dependencies declared that are both outdated and also have known security issues.  They should be removed, just like they were removed from 6.x and master via #1359

This is essentially a smaller version of #1359 which just concentrates on removing the outdated, unused jackson dependencies.

I have not yet tested this, but it builds & passes OAI-PMH unit tests.