### PR TITLE
DS-4065: resource policy aware REST API hibernate queries

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/dao/BitstreamDAO.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/BitstreamDAO.java
@@ -12,10 +12,13 @@ import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
 
 import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Database Access Object interface class for the Bitstream object.
@@ -25,6 +28,8 @@ import java.util.List;
  * @author kevinvandevelde at atmire.com
  */
 public interface BitstreamDAO extends DSpaceObjectLegacySupportDAO<Bitstream> {
+
+    public Iterator<Bitstream> findAll(Context context, int limit, int offset) throws SQLException;
 
     public List<Bitstream> findDeletedBitstreams(Context context) throws SQLException;
 
@@ -49,4 +54,6 @@ public interface BitstreamDAO extends DSpaceObjectLegacySupportDAO<Bitstream> {
     int countWithNoPolicy(Context context) throws SQLException;
 
     List<Bitstream> getNotReferencedBitstreams(Context context) throws SQLException;
+
+    Iterator<Bitstream> findAllAuthorized(Context context, int pageSize, int pageOffset, EPerson currentUser, int action, Set<Group> groups) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/content/dao/ItemDAO.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/ItemDAO.java
@@ -12,12 +12,15 @@ import org.dspace.content.Item;
 import org.dspace.content.MetadataField;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
 
 import java.sql.SQLException;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+
 
 /**
  * Database Access Object interface class for the Item object.
@@ -29,6 +32,8 @@ import java.util.UUID;
 public interface ItemDAO extends DSpaceObjectLegacySupportDAO<Item>
 {
     public Iterator<Item> findAll(Context context, boolean archived) throws SQLException;
+
+    public Iterator<Item> findAll(Context context, boolean archived, int limit, int offset) throws SQLException;
 
     public Iterator<Item> findAll(Context context, boolean archived, boolean withdrawn) throws SQLException;
 
@@ -116,5 +121,9 @@ public interface ItemDAO extends DSpaceObjectLegacySupportDAO<Item>
      * @throws SQLException if database error
      */
     int countItems(Context context, boolean includeArchived, boolean includeWithdrawn) throws SQLException;
+
+    Iterator<Item> findAllAuthorized(Context context, int pageSize, int pageOffset, EPerson currentUser, int action, Set<Group> groups) throws SQLException;
+
+    int countTotalAuthorized(Context context, EPerson currentUser, int action, Set<Group> groups) throws SQLException;
     
 }

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/BitstreamDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/BitstreamDAOImpl.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.content.dao.impl;
 
+import org.apache.log4j.Logger;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
@@ -15,13 +16,16 @@ import org.dspace.content.dao.BitstreamDAO;
 import org.dspace.core.AbstractHibernateDSODAO;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
 import org.hibernate.Criteria;
 import org.hibernate.Query;
 import org.hibernate.criterion.Restrictions;
 
 import java.sql.SQLException;
-import java.util.Iterator;
-import java.util.List;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
 
 /**
  * Hibernate implementation of the Database Access Object interface class for the Bitstream object.
@@ -32,6 +36,8 @@ import java.util.List;
  */
 public class BitstreamDAOImpl extends AbstractHibernateDSODAO<Bitstream> implements BitstreamDAO
 {
+
+    private static final Logger log = Logger.getLogger(BitstreamDAO.class);
 
     protected BitstreamDAOImpl()
     {
@@ -152,5 +158,48 @@ public class BitstreamDAOImpl extends AbstractHibernateDSODAO<Bitstream> impleme
                 " and bit.id not in (select com.logo.id from Community com)" +
                 " and bit.id not in (select col.logo.id from Collection col)" +
                 " and bit.id not in (select bun.primaryBitstream.id from Bundle bun)"));
+    }
+
+    @Override
+    public Iterator<Bitstream> findAll(Context context, int limit, int offset) throws SQLException {
+        Query query = createQuery(context, "select b FROM Bitstream b");
+        query.setFirstResult(offset);
+        query.setMaxResults(limit);
+        return iterate(query);
+    }
+
+    @Override
+    public Iterator<Bitstream> findAllAuthorized(Context context, int pageSize, int pageOffset, EPerson currentUser, int action, Set<Group> groups) throws SQLException{
+        Query query = createQuery(context, "SELECT DISTINCT b" +
+                " FROM Bitstream b" +
+                " JOIN b.resourcePolicies r" +
+                " WHERE (r.epersonGroup.id IN (:groupIdList) OR r.eperson.id = :currentUserId)" +
+                " AND (r.actionId = :actionId)" +
+                " AND (r.startDate IS NULL or r.startDate <= :currentDate)" +
+                " AND (r.endDate IS NULL or r.endDate >= :currentDate)");
+        LinkedList<UUID> list = new LinkedList<>();
+        for(Group group: groups){
+            list.add(group.getID());
+        }
+        query.setParameterList("groupIdList", list);
+        if(currentUser == null){
+            query.setParameter("currentUserId", null);
+        }
+        else{
+            query.setParameter("currentUserId", currentUser.getID());
+        }
+        query.setParameter("actionId", action);
+        SimpleDateFormat dateFormatUtc = new SimpleDateFormat("yyyy-MMM-dd");
+        dateFormatUtc.setTimeZone(TimeZone.getTimeZone("UTC"));
+        Date currentDate = null;
+        try{
+            currentDate = dateFormatUtc.parse(dateFormatUtc.format(new Date()));
+        } catch(ParseException e){
+            log.error(e,e);
+        }
+        query.setParameter("currentDate", currentDate);
+        query.setFirstResult(pageOffset);
+        query.setMaxResults(pageSize);
+        return iterate(query);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/service/BitstreamService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/BitstreamService.java
@@ -27,6 +27,8 @@ public interface BitstreamService extends DSpaceObjectService<Bitstream>, DSpace
 
     public List<Bitstream> findAll(Context context) throws SQLException;
 
+    public Iterator<Bitstream> findAll(Context context, int limit, int offset) throws SQLException;
+
     /**
      * Clone the given bitstream by firstly creating a new bitstream, with a new ID.
      * Then set the internal identifier, file size, checksum, and 
@@ -216,4 +218,6 @@ public interface BitstreamService extends DSpaceObjectService<Bitstream>, DSpace
     int countBitstreamsWithoutPolicy(Context context) throws SQLException;
 
     List<Bitstream> getNotReferencedBitstreams(Context context) throws SQLException;
+
+    Iterator<Bitstream> findAllAuthorized(Context context, int pageSize, int pageOffset) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
@@ -70,6 +70,18 @@ public interface ItemService extends DSpaceObjectService<Item>, DSpaceObjectLega
     public Iterator<Item> findAll(Context context) throws SQLException;
 
     /**
+     * Get all the items in the archive. Only items with the "in archive" flag
+     * set are included. The order of the list is indeterminate.
+     *
+     * @param context DSpace context object
+     * @param limit limit
+     * @param offset offset
+     * @return an iterator over the items in the archive.
+     * @throws SQLException if database error
+     */
+    public Iterator<Item> findAll(Context context, Integer limit, Integer offset) throws SQLException;
+
+    /**
      * Get all "final" items in the archive, both archived ("in archive" flag) or
      * withdrawn items are included. The order of the list is indeterminate.
      *
@@ -613,4 +625,9 @@ public interface ItemService extends DSpaceObjectService<Item>, DSpaceObjectLega
 	 * @return <code>true</code> if the item is linked to a workspaceitem or workflowitem
 	 */
     boolean isInProgressSubmission(Context context, Item item) throws SQLException;
+
+    Iterator<Item> findAllAuthorized(Context context, int pageSize, int pageOffset) throws SQLException;
+
+    int countTotalAuthorized(Context context) throws SQLException;
+
 }

