### PR TITLE
[DS-4126] 4x: Optimize docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 .settings/
 */target/
 dspace/modules/*/target/
+Dockerfile.*

--- a/Dockerfile.dependencies
+++ b/Dockerfile.dependencies
@@ -1,0 +1,24 @@
+# This image will be published as dspace/dspace-dependencies:dspace-5_x
+# The purpose of this image is to make the build for dspace/dspace run faster 
+
+# Step 1 - Run Maven Build
+FROM maven:3-jdk-7 as build
+WORKDIR /app
+
+# The Mirage2 build cannot run as root.  Setting the user to dspace.
+RUN useradd dspace \
+    && mkdir /home/dspace /app/target \
+    && chown -Rv dspace: /home/dspace /app /app/target
+USER dspace
+
+# Copy the DSpace source code into the workdir (excluding .dockerignore contents)
+ADD --chown=dspace . /app/
+COPY --chown=dspace dspace/src/main/docker/build.properties /app/build.properties
+
+# Trigger the installation of all maven dependencies including the Mirage2 dependencies
+# Clean up the built artifacts in the same step to keep the docker image small
+RUN mvn package -Dmirage2.on=true && cd /app && mvn clean
+
+# Clear the contents of the /app directory so no artifacts are left when dspace:dspace is built
+USER root
+RUN rm -rf /app/*

--- a/Dockerfile.dependencies
+++ b/Dockerfile.dependencies
@@ -1,4 +1,4 @@
-# This image will be published as dspace/dspace-dependencies:dspace-5_x
+# This image will be published as dspace/dspace-dependencies:dspace-4_x
 # The purpose of this image is to make the build for dspace/dspace run faster 
 
 # Step 1 - Run Maven Build

--- a/Dockerfile.jdk7
+++ b/Dockerfile.jdk7
@@ -42,7 +42,7 @@ ENV PATH $ANT_HOME/bin:$PATH
 RUN mkdir $ANT_HOME && \
     wget -qO- "https://www.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
 
-RUN ant init_installation update_configs update_code update_webapps update_solr_indexes
+RUN ant init_installation update_configs update_code update_webapps
 
 # Step 3 - Run tomcat
 # Create a new tomcat image that does not retain the the build directory contents

--- a/Dockerfile.jdk7
+++ b/Dockerfile.jdk7
@@ -9,7 +9,7 @@
 # - default tag for branch: dspace/dspace: dspace/dspace:dspace-4_x-jdk7
 
 # Step 1 - Run Maven Build
-FROM dspace/dspace-dependencies:dspace-4_x- as build
+FROM dspace/dspace-dependencies:dspace-4_x as build
 ARG TARGET_DIR=dspace-build
 WORKDIR /app
 

--- a/Dockerfile.jdk7
+++ b/Dockerfile.jdk7
@@ -1,28 +1,38 @@
 # This image will be published as dspace/dspace
 # See https://dspace-labs.github.io/DSpace-Docker-Images/ for usage details
-
+# 
 # This version is JDK7 compatible
 # - tomcat:7-jre7
 # - ANT 1.9.13
 # - maven:3-jdk-7
-# - note: solr localhost restriction removed for testing
-# - default tag for branch: dspace/dspace: dspace/dspace:dspace-4_x-jdk7-test
+# - note: 
+# - default tag for branch: dspace/dspace: dspace/dspace:dspace-4_x-jdk7
 
 # Step 1 - Run Maven Build
-FROM maven:3-jdk-7 as build
+FROM dspace/dspace-dependencies:dspace-4_x- as build
+ARG TARGET_DIR=dspace-build
 WORKDIR /app
 
-# Copy the DSpace source code into the workdir (excluding .dockerignore contents)
-ADD . /app/
-COPY dspace/src/main/docker/build.properties /app/build.properties
+# The dspace-install directory will be written to /install
+RUN mkdir /install \
+    && chown -Rv dspace: /install
 
-RUN mvn package
+USER dspace
+
+# Copy the DSpace source code into the workdir (excluding .dockerignore contents)
+ADD --chown=dspace . /app/
+COPY --chown=dspace dspace/src/main/docker/build.properties /app/build.properties
+
+# Build DSpace.  Copy the dspace-install directory to /install.  Clean up the build to keep the docker image small
+RUN mvn package -Dmirage2.on=true && \
+  mv /app/dspace/target/${TARGET_DIR}/* /install && \
+  mvn clean
 
 # Step 2 - Run Ant Deploy
 FROM tomcat:7-jre7 as ant_build
-ARG TARGET_DIR=dspace-build
-COPY --from=build /app /dspace-src
-WORKDIR /dspace-src/dspace/target/${TARGET_DIR}
+ARG TARGET_DIR=dspace-installer
+COPY --from=build /install /dspace-src
+WORKDIR /dspace-src
 
 # Create the initial install deployment using ANT
 ENV ANT_VERSION 1.9.13
@@ -32,23 +42,15 @@ ENV PATH $ANT_HOME/bin:$PATH
 RUN mkdir $ANT_HOME && \
     wget -qO- "https://www.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
 
-RUN ant update_configs update_code update_webapps
+RUN ant init_installation update_configs update_code update_webapps update_solr_indexes
 
 # Step 3 - Run tomcat
 # Create a new tomcat image that does not retain the the build directory contents
 FROM tomcat:7-jre7
-COPY --from=ant_build /dspace /dspace
+ENV DSPACE_INSTALL=/dspace
+COPY --from=ant_build /dspace $DSPACE_INSTALL
 EXPOSE 8080 8009
 
-# Ant will be embedded in the final container to allow additional deployments
-ENV ANT_VERSION 1.9.13
-ENV ANT_HOME /tmp/ant-$ANT_VERSION
-ENV PATH $ANT_HOME/bin:$PATH
-
-RUN mkdir $ANT_HOME && \
-    wget -qO- "https://www.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
-
-ENV DSPACE_INSTALL=/dspace
 ENV JAVA_OPTS=-Xmx2000m
 
 RUN ln -s $DSPACE_INSTALL/webapps/solr    /usr/local/tomcat/webapps/solr    && \

--- a/Dockerfile.jdk7-test
+++ b/Dockerfile.jdk7-test
@@ -63,3 +63,5 @@ RUN ln -s $DSPACE_INSTALL/webapps/solr    /usr/local/tomcat/webapps/solr    && \
     ln -s $DSPACE_INSTALL/webapps/swordv2 /usr/local/tomcat/webapps/swordv2
 
 COPY dspace/src/main/docker/test/solr_web.xml /app/dspace-solr/src/main/webapp/WEB-INF/web.xml
+
+RUN sed -i -e "s|\${dspace.dir}|$DSPACE_INSTALL|" $DSPACE_INSTALL/webapps/solr/WEB-INF/web.xml

--- a/Dockerfile.jdk7-test
+++ b/Dockerfile.jdk7-test
@@ -42,7 +42,7 @@ ENV PATH $ANT_HOME/bin:$PATH
 RUN mkdir $ANT_HOME && \
     wget -qO- "https://www.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
 
-RUN ant init_installation update_configs update_code update_webapps update_solr_indexes
+RUN ant init_installation update_configs update_code update_webapps
 
 # Step 3 - Run tomcat
 # Create a new tomcat image that does not retain the the build directory contents

--- a/Dockerfile.jdk7-test
+++ b/Dockerfile.jdk7-test
@@ -9,7 +9,7 @@
 # - default tag for branch: dspace/dspace: dspace/dspace:dspace-4_x-jdk7-test
 
 # Step 1 - Run Maven Build
-FROM dspace/dspace-dependencies:dspace-4_x- as build
+FROM dspace/dspace-dependencies:dspace-4_x as build
 ARG TARGET_DIR=dspace-build
 WORKDIR /app
 

--- a/Dockerfile.jdk7-test
+++ b/Dockerfile.jdk7-test
@@ -22,6 +22,7 @@ USER dspace
 # Copy the DSpace source code into the workdir (excluding .dockerignore contents)
 ADD --chown=dspace . /app/
 COPY --chown=dspace dspace/src/main/docker/build.properties /app/build.properties
+COPY dspace/src/main/docker/test/solr_web.xml /app/dspace-solr/src/main/webapp/WEB-INF/web.xml
 
 # Build DSpace.  Copy the dspace-install directory to /install.  Clean up the build to keep the docker image small
 RUN mvn package -Dmirage2.on=true && \
@@ -61,7 +62,3 @@ RUN ln -s $DSPACE_INSTALL/webapps/solr    /usr/local/tomcat/webapps/solr    && \
     ln -s $DSPACE_INSTALL/webapps/rdf     /usr/local/tomcat/webapps/rdf     && \
     ln -s $DSPACE_INSTALL/webapps/sword   /usr/local/tomcat/webapps/sword   && \
     ln -s $DSPACE_INSTALL/webapps/swordv2 /usr/local/tomcat/webapps/swordv2
-
-COPY dspace/src/main/docker/test/solr_web.xml /app/dspace-solr/src/main/webapp/WEB-INF/web.xml
-
-RUN sed -i -e "s|\${dspace.dir}|$DSPACE_INSTALL|" $DSPACE_INSTALL/webapps/solr/WEB-INF/web.xml

--- a/Dockerfile.jdk7-test
+++ b/Dockerfile.jdk7-test
@@ -1,31 +1,38 @@
 # This image will be published as dspace/dspace
 # See https://dspace-labs.github.io/DSpace-Docker-Images/ for usage details
-
+# 
 # This version is JDK7 compatible
 # - tomcat:7-jre7
 # - ANT 1.9.13
 # - maven:3-jdk-7
 # - note: 
-# - default tag for branch: dspace/dspace: dspace/dspace:dspace-4_x-jdk7
+# - default tag for branch: dspace/dspace: dspace/dspace:dspace-4_x-jdk7-test
 
 # Step 1 - Run Maven Build
-FROM maven:3-jdk-7 as build
+FROM dspace/dspace-dependencies:dspace-4_x- as build
+ARG TARGET_DIR=dspace-build
 WORKDIR /app
 
+# The dspace-install directory will be written to /install
+RUN mkdir /install \
+    && chown -Rv dspace: /install
+
+USER dspace
+
 # Copy the DSpace source code into the workdir (excluding .dockerignore contents)
-ADD . /app/
-COPY dspace/src/main/docker/build.properties /app/build.properties
+ADD --chown=dspace . /app/
+COPY --chown=dspace dspace/src/main/docker/build.properties /app/build.properties
 
-# Provide web.xml overrides to make webapps easier to test
-COPY dspace/src/main/docker/test/solr_web.xml /app/dspace-solr/src/main/webapp/WEB-INF/web.xml
-
-RUN mvn package
+# Build DSpace.  Copy the dspace-install directory to /install.  Clean up the build to keep the docker image small
+RUN mvn package -Dmirage2.on=true && \
+  mv /app/dspace/target/${TARGET_DIR}/* /install && \
+  mvn clean
 
 # Step 2 - Run Ant Deploy
 FROM tomcat:7-jre7 as ant_build
-ARG TARGET_DIR=dspace-build
-COPY --from=build /app /dspace-src
-WORKDIR /dspace-src/dspace/target/${TARGET_DIR}
+ARG TARGET_DIR=dspace-installer
+COPY --from=build /install /dspace-src
+WORKDIR /dspace-src
 
 # Create the initial install deployment using ANT
 ENV ANT_VERSION 1.9.13
@@ -35,23 +42,15 @@ ENV PATH $ANT_HOME/bin:$PATH
 RUN mkdir $ANT_HOME && \
     wget -qO- "https://www.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
 
-RUN ant update_configs update_code update_webapps
+RUN ant init_installation update_configs update_code update_webapps update_solr_indexes
 
 # Step 3 - Run tomcat
 # Create a new tomcat image that does not retain the the build directory contents
 FROM tomcat:7-jre7
-COPY --from=ant_build /dspace /dspace
+ENV DSPACE_INSTALL=/dspace
+COPY --from=ant_build /dspace $DSPACE_INSTALL
 EXPOSE 8080 8009
 
-# Ant will be embedded in the final container to allow additional deployments
-ENV ANT_VERSION 1.9.13
-ENV ANT_HOME /tmp/ant-$ANT_VERSION
-ENV PATH $ANT_HOME/bin:$PATH
-
-RUN mkdir $ANT_HOME && \
-    wget -qO- "https://www.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
-
-ENV DSPACE_INSTALL=/dspace
 ENV JAVA_OPTS=-Xmx2000m
 
 RUN ln -s $DSPACE_INSTALL/webapps/solr    /usr/local/tomcat/webapps/solr    && \
@@ -62,3 +61,5 @@ RUN ln -s $DSPACE_INSTALL/webapps/solr    /usr/local/tomcat/webapps/solr    && \
     ln -s $DSPACE_INSTALL/webapps/rdf     /usr/local/tomcat/webapps/rdf     && \
     ln -s $DSPACE_INSTALL/webapps/sword   /usr/local/tomcat/webapps/sword   && \
     ln -s $DSPACE_INSTALL/webapps/swordv2 /usr/local/tomcat/webapps/swordv2
+
+COPY dspace/src/main/docker/test/solr_web.xml /app/dspace-solr/src/main/webapp/WEB-INF/web.xml


### PR DESCRIPTION
Port of https://github.com/DSpace/DSpace/pull/2307

Images have been built on DockerHub at terrywbrady/dspace.

![image](https://user-images.githubusercontent.com/1111057/52393769-70d6e480-2a5c-11e9-8994-3a8f947d59c3.png)

[verifyImages.sh](https://github.com/DSpace-Labs/DSpace-Docker-Images/blob/8494b5789e16cfb2f2023fc136824e38a49d4b79/tools/verifyImages.sh) has been run

```
 ===== dspace-4_x-jdk7 =====
DSpace version:  4.10-SNAPSHOT
           JRE:  Oracle Corporation version 1.7.0_181
  ---> http://localhost:8080/xmlui
  ---> http://localhost:8080/oai/request
  ---> http://localhost:8080/solr
  ---> http://localhost:8080/rest
$ ../../tools/verifyImages.sh
 ===== terrywbrady/dspace:dspace-4_x-jdk7-test =====
DSpace version:  4.10-SNAPSHOT
           JRE:  Oracle Corporation version 1.7.0_181
  ---> http://localhost:8080/xmlui
  ---> http://localhost:8080/oai/request
  ---> http://localhost:8080/solr
  ---> http://localhost:8080/rest

```