### PR TITLE
DS-4083 Move all Schema constants to a new MetadataSchemaEnum class

### DIFF
--- a/dspace-api/src/main/java/org/dspace/administer/MetadataImporter.java
+++ b/dspace-api/src/main/java/org/dspace/administer/MetadataImporter.java
@@ -21,6 +21,7 @@ import org.apache.xpath.XPathAPI;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.MetadataField;
 import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.NonUniqueMetadataException;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.MetadataFieldService;
@@ -248,7 +249,7 @@ public class MetadataImporter {
 
         // If the schema is not provided default to DC
         if (schema == null) {
-            schema = MetadataSchema.DC_SCHEMA;
+            schema = MetadataSchemaEnum.DC.getName();
         }
 
 

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSV.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSV.java
@@ -35,6 +35,7 @@ import org.dspace.content.Collection;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataField;
 import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.authority.Choices;
 import org.dspace.content.factory.ContentServiceFactory;
@@ -199,7 +200,7 @@ public class DSpaceCSV implements Serializable {
                     }
 
                     // Check that the scheme exists
-                    if (!StringUtils.equals(metadataSchema, "relation")) {
+                    if (!StringUtils.equals(metadataSchema, MetadataSchemaEnum.RELATION.getName())) {
                         MetadataSchema foundSchema = metadataSchemaService.find(c, metadataSchema);
                         if (foundSchema == null) {
                             throw new MetadataImportInvalidHeadingException(clean[0],

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -37,6 +37,7 @@ import org.dspace.content.DSpaceObject;
 import org.dspace.content.Entity;
 import org.dspace.content.EntityType;
 import org.dspace.content.Item;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.Relationship;
 import org.dspace.content.RelationshipType;
@@ -356,7 +357,7 @@ public class MetadataImport {
                         // Add the metadata to the item
                         List<BulkEditMetadataValue> relationships = new LinkedList<>();
                         for (BulkEditMetadataValue dcv : whatHasChanged.getAdds()) {
-                            if (StringUtils.equals(dcv.getSchema(), "relation")) {
+                            if (StringUtils.equals(dcv.getSchema(), MetadataSchemaEnum.RELATION.getName())) {
 
                                 if (!StringUtils.equals(dcv.getElement(), "type")) {
                                     relationships.add(dcv);
@@ -637,7 +638,7 @@ public class MetadataImport {
             }
 
 
-            if (StringUtils.equals(schema, "relation")) {
+            if (StringUtils.equals(schema, MetadataSchemaEnum.RELATION.getName())) {
                 handleRelationMetadata(c, item, schema, element, qualifier, language, values, authorities, confidences);
             } else {
                 itemService.clearMetadata(c, item, schema, element, qualifier, language);

--- a/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
@@ -42,7 +42,7 @@ import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataField;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.CommunityService;
@@ -214,7 +214,7 @@ public class ItemExportServiceImpl implements ItemExportService {
     protected void writeMetadata(Context c, String schema, Item i,
                                  File destDir, boolean migrate) throws Exception {
         String filename;
-        if (schema.equals(MetadataSchema.DC_SCHEMA)) {
+        if (schema.equals(MetadataSchemaEnum.DC.getName())) {
             filename = "dublin_core.xml";
         } else {
             filename = "metadata_" + schema + ".xml";

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -74,6 +74,7 @@ import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataField;
 import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.content.service.BitstreamFormatService;
 import org.dspace.content.service.BitstreamService;
@@ -677,7 +678,7 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
         Node schemaAttr = metadata.item(0).getAttributes().getNamedItem(
             "schema");
         if (schemaAttr == null) {
-            schema = MetadataSchema.DC_SCHEMA;
+            schema = MetadataSchemaEnum.DC.getName();
         } else {
             schema = schemaAttr.getNodeValue();
         }

--- a/dspace-api/src/main/java/org/dspace/app/itemupdate/MetadataUtilities.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemupdate/MetadataUtilities.java
@@ -34,6 +34,7 @@ import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataField;
 import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.ItemService;
@@ -189,7 +190,7 @@ public class MetadataUtilities {
         NodeList metadata = XPathAPI.selectNodeList(document, "/dublin_core");
         Node schemaAttr = metadata.item(0).getAttributes().getNamedItem("schema");
         if (schemaAttr == null) {
-            schema = MetadataSchema.DC_SCHEMA;
+            schema = MetadataSchemaEnum.DC.getName();
         } else {
             schema = schemaAttr.getNodeValue();
         }

--- a/dspace-api/src/main/java/org/dspace/app/statistics/ReportGenerator.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/ReportGenerator.java
@@ -28,7 +28,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.dspace.content.Item;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.ItemService;
@@ -763,9 +763,10 @@ public class ReportGenerator {
         // build the referece
         // FIXME: here we have blurred the line between content and presentation
         // and it should probably be un-blurred
-        List<MetadataValue> title = itemService.getMetadata(item, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
+        List<MetadataValue> title = itemService.getMetadata(item, MetadataSchemaEnum.DC.getName(),
+                                                            "title", null, Item.ANY);
         List<MetadataValue> author = itemService
-            .getMetadata(item, MetadataSchema.DC_SCHEMA, "contributor", "author", Item.ANY);
+            .getMetadata(item, MetadataSchemaEnum.DC.getName(), "contributor", "author", Item.ANY);
 
         StringBuffer authors = new StringBuffer();
         if (author.size() > 0) {

--- a/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
@@ -14,7 +14,7 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import org.apache.commons.lang.StringUtils;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.core.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -160,7 +160,7 @@ public class DCInput {
         // Default the schema to dublin core
         dcSchema = fieldMap.get("dc-schema");
         if (dcSchema == null) {
-            dcSchema = MetadataSchema.DC_SCHEMA;
+            dcSchema = MetadataSchemaEnum.DC.getName();
         }
 
         //check if the input have a language tag

--- a/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
@@ -21,7 +21,7 @@ import javax.xml.parsers.FactoryConfigurationError;
 
 import org.apache.commons.lang3.StringUtils;
 import org.dspace.content.Collection;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.core.Utils;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.w3c.dom.Document;
@@ -464,7 +464,7 @@ public class DCInputsReader {
         String elem = field.get("dc-element");
         String qual = field.get("dc-qualifier");
         if ((schema == null) || (schema.equals(""))) {
-            schema = MetadataSchema.DC_SCHEMA;
+            schema = MetadataSchemaEnum.DC.getName();
         }
         String schemaTest;
 
@@ -474,7 +474,7 @@ public class DCInputsReader {
                 Map<String, String> fld = pg.get(j);
                 if ((fld.get("dc-schema") == null) ||
                     ((fld.get("dc-schema")).equals(""))) {
-                    schemaTest = MetadataSchema.DC_SCHEMA;
+                    schemaTest = MetadataSchemaEnum.DC.getName();
                 } else {
                     schemaTest = fld.get("dc-schema");
                 }

--- a/dspace-api/src/main/java/org/dspace/content/Bitstream.java
+++ b/dspace-api/src/main/java/org/dspace/content/Bitstream.java
@@ -122,7 +122,8 @@ public class Bitstream extends DSpaceObject implements DSpaceObjectLegacySupport
      */
     @Override
     public String getName() {
-        return getBitstreamService().getMetadataFirstValue(this, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
+        return getBitstreamService().getMetadataFirstValue(this, MetadataSchemaEnum.DC.getName(),
+                                                           "title", null, Item.ANY);
     }
 
     /**
@@ -133,7 +134,8 @@ public class Bitstream extends DSpaceObject implements DSpaceObjectLegacySupport
      * @throws SQLException if database error
      */
     public void setName(Context context, String n) throws SQLException {
-        getBitstreamService().setMetadataSingleValue(context, this, MetadataSchema.DC_SCHEMA, "title", null, null, n);
+        getBitstreamService().setMetadataSingleValue(context, this, MetadataSchemaEnum.DC.getName(),
+                                                     "title", null, null, n);
     }
 
     /**
@@ -144,7 +146,8 @@ public class Bitstream extends DSpaceObject implements DSpaceObjectLegacySupport
      * @return the source of the bitstream
      */
     public String getSource() {
-        return getBitstreamService().getMetadataFirstValue(this, MetadataSchema.DC_SCHEMA, "source", null, Item.ANY);
+        return getBitstreamService().getMetadataFirstValue(this, MetadataSchemaEnum.DC.getName(),
+                                                           "source", null, Item.ANY);
     }
 
     /**
@@ -155,7 +158,8 @@ public class Bitstream extends DSpaceObject implements DSpaceObjectLegacySupport
      * @throws SQLException if database error
      */
     public void setSource(Context context, String n) throws SQLException {
-        getBitstreamService().setMetadataSingleValue(context, this, MetadataSchema.DC_SCHEMA, "source", null, null, n);
+        getBitstreamService().setMetadataSingleValue(context, this, MetadataSchemaEnum.DC.getName(),
+                                                     "source", null, null, n);
     }
 
     /**
@@ -166,7 +170,8 @@ public class Bitstream extends DSpaceObject implements DSpaceObjectLegacySupport
      */
     public String getDescription() {
         return getBitstreamService()
-            .getMetadataFirstValue(this, MetadataSchema.DC_SCHEMA, "description", null, Item.ANY);
+            .getMetadataFirstValue(this, MetadataSchemaEnum.DC.getName(), "description",
+                                   null, Item.ANY);
     }
 
     /**
@@ -178,7 +183,7 @@ public class Bitstream extends DSpaceObject implements DSpaceObjectLegacySupport
      */
     public void setDescription(Context context, String n) throws SQLException {
         getBitstreamService()
-            .setMetadataSingleValue(context, this, MetadataSchema.DC_SCHEMA, "description", null, null, n);
+            .setMetadataSingleValue(context, this, MetadataSchemaEnum.DC.getName(), "description", null, null, n);
     }
 
     /**
@@ -227,7 +232,8 @@ public class Bitstream extends DSpaceObject implements DSpaceObjectLegacySupport
      * @return the user's format description.
      */
     public String getUserFormatDescription() {
-        return getBitstreamService().getMetadataFirstValue(this, MetadataSchema.DC_SCHEMA, "format", null, Item.ANY);
+        return getBitstreamService().getMetadataFirstValue(this, MetadataSchemaEnum.DC.getName(),
+                                                           "format", null, Item.ANY);
     }
 
     protected BitstreamFormat getBitstreamFormat() {

--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -203,7 +203,7 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
     @Override
     public void setUserFormatDescription(Context context, Bitstream bitstream, String desc) throws SQLException {
         setFormat(context, bitstream, null);
-        setMetadataSingleValue(context, bitstream, MetadataSchema.DC_SCHEMA, "format", null, null, desc);
+        setMetadataSingleValue(context, bitstream, MetadataSchemaEnum.DC.getName(), "format", null, null, desc);
     }
 
     @Override
@@ -233,7 +233,7 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
         }
 
         // Remove user type description
-        clearMetadata(context, bitstream, MetadataSchema.DC_SCHEMA, "format", null, Item.ANY);
+        clearMetadata(context, bitstream, MetadataSchemaEnum.DC.getName(), "format", null, Item.ANY);
 
         // Update the ID in the table row
         bitstream.setFormat(bitstreamFormat);

--- a/dspace-api/src/main/java/org/dspace/content/Bundle.java
+++ b/dspace-api/src/main/java/org/dspace/content/Bundle.java
@@ -88,7 +88,7 @@ public class Bundle extends DSpaceObject implements DSpaceObjectLegacySupport {
      */
     @Override
     public String getName() {
-        return getBundleService().getMetadataFirstValue(this, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
+        return getBundleService().getMetadataFirstValue(this, MetadataSchemaEnum.DC.getName(), "title", null, Item.ANY);
     }
 
     /**
@@ -100,7 +100,8 @@ public class Bundle extends DSpaceObject implements DSpaceObjectLegacySupport {
      * @throws SQLException if database error
      */
     public void setName(Context context, String name) throws SQLException {
-        getBundleService().setMetadataSingleValue(context, this, MetadataSchema.DC_SCHEMA, "title", null, null, name);
+        getBundleService().setMetadataSingleValue(context, this, MetadataSchemaEnum.DC.getName(),
+                                                  "title", null, null, name);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/Collection.java
+++ b/dspace-api/src/main/java/org/dspace/content/Collection.java
@@ -134,7 +134,7 @@ public class Collection extends DSpaceObject implements DSpaceObjectLegacySuppor
     @Override
     public String getName() {
         String value = getCollectionService()
-            .getMetadataFirstValue(this, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
+            .getMetadataFirstValue(this, MetadataSchemaEnum.DC.getName(), "title", null, Item.ANY);
         return value == null ? "" : value;
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -143,10 +143,11 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
 
     @Override
     public List<Collection> findAll(Context context) throws SQLException {
-        MetadataField nameField = metadataFieldService.findByElement(context, MetadataSchema.DC_SCHEMA, "title", null);
+        MetadataField nameField = metadataFieldService.findByElement(context, MetadataSchemaEnum.DC.getName(),
+                                                                     "title", null);
         if (nameField == null) {
             throw new IllegalArgumentException(
-                "Required metadata field '" + MetadataSchema.DC_SCHEMA + ".title' doesn't exist!");
+                "Required metadata field '" + MetadataSchemaEnum.DC.getName() + ".title' doesn't exist!");
         }
 
         return collectionDAO.findAll(context, nameField);
@@ -154,10 +155,11 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
 
     @Override
     public List<Collection> findAll(Context context, Integer limit, Integer offset) throws SQLException {
-        MetadataField nameField = metadataFieldService.findByElement(context, MetadataSchema.DC_SCHEMA, "title", null);
+        MetadataField nameField = metadataFieldService.findByElement(context, MetadataSchemaEnum.DC.getName(),
+                                                                     "title", null);
         if (nameField == null) {
             throw new IllegalArgumentException(
-                "Required metadata field '" + MetadataSchema.DC_SCHEMA + ".title' doesn't exist!");
+                "Required metadata field '" + MetadataSchemaEnum.DC.getName() + ".title' doesn't exist!");
         }
 
         return collectionDAO.findAll(context, nameField, limit, offset);

--- a/dspace-api/src/main/java/org/dspace/content/Community.java
+++ b/dspace-api/src/main/java/org/dspace/content/Community.java
@@ -254,7 +254,7 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
     @Override
     public String getName() {
         String value = getCommunityService()
-            .getMetadataFirstValue(this, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
+            .getMetadataFirstValue(this, MetadataSchemaEnum.DC.getName(), "title", null, Item.ANY);
         return value == null ? "" : value;
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
@@ -139,10 +139,11 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
 
     @Override
     public List<Community> findAll(Context context) throws SQLException {
-        MetadataField sortField = metadataFieldService.findByElement(context, MetadataSchema.DC_SCHEMA, "title", null);
+        MetadataField sortField = metadataFieldService.findByElement(context, MetadataSchemaEnum.DC.getName(),
+                                                                     "title", null);
         if (sortField == null) {
             throw new IllegalArgumentException(
-                "Required metadata field '" + MetadataSchema.DC_SCHEMA + ".title' doesn't exist!");
+                "Required metadata field '" + MetadataSchemaEnum.DC.getName() + ".title' doesn't exist!");
         }
 
         return communityDAO.findAll(context, sortField);
@@ -150,10 +151,11 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
 
     @Override
     public List<Community> findAll(Context context, Integer limit, Integer offset) throws SQLException {
-        MetadataField nameField = metadataFieldService.findByElement(context, MetadataSchema.DC_SCHEMA, "title", null);
+        MetadataField nameField = metadataFieldService.findByElement(context, MetadataSchemaEnum.DC.getName(),
+                                                                     "title", null);
         if (nameField == null) {
             throw new IllegalArgumentException(
-                "Required metadata field '" + MetadataSchema.DC_SCHEMA + ".title' doesn't exist!");
+                "Required metadata field '" + MetadataSchemaEnum.DC.getName() + ".title' doesn't exist!");
         }
 
         return communityDAO.findAll(context, nameField, limit, offset);
@@ -162,10 +164,11 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
     @Override
     public List<Community> findAllTop(Context context) throws SQLException {
         // get all communities that are not children
-        MetadataField sortField = metadataFieldService.findByElement(context, MetadataSchema.DC_SCHEMA, "title", null);
+        MetadataField sortField = metadataFieldService.findByElement(context, MetadataSchemaEnum.DC.getName(),
+                                                                     "title", null);
         if (sortField == null) {
             throw new IllegalArgumentException(
-                "Required metadata field '" + MetadataSchema.DC_SCHEMA + ".title' doesn't exist!");
+                "Required metadata field '" + MetadataSchemaEnum.DC.getName() + ".title' doesn't exist!");
         }
 
         return communityDAO.findAllNoParent(context, sortField);

--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
@@ -67,7 +67,7 @@ public abstract class DSpaceObjectServiceImpl<T extends DSpaceObject> implements
 
     @Override
     public String getName(T dso) {
-        String value = getMetadataFirstValue(dso, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
+        String value = getMetadataFirstValue(dso, MetadataSchemaEnum.DC.getName(), "title", null, Item.ANY);
         return value == null ? "" : value;
     }
 
@@ -578,23 +578,23 @@ public abstract class DSpaceObjectServiceImpl<T extends DSpaceObject> implements
     protected String[] getMDValueByLegacyField(String field) {
         switch (field) {
             case "introductory_text":
-                return new String[] {MetadataSchema.DC_SCHEMA, "description", null};
+                return new String[] {MetadataSchemaEnum.DC.getName(), "description", null};
             case "short_description":
-                return new String[] {MetadataSchema.DC_SCHEMA, "description", "abstract"};
+                return new String[] {MetadataSchemaEnum.DC.getName(), "description", "abstract"};
             case "side_bar_text":
-                return new String[] {MetadataSchema.DC_SCHEMA, "description", "tableofcontents"};
+                return new String[] {MetadataSchemaEnum.DC.getName(), "description", "tableofcontents"};
             case "copyright_text":
-                return new String[] {MetadataSchema.DC_SCHEMA, "rights", null};
+                return new String[] {MetadataSchemaEnum.DC.getName(), "rights", null};
             case "name":
-                return new String[] {MetadataSchema.DC_SCHEMA, "title", null};
+                return new String[] {MetadataSchemaEnum.DC.getName(), "title", null};
             case "provenance_description":
-                return new String[] {MetadataSchema.DC_SCHEMA, "provenance", null};
+                return new String[] {MetadataSchemaEnum.DC.getName(), "provenance", null};
             case "license":
-                return new String[] {MetadataSchema.DC_SCHEMA, "rights", "license"};
+                return new String[] {MetadataSchemaEnum.DC.getName(), "rights", "license"};
             case "user_format_description":
-                return new String[] {MetadataSchema.DC_SCHEMA, "format", null};
+                return new String[] {MetadataSchemaEnum.DC.getName(), "format", null};
             case "source":
-                return new String[] {MetadataSchema.DC_SCHEMA, "source", null};
+                return new String[] {MetadataSchemaEnum.DC.getName(), "source", null};
             case "firstname":
                 return new String[] {"eperson", "firstname", null};
             case "lastname":

--- a/dspace-api/src/main/java/org/dspace/content/InstallItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/InstallItemServiceImpl.java
@@ -104,9 +104,10 @@ public class InstallItemServiceImpl implements InstallItemService {
 
         // If the item doesn't have a date.accessioned, set it to today
         List<MetadataValue> dateAccessioned = itemService
-            .getMetadata(item, MetadataSchema.DC_SCHEMA, "date", "accessioned", Item.ANY);
+            .getMetadata(item, MetadataSchemaEnum.DC.getName(), "date", "accessioned", Item.ANY);
         if (dateAccessioned.isEmpty()) {
-            itemService.addMetadata(c, item, MetadataSchema.DC_SCHEMA, "date", "accessioned", null, now.toString());
+            itemService.addMetadata(c, item, MetadataSchemaEnum.DC.getName(),
+                                    "date", "accessioned", null, now.toString());
         }
 
         // If issue date is set as "today" (literal string), then set it to current date
@@ -114,8 +115,8 @@ public class InstallItemServiceImpl implements InstallItemService {
         // replacing "today" with today's date.
         // NOTE: As of DSpace 4.0, DSpace no longer sets an issue date by default
         List<MetadataValue> currentDateIssued = itemService
-            .getMetadata(item, MetadataSchema.DC_SCHEMA, "date", "issued", Item.ANY);
-        itemService.clearMetadata(c, item, MetadataSchema.DC_SCHEMA, "date", "issued", Item.ANY);
+            .getMetadata(item, MetadataSchemaEnum.DC.getName(), "date", "issued", Item.ANY);
+        itemService.clearMetadata(c, item, MetadataSchemaEnum.DC.getName(), "date", "issued", Item.ANY);
         for (MetadataValue dcv : currentDateIssued) {
             if (dcv.getValue() != null && dcv.getValue().equalsIgnoreCase("today")) {
                 DCDate issued = new DCDate(now.getYear(), now.getMonth(), now.getDay(), -1, -1, -1);
@@ -127,7 +128,8 @@ public class InstallItemServiceImpl implements InstallItemService {
 
         // Record that the item was restored
         String provDescription = "Restored into DSpace on " + now + " (GMT).";
-        itemService.addMetadata(c, item, MetadataSchema.DC_SCHEMA, "description", "provenance", "en", provDescription);
+        itemService.addMetadata(c, item, MetadataSchemaEnum.DC.getName(),
+                                "description", "provenance", "en", provDescription);
 
         return finishItem(c, item, is);
     }
@@ -137,14 +139,16 @@ public class InstallItemServiceImpl implements InstallItemService {
         throws SQLException, AuthorizeException {
         // create accession date
         DCDate now = DCDate.getCurrent();
-        itemService.addMetadata(c, item, MetadataSchema.DC_SCHEMA, "date", "accessioned", null, now.toString());
+        itemService.addMetadata(c, item, MetadataSchemaEnum.DC.getName(),
+                                "date", "accessioned", null, now.toString());
 
         // add date available if not under embargo, otherwise it will
         // be set when the embargo is lifted.
         // this will flush out fatal embargo metadata
         // problems before we set inArchive.
         if (embargoService.getEmbargoTermsAsDate(c, item) == null) {
-            itemService.addMetadata(c, item, MetadataSchema.DC_SCHEMA, "date", "available", null, now.toString());
+            itemService.addMetadata(c, item, MetadataSchemaEnum.DC.getName(),
+                                    "date", "available", null, now.toString());
         }
 
         // If issue date is set as "today" (literal string), then set it to current date
@@ -152,8 +156,8 @@ public class InstallItemServiceImpl implements InstallItemService {
         // replacing "today" with today's date.
         // NOTE: As of DSpace 4.0, DSpace no longer sets an issue date by default
         List<MetadataValue> currentDateIssued = itemService
-            .getMetadata(item, MetadataSchema.DC_SCHEMA, "date", "issued", Item.ANY);
-        itemService.clearMetadata(c, item, MetadataSchema.DC_SCHEMA, "date", "issued", Item.ANY);
+            .getMetadata(item, MetadataSchemaEnum.DC.getName(), "date", "issued", Item.ANY);
+        itemService.clearMetadata(c, item, MetadataSchemaEnum.DC.getName(), "date", "issued", Item.ANY);
         for (MetadataValue dcv : currentDateIssued) {
             if (dcv.getValue() != null && dcv.getValue().equalsIgnoreCase("today")) {
                 DCDate issued = new DCDate(now.getYear(), now.getMonth(), now.getDay(), -1, -1, -1);
@@ -178,7 +182,8 @@ public class InstallItemServiceImpl implements InstallItemService {
         }
 
         // Add provenance description
-        itemService.addMetadata(c, item, MetadataSchema.DC_SCHEMA, "description", "provenance", "en", provDescription);
+        itemService.addMetadata(c, item, MetadataSchemaEnum.DC.getName(),
+                                "description", "provenance", "en", provDescription);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/Item.java
+++ b/dspace-api/src/main/java/org/dspace/content/Item.java
@@ -352,7 +352,7 @@ public class Item extends DSpaceObject implements DSpaceObjectLegacySupport {
 
     @Override
     public String getName() {
-        return getItemService().getMetadataFirstValue(this, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
+        return getItemService().getMetadataFirstValue(this, MetadataSchemaEnum.DC.getName(), "title", null, Item.ANY);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/ItemComparator.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemComparator.java
@@ -174,7 +174,7 @@ public class ItemComparator implements Comparator, Serializable {
     protected String getValue(Item item) {
         // The overall array and each element are guaranteed non-null
         List<MetadataValue> dcvalues = itemService
-            .getMetadata(item, MetadataSchema.DC_SCHEMA, element, qualifier, language);
+            .getMetadata(item, MetadataSchemaEnum.DC.getName(), element, qualifier, language);
 
         if (dcvalues.isEmpty()) {
             return null;

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -229,10 +229,10 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         throws SQLException {
 
         MetadataField metadataField = metadataFieldService
-            .findByElement(context, MetadataSchema.DC_SCHEMA, "date", "accessioned");
+            .findByElement(context, MetadataSchemaEnum.DC.getName(), "date", "accessioned");
         if (metadataField == null) {
             throw new IllegalArgumentException(
-                "Required metadata field '" + MetadataSchema.DC_SCHEMA + ".date.accessioned' doesn't exist!");
+                "Required metadata field '" + MetadataSchemaEnum.DC.getName() + ".date.accessioned' doesn't exist!");
         }
 
         return itemDAO.findBySubmitter(context, eperson, metadataField, limit);
@@ -553,7 +553,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
 
         prov.append(installItemService.getBitstreamProvenanceMessage(context, item));
 
-        addMetadata(context, item, MetadataSchema.DC_SCHEMA, "description", "provenance", "en", prov.toString());
+        addMetadata(context, item, MetadataSchemaEnum.DC.getName(), "description", "provenance", "en", prov.toString());
 
         // Update item in DB
         update(context, item);
@@ -608,7 +608,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         // bitstream checksums
         prov.append(installItemService.getBitstreamProvenanceMessage(context, item));
 
-        addMetadata(context, item, MetadataSchema.DC_SCHEMA, "description", "provenance", "en", prov.toString());
+        addMetadata(context, item, MetadataSchemaEnum.DC.getName(), "description", "provenance", "en", prov.toString());
 
         // Update item in DB
         update(context, item);

--- a/dspace-api/src/main/java/org/dspace/content/MetadataSchema.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataSchema.java
@@ -39,10 +39,6 @@ import org.hibernate.proxy.HibernateProxyHelper;
 @org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @Table(name = "metadataschemaregistry")
 public class MetadataSchema implements ReloadableEntity<Integer> {
-    /**
-     * Short Name of built-in Dublin Core schema.
-     */
-    public static final String DC_SCHEMA = "dc";
 
     @Id
     @Column(name = "metadata_schema_id")

--- a/dspace-api/src/main/java/org/dspace/content/MetadataSchemaEnum.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataSchemaEnum.java
@@ -1,0 +1,39 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content;
+
+/**
+ * This is an enum that holds track of a few special MetadataSchema types.
+ * It is important to note that this list is not exhaustive for the MetadataSchema
+ * types and different MetadataSchema can easily be made.
+ * These MetadataSchema objects are simply required.
+ */
+public enum MetadataSchemaEnum {
+    DC("dc"), RELATION("relation");
+
+    /**
+     * The String representation of the MetadataSchemaEnum
+     */
+    private String name;
+
+    /**
+     * Default constructor with the name parameter
+     * @param name  The name parameter
+     */
+    MetadataSchemaEnum(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Generic getter for the String representation of the enum object
+     * @return  The name of the enum object
+     */
+    public String getName() {
+        return name;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/OAIDCIngestionCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/OAIDCIngestionCrosswalk.java
@@ -15,7 +15,7 @@ import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataField;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Constants;
@@ -67,7 +67,8 @@ public class OAIDCIngestionCrosswalk
                 lang = element.getAttributeValue("lang");
             }
             MetadataField metadataField = metadataValidator
-                .checkMetadata(context, MetadataSchema.DC_SCHEMA, element.getName(), null, createMissingMetadataFields);
+                .checkMetadata(context, MetadataSchemaEnum.DC.getName(),
+                               element.getName(), null, createMissingMetadataFields);
             itemService.addMetadata(context, item, metadataField, lang, element.getText());
         }
 

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/OREDisseminationCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/OREDisseminationCrosswalk.java
@@ -22,7 +22,7 @@ import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.ItemService;
@@ -122,7 +122,7 @@ public class OREDisseminationCrosswalk
 
         Element aggLink;
         List<MetadataValue> uris = itemService
-            .getMetadata(item, MetadataSchema.DC_SCHEMA, "identifier", "uri", Item.ANY);
+            .getMetadata(item, MetadataSchemaEnum.DC.getName(), "identifier", "uri", Item.ANY);
         for (MetadataValue uri : uris) {
             aggLink = new Element("link", ATOM_NS);
             aggLink.setAttribute("rel", "alternate");
@@ -159,7 +159,8 @@ public class OREDisseminationCrosswalk
 
         // Information about the aggregation (item) itself
         Element aggTitle = new Element("title", ATOM_NS);
-        List<MetadataValue> titles = itemService.getMetadata(item, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
+        List<MetadataValue> titles = itemService.getMetadata(item, MetadataSchemaEnum.DC.getName(),
+                                                             "title", null, Item.ANY);
         if (titles != null && titles.size() > 0) {
             aggTitle.addContent(titles.get(0).getValue());
         } else {
@@ -170,7 +171,7 @@ public class OREDisseminationCrosswalk
         Element aggAuthor;
         Element aggAuthorName;
         List<MetadataValue> authors = itemService
-            .getMetadata(item, MetadataSchema.DC_SCHEMA, "contributor", "author", Item.ANY);
+            .getMetadata(item, MetadataSchemaEnum.DC.getName(), "contributor", "author", Item.ANY);
         for (MetadataValue author : authors) {
             aggAuthor = new Element("author", ATOM_NS);
             aggAuthorName = new Element("name", ATOM_NS);

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/QDCCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/QDCCrosswalk.java
@@ -26,6 +26,7 @@ import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataField;
 import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.ItemService;
@@ -353,7 +354,7 @@ public class QDCCrosswalk extends SelfNamedPlugin
 
             // only complain about missing elements in the DC schema:
             if (elt == null) {
-                if (metadataField.getMetadataSchema().getName().equals(MetadataSchema.DC_SCHEMA)) {
+                if (metadataField.getMetadataSchema().getName().equals(MetadataSchemaEnum.DC.getName())) {
                     log.warn("WARNING: " + myName + ": No QDC mapping for \"" + qdc + "\"");
                 }
             } else {

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/SimpleDCDisseminationCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/SimpleDCDisseminationCrosswalk.java
@@ -17,7 +17,7 @@ import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataField;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.ItemService;
@@ -101,7 +101,7 @@ public class SimpleDCDisseminationCrosswalk extends SelfNamedPlugin
 
         Item item = (Item) dso;
         List<MetadataValue> allDC = itemService
-            .getMetadata(item, MetadataSchema.DC_SCHEMA, Item.ANY, Item.ANY, Item.ANY);
+            .getMetadata(item, MetadataSchemaEnum.DC.getName(), Item.ANY, Item.ANY, Item.ANY);
 
         List<Element> dcl = new ArrayList<Element>(allDC.size());
 

--- a/dspace-api/src/main/java/org/dspace/content/packager/PDFPackager.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/PDFPackager.java
@@ -33,7 +33,7 @@ import org.dspace.content.Collection;
 import org.dspace.content.DCDate;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.content.crosswalk.CrosswalkException;
 import org.dspace.content.crosswalk.MetadataValidationException;
@@ -377,10 +377,11 @@ public class PDFPackager
             if (log.isDebugEnabled()) {
                 log.debug("PDF Info dict title=\"" + title + "\"");
             }
-            itemService.addMetadata(context, item, MetadataSchema.DC_SCHEMA, "title", null, "en", title);
+            itemService.addMetadata(context, item, MetadataSchemaEnum.DC.getName(), "title", null, "en", title);
             String value = docinfo.getAuthor();
             if (value != null) {
-                itemService.addMetadata(context, item, MetadataSchema.DC_SCHEMA, "contributor", "author", null, value);
+                itemService.addMetadata(context, item, MetadataSchemaEnum.DC.getName(),
+                                        "contributor", "author", null, value);
                 if (log.isDebugEnabled()) {
                     log.debug("PDF Info dict author=\"" + value + "\"");
                 }
@@ -388,25 +389,29 @@ public class PDFPackager
 
             value = docinfo.getCreator();
             if (value != null) {
-                itemService.addMetadata(context, item, MetadataSchema.DC_SCHEMA, "description", "provenance", "en",
+                itemService.addMetadata(context, item, MetadataSchemaEnum.DC.getName(),
+                                        "description", "provenance", "en",
                                         "Application that created the original document: " + value);
             }
 
             value = docinfo.getProducer();
             if (value != null) {
-                itemService.addMetadata(context, item, MetadataSchema.DC_SCHEMA, "description", "provenance", "en",
+                itemService.addMetadata(context, item, MetadataSchemaEnum.DC.getName(),
+                                        "description", "provenance", "en",
                                         "Original document converted to PDF by: " + value);
             }
 
             value = docinfo.getSubject();
             if (value != null) {
                 itemService
-                    .addMetadata(context, item, MetadataSchema.DC_SCHEMA, "description", "abstract", null, value);
+                    .addMetadata(context, item, MetadataSchemaEnum.DC.getName(),
+                                 "description", "abstract", null, value);
             }
 
             value = docinfo.getKeywords();
             if (value != null) {
-                itemService.addMetadata(context, item, MetadataSchema.DC_SCHEMA, "subject", "other", null, value);
+                itemService.addMetadata(context, item, MetadataSchemaEnum.DC.getName(),
+                                        "subject", "other", null, value);
             }
 
             // Take either CreationDate or ModDate as "date.created",
@@ -417,7 +422,7 @@ public class PDFPackager
             }
 
             if (calValue != null) {
-                itemService.addMetadata(context, item, MetadataSchema.DC_SCHEMA, "date", "created", null,
+                itemService.addMetadata(context, item, MetadataSchemaEnum.DC.getName(), "date", "created", null,
                                         (new DCDate(calValue.getTime())).toString());
             }
             itemService.update(context, item);

--- a/dspace-api/src/main/java/org/dspace/content/packager/PackageUtils.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/PackageUtils.java
@@ -30,7 +30,7 @@ import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.content.factory.ContentServiceFactory;
@@ -158,7 +158,7 @@ public class PackageUtils {
      */
     public static void checkItemMetadata(Item item)
         throws PackageValidationException {
-        List<MetadataValue> t = itemService.getMetadata(item, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
+        List<MetadataValue> t = itemService.getMetadata(item, MetadataSchemaEnum.DC.getName(), "title", null, Item.ANY);
         if (t == null || t.size() == 0) {
             throw new PackageValidationException("Item cannot be created without the required \"title\" DC metadata.");
         }

--- a/dspace-api/src/main/java/org/dspace/embargo/EmbargoServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/embargo/EmbargoServiceImpl.java
@@ -17,7 +17,7 @@ import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.DCDate;
 import org.dspace.content.Item;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
@@ -153,8 +153,8 @@ public class EmbargoServiceImpl implements EmbargoService {
         itemService.clearMetadata(context, item, lift_schema, lift_element, lift_qualifier, Item.ANY);
 
         // set the dc.date.available value to right now
-        itemService.clearMetadata(context, item, MetadataSchema.DC_SCHEMA, "date", "available", Item.ANY);
-        itemService.addMetadata(context, item, MetadataSchema.DC_SCHEMA, "date", "available", null,
+        itemService.clearMetadata(context, item, MetadataSchemaEnum.DC.getName(), "date", "available", Item.ANY);
+        itemService.addMetadata(context, item, MetadataSchemaEnum.DC.getName(), "date", "available", null,
                                 DCDate.getCurrent().toString());
 
         log.info("Lifting embargo on Item " + item.getHandle());

--- a/dspace-api/src/main/java/org/dspace/eperson/SubscribeCLITool.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/SubscribeCLITool.java
@@ -31,7 +31,7 @@ import org.apache.log4j.Logger;
 import org.dspace.content.Collection;
 import org.dspace.content.DCDate;
 import org.dspace.content.Item;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.ItemService;
@@ -229,7 +229,7 @@ public class SubscribeCLITool {
                         }
 
                         List<MetadataValue> authors = itemService
-                            .getMetadata(hii.item, MetadataSchema.DC_SCHEMA, "contributor", Item.ANY, Item.ANY);
+                            .getMetadata(hii.item, MetadataSchemaEnum.DC.getName(), "contributor", Item.ANY, Item.ANY);
 
                         if (authors.size() > 0) {
                             emailText.append("\n    ").append(labels.getString("org.dspace.eperson.Subscribe.authors"))

--- a/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
@@ -15,7 +15,7 @@ import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.ConfigurationManager;
@@ -228,14 +228,15 @@ public class HandleIdentifierProvider extends IdentifierProvider {
         // First check that identifier doesn't already exist.
         boolean identifierExists = false;
         List<MetadataValue> identifiers = itemService
-            .getMetadata(item, MetadataSchema.DC_SCHEMA, "identifier", "uri", Item.ANY);
+            .getMetadata(item, MetadataSchemaEnum.DC.getName(), "identifier", "uri", Item.ANY);
         for (MetadataValue identifier : identifiers) {
             if (handleref.equals(identifier.getValue())) {
                 identifierExists = true;
             }
         }
         if (!identifierExists) {
-            itemService.addMetadata(context, item, MetadataSchema.DC_SCHEMA, "identifier", "uri", null, handleref);
+            itemService.addMetadata(context, item, MetadataSchemaEnum.DC.getName(),
+                                    "identifier", "uri", null, handleref);
         }
     }
 }

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
@@ -19,7 +19,7 @@ import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.ConfigurationManager;
@@ -417,9 +417,9 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
         // load all identifiers, clear the metadata field, re add all
         // identifiers which are not from type handle and add the new handle.
         List<MetadataValue> identifiers = itemService.getMetadata(item,
-                                                                  MetadataSchema.DC_SCHEMA, "identifier", "uri",
+                                                                  MetadataSchemaEnum.DC.getName(), "identifier", "uri",
                                                                   Item.ANY);
-        itemService.clearMetadata(context, item, MetadataSchema.DC_SCHEMA,
+        itemService.clearMetadata(context, item, MetadataSchemaEnum.DC.getName(),
                                   "identifier", "uri", Item.ANY);
         for (MetadataValue identifier : identifiers) {
             if (this.supports(identifier.getValue())) {
@@ -439,7 +439,8 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
 
         // Add handle as identifier.uri DC value.
         if (StringUtils.isNotBlank(handleref)) {
-            itemService.addMetadata(context, item, MetadataSchema.DC_SCHEMA, "identifier", "uri", null, handleref);
+            itemService.addMetadata(context, item, MetadataSchemaEnum.DC.getName(),
+                                    "identifier", "uri", null, handleref);
         }
         itemService.update(context, item);
     }

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
@@ -17,7 +17,7 @@ import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.ConfigurationManager;
@@ -492,8 +492,8 @@ public class VersionedHandleIdentifierProviderWithCanonicalHandles extends Ident
         // identifiers which are not from type handle and add the new handle.
         String handleref = handleService.getCanonicalForm(handle);
         List<MetadataValue> identifiers = itemService
-            .getMetadata(item, MetadataSchema.DC_SCHEMA, "identifier", "uri", Item.ANY);
-        itemService.clearMetadata(context, item, MetadataSchema.DC_SCHEMA, "identifier", "uri", Item.ANY);
+            .getMetadata(item, MetadataSchemaEnum.DC.getName(), "identifier", "uri", Item.ANY);
+        itemService.clearMetadata(context, item, MetadataSchemaEnum.DC.getName(), "identifier", "uri", Item.ANY);
         for (MetadataValue identifier : identifiers) {
             if (this.supports(identifier.getValue())) {
                 // ignore handles
@@ -508,7 +508,8 @@ public class VersionedHandleIdentifierProviderWithCanonicalHandles extends Ident
                                     identifier.getConfidence());
         }
         if (!StringUtils.isEmpty(handleref)) {
-            itemService.addMetadata(context, item, MetadataSchema.DC_SCHEMA, "identifier", "uri", null, handleref);
+            itemService.addMetadata(context, item, MetadataSchemaEnum.DC.getName(),
+                                    "identifier", "uri", null, handleref);
         }
         itemService.update(context, item);
     }

--- a/dspace-api/src/main/java/org/dspace/rdf/conversion/MetadataConverterPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/rdf/conversion/MetadataConverterPlugin.java
@@ -33,6 +33,7 @@ import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataField;
 import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.DSpaceObjectService;
@@ -133,7 +134,7 @@ public class MetadataConverterPlugin implements ConverterPlugin {
         }
 
         List<MetadataValue> metadata_values = dsoService
-            .getMetadata(dso, MetadataSchema.DC_SCHEMA, Item.ANY, Item.ANY, Item.ANY);
+            .getMetadata(dso, MetadataSchemaEnum.DC.getName(), Item.ANY, Item.ANY, Item.ANY);
         for (MetadataValue value : metadata_values) {
             MetadataField metadataField = value.getMetadataField();
             MetadataSchema metadataSchema = metadataField.getMetadataSchema();

--- a/dspace-api/src/main/java/org/dspace/workflowbasic/BasicWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/workflowbasic/BasicWorkflowServiceImpl.java
@@ -31,7 +31,7 @@ import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
 import org.dspace.content.DCDate;
 import org.dspace.content.Item;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.InstallItemService;
@@ -910,8 +910,8 @@ public class BasicWorkflowServiceImpl implements BasicWorkflowService {
             + rejection_message + " on " + now + " (GMT) ";
 
         // Add to item as a DC field
-        itemService
-            .addMetadata(context, myitem, MetadataSchema.DC_SCHEMA, "description", "provenance", "en", provDescription);
+        itemService.addMetadata(context, myitem, MetadataSchemaEnum.DC.getName(),
+                         "description", "provenance", "en", provDescription);
         itemService.update(context, myitem);
 
         // convert into personal workspace
@@ -1135,8 +1135,8 @@ public class BasicWorkflowServiceImpl implements BasicWorkflowService {
         provDescription += installItemService.getBitstreamProvenanceMessage(context, item);
 
         // Add to item as a DC field
-        itemService
-            .addMetadata(context, item, MetadataSchema.DC_SCHEMA, "description", "provenance", "en", provDescription);
+        itemService.addMetadata(context, item, MetadataSchemaEnum.DC.getName(),
+                                "description", "provenance", "en", provDescription);
         itemService.update(context, item);
     }
 
@@ -1163,8 +1163,8 @@ public class BasicWorkflowServiceImpl implements BasicWorkflowService {
         provmessage += installItemService.getBitstreamProvenanceMessage(context, myitem);
 
         // Add message to the DC
-        itemService
-            .addMetadata(context, myitem, MetadataSchema.DC_SCHEMA, "description", "provenance", "en", provmessage);
+        itemService.addMetadata(context, myitem, MetadataSchemaEnum.DC.getName(),
+                                "description", "provenance", "en", provmessage);
         itemService.update(context, myitem);
     }
 

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
@@ -31,7 +31,7 @@ import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
 import org.dspace.content.DCDate;
 import org.dspace.content.Item;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.content.service.InstallItemService;
@@ -573,7 +573,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
 
             // Get title
             List<MetadataValue> titles = itemService
-                .getMetadata(item, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
+                .getMetadata(item, MetadataSchemaEnum.DC.getName(), "title", null, Item.ANY);
             String title = "";
             try {
                 title = I18nUtil.getMessage("org.dspace.workflow.WorkflowManager.untitled");
@@ -874,7 +874,8 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
 
         // Add to item as a DC field
         itemService
-            .addMetadata(context, myitem, MetadataSchema.DC_SCHEMA, "description", "provenance", "en", provDescription);
+            .addMetadata(context, myitem, MetadataSchemaEnum.DC.getName(),
+                         "description", "provenance", "en", provDescription);
 
         //Clear any workflow schema related metadata
         itemService
@@ -1002,7 +1003,8 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
 
         // Add message to the DC
         itemService
-            .addMetadata(context, myitem, MetadataSchema.DC_SCHEMA, "description", "provenance", "en", provmessage);
+            .addMetadata(context, myitem, MetadataSchemaEnum.DC.getName(),
+                         "description", "provenance", "en", provmessage);
         itemService.update(context, myitem);
     }
 

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/AcceptEditRejectAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/AcceptEditRejectAction.java
@@ -14,7 +14,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.dspace.app.util.Util;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.DCDate;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.core.Context;
 import org.dspace.xmlworkflow.factory.XmlWorkflowServiceFactory;
 import org.dspace.xmlworkflow.state.Step;
@@ -112,7 +112,7 @@ public class AcceptEditRejectAction extends ProcessingAction {
             + usersName + " on " + now + " (GMT) ";
 
         // Add to item as a DC field
-        itemService.addMetadata(c, wfi.getItem(), MetadataSchema.DC_SCHEMA, "description", "provenance", "en",
+        itemService.addMetadata(c, wfi.getItem(), MetadataSchemaEnum.DC.getName(), "description", "provenance", "en",
                                 provDescription);
         itemService.update(c, wfi.getItem());
     }

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/FinalEditAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/FinalEditAction.java
@@ -13,7 +13,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.DCDate;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.core.Context;
 import org.dspace.xmlworkflow.factory.XmlWorkflowServiceFactory;
 import org.dspace.xmlworkflow.state.Step;
@@ -68,7 +68,7 @@ public class FinalEditAction extends ProcessingAction {
             + usersName + " on " + now + " (GMT) ";
 
         // Add to item as a DC field
-        itemService.addMetadata(c, wfi.getItem(), MetadataSchema.DC_SCHEMA, "description", "provenance", "en",
+        itemService.addMetadata(c, wfi.getItem(), MetadataSchemaEnum.DC.getName(), "description", "provenance", "en",
                                 provDescription);
         itemService.update(c, wfi.getItem());
     }

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/ReviewAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/ReviewAction.java
@@ -14,7 +14,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.dspace.app.util.Util;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.DCDate;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.core.Context;
 import org.dspace.xmlworkflow.factory.XmlWorkflowServiceFactory;
 import org.dspace.xmlworkflow.state.Step;
@@ -85,7 +85,7 @@ public class ReviewAction extends ProcessingAction {
             + usersName + " on " + now + " (GMT) ";
 
         // Add to item as a DC field
-        itemService.addMetadata(c, wfi.getItem(), MetadataSchema.DC_SCHEMA, "description", "provenance", "en",
+        itemService.addMetadata(c, wfi.getItem(), MetadataSchemaEnum.DC.getName(), "description", "provenance", "en",
                                 provDescription);
         itemService.update(c, wfi.getItem());
     }

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/ScoreEvaluationAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/ScoreEvaluationAction.java
@@ -14,7 +14,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Item;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.MetadataValue;
 import org.dspace.core.Context;
 import org.dspace.workflow.WorkflowException;
@@ -66,8 +66,8 @@ public class ScoreEvaluationAction extends ProcessingAction {
 
             String provDescription = getProvenanceStartId() + " Approved for entry into archive with a score of: " +
                 scoreMean;
-            itemService.addMetadata(c, wfi.getItem(), MetadataSchema.DC_SCHEMA, "description", "provenance", "en",
-                                    provDescription);
+            itemService.addMetadata(c, wfi.getItem(), MetadataSchemaEnum.DC.getName(),
+                                    "description", "provenance", "en", provDescription);
             itemService.update(c, wfi.getItem());
         }
         if (hasPassed) {

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/SingleUserReviewAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/SingleUserReviewAction.java
@@ -14,7 +14,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.dspace.app.util.Util;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.DCDate;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.core.Context;
 import org.dspace.xmlworkflow.factory.XmlWorkflowServiceFactory;
 import org.dspace.xmlworkflow.state.Step;
@@ -91,7 +91,7 @@ public class SingleUserReviewAction extends ProcessingAction {
             + usersName + " on " + now + " (GMT) ";
 
         // Add to item as a DC field
-        itemService.addMetadata(c, wfi.getItem(), MetadataSchema.DC_SCHEMA, "description", "provenance", "en",
+        itemService.addMetadata(c, wfi.getItem(), MetadataSchemaEnum.DC.getName(), "description", "provenance", "en",
                                 provDescription);
         itemService.update(c, wfi.getItem());
     }

--- a/dspace-api/src/test/java/org/dspace/content/CollectionTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/CollectionTest.java
@@ -1834,16 +1834,16 @@ public class CollectionTest extends AbstractDSpaceObjectTest {
     public void testGetCommunities() throws Exception {
         context.turnOffAuthorisationSystem();
         Community community = communityService.create(null, context);
-        communityService.setMetadataSingleValue(context, community, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY,
-                                                "community 3");
+        communityService.setMetadataSingleValue(context, community, MetadataSchemaEnum.DC.getName(),
+                                                "title", null, Item.ANY, "community 3");
         this.collection.addCommunity(community);
         community = communityService.create(null, context);
-        communityService.setMetadataSingleValue(context, community, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY,
-                                                "community 1");
+        communityService.setMetadataSingleValue(context, community, MetadataSchemaEnum.DC.getName(),
+                                                "title", null, Item.ANY, "community 1");
         this.collection.addCommunity(community);
         community = communityService.create(null, context);
-        communityService.setMetadataSingleValue(context, community, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY,
-                                                "community 2");
+        communityService.setMetadataSingleValue(context, community, MetadataSchemaEnum.DC.getName(),
+                                                "title", null, Item.ANY, "community 2");
         this.collection.addCommunity(community);
         context.restoreAuthSystemState();
         assertTrue("testGetCommunities 0", collection.getCommunities().size() == 4);

--- a/dspace-api/src/test/java/org/dspace/content/CommunityTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/CommunityTest.java
@@ -673,14 +673,17 @@ public class CommunityTest extends AbstractDSpaceObjectTest {
 
         context.turnOffAuthorisationSystem();
         Collection collection = collectionService.create(context, c);
-        collectionService.setMetadataSingleValue(context, collection, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY,
-                                                 "collection B");
+        collectionService
+            .setMetadataSingleValue(context, collection, MetadataSchemaEnum.DC.getName(),
+                                    "title", null, Item.ANY, "collection B");
         collection = collectionService.create(context, c);
-        collectionService.setMetadataSingleValue(context, collection, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY,
-                                                 "collection C");
+        collectionService
+            .setMetadataSingleValue(context, collection, MetadataSchemaEnum.DC.getName(),
+                                    "title", null, Item.ANY, "collection C");
         collection = collectionService.create(context, c);
-        collectionService.setMetadataSingleValue(context, collection, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY,
-                                                 "collection A");
+        collectionService
+            .setMetadataSingleValue(context, collection, MetadataSchemaEnum.DC.getName(),
+                                    "title", null, Item.ANY, "collection A");
         //we need to commit the changes so we don't block the table for testing
         context.restoreAuthSystemState();
 
@@ -712,14 +715,17 @@ public class CommunityTest extends AbstractDSpaceObjectTest {
 
         context.turnOffAuthorisationSystem();
         Community community = communityService.create(c, context);
-        communityService.setMetadataSingleValue(context, community, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY,
-                                                "subcommunity B");
+        communityService
+            .setMetadataSingleValue(context, community, MetadataSchemaEnum.DC.getName(),
+                                    "title", null, Item.ANY, "subcommunity B");
         community = communityService.create(c, context);
-        communityService.setMetadataSingleValue(context, community, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY,
-                                                "subcommunity A");
+        communityService
+            .setMetadataSingleValue(context, community, MetadataSchemaEnum.DC.getName(),
+                                    "title", null, Item.ANY, "subcommunity A");
         community = communityService.create(c, context);
-        communityService.setMetadataSingleValue(context, community, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY,
-                                                "subcommunity C");
+        communityService
+            .setMetadataSingleValue(context, community, MetadataSchemaEnum.DC.getName(),
+                                    "title", null, Item.ANY, "subcommunity C");
         //we need to commit the changes so we don't block the table for testing
         context.restoreAuthSystemState();
 

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -737,12 +737,12 @@ public class ItemTest extends AbstractDSpaceObjectTest {
     public void testGetCollections() throws Exception {
         context.turnOffAuthorisationSystem();
         Collection collection = collectionService.create(context, owningCommunity);
-        collectionService.setMetadataSingleValue(context, collection, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY,
-                                                 "collection B");
+        collectionService.setMetadataSingleValue(context, collection, MetadataSchemaEnum.DC.getName(),
+                                                 "title", null, Item.ANY, "collection B");
         it.addCollection(collection);
         collection = collectionService.create(context, owningCommunity);
-        collectionService.setMetadataSingleValue(context, collection, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY,
-                                                 "collection A");
+        collectionService.setMetadataSingleValue(context, collection, MetadataSchemaEnum.DC.getName(),
+                                                 "title", null, Item.ANY, "collection A");
         it.addCollection(collection);
         context.restoreAuthSystemState();
         assertThat("testGetCollections 0", it.getCollections(), notNullValue());

--- a/dspace-api/src/test/java/org/dspace/content/MetadataFieldTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/MetadataFieldTest.java
@@ -78,14 +78,14 @@ public class MetadataFieldTest extends AbstractUnitTest {
     public void init() {
         super.init();
         try {
-            this.dcSchema = metadataSchemaService.find(context, MetadataSchema.DC_SCHEMA);
+            this.dcSchema = metadataSchemaService.find(context, MetadataSchemaEnum.DC.getName());
             this.mf = metadataFieldService.findByElement(context,
-                                                         MetadataSchema.DC_SCHEMA, element, qualifier);
+                                                         MetadataSchemaEnum.DC.getName(), element, qualifier);
             if (mf == null) {
                 context.turnOffAuthorisationSystem();
                 this.mf = metadataFieldService
-                    .create(context, metadataSchemaService.find(context, MetadataSchema.DC_SCHEMA), element, qualifier,
-                            scopeNote);
+                    .create(context, metadataSchemaService.find(context, MetadataSchemaEnum.DC.getName()),
+                            element, qualifier, scopeNote);
                 context.restoreAuthSystemState();
             }
 
@@ -165,7 +165,7 @@ public class MetadataFieldTest extends AbstractUnitTest {
      */
     @Test
     public void testGetSchema() {
-        assertThat("testGetSchemaID 0", mf.getMetadataSchema().getName(), equalTo(MetadataSchema.DC_SCHEMA));
+        assertThat("testGetSchemaID 0", mf.getMetadataSchema().getName(), equalTo(MetadataSchemaEnum.DC.getName()));
     }
 
     /**
@@ -259,7 +259,8 @@ public class MetadataFieldTest extends AbstractUnitTest {
      */
     @Test
     public void testFindByElement() throws Exception {
-        MetadataField found = metadataFieldService.findByElement(context, MetadataSchema.DC_SCHEMA, element, qualifier);
+        MetadataField found = metadataFieldService.findByElement(context, MetadataSchemaEnum.DC.getName(),
+                                                                 element, qualifier);
         assertThat("testFindByElement 0", found, notNullValue());
         assertThat("testFindByElement 1", found.getID(), equalTo(mf.getID()));
         assertThat("testFindByElement 2", found.getElement(), equalTo(mf.getElement()));
@@ -290,7 +291,7 @@ public class MetadataFieldTest extends AbstractUnitTest {
     @Test
     public void testFindAllInSchema() throws Exception {
         List<MetadataField> found = metadataFieldService
-            .findAllInSchema(context, metadataSchemaService.find(context, MetadataSchema.DC_SCHEMA));
+            .findAllInSchema(context, metadataSchemaService.find(context, MetadataSchemaEnum.DC.getName()));
         assertThat("testFindAllInSchema 0", found, notNullValue());
         assertTrue("testFindAllInSchema 1", found.size() >= 1);
         assertTrue("testFindAllInSchema 2", found.size() <= metadataFieldService.findAll(context).size());
@@ -320,7 +321,7 @@ public class MetadataFieldTest extends AbstractUnitTest {
         MetadataField m = metadataFieldService.create(context, dcSchema, elem, qual, null);
         metadataFieldService.update(context, m);
 
-        MetadataField found = metadataFieldService.findByElement(context, MetadataSchema.DC_SCHEMA, elem, qual);
+        MetadataField found = metadataFieldService.findByElement(context, MetadataSchemaEnum.DC.getName(), elem, qual);
         assertThat("testUpdateAuth 0", found.getID(), equalTo(m.getID()));
     }
 
@@ -380,7 +381,7 @@ public class MetadataFieldTest extends AbstractUnitTest {
 
         metadataFieldService.delete(context, m);
 
-        MetadataField found = metadataFieldService.findByElement(context, MetadataSchema.DC_SCHEMA, elem, qual);
+        MetadataField found = metadataFieldService.findByElement(context, MetadataSchemaEnum.DC.getName(), elem, qual);
         assertThat("testDeleteAuth 0", found, nullValue());
     }
 

--- a/dspace-api/src/test/java/org/dspace/content/MetadataSchemaTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/MetadataSchemaTest.java
@@ -59,7 +59,7 @@ public class MetadataSchemaTest extends AbstractUnitTest {
     public void init() {
         super.init();
         try {
-            this.ms = metadataSchemaService.find(context, MetadataSchema.DC_SCHEMA);
+            this.ms = metadataSchemaService.find(context, MetadataSchemaEnum.DC.getName());
         } catch (SQLException ex) {
             log.error("SQL Error in init", ex);
             fail("SQL Error in init: " + ex.getMessage());
@@ -122,7 +122,7 @@ public class MetadataSchemaTest extends AbstractUnitTest {
     @Test
     public void testGetSchemaID() throws SQLException {
         assertThat("testGetSchemaID 0", ms.getID(),
-                   equalTo(metadataSchemaService.find(context, MetadataSchema.DC_SCHEMA).getID()));
+                   equalTo(metadataSchemaService.find(context, MetadataSchemaEnum.DC.getName()).getID()));
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/content/MetadataValueTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/MetadataValueTest.java
@@ -95,7 +95,7 @@ public class MetadataValueTest extends AbstractUnitTest {
             this.it = installItemService.installItem(context, workspaceItem);
 
             this.mf = metadataFieldService.findByElement(context,
-                                                         MetadataSchema.DC_SCHEMA, element, qualifier);
+                                                         MetadataSchemaEnum.DC.getName(), element, qualifier);
             this.mv = metadataValueService.create(context, it, mf);
             context.restoreAuthSystemState();
         } catch (AuthorizeException ex) {

--- a/dspace-api/src/test/java/org/dspace/content/packager/ITDSpaceAIP.java
+++ b/dspace-api/src/test/java/org/dspace/content/packager/ITDSpaceAIP.java
@@ -36,7 +36,7 @@ import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.content.crosswalk.CrosswalkException;
 import org.dspace.content.factory.ContentServiceFactory;
@@ -164,17 +164,18 @@ public class ITDSpaceAIP extends AbstractUnitTest {
             //
             Community topCommunity = communityService.create(null, context);
             communityService
-                .addMetadata(context, topCommunity, MetadataSchema.DC_SCHEMA, "title", null, null, "Top Community");
+                .addMetadata(context, topCommunity, MetadataSchemaEnum.DC.getName(),
+                             "title", null, null, "Top Community");
             communityService.update(context, topCommunity);
             topCommunityHandle = topCommunity.getHandle();
 
             Community child = communityService.createSubcommunity(context, topCommunity);
             communityService
-                .addMetadata(context, child, MetadataSchema.DC_SCHEMA, "title", null, null, "Child Community");
+                .addMetadata(context, child, MetadataSchemaEnum.DC.getName(), "title", null, null, "Child Community");
             communityService.update(context, child);
 
             Community grandchild = communityService.createSubcommunity(context, child);
-            communityService.addMetadata(context, grandchild, MetadataSchema.DC_SCHEMA, "title", null, null,
+            communityService.addMetadata(context, grandchild, MetadataSchemaEnum.DC.getName(), "title", null, null,
                                          "Grandchild Community");
             communityService.update(context, grandchild);
 
@@ -558,8 +559,9 @@ public class ITDSpaceAIP extends AbstractUnitTest {
 
         // Change the Community name
         String newName = "This is NOT my Community name!";
-        communityService.clearMetadata(context, topCommunity, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
-        communityService.addMetadata(context, topCommunity, MetadataSchema.DC_SCHEMA, "title", null, null, newName);
+        communityService.clearMetadata(context, topCommunity, MetadataSchemaEnum.DC.getName(), "title", null, Item.ANY);
+        communityService.addMetadata(context, topCommunity, MetadataSchemaEnum.DC.getName(),
+                                     "title", null, null, newName);
 
         // Ensure name is changed
         assertEquals("testReplaceCommunityOnly() new name", topCommunity.getName(), newName);
@@ -781,8 +783,10 @@ public class ITDSpaceAIP extends AbstractUnitTest {
 
         // Change the Collection name
         String newName = "This is NOT my Collection name!";
-        collectionService.clearMetadata(context, testCollection, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
-        collectionService.addMetadata(context, testCollection, MetadataSchema.DC_SCHEMA, "title", null, null, newName);
+        collectionService.clearMetadata(context, testCollection, MetadataSchemaEnum.DC.getName(),
+                                        "title", null, Item.ANY);
+        collectionService.addMetadata(context, testCollection, MetadataSchemaEnum.DC.getName(),
+                                      "title", null, null, newName);
 
         // Ensure name is changed
         assertEquals("testReplaceCollectionOnly() new name", testCollection.getName(), newName);
@@ -1029,8 +1033,8 @@ public class ITDSpaceAIP extends AbstractUnitTest {
 
         // Change the Item name
         String newName = "This is NOT my Item name!";
-        itemService.clearMetadata(context, testItem, MetadataSchema.DC_SCHEMA, "title", null, Item.ANY);
-        itemService.addMetadata(context, testItem, MetadataSchema.DC_SCHEMA, "title", null, null, newName);
+        itemService.clearMetadata(context, testItem, MetadataSchemaEnum.DC.getName(), "title", null, Item.ANY);
+        itemService.addMetadata(context, testItem, MetadataSchemaEnum.DC.getName(), "title", null, null, newName);
 
         // Ensure name is changed
         assertEquals("testReplaceItem() new name", testItem.getName(), newName);

--- a/dspace-api/src/test/java/org/dspace/content/packager/PackageUtilsTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/packager/PackageUtilsTest.java
@@ -20,7 +20,7 @@ import org.dspace.AbstractUnitTest;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.CommunityService;
@@ -87,13 +87,14 @@ public class PackageUtilsTest extends AbstractUnitTest {
             //
             Community topCommunity = communityService.create(null, context);
             communityService
-                .addMetadata(context, topCommunity, MetadataSchema.DC_SCHEMA, "title", null, null, "Top Community");
+                .addMetadata(context, topCommunity, MetadataSchemaEnum.DC.getName(), "title", null, null,
+                             "Top Community");
             communityService.update(context, topCommunity);
             topCommunityHandle = topCommunity.getHandle();
 
             Community child = communityService.createSubcommunity(context, topCommunity);
             communityService
-                .addMetadata(context, child, MetadataSchema.DC_SCHEMA, "title", null, null, "Child Community");
+                .addMetadata(context, child, MetadataSchemaEnum.DC.getName(), "title", null, null, "Child Community");
             communityService.update(context, child);
 
             // Create our primary Test Collection

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/builder/CollectionBuilder.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/builder/CollectionBuilder.java
@@ -16,7 +16,7 @@ import org.apache.commons.lang3.CharEncoding;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.service.DSpaceObjectService;
 import org.dspace.core.Context;
 
@@ -50,7 +50,7 @@ public class CollectionBuilder extends AbstractDSpaceObjectBuilder<Collection> {
     }
 
     public CollectionBuilder withName(final String name) {
-        return setMetadataSingleValue(collection, MetadataSchema.DC_SCHEMA, "title", null, name);
+        return setMetadataSingleValue(collection, MetadataSchemaEnum.DC.getName(), "title", null, name);
     }
 
     public CollectionBuilder withLogo(final String content) throws AuthorizeException, IOException, SQLException {

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/builder/CommunityBuilder.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/builder/CommunityBuilder.java
@@ -15,7 +15,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.CharEncoding;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Community;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.service.DSpaceObjectService;
 import org.dspace.core.Context;
 
@@ -59,7 +59,7 @@ public class CommunityBuilder extends AbstractDSpaceObjectBuilder<Community> {
     }
 
     public CommunityBuilder withName(final String communityName) {
-        return setMetadataSingleValue(community, MetadataSchema.DC_SCHEMA, "title", null, communityName);
+        return setMetadataSingleValue(community, MetadataSchemaEnum.DC.getName(), "title", null, communityName);
     }
 
     public CommunityBuilder withLogo(String content) throws AuthorizeException, IOException, SQLException {

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/builder/ItemBuilder.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/builder/ItemBuilder.java
@@ -10,7 +10,7 @@ package org.dspace.app.rest.builder;
 import org.dspace.content.Collection;
 import org.dspace.content.DCDate;
 import org.dspace.content.Item;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.content.service.DSpaceObjectService;
 import org.dspace.core.Context;
@@ -52,19 +52,20 @@ public class ItemBuilder extends AbstractDSpaceObjectBuilder<Item> {
     }
 
     public ItemBuilder withTitle(final String title) {
-        return setMetadataSingleValue(item, MetadataSchema.DC_SCHEMA, "title", null, title);
+        return setMetadataSingleValue(item, MetadataSchemaEnum.DC.getName(), "title", null, title);
     }
 
     public ItemBuilder withIssueDate(final String issueDate) {
-        return addMetadataValue(item, MetadataSchema.DC_SCHEMA, "date", "issued", new DCDate(issueDate).toString());
+        return addMetadataValue(item, MetadataSchemaEnum.DC.getName(),
+                                "date", "issued", new DCDate(issueDate).toString());
     }
 
     public ItemBuilder withAuthor(final String authorName) {
-        return addMetadataValue(item, MetadataSchema.DC_SCHEMA, "contributor", "author", authorName);
+        return addMetadataValue(item, MetadataSchemaEnum.DC.getName(), "contributor", "author", authorName);
     }
 
     public ItemBuilder withSubject(final String subject) {
-        return addMetadataValue(item, MetadataSchema.DC_SCHEMA, "subject", null, subject);
+        return addMetadataValue(item, MetadataSchemaEnum.DC.getName(), "subject", null, subject);
     }
 
     public ItemBuilder withRelationshipType(final String relationshipType) {

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/builder/WorkspaceItemBuilder.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/builder/WorkspaceItemBuilder.java
@@ -14,7 +14,7 @@ import org.dspace.content.Collection;
 import org.dspace.content.DCDate;
 import org.dspace.content.Item;
 import org.dspace.content.LicenseUtils;
-import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Context;
@@ -101,19 +101,19 @@ public class WorkspaceItemBuilder extends AbstractBuilder<WorkspaceItem, Workspa
     }
 
     public WorkspaceItemBuilder withTitle(final String title) {
-        return setMetadataSingleValue(MetadataSchema.DC_SCHEMA, "title", null, title);
+        return setMetadataSingleValue(MetadataSchemaEnum.DC.getName(), "title", null, title);
     }
 
     public WorkspaceItemBuilder withIssueDate(final String issueDate) {
-        return addMetadataValue(MetadataSchema.DC_SCHEMA, "date", "issued", new DCDate(issueDate).toString());
+        return addMetadataValue(MetadataSchemaEnum.DC.getName(), "date", "issued", new DCDate(issueDate).toString());
     }
 
     public WorkspaceItemBuilder withAuthor(final String authorName) {
-        return addMetadataValue(MetadataSchema.DC_SCHEMA, "contributor", "author", authorName);
+        return addMetadataValue(MetadataSchemaEnum.DC.getName(), "contributor", "author", authorName);
     }
 
     public WorkspaceItemBuilder withSubject(final String subject) {
-        return addMetadataValue(MetadataSchema.DC_SCHEMA, "subject", null, subject);
+        return addMetadataValue(MetadataSchemaEnum.DC.getName(), "subject", null, subject);
     }
 
     public WorkspaceItemBuilder grantLicense() {


### PR DESCRIPTION
This pull request replaces the "dc" and "relation" metadata schemas to an Enum: `MetadataSchemaEnum`
This corresponds to https://jira.duraspace.org/browse/DS-4083 and the PR comment: https://github.com/DSpace/DSpace/pull/2246#discussion_r233552116