--- a/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
@@ -723,4 +723,14 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
     public List<Group> findByMetadataField(final Context context, final String searchValue, final MetadataField metadataField) throws SQLException {
         return groupDAO.findByMetadataField(context, searchValue, metadataField);
     }
+
+    @Override
+    public List<Group> getAllParentGroups(Context context, UUID groupUuid) throws SQLException{
+        return groupDAO.getAllParentGroups(context, groupUuid);
+    }
+
+    /*@Override
+    public List<Group> getAllParentGroups(Context context, LinkedList<UUID> groupUuid) throws SQLException {
+        return groupDAO.getAllParentGroups(context, groupUuid);
+    }*/
 }

--- a/dspace-api/src/main/java/org/dspace/eperson/dao/GroupDAO.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/dao/GroupDAO.java
@@ -128,4 +128,7 @@ public interface GroupDAO extends DSpaceObjectDAO<Group>, DSpaceObjectLegacySupp
      */
     Group findByIdAndMembership(Context context, UUID id, EPerson ePerson) throws SQLException;
 
+    List<Group> getAllParentGroups(Context context, UUID groupUuid) throws SQLException;
+    //List<Group> getAllParentGroups(Context context, LinkedList<UUID> groupUuid) throws SQLException;
+
 }

--- a/dspace-api/src/main/java/org/dspace/eperson/dao/impl/GroupDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/dao/impl/GroupDAOImpl.java
@@ -185,4 +185,26 @@ public class GroupDAOImpl extends AbstractHibernateDSODAO<Group> implements Grou
         return count(createQuery(context, "SELECT count(*) FROM Group"));
     }
 
