### PR TITLE
DS-4157: Save and Exit on workflow edit metadata

### DIFF
--- a/dspace-api/src/main/java/org/dspace/submit/step/DescribeStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/DescribeStep.java
@@ -346,7 +346,7 @@ public class DescribeStep extends AbstractProcessingStep
         ContentServiceFactory.getInstance().getInProgressSubmissionService(subInfo.getSubmissionItem()).update(context, subInfo.getSubmissionItem());
 
         // commit changes
-        context.dispatchEvents();
+        context.commit();
 
         // check for request for more input fields, first
         if (moreInput)

--- a/dspace-api/src/main/java/org/dspace/submit/step/DescribeStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/DescribeStep.java
@@ -346,7 +346,7 @@ public class DescribeStep extends AbstractProcessingStep
         ContentServiceFactory.getInstance().getInProgressSubmissionService(subInfo.getSubmissionItem()).update(context, subInfo.getSubmissionItem());
 
         // commit changes
-        context.commit();
+        context.dispatchEvents();
 
         // check for request for more input fields, first
         if (moreInput)

--- a/dspace-xmlui/src/main/resources/aspects/Submission/submission.js
+++ b/dspace-xmlui/src/main/resources/aspects/Submission/submission.js
@@ -392,7 +392,8 @@ function submissionControl(collectionHandle, workspaceID, initStepAndPage)
         	{
         		var contextPath = cocoon.request.getContextPath();
         		cocoon.redirectTo(contextPath+"/submissions",true);
-        		cocoon.exit();
+				getDSContext().complete();
+				cocoon.exit();
         	}
         	else if (!inWorkflow)
         	{


### PR DESCRIPTION
This PR replaces the context dispatchEvents with a context commit in the describe step to make sure the changes made during the describe step are always pushed to the database.

Jira ticket: https://jira.duraspace.org/browse/DS-4157

Fixes #7499