### PR TITLE
fix slow discovery

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/AbstractSearch.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/AbstractSearch.java
@@ -166,7 +166,7 @@ public abstract class AbstractSearch extends AbstractDSpaceTransformer implement
                     validity.add("size:" + results.size());
 
                     for (DSpaceObject dso : results) {
-                        validity.add(dso);
+                        validity.addIfItemOnlyAddOriginalBundles(dso);
                     }
                 }
 


### PR DESCRIPTION
Fixes issue reported at https://groups.google.com/forum/#!topic/dspace-tech/PbKbDfQlhok.

`DSpaceValidity`, which is used to cache search results in `AbstractSearch`, looks up all bundles, and all bitstreams of those bundles, for each item in a search results page. When an item has lots of bitstreams, this can lead to thousands upon thousands of SQL queries per page load.

This PR only looks at ORIGINAL bundles when determining the cache validity key.