+    @Override
+    public List<Group> getAllParentGroups(Context context, UUID groupUuid) throws SQLException{
+        Query query = createQuery(context,
+                "SELECT gc.parent FROM Group2GroupCache gc " +
+                        "JOIN gc.child child " +
+                        "WHERE child.id = :groupId ");
+        query.setParameter("groupId", groupUuid);
+        query.setCacheable(true);
+        return query.list();
+    }
+
+    /*@Override
+    public List<Group> getAllParentGroups(Context context, LinkedList<UUID> groupUuid) throws SQLException{
+        Query query = createQuery(context,
+                "SELECT gc.parent FROM Group2GroupCache gc " +
+                        "JOIN gc.child child " +
+                        "WHERE child.id IN (:groupId) ");
+        query.setParameterList("groupId", groupUuid);
+        query.setCacheable(true);
+        return query.list();
+    }*/
+
 }

--- a/dspace-api/src/main/java/org/dspace/eperson/service/GroupService.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/service/GroupService.java
@@ -16,8 +16,10 @@ import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 
 import java.sql.SQLException;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * Service interface class for the Group object.
@@ -331,4 +333,8 @@ public interface GroupService extends DSpaceObjectService<Group>, DSpaceObjectLe
      * @throws SQLException database exception
      */
     List<Group> findByMetadataField(Context context, String searchValue, MetadataField metadataField) throws SQLException;
+
+    List<Group> getAllParentGroups(Context context, UUID groupUuid) throws SQLException;
+
+    //List<Group> getAllParentGroups(Context context, LinkedList<UUID> groupUuid) throws SQLException;
 }

--- a/dspace-rest/src/main/java/org/dspace/rest/BitstreamResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/BitstreamResource.java
@@ -12,6 +12,7 @@ import java.io.InputStream;
 import java.net.URLConnection;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 
