### PR TITLE
[DS-4145] Curation basic link checker doesn't follow redirects

### DIFF
--- a/dspace-api/src/main/java/org/dspace/ctask/general/BasicLinkChecker.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/BasicLinkChecker.java
@@ -138,15 +138,13 @@ public class BasicLinkChecker extends AbstractCurationTask {
             if (statusCode != HttpURLConnection.HTTP_OK &&
                     (statusCode == HttpURLConnection.HTTP_MOVED_TEMP ||
                             statusCode == HttpURLConnection.HTTP_MOVED_PERM ||
-                            statusCode == HttpURLConnection.HTTP_SEE_OTHER))
-            {
+                            statusCode == HttpURLConnection.HTTP_SEE_OTHER)) {
                 String newUrl = connection.getHeaderField("Location");
-                if(newUrl != null)
-                {
+                if (newUrl != null) {
                     return getResponseStatus(newUrl);
                 }
 
-           	}
+            }
             return statusCode;
 
         } catch (IOException ioe) {

--- a/dspace-api/src/main/java/org/dspace/ctask/general/BasicLinkChecker.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/BasicLinkChecker.java
@@ -132,10 +132,22 @@ public class BasicLinkChecker extends AbstractCurationTask {
         try {
             URL theURL = new URL(url);
             HttpURLConnection connection = (HttpURLConnection) theURL.openConnection();
-            int code = connection.getResponseCode();
+            connection.setInstanceFollowRedirects(true);
+            int statusCode = connection.getResponseCode();
             connection.disconnect();
+            if (statusCode != HttpURLConnection.HTTP_OK &&
+                    (statusCode == HttpURLConnection.HTTP_MOVED_TEMP ||
+                            statusCode == HttpURLConnection.HTTP_MOVED_PERM ||
+                            statusCode == HttpURLConnection.HTTP_SEE_OTHER))
+            {
+                String newUrl = connection.getHeaderField("Location");
+                if(newUrl != null)
+                {
+                    return getResponseStatus(newUrl);
+                }
 
-            return code;
+           	}
+            return statusCode;
 
         } catch (IOException ioe) {
             // Must be a bad URL

--- a/dspace-api/src/main/java/org/dspace/ctask/general/BasicLinkChecker.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/BasicLinkChecker.java
@@ -133,6 +133,8 @@ public class BasicLinkChecker extends AbstractCurationTask {
             URL theURL = new URL(url);
             HttpURLConnection connection = (HttpURLConnection) theURL.openConnection();
             connection.setInstanceFollowRedirects(true);
+            connection.setConnectTimeout(10000);
+            connection.setReadTimeout(10000);
             int statusCode = connection.getResponseCode();
             connection.disconnect();
             if (statusCode != HttpURLConnection.HTTP_OK &&


### PR DESCRIPTION
JIRA: https://jira.duraspace.org/browse/DS-4145
Fixes #7488 

The curation task that verifies if links attached to items are still operational doesn't follow redirects.

The most simple of links (a call to hdl.handle.net) will be marked as failed because of the 302 code that is returned.

This fix is contributed by ETH Zürich.