### PR TITLE
DS-4177 SearchFacetFilter does not respect starts_with param

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SearchFacetFilter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SearchFacetFilter.java
@@ -652,6 +652,7 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
         queryParams.putAll(params.getCommonBrowseParams());
         Request request = ObjectModelHelper.getRequest(objectModel);
         queryParams.put("order",request.getParameter("order"));
+        queryParams.put("starts_with",request.getParameter("starts_with"));
         String facetField = request.getParameter(SearchFilterParam.FACET_FIELD);
         Division controls = div.addInteractiveDivision("browse-controls", "search-filter?field="+facetField,
                 Division.METHOD_POST, "browse controls");


### PR DESCRIPTION
From:  https://jira.duraspace.org/browse/DS-4177
Fixes #7518

From the `/search-filter` page, utilizing the alphabetical jump-list adds the `starts_with` parameter to the URI. However, updating the RPP from the respective page does not carry over the respective `starts_with` parameter.