### PR TITLE
[DS-3894] Fixed facet’s "view more" link throwing exception when results are sorted

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SidebarFacetsTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SidebarFacetsTransformer.java
@@ -292,7 +292,7 @@ public class SidebarFacetsTransformer extends AbstractDSpaceTransformer implemen
             parameters.add("sort_by=" + request.getParameter("sort_by"));
         }
         if(StringUtils.isNotBlank(request.getParameter("order"))){
-            parameters.add("order=" + request.getParameter("order"));
+            parameters.add("sort_order=" + request.getParameter("order"));
         }
         if(StringUtils.isNotBlank(request.getParameter("rpp"))){
             parameters.add("rpp=" + request.getParameter("rpp"));


### PR DESCRIPTION
Changed the "order" parameter included in facet’s "view more" links to "sort_order" to avoid conflicts with the order parameter used in discovery.
This fixes the exception being thrown when clicking a search facet while being on a sorted discovery page.

Related Jira issue: https://jira.duraspace.org/browse/DS-3894

[The King Abdullah University of Science and Technology (KAUST) Repository](https://repository.kaust.edu.sa/) commissioned Atmire to fix and contribute this issue as an effort to continually improve the DSpace codebase.