### PR TITLE
[DS-4126] 5x: Optimize docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 .settings/
 */target/
 dspace/modules/*/target/
+Dockerfile.*

--- a/Dockerfile.dependencies-jdk7
+++ b/Dockerfile.dependencies-jdk7
@@ -1,0 +1,25 @@
+# This image will be published as dspace/dspace-dependencies
+# The purpose of this image is to make the build for dspace/dspace run faster 
+
+# Step 1 - Run Maven Build
+FROM maven:3-jdk-7 as build
+ARG TARGET_DIR=dspace-installer
+WORKDIR /app
+
+# The Mirage2 build cannot run as root.  Setting the user to dspace.
+RUN useradd dspace \
+    && mkdir /home/dspace \
+    && chown -Rv dspace: /home/dspace
+USER dspace
+
+# Copy the DSpace source code into the workdir (excluding .dockerignore contents)
+ADD --chown=dspace . /app/
+COPY dspace/src/main/docker/local.cfg /app/local.cfg
+
+# Trigger the installation of all maven dependencies including the Mirage2 dependencies
+# Clean up the built artifacts in the same step to keep the docker image small
+RUN mvn package -Dmirage2.on=true && mvn clean
+
+# Clear the contents of the /app directory so no artifacts are left when dspace:dspace is built
+USER root
+RUN rm -rf /app/*

--- a/Dockerfile.dependencies-jdk7
+++ b/Dockerfile.dependencies-jdk7
@@ -1,24 +1,23 @@
-# This image will be published as dspace/dspace-dependencies
+# This image will be published as dspace/dspace-dependencies:dspace-5_x-jdk7
 # The purpose of this image is to make the build for dspace/dspace run faster 
 
 # Step 1 - Run Maven Build
 FROM maven:3-jdk-7 as build
-ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 
 # The Mirage2 build cannot run as root.  Setting the user to dspace.
 RUN useradd dspace \
-    && mkdir /home/dspace \
-    && chown -Rv dspace: /home/dspace
+    && mkdir /home/dspace /app/target \
+    && chown -Rv dspace: /home/dspace /app /app/target
 USER dspace
 
 # Copy the DSpace source code into the workdir (excluding .dockerignore contents)
 ADD --chown=dspace . /app/
-COPY dspace/src/main/docker/local.cfg /app/local.cfg
+COPY --chown=dspace dspace/src/main/docker/build.properties /app/build.properties
 
 # Trigger the installation of all maven dependencies including the Mirage2 dependencies
 # Clean up the built artifacts in the same step to keep the docker image small
-RUN mvn package -Dmirage2.on=true && mvn clean
+RUN mvn package -Dmirage2.on=true && cd /app && mvn clean
 
 # Clear the contents of the /app directory so no artifacts are left when dspace:dspace is built
 USER root

--- a/Dockerfile.dependencies-jdk8
+++ b/Dockerfile.dependencies-jdk8
@@ -1,0 +1,25 @@
+# This image will be published as dspace/dspace-dependencies
+# The purpose of this image is to make the build for dspace/dspace run faster 
+
+# Step 1 - Run Maven Build
+FROM maven:3-jdk-8 as build
+ARG TARGET_DIR=dspace-installer
+WORKDIR /app
+
+# The Mirage2 build cannot run as root.  Setting the user to dspace.
+RUN useradd dspace \
+    && mkdir /home/dspace \
+    && chown -Rv dspace: /home/dspace
+USER dspace
+
+# Copy the DSpace source code into the workdir (excluding .dockerignore contents)
+ADD --chown=dspace . /app/
+COPY dspace/src/main/docker/local.cfg /app/local.cfg
+
+# Trigger the installation of all maven dependencies including the Mirage2 dependencies
+# Clean up the built artifacts in the same step to keep the docker image small
+RUN mvn package -Dmirage2.on=true && mvn clean
+
+# Clear the contents of the /app directory so no artifacts are left when dspace:dspace is built
+USER root
+RUN rm -rf /app/*

--- a/Dockerfile.dependencies-jdk8
+++ b/Dockerfile.dependencies-jdk8
@@ -1,20 +1,19 @@
-# This image will be published as dspace/dspace-dependencies
+# This image will be published as dspace/dspace-dependencies:dspace-5_x-jdk8
 # The purpose of this image is to make the build for dspace/dspace run faster 
 
 # Step 1 - Run Maven Build
 FROM maven:3-jdk-8 as build
-ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 
 # The Mirage2 build cannot run as root.  Setting the user to dspace.
 RUN useradd dspace \
-    && mkdir /home/dspace \
-    && chown -Rv dspace: /home/dspace
+    && mkdir /home/dspace /app/target \
+    && chown -Rv dspace: /home/dspace /app /app/target
 USER dspace
 
 # Copy the DSpace source code into the workdir (excluding .dockerignore contents)
 ADD --chown=dspace . /app/
-COPY dspace/src/main/docker/local.cfg /app/local.cfg
+COPY dspace/src/main/docker/build.properties /app/build.properties
 
 # Trigger the installation of all maven dependencies including the Mirage2 dependencies
 # Clean up the built artifacts in the same step to keep the docker image small

--- a/Dockerfile.jdk7
+++ b/Dockerfile.jdk7
@@ -1,7 +1,7 @@
 # This image will be published as dspace/dspace
 # See https://dspace-labs.github.io/DSpace-Docker-Images/ for usage details
 # 
-# This version is JDK7 compatible
+# This version is JDK8 compatible
 # - tomcat:7-jre7
 # - ANT 1.9.13
 # - maven:3-jdk-7
@@ -9,26 +9,30 @@
 # - default tag for branch: dspace/dspace: dspace/dspace:dspace-5_x-jdk7
 
 # Step 1 - Run Maven Build
-FROM maven:3-jdk-7 as build
+FROM dspace/dspace-dependencies:dspace-5_x-jdk8 as build
+ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 
-# The Mirage2 build cannot run as root.  Setting the user to dspace.
-RUN useradd dspace \
-    && mkdir /home/dspace \
-    && chown -Rv dspace: /home/dspace /app
+# The dspace-install directory will be written to /install
+RUN mkdir /install \
+    && chown -Rv dspace: /install
+
 USER dspace
 
 # Copy the DSpace source code into the workdir (excluding .dockerignore contents)
 ADD --chown=dspace . /app/
 COPY --chown=dspace dspace/src/main/docker/build.properties /app/build.properties
 
-RUN mvn package -Dmirage2.on=true
+# Build DSpace.  Copy the dspace-install directory to /install.  Clean up the build to keep the docker image small
+RUN mvn package -Dmirage2.on=true && \
+  mv /app/dspace/target/${TARGET_DIR}/* /install && \
+  mvn clean
 
 # Step 2 - Run Ant Deploy
 FROM tomcat:7-jre7 as ant_build
 ARG TARGET_DIR=dspace-installer
-COPY --from=build /app /dspace-src
-WORKDIR /dspace-src/dspace/target/${TARGET_DIR}
+COPY --from=build /install /dspace-src
+WORKDIR /dspace-src
 
 # Create the initial install deployment using ANT
 ENV ANT_VERSION 1.9.13
@@ -38,23 +42,15 @@ ENV PATH $ANT_HOME/bin:$PATH
 RUN mkdir $ANT_HOME && \
     wget -qO- "https://www.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
 
-RUN ant update_configs update_code update_webapps update_solr_indexes
+RUN ant init_installation update_configs update_code update_webapps update_solr_indexes
 
 # Step 3 - Run tomcat
 # Create a new tomcat image that does not retain the the build directory contents
 FROM tomcat:7-jre7
-COPY --from=ant_build /dspace /dspace
+ENV DSPACE_INSTALL=/dspace
+COPY --from=ant_build /dspace $DSPACE_INSTALL
 EXPOSE 8080 8009
 
-# Ant will be embedded in the final container to allow additional deployments
-ENV ANT_VERSION 1.9.13
-ENV ANT_HOME /tmp/ant-$ANT_VERSION
-ENV PATH $ANT_HOME/bin:$PATH
-
-RUN mkdir $ANT_HOME && \
-    wget -qO- "https://www.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
-
-ENV DSPACE_INSTALL=/dspace
 ENV JAVA_OPTS=-Xmx2000m
 
 RUN ln -s $DSPACE_INSTALL/webapps/solr    /usr/local/tomcat/webapps/solr    && \

--- a/Dockerfile.jdk7
+++ b/Dockerfile.jdk7
@@ -9,7 +9,7 @@
 # - default tag for branch: dspace/dspace: dspace/dspace:dspace-5_x-jdk7
 
 # Step 1 - Run Maven Build
-FROM dspace/dspace-dependencies:dspace-5_x-jdk8 as build
+FROM dspace/dspace-dependencies:dspace-5_x-jdk7 as build
 ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 

--- a/Dockerfile.jdk7
+++ b/Dockerfile.jdk7
@@ -1,7 +1,7 @@
 # This image will be published as dspace/dspace
 # See https://dspace-labs.github.io/DSpace-Docker-Images/ for usage details
 # 
-# This version is JDK8 compatible
+# This version is JDK7 compatible
 # - tomcat:7-jre7
 # - ANT 1.9.13
 # - maven:3-jdk-7

--- a/Dockerfile.jdk7-test
+++ b/Dockerfile.jdk7-test
@@ -1,39 +1,38 @@
 # This image will be published as dspace/dspace
 # See https://dspace-labs.github.io/DSpace-Docker-Images/ for usage details
 # 
-# This version is JDK7 compatible
+# This version is JDK8 compatible
 # - tomcat:7-jre7
 # - ANT 1.9.13
 # - maven:3-jdk-7
-# - note: expose /solr to any host; provide /rest over http
-# - default tag for branch: dspace/dspace: dspace/dspace:dspace-5_x-jdk7-test
+# - note: 
+# - default tag for branch: dspace/dspace: dspace/dspace:dspace-5_x-jdk7
 
 # Step 1 - Run Maven Build
-FROM maven:3-jdk-7 as build
+FROM dspace/dspace-dependencies:dspace-5_x-jdk8 as build
+ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 
-# The Mirage2 build cannot run as root.  Setting the user to dspace.
-RUN useradd dspace \
-    && mkdir /home/dspace \
-    && chown -Rv dspace: /home/dspace /app
+# The dspace-install directory will be written to /install
+RUN mkdir /install \
+    && chown -Rv dspace: /install
+
 USER dspace
 
 # Copy the DSpace source code into the workdir (excluding .dockerignore contents)
 ADD --chown=dspace . /app/
-
 COPY --chown=dspace dspace/src/main/docker/build.properties /app/build.properties
 
-# Provide web.xml overrides to make webapps easier to test
-COPY dspace/src/main/docker/test/solr_web.xml /app/dspace-solr/src/main/webapp/WEB-INF/web.xml
-COPY dspace/src/main/docker/test/rest_web.xml /app/dspace-rest/src/main/webapp/WEB-INF/web.xml
-
-RUN mvn package -Dmirage2.on=true
+# Build DSpace.  Copy the dspace-install directory to /install.  Clean up the build to keep the docker image small
+RUN mvn package -Dmirage2.on=true && \
+  mv /app/dspace/target/${TARGET_DIR}/* /install && \
+  mvn clean
 
 # Step 2 - Run Ant Deploy
 FROM tomcat:7-jre7 as ant_build
 ARG TARGET_DIR=dspace-installer
-COPY --from=build /app /dspace-src
-WORKDIR /dspace-src/dspace/target/${TARGET_DIR}
+COPY --from=build /install /dspace-src
+WORKDIR /dspace-src
 
 # Create the initial install deployment using ANT
 ENV ANT_VERSION 1.9.13
@@ -43,23 +42,15 @@ ENV PATH $ANT_HOME/bin:$PATH
 RUN mkdir $ANT_HOME && \
     wget -qO- "https://www.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
 
-RUN ant update_configs update_code update_webapps update_solr_indexes
+RUN ant init_installation update_configs update_code update_webapps update_solr_indexes
 
 # Step 3 - Run tomcat
 # Create a new tomcat image that does not retain the the build directory contents
 FROM tomcat:7-jre7
-COPY --from=ant_build /dspace /dspace
+ENV DSPACE_INSTALL=/dspace
+COPY --from=ant_build /dspace $DSPACE_INSTALL
 EXPOSE 8080 8009
 
-# Ant will be embedded in the final container to allow additional deployments
-ENV ANT_VERSION 1.9.13
-ENV ANT_HOME /tmp/ant-$ANT_VERSION
-ENV PATH $ANT_HOME/bin:$PATH
-
-RUN mkdir $ANT_HOME && \
-    wget -qO- "https://www.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
-
-ENV DSPACE_INSTALL=/dspace
 ENV JAVA_OPTS=-Xmx2000m
 
 RUN ln -s $DSPACE_INSTALL/webapps/solr    /usr/local/tomcat/webapps/solr    && \
@@ -70,3 +61,9 @@ RUN ln -s $DSPACE_INSTALL/webapps/solr    /usr/local/tomcat/webapps/solr    && \
     ln -s $DSPACE_INSTALL/webapps/rdf     /usr/local/tomcat/webapps/rdf     && \
     ln -s $DSPACE_INSTALL/webapps/sword   /usr/local/tomcat/webapps/sword   && \
     ln -s $DSPACE_INSTALL/webapps/swordv2 /usr/local/tomcat/webapps/swordv2
+
+COPY dspace/src/main/docker/test/solr_web.xml $DSPACE_INSTALL/webapps/solr/WEB-INF/web.xml
+COPY dspace/src/main/docker/test/rest_web.xml $DSPACE_INSTALL/webapps/rest/WEB-INF/web.xml
+
+RUN sed -i -e "s|\${dspace.dir}|$DSPACE_INSTALL|" $DSPACE_INSTALL/webapps/solr/WEB-INF/web.xml && \
+    sed -i -e "s|\${dspace.dir}|$DSPACE_INSTALL|" $DSPACE_INSTALL/webapps/rest/WEB-INF/web.xml

--- a/Dockerfile.jdk7-test
+++ b/Dockerfile.jdk7-test
@@ -9,7 +9,7 @@
 # - default tag for branch: dspace/dspace: dspace/dspace:dspace-5_x-jdk7
 
 # Step 1 - Run Maven Build
-FROM dspace/dspace-dependencies:dspace-5_x-jdk8 as build
+FROM dspace/dspace-dependencies:dspace-5_x-jdk7 as build
 ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 

--- a/Dockerfile.jdk7-test
+++ b/Dockerfile.jdk7-test
@@ -1,7 +1,7 @@
 # This image will be published as dspace/dspace
 # See https://dspace-labs.github.io/DSpace-Docker-Images/ for usage details
 # 
-# This version is JDK8 compatible
+# This version is JDK7 compatible
 # - tomcat:7-jre7
 # - ANT 1.9.13
 # - maven:3-jdk-7

--- a/Dockerfile.jdk8
+++ b/Dockerfile.jdk8
@@ -2,7 +2,7 @@
 # See https://dspace-labs.github.io/DSpace-Docker-Images/ for usage details
 # 
 # This version is JDK8 compatible
-# - tomcat:8-jre8
+# - tomcat:7-jre8
 # - ANT 1.10.5
 # - maven:3-jdk-8
 # - note: 
@@ -29,7 +29,7 @@ RUN mvn package -Dmirage2.on=true && \
   mvn clean
 
 # Step 2 - Run Ant Deploy
-FROM tomcat:8-jre8 as ant_build
+FROM tomcat:7-jre8 as ant_build
 ARG TARGET_DIR=dspace-installer
 COPY --from=build /install /dspace-src
 WORKDIR /dspace-src
@@ -46,7 +46,7 @@ RUN ant init_installation update_configs update_code update_webapps update_solr_
 
 # Step 3 - Run tomcat
 # Create a new tomcat image that does not retain the the build directory contents
-FROM tomcat:8-jre8
+FROM tomcat:7-jre8
 ENV DSPACE_INSTALL=/dspace
 COPY --from=ant_build /dspace $DSPACE_INSTALL
 EXPOSE 8080 8009

--- a/Dockerfile.jdk8
+++ b/Dockerfile.jdk8
@@ -2,33 +2,37 @@
 # See https://dspace-labs.github.io/DSpace-Docker-Images/ for usage details
 # 
 # This version is JDK8 compatible
-# - tomcat:7-jre8
+# - tomcat:8-jre8
 # - ANT 1.10.5
 # - maven:3-jdk-8
 # - note: 
 # - default tag for branch: dspace/dspace: dspace/dspace:dspace-5_x-jdk8
 
 # Step 1 - Run Maven Build
-FROM maven:3-jdk-8 as build
+FROM dspace/dspace-dependencies:dspace-5_x-jdk8 as build
+ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 
-# The Mirage2 build cannot run as root.  Setting the user to dspace.
-RUN useradd dspace \
-    && mkdir /home/dspace \
-    && chown -Rv dspace: /home/dspace /app
+# The dspace-install directory will be written to /install
+RUN mkdir /install \
+    && chown -Rv dspace: /install
+
 USER dspace
 
 # Copy the DSpace source code into the workdir (excluding .dockerignore contents)
 ADD --chown=dspace . /app/
 COPY --chown=dspace dspace/src/main/docker/build.properties /app/build.properties
 
-RUN mvn package -Dmirage2.on=true
+# Build DSpace.  Copy the dspace-install directory to /install.  Clean up the build to keep the docker image small
+RUN mvn package -Dmirage2.on=true && \
+  mv /app/dspace/target/${TARGET_DIR}/* /install && \
+  mvn clean
 
 # Step 2 - Run Ant Deploy
-FROM tomcat:7-jre8 as ant_build
+FROM tomcat:8-jre8 as ant_build
 ARG TARGET_DIR=dspace-installer
-COPY --from=build /app /dspace-src
-WORKDIR /dspace-src/dspace/target/${TARGET_DIR}
+COPY --from=build /install /dspace-src
+WORKDIR /dspace-src
 
 # Create the initial install deployment using ANT
 ENV ANT_VERSION 1.10.5
@@ -38,23 +42,15 @@ ENV PATH $ANT_HOME/bin:$PATH
 RUN mkdir $ANT_HOME && \
     wget -qO- "https://www.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
 
-RUN ant update_configs update_code update_webapps update_solr_indexes
+RUN ant init_installation update_configs update_code update_webapps update_solr_indexes
 
 # Step 3 - Run tomcat
 # Create a new tomcat image that does not retain the the build directory contents
-FROM tomcat:7-jre8
-COPY --from=ant_build /dspace /dspace
+FROM tomcat:8-jre8
+ENV DSPACE_INSTALL=/dspace
+COPY --from=ant_build /dspace $DSPACE_INSTALL
 EXPOSE 8080 8009
 
-# Ant will be embedded in the final container to allow additional deployments
-ENV ANT_VERSION 1.10.5
-ENV ANT_HOME /tmp/ant-$ANT_VERSION
-ENV PATH $ANT_HOME/bin:$PATH
-
-RUN mkdir $ANT_HOME && \
-    wget -qO- "https://www.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
-
-ENV DSPACE_INSTALL=/dspace
 ENV JAVA_OPTS=-Xmx2000m
 
 RUN ln -s $DSPACE_INSTALL/webapps/solr    /usr/local/tomcat/webapps/solr    && \

--- a/Dockerfile.jdk8-test
+++ b/Dockerfile.jdk8-test
@@ -2,7 +2,7 @@
 # See https://dspace-labs.github.io/DSpace-Docker-Images/ for usage details
 # 
 # This version is JDK8 compatible
-# - tomcat:8-jre8
+# - tomcat:7-jre8
 # - ANT 1.10.5
 # - maven:3-jdk-8
 # - note: 
@@ -29,7 +29,7 @@ RUN mvn package -Dmirage2.on=true && \
   mvn clean
 
 # Step 2 - Run Ant Deploy
-FROM tomcat:8-jre8 as ant_build
+FROM tomcat:7-jre8 as ant_build
 ARG TARGET_DIR=dspace-installer
 COPY --from=build /install /dspace-src
 WORKDIR /dspace-src
@@ -46,7 +46,7 @@ RUN ant init_installation update_configs update_code update_webapps update_solr_
 
 # Step 3 - Run tomcat
 # Create a new tomcat image that does not retain the the build directory contents
-FROM tomcat:8-jre8
+FROM tomcat:7-jre8
 ENV DSPACE_INSTALL=/dspace
 COPY --from=ant_build /dspace $DSPACE_INSTALL
 EXPOSE 8080 8009

--- a/Dockerfile.jdk8-test
+++ b/Dockerfile.jdk8-test
@@ -2,38 +2,37 @@
 # See https://dspace-labs.github.io/DSpace-Docker-Images/ for usage details
 # 
 # This version is JDK8 compatible
-# - tomcat:7-jre8
+# - tomcat:8-jre8
 # - ANT 1.10.5
 # - maven:3-jdk-8
-# - note: expose /solr to any host; provide /rest over http
-# - default tag for branch: dspace/dspace: dspace/dspace:dspace-5_x-jdk8-test
+# - note: 
+# - default tag for branch: dspace/dspace: dspace/dspace:dspace-5_x-jdk8
 
 # Step 1 - Run Maven Build
-FROM maven:3-jdk-8 as build
+FROM dspace/dspace-dependencies:dspace-5_x-jdk8 as build
+ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 
-# The Mirage2 build cannot run as root.  Setting the user to dspace.
-RUN useradd dspace \
-    && mkdir /home/dspace \
-    && chown -Rv dspace: /home/dspace /app
+# The dspace-install directory will be written to /install
+RUN mkdir /install \
+    && chown -Rv dspace: /install
+
 USER dspace
 
 # Copy the DSpace source code into the workdir (excluding .dockerignore contents)
 ADD --chown=dspace . /app/
-
 COPY --chown=dspace dspace/src/main/docker/build.properties /app/build.properties
 
-# Provide web.xml overrides to make webapps easier to test
-COPY dspace/src/main/docker/test/solr_web.xml /app/dspace-solr/src/main/webapp/WEB-INF/web.xml
-COPY dspace/src/main/docker/test/rest_web.xml /app/dspace-rest/src/main/webapp/WEB-INF/web.xml
-
-RUN mvn package -Dmirage2.on=true
+# Build DSpace.  Copy the dspace-install directory to /install.  Clean up the build to keep the docker image small
+RUN mvn package -Dmirage2.on=true && \
+  mv /app/dspace/target/${TARGET_DIR}/* /install && \
+  mvn clean
 
 # Step 2 - Run Ant Deploy
-FROM tomcat:7-jre8 as ant_build
+FROM tomcat:8-jre8 as ant_build
 ARG TARGET_DIR=dspace-installer
-COPY --from=build /app /dspace-src
-WORKDIR /dspace-src/dspace/target/${TARGET_DIR}
+COPY --from=build /install /dspace-src
+WORKDIR /dspace-src
 
 # Create the initial install deployment using ANT
 ENV ANT_VERSION 1.10.5
@@ -43,23 +42,15 @@ ENV PATH $ANT_HOME/bin:$PATH
 RUN mkdir $ANT_HOME && \
     wget -qO- "https://www.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
 
-RUN ant update_configs update_code update_webapps update_solr_indexes
+RUN ant init_installation update_configs update_code update_webapps update_solr_indexes
 
 # Step 3 - Run tomcat
 # Create a new tomcat image that does not retain the the build directory contents
-FROM tomcat:7-jre8
-COPY --from=ant_build /dspace /dspace
+FROM tomcat:8-jre8
+ENV DSPACE_INSTALL=/dspace
+COPY --from=ant_build /dspace $DSPACE_INSTALL
 EXPOSE 8080 8009
 
-# Ant will be embedded in the final container to allow additional deployments
-ENV ANT_VERSION 1.10.5
-ENV ANT_HOME /tmp/ant-$ANT_VERSION
-ENV PATH $ANT_HOME/bin:$PATH
-
-RUN mkdir $ANT_HOME && \
-    wget -qO- "https://www.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
-
-ENV DSPACE_INSTALL=/dspace
 ENV JAVA_OPTS=-Xmx2000m
 
 RUN ln -s $DSPACE_INSTALL/webapps/solr    /usr/local/tomcat/webapps/solr    && \
@@ -70,3 +61,9 @@ RUN ln -s $DSPACE_INSTALL/webapps/solr    /usr/local/tomcat/webapps/solr    && \
     ln -s $DSPACE_INSTALL/webapps/rdf     /usr/local/tomcat/webapps/rdf     && \
     ln -s $DSPACE_INSTALL/webapps/sword   /usr/local/tomcat/webapps/sword   && \
     ln -s $DSPACE_INSTALL/webapps/swordv2 /usr/local/tomcat/webapps/swordv2
+    
+COPY dspace/src/main/docker/test/solr_web.xml $DSPACE_INSTALL/webapps/solr/WEB-INF/web.xml
+COPY dspace/src/main/docker/test/rest_web.xml $DSPACE_INSTALL/webapps/rest/WEB-INF/web.xml
+
+RUN sed -i -e "s|\${dspace.dir}|$DSPACE_INSTALL|" $DSPACE_INSTALL/webapps/solr/WEB-INF/web.xml && \
+    sed -i -e "s|\${dspace.dir}|$DSPACE_INSTALL|" $DSPACE_INSTALL/webapps/rest/WEB-INF/web.xml


### PR DESCRIPTION
Port of #2307 

Images have been built on DockerHub at terrywbrady/dspace.

![image](https://user-images.githubusercontent.com/1111057/52393651-fd34d780-2a5b-11e9-881e-3276ede663d9.png)

[verifyImages.sh](https://github.com/DSpace-Labs/DSpace-Docker-Images/blob/8494b5789e16cfb2f2023fc136824e38a49d4b79/tools/verifyImages.sh) has been run.

```
 ===== dspace-5_x-jdk8 =====
DSpace version:  5.11-SNAPSHOT
           JRE:  Oracle Corporation version 1.8.0_181
  ---> http://localhost:8080/xmlui
  ---> http://localhost:8080/oai/request
  ---> http://localhost:8080/solr
  ---> http://localhost:8080/rest
 ===== dspace-5_x-jdk7 =====
DSpace version:  5.11-SNAPSHOT
           JRE:  Oracle Corporation version 1.7.0_181
  ---> http://localhost:8080/xmlui
  ---> http://localhost:8080/oai/request
  ---> http://localhost:8080/solr
  ---> http://localhost:8080/rest
 ===== dspace-5_x-jdk8-test =====
DSpace version:  5.11-SNAPSHOT
           JRE:  Oracle Corporation version 1.8.0_181
  ---> http://localhost:8080/xmlui
  ---> http://localhost:8080/oai/request
  ---> http://localhost:8080/solr
  ---> http://localhost:8080/rest
 ===== dspace-5_x-jdk7-test =====
DSpace version:  5.11-SNAPSHOT
           JRE:  Oracle Corporation version 1.7.0_181
  ---> http://localhost:8080/xmlui
  ---> http://localhost:8080/oai/request
  ---> http://localhost:8080/solr
  ---> http://localhost:8080/rest
```