### PR TITLE
[DS-4120] Add configurable limit to results per page

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfiguration.java
@@ -37,7 +37,7 @@ public class DiscoveryConfiguration implements InitializingBean{
     private DiscoverySortConfiguration searchSortConfiguration;
 
     private int defaultRpp = 10;
-    private int maxRpp = 20;
+    private int maxRpp = 100;
     
     private String id;
     private DiscoveryHitHighlightingConfiguration hitHighlightingConfiguration;

--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfiguration.java
@@ -37,6 +37,7 @@ public class DiscoveryConfiguration implements InitializingBean{
     private DiscoverySortConfiguration searchSortConfiguration;
 
     private int defaultRpp = 10;
+    private int maxRpp = 20;
     
     private String id;
     private DiscoveryHitHighlightingConfiguration hitHighlightingConfiguration;
@@ -111,10 +112,20 @@ public class DiscoveryConfiguration implements InitializingBean{
     {
         this.defaultRpp = defaultRpp;
     }
+
+    public void setMaxRpp(int maxRpp)
+    {
+        this.maxRpp = maxRpp;
+    }
     
     public int getDefaultRpp()
     {
         return defaultRpp;
+    }
+
+    public int getMaxRpp()
+    {
+        return maxRpp;
     }
 
     public void setHitHighlightingConfiguration(DiscoveryHitHighlightingConfiguration hitHighlightingConfiguration) {

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/discovery/DiscoverUtility.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/discovery/DiscoverUtility.java
@@ -448,9 +448,13 @@ public class DiscoverUtility
             //
             // }
 
-            if (rpp > 0)
+            if (rpp > 0 && rpp < discoveryConfiguration.getMaxRpp())
             {
                 queryArgs.setMaxResults(rpp);
+            }
+            else if (rpp > 0 && rpp > discoveryConfiguration.getMaxRpp())
+            {
+                queryArgs.setMaxResults(discoveryConfiguration.getMaxRpp());
             }
             else
             {

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/discovery/DiscoverUtility.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/discovery/DiscoverUtility.java
@@ -448,7 +448,7 @@ public class DiscoverUtility
             //
             // }
 
-            if (rpp > 0 && rpp < discoveryConfiguration.getMaxRpp())
+            if (rpp > 0 && rpp <= discoveryConfiguration.getMaxRpp())
             {
                 queryArgs.setMaxResults(rpp);
             }

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -150,6 +150,7 @@
         </property>
         <!--Default result per page  -->
         <property name="defaultRpp" value="10" />
+        <property name="maxRpp" value="100" />
         <property name="hitHighlightingConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
                 <property name="metadataFields">


### PR DESCRIPTION
# Rationale
When searching for publications in DSpace, the user can modify the `rpp` GET param and set an arbitrary high number to request all publications at once.

This can result in an internal server error, since SOLR is overloaded, or an 503 service not available error, since the connection pool is exhausted. Nevertheless, this renders the page unreachable for several minutes.

This pull requests adds an configurable limit to results per page to prevent this kind of DOS attack.
  