### PR TITLE
[DS-4113] Configure clean plugin in parent pom to also clean sub-modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,22 @@
                         </execution>
                     </executions>
                 </plugin>
+                <!-- Used to clean all 'target' directories from parent project -->
+                <!-- This additional configuration also cleans sub-modules -->
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>2.5</version>
+                    <configuration>
+                        <filesets>
+                            <fileset>
+                                <directory>dspace/modules</directory>
+                                <includes>
+                                    <include>**/target</include>
+                                </includes>
+                            </fileset>
+                        </filesets>
+                    </configuration>
+                </plugin>
                 <plugin>
                     <artifactId>maven-antrun-plugin</artifactId>
                     <version>1.8</version>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-4113

This change will get the 'clean' maven task to also clean target directories from sub-modules. Currently, they never get touched by a 'clean' from the parent project.

It does refer to 'dspace/modules' as the path for submodules so if that ever changes, this plugin configuration will need to be updated (but so will a lot of pom configuration).

I'd like to port this to 6.x as well if others agree.