### PR TITLE
DS-4072 Generate password reset link from command line

### DIFF
--- a/dspace-api/src/main/java/org/dspace/eperson/service/AccountService.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/service/AccountService.java
@@ -36,6 +36,9 @@ public interface AccountService {
 
     public void sendForgotPasswordInfo(Context context, String email) throws SQLException, IOException, MessagingException, AuthorizeException;
 
+    public String getForgotPasswordLink(Context context, String email)
+                throws SQLException, AuthorizeException;
+
     public EPerson getEPerson(Context context, String token)
                 throws SQLException, AuthorizeException;
 


### PR DESCRIPTION
This PR adds the ability to generate password reset link from command-line without sending an email (DS-4072). The usage of the command will be:

bin/dspace user -R -m {email}
OR 
bin/dspace user --reset -m {email}

The output of the command will be:
Password Reset Link: http://{dspace.url}/forgot?token={token}

Most other options are same as the user delete (-d) option.

Documentation can be updated after the PR is approved and merged.