### PR TITLE
DS-4119: Enable ENTER key in textareas and add suitable rendering of running text (e.g. abstracts, etc.)

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemTag.java
@@ -672,7 +672,7 @@ public class ItemTag extends TagSupport
 	                    }
                         else
                         {
-                            out.print(Utils.addEntities(val.getValue()));
+                            out.print(Utils.addEntities(val.getValue().replace("&#x0A;", "<br/>")));
                         }
                     }
                 }

--- a/dspace-jspui/src/main/webapp/submit/review-metadata.jsp
+++ b/dspace-jspui/src/main/webapp/submit/review-metadata.jsp
@@ -194,7 +194,7 @@
                     }
                     else
                     {
-                        row.append(Utils.addEntities(values.get(i).getValue()));
+                        row.append(Utils.addEntities(values.get(i).getValue()).replace("&#x0A;", "<br/>"));
                     }
                     if (isAuthorityControlled)
                     {

--- a/dspace-jspui/src/main/webapp/utils.js
+++ b/dspace-jspui/src/main/webapp/utils.js
@@ -149,7 +149,7 @@ function disableEnterKey(e)
      else
           key = e.which;     //Firefox & Netscape
 
-     if(key == 13)  //if "Enter" pressed, then disable!
+     if(key == 13 && event.target.nodeName!='TEXTAREA')
           return false;
      else
           return true;


### PR DESCRIPTION
Fixes #7466

## Rationale (for DSpace 6_x, JSPUI)
This pull requests addresses DSpace's issue with `textareas`, not allowing the user to insert a line break in a suitable way.
By default DSpace disables the 'ENTER' key in general to prevent "accidentally submitting a form when the 'Enter' key is pressed".

Running text, e.g. abstracts or descriptions, can only be inserted as continuous text, without sensible structure through paragraphs.

## Insert line breaks in `textarea`
This pull request restricts the 'disabled ENTER key' functionality to `inputs` other than `textarea`.

![textarea_form](https://user-images.githubusercontent.com/24757415/49732406-e43bc000-fc7e-11e8-9a26-d9396831de8c.gif)

## Render running text in a submission's "Verify" step and when displaying an item in a suitable way
This pull request also addresses an issue with running text being rendered as one continuous block of text in the submission's "Verify" step, because it turned out, that the user may be confused by this representation.

![screenshot from 2018-12-10 12 47 08](https://user-images.githubusercontent.com/24757415/49732717-c9b61680-fc7f-11e8-9d32-807d07d114e6.png)

*I'll create a corresponding issue on https://jira.duraspace.org/projects/DS/issues/ as soon as I get my account.*  