### PR TITLE
Manage metadata registry

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/MetadataSchemaServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataSchemaServiceImpl.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.dao.MetadataSchemaDAO;
+import org.dspace.content.service.MetadataFieldService;
 import org.dspace.content.service.MetadataSchemaService;
 import org.dspace.core.Context;
 import org.dspace.core.LogManager;
@@ -32,6 +33,9 @@ public class MetadataSchemaServiceImpl implements MetadataSchemaService {
      * log4j logger
      */
     private static Logger log = org.apache.logging.log4j.LogManager.getLogger(MetadataSchemaServiceImpl.class);
+
+    @Autowired
+    protected MetadataFieldService metadataFieldService;
 
     @Autowired(required = true)
     protected AuthorizeService authorizeService;
@@ -115,10 +119,14 @@ public class MetadataSchemaServiceImpl implements MetadataSchemaService {
                 "Only administrators may modify the metadata registry");
         }
 
-        log.info(LogManager.getHeader(context, "delete_metadata_schema",
-                                      "metadata_schema_id=" + metadataSchema.getID()));
+        for (MetadataField metadataField : metadataFieldService.findAllInSchema(context, metadataSchema)) {
+            metadataFieldService.delete(context, metadataField);
+        }
 
         metadataSchemaDAO.delete(context, metadataSchema);
+
+        log.info(LogManager.getHeader(context, "delete_metadata_schema",
+                "metadata_schema_id=" + metadataSchema.getID()));
     }
 
     @Override

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -987,11 +987,31 @@ public class RestResourceController implements InitializingBean {
     }
 
 
+
+    /**
+     * Execute a PUT request for an entity with id of type Integer;
+     *
+     * curl -X PUT http://<dspace.url>/dspace-spring-rest/api/{apiCategory}/{model}
+     *
+     * Example:
+     * <pre>
+     * {@code
+     *      curl -X PUT http://<dspace.url>/dspace-spring-rest/api/metadatafield
+     * }
+     * </pre>
+     *
+     * @param request     the http request
+     * @param apiCategory the API category e.g. "api"
+     * @param model       the DSpace model e.g. "metadatafield"
+     * @param id          the ID of the target REST object
+     * @param jsonNode    the part of the request body representing the updated rest object
+     * @return the relevant REST resource
+     */
     @RequestMapping(method = RequestMethod.PUT, value = REGEX_REQUESTMAPPING_IDENTIFIER_AS_DIGIT)
     public DSpaceResource<RestAddressableModel> put(HttpServletRequest request,
                                                     @PathVariable String apiCategory, @PathVariable String model,
                                                     @PathVariable Integer id,
-                                                    @RequestBody(required = true) JsonNode jsonNode) {
+                                                    @RequestBody JsonNode jsonNode) {
         return putOneInternal(request, apiCategory, model, id, jsonNode);
     }
 
