### PR TITLE
[DS-4136] Improve OAI import performance for a large install

### DIFF
--- a/dspace/config/modules/oai.cfg
+++ b/dspace/config/modules/oai.cfg
@@ -32,6 +32,13 @@ oai.cache.enabled = true
 oai.cache.dir = ${dspace.dir}/var/oai
 
 #---------------------------------------------------------------#
+#--------------OAI IMPORT CONFIGURATION ------------------------#
+#---------------------------------------------------------------#
+
+# Size of batches to commit to solr at a time 
+oai.import.batch.size = 1000
+
+#---------------------------------------------------------------#
 #--------------OAI HARVESTING CONFIGURATIONS--------------------#
 #---------------------------------------------------------------#
 # These configs are only used by the OAI-ORE related functions  #


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-4136

This program runs one very long operation using an uncommited Context object.  Therefore, it is necessary to uncache items as the process executes.

The program was successfully uncaching Item objects.  By adding debug statements into the code, I discovered that the hibernate cache was never releasing ResourcePolicy objects for the Items that were processed.

Since XOAI.java loads ResourcePolicy objects into the hibernate cache directly (rather than through a call to DSO getPolicies()), it seemed sensible for this class to manage the uncaching of those policy objects.

With this code in place, I am able to process a repository with 550,000 objects in approximately 1 hour.

Additionally, this code batches updates to Solr.  I did not independently verify a performance improvement for that change.