@@ -224,7 +225,6 @@ public class BitstreamResource extends Resource
         try
         {
             context = createContext();
-            List<org.dspace.content.Bitstream> dspaceBitstreams = bitstreamService.findAll(context);
 
             if (!((limit != null) && (limit >= 0) && (offset != null) && (offset >= 0)))
             {
@@ -233,8 +233,19 @@ public class BitstreamResource extends Resource
                 offset = 0;
             }
 
+            Iterator<org.dspace.content.Bitstream> dspaceBitstreams = bitstreamService.findAllAuthorized(context, limit, offset);
+
+            while(dspaceBitstreams.hasNext()) {
+                org.dspace.content.Bitstream dspaceBitstream = dspaceBitstreams.next();
+
+                bitstreams.add(new Bitstream(dspaceBitstream, servletContext, expand, context));
+                writeStats(dspaceBitstream, UsageEvent.Action.VIEW, user_ip, user_agent,
+                        xforwardedfor, headers, request, context);
+
+            }
+
             // TODO If bitstream doesn't exist, throws exception.
-            for (int i = offset; (i < (offset + limit)) && (i < dspaceBitstreams.size()); i++)
+            /*for (int i = offset; (i < (offset + limit)) && (i < dspaceBitstreams.size()); i++)
             {
                 if (authorizeService.authorizeActionBoolean(context, dspaceBitstreams.get(i), org.dspace.core.Constants.READ))
                 {
@@ -246,7 +257,7 @@ public class BitstreamResource extends Resource
                                 xforwardedfor, headers, request, context);
                     }
                 }
-            }
+            }*/
 
             context.complete();
             log.trace("Bitstreams were successfully read.");

--- a/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
@@ -161,7 +161,6 @@ public class ItemsResource extends Resource
         {
             context = createContext();
 
-            Iterator<org.dspace.content.Item> dspaceItems = itemService.findAllUnfiltered(context);
             items = new ArrayList<Item>();
 
             if (!((limit != null) && (limit >= 0) && (offset != null) && (offset >= 0)))
@@ -171,19 +170,16 @@ public class ItemsResource extends Resource
                 offset = 0;
             }
 
-            for (int i = 0; (dspaceItems.hasNext()) && (i < (limit + offset)); i++)
-            {
+            Iterator<org.dspace.content.Item> dspaceItems = itemService.findAllAuthorized(context, limit, offset);
+
+            while(dspaceItems.hasNext()) {
                 org.dspace.content.Item dspaceItem = dspaceItems.next();
-                if (i >= offset)
-                {
-                    if (itemService.isItemListedForUser(context, dspaceItem))
-                    {
-                        items.add(new Item(dspaceItem, servletContext, expand, context));
-                        writeStats(dspaceItem, UsageEvent.Action.VIEW, user_ip, user_agent, xforwardedfor,
-                                headers, request, context);
-                    }
-                }
+
+                items.add(new Item(dspaceItem, servletContext, expand, context));
+                writeStats(dspaceItem, UsageEvent.Action.VIEW, user_ip, user_agent, xforwardedfor,
+                        headers, request, context);
             }
+
             context.complete();
         }
         catch (SQLException e)


### PR DESCRIPTION
Fixes #7412 
This PR borrows from #1879 to make the item and bitstream endpoints resourcepolicy aware.

This prevents the current behaviour of internally fetching offset-limit and returning from that subset, a subset of authorized items, with the authorization check being done in-memory.

Instead, findAllAuthorized methods are created for the DAOs and these are called via the REST api.

------

OUTDATED DISCUSSION BELOW
This is an unfinished work in progress focusing on the REST ["items" endpoint](https://github.com/DSpace/DSpace/blob/4bfa0e27d5af40c8e5662e0db3b0059da385648b/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java#L149-L203).

As has been [discussed](https://github.com/DSpace/DSpace/pull/1879#issuecomment-340797819) in PR https://github.com/DSpace/DSpace/pull/1879 the DSpace 6 REST API checks resource policies in memory. Moreover this breaks the limit/offset functionality because a set number of results are retrieved and of those anywhere between none and all are withheld pending authorisation checks.  (see [DS-4065](https://jira.duraspace.org/browse/DS-4065))

This PR ports the code for the DSpace 7 REST API from [PR 1879](https://github.com/DSpace/DSpace/pull/1879)

There is currently a problem with forming the Hibernate query correctly. In the resource policy aware query [findAllAuthorized](https://github.com/J4bbi/DSpace/blob/d75d97e2a65f047f75f4d62f9bdf70a5ad9918b7/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java#L310-L337)  the following condition has been commented out: 

       `" AND (r.epersonGroup.id IN (:groupIdList) OR r.eperson.id = :currentUserId)" +`

with the groupIdList parameter being defined as

```
       LinkedList<UUID> list = new LinkedList<>();
        for(Group group: groups){
            list.add(group.getID());
        }
        query.setParameter("groupIdList", list);
```

because else 

```
java.lang.ClassCastException: java.util.LinkedList cannot be cast to java.util.UUID
 	at org.hibernate.type.descriptor.java.UUIDTypeDescriptor.unwrap(UUIDTypeDescriptor.java:37)
 	at org.hibernate.type.PostgresUUIDType$PostgresUUIDSqlTypeDescriptor$1.doBind(PostgresUUIDType.java:76)
 	at org.hibernate.type.descriptor.sql.BasicBinder.bind(BasicBinder.java:93)
 	at org.hibernate.type.AbstractStandardBasicType.nullSafeSet(AbstractStandardBasicType.java:284)
 	at org.hibernate.type.AbstractStandardBasicType.nullSafeSet(AbstractStandardBasicType.java:279)
 	at org.hibernate.param.NamedParameterSpecification.bind(NamedParameterSpecification.java:66)
 	at org.hibernate.loader.hql.QueryLoader.bindParameterValues(QueryLoader.java:612)
 	at org.hibernate.loader.Loader.prepareQueryStatement(Loader.java:1897)
 	at org.hibernate.loader.Loader.executeQueryStatement(Loader.java:1858)
 	at org.hibernate.loader.Loader.executeQueryStatement(Loader.java:1838)
 	at org.hibernate.loader.hql.QueryLoader.iterate(QueryLoader.java:518)
 	at org.hibernate.hql.internal.ast.QueryTranslatorImpl.iterate(QueryTranslatorImpl.java:399)
 	at org.hibernate.engine.query.spi.HQLQueryPlan.performIterate(HQLQueryPlan.java:284)
 	at org.hibernate.internal.SessionImpl.iterate(SessionImpl.java:1292)
 	at org.hibernate.internal.QueryImpl.iterate(QueryImpl.java:68)
 	at org.dspace.core.AbstractHibernateDAO.iterate(AbstractHibernateDAO.java:247)
 	at org.dspace.content.dao.impl.ItemDAOImpl.findAllAuthorized(ItemDAOImpl.java:336)
 	at org.dspace.content.ItemServiceImpl.findAllAuthorized(ItemServiceImpl.java:1303)
 	at org.dspace.rest.ItemsResource.getItems(ItemsResource.java:174)
 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
 	at java.lang.reflect.Method.invoke(Method.java:498)
```

where and how Hibernate is told to expect a LinkedList < UUID >  and not a single UUID is currently beyond me. But as far as I can understand that's the single current problem.