### PR TITLE
DS-4142 updated maven docker build to specify jdk8

### DIFF
--- a/Dockerfile.jdk8
+++ b/Dockerfile.jdk8
@@ -9,7 +9,7 @@
 # - default tag for branch: dspace/dspace: dspace/dspace:dspace-6_x-jdk8
 
 # Step 1 - Run Maven Build
-FROM maven as build
+FROM maven:3-jdk-8 as build
 WORKDIR /app
 
 # The Mirage2 build cannot run as root.  Setting the user to dspace.

--- a/Dockerfile.jdk8
+++ b/Dockerfile.jdk8
@@ -4,7 +4,7 @@
 # This version is JDK8 compatible
 # - tomcat:8-jre8
 # - ANT 1.10.5
-# - maven:latest
+# - maven:3-jdk-8
 # - note: 
 # - default tag for branch: dspace/dspace: dspace/dspace:dspace-6_x-jdk8
 

--- a/Dockerfile.jdk8-test
+++ b/Dockerfile.jdk8-test
@@ -9,7 +9,7 @@
 # - default tag for branch: dspace/dspace: dspace/dspace:dspace-6_x-jdk8
 
 # Step 1 - Run Maven Build
-FROM maven as build
+FROM maven:3-jdk-8 as build
 WORKDIR /app
 
 # The Mirage2 build cannot run as root.  Setting the user to dspace.

--- a/Dockerfile.jdk8-test
+++ b/Dockerfile.jdk8-test
@@ -4,7 +4,7 @@
 # This version is JDK8 compatible
 # - tomcat:8-jre8
 # - ANT 1.10.5
-# - maven:latest
+# - maven:3-jdk-8
 # - note: expose /solr to any host; provide /rest over http
 # - default tag for branch: dspace/dspace: dspace/dspace:dspace-6_x-jdk8
 


### PR DESCRIPTION
Docker build is failing for DSpace 6 because maven latest now (since Nov) uses jdk11.