### PR TITLE
DS-4117: Add the resource policy type TYPE_CUSTOM …

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/METSRightsCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/METSRightsCrosswalk.java
@@ -595,8 +595,9 @@ public class METSRightsCrosswalk
                         log.error("Unrecognized CONTEXTCLASS:  " + contextClass);
                     }
 
-                    //set permissions on policy add to list of policies
+                    //set permissions and type on policy and add to list of policies
                     rp.setAction(parsePermissions(permsElement));
+                    rp.setRpType(ResourcePolicy.TYPE_CUSTOM);
                     policies.add(rp);
                 } //end if "Context" element
             }//end for loop


### PR DESCRIPTION
…to the METSRightsCrosswalk.ingests(...) because all the policies are added by users at this stage.

Fixes #7464