### PR TITLE
DS-4162. Bower upgrade due to security vulnerability

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/package.json
+++ b/dspace-xmlui-mirage2/src/main/webapp/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.2",
   "dependencies": {},
   "devDependencies": {
-    "bower": "1.7.9",
+    "bower": "1.8.8",
     "grunt": "~1.0.1",
     "grunt-cli": "1.2.0",
     "grunt-contrib-coffee": "~1.0.0",


### PR DESCRIPTION
Upgrades bower dependency for Mirage2 from 1.7.9 to 1.8.8 because of
a serious security vulnerability, see:
https://snyk.io/blog/severe-security-vulnerability-in-bowers-zip-archive-extraction/