@@ -1018,7 +1038,7 @@ public class RestResourceController implements InitializingBean {
     public DSpaceResource<RestAddressableModel> put(HttpServletRequest request,
                                                     @PathVariable String apiCategory, @PathVariable String model,
                                                     @PathVariable UUID uuid,
-                                                    @RequestBody(required = true) JsonNode jsonNode) {
+                                                    @RequestBody JsonNode jsonNode) {
         return putOneInternal(request, apiCategory, model, uuid, jsonNode);
     }
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -991,17 +991,17 @@ public class RestResourceController implements InitializingBean {
     /**
      * Execute a PUT request for an entity with id of type Integer;
      *
-     * curl -X PUT http://<dspace.url>/dspace-spring-rest/api/{apiCategory}/{model}
+     * curl -X PUT http://<dspace.restUrl>/api/{apiCategory}/{model}/{id}
      *
      * Example:
      * <pre>
      * {@code
-     *      curl -X PUT http://<dspace.url>/dspace-spring-rest/api/metadatafield
+     *      curl -X PUT http://<dspace.restUrl>/api/core/metadatafield/1
      * }
      * </pre>
      *
      * @param request     the http request
-     * @param apiCategory the API category e.g. "api"
+     * @param apiCategory the API category e.g. "core"
      * @param model       the DSpace model e.g. "metadatafield"
      * @param id          the ID of the target REST object
      * @param jsonNode    the part of the request body representing the updated rest object
@@ -1018,17 +1018,17 @@ public class RestResourceController implements InitializingBean {
     /**
      * Execute a PUT request for an entity with id of type UUID;
      *
-     * curl -X PUT http://<dspace.url>/dspace-spring-rest/api/{apiCategory}/{model}/{uuid}
+     * curl -X PUT http://<dspace.restUrl>/api/{apiCategory}/{model}/{uuid}
      *
      * Example:
      * <pre>
      * {@code
-     *      curl -X PUT http://<dspace.url>/dspace-spring-rest/api/collection/320c0492-de1d-4646-9e69-193d36b366e9
+     *      curl -X PUT http://<dspace.restUrl>/api/core/collection/8b632938-77c2-487c-81f0-e804f63e68e6
      * }
      * </pre>
      *
      * @param request     the http request
-     * @param apiCategory the API category e.g. "api"
+     * @param apiCategory the API category e.g. "core"
      * @param model       the DSpace model e.g. "collection"
      * @param uuid        the ID of the target REST object
      * @param jsonNode    the part of the request body representing the updated rest object

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -987,6 +987,14 @@ public class RestResourceController implements InitializingBean {
     }
 
 
+    @RequestMapping(method = RequestMethod.PUT, value = REGEX_REQUESTMAPPING_IDENTIFIER_AS_DIGIT)
+    public DSpaceResource<RestAddressableModel> put(HttpServletRequest request,
+                                                    @PathVariable String apiCategory, @PathVariable String model,
+                                                    @PathVariable Integer id,
+                                                    @RequestBody(required = true) JsonNode jsonNode) {
+        return putOneInternal(request, apiCategory, model, id, jsonNode);
+    }
+
     /**
      * Execute a PUT request for an entity with id of type UUID;
      *

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/PatchBadRequestException.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/exception/PatchBadRequestException.java
@@ -22,7 +22,10 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 public class PatchBadRequestException extends RuntimeException {
 
     public PatchBadRequestException(String message) {
-        super(message);
+        this(message, null);
     }
 
+    public PatchBadRequestException(String message, Exception e) {
+        super(message, e);
+    }
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataFieldRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataFieldRest.java
@@ -8,7 +8,7 @@
 package org.dspace.app.rest.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.dspace.app.rest.RestResourceController;
 
 /**
@@ -16,7 +16,6 @@ import org.dspace.app.rest.RestResourceController;
  *
  * @author Andrea Bollini (andrea.bollini at 4science.it)
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class MetadataFieldRest extends BaseObjectRest<Integer> {
     public static final String NAME = "metadatafield";
     public static final String CATEGORY = RestAddressableModel.CORE;
@@ -63,6 +62,7 @@ public class MetadataFieldRest extends BaseObjectRest<Integer> {
     }
 
     @Override
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     public String getType() {
         return NAME;
     }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataFieldRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataFieldRest.java
@@ -8,6 +8,7 @@
 package org.dspace.app.rest.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.dspace.app.rest.RestResourceController;
 
 /**
@@ -15,6 +16,7 @@ import org.dspace.app.rest.RestResourceController;
  *
  * @author Andrea Bollini (andrea.bollini at 4science.it)
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class MetadataFieldRest extends BaseObjectRest<Integer> {
     public static final String NAME = "metadatafield";
     public static final String CATEGORY = RestAddressableModel.CORE;

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataSchemaRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataSchemaRest.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.app.rest.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.dspace.app.rest.RestResourceController;
 
 /**
@@ -14,6 +15,7 @@ import org.dspace.app.rest.RestResourceController;
  *
  * @author Andrea Bollini (andrea.bollini at 4science.it)
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class MetadataSchemaRest extends BaseObjectRest<Integer> {
     public static final String NAME = "metadataschema";
     public static final String CATEGORY = RestAddressableModel.CORE;

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataSchemaRest.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/model/MetadataSchemaRest.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.dspace.app.rest.RestResourceController;
 
 /**
@@ -15,7 +15,6 @@ import org.dspace.app.rest.RestResourceController;
  *
  * @author Andrea Bollini (andrea.bollini at 4science.it)
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class MetadataSchemaRest extends BaseObjectRest<Integer> {
     public static final String NAME = "metadataschema";
     public static final String CATEGORY = RestAddressableModel.CORE;
@@ -41,6 +40,7 @@ public class MetadataSchemaRest extends BaseObjectRest<Integer> {
     }
 
     @Override
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     public String getType() {
         return NAME;
     }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/DSpaceRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/DSpaceRestRepository.java
@@ -409,7 +409,8 @@ public abstract class DSpaceRestRepository<T extends RestAddressableModel, ID ex
     }
 
     /**
-     * Method to support updating a DSpace instance.
+     * This method will fully replace the REST object with the given UUID with the REST object that is described
+     * in the JsonNode parameter
      *
      * @param request     the http request
      * @param apiCategory the API category e.g. "api"
@@ -433,7 +434,9 @@ public abstract class DSpaceRestRepository<T extends RestAddressableModel, ID ex
     }
 
     /**
-     * Implement this method in the subclass to support updating a DSpace instance.
+     * Implement this method in the subclass to support the PUT functionality for a REST object.
+     * This PUT functionality will fully replace the REST object with the given UUID with the REST object that is
+     * described in the JsonNode parameter
      *
      * @param context     the dspace context
      * @param request     the http request

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/DSpaceRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/DSpaceRestRepository.java
@@ -71,7 +71,7 @@ public abstract class DSpaceRestRepository<T extends RestAddressableModel, ID ex
 
     /**
      * Method to implement to support full update of a REST object. This is usually required by a PUT request.
-     * 
+     *
      * @param context
      *            the dspace context
      * @param entity
@@ -98,7 +98,7 @@ public abstract class DSpaceRestRepository<T extends RestAddressableModel, ID ex
     @Override
     /**
      * Return a specific REST object
-     * 
+     *
      * @return the REST object identified by its ID
      */
     public T findOne(ID id) {
@@ -108,7 +108,7 @@ public abstract class DSpaceRestRepository<T extends RestAddressableModel, ID ex
 
     /**
      * Method to implement to support retrieval of a specific REST object instance
-     * 
+     *
      * @param context
      *            the dspace context
      * @param id
@@ -171,7 +171,7 @@ public abstract class DSpaceRestRepository<T extends RestAddressableModel, ID ex
 
     /**
      * Method to implement to support delete of a single object instance
-     * 
+     *
      * @param context
      *            the dspace context
      * @param id
@@ -229,7 +229,7 @@ public abstract class DSpaceRestRepository<T extends RestAddressableModel, ID ex
 
     /**
      * Method to implement to support scroll of entity instances from the collection resource endpoin
-     * 
+     *
      * @param context
      *            the dspace context
      * @param pageable
@@ -245,7 +245,7 @@ public abstract class DSpaceRestRepository<T extends RestAddressableModel, ID ex
 
     /**
      * Wrap the REST model in a REST HAL Resource
-     * 
+     *
      * @param model
      *            the rest model instance
      * @param rels
@@ -256,7 +256,7 @@ public abstract class DSpaceRestRepository<T extends RestAddressableModel, ID ex
 
     /**
      * Create and return a new instance. Data are usually retrieved from the thread bound http request
-     * 
+     *
      * @return the created REST object
      */
     public T createAndReturn() {
@@ -276,7 +276,7 @@ public abstract class DSpaceRestRepository<T extends RestAddressableModel, ID ex
     /**
      * Method to implement to support the creation of a new instance. Usually require to retrieve the http request from
      * the thread bound attribute
-     * 
+     *
      * @param context
      *            the dspace context
      * @return the created REST object
@@ -292,7 +292,7 @@ public abstract class DSpaceRestRepository<T extends RestAddressableModel, ID ex
 
     /**
      * Method to implement to attach/upload a file to a specific REST object
-     * 
+     *
      * @param request
      *            the http request
      * @param apiCategory
@@ -311,7 +311,7 @@ public abstract class DSpaceRestRepository<T extends RestAddressableModel, ID ex
 
     /**
      * Apply a partial update to the REST object via JSON Patch
-     * 
+     *
      * @param request
      *            the http request
      * @param apiCategory
@@ -341,7 +341,7 @@ public abstract class DSpaceRestRepository<T extends RestAddressableModel, ID ex
 
     /**
      * Method to implement to allow partial update of the REST object via JSON Patch
-     * 
+     *
      * @param request
      *            the http request
      * @param apiCategory
@@ -356,7 +356,7 @@ public abstract class DSpaceRestRepository<T extends RestAddressableModel, ID ex
      * @throws PatchBadRequestException
      * @throws RepositoryMethodNotImplementedException
      *             returned by the default implementation when the operation is not supported for the entity
-     * 
+     *
      * @throws SQLException
      * @throws AuthorizeException
      * @throws DCInputsReaderException
@@ -369,7 +369,7 @@ public abstract class DSpaceRestRepository<T extends RestAddressableModel, ID ex
 
     /**
      * Bulk create object instances from an uploaded file
-     * 
+     *
      * @param request
      *            the http request
      * @param uploadfile
@@ -390,7 +390,7 @@ public abstract class DSpaceRestRepository<T extends RestAddressableModel, ID ex
 
     /**
      * Method to implement to support bulk creation of objects from a file
-     * 
+     *
      * @param request
      *            the http request
      * @param uploadfile
@@ -436,6 +436,7 @@ public abstract class DSpaceRestRepository<T extends RestAddressableModel, ID ex
      * Implement this method in the subclass to support updating a DSpace instance.
      *
      * @param context     the dspace context
+     * @param request     the http request
      * @param apiCategory the API category e.g. "api"
      * @param model       the DSpace model e.g. "metadatafield"
      * @param id          the ID of the target REST object

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
@@ -191,16 +191,16 @@ public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFi
         MetadataFieldRest metadataFieldRest = new Gson().fromJson(jsonNode.toString(), MetadataFieldRest.class);
 
         if (isBlank(metadataFieldRest.getElement())) {
-            throw new UnprocessableEntityException("metadata element can be blank not");
+            throw new UnprocessableEntityException("metadata element (in request body) cannot be blank");
         }
 
         if (!Objects.equals(id, metadataFieldRest.getId())) {
-            throw new UnprocessableEntityException("body id matches path id... not");
+            throw new UnprocessableEntityException("ID in request body doesn't match path ID");
         }
 
         MetadataField metadataField = metadataFieldService.find(context, id);
         if (metadataField == null) {
-            throw new ResourceNotFoundException("metadata field with id: " + id + " is found not");
+            throw new ResourceNotFoundException("metadata field with id: " + id + " not found");
         }
 
         metadataField.setElement(metadataFieldRest.getElement());

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
@@ -133,16 +133,16 @@ public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFi
         // validate fields
         String schemaId = getRequestService().getCurrentRequest().getHttpServletRequest().getParameter("schemaId");
         if (isBlank(schemaId)) {
-            throw new UnprocessableEntityException("metadata schema ID can be blank not");
+            throw new UnprocessableEntityException("metadata schema ID cannot be blank");
         }
 
         MetadataSchema schema = metadataSchemaService.find(context, parseInt(schemaId));
         if (schema == null) {
-            throw new UnprocessableEntityException("metadata schema is found not");
+            throw new UnprocessableEntityException("metadata schema with ID " + schemaId + " not found");
         }
 
         if (isBlank(metadataFieldRest.getElement())) {
-            throw new UnprocessableEntityException("metadata element can be blank not");
+            throw new UnprocessableEntityException("metadata element (in request body) cannot be blank");
         }
 
         // create

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
@@ -8,7 +8,7 @@
 package org.dspace.app.rest.repository;
 
 import static java.lang.Integer.parseInt;
-import static org.apache.commons.lang.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -120,7 +120,6 @@ public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFi
             throws AuthorizeException, SQLException {
 
         // parse request body
-
         MetadataFieldRest metadataFieldRest;
         try {
             metadataFieldRest = new ObjectMapper().readValue(
@@ -132,7 +131,6 @@ public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFi
         }
 
         // validate fields
-
         String schemaId = getRequestService().getCurrentRequest().getHttpServletRequest().getParameter("schemaId");
         if (isBlank(schemaId)) {
             throw new UnprocessableEntityException("metadata schema ID can be blank not");
@@ -148,7 +146,6 @@ public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFi
         }
 
         // create
-
         MetadataField metadataField;
         try {
             metadataField = metadataFieldService.create(context, schema,
@@ -166,7 +163,6 @@ public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFi
         }
 
         // return
-
         return converter.convert(metadataField);
     }
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
@@ -127,7 +127,7 @@ public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFi
                     MetadataFieldRest.class
             );
         } catch (IOException excIO) {
-            throw new PatchBadRequestException("error parsing the body ..." + excIO.getMessage());
+            throw new PatchBadRequestException("error parsing request body", excIO);
         }
 
         // validate fields
@@ -179,7 +179,7 @@ public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFi
 
             metadataFieldService.delete(context, metadataField);
         } catch (SQLException e) {
-            throw new RuntimeException(e.getMessage(), e);
+            throw new RuntimeException("error while trying to delete " + MetadataFieldRest.NAME + " with id: " + id, e);
         }
     }
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
@@ -7,22 +7,37 @@
  */
 package org.dspace.app.rest.repository;
 
+import static java.lang.Integer.parseInt;
+import static org.apache.commons.lang.StringUtils.isBlank;
+
+import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Objects;
+import javax.servlet.http.HttpServletRequest;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
 import org.dspace.app.rest.Parameter;
 import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.converter.MetadataFieldConverter;
+import org.dspace.app.rest.exception.PatchBadRequestException;
+import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.MetadataFieldRest;
 import org.dspace.app.rest.model.hateoas.MetadataFieldResource;
+import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.MetadataField;
 import org.dspace.content.MetadataSchema;
+import org.dspace.content.NonUniqueMetadataException;
 import org.dspace.content.service.MetadataFieldService;
 import org.dspace.content.service.MetadataSchemaService;
 import org.dspace.core.Context;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Component;
 
 /**
@@ -34,7 +49,7 @@ import org.springframework.stereotype.Component;
 public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFieldRest, Integer> {
 
     @Autowired
-    MetadataFieldService metaFieldService;
+    MetadataFieldService metadataFieldService;
 
     @Autowired
     MetadataSchemaService metadataSchemaService;
@@ -49,7 +64,7 @@ public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFi
     public MetadataFieldRest findOne(Context context, Integer id) {
         MetadataField metadataField = null;
         try {
-            metadataField = metaFieldService.find(context, id);
+            metadataField = metadataFieldService.find(context, id);
         } catch (SQLException e) {
             throw new RuntimeException(e.getMessage(), e);
         }
@@ -63,7 +78,7 @@ public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFi
     public Page<MetadataFieldRest> findAll(Context context, Pageable pageable) {
         List<MetadataField> metadataField = null;
         try {
-            metadataField = metaFieldService.findAll(context);
+            metadataField = metadataFieldService.findAll(context);
         } catch (SQLException e) {
             throw new RuntimeException(e.getMessage(), e);
         }
@@ -73,7 +88,7 @@ public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFi
 
     @SearchRestMethod(name = "bySchema")
     public Page<MetadataFieldRest> findBySchema(@Parameter(value = "schema", required = true) String schemaName,
-                                                          Pageable pageable) {
+                                                Pageable pageable) {
         Context context = obtainContext();
         List<MetadataField> metadataFields = null;
         try {
@@ -81,7 +96,7 @@ public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFi
             if (schema == null) {
                 return null;
             }
-            metadataFields = metaFieldService.findAllInSchema(context, schema);
+            metadataFields = metadataFieldService.findAllInSchema(context, schema);
         } catch (SQLException e) {
             throw new RuntimeException(e.getMessage(), e);
         }
@@ -97,5 +112,117 @@ public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFi
     @Override
     public MetadataFieldResource wrapResource(MetadataFieldRest bs, String... rels) {
         return new MetadataFieldResource(bs, utils, rels);
+    }
+
+    @Override
+    @PreAuthorize("hasAuthority('ADMIN')")
+    protected MetadataFieldRest createAndReturn(Context context)
+            throws AuthorizeException, SQLException {
+
+        // parse request body
+
+        MetadataFieldRest metadataFieldRest;
+        try {
+            metadataFieldRest = new ObjectMapper().readValue(
+                    getRequestService().getCurrentRequest().getHttpServletRequest().getInputStream(),
+                    MetadataFieldRest.class
+            );
+        } catch (IOException excIO) {
+            throw new PatchBadRequestException("error parsing the body ..." + excIO.getMessage());
+        }
+
+        // validate fields
+
+        String schemaId = getRequestService().getCurrentRequest().getHttpServletRequest().getParameter("schemaId");
+        if (isBlank(schemaId)) {
+            throw new UnprocessableEntityException("metadata schema ID can be blank not");
+        }
+
+        MetadataSchema schema = metadataSchemaService.find(context, parseInt(schemaId));
+        if (schema == null) {
+            throw new UnprocessableEntityException("metadata schema is found not");
+        }
+
+        if (isBlank(metadataFieldRest.getElement())) {
+            throw new UnprocessableEntityException("metadata element can be blank not");
+        }
+
+        // create
+
+        MetadataField metadataField;
+        try {
+            metadataField = metadataFieldService.create(context, schema,
+                    metadataFieldRest.getElement(), metadataFieldRest.getQualifier(), metadataFieldRest.getScopeNote());
+            metadataFieldService.update(context, metadataField);
+        } catch (NonUniqueMetadataException e) {
+            throw new UnprocessableEntityException(
+                    "metadata field "
+                            + schema.getName() + "." + metadataFieldRest.getElement()
+                            + (metadataFieldRest.getQualifier() != null ? "." + metadataFieldRest.getQualifier() : "")
+                            + " already exists"
+            );
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        // return
+
+        return converter.convert(metadataField);
+    }
+
+    @Override
+    @PreAuthorize("hasAuthority('ADMIN')")
+    protected void delete(Context context, Integer id) throws AuthorizeException {
+
+        try {
+            MetadataField metadataField = metadataFieldService.find(context, id);
+
+            if (metadataField == null) {
+                throw new ResourceNotFoundException("metadata field with id: " + id + " not found");
+            }
+
+            metadataFieldService.delete(context, metadataField);
+        } catch (SQLException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    @PreAuthorize("hasAuthority('ADMIN')")
+    protected MetadataFieldRest put(Context context, HttpServletRequest request, String apiCategory, String model,
+                                    Integer id, JsonNode jsonNode) throws SQLException, AuthorizeException {
+
+        MetadataFieldRest metadataFieldRest = new Gson().fromJson(jsonNode.toString(), MetadataFieldRest.class);
+
+        if (isBlank(metadataFieldRest.getElement())) {
+            throw new UnprocessableEntityException("metadata element can be blank not");
+        }
+
+        if (!Objects.equals(id, metadataFieldRest.getId())) {
+            throw new UnprocessableEntityException("body id matches path id... not");
+        }
+
+        MetadataField metadataField = metadataFieldService.find(context, id);
+        if (metadataField == null) {
+            throw new ResourceNotFoundException("metadata field with id: " + id + " is found not");
+        }
+
+        metadataField.setElement(metadataFieldRest.getElement());
+        metadataField.setQualifier(metadataFieldRest.getQualifier());
+        metadataField.setScopeNote(metadataFieldRest.getScopeNote());
+
+        try {
+            metadataFieldService.update(context, metadataField);
+            context.commit();
+        } catch (NonUniqueMetadataException e) {
+            throw new UnprocessableEntityException("metadata field "
+                    + metadataField.getMetadataSchema().getName() + "." + metadataFieldRest.getElement()
+                    + (metadataFieldRest.getQualifier() != null ? "." + metadataFieldRest.getQualifier() : "")
+                    + " already exists");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return converter.fromModel(metadataField);
     }
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/MetadataSchemaRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/MetadataSchemaRestRepository.java
@@ -101,7 +101,7 @@ public class MetadataSchemaRestRepository extends DSpaceRestRepository<MetadataS
                     MetadataSchemaRest.class
             );
         } catch (IOException excIO) {
-            throw new PatchBadRequestException("error parsing the body ..." + excIO.getMessage());
+            throw new PatchBadRequestException("error parsing request body", excIO);
         }
 
         // validate fields
@@ -141,7 +141,9 @@ public class MetadataSchemaRestRepository extends DSpaceRestRepository<MetadataS
 
             metadataSchemaService.delete(context, metadataSchema);
         } catch (SQLException e) {
-            throw new RuntimeException(e.getMessage(), e);
+            throw new RuntimeException(
+                    "error while trying to delete " + MetadataSchemaRest.NAME + " with id: " + id, e
+            );
         }
     }
 

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/MetadataSchemaRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/MetadataSchemaRestRepository.java
@@ -106,10 +106,10 @@ public class MetadataSchemaRestRepository extends DSpaceRestRepository<MetadataS
 
         // validate fields
         if (isBlank(metadataSchemaRest.getPrefix())) {
-            throw new UnprocessableEntityException("metadata schema name can be blank not");
+            throw new UnprocessableEntityException("metadata schema name cannot be blank");
         }
         if (isBlank(metadataSchemaRest.getNamespace())) {
-            throw new UnprocessableEntityException("metadata schema namespace can be blank not");
+            throw new UnprocessableEntityException("metadata schema namespace cannot be blank");
         }
 
         // create
@@ -155,14 +155,14 @@ public class MetadataSchemaRestRepository extends DSpaceRestRepository<MetadataS
         MetadataSchemaRest metadataSchemaRest = new Gson().fromJson(jsonNode.toString(), MetadataSchemaRest.class);
 
         if (isBlank(metadataSchemaRest.getPrefix())) {
-            throw new UnprocessableEntityException("metadata schema name can be blank not");
+            throw new UnprocessableEntityException("metadata schema name cannot be blank");
         }
         if (isBlank(metadataSchemaRest.getNamespace())) {
-            throw new UnprocessableEntityException("metadata schema namespace can be blank not");
+            throw new UnprocessableEntityException("metadata schema namespace cannot be blank");
         }
 
         if (!Objects.equals(id, metadataSchemaRest.getId())) {
-            throw new UnprocessableEntityException("body id matches path id... not");
+            throw new UnprocessableEntityException("ID in request doesn't match path ID");
         }
 
         MetadataSchema metadataSchema = metadataSchemaService.find(context, id);

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/MetadataSchemaRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/MetadataSchemaRestRepository.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.repository;
 
-import static org.apache.commons.lang.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -94,7 +94,6 @@ public class MetadataSchemaRestRepository extends DSpaceRestRepository<MetadataS
             throws AuthorizeException, SQLException {
 
         // parse request body
-
         MetadataSchemaRest metadataSchemaRest;
         try {
             metadataSchemaRest = new ObjectMapper().readValue(
@@ -106,7 +105,6 @@ public class MetadataSchemaRestRepository extends DSpaceRestRepository<MetadataS
         }
 
         // validate fields
-
         if (isBlank(metadataSchemaRest.getPrefix())) {
             throw new UnprocessableEntityException("metadata schema name can be blank not");
         }
@@ -115,7 +113,6 @@ public class MetadataSchemaRestRepository extends DSpaceRestRepository<MetadataS
         }
 
         // create
-
         MetadataSchema metadataSchema;
         try {
             metadataSchema = metadataSchemaService.create(
@@ -128,7 +125,6 @@ public class MetadataSchemaRestRepository extends DSpaceRestRepository<MetadataS
         }
 
         // return
-
         return converter.convert(metadataSchema);
     }
 

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/MetadataSchemaRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/MetadataSchemaRestRepositoryIT.java
@@ -7,50 +7,255 @@
  */
 package org.dspace.app.rest;
 
+import static com.jayway.jsonpath.JsonPath.read;
+import static org.dspace.app.rest.matcher.MetadataschemaMatcher.matchEntry;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.sql.SQLException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dspace.app.rest.builder.MetadataSchemaBuilder;
-import org.dspace.app.rest.matcher.MetadataschemaMatcher;
+import org.dspace.app.rest.model.MetadataSchemaRest;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.MetadataSchema;
+import org.dspace.content.NonUniqueMetadataException;
+import org.dspace.content.service.MetadataSchemaService;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 public class MetadataSchemaRestRepositoryIT extends AbstractControllerIntegrationTest {
+
+    private static final String TEST_NAME = "testSchemaName";
+    private static final String TEST_NAMESPACE = "testSchemaNameSpace";
+
+    private static final String TEST_NAME_UPDATED = "testSchemaNameUpdated";
+    private static final String TEST_NAMESPACE_UPDATED = "testSchemaNameSpaceUpdated";
+
+    @Autowired
+    private MetadataSchemaService metadataSchemaService;
 
     @Test
     public void findAll() throws Exception {
 
         context.turnOffAuthorisationSystem();
         MetadataSchema metadataSchema = MetadataSchemaBuilder.createMetadataSchema(context, "ATest", "ANamespace")
-                                                             .build();
+                .build();
 
         getClient().perform(get("/api/core/metadataschemas"))
-                   .andExpect(status().isOk())
-                   .andExpect(content().contentType(contentType))
-                   .andExpect(jsonPath("$._embedded.metadataschemas", Matchers.hasItem(
-                       MetadataschemaMatcher.matchEntry()
-                   )))
-                   .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/metadataschemas")))
-                   .andExpect(jsonPath("$.page.size", is(20)));
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(contentType))
+                .andExpect(jsonPath("$._embedded.metadataschemas", Matchers.hasItem(
+                        matchEntry()
+                )))
+                .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/metadataschemas")))
+                .andExpect(jsonPath("$.page.size", is(20)));
     }
-
 
     @Test
     public void findOne() throws Exception {
 
         context.turnOffAuthorisationSystem();
         MetadataSchema metadataSchema = MetadataSchemaBuilder.createMetadataSchema(context, "ATest", "ANamespace")
-                                                             .build();
+                .build();
 
         getClient().perform(get("/api/core/metadataschemas/" + metadataSchema.getID()))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$", is(
-                       MetadataschemaMatcher.matchEntry(metadataSchema)
-                   )));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", is(
+                        matchEntry(metadataSchema)
+                )));
+    }
+
+    @Test
+    public void createSuccess() throws Exception {
+
+        MetadataSchemaRest metadataSchemaRest = new MetadataSchemaRest();
+        metadataSchemaRest.setPrefix(TEST_NAME);
+        metadataSchemaRest.setNamespace(TEST_NAMESPACE);
+
+        String authToken = getAuthToken(admin.getEmail(), password);
+        AtomicReference<Integer> idRef = new AtomicReference<>();
+
+        try {
+
+            assertThat(metadataSchemaService.find(context, TEST_NAME), nullValue());
+
+            getClient(authToken)
+                    .perform(post("/api/core/metadataschemas")
+                            .content(new ObjectMapper().writeValueAsBytes(metadataSchemaRest))
+                            .contentType(contentType))
+                    .andExpect(status().isCreated())
+                    .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(), "$.id")));
+
+            MetadataSchema metadataSchema = metadataSchemaService.find(context, idRef.get());
+            assertThat(metadataSchema, notNullValue());
+
+            assertEquals(metadataSchema.getID(), idRef.get());
+            assertEquals(metadataSchema.getName(), TEST_NAME);
+            assertEquals(metadataSchema.getNamespace(), TEST_NAMESPACE);
+
+        } finally {
+            deleteMetadataSchemaIfExists(TEST_NAME);
+        }
+    }
+
+    @Test
+    public void createUnauthauthorizedTest()
+            throws Exception {
+
+        MetadataSchemaRest metadataSchemaRest = new MetadataSchemaRest();
+        metadataSchemaRest.setPrefix(TEST_NAME);
+        metadataSchemaRest.setNamespace(TEST_NAMESPACE);
+
+        try {
+            getClient()
+                    .perform(post("/api/core/metadataschemas")
+                            .content(new ObjectMapper().writeValueAsBytes(metadataSchemaRest))
+                            .contentType(contentType))
+                    .andExpect(status().isUnauthorized());
+
+        } finally {
+            deleteMetadataSchemaIfExists(TEST_NAME);
+        }
+    }
+
+    @Test
+    public void deleteSuccess() throws Exception {
+
+        MetadataSchema metadataSchema = createMetadataSchema();
+
+        try {
+
+            assertThat(metadataSchemaService.find(context, metadataSchema.getID()), notNullValue());
+
+            getClient(getAuthToken(admin.getEmail(), password))
+                    .perform(delete("/api/core/metadataschemas/" + metadataSchema.getID()))
+                    .andExpect(status().isNoContent());
+
+            assertThat(metadataSchemaService.find(context, metadataSchema.getID()), nullValue());
+
+        } finally {
+            deleteMetadataSchemaIfExists(TEST_NAME);
+        }
+    }
+
+    @Test
+    public void deleteUnauthorized() throws Exception {
+
+        MetadataSchema metadataSchema = createMetadataSchema();
+
+        try {
+
+            assertThat(metadataSchemaService.find(context, metadataSchema.getID()), notNullValue());
+
+            getClient()
+                    .perform(delete("/api/core/metadataschemas/" + metadataSchema.getID()))
+                    .andExpect(status().isUnauthorized());
+
+            assertThat(metadataSchemaService.find(context, metadataSchema.getID()), notNullValue());
+
+        } finally {
+            deleteMetadataSchemaIfExists(TEST_NAME);
+        }
+    }
+
+    @Test
+    public void deleteNonExisting() throws Exception {
+
+        MetadataSchema metadataSchema = createMetadataSchema();
+        deleteMetadataSchemaIfExists(TEST_NAME);
+
+        Integer id = metadataSchema.getID();
+        assertThat(metadataSchemaService.find(context, id), nullValue());
+
+        getClient(getAuthToken(admin.getEmail(), password))
+                .perform(delete("/api/core/metadataschemas/" + id))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void update() throws Exception {
+
+        MetadataSchema metadataSchema = createMetadataSchema();
+
+        MetadataSchemaRest metadataSchemaRest = new MetadataSchemaRest();
+        metadataSchemaRest.setId(metadataSchema.getID());
+        metadataSchemaRest.setPrefix(TEST_NAME_UPDATED);
+        metadataSchemaRest.setNamespace(TEST_NAMESPACE_UPDATED);
+
+        try {
+            getClient(getAuthToken(admin.getEmail(), password))
+                    .perform(put("/api/core/metadataschemas/" + metadataSchema.getID())
+                            .content(new ObjectMapper().writeValueAsBytes(metadataSchemaRest))
+                            .contentType(contentType))
+                    .andExpect(status().isOk());
+
+            metadataSchema = metadataSchemaService.find(context, metadataSchema.getID());
+
+            assertEquals(TEST_NAME_UPDATED, metadataSchema.getName());
+            assertEquals(TEST_NAMESPACE_UPDATED, metadataSchema.getNamespace());
+        } finally {
+            deleteMetadataSchemaIfExists(metadataSchema);
+        }
+    }
+
+    @Test
+    public void updateUnauthorized() throws Exception {
+
+        MetadataSchema metadataSchema = createMetadataSchema();
+
+        MetadataSchemaRest metadataSchemaRest = new MetadataSchemaRest();
+        metadataSchemaRest.setId(metadataSchema.getID());
+        metadataSchemaRest.setPrefix(TEST_NAME_UPDATED);
+        metadataSchemaRest.setNamespace(TEST_NAMESPACE_UPDATED);
+
+        try {
+            getClient()
+                    .perform(put("/api/core/metadataschemas/" + metadataSchema.getID())
+                            .content(new ObjectMapper().writeValueAsBytes(metadataSchemaRest))
+                            .contentType(contentType))
+                    .andExpect(status().isUnauthorized());
+
+            metadataSchema = metadataSchemaService.find(context, metadataSchema.getID());
+
+            assertEquals(TEST_NAME, metadataSchema.getName());
+            assertEquals(TEST_NAMESPACE, metadataSchema.getNamespace());
+        } finally {
+            deleteMetadataSchemaIfExists(metadataSchema);
+        }
+    }
+
+    private MetadataSchema createMetadataSchema() throws SQLException, AuthorizeException, NonUniqueMetadataException {
+        context.turnOffAuthorisationSystem();
+        MetadataSchema metadataSchema = metadataSchemaService.create(context, TEST_NAME, TEST_NAMESPACE);
+        context.commit();
+        return metadataSchema;
+    }
+
+    private void deleteMetadataSchemaIfExists(String name) throws SQLException, AuthorizeException {
+
+        deleteMetadataSchemaIfExists(metadataSchemaService.find(context, name));
+    }
+
+    private void deleteMetadataSchemaIfExists(MetadataSchema metadataSchema) throws SQLException, AuthorizeException {
+
+        if (metadataSchema != null) {
+            context.turnOffAuthorisationSystem();
+            metadataSchemaService.delete(context, metadataSchema);
+            context.commit();
+        }
     }
 }

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/MetadatafieldRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/MetadatafieldRestRepositoryIT.java
@@ -7,23 +7,62 @@
  */
 package org.dspace.app.rest;
 
