### PR TITLE
[DS-4127] Add Docker Build/Push to Travis Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ script:
     mvn package -Dmirage2.on=true -Dmirage2.deps.included=false -P !assembly -B -V -Dsurefire.rerunFailingTestsCount=2 &&
     cd .. &&
     echo "Building docker image dspace/dspace:${TRAVIS_BRANCH}_${TRAVIS_PULL_REQUEST_BRANCH:-branch}" &&
-    docker build -t dspace/dspace:${TRAVIS_BRANCH}_${TRAVIS_PULL_REQUEST_BRANCH:-branch} -f Dockerfile.jdk8-test . | egrep "^\[(INFO|WARNING|ERROR)\]" &&
+    docker build -t dspace/dspace:${TRAVIS_BRANCH}_${TRAVIS_PULL_REQUEST_BRANCH:-branch} -f Dockerfile.jdk8-test . | egrep "^Step|^\[(ERROR|WARNING)|\]$" &&
     echo "Pushing docker image dspace/dspace:${TRAVIS_BRANCH}_${TRAVIS_PULL_REQUEST_BRANCH:-branch}" &&
     echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USER}" --password-stdin &&
     docker push dspace/dspace:${TRAVIS_BRANCH}_${TRAVIS_PULL_REQUEST_BRANCH:-branch}

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,6 @@ script:
     cd dspace && 
     mvn package -Dmirage2.on=true -Dmirage2.deps.included=false -P !assembly -B -V -Dsurefire.rerunFailingTestsCount=2 &&
     cd .. && 
-    docker build -t dspace/dspace:${TRAVIS_BRANCH}_${TRAVIS_PULL_REQUEST_BRANCH:-branch} -f Dockerfile.jdk8-test . &&
+    docker build -t dspace/dspace:${TRAVIS_BRANCH}_${TRAVIS_PULL_REQUEST_BRANCH:-branch} -f Dockerfile.jdk8-test -q . &&
     echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USER}" --password-stdin &&
     docker push dspace/dspace:${TRAVIS_BRANCH}_${TRAVIS_PULL_REQUEST_BRANCH:-branch}

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,8 @@ script:
     cd dspace && 
     mvn package -Dmirage2.on=true -Dmirage2.deps.included=false -P !assembly -B -V -Dsurefire.rerunFailingTestsCount=2 &&
     cd .. && 
-    docker build -t dspace/dspace:${TRAVIS_BRANCH}_${TRAVIS_PULL_REQUEST_BRANCH:-branch} -f Dockerfile.jdk8-test . | egrep "^\[(INFO|WARNING|ERROR).*" &&
+    echo "Building docker image dspace/dspace:${TRAVIS_BRANCH}_${TRAVIS_PULL_REQUEST_BRANCH:-branch}" &&
+    docker build -t dspace/dspace:${TRAVIS_BRANCH}_${TRAVIS_PULL_REQUEST_BRANCH:-branch} -f Dockerfile.jdk8-test . | egrep "^\[(INFO|WARNING|ERROR)\]" &&
+    echo "Pushing docker image dspace/dspace:${TRAVIS_BRANCH}_${TRAVIS_PULL_REQUEST_BRANCH:-branch}" &&
     echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USER}" --password-stdin &&
     docker push dspace/dspace:${TRAVIS_BRANCH}_${TRAVIS_PULL_REQUEST_BRANCH:-branch}

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,6 @@ script:
     cd dspace && 
     mvn package -Dmirage2.on=true -Dmirage2.deps.included=false -P !assembly -B -V -Dsurefire.rerunFailingTestsCount=2 &&
     cd .. && 
-    docker build -t dspace/dspace:${TRAVIS_BRANCH}_${TRAVIS_PULL_REQUEST_BRANCH:-branch} -f Dockerfile.jdk8-test -q . &&
+    docker build -t dspace/dspace:${TRAVIS_BRANCH}_${TRAVIS_PULL_REQUEST_BRANCH:-branch} -f Dockerfile.jdk8-test . | egrep "^\[(INFO|WARNING|ERROR).*" &&
     echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USER}" --password-stdin &&
     docker push dspace/dspace:${TRAVIS_BRANCH}_${TRAVIS_PULL_REQUEST_BRANCH:-branch}

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ env:
   # Give Maven 1GB of memory to work with
   - MAVEN_OPTS=-Xmx1024M
 
