### PR TITLE
Item: Remove duplicated getBundles(name) method

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/Item.java
+++ b/dspace-api/src/main/java/org/dspace/content/Item.java
@@ -291,26 +291,6 @@ public class Item extends DSpaceObject implements DSpaceObjectLegacySupport {
     }
 
     /**
-     * Get the bundles matching a bundle name (name corresponds roughly to type)
-     *
-     * @param name
-     *            name of bundle (ORIGINAL/TEXT/THUMBNAIL)
-     *
-     * @return the bundles in an unordered array
-     */
-    public List<Bundle> getBundles(String name) {
-        List<Bundle> matchingBundles = new ArrayList<>();
-         // now only keep bundles with matching names
-        List<Bundle> bunds = getBundles();
-        for (Bundle bundle : bunds) {
-            if (name.equals(bundle.getName())) {
-                matchingBundles.add(bundle);
-            }
-        }
-        return matchingBundles;
-    }
-
-    /**
      * Add a bundle to the item, should not be made public since we don't want to skip business logic
      *
      * @param bundle the bundle to be added

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordAuthenticator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordAuthenticator.java
@@ -702,7 +702,7 @@ public class SwordAuthenticator {
                 }
 
                 // get the "ORIGINAL" bundle(s)
-                List<Bundle> bundles = item.getBundles(Constants.CONTENT_BUNDLE_NAME);
+                List<Bundle> bundles = itemService.getBundles(item, Constants.CONTENT_BUNDLE_NAME);
 
                 // look up the READ policy on the community.  This will include determining if the user is an
                 // administrator
@@ -871,7 +871,7 @@ public class SwordAuthenticator {
             boolean write = authorizeService
                 .authorizeActionBoolean(allowContext, item, Constants.WRITE);
 
-            List<Bundle> bundles = item.getBundles(Constants.CONTENT_BUNDLE_NAME);
+            List<Bundle> bundles = itemService.getBundles(item, Constants.CONTENT_BUNDLE_NAME);
             boolean add = false;
             if (bundles.isEmpty()) {
                 add = authorizeService.authorizeActionBoolean(


### PR DESCRIPTION
The `getBundles(String name)` method is already provided by the [ItemService](https://github.com/DSpace/DSpace/blob/7f4b4e9/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java#L291-L301). This was introduced in #1910 to fix DS-3310. I think it was simply missed, that this method already exists in the ItemService.