+import static com.jayway.jsonpath.JsonPath.read;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.sql.SQLException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dspace.app.rest.builder.MetadataFieldBuilder;
 import org.dspace.app.rest.builder.MetadataSchemaBuilder;
 import org.dspace.app.rest.matcher.MetadataFieldMatcher;
+import org.dspace.app.rest.model.MetadataFieldRest;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.MetadataField;
+import org.dspace.content.MetadataFieldServiceImpl;
 import org.dspace.content.MetadataSchema;
+import org.dspace.content.NonUniqueMetadataException;
+import org.dspace.content.service.MetadataSchemaService;
 import org.hamcrest.Matchers;
+import org.junit.Before;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegrationTest {
 
+    private static final String ELEMENT = "test element";
+    private static final String QUALIFIER = "test qualifier";
+    private static final String SCOPE_NOTE = "test scope_note";
+
+    private static final String ELEMENT_UPDATED = "test element updated";
+    private static final String QUALIFIER_UPDATED = "test qualifier updated";
+    private static final String SCOPE_NOTE_UPDATED = "test scope_note updated";
+
+    private MetadataSchema metadataSchema;
+
+    @Autowired
+    private MetadataSchemaService metadataSchemaService;
+
+    @Autowired
+    private MetadataFieldServiceImpl metadataFieldService;
+
+    @Before
+    public void setup() throws Exception {
+        metadataSchema = metadataSchemaService.findAll(context).get(0);
+    }
 
     @Test
     public void findAll() throws Exception {
@@ -66,12 +105,12 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
     @Test
     public void searchMethodsExist() throws Exception {
         getClient().perform(get("/api/core/metadatafields"))
-                   .andExpect(jsonPath("$._links.search.href", Matchers.notNullValue()));
+                   .andExpect(jsonPath("$._links.search.href", notNullValue()));
 
         getClient().perform(get("/api/core/metadatafields/search"))
                    .andExpect(status().isOk())
                    .andExpect(content().contentType(contentType))
-                   .andExpect(jsonPath("$._links.bySchema", Matchers.notNullValue()));
+                   .andExpect(jsonPath("$._links.bySchema", notNullValue()));
     }
 
     @Test
@@ -124,4 +163,190 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
                    .andExpect(status().isUnprocessableEntity());
     }
 
+    @Test
+    public void createSuccess() throws Exception {
+
+        MetadataFieldRest metadataFieldRest = new MetadataFieldRest();
+        metadataFieldRest.setElement(ELEMENT);
+        metadataFieldRest.setQualifier(QUALIFIER);
+        metadataFieldRest.setScopeNote(SCOPE_NOTE);
+
+        String authToken = getAuthToken(admin.getEmail(), password);
+        AtomicReference<Integer> idRef = new AtomicReference<>();
+
+        try {
+            assertThat(metadataFieldService.findByElement(context, metadataSchema, ELEMENT, QUALIFIER), nullValue());
+
+            getClient(authToken)
+                    .perform(post("/api/core/metadatafields")
+                            .param("schemaId", metadataSchema.getID() + "")
+                            .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                            .contentType(contentType))
+                    .andExpect(status().isCreated())
+                    .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(), "$.id")));
+
+            MetadataField metadataField = metadataFieldService.find(context, idRef.get());
+            assertThat(metadataField, notNullValue());
+
+            assertEquals(metadataField.getMetadataSchema(), metadataSchema);
+            assertEquals(metadataField.getElement(), ELEMENT);
+            assertEquals(metadataField.getQualifier(), QUALIFIER);
+            assertEquals(metadataField.getScopeNote(), SCOPE_NOTE);
+
+        } finally {
+            deleteMetadataFieldIfExists();
+        }
+    }
+
+    @Test
+    public void createUnauthauthorized() throws Exception {
+
+        MetadataFieldRest metadataFieldRest = new MetadataFieldRest();
+        metadataFieldRest.setElement(ELEMENT);
+        metadataFieldRest.setQualifier(QUALIFIER);
+        metadataFieldRest.setScopeNote(SCOPE_NOTE);
+
+        try {
+            getClient()
+                    .perform(post("/api/core/metadatafields")
+                            .param("schemaId", metadataSchema.getID() + "")
+                            .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                            .contentType(contentType))
+                    .andExpect(status().isUnauthorized());
+        } finally {
+            deleteMetadataFieldIfExists();
+        }
+    }
+
+    @Test
+    public void deleteSuccess() throws Exception {
+
+        MetadataField metadataField = createMetadataField();
+
+        try {
+
+            assertThat(metadataFieldService.find(context, metadataField.getID()), notNullValue());
+
+            getClient(getAuthToken(admin.getEmail(), password))
+                    .perform(delete("/api/core/metadatafields/" + metadataField.getID()))
+                    .andExpect(status().isNoContent());
+
+            assertThat(metadataFieldService.find(context, metadataField.getID()), nullValue());
+
+        } finally {
+            deleteMetadataFieldIfExists();
+        }
+    }
+
+    @Test
+    public void deleteUnauthorized() throws Exception {
+
+        MetadataField metadataField = createMetadataField();
+
+        try {
+
+            assertThat(metadataFieldService.find(context, metadataField.getID()), notNullValue());
+
+            getClient()
+                    .perform(delete("/api/core/metadatafields/" + metadataField.getID()))
+                    .andExpect(status().isUnauthorized());
+
+            assertThat(metadataFieldService.find(context, metadataField.getID()), notNullValue());
+
+        } finally {
+            deleteMetadataFieldIfExists();
+        }
+    }
+
+    @Test
+    public void deleteNonExisting() throws Exception {
+
+        MetadataField metadataField = createMetadataField();
+        deleteMetadataFieldIfExists();
+
+        Integer id = metadataField.getID();
+        assertThat(metadataFieldService.find(context, id), nullValue());
+
+        getClient(getAuthToken(admin.getEmail(), password))
+                .perform(delete("/api/core/metadatafields/" + id))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void update() throws Exception {
+
+        MetadataField metadataField = createMetadataField();
+
+        MetadataFieldRest metadataFieldRest = new MetadataFieldRest();
+        metadataFieldRest.setId(metadataField.getID());
+        metadataFieldRest.setElement(ELEMENT_UPDATED);
+        metadataFieldRest.setQualifier(QUALIFIER_UPDATED);
+        metadataFieldRest.setScopeNote(SCOPE_NOTE_UPDATED);
+
+        try {
+            getClient(getAuthToken(admin.getEmail(), password))
+                    .perform(put("/api/core/metadatafields/" + metadataField.getID())
+                            .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                            .contentType(contentType))
+                    .andExpect(status().isOk());
+
+            metadataField = metadataFieldService.find(context, metadataField.getID());
+
+            assertEquals(ELEMENT_UPDATED, metadataField.getElement());
+            assertEquals(QUALIFIER_UPDATED, metadataField.getQualifier());
+            assertEquals(SCOPE_NOTE_UPDATED, metadataField.getScopeNote());
+        } finally {
+            deleteMetadataFieldIfExists(metadataField);
+        }
+    }
+
+    @Test
+    public void updateUnauthorized() throws Exception {
+
+        MetadataField metadataField = createMetadataField();
+
+        MetadataFieldRest metadataFieldRest = new MetadataFieldRest();
+        metadataFieldRest.setId(metadataField.getID());
+        metadataFieldRest.setElement(ELEMENT_UPDATED);
+        metadataFieldRest.setQualifier(QUALIFIER_UPDATED);
+        metadataFieldRest.setScopeNote(SCOPE_NOTE_UPDATED);
+
+        try {
+            getClient()
+                    .perform(put("/api/core/metadatafields/" + metadataField.getID())
+                            .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                            .contentType(contentType))
+                    .andExpect(status().isUnauthorized());
+
+            metadataField = metadataFieldService.find(context, metadataField.getID());
+
+            assertEquals(ELEMENT, metadataField.getElement());
+            assertEquals(QUALIFIER, metadataField.getQualifier());
+            assertEquals(SCOPE_NOTE, metadataField.getScopeNote());
+        } finally {
+            deleteMetadataFieldIfExists(metadataField);
+        }
+    }
+
+    private MetadataField createMetadataField() throws AuthorizeException, SQLException, NonUniqueMetadataException {
+        context.turnOffAuthorisationSystem();
+        MetadataField metadataField = metadataFieldService.create(
+                context, metadataSchema, ELEMENT, QUALIFIER, SCOPE_NOTE
+        );
+        context.commit();
+        return metadataField;
+    }
+
+    private void deleteMetadataFieldIfExists() throws SQLException, AuthorizeException {
+
+        deleteMetadataFieldIfExists(metadataFieldService.findByElement(context, metadataSchema, ELEMENT, QUALIFIER));
+    }
+
+    private void deleteMetadataFieldIfExists(MetadataField metadataField) throws SQLException, AuthorizeException {
+        if (metadataField != null) {
+            context.turnOffAuthorisationSystem();
+            metadataFieldService.delete(context, metadataField);
+            context.commit();
+        }
+    }
 }

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/MetadatafieldRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/MetadatafieldRestRepositoryIT.java
@@ -37,6 +37,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+/**
+ * Integration tests for the {@link org.dspace.app.rest.repository.MetadataFieldRestRepository}
+ * This class will include all the tests for the logic with regards to the
+ * {@link org.dspace.app.rest.repository.MetadataFieldRestRepository}
+ */
 public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegrationTest {
 
     private static final String ELEMENT = "test element";
@@ -66,14 +71,15 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
         context.turnOffAuthorisationSystem();
         MetadataField metadataField = MetadataFieldBuilder
             .createMetadataField(context, "AnElement", "AQualifier", "AScopeNote").build();
+        context.restoreAuthSystemState();
 
         getClient().perform(get("/api/core/metadatafields")
-                        .param("size", String.valueOf(100)))
+                                .param("size", String.valueOf(100)))
                    .andExpect(status().isOk())
                    .andExpect(content().contentType(contentType))
                    .andExpect(jsonPath("$._embedded.metadatafields", Matchers.hasItems(
-                           MetadataFieldMatcher.matchMetadataFieldByKeys("dc","title", null),
-                           MetadataFieldMatcher.matchMetadataFieldByKeys("dc","date", "issued"))
+                       MetadataFieldMatcher.matchMetadataFieldByKeys("dc", "title", null),
+                       MetadataFieldMatcher.matchMetadataFieldByKeys("dc", "date", "issued"))
                    ))
                    .andExpect(jsonPath("$._links.first.href", Matchers.containsString("/api/core/metadatafields")))
                    .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/metadatafields")))
