### PR TITLE
Temporary fix for Integration Test memory issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -424,7 +424,7 @@
         </profile>
 
         <!-- Allow for passing extra memory to Unit/Integration tests.
-             By default this gives unit tests 512MB of memory (when tests are enabled),
+             By default this gives unit tests 1GB of memory max (when tests are enabled),
              unless tweaked on commandline (e.g. "-Dtest.argLine=-Xmx512m"). Since
              m-surefire-p and m-failsafe-p both fork a new JVM for testing, they ignores MAVEN_OPTS. -->
         <profile>
@@ -435,7 +435,7 @@
                 </property>
             </activation>
             <properties>
-                <test.argLine>-Xmx512m</test.argLine>
+                <test.argLine>-Xmx1024m</test.argLine>
             </properties>
         </profile>
 


### PR DESCRIPTION
Recent PRs to our shared `configurable_entities` branch have hit frequent out of memory errors when running the Integration Tests for `dspace-spring-rest`.

These errors look like this:
```
java.lang.IllegalStateException: Failed to load ApplicationContext
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration': Post-processing of merged bean definition failed; nested exception is java.lang.OutOfMemoryError: GC overhead limit exceeded
Caused by: java.lang.OutOfMemoryError: GC overhead limit exceeded
```
See for example this Travis CI build of the `configurable_entities` branch: https://travis-ci.org/DSpace/DSpace/builds/464514052#L5692

This PR provides a quick fix which is to simply provide more memory to both our Unit Tests and Integration Tests.  Instead of only having 512MB to work with, they now have 1GB available.  At least locally, this allows tests to run more smoothly (and slightly more quickly -- as they used to slow to a crawl once they approached memory limits).

I'm still investigating our Integration Test setup/framework itself in the REST API v7, as I suspect it's not as streamlined as it could be. However, this seems to provide a quick fix (but we'll see what Travis CI thinks).