### PR TITLE
DS-4078: Bitstreams should keep their formats when being versioned. (Master port)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -103,6 +103,8 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
         clonedBitstream.setSizeBytes(bitstream.getSizeBytes());
         clonedBitstream.setChecksum(bitstream.getChecksum());
         clonedBitstream.setChecksumAlgorithm(bitstream.getChecksumAlgorithm());
+        clonedBitstream.setFormat(bitstream.getBitstreamFormat());
+
         try {
             //Update our bitstream but turn off the authorization system since permissions
             //haven't been set at this point in time.


### PR DESCRIPTION
Port to `master` of #2261  (Unfortunately, a simple cherry-pick resulted in conflicts.)

This is a simple one-liner, already approved/tested by @pnbecker , @terrywbrady and @marsaoua (see #2261).  Once Travis CI approves this port, we should merge it immediately.