+services:
+  docker
+
 # Install prerequisites for building Mirage2 more rapidly
 # These versions should be kept in sync with ./dspace/modules/xml-mirage2/pom.xml
 before_install:
@@ -50,4 +53,10 @@ script:
   #        -Dmirage2.on=true => Build Mirage2
   #        -Dmirage2.deps.included=false => Don't include Mirage2 build dependencies (We installed them in before_install)
   #        -P !assembly => SKIP the actual building of [src]/dspace/dspace-installer (as it can be memory intensive)
-  - "cd dspace && mvn package -Dmirage2.on=true -Dmirage2.deps.included=false -P !assembly -B -V -Dsurefire.rerunFailingTestsCount=2"
+  - > 
+    cd dspace && 
+    mvn package -Dmirage2.on=true -Dmirage2.deps.included=false -P !assembly -B -V -Dsurefire.rerunFailingTestsCount=2 &&
+    cd .. && 
+    docker build -t dspace/dspace:${TRAVIS_BRANCH}_${TRAVIS_PULL_REQUEST_BRANCH:-branch} -f Dockerfile.jdk8-test . &&
+    echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USER}" --password-stdin &&
+    docker push dspace/dspace:${TRAVIS_BRANCH}_${TRAVIS_PULL_REQUEST_BRANCH:-branch}

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ script:
   - > 
     cd dspace && 
     mvn package -Dmirage2.on=true -Dmirage2.deps.included=false -P !assembly -B -V -Dsurefire.rerunFailingTestsCount=2 &&
-    cd .. && 
+    cd .. &&
     echo "Building docker image dspace/dspace:${TRAVIS_BRANCH}_${TRAVIS_PULL_REQUEST_BRANCH:-branch}" &&
     docker build -t dspace/dspace:${TRAVIS_BRANCH}_${TRAVIS_PULL_REQUEST_BRANCH:-branch} -f Dockerfile.jdk8-test . | egrep "^\[(INFO|WARNING|ERROR)\]" &&
     echo "Pushing docker image dspace/dspace:${TRAVIS_BRANCH}_${TRAVIS_PULL_REQUEST_BRANCH:-branch}" &&


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-4127

(Depends on https://github.com/DSpace/DSpace/pull/2307)

## purpose of this PR

The purpose of this PR is to generate a new Docker image for each DSpace pull request that passes the travis build checks.  This would allow other DSpace users to test the PR (in docker) without needing to compile a local instance of the pull request.

### Sample Execution

*This example assumes https://github.com/DSpace-Labs/DSpace-Docker-Images/pull/68 has been merged.*

Assumption: a branch named pr1001 has been created for dspace-6_x.  At the end of the travis build, the following image will be published: **dspace/dspace:dspace-6_x_pr1001**.  To launch DSpace using that image, run the following.

    export DSPACE_VER=dspace-6_x_pr1001
    docker-compose -p d6 -f docker-compose.yml -f d6.override.yml up -d

## Pre-requisites
- A new team has been created in the dspace dockerhub repo that has write access to dspace/dspace
- A new docker user has been created and added to that group
- The username and password will need to be added as repository environment variables in travis for DSpace/DSpace

## Build Output
- Travis will terminate the build if the full docker build output is logged
- Travis will terminate the build if no output is generated from the build step (note the egrep added to the docker build step)
- The docker push step of the build is currently failing because a docker id/password have not yet been added to Travis

## This pull request is part of a larger set of goals for DSpace and Docker

- Make DSpace Docker Images the recommended approach for developing and testing changes to DSpace.  By creating a default development and testing environment for DSpace, the process of on-boarding and supporting new developers could be simplified.
- Publish docker images for each pull request submitted to DSpace.  Because this would eliminate the need to run a local build for a given PR, the review cycle for PR's should be improved.
- Document instructions for running published DSpace docker images on each of the major cloud providers.
