### PR TITLE
[DS-4167] 5x Port: Migrate update-sequences.sql to `database` command

### DIFF
--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/README.md
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/README.md
@@ -77,3 +77,16 @@ to upper case.
 Oracle complains with ORA-01408 if you attempt to create an index on a column which
 has already had the UNIQUE contraint added (such an index is implicit in maintaining the uniqueness
 of the column). See [DS-1370](https://jira.duraspace.org/browse/DS-1370) for details.
+
+## Using the update-sequences.sql script
+
+The `update-sequences.sql` script in this directory may still be used to update
+your internal database counts if you feel they have gotten out of "sync". This
+may sometimes occur after large restores of content (e.g. when using the DSpace
+[AIP Backup and Restore](https://wiki.duraspace.org/display/DSDOC5x/AIP+Backup+and+Restore) 
+feature).
+
+This `update-sequences.sql` script can be executed by running 
+"dspace database update-sequences". It will not harm your 
+database (or its contents) in any way. It just ensures all database counts (i.e.
+sequences) are properly set to the next available value.

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/update-sequences.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/update-sequences.sql
@@ -65,7 +65,6 @@ BEGIN
   updateseq('harvested_item_seq', 'harvested_item', 'id');
   updateseq('webapp_seq', 'webapp', 'webapp_id');
   updateseq('requestitem_seq', 'requestitem', 'requestitem_id');
-  updateseq('handle_id_seq', 'handle', 'handle_id');
   updateseq('bitstream_seq', 'bitstream', 'bitstream_id');
   updateseq('eperson_seq', 'eperson', 'eperson_id');
   updateseq('epersongroup_seq', 'epersongroup', 'eperson_group_id');
@@ -75,7 +74,6 @@ BEGIN
   updateseq('bundle_seq', 'bundle', 'bundle_id');
   updateseq('item2bundle_seq', 'item2bundle', 'id');
   updateseq('bundle2bitstream_seq', 'bundle2bitstream', 'id');
-  updateseq('dcvalue_seq', 'dcvalue', 'dc_value_id');
   updateseq('community_seq', 'community', 'community_id');
   updateseq('community2community_seq', 'community2community', 'id');
   updateseq('collection_seq', 'collection', 'collection_id');

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/update-sequences.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/update-sequences.sql
@@ -1,0 +1,101 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-- SQL code to update the ID (primary key) generating sequences, if some
+-- import operation has set explicit IDs.
+--
+-- Sequences are used to generate IDs for new rows in the database.  If a
+-- bulk import operation, such as an SQL dump, specifies primary keys for
+-- imported data explicitly, the sequences are out of sync and need updating.
+-- This SQL code does just that.
+--
+-- This should rarely be needed; any bulk import should be performed using the
+-- org.dspace.content API which is safe to use concurrently and in multiple
+-- JVMs.  The SQL code below will typically only be required after a direct
+-- SQL data dump from a backup or somesuch.
+ 
+
+-- There should be one of these calls for every ID sequence defined in
+-- database_schema.sql.
+
+-- depends on being run from sqlplus with incseq.sql in the current path
+-- you can find incseq.sql at: http://akadia.com/services/scripts/incseq.sql
+
+DECLARE
+ PROCEDURE updateseq ( seq IN VARCHAR,
+                       tbl IN VARCHAR,
+                       attr IN VARCHAR,
+                       cond IN VARCHAR DEFAULT '' ) IS
+   curr NUMBER := 0;
+   BEGIN
+     EXECUTE IMMEDIATE 'SELECT max(' || attr
+             || ') FROM ' || tbl
+             || ' ' || cond
+             INTO curr;
+     curr := curr + 1;
+     EXECUTE IMMEDIATE 'DROP SEQUENCE ' || seq;
+     EXECUTE IMMEDIATE 'CREATE SEQUENCE '
+             || seq
+             || ' START WITH '
+             || NVL(curr, 1);
+   END updateseq;
+
+BEGIN
+  updateseq('bitstreamformatregistry_seq', 'bitstreamformatregistry',
+            'bitstream_format_id');
+  updateseq('fileextension_seq', 'fileextension', 'file_extension_id');
+  updateseq('resourcepolicy_seq', 'resourcepolicy', 'policy_id');
+  updateseq('workspaceitem_seq', 'workspaceitem', 'workspace_item_id');
+  updateseq('workflowitem_seq', 'workflowitem', 'workflow_id');
+  updateseq('tasklistitem_seq', 'tasklistitem', 'tasklist_id');
+  updateseq('registrationdata_seq', 'registrationdata',
+            'registrationdata_id');
+  updateseq('subscription_seq', 'subscription', 'subscription_id');
+  updateseq('metadatafieldregistry_seq', 'metadatafieldregistry',
+            'metadata_field_id');
+  updateseq('metadatavalue_seq', 'metadatavalue', 'metadata_value_id');
+  updateseq('metadataschemaregistry_seq', 'metadataschemaregistry',
+            'metadata_schema_id');
+  updateseq('harvested_collection_seq', 'harvested_collection', 'id');
+  updateseq('harvested_item_seq', 'harvested_item', 'id');
+  updateseq('webapp_seq', 'webapp', 'webapp_id');
+  updateseq('requestitem_seq', 'requestitem', 'requestitem_id');
+  updateseq('handle_id_seq', 'handle', 'handle_id');
+  updateseq('bitstream_seq', 'bitstream', 'bitstream_id');
+  updateseq('eperson_seq', 'eperson', 'eperson_id');
+  updateseq('epersongroup_seq', 'epersongroup', 'eperson_group_id');
+  updateseq('group2group_seq', 'group2group', 'id');
+  updateseq('group2groupcache_seq', 'group2groupcache', 'id');
+  updateseq('item_seq item', 'item_id');
+  updateseq('bundle_seq', 'bundle', 'bundle_id');
+  updateseq('item2bundle_seq', 'item2bundle', 'id');
+  updateseq('bundle2bitstream_seq', 'bundle2bitstream', 'id');
+  updateseq('dcvalue_seq', 'dcvalue', 'dc_value_id');
+  updateseq('community_seq', 'community', 'community_id');
+  updateseq('community2community_seqvcommunity2community', 'id');
+  updateseq('collection_seq', 'collection', 'collection_id');
+  updateseq('community2collection_seq', 'community2collection', 'id');
+  updateseq('collection2item_seq', 'collection2item', 'id');
+  updateseq('epersongroup2eperson_seq', 'epersongroup2eperson', 'id');
+  updateseq('communities2item_seq', 'communities2item', 'id');
+  updateseq('epersongroup2workspaceitem_seq', 'epersongroup2workspaceitem', 'id');
+
+  -- Handle Sequence is a special case.  Since Handles minted by DSpace
+  -- use the 'handle_seq', we need to ensure the next assigned handle
+  -- will *always* be unique.  So, 'handle_seq' always needs to be set
+  -- to the value of the *largest* handle suffix.  That way when the
+  -- next handle is assigned, it will use the next largest number. This
+  -- query does the following:
+  --   For all 'handle' values which have a number in their suffix
+  --   (after '/'), find the maximum suffix value, convert it to a
+  --   number, and set the 'handle_seq' to start at the next value (see
+  --   updateseq above for more).
+  updateseq('handle_seq', 'handle',
+            q'{to_number(regexp_replace(handle, '.*/', ''), '999999999999')}',
+            q'{WHERE REGEXP_LIKE(handle, '^.*/[0123456789]*$')}');
+END;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/update-sequences.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/update-sequences.sql
@@ -71,13 +71,13 @@ BEGIN
   updateseq('epersongroup_seq', 'epersongroup', 'eperson_group_id');
   updateseq('group2group_seq', 'group2group', 'id');
   updateseq('group2groupcache_seq', 'group2groupcache', 'id');
-  updateseq('item_seq item', 'item_id');
+  updateseq('item_seq', 'item', 'item_id');
   updateseq('bundle_seq', 'bundle', 'bundle_id');
   updateseq('item2bundle_seq', 'item2bundle', 'id');
   updateseq('bundle2bitstream_seq', 'bundle2bitstream', 'id');
   updateseq('dcvalue_seq', 'dcvalue', 'dc_value_id');
   updateseq('community_seq', 'community', 'community_id');
-  updateseq('community2community_seqvcommunity2community', 'id');
+  updateseq('community2community_seq', 'community2community', 'id');
   updateseq('collection_seq', 'collection', 'collection_id');
   updateseq('community2collection_seq', 'community2collection', 'id');
   updateseq('collection2item_seq', 'collection2item', 'id');

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/README.md
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/README.md
@@ -17,4 +17,15 @@ not realize you manually ran one or more scripts.
 
 Please see the Flyway Documentation for more information: http://flywaydb.org/
 
+## Using the update-sequences.sql script
 
+The `update-sequences.sql` script in this directory may still be used to update
+your internal database counts if you feel they have gotten out of "sync". This
+may sometimes occur after large restores of content (e.g. when using the DSpace
+[AIP Backup and Restore](https://wiki.duraspace.org/display/DSDOC5x/AIP+Backup+and+Restore) 
+feature).
+
+This `update-sequences.sql` script can be executed by running 
+"dspace database update-sequences". It will not harm your 
+database (or its contents) in any way. It just ensures all database counts (i.e.
+sequences) are properly set to the next available value.

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/update-sequences.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/update-sequences.sql
@@ -1,0 +1,75 @@
+---
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-- SQL code to update the ID (primary key) generating sequences, if some
+-- import operation has set explicit IDs.
+--
+-- Sequences are used to generate IDs for new rows in the database.  If a
+-- bulk import operation, such as an SQL dump, specifies primary keys for
+-- imported data explicitly, the sequences are out of sync and need updating.
+-- This SQL code does just that.
+--
+-- This should rarely be needed; any bulk import should be performed using the
+-- org.dspace.content API which is safe to use concurrently and in multiple
+-- JVMs.  The SQL code below will typically only be required after a direct
+-- SQL data dump from a backup or somesuch.
+ 
+
+-- There should be one of these calls for every ID sequence defined in
+-- database_schema.sql.
+
+
+SELECT setval('bitstreamformatregistry_seq', max(bitstream_format_id)) FROM bitstreamformatregistry;
+SELECT setval('fileextension_seq', max(file_extension_id)) FROM fileextension;
+SELECT setval('bitstream_seq', max(bitstream_id)) FROM bitstream;
+SELECT setval('eperson_seq', max(eperson_id)) FROM eperson;
+SELECT setval('epersongroup_seq', max(eperson_group_id)) FROM epersongroup;
+SELECT setval('group2group_seq', max(id)) FROM group2group;
+SELECT setval('group2groupcache_seq', max(id)) FROM group2groupcache;
+SELECT setval('item_seq', max(item_id)) FROM item;
+SELECT setval('bundle_seq', max(bundle_id)) FROM bundle;
+SELECT setval('item2bundle_seq', max(id)) FROM item2bundle;
+SELECT setval('bundle2bitstream_seq', max(id)) FROM bundle2bitstream;
+SELECT setval('dcvalue_seq', max(dc_value_id)) FROM dcvalue;
+SELECT setval('community_seq', max(community_id)) FROM community;
+SELECT setval('community2community_seq', max(id)) FROM community2community;
+SELECT setval('collection_seq', max(collection_id)) FROM collection;
+SELECT setval('community2collection_seq', max(id)) FROM community2collection;
+SELECT setval('collection2item_seq', max(id)) FROM collection2item;
+SELECT setval('resourcepolicy_seq', max(policy_id)) FROM resourcepolicy;
+SELECT setval('epersongroup2eperson_seq', max(id)) FROM epersongroup2eperson;
+SELECT setval('workspaceitem_seq', max(workspace_item_id)) FROM workspaceitem;
+SELECT setval('workflowitem_seq', max(workflow_id)) FROM workflowitem;
+SELECT setval('tasklistitem_seq', max(tasklist_id)) FROM tasklistitem;
+SELECT setval('registrationdata_seq', max(registrationdata_id)) FROM registrationdata;
+SELECT setval('subscription_seq', max(subscription_id)) FROM subscription;
+SELECT setval('communities2item_seq', max(id)) FROM communities2item;
+SELECT setval('epersongroup2workspaceitem_seq', max(id)) FROM epersongroup2workspaceitem;
+SELECT setval('metadatafieldregistry_seq', max(metadata_field_id)) FROM metadatafieldregistry;
+SELECT setval('metadatavalue_seq', max(metadata_value_id)) FROM metadatavalue;
+SELECT setval('metadataschemaregistry_seq', max(metadata_schema_id)) FROM metadataschemaregistry;
+SELECT setval('harvested_collection_seq', max(id)) FROM harvested_collection;
+SELECT setval('harvested_item_seq', max(id)) FROM harvested_item;
+SELECT setval('webapp_seq', max(webapp_id)) FROM webapp;
+SELECT setval('requestitem_seq', max(requestitem_id)) FROM requestitem;
+
+-- Handle Sequence is a special case.  Since Handles minted by DSpace use the 'handle_seq',
+-- we need to ensure the next assigned handle will *always* be unique.  So, 'handle_seq'
+-- always needs to be set to the value of the *largest* handle suffix.  That way when the
+-- next handle is assigned, it will use the next largest number. This query does the following:
+--  For all 'handle' values which have a number in their suffix (after '/'), find the maximum
+--  suffix value, convert it to a 'bigint' type, and set the 'handle_seq' to that max value.
+SELECT setval('handle_seq',
+              CAST (
+                    max(
+                        to_number(regexp_replace(handle, '.*/', ''), '999999999999')
+                       )
+                    AS BIGINT)
+             )
+    FROM handle
+    WHERE handle SIMILAR TO '%/[0123456789]*';


### PR DESCRIPTION
Fixes #7509
Port of #2348

### Postgres Test Results (TBD)
```
$ docker ps
CONTAINER ID        IMAGE                             COMMAND                  CREATED             STATUS              PORTS                              NAMES
9e35199b3529        terrywbrady/dspace:ds4167r5       "/dspace-docker-tool…"   42 seconds ago      Up 41 seconds       8009/tcp, 0.0.0.0:8080->8080/tcp   dspace
334f2d72c77e        dspace/dspace-postgres-pgcrypto   "docker-entrypoint.s…"   43 seconds ago      Up 42 seconds       5432/tcp                           dspacedb

$ winpty docker exec -it dspace grep db.url //dspace/config/dspace.cfg
db.url = jdbc:postgresql://dspacedb:5432/dspace

$ winpty docker exec -it dspace //dspace/bin/dspace database

Database action argument is missing.
Valid actions: 'test', 'info', 'migrate', 'repair', 'update-sequences' or 'clean'

Or, type 'database help' for more information.


$ winpty docker exec -it dspace //dspace/bin/dspace database update-sequences
Running org/dspace/storage/rdbms/sqlmigration/postgres/update-sequences.sql
update-sequences complete

```

### Oracle Test Results (TBD)
```
$ winpty docker exec -it dspace //dspace/bin/dspace database

Database action argument is missing.
Valid actions: 'test', 'info', 'migrate', 'repair', 'update-sequences' or 'clean'

Or, type 'database help' for more information.


$ winpty docker exec -it dspace //dspace/bin/dspace database update-sequences
Running org/dspace/storage/rdbms/sqlmigration/oracle/update-sequences.sql
update-sequences complete


```