### PR TITLE
DS-4169: Treat empty language as null in edit item

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowItemUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowItemUtils.java
@@ -14,6 +14,7 @@ import java.util.*;
 
 import org.apache.cocoon.environment.Request;
 import org.apache.cocoon.servlet.multipart.Part;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.time.DateUtils;
 import org.dspace.app.util.Util;
 import org.dspace.app.xmlui.utils.UIException;
@@ -211,6 +212,12 @@ public class FlowItemUtils
 			String lang = request.getParameter("language_"+index);
 			String remove = request.getParameter("remove_"+index);
 			
+			// Empty lang is null lang
+			if (StringUtils.isBlank(lang))
+			{
+				lang = null;
+			}
+
 			// the user selected the remove checkbox.
 			if (remove != null)
                         {


### PR DESCRIPTION
The metadata editor in the admin edit item view always submits an empty string
if there is no language (the HTML input fields cannot submit null values). To
preserve the null values of the language attributes all empty strings in the
language input fields are treated as null values, now.

https://jira.duraspace.org/browse/DS-4169