### PR TITLE
DS-3444 JSPUI must keep shibboleth attributes on session renewal

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/util/Authenticate.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/util/Authenticate.java
@@ -12,6 +12,7 @@ import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.UUID;
+import java.util.List;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -29,6 +30,7 @@ import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 import org.dspace.core.LogManager;
 import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
 
@@ -278,7 +280,11 @@ public class Authenticate
 
             // Get the original URL of interrupted request, if set
             String requestUrl = (String) session.getAttribute("interrupted.request.url");
-
+            
+            // Shibboleth stores information about special groups in the session. Preserve these information.
+	    Boolean shibbolethAuthenticated = (Boolean) session.getAttribute("shib.authenticated");
+            List<UUID> shibbolethSpecialGroups = (List<UUID>) session.getAttribute("shib.specialgroup");
+           
             // Invalidate session unless dspace.cfg says not to
             if(ConfigurationManager.getBooleanProperty("webui.session.invalidate", true))
             {
@@ -298,6 +304,14 @@ public class Authenticate
             if (requestInfo != null && requestUrl != null) {
                 session.setAttribute("interrupted.request.info", requestInfo);
                 session.setAttribute("interrupted.request.url", requestUrl);
+            }
+            
+            // Restore shibboleth special groups
+	    if (shibbolethAuthenticated != null) {
+		    session.setAttribute("shib.authenticated", shibbolethAuthenticated.booleanValue());
+	    }
+            if (shibbolethSpecialGroups != null) {
+                session.setAttribute("shib.specialgroup", shibbolethSpecialGroups);
             }
         }
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1809,9 +1809,11 @@ webui.suggest.enable = false
 #### Session invalidation #####
 
 # Enable or disable session invalidation upon login or logout.
-# This feature is enabled by default to help prevent session hijacking
-# but may cause problems for shibboleth, etc
-#
+# This feature is enabled by default to help prevent session hijacking.
+# In case you run into problems with special groups or other session
+# information that seems to get lost, it can be helpful to switch this off as
+# part of debugging. Do not switch this off unless your installation is
+# running in a test or development environment.
 # webui.session.invalidate = true
 
 # If you would like to use Google Analytics to track general website statistics then


### PR DESCRIPTION
Fixes #6797

When a user logs into DSpace, JSPUI creates a new session to prevent session hijacking. While doing so, it must carry over to the information shibboleth stored to the old session. These information are:
- that a the actual user was authorized using shibboleth, and
- the special groups that were assigned to the user by shibboleth attributes, if any.

This fix was developed by The Library Code GmbH with the support of the Universitätsbibliothek Mainz and the Fraunhofer IRB, Research Services & Open Science.