### PR TITLE
Ds 4096 updating owning collections attempt #2

### DIFF
--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/ItemOwningCollectionUpdateRestController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/ItemOwningCollectionUpdateRestController.java
@@ -25,6 +25,7 @@ import org.dspace.content.service.ItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.security.access.prepost.PostAuthorize;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -50,7 +51,7 @@ public class ItemOwningCollectionUpdateRestController {
     @Autowired
     CollectionConverter converter;
 
-    @RequestMapping(method = RequestMethod.POST, value = "/{targetUuid}")
+    @RequestMapping(method = RequestMethod.PUT, value = "/{targetUuid}")
     @PreAuthorize("hasPermission(#itemUuid, 'ITEM','WRITE') && hasPermission(#targetUuid,'COLLECTION','ADD')")
     @PostAuthorize("returnObject != null")
     public CollectionRest move(@PathVariable UUID itemUuid, HttpServletResponse response,
@@ -80,6 +81,10 @@ public class ItemOwningCollectionUpdateRestController {
             throws SQLException, IOException, AuthorizeException {
 
         Item item = itemService.find(context, itemUuid);
+
+        if (item == null) {
+            throw new ResourceNotFoundException("Item with id: " + itemUuid + " not found");
+        }
 
         Collection currentCollection = item.getOwningCollection();
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/ItemOwningCollectionUpdateRestController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/ItemOwningCollectionUpdateRestController.java
@@ -1,0 +1,94 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.UUID;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.dspace.app.rest.converter.CollectionConverter;
+import org.dspace.app.rest.model.CollectionRest;
+import org.dspace.app.rest.utils.ContextUtil;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.content.service.CollectionService;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PostAuthorize;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/core/items/" +
+        "{itemUuid:[0-9a-fxA-FX]{8}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{12" +
+        "}}/owningCollection/move")
+public class ItemOwningCollectionUpdateRestController {
+
+    @Autowired
+    ItemService itemService;
+
+    @Autowired
+    CollectionService collectionService;
+
+    @Autowired
+    AuthorizeService authorizeService;
+
+    @Autowired
+    CollectionConverter converter;
+
+    @RequestMapping(method = RequestMethod.POST, value = "/{targetUuid}")
+    @PreAuthorize("hasPermission(#itemUuid, 'ITEM','WRITE') && hasPermission(#targetUuid,'COLLECTION','ADD')")
+    @PostAuthorize("returnObject != null")
+    public CollectionRest move(@PathVariable UUID itemUuid, HttpServletResponse response,
+                               HttpServletRequest request, @PathVariable UUID targetUuid)
+            throws SQLException, IOException, AuthorizeException {
+        Context context = ContextUtil.obtainContext(request);
+
+        Collection targetCollection = performItemMove(context, itemUuid, targetUuid);
+
+        if (targetCollection == null) {
+            return null;
+        }
+        return converter.fromModel(targetCollection);
+
+    }
+
+    private Collection moveItem(final Context context, final Item item, final Collection currentCollection,
+                                final Collection targetCollection)
+            throws SQLException, IOException, AuthorizeException {
+        itemService.move(context, item, currentCollection, targetCollection);
+        context.commit();
+
+        return context.reloadEntity(targetCollection);
+    }
+
+    private Collection performItemMove(final Context context, final UUID itemUuid, final UUID targetUuid)
+            throws SQLException, IOException, AuthorizeException {
+
+        Item item = itemService.find(context, itemUuid);
+
+        Collection currentCollection = item.getOwningCollection();
+
+        if (authorizeService.authorizeActionBoolean(context, currentCollection, Constants.ADMIN)) {
+            Collection targetCollection = collectionService.find(context, targetUuid);
+            return moveItem(context, item, currentCollection, targetCollection);
+        }
+
+        return null;
+    }
+
+}

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/security/DSpaceRestPermission.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/security/DSpaceRestPermission.java
@@ -16,7 +16,8 @@ public enum DSpaceRestPermission {
 
     READ(Constants.READ),
     WRITE(Constants.WRITE),
-    DELETE(Constants.DELETE);
+    DELETE(Constants.DELETE),
+    ADD(Constants.ADD);
 
     private int dspaceApiActionId;
 

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/ItemOwningCollectionUpdateRestControllerIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/ItemOwningCollectionUpdateRestControllerIT.java
@@ -9,7 +9,7 @@ package org.dspace.app.rest;
 
 import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -52,7 +52,7 @@ public class ItemOwningCollectionUpdateRestControllerIT extends AbstractControll
 
 
         //When we call this owningCollection/move endpoint
-        getClient().perform(post("/api/core/items/" + publicItem1.getID() + "/owningCollection/move/"
+        getClient().perform(put("/api/core/items/" + publicItem1.getID() + "/owningCollection/move/"
                                          + col2.getID()))
 
                    //We expect a 401 Unauthorized status when performed by anonymous
@@ -85,7 +85,7 @@ public class ItemOwningCollectionUpdateRestControllerIT extends AbstractControll
 
         //When we call this owningCollection/move endpoint
         getClient(token)
-                .perform(post("/api/core/items/" + publicItem1.getID() + "/owningCollection/move/"
+                .perform(put("/api/core/items/" + publicItem1.getID() + "/owningCollection/move/"
                                       + col2.getID()))
 
                 //We expect a 401 Unauthorized status when performed by anonymous
@@ -135,7 +135,7 @@ public class ItemOwningCollectionUpdateRestControllerIT extends AbstractControll
         String token = getAuthToken(itemMoveEperson.getEmail(), "test");
 
         getClient(token)
-                .perform(post("/api/core/items/" + publicItem1.getID() + "/owningCollection/move/"
+                .perform(put("/api/core/items/" + publicItem1.getID() + "/owningCollection/move/"
                                       + col2.getID()))
 
                 //We expect a 401 Unauthorized status when performed by anonymous
@@ -178,7 +178,7 @@ public class ItemOwningCollectionUpdateRestControllerIT extends AbstractControll
 
         String token = getAuthToken(itemMoveEperson.getEmail(), "test");
 
-        getClient(token).perform(post("/api/core/items/" + publicItem1.getID() + "/owningCollection/move/"
+        getClient(token).perform(put("/api/core/items/" + publicItem1.getID() + "/owningCollection/move/"
                                               + col2.getID()))
 
                         //We expect a 401 Unauthorized status when performed by anonymous
@@ -216,7 +216,7 @@ public class ItemOwningCollectionUpdateRestControllerIT extends AbstractControll
 
         String token = getAuthToken(itemMoveEperson.getEmail(), "test");
 
-        getClient(token).perform(post("/api/core/items/" + publicItem1.getID() + "/owningCollection/move/"
+        getClient(token).perform(put("/api/core/items/" + publicItem1.getID() + "/owningCollection/move/"
                                               + col2.getID()))
 
                         //We expect a 401 Unauthorized status when performed by anonymous
@@ -254,7 +254,7 @@ public class ItemOwningCollectionUpdateRestControllerIT extends AbstractControll
 
         String token = getAuthToken(itemMoveEperson.getEmail(), "test");
 
-        getClient(token).perform(post("/api/core/items/" + publicItem1.getID() + "/owningCollection/move/"
+        getClient(token).perform(put("/api/core/items/" + publicItem1.getID() + "/owningCollection/move/"
                                               + col2.getID()))
 
                         //We expect a 401 Unauthorized status when performed by anonymous

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/ItemOwningCollectionUpdateRestControllerIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/ItemOwningCollectionUpdateRestControllerIT.java
@@ -1,0 +1,265 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.dspace.app.rest.builder.CollectionBuilder;
+import org.dspace.app.rest.builder.CommunityBuilder;
+import org.dspace.app.rest.builder.EPersonBuilder;
+import org.dspace.app.rest.builder.ItemBuilder;
+import org.dspace.app.rest.builder.ResourcePolicyBuilder;
+import org.dspace.app.rest.matcher.CollectionMatcher;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.core.Constants;
+import org.dspace.eperson.EPerson;
+import org.junit.Test;
+
+public class ItemOwningCollectionUpdateRestControllerIT extends AbstractControllerIntegrationTest {
+
+    @Test
+    public void moveItemTestByAnonymous() throws Exception {
+
+        //Turn off the authorization system, otherwise we can't make the objects
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 2").build();
+
+        //2. A public item that is readable by Anonymous
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                                      .withTitle("Public item 1")
+                                      .withIssueDate("2017-10-17")
+                                      .withAuthor("Smith, Donald")
+                                      .build();
+
+
+        //When we call this owningCollection/move endpoint
+        getClient().perform(post("/api/core/items/" + publicItem1.getID() + "/owningCollection/move/"
+                                         + col2.getID()))
+
+                   //We expect a 401 Unauthorized status when performed by anonymous
+                   .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void moveItemTestByAuthorizedUser() throws Exception {
+
+        //Turn off the authorization system, otherwise we can't make the objects
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 2").build();
+
+        //2. A public item that is readable by Anonymous
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                                      .withTitle("Public item 1")
+                                      .withIssueDate("2017-10-17")
+                                      .withAuthor("Smith, Donald")
+                                      .build();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+
+        //When we call this owningCollection/move endpoint
+        getClient(token)
+                .perform(post("/api/core/items/" + publicItem1.getID() + "/owningCollection/move/"
+                                      + col2.getID()))
+
+                //We expect a 401 Unauthorized status when performed by anonymous
+                .andExpect(status().isOk());
+        getClient().perform(get("/api/core/items/" + publicItem1.getID() + "/owningCollection"))
+                   .andExpect(jsonPath("$",
+                                       is(CollectionMatcher
+                                                  .matchCollectionEntry(col2.getName(), col2.getID(), col2.getHandle())
+                                       )));
+    }
+
+    /**
+     * The user minimally needs ADD for the new collection, ADMIN for the old collection and WRITE for the item to move.
+     * This test will verify that these rights are sufficient
+     *
+     * @throws Exception
+     */
+    @Test
+    public void moveItemTestByMinimallyAuthorizedUser() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 2").build();
+
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                                      .withTitle("Public item 1")
+                                      .withIssueDate("2017-10-17")
+                                      .withAuthor("Smith, Donald")
+                                      .build();
+
+        EPerson itemMoveEperson = EPersonBuilder.createEPerson(context).withEmail("item@move.org").withPassword("test")
+                                                .withNameInMetadata("Item", "Move").build();
+
+        ResourcePolicy rp1 = ResourcePolicyBuilder.createResourcePolicy(context).withUser(itemMoveEperson)
+                                                  .withAction(Constants.ADMIN)
+                                                  .withDspaceObject(col1).build();
+        ResourcePolicy rp2 = ResourcePolicyBuilder.createResourcePolicy(context).withUser(itemMoveEperson)
+                                                  .withAction(Constants.WRITE)
+                                                  .withDspaceObject(publicItem1).build();
+        ResourcePolicy rp3 = ResourcePolicyBuilder.createResourcePolicy(context).withUser(itemMoveEperson)
+                                                  .withAction(Constants.ADD)
+                                                  .withDspaceObject(col2).build();
+
+        String token = getAuthToken(itemMoveEperson.getEmail(), "test");
+
+        getClient(token)
+                .perform(post("/api/core/items/" + publicItem1.getID() + "/owningCollection/move/"
+                                      + col2.getID()))
+
+                //We expect a 401 Unauthorized status when performed by anonymous
+                .andExpect(status().isOk());
+        getClient().perform(get("/api/core/items/" + publicItem1.getID() + "/owningCollection"))
+                   .andExpect(jsonPath("$",
+                                       is(CollectionMatcher
+                                                  .matchCollectionEntry(col2.getName(), col2.getID(), col2.getHandle())
+                                       )));
+
+
+    }
+
+    @Test
+    public void moveItemTestByAuthorizedUserWithoutAdd() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 2").build();
+
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                                      .withTitle("Public item 1")
+                                      .withIssueDate("2017-10-17")
+                                      .withAuthor("Smith, Donald")
+                                      .build();
+
+        EPerson itemMoveEperson = EPersonBuilder.createEPerson(context).withEmail("item@move.org").withPassword("test")
+                                                .withNameInMetadata("Item", "Move").build();
+
+        ResourcePolicy rp1 = ResourcePolicyBuilder.createResourcePolicy(context).withUser(itemMoveEperson)
+                                                  .withAction(Constants.ADMIN)
+                                                  .withDspaceObject(col1).build();
+        ResourcePolicy rp2 = ResourcePolicyBuilder.createResourcePolicy(context).withUser(itemMoveEperson)
+                                                  .withAction(Constants.WRITE)
+                                                  .withDspaceObject(publicItem1).build();
+
+
+        String token = getAuthToken(itemMoveEperson.getEmail(), "test");
+
+        getClient(token).perform(post("/api/core/items/" + publicItem1.getID() + "/owningCollection/move/"
+                                              + col2.getID()))
+
+                        //We expect a 401 Unauthorized status when performed by anonymous
+                        .andExpect(status().isForbidden());
+
+
+    }
+
+    @Test
+    public void moveItemTestByAuthorizedUserWithoutAdmin() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 2").build();
+
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                                      .withTitle("Public item 1")
+                                      .withIssueDate("2017-10-17")
+                                      .withAuthor("Smith, Donald")
+                                      .build();
+
+        EPerson itemMoveEperson = EPersonBuilder.createEPerson(context).withEmail("item@move.org").withPassword("test")
+                                                .withNameInMetadata("Item", "Move").build();
+
+        ResourcePolicy rp2 = ResourcePolicyBuilder.createResourcePolicy(context).withUser(itemMoveEperson)
+                                                  .withAction(Constants.WRITE)
+                                                  .withDspaceObject(publicItem1).build();
+        ResourcePolicy rp3 = ResourcePolicyBuilder.createResourcePolicy(context).withUser(itemMoveEperson)
+                                                  .withAction(Constants.ADD)
+                                                  .withDspaceObject(col2).build();
+
+
+        String token = getAuthToken(itemMoveEperson.getEmail(), "test");
+
+        getClient(token).perform(post("/api/core/items/" + publicItem1.getID() + "/owningCollection/move/"
+                                              + col2.getID()))
+
+                        //We expect a 401 Unauthorized status when performed by anonymous
+                        .andExpect(status().isForbidden());
+
+
+    }
+
+    @Test
+    public void moveItemTestByAuthorizedUserWithoutWrite() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 2").build();
+
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                                      .withTitle("Public item 1")
+                                      .withIssueDate("2017-10-17")
+                                      .withAuthor("Smith, Donald")
+                                      .build();
+
+        EPerson itemMoveEperson = EPersonBuilder.createEPerson(context).withEmail("item@move.org").withPassword("test")
+                                                .withNameInMetadata("Item", "Move").build();
+
+        ResourcePolicy rp1 = ResourcePolicyBuilder.createResourcePolicy(context).withUser(itemMoveEperson)
+                                                  .withAction(Constants.ADMIN)
+                                                  .withDspaceObject(col1).build();
+        ResourcePolicy rp3 = ResourcePolicyBuilder.createResourcePolicy(context).withUser(itemMoveEperson)
+                                                  .withAction(Constants.ADD)
+                                                  .withDspaceObject(col2).build();
+
+
+        String token = getAuthToken(itemMoveEperson.getEmail(), "test");
+
+        getClient(token).perform(post("/api/core/items/" + publicItem1.getID() + "/owningCollection/move/"
+                                              + col2.getID()))
+
+                        //We expect a 401 Unauthorized status when performed by anonymous
+                        .andExpect(status().isForbidden());
+
+
+    }
+}

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/builder/ResourcePolicyBuilder.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/builder/ResourcePolicyBuilder.java
@@ -1,0 +1,108 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.builder;
+
+import java.sql.SQLException;
+
+import org.apache.log4j.Logger;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.authorize.service.ResourcePolicyService;
+import org.dspace.content.DSpaceObject;
+import org.dspace.core.Context;
+import org.dspace.discovery.SearchServiceException;
+import org.dspace.eperson.EPerson;
+
+public class ResourcePolicyBuilder extends AbstractBuilder<ResourcePolicy, ResourcePolicyService> {
+
+    /* Log4j logger*/
+    private static final Logger log = Logger.getLogger(ResourcePolicyBuilder.class);
+
+    private ResourcePolicy resourcePolicy;
+
+    @Override
+    protected int getPriority() {
+        return Integer.MAX_VALUE;
+    }
+
+    protected ResourcePolicyBuilder(Context context) {
+        super(context);
+    }
+
+    @Override
+    protected ResourcePolicyService getService() {
+        return resourcePolicyService;
+    }
+
+    @Override
+    protected void cleanup() throws Exception {
+        delete(resourcePolicy);
+    }
+
+    @Override
+    public ResourcePolicy build() {
+        try {
+
+            resourcePolicyService.update(context, resourcePolicy);
+            context.dispatchEvents();
+
+            indexingService.commit();
+        } catch (SearchServiceException e) {
+            log.error(e);
+        } catch (SQLException e) {
+            log.error(e);
+        } catch (AuthorizeException e) {
+            log.error(e);
+            ;
+        }
+        return resourcePolicy;
+    }
+
+    public void delete(ResourcePolicy rp) throws Exception {
+        try (Context c = new Context()) {
+            c.turnOffAuthorisationSystem();
+            ResourcePolicy attachedDso = c.reloadEntity(rp);
+            if (attachedDso != null) {
+                getService().delete(c, attachedDso);
+            }
+            c.complete();
+        }
+
+        indexingService.commit();
+    }
+
+
+    public static ResourcePolicyBuilder createResourcePolicy(Context context)
+            throws SQLException, AuthorizeException {
+        ResourcePolicyBuilder resourcePolicyBuilder = new ResourcePolicyBuilder(context);
+        return resourcePolicyBuilder.create(context);
+    }
+
+    private ResourcePolicyBuilder create(Context context)
+            throws SQLException, AuthorizeException {
+        this.context = context;
+
+        resourcePolicy = resourcePolicyService.create(context);
+
+        return this;
+    }
+
+    public ResourcePolicyBuilder withUser(EPerson ePerson) throws SQLException {
+        resourcePolicy.setEPerson(ePerson);
+        return this;
+    }
+    public ResourcePolicyBuilder withAction(int action) throws SQLException {
+        resourcePolicy.setAction(action);
+        return this;
+    }
+    public ResourcePolicyBuilder withDspaceObject(DSpaceObject dspaceObject) throws SQLException {
+        resourcePolicy.setdSpaceObject(dspaceObject);
+        return this;
+    }
+
+}


### PR DESCRIPTION
In this PR we have created support for moving an item between collections.
A new rest controller (ItemOwningCollectionUpdateRestController) was added to support the behavior which works using PUT.

Jira link: https://jira.duraspace.org/browse/DS-4096
RestContract PR link: DSpace/Rest7Contract#34

