### PR TITLE
[DS-4085] Update abdera-client dependency to 1.1.3

### DIFF
--- a/dspace-swordv2/pom.xml
+++ b/dspace-swordv2/pom.xml
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>org.apache.abdera</groupId>
             <artifactId>abdera-client</artifactId>
-            <version>1.1.1</version>
+            <version>1.1.3</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-4085
Updating abdera-client dependency for Sword V2 resolves an issue where HTTP 500 errors would be returned when attempting to create an item.