@@ -89,6 +95,7 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
         context.turnOffAuthorisationSystem();
         MetadataField metadataField = MetadataFieldBuilder
             .createMetadataField(context, "AnElement", "AQualifier", "AScopeNote").build();
+        context.restoreAuthSystemState();
 
         getClient().perform(get("/api/core/metadatafields/" + metadataField.getID()))
                    .andExpect(status().isOk())
@@ -100,7 +107,6 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
 
     @Test
     public void searchMethodsExist() throws Exception {
-        context.turnOffAuthorisationSystem();
 
         getClient().perform(get("/api/core/metadatafields"))
                    .andExpect(jsonPath("$._links.search.href", notNullValue()));
@@ -116,39 +122,39 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
 
         context.turnOffAuthorisationSystem();
         MetadataSchema schema = MetadataSchemaBuilder.createMetadataSchema(context, "ASchema",
-                "http://www.dspace.org/ns/aschema").build();
+                                                                           "http://www.dspace.org/ns/aschema").build();
 
         MetadataField metadataField = MetadataFieldBuilder
             .createMetadataField(context, schema, "AnElement", "AQualifier", "AScopeNote").build();
+        context.restoreAuthSystemState();
 
         getClient().perform(get("/api/core/metadatafields/search/bySchema")
-                        .param("schema", "dc")
-                        .param("size", String.valueOf(100)))
+                                .param("schema", "dc")
+                                .param("size", String.valueOf(100)))
                    .andExpect(status().isOk())
                    .andExpect(content().contentType(contentType))
                    .andExpect(jsonPath("$._embedded.metadatafields", Matchers.hasItems(
-                       MetadataFieldMatcher.matchMetadataFieldByKeys("dc","title", null),
-                       MetadataFieldMatcher.matchMetadataFieldByKeys("dc","date", "issued"))
+                       MetadataFieldMatcher.matchMetadataFieldByKeys("dc", "title", null),
+                       MetadataFieldMatcher.matchMetadataFieldByKeys("dc", "date", "issued"))
                    ))
                    .andExpect(jsonPath("$.page.size", is(100)));
 
         getClient().perform(get("/api/core/metadatafields/search/bySchema")
-                .param("schema", schema.getName()))
-           .andExpect(status().isOk())
-           .andExpect(content().contentType(contentType))
-           .andExpect(jsonPath("$._embedded.metadatafields", Matchers.hasItem(
-                   MetadataFieldMatcher.matchMetadataField(metadataField))
-           ))
-           .andExpect(jsonPath("$.page.size", is(20)))
-           .andExpect(jsonPath("$.page.totalElements", is(1)));
+                                .param("schema", schema.getName()))
+                   .andExpect(status().isOk())
+                   .andExpect(content().contentType(contentType))
+                   .andExpect(jsonPath("$._embedded.metadatafields", Matchers.hasItem(
+                       MetadataFieldMatcher.matchMetadataField(metadataField))
+                   ))
+                   .andExpect(jsonPath("$.page.size", is(20)))
+                   .andExpect(jsonPath("$.page.totalElements", is(1)));
     }
 
     @Test
     public void findByUndefinedSchema() throws Exception {
-        context.turnOffAuthorisationSystem();
 
         getClient().perform(get("/api/core/metadatafields/search/bySchema")
-                        .param("schema", "undefined"))
+                                .param("schema", "undefined"))
                    .andExpect(status().isOk())
                    .andExpect(content().contentType(contentType))
                    .andExpect(jsonPath("$.page.size", is(20)))
