### PR TITLE
[DS-4167] 6x Port: Migrate update-sequences.sql to `database` command

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -10,6 +10,7 @@ package org.dspace.storage.rdbms;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -23,6 +24,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.sql.DataSource;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.dspace.core.Context;
@@ -83,7 +85,8 @@ public class DatabaseUtils
         if (argv.length < 1)
         {
             System.out.println("\nDatabase action argument is missing.");
-            System.out.println("Valid actions: 'test', 'info', 'migrate', 'repair', 'validate' or 'clean'");
+            System.out.println("Valid actions: 'test', 'info', 'migrate', 'repair', 'validate' "
+                    + "'update-sequences' or 'clean'");
             System.out.println("\nOr, type 'database help' for more information.\n");
             System.exit(1);
         }
@@ -334,16 +337,37 @@ public class DatabaseUtils
                     System.exit(1);
                 }
             }
+            else if(argv[0].equalsIgnoreCase("update-sequences")) {
+                try (Connection connection = dataSource.getConnection()) {
+                    String dbType = getDbType(connection);
+                    String sqlfile = "org/dspace/storage/rdbms/sqlmigration/" + dbType +
+                             "/update-sequences.sql";
+                    InputStream sqlstream = DatabaseUtils.class.getClassLoader().getResourceAsStream(sqlfile);
+                    if (sqlstream != null) {
+                        String s = IOUtils.toString(sqlstream, "UTF-8");
+                        if (!s.isEmpty()) {
+                            System.out.println("Running " + sqlfile);
+                            connection.createStatement().execute(s);
+                            System.out.println("update-sequences complete");
+                        } else {
+                            System.err.println(sqlfile + " contains no SQL to execute");
+                        }
+                    } else {
+                        System.err.println(sqlfile + " not found");
+                    }
+                }
+            }
             else
             {
                 System.out.println("\nUsage: database [action]");
-                System.out.println("Valid actions: 'test', 'info', 'migrate', 'repair' or 'clean'");
-                System.out.println(" - test          = Performs a test connection to database to validate connection settings");
-                System.out.println(" - info / status = Describe basic info/status about database, including validating the compatibility of this database");
-                System.out.println(" - migrate       = Migrate the database to the latest version");
-                System.out.println(" - repair        = Attempt to repair any previously failed database migrations or checksum mismatches (via Flyway repair)");
-                System.out.println(" - validate      = Validate current database's migration status (via Flyway validate), validating all migration checksums.");
-                System.out.println(" - clean         = DESTROY all data and tables in database (WARNING there is no going back!). Requires 'db.cleanDisabled=false' setting in config.");
+                System.out.println("Valid actions: 'test', 'info', 'migrate', 'repair', 'update-sequences' or 'clean'");
+                System.out.println(" - test             = Performs a test connection to database to validate connection settings");
+                System.out.println(" - info / status    = Describe basic info/status about database, including validating the compatibility of this database");
+                System.out.println(" - migrate          = Migrate the database to the latest version");
+                System.out.println(" - repair           = Attempt to repair any previously failed database migrations or checksum mismatches (via Flyway repair)");
+                System.out.println(" - validate         = Validate current database's migration status (via Flyway validate), validating all migration checksums.");
+                System.out.println(" - update-sequences = Update database sequences after running AIP ingest.");
+                System.out.println(" - clean            = DESTROY all data and tables in database (WARNING there is no going back!). Requires 'db.cleanDisabled=false' setting in config.");
                 System.out.println("");
                 System.exit(0);
             }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -85,7 +85,7 @@ public class DatabaseUtils
         if (argv.length < 1)
         {
             System.out.println("\nDatabase action argument is missing.");
-            System.out.println("Valid actions: 'test', 'info', 'migrate', 'repair', 'validate' "
+            System.out.println("Valid actions: 'test', 'info', 'migrate', 'repair', 'validate', "
                     + "'update-sequences' or 'clean'");
             System.out.println("\nOr, type 'database help' for more information.\n");
             System.exit(1);

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/README.md
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/README.md
@@ -77,3 +77,16 @@ to upper case.
 Oracle complains with ORA-01408 if you attempt to create an index on a column which
 has already had the UNIQUE contraint added (such an index is implicit in maintaining the uniqueness
 of the column). See [DS-1370](https://jira.duraspace.org/browse/DS-1370) for details.
+
+## Using the update-sequences.sql script
+
+The `update-sequences.sql` script in this directory may still be used to update
+your internal database counts if you feel they have gotten out of "sync". This
+may sometimes occur after large restores of content (e.g. when using the DSpace
+[AIP Backup and Restore](https://wiki.duraspace.org/display/DSDOC5x/AIP+Backup+and+Restore) 
+feature).
+
+This `update-sequences.sql` script can be executed by running 
+"dspace database update-sequences". It will not harm your 
+database (or its contents) in any way. It just ensures all database counts (i.e.
+sequences) are properly set to the next available value.

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/update-sequences.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/update-sequences.sql
@@ -1,0 +1,80 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-- SQL code to update the ID (primary key) generating sequences, if some
+-- import operation has set explicit IDs.
+--
+-- Sequences are used to generate IDs for new rows in the database.  If a
+-- bulk import operation, such as an SQL dump, specifies primary keys for
+-- imported data explicitly, the sequences are out of sync and need updating.
+-- This SQL code does just that.
+--
+-- This should rarely be needed; any bulk import should be performed using the
+-- org.dspace.content API which is safe to use concurrently and in multiple
+-- JVMs.  The SQL code below will typically only be required after a direct
+-- SQL data dump from a backup or somesuch.
+
+-- Depends on being run from sqlplus with incseq.sql in the current path
+-- you can find incseq.sql at: http://www.akadia.com/services/scripts/incseq.sql
+-- Here that script was renamed to updateseq.sql.
+
+DECLARE
+ PROCEDURE updateseq ( seq IN VARCHAR,
+                       tbl IN VARCHAR,
+                       attr IN VARCHAR,
+                       cond IN VARCHAR DEFAULT '' ) IS
+   curr NUMBER := 0;
+   BEGIN
+     EXECUTE IMMEDIATE 'SELECT max(' || attr
+             || ') FROM ' || tbl
+             || ' ' || cond
+             INTO curr;
+     curr := curr + 1;
+     EXECUTE IMMEDIATE 'DROP SEQUENCE ' || seq;
+     EXECUTE IMMEDIATE 'CREATE SEQUENCE '
+             || seq
+             || ' START WITH '
+             || NVL(curr, 1);
+   END updateseq;
+
+BEGIN
+  updateseq('bitstreamformatregistry_seq', 'bitstreamformatregistry',
+            'bitstream_format_id');
+  updateseq('fileextension_seq', 'fileextension', 'file_extension_id');
+  updateseq('resourcepolicy_seq', 'resourcepolicy', 'policy_id');
+  updateseq('workspaceitem_seq', 'workspaceitem', 'workspace_item_id');
+  updateseq('workflowitem_seq', 'workflowitem', 'workflow_id');
+  updateseq('tasklistitem_seq', 'tasklistitem', 'tasklist_id');
+  updateseq('registrationdata_seq', 'registrationdata',
+            'registrationdata_id');
+  updateseq('subscription_seq', 'subscription', 'subscription_id');
+  updateseq('metadatafieldregistry_seq', 'metadatafieldregistry',
+            'metadata_field_id');
+  updateseq('metadatavalue_seq', 'metadatavalue', 'metadata_value_id');
+  updateseq('metadataschemaregistry_seq', 'metadataschemaregistry',
+            'metadata_schema_id');
+  updateseq('harvested_collection_seq', 'harvested_collection', 'id');
+  updateseq('harvested_item_seq', 'harvested_item', 'id');
+  updateseq('webapp_seq', 'webapp', 'webapp_id');
+  updateseq('requestitem_seq', 'requestitem', 'requestitem_id');
+  updateseq('handle_id_seq', 'handle', 'handle_id');
+
+  -- Handle Sequence is a special case.  Since Handles minted by DSpace
+  -- use the 'handle_seq', we need to ensure the next assigned handle
+  -- will *always* be unique.  So, 'handle_seq' always needs to be set
+  -- to the value of the *largest* handle suffix.  That way when the
+  -- next handle is assigned, it will use the next largest number. This
+  -- query does the following:
+  --   For all 'handle' values which have a number in their suffix
+  --   (after '/'), find the maximum suffix value, convert it to a
+  --   number, and set the 'handle_seq' to start at the next value (see
+  --   updateseq above for more).
+  updateseq('handle_seq', 'handle',
+            q'{to_number(regexp_replace(handle, '.*/', ''), '999999999999')}',
+            q'{WHERE REGEXP_LIKE(handle, '^.*/[0123456789]*$')}');
+END;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/README.md
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/README.md
@@ -17,4 +17,15 @@ not realize you manually ran one or more scripts.
 
 Please see the Flyway Documentation for more information: http://flywaydb.org/
 
+## Using the update-sequences.sql script
 
+The `update-sequences.sql` script in this directory may still be used to update
+your internal database counts if you feel they have gotten out of "sync". This
+may sometimes occur after large restores of content (e.g. when using the DSpace
+[AIP Backup and Restore](https://wiki.duraspace.org/display/DSDOC5x/AIP+Backup+and+Restore) 
+feature).
+
+This `update-sequences.sql` script can be executed by running 
+"dspace database update-sequences". It will not harm your 
+database (or its contents) in any way. It just ensures all database counts (i.e.
+sequences) are properly set to the next available value.

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/update-sequences.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/update-sequences.sql
@@ -1,0 +1,54 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-- SQL code to update the ID (primary key) generating sequences, if some
+-- import operation has set explicit IDs.
+--
+-- Sequences are used to generate IDs for new rows in the database.  If a
+-- bulk import operation, such as an SQL dump, specifies primary keys for
+-- imported data explicitly, the sequences are out of sync and need updating.
+-- This SQL code does just that.
+--
+-- This should rarely be needed; any bulk import should be performed using the
+-- org.dspace.content API which is safe to use concurrently and in multiple
+-- JVMs.  The SQL code below will typically only be required after a direct
+-- SQL data dump from a backup or somesuch.
+
+
+SELECT setval('bitstreamformatregistry_seq', max(bitstream_format_id)) FROM bitstreamformatregistry;
+SELECT setval('fileextension_seq', max(file_extension_id)) FROM fileextension;
+SELECT setval('resourcepolicy_seq', max(policy_id)) FROM resourcepolicy;
+SELECT setval('workspaceitem_seq', max(workspace_item_id)) FROM workspaceitem;
+SELECT setval('workflowitem_seq', max(workflow_id)) FROM workflowitem;
+SELECT setval('tasklistitem_seq', max(tasklist_id)) FROM tasklistitem;
+SELECT setval('registrationdata_seq', max(registrationdata_id)) FROM registrationdata;
+SELECT setval('subscription_seq', max(subscription_id)) FROM subscription;
+SELECT setval('metadatafieldregistry_seq', max(metadata_field_id)) FROM metadatafieldregistry;
+SELECT setval('metadatavalue_seq', max(metadata_value_id)) FROM metadatavalue;
+SELECT setval('metadataschemaregistry_seq', max(metadata_schema_id)) FROM metadataschemaregistry;
+SELECT setval('harvested_collection_seq', max(id)) FROM harvested_collection;
+SELECT setval('harvested_item_seq', max(id)) FROM harvested_item;
+SELECT setval('webapp_seq', max(webapp_id)) FROM webapp;
+SELECT setval('requestitem_seq', max(requestitem_id)) FROM requestitem;
+SELECT setval('handle_id_seq', max(handle_id)) FROM handle;
+
+-- Handle Sequence is a special case.  Since Handles minted by DSpace use the 'handle_seq',
+-- we need to ensure the next assigned handle will *always* be unique.  So, 'handle_seq'
+-- always needs to be set to the value of the *largest* handle suffix.  That way when the
+-- next handle is assigned, it will use the next largest number. This query does the following:
+--  For all 'handle' values which have a number in their suffix (after '/'), find the maximum
+--  suffix value, convert it to a 'bigint' type, and set the 'handle_seq' to that max value.
+SELECT setval('handle_seq',
+              CAST (
+                    max(
+                        to_number(regexp_replace(handle, '.*/', ''), '999999999999')
+                       )
+                    AS BIGINT)
+             )
+    FROM handle
+    WHERE handle SIMILAR TO '%/[0123456789]*';


### PR DESCRIPTION
Port of https://github.com/DSpace/DSpace/pull/2348

### Postgres Test Results (TBD)
```
$ winpty docker exec -it dspace //dspace/bin/dspace database

Database action argument is missing.
Valid actions: 'test', 'info', 'migrate', 'repair', 'validate', 'update-sequences' or 'clean'

Or, type 'database help' for more information.


$ winpty docker exec -it dspace //dspace/bin/dspace database update-sequences
Running org/dspace/storage/rdbms/sqlmigration/postgres/update-sequences.sql
update-sequences complete

```

### Oracle Test Results (TBD)
```
$ winpty docker exec -it dspace //dspace/bin/dspace database

Database action argument is missing.
Valid actions: 'test', 'info', 'migrate', 'repair', 'validate', 'update-sequences' or 'clean'

Or, type 'database help' for more information.

$ winpty docker exec -it dspace //dspace/bin/dspace database update-sequences
Running org/dspace/storage/rdbms/sqlmigration/oracle/update-sequences.sql
update-sequences complete

```