### PR TITLE
DS-4069 Use Google Analytics cookie for more consistent session tracking

### DIFF
--- a/dspace-api/src/main/java/org/dspace/google/GoogleAnalyticsEvent.java
+++ b/dspace-api/src/main/java/org/dspace/google/GoogleAnalyticsEvent.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 

--- a/dspace-api/src/main/java/org/dspace/google/GoogleAnalyticsEvent.java
+++ b/dspace-api/src/main/java/org/dspace/google/GoogleAnalyticsEvent.java
@@ -1,0 +1,94 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ * <p>
+ * http://www.dspace.org/license/
+ */
+
+package org.dspace.google;
+
+/**
+ * This is a dataholder class for an individual event to be sent to Google Analaytics
+ *
+ * @author Chris Herron
+ */
+public class GoogleAnalyticsEvent {
+
+    private String cid, uip, ua, dr, dp, dt;
+    private long time;
+
+    GoogleAnalyticsEvent(String cid, String uip, String ua, String dr, String dp, String dt, long time) {
+        this.cid = cid;                      // Client ID
+        this.uip = uip;                      // User IP
+        this.ua = ua;                        // User Agent
+        this.dr = dr;                        // Document Referrer
+        this.dp = dp;                        // Document Path
+        this.dt = dt;                        // Document Title
+        this.time = time;                    // Time of event
+    }
+
+    public String getCid() {
+        return cid;
+    }
+
+    public void setCid(String cid) {
+        this.cid = cid;
+    }
+
+    public String getUip() {
+        return uip;
+    }
+
+    public void setUip(String uip) {
+        this.uip = uip;
+    }
+
+    public String getUa() {
+        if (ua == null) {
+            return "";
+        } else {
+            return ua;
+        }
+    }
+
+    public void setUa(String ua) {
+        this.ua = ua;
+    }
+
+    public String getDr() {
+        if (dr == null) {
+            return "";
+        } else {
+            return dr;
+        }
+    }
+
+    public void setDr(String dr) {
+        this.dr = dr;
+    }
+
+    public String getDp() {
+        return dp;
+    }
+
+    public void setDp(String dp) {
+        this.dp = dp;
+    }
+
+    public String getDt() {
+        return dt;
+    }
+
+    public void setDt(String dt) {
+        this.dt = dt;
+    }
+
+    public long getTime() {
+        return time;
+    }
+
+    public void setTime(long time) {
+        this.time = time;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/google/GoogleAsyncEventListener.java
+++ b/dspace-api/src/main/java/org/dspace/google/GoogleAsyncEventListener.java
@@ -1,0 +1,224 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ * <p>
+ * http://www.dspace.org/license/
+ */
+
+package org.dspace.google;
+
+import com.google.common.base.Throwables;
+import org.apache.commons.collections.Buffer;
+import org.apache.commons.collections.BufferUtils;
+import org.apache.commons.collections.buffer.CircularFifoBuffer;
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.log4j.Logger;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.model.Event;
+import org.dspace.usage.AbstractUsageEventListener;
+import org.dspace.usage.UsageEvent;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+
+/**
+ * Notifies Google Analytics of Bitstream VIEW events. These events are stored in memory and then
+ * asynchronously processed by a single seperate thread.
+ *
+ * @author Chris Herron
+ */
+public class GoogleAsyncEventListener extends AbstractUsageEventListener {
+
+    private static final int MAX_TIME_SINCE_EVENT = 14400000;
+    private static final String ANALYTICS_BATCH_ENDPOINT = "https://www.google-analytics.com/batch";
+    private static Logger log = Logger.getLogger(GoogleAsyncEventListener.class);
+    private static String analyticsKey;
+    private static CloseableHttpClient httpclient;
+    private static Buffer buffer;
+    private static ExecutorService executor;
+    private static Future future;
+    private static boolean destroyed = false;
+    private static ConfigurationService configurationService;
+
+    public GoogleAsyncEventListener(ConfigurationService configurationServiceRef) {
+        configurationService = configurationServiceRef;
+        analyticsKey = configurationService.getProperty("google.analytics.key");
+        if (StringUtils.isNotEmpty(analyticsKey)) {
+            int analyticsBufferlimit = configurationService.getIntProperty("google.analytics.buffer.limit", 256);
+            buffer = BufferUtils.synchronizedBuffer(new CircularFifoBuffer(analyticsBufferlimit));
+            httpclient = HttpClients.createDefault();
+            executor = Executors.newSingleThreadExecutor();
+            future = executor.submit(new GoogleAnalyticsTask());
+        }
+    }
+
+    @Override
+    public void receiveEvent(Event event) {
+        if ((event instanceof UsageEvent)) {
+            if (StringUtils.isNotEmpty(analyticsKey)) {
+                UsageEvent ue = (UsageEvent) event;
+                log.debug("Usage event received " + event.getName());
+                try {
+                    if (ue.getAction() == UsageEvent.Action.VIEW &&
+                            ue.getObject().getType() == Constants.BITSTREAM) {
+
+                        // Client Id, should uniquely identify the user or device. If we have a session id for the user
+                        // then lets use it, else generate a UUID.
+                        String cid;
+                        if (ue.getRequest().getSession(false) != null) {
+                            cid = ue.getRequest().getSession().getId();
+                        } else {
+                            cid = UUID.randomUUID().toString();
+                        }
+                        buffer.add(new GoogleAnalyticsEvent(cid, getIPAddress(ue.getRequest()), ue.getRequest().getHeader("USER-AGENT"), ue.getRequest().getHeader("referer"), ue.getRequest().getRequestURI() + "?" + ue.getRequest().getQueryString(), getObjectName(ue), System.currentTimeMillis()));
+                    }
+                } catch (Exception e) {
+                    log.error("Failed to add event to buffer", e);
+                    log.error("Event information: " + ue);
+                    Context context = ue.getContext();
+                    if (context != null) {
+                        log.error("Context information:");
+                        log.error("    Current User: " + context.getCurrentUser());
+                        log.error("    Extra log info: " + context.getExtraLogInfo());
+                        if (context.getEvents() != null && !context.getEvents().isEmpty()) {
+                            for (int x = 1; x <= context.getEvents().size(); x++) {
+                                log.error("    Context Event " + x + ": " + context.getEvents().get(x));
+                            }
+                        }
+                    } else {
+                        log.error("UsageEvent has no Context object");
+                    }
+                }
+            }
+        }
+    }
+
+    private String getObjectName(UsageEvent ue) {
+        try {
+            if (ue.getObject().getType() == Constants.BITSTREAM) {
+                // For a bitstream download we really want to know the title of the owning item rather than the bitstream name.
+                return ContentServiceFactory.getInstance().getDSpaceObjectService(ue.getObject()).getParentObject(ue.getContext(), ue.getObject()).getName();
+            } else {
+                return ue.getObject().getName();
+            }
+        } catch (SQLException e) {
+            // This shouldn't merit interrupting the user's transaction so log the error and continue.
+            log.error("Error in Google Analytics recording - can't determine ParentObjectName for bitstream " + ue.getObject().getID(), e);
+        }
+
+        return null;
+
+    }
+
+    private String getIPAddress(HttpServletRequest request) {
+        String clientIP = request.getRemoteAddr();
+        if (configurationService.getBooleanProperty("useProxies", false) && request.getHeader("X-Forwarded-For") != null) {
+            /* This header is a comma delimited list */
+            for (String xfip : request.getHeader("X-Forwarded-For").split(",")) {
+                /* proxy itself will sometime populate this header with the same value in
+                    remote address. ordering in spec is vague, we'll just take the last
+                    not equal to the proxy
+                */
+                if (!request.getHeader("X-Forwarded-For").contains(clientIP)) {
+                    clientIP = xfip.trim();
+                }
+            }
+        }
+
+        return clientIP;
+    }
+
+    public void destroy() throws InterruptedException {
+        destroyed = true;
+        if (StringUtils.isNotEmpty(analyticsKey)) {
+            future.cancel(true);
+            executor.shutdown();
+            executor.awaitTermination(1, TimeUnit.SECONDS);
+        }
+    }
+
+    private static class GoogleAnalyticsTask implements Runnable {
+        public void run() {
+            while (!destroyed) {
+                try {
+                    boolean sleep = false;
+                    StringBuilder request = null;
+                    List<GoogleAnalyticsEvent> events = new ArrayList<>();
+                    Iterator iterator = buffer.iterator();
+                    for (int x = 0; x < 20 && iterator.hasNext(); x++) {
+                        GoogleAnalyticsEvent event = (GoogleAnalyticsEvent) iterator.next();
+                        events.add(event);
+                        if ((System.currentTimeMillis() - event.getTime()) < MAX_TIME_SINCE_EVENT) {
+                            String download = "v=1" +
+                                    "&tid=" + analyticsKey +
+                                    "&cid=" + event.getCid() +
+                                    "&t=event" +
+                                    "&uip=" + URLEncoder.encode(event.getUip(), "UTF-8") +
+                                    "&ua=" + URLEncoder.encode(event.getUa(), "UTF-8") +
+                                    "&dr=" + URLEncoder.encode(event.getDr(), "UTF-8") +
+                                    "&dp=" + URLEncoder.encode(event.getDp(), "UTF-8") +
+                                    "&dt=" + URLEncoder.encode(event.getDt(), "UTF-8") +
+                                    "&qt=" + (System.currentTimeMillis() - event.getTime()) +
+                                    "&ec=bitstream" +
+                                    "&ea=download" +
+                                    "&el=item";
+                            if (request == null) {
+                                request = new StringBuilder(download);
+                            } else {
+                                request.append("\n").append(download);
+                            }
+                        }
+                    }
+
+                    if (request != null) {
+                        HttpPost httpPost = new HttpPost(ANALYTICS_BATCH_ENDPOINT);
+                        httpPost.setEntity(new StringEntity(request.toString()));
+                        try (final CloseableHttpResponse response2 = httpclient.execute(httpPost)) {
+                            // I can't find a list of what are acceptable responses, so I log the response but take no action.
+                            log.debug("Google Analytics response is " + response2.getStatusLine());
+                            // Cleanup processed events
+                            buffer.removeAll(events);
+                        } catch (IOException e) {
+                            log.error("GA post failed", e);
+                        }
+                    } else {
+                        sleep = true;
+                    }
+
+                    if (sleep) {
+                        try {
+                            Thread.sleep(60000);
+                        } catch (InterruptedException e) {
+                            log.debug("Interrupted; checking if we should stop");
+                        }
+                    }
+                } catch (Throwable t) {
+                    log.error("Unexpected error; aborting GA event recording", t);
+                    Throwables.propagate(t);
+                }
+            }
+            log.info("Stopping GA event recording");
+        }
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/google/GoogleAsyncEventListener.java
+++ b/dspace-api/src/main/java/org/dspace/google/GoogleAsyncEventListener.java
@@ -2,7 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- * <p>
+ *
  * http://www.dspace.org/license/
  */
 
@@ -83,10 +83,27 @@ public class GoogleAsyncEventListener extends AbstractUsageEventListener {
                     if (ue.getAction() == UsageEvent.Action.VIEW &&
                             ue.getObject().getType() == Constants.BITSTREAM) {
 
-                        // Client Id, should uniquely identify the user or device. If we have a session id for the user
-                        // then lets use it, else generate a UUID.
+                        // Client Id, should uniquely identify the user or device. If we have a _ga cookie, get the value
+                        // from it. Otherwise, if we have a session id for the user then let's use it. Else generate a UUID.
+                        Cookie gaCookie = null;
+                        if (ue.getRequest().getCookies() != null) {
+                            for (Cookie cookie : ue.getRequest().getCookies()) {
+                                if ("_ga".equals(cookie.getName())) {
+                                    gaCookie = cookie;
+                                    break;
+                                }
+                            }
+                        }
+
                         String cid;
-                        if (ue.getRequest().getSession(false) != null) {
+                        if (gaCookie != null) {
+                            String[] gaValue = gaCookie.getValue().split("\\.");
+                            if (gaValue.length >=2 ) {
+                                cid = gaValue[gaValue.length-2] + "." + gaValue[gaValue.length-1];
+                            } else {
+                                cid = gaCookie.getValue();
+                            }
+                        } else if (ue.getRequest().getSession(false) != null) {
                             cid = ue.getRequest().getSession().getId();
                         } else {
                             cid = UUID.randomUUID().toString();

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1807,6 +1807,7 @@ webui.suggest.enable = false
 # _uacct = "UA-XXXXXXX-X"
 # Take this key (just the UA-XXXXXX-X part) and place it here in this parameter.
 # google.analytics.key=UA-XXXXXX-X
+# google.analytics.buffer.limit=256
 
 #---------------------------------------------------------------#
 #--------------XMLUI SPECIFIC CONFIGURATIONS--------------------#

--- a/dspace/config/spring/rest/event-service-listeners.xml
+++ b/dspace/config/spring/rest/event-service-listeners.xml
@@ -17,8 +17,9 @@
     </bean>
 
     <!-- Google Analytics recording  -->
-    <bean class="org.dspace.google.GoogleRecorderEventListener">
+    <bean class="org.dspace.google.GoogleAsyncEventListener" destroy-method="destroy">
         <property name="eventService" ref="org.dspace.services.EventService"/>
+        <constructor-arg ref="org.dspace.services.ConfigurationService"/>
     </bean>
 
 </beans>


### PR DESCRIPTION
Currently, Google Analytics looks for the "Client ID" in the request's session. If none exists, it simply creates a new random UUID. This can result to poor tracking of a user's session. To improve on this, we can check the "_ga" cookie for the session ID. This greatly improves user session tracking.

This PR is based on [PR-2248](https://github.com/DSpace/DSpace/pull/2248)

Fixes #7416 