@@ -157,7 +163,6 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
 
     @Test
     public void findByNullSchema() throws Exception {
-        context.turnOffAuthorisationSystem();
 
         getClient().perform(get("/api/core/metadatafields/search/bySchema"))
                    .andExpect(status().isUnprocessableEntity());
@@ -165,7 +170,6 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
 
     @Test
     public void createSuccess() throws Exception {
-        context.turnOffAuthorisationSystem();
 
         MetadataFieldRest metadataFieldRest = new MetadataFieldRest();
         metadataFieldRest.setElement("testElementForCreate");
@@ -178,12 +182,12 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
         assertThat(metadataFieldService.findByElement(context, metadataSchema, ELEMENT, QUALIFIER), nullValue());
 
         getClient(authToken)
-                .perform(post("/api/core/metadatafields")
-                        .param("schemaId", metadataSchema.getID() + "")
-                        .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
-                        .contentType(contentType))
-                .andExpect(status().isCreated())
-                .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(), "$.id")));
+            .perform(post("/api/core/metadatafields")
+                         .param("schemaId", metadataSchema.getID() + "")
+                         .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                         .contentType(contentType))
+            .andExpect(status().isCreated())
+            .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(), "$.id")));
 
         getClient(authToken).perform(get("/api/core/metadatafields/" + idRef.get()))
                             .andExpect(status().isOk())
