### PR TITLE
DS-4034 Remove diacritics when indexing and browsing content 

### DIFF
--- a/dspace-api/src/main/java/org/dspace/browse/BrowseEngine.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseEngine.java
@@ -409,7 +409,7 @@ public class BrowseEngine
             // get the table name that we are going to be getting our data from
             // this is the distinct table constrained to either community or collection
             dao.setTable(browseIndex.getDistinctTableName());
-            dao.setStartsWith(StringUtils.lowerCase(scope.getStartsWith()));
+            dao.setStartsWith(StringUtils.stripAccents(StringUtils.lowerCase(scope.getStartsWith())));
             // remind the DAO that this is a distinct value browse, so it knows what sort
             // of query to build
             dao.setDistinct(true);

--- a/dspace-api/src/main/java/org/dspace/sort/OrderFormatText.java
+++ b/dspace-api/src/main/java/org/dspace/sort/OrderFormatText.java
@@ -9,6 +9,7 @@ package org.dspace.sort;
 
 import org.dspace.text.filter.DecomposeDiactritics;
 import org.dspace.text.filter.LowerCaseAndTrim;
+import org.dspace.text.filter.StripDiacritics;
 import org.dspace.text.filter.TextFilter;
 import org.dspace.sort.AbstractTextFilterOFD;
 
@@ -21,6 +22,7 @@ public class OrderFormatText extends AbstractTextFilterOFD
 {
 	{
 		filters = new TextFilter[] { new DecomposeDiactritics(),
+				                     new StripDiacritics(),
 				                     new LowerCaseAndTrim() };
 	}
 }


### PR DESCRIPTION
Added StripDiacritics filter to the list of filters at OrderFormatText, in order to remove diacritic characters when indexing content. Also remove accents in DAO query at BrowseEngine in order when quering to Solr.

[DS-4034](https://jira.duraspace.org/browse/DS-4034)