### PR TITLE
DS-3427: Update DataCite crosswalk to version 4.0

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -473,13 +473,12 @@ crosswalk.dissemination.DataCite.stylesheet = crosswalks/DIM2DataCite.xsl
 ## For DataCite via EZID, comment above and uncomment this:
 #crosswalk.dissemination.DataCite.stylesheet = crosswalks/DIM2EZID.xsl
 crosswalk.dissemination.DataCite.schemaLocation = \
-    http://datacite.org/schema/kernel-3 \
-    http://schema.datacite.org/meta/kernel-3/metadata.xsd
-crosswalk.dissemination.DataCite.preferList = false
+    http://datacite.org/schema/kernel-4 \
+    http://schema.datacite.org/meta/kernel-4/metadata.xsd
 crosswalk.dissemination.DataCite.publisher = My University
 #crosswalk.dissemination.DataCite.dataManager = # defaults to publisher
 #crosswalk.dissemination.DataCite.hostingInstitution = # defaults to publisher
-crosswalk.dissemination.DataCite.namespace = http://datacite.org/schema/kernel-3
+crosswalk.dissemination.DataCite.namespace = http://datacite.org/schema/kernel-4
 
 # Crosswalk Plugin Configuration:
 #   The purpose of Crosswalks is to translate an external metadata format to/from


### PR DESCRIPTION
Updated the DataCite crosswalk to be compliant with DataCite Schema 4.0.

- updated version numbers
- resourceTypeGeneral is now always included
- added property FundingReference which will contain the value of DSpace metadata field dc.description.sponsorship

Jira ticket: https://jira.duraspace.org/browse/DS-3427
Fixes #6781 