@@ -193,7 +197,6 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
 
     @Test
     public void createUnauthorized() throws Exception {
-        context.turnOffAuthorisationSystem();
 
         MetadataFieldRest metadataFieldRest = new MetadataFieldRest();
         metadataFieldRest.setElement(ELEMENT);
@@ -201,16 +204,15 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
         metadataFieldRest.setScopeNote(SCOPE_NOTE);
 
         getClient()
-                .perform(post("/api/core/metadatafields")
-                        .param("schemaId", metadataSchema.getID() + "")
-                        .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
-                        .contentType(contentType))
-                .andExpect(status().isUnauthorized());
+            .perform(post("/api/core/metadatafields")
+                         .param("schemaId", metadataSchema.getID() + "")
+                         .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                         .contentType(contentType))
+            .andExpect(status().isUnauthorized());
     }
 
     @Test
     public void createUnauthorizedEPersonNoAdminRights() throws Exception {
-        context.turnOffAuthorisationSystem();
 
         MetadataFieldRest metadataFieldRest = new MetadataFieldRest();
         metadataFieldRest.setElement(ELEMENT);
@@ -233,13 +235,14 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
 
         MetadataField metadataField = MetadataFieldBuilder.createMetadataField(context, ELEMENT, QUALIFIER, SCOPE_NOTE)
                                                           .build();
+        context.restoreAuthSystemState();
 
 
         getClient().perform(get("/api/core/metadatafields/" + metadataField.getID()))
                    .andExpect(status().isOk());
         getClient(getAuthToken(admin.getEmail(), password))
-                .perform(delete("/api/core/metadatafields/" + metadataField.getID()))
-                .andExpect(status().isNoContent());
+            .perform(delete("/api/core/metadatafields/" + metadataField.getID()))
+            .andExpect(status().isNoContent());
 
         getClient().perform(get("/api/core/metadatafields/" + metadataField.getID()))
                    .andExpect(status().isNotFound());
@@ -252,11 +255,13 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
         MetadataField metadataField = MetadataFieldBuilder.createMetadataField(context, ELEMENT, QUALIFIER, SCOPE_NOTE)
                                                           .build();
 
+        context.restoreAuthSystemState();
+
         getClient().perform(get("/api/core/metadatafields/" + metadataField.getID()))
                    .andExpect(status().isOk());
         getClient()
-                .perform(delete("/api/core/metadatafields/" + metadataField.getID()))
-                .andExpect(status().isUnauthorized());
+            .perform(delete("/api/core/metadatafields/" + metadataField.getID()))
+            .andExpect(status().isUnauthorized());
 
         getClient().perform(get("/api/core/metadatafields/" + metadataField.getID()))
                    .andExpect(status().isOk());
@@ -268,6 +273,9 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
 
         MetadataField metadataField = MetadataFieldBuilder.createMetadataField(context, ELEMENT, QUALIFIER, SCOPE_NOTE)
                                                           .build();
+
+        context.restoreAuthSystemState();
+
         String token = getAuthToken(eperson.getEmail(), password);
 
 
@@ -289,6 +297,8 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
         MetadataField metadataField = MetadataFieldBuilder.createMetadataField(context, ELEMENT, QUALIFIER, SCOPE_NOTE)
                                                           .build();
 
+        context.restoreAuthSystemState();
+
         Integer id = metadataField.getID();
         getClient(getAuthToken(admin.getEmail(), password))
             .perform(delete("/api/core/metadatafields/" + id))
@@ -297,8 +307,8 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
         assertThat(metadataFieldService.find(context, id), nullValue());
 
         getClient(getAuthToken(admin.getEmail(), password))
-                .perform(delete("/api/core/metadatafields/" + id))
-                .andExpect(status().isNotFound());
+            .perform(delete("/api/core/metadatafields/" + id))
+            .andExpect(status().isNotFound());
     }
 
     @Test
