### PR TITLE
[DS-4126] master: Optimize docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 .settings/
 */target/
 dspace/modules/*/target/
+Dockerfile.*

--- a/Dockerfile.jdk8
+++ b/Dockerfile.jdk8
@@ -9,20 +9,30 @@
 # - default tag for branch: dspace/dspace: dspace/dspace:dspace-7_x-jdk8
 
 # Step 1 - Run Maven Build
-FROM maven:3-jdk-8 as build
+FROM dspace/dspace-dependencies:dspace-7_x as build
+ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 
+# The dspace-install directory will be written to /install
+RUN mkdir /install \
+    && chown -Rv dspace: /install
+
+USER dspace
+
 # Copy the DSpace source code into the workdir (excluding .dockerignore contents)
-ADD . /app/
+ADD --chown=dspace . /app/
 COPY dspace/src/main/docker/local.cfg /app/local.cfg
 
-RUN mvn package
+# Build DSpace.  Copy the dspace-install directory to /install.  Clean up the build to keep the docker image small
+RUN mvn package && \
+  mv /app/dspace/target/${TARGET_DIR}/* /install && \
+  mvn clean
 
 # Step 2 - Run Ant Deploy
 FROM tomcat:8-jre8 as ant_build
 ARG TARGET_DIR=dspace-installer
-COPY --from=build /app /dspace-src
-WORKDIR /dspace-src/dspace/target/${TARGET_DIR}
+COPY --from=build /install /dspace-src
+WORKDIR /dspace-src
 
 # Create the initial install deployment using ANT
 ENV ANT_VERSION 1.10.5
@@ -32,23 +42,15 @@ ENV PATH $ANT_HOME/bin:$PATH
 RUN mkdir $ANT_HOME && \
     wget -qO- "https://www.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
 
-RUN ant update_configs update_code update_webapps update_solr_indexes
+RUN ant init_installation update_configs update_code update_webapps update_solr_indexes
 
 # Step 3 - Run tomcat
 # Create a new tomcat image that does not retain the the build directory contents
 FROM tomcat:8-jre8
-COPY --from=ant_build /dspace /dspace
+ENV DSPACE_INSTALL=/dspace
+COPY --from=ant_build /dspace $DSPACE_INSTALL
 EXPOSE 8080 8009
 
-# Ant will be embedded in the final container to allow additional deployments
-ENV ANT_VERSION 1.10.5
-ENV ANT_HOME /tmp/ant-$ANT_VERSION
-ENV PATH $ANT_HOME/bin:$PATH
-
-RUN mkdir $ANT_HOME && \
-    wget -qO- "https://www.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
-
-ENV DSPACE_INSTALL=/dspace
 ENV JAVA_OPTS=-Xmx2000m
 
 RUN ln -s $DSPACE_INSTALL/webapps/solr          /usr/local/tomcat/webapps/solr    && \

--- a/Dockerfile.jdk8-test
+++ b/Dockerfile.jdk8-test
@@ -5,28 +5,34 @@
 # - tomcat:8-jre8
 # - ANT 1.10.5
 # - maven:3-jdk-8
-# - note: expose /solr to any host; provide /rest over http
+# - note: 
 # - default tag for branch: dspace/dspace: dspace/dspace:dspace-7_x-jdk8-test
 
 # Step 1 - Run Maven Build
-FROM maven:3-jdk-8 as build
+FROM dspace/dspace-dependencies:dspace-7_x as build
+ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 
+# The dspace-install directory will be written to /install
+RUN mkdir /install \
+    && chown -Rv dspace: /install
+
+USER dspace
+
 # Copy the DSpace source code into the workdir (excluding .dockerignore contents)
-ADD . /app/
+ADD --chown=dspace . /app/
 COPY dspace/src/main/docker/local.cfg /app/local.cfg
 
-# Provide web.xml overrides to make webapps easier to test
-COPY dspace/src/main/docker/test/solr_web.xml /app/dspace-solr/src/main/webapp/WEB-INF/web.xml
-COPY dspace/src/main/docker/test/rest_web.xml /app/dspace-rest/src/main/webapp/WEB-INF/web.xml
-
-RUN mvn package
+# Build DSpace.  Copy the dspace-install directory to /install.  Clean up the build to keep the docker image small
+RUN mvn package && \
+  mv /app/dspace/target/${TARGET_DIR}/* /install && \
+  mvn clean
 
 # Step 2 - Run Ant Deploy
 FROM tomcat:8-jre8 as ant_build
 ARG TARGET_DIR=dspace-installer
-COPY --from=build /app /dspace-src
-WORKDIR /dspace-src/dspace/target/${TARGET_DIR}
+COPY --from=build /install /dspace-src
+WORKDIR /dspace-src
 
 # Create the initial install deployment using ANT
 ENV ANT_VERSION 1.10.5
@@ -36,23 +42,15 @@ ENV PATH $ANT_HOME/bin:$PATH
 RUN mkdir $ANT_HOME && \
     wget -qO- "https://www.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
 
-RUN ant update_configs update_code update_webapps update_solr_indexes
+RUN ant init_installation update_configs update_code update_webapps update_solr_indexes
 
 # Step 3 - Run tomcat
 # Create a new tomcat image that does not retain the the build directory contents
 FROM tomcat:8-jre8
-COPY --from=ant_build /dspace /dspace
+ENV DSPACE_INSTALL=/dspace
+COPY --from=ant_build /dspace $DSPACE_INSTALL
 EXPOSE 8080 8009
 
-# Ant will be embedded in the final container to allow additional deployments
-ENV ANT_VERSION 1.10.5
-ENV ANT_HOME /tmp/ant-$ANT_VERSION
-ENV PATH $ANT_HOME/bin:$PATH
-
-RUN mkdir $ANT_HOME && \
-    wget -qO- "https://www.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
-
-ENV DSPACE_INSTALL=/dspace
 ENV JAVA_OPTS=-Xmx2000m
 
 RUN ln -s $DSPACE_INSTALL/webapps/solr          /usr/local/tomcat/webapps/solr    && \
@@ -62,3 +60,9 @@ RUN ln -s $DSPACE_INSTALL/webapps/solr          /usr/local/tomcat/webapps/solr  
     ln -s $DSPACE_INSTALL/webapps/rdf           /usr/local/tomcat/webapps/rdf     && \
     ln -s $DSPACE_INSTALL/webapps/sword         /usr/local/tomcat/webapps/sword   && \
     ln -s $DSPACE_INSTALL/webapps/swordv2       /usr/local/tomcat/webapps/swordv2
+
+COPY dspace/src/main/docker/test/solr_web.xml $DSPACE_INSTALL/webapps/solr/WEB-INF/web.xml
+COPY dspace/src/main/docker/test/rest_web.xml $DSPACE_INSTALL/webapps/rest/WEB-INF/web.xml
+
+RUN sed -i -e "s|\${dspace.dir}|$DSPACE_INSTALL|" $DSPACE_INSTALL/webapps/solr/WEB-INF/web.xml && \
+    sed -i -e "s|\${dspace.dir}|$DSPACE_INSTALL|" $DSPACE_INSTALL/webapps/rest/WEB-INF/web.xml

--- a/dspace/src/main/docker/test/solr_web.xml
+++ b/dspace/src/main/docker/test/solr_web.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-        "http://java.sun.com/dtd/web-app_2_3.dtd">
 <!--
 
     The contents of this file are subject to the license and copyright
@@ -15,7 +13,11 @@
     This file overrides the solr localhost restriction.
  -->
 
-<web-app>
+<web-app version='2.5'
+         xmlns='http://java.sun.com/xml/ns/javaee'
+         xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+         xsi:schemaLocation='http://java.sun.com/xml/ns/javaee
+	      http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd'>
 
     <!-- Uncomment if you are trying to use a Resin version before 3.0.19.
       Their XML implementation isn't entirely compatible with Xerces.
@@ -28,31 +30,34 @@
                "com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl"/>
      -->
 
-    <!-- People who want to hardcode their "Solr Home" directly into the
-         WAR File can set the JNDI property here...
-     -->
-    <!--
       <env-entry>
+        <description>Solr home:  configuration, cores etc.</description>
          <env-entry-name>solr/home</env-entry-name>
-         <env-entry-value>/put/your/solr/home/here</env-entry-value>
-         <env-entry-type>java.lang.String</env-entry-type>
-      </env-entry>
-     -->
-    <env-entry>
-        <env-entry-name>solr/home</env-entry-name>
         <env-entry-value>${dspace.dir}/solr</env-entry-value>
         <env-entry-type>java.lang.String</env-entry-type>
     </env-entry>
 
     <!-- Tell Solr where its log4j configuration is located -->
-    <!-- NOTE: Solr cannot use the default DSpace log4j configuration as it isn't
-         initialized until the DSpace Kernel starts up, and we don't want Solr to
-         depend on the DSpace Kernel/API -->
+    <!-- NOTE: Solr cannot use the default DSpace log4j configuration as it
+         isn't initialized until the DSpace Kernel starts up, and we don't want
+         Solr to depend on the DSpace Kernel/API -->
     <context-param>
-        <param-name>log4j.configuration</param-name>
-        <param-value>${dspace.dir}/config/log4j-solr.properties</param-value>
-        <description>URL locating a Log4J configuration file (properties or XML).</description>
+        <description>
+	    URL locating a Log4J configuration file (properties or XML).
+	</description>
+        <param-name>log4jConfiguration</param-name>
+        <param-value>${dspace.dir}/config/log4j-solr.xml</param-value>
     </context-param>
+
+    <listener>
+        <listener-class>org.apache.logging.log4j.web.Log4jServletContextListener</listener-class>
+    </listener>
+
+    <filter>
+        <description>Activate logging</description>
+        <filter-name>log4jServletFilter</filter-name>
+        <filter-class>org.apache.logging.log4j.web.Log4jServletFilter</filter-class>
+    </filter>
 
     <!-- Any path (name) registered in solrconfig.xml will be sent to that filter -->
     <filter>
@@ -87,7 +92,16 @@
         -->
     </filter>
 
-    <!-- 
+    <filter-mapping>
+        <filter-name>log4jServletFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+        <dispatcher>REQUEST</dispatcher>
+        <dispatcher>FORWARD</dispatcher>
+        <dispatcher>INCLUDE</dispatcher>
+        <dispatcher>ERROR</dispatcher>
+    </filter-mapping>
+
+    <!--
     <filter-mapping>
         <filter-name>LocalHostRestrictionFilter</filter-name>
         <url-pattern>/*</url-pattern>
@@ -110,10 +124,6 @@
     </filter-mapping>
 
     <!-- Otherwise it will continue to the old servlets -->
-
-    <listener>
-        <listener-class>org.dspace.solr.filters.ConfigureLog4jListener</listener-class>
-    </listener>
 
     <servlet>
         <servlet-name>Zookeeper</servlet-name>


### PR DESCRIPTION
Port of https://github.com/DSpace/DSpace/pull/2307

Also resolved a bug.  The docker override of the solr web.xml for dspace/dspace:dspace-7_x-jdk8-test was out of sync with the web.xml for the branch.

Images have been built on DockerHub at terrywbrady/dspace.

![image](https://user-images.githubusercontent.com/1111057/52394409-096e6400-2a5f-11e9-98a8-37bc2e68a355.png)

[verifyImages.sh](https://github.com/DSpace-Labs/DSpace-Docker-Images/blob/8494b5789e16cfb2f2023fc136824e38a49d4b79/tools/verifyImages.sh) has been run

```
 ===== dspace-7_x-jdk8 =====
DSpace version:  7.0-SNAPSHOT
           JRE:  Oracle Corporation version 1.8.0_181
  ---> http://localhost:8080/xmlui
  ---> http://localhost:8080/oai/request
  ---> http://localhost:8080/solr
  ---> http://localhost:8080/rest
 ===== dspace-7_x-jdk8-test =====
DSpace version:  7.0-SNAPSHOT
           JRE:  Oracle Corporation version 1.8.0_181
  ---> http://localhost:8080/xmlui
  ---> http://localhost:8080/oai/request
  ---> http://localhost:8080/solr
  ---> http://localhost:8080/rest
```