### PR TITLE
DS-4114: Add function to keep existing GET params when changing language

### DIFF
--- a/dspace-jspui/src/main/webapp/layout/navbar-default.jsp
+++ b/dspace-jspui/src/main/webapp/layout/navbar-default.jsp
@@ -135,7 +135,7 @@
  %>
       <li>
         <a onclick="javascript:document.repost.locale.value='<%=supportedLocales[i].toString()%>';
-                  document.repost.submit();" href="<%= currentPage %>?locale=<%=supportedLocales[i].toString()%>">
+                 document.repost.submit();" href="javascript:updateURLParam('locale', '<%=supportedLocales[i].toString()%>');">
          <%= supportedLocales[i].getDisplayLanguage(supportedLocales[i])%>
        </a>
       </li>

--- a/dspace-jspui/src/main/webapp/utils.js
+++ b/dspace-jspui/src/main/webapp/utils.js
@@ -265,5 +265,19 @@ function isBrowser(b,v) {
 		  return browserOk && versionOk;
 }
 
-
+/*
+ * Add/Update GET parameter of URL
+ */
+function updateURLParam(name, value) {
+ var href = window.location.href;
+ var regex = new RegExp("[&\\?]" + name + "=");
+ if(regex.test(href)) {
+	 regex = new RegExp("([&\\?])" + name + "=[^&]*");
+	 window.location.href = href.replace(regex, "$1" + name + "=" + value);
+ } else if(href.indexOf("?") > -1) {
+	 window.location.href = href + "&" + name + "=" + value;
+ } else {
+	 window.location.href = href + "?" + name + "=" + value;
+ }
+}
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-4114
Fixes #7461

# Rationale (for DSpace 6_x, JSPUI)
This pull request addresses an issue with _when changing the language in DSpace, already existing GET params are dismissed:
https://github.com/DSpace/DSpace/blob/9c16711dbef079e9eee55b660997b52adf487354/dspace-jspui/src/main/webapp/layout/navbar-default.jsp#L138

This leads to odd behaviour, since it dismisses current search results, etc.. The implemented functionality addresses this problem by keeping already existing GET params and adding/updating only the `locale` param.

![search_locale](https://user-images.githubusercontent.com/24757415/49792619-80bf9a00-fd33-11e8-9d67-3b7022c4d002.gif)

This functionality can be used with arbitrary params, but is currently only implemented for switching language.

This patch can be applied to to DSpace 5, too, with minor changes._