### PR TITLE
[DS-3881] Fixed discovery "view more" facet displaying incorrect totals

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SearchFacetFilter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/SearchFacetFilter.java
@@ -355,7 +355,7 @@ public class SearchFacetFilter extends AbstractDSpaceTransformer implements Cach
 
                     // We put our total results to -1 so this doesn't get shown in the results (will be hidden by the xsl)
                     // The reason why we do this is because solr 1.4 can't retrieve the total number of facets found
-                    results.setSimplePagination((int) queryResults.getTotalSearchResults(), offSet + 1,
+                    results.setSimplePagination(-1, offSet + 1,
                                                     shownItemsMax, getPreviousPageURL(browseParams, request), nextPageUrl);
 
                     Table singleTable = results.addTable("browse-by-" + facetField + "-results", (int) (queryResults.getDspaceObjects().size() + 1), 1);


### PR DESCRIPTION
Because the "view more" page for a discovery facet shows the number of items returned by the search rather than the number of values in the relevant field, the total amount being displayed is incorrect.
To fix this, we can simply hide the total amount, so it will show "Now showing items x-y" instead of "Now showing items x-y of z", where "z" was incorrect.

Related Jira issue: https://jira.duraspace.org/browse/DS-3881
Fixes #7228

[The King Abdullah University of Science and Technology (KAUST) Repository](https://repository.kaust.edu.sa/) commissioned Atmire to fix and contribute this issue as an effort to continually improve the DSpace codebase.