@@ -307,6 +317,9 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
 
         MetadataField metadataField = MetadataFieldBuilder.createMetadataField(context, ELEMENT, QUALIFIER, SCOPE_NOTE)
                                                           .build();
+
+        context.restoreAuthSystemState();
+
         MetadataFieldRest metadataFieldRest = new MetadataFieldRest();
         metadataFieldRest.setId(metadataField.getID());
         metadataFieldRest.setElement(ELEMENT_UPDATED);
@@ -314,10 +327,10 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
         metadataFieldRest.setScopeNote(SCOPE_NOTE_UPDATED);
 
         getClient(getAuthToken(admin.getEmail(), password))
-                .perform(put("/api/core/metadatafields/" + metadataField.getID())
-                        .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
-                        .contentType(contentType))
-                .andExpect(status().isOk());
+            .perform(put("/api/core/metadatafields/" + metadataField.getID())
+                         .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                         .contentType(contentType))
+            .andExpect(status().isOk());
 
         getClient().perform(get("/api/core/metadatafields/" + metadataField.getID()))
                    .andExpect(status().isOk())
@@ -332,6 +345,9 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
 
         MetadataField metadataField = MetadataFieldBuilder.createMetadataField(context, ELEMENT, QUALIFIER, SCOPE_NOTE)
                                                           .build();
+
+        context.restoreAuthSystemState();
+
         MetadataFieldRest metadataFieldRest = new MetadataFieldRest();
         metadataFieldRest.setId(metadataField.getID());
         metadataFieldRest.setElement(ELEMENT_UPDATED);
@@ -339,10 +355,40 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
         metadataFieldRest.setScopeNote(SCOPE_NOTE_UPDATED);
 
         getClient()
-                .perform(put("/api/core/metadatafields/" + metadataField.getID())
-                        .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
-                        .contentType(contentType))
-                .andExpect(status().isUnauthorized());
+            .perform(put("/api/core/metadatafields/" + metadataField.getID())
+                         .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                         .contentType(contentType))
+            .andExpect(status().isUnauthorized());
+
+        getClient().perform(get("/api/core/metadatafields/" + metadataField.getID()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", MetadataFieldMatcher.matchMetadataFieldByKeys(
+                       metadataSchema.getName(), ELEMENT, QUALIFIER)
+                   ));
+
+
+    }
+
+    @Test
+    public void updateWrongRights() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        MetadataField metadataField = MetadataFieldBuilder.createMetadataField(context, ELEMENT, QUALIFIER, SCOPE_NOTE)
+                                                          .build();
+
+        context.restoreAuthSystemState();
+
+        MetadataFieldRest metadataFieldRest = new MetadataFieldRest();
+        metadataFieldRest.setId(metadataField.getID());
+        metadataFieldRest.setElement(ELEMENT_UPDATED);
+        metadataFieldRest.setQualifier(QUALIFIER_UPDATED);
+        metadataFieldRest.setScopeNote(SCOPE_NOTE_UPDATED);
+
+        getClient(getAuthToken(eperson.getEmail(), password))
+            .perform(put("/api/core/metadatafields/" + metadataField.getID())
+                         .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                         .contentType(contentType))
+            .andExpect(status().isForbidden());
 
         getClient().perform(get("/api/core/metadatafields/" + metadataField.getID()))
                    .andExpect(status().isOk())

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/MetadatafieldRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/MetadatafieldRestRepositoryIT.java
@@ -11,7 +11,6 @@ import static com.jayway.jsonpath.JsonPath.read;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -21,7 +20,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.sql.SQLException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -30,11 +28,9 @@ import org.dspace.app.rest.builder.MetadataSchemaBuilder;
 import org.dspace.app.rest.matcher.MetadataFieldMatcher;
 import org.dspace.app.rest.model.MetadataFieldRest;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
-import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.MetadataField;
 import org.dspace.content.MetadataFieldServiceImpl;
 import org.dspace.content.MetadataSchema;
-import org.dspace.content.NonUniqueMetadataException;
 import org.dspace.content.service.MetadataSchemaService;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -104,6 +100,8 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
 
     @Test
     public void searchMethodsExist() throws Exception {
+        context.turnOffAuthorisationSystem();
+
         getClient().perform(get("/api/core/metadatafields"))
                    .andExpect(jsonPath("$._links.search.href", notNullValue()));
 
@@ -147,6 +145,7 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
 
     @Test
     public void findByUndefinedSchema() throws Exception {
+        context.turnOffAuthorisationSystem();
 
         getClient().perform(get("/api/core/metadatafields/search/bySchema")
                         .param("schema", "undefined"))
@@ -158,6 +157,7 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
 
     @Test
     public void findByNullSchema() throws Exception {
+        context.turnOffAuthorisationSystem();
 
         getClient().perform(get("/api/core/metadatafields/search/bySchema"))
                    .andExpect(status().isUnprocessableEntity());
@@ -165,106 +165,135 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
 
     @Test
     public void createSuccess() throws Exception {
+        context.turnOffAuthorisationSystem();
 
         MetadataFieldRest metadataFieldRest = new MetadataFieldRest();
-        metadataFieldRest.setElement(ELEMENT);
-        metadataFieldRest.setQualifier(QUALIFIER);
+        metadataFieldRest.setElement("testElementForCreate");
+        metadataFieldRest.setQualifier("testQualifierForCreate");
         metadataFieldRest.setScopeNote(SCOPE_NOTE);
 
         String authToken = getAuthToken(admin.getEmail(), password);
         AtomicReference<Integer> idRef = new AtomicReference<>();
 
-        try {
-            assertThat(metadataFieldService.findByElement(context, metadataSchema, ELEMENT, QUALIFIER), nullValue());
+        assertThat(metadataFieldService.findByElement(context, metadataSchema, ELEMENT, QUALIFIER), nullValue());
 
-            getClient(authToken)
-                    .perform(post("/api/core/metadatafields")
-                            .param("schemaId", metadataSchema.getID() + "")
-                            .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
-                            .contentType(contentType))
-                    .andExpect(status().isCreated())
-                    .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(), "$.id")));
+        getClient(authToken)
+                .perform(post("/api/core/metadatafields")
+                        .param("schemaId", metadataSchema.getID() + "")
+                        .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                        .contentType(contentType))
+                .andExpect(status().isCreated())
+                .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(), "$.id")));
 
-            MetadataField metadataField = metadataFieldService.find(context, idRef.get());
-            assertThat(metadataField, notNullValue());
-
-            assertEquals(metadataField.getMetadataSchema(), metadataSchema);
-            assertEquals(metadataField.getElement(), ELEMENT);
-            assertEquals(metadataField.getQualifier(), QUALIFIER);
-            assertEquals(metadataField.getScopeNote(), SCOPE_NOTE);
-
-        } finally {
-            deleteMetadataFieldIfExists();
-        }
+        getClient(authToken).perform(get("/api/core/metadatafields/" + idRef.get()))
+                            .andExpect(status().isOk())
+                            .andExpect(jsonPath("$", MetadataFieldMatcher.matchMetadataFieldByKeys(
+                                metadataSchema.getName(), "testElementForCreate", "testQualifierForCreate")));
     }
 
     @Test
-    public void createUnauthauthorized() throws Exception {
+    public void createUnauthorized() throws Exception {
+        context.turnOffAuthorisationSystem();
 
         MetadataFieldRest metadataFieldRest = new MetadataFieldRest();
         metadataFieldRest.setElement(ELEMENT);
         metadataFieldRest.setQualifier(QUALIFIER);
         metadataFieldRest.setScopeNote(SCOPE_NOTE);
 
-        try {
-            getClient()
-                    .perform(post("/api/core/metadatafields")
-                            .param("schemaId", metadataSchema.getID() + "")
-                            .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
-                            .contentType(contentType))
-                    .andExpect(status().isUnauthorized());
-        } finally {
-            deleteMetadataFieldIfExists();
-        }
+        getClient()
+                .perform(post("/api/core/metadatafields")
+                        .param("schemaId", metadataSchema.getID() + "")
+                        .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                        .contentType(contentType))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void createUnauthorizedEPersonNoAdminRights() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        MetadataFieldRest metadataFieldRest = new MetadataFieldRest();
+        metadataFieldRest.setElement(ELEMENT);
+        metadataFieldRest.setQualifier(QUALIFIER);
+        metadataFieldRest.setScopeNote(SCOPE_NOTE);
+
+        String token = getAuthToken(eperson.getEmail(), password);
+
+        getClient(token)
+            .perform(post("/api/core/metadatafields")
+                         .param("schemaId", metadataSchema.getID() + "")
+                         .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                         .contentType(contentType))
+            .andExpect(status().isForbidden());
     }
 
     @Test
     public void deleteSuccess() throws Exception {
+        context.turnOffAuthorisationSystem();
 
-        MetadataField metadataField = createMetadataField();
+        MetadataField metadataField = MetadataFieldBuilder.createMetadataField(context, ELEMENT, QUALIFIER, SCOPE_NOTE)
+                                                          .build();
 
-        try {
 
-            assertThat(metadataFieldService.find(context, metadataField.getID()), notNullValue());
+        getClient().perform(get("/api/core/metadatafields/" + metadataField.getID()))
+                   .andExpect(status().isOk());
+        getClient(getAuthToken(admin.getEmail(), password))
+                .perform(delete("/api/core/metadatafields/" + metadataField.getID()))
+                .andExpect(status().isNoContent());
 
-            getClient(getAuthToken(admin.getEmail(), password))
-                    .perform(delete("/api/core/metadatafields/" + metadataField.getID()))
-                    .andExpect(status().isNoContent());
-
-            assertThat(metadataFieldService.find(context, metadataField.getID()), nullValue());
-
-        } finally {
-            deleteMetadataFieldIfExists();
-        }
+        getClient().perform(get("/api/core/metadatafields/" + metadataField.getID()))
+                   .andExpect(status().isNotFound());
     }
 
     @Test
     public void deleteUnauthorized() throws Exception {
+        context.turnOffAuthorisationSystem();
 
-        MetadataField metadataField = createMetadataField();
+        MetadataField metadataField = MetadataFieldBuilder.createMetadataField(context, ELEMENT, QUALIFIER, SCOPE_NOTE)
+                                                          .build();
 
-        try {
+        getClient().perform(get("/api/core/metadatafields/" + metadataField.getID()))
+                   .andExpect(status().isOk());
+        getClient()
+                .perform(delete("/api/core/metadatafields/" + metadataField.getID()))
+                .andExpect(status().isUnauthorized());
 
-            assertThat(metadataFieldService.find(context, metadataField.getID()), notNullValue());
-
-            getClient()
-                    .perform(delete("/api/core/metadatafields/" + metadataField.getID()))
-                    .andExpect(status().isUnauthorized());
-
-            assertThat(metadataFieldService.find(context, metadataField.getID()), notNullValue());
-
-        } finally {
-            deleteMetadataFieldIfExists();
-        }
+        getClient().perform(get("/api/core/metadatafields/" + metadataField.getID()))
+                   .andExpect(status().isOk());
     }
 
     @Test
-    public void deleteNonExisting() throws Exception {
+    public void deleteUnauthorizedEPersonNoAdminRights() throws Exception {
+        context.turnOffAuthorisationSystem();
 
-        MetadataField metadataField = createMetadataField();
-        deleteMetadataFieldIfExists();
+        MetadataField metadataField = MetadataFieldBuilder.createMetadataField(context, ELEMENT, QUALIFIER, SCOPE_NOTE)
+                                                          .build();
+        String token = getAuthToken(eperson.getEmail(), password);
+
+
+        getClient().perform(get("/api/core/metadatafields/" + metadataField.getID()))
+                   .andExpect(status().isOk());
+        getClient(token)
+            .perform(delete("/api/core/metadatafields/" + metadataField.getID()))
+            .andExpect(status().isForbidden());
+
+        getClient().perform(get("/api/core/metadatafields/" + metadataField.getID()))
+                   .andExpect(status().isOk());
+    }
+
+
+    @Test
+    public void deleteNonExisting() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        MetadataField metadataField = MetadataFieldBuilder.createMetadataField(context, ELEMENT, QUALIFIER, SCOPE_NOTE)
+                                                          .build();
 
         Integer id = metadataField.getID();
+        getClient(getAuthToken(admin.getEmail(), password))
+            .perform(delete("/api/core/metadatafields/" + id))
+            .andExpect(status().isNoContent());
+
         assertThat(metadataFieldService.find(context, id), nullValue());
 
         getClient(getAuthToken(admin.getEmail(), password))
@@ -274,79 +303,55 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
 
     @Test
     public void update() throws Exception {
+        context.turnOffAuthorisationSystem();
 
-        MetadataField metadataField = createMetadataField();
-
+        MetadataField metadataField = MetadataFieldBuilder.createMetadataField(context, ELEMENT, QUALIFIER, SCOPE_NOTE)
+                                                          .build();
         MetadataFieldRest metadataFieldRest = new MetadataFieldRest();
         metadataFieldRest.setId(metadataField.getID());
         metadataFieldRest.setElement(ELEMENT_UPDATED);
         metadataFieldRest.setQualifier(QUALIFIER_UPDATED);
         metadataFieldRest.setScopeNote(SCOPE_NOTE_UPDATED);
 
-        try {
-            getClient(getAuthToken(admin.getEmail(), password))
-                    .perform(put("/api/core/metadatafields/" + metadataField.getID())
-                            .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
-                            .contentType(contentType))
-                    .andExpect(status().isOk());
+        getClient(getAuthToken(admin.getEmail(), password))
+                .perform(put("/api/core/metadatafields/" + metadataField.getID())
+                        .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                        .contentType(contentType))
+                .andExpect(status().isOk());
 
-            metadataField = metadataFieldService.find(context, metadataField.getID());
-
-            assertEquals(ELEMENT_UPDATED, metadataField.getElement());
-            assertEquals(QUALIFIER_UPDATED, metadataField.getQualifier());
-            assertEquals(SCOPE_NOTE_UPDATED, metadataField.getScopeNote());
-        } finally {
-            deleteMetadataFieldIfExists(metadataField);
-        }
+        getClient().perform(get("/api/core/metadatafields/" + metadataField.getID()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", MetadataFieldMatcher.matchMetadataFieldByKeys(
+                       metadataSchema.getName(), ELEMENT_UPDATED, QUALIFIER_UPDATED)
+                   ));
     }
 
     @Test
     public void updateUnauthorized() throws Exception {
+        context.turnOffAuthorisationSystem();
 
-        MetadataField metadataField = createMetadataField();
-
+        MetadataField metadataField = MetadataFieldBuilder.createMetadataField(context, ELEMENT, QUALIFIER, SCOPE_NOTE)
+                                                          .build();
         MetadataFieldRest metadataFieldRest = new MetadataFieldRest();
         metadataFieldRest.setId(metadataField.getID());
         metadataFieldRest.setElement(ELEMENT_UPDATED);
         metadataFieldRest.setQualifier(QUALIFIER_UPDATED);
         metadataFieldRest.setScopeNote(SCOPE_NOTE_UPDATED);
 
-        try {
-            getClient()
-                    .perform(put("/api/core/metadatafields/" + metadataField.getID())
-                            .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
-                            .contentType(contentType))
-                    .andExpect(status().isUnauthorized());
+        getClient()
+                .perform(put("/api/core/metadatafields/" + metadataField.getID())
+                        .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                        .contentType(contentType))
+                .andExpect(status().isUnauthorized());
 
-            metadataField = metadataFieldService.find(context, metadataField.getID());
+        getClient().perform(get("/api/core/metadatafields/" + metadataField.getID()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", MetadataFieldMatcher.matchMetadataFieldByKeys(
+                       metadataSchema.getName(), ELEMENT, QUALIFIER)
+                   ));
 
-            assertEquals(ELEMENT, metadataField.getElement());
-            assertEquals(QUALIFIER, metadataField.getQualifier());
-            assertEquals(SCOPE_NOTE, metadataField.getScopeNote());
-        } finally {
-            deleteMetadataFieldIfExists(metadataField);
-        }
+
     }
 
-    private MetadataField createMetadataField() throws AuthorizeException, SQLException, NonUniqueMetadataException {
-        context.turnOffAuthorisationSystem();
-        MetadataField metadataField = metadataFieldService.create(
-                context, metadataSchema, ELEMENT, QUALIFIER, SCOPE_NOTE
-        );
-        context.commit();
-        return metadataField;
-    }
 
-    private void deleteMetadataFieldIfExists() throws SQLException, AuthorizeException {
-
-        deleteMetadataFieldIfExists(metadataFieldService.findByElement(context, metadataSchema, ELEMENT, QUALIFIER));
-    }
-
-    private void deleteMetadataFieldIfExists(MetadataField metadataField) throws SQLException, AuthorizeException {
-        if (metadataField != null) {
-            context.turnOffAuthorisationSystem();
-            metadataFieldService.delete(context, metadataField);
-            context.commit();
-        }
-    }
 }

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/MetadataschemaMatcher.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/matcher/MetadataschemaMatcher.java
@@ -29,11 +29,15 @@ public class MetadataschemaMatcher {
     }
 
     public static Matcher<? super Object> matchEntry(MetadataSchema metadataSchema) {
+        return matchEntry(metadataSchema.getName(), metadataSchema.getNamespace());
+    }
+
+    public static Matcher<? super Object> matchEntry(String name, String nameSpace) {
         return allOf(
-            hasJsonPath("$.prefix", is(metadataSchema.getName())),
-            hasJsonPath("$.namespace", is(metadataSchema.getNamespace())),
-            hasJsonPath("$.type", is("metadataschema")),
-            hasJsonPath("$._links.self.href", Matchers.containsString("/api/core/metadataschemas"))
+                hasJsonPath("$.prefix", is(name)),
+                hasJsonPath("$.namespace", is(nameSpace)),
+                hasJsonPath("$.type", is("metadataschema")),
+                hasJsonPath("$._links.self.href", Matchers.containsString("/api/core/metadataschemas"))
         );
     }
 }


### PR DESCRIPTION
This PR covers the CRUD operations on both the MetadataField and MetadataSchema endpoints for the REST api:

* The createAndReturn (create), put (update) and delete (delete) methods have been implemented in the MetadataFieldRestRepository and the MetadataSchemaRestRepository.
* Additional tests have been added to the MetadataFieldRestRepositoryIT and MetadataSchemaRestRepositoryIT to keep the functionality properly tested.

Jira link: https://jira.duraspace.org/browse/DS-4109
RestContract PR link: https://github.com/DSpace/Rest7Contract/pull/38