### PR TITLE
DS-4190. Word-break CSS class breaks words without hyphens in Firefox…

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/styles/classic_mirage_color_scheme/_utils.scss
+++ b/dspace-xmlui-mirage2/src/main/webapp/styles/classic_mirage_color_scheme/_utils.scss
@@ -5,14 +5,15 @@
  *
  * http://www.dspace.org/license/
  */
+
+/* Word-break class borrowed from:
+https://justmarkup.com/log/2015/07/dealing-with-long-words-in-css/ */
+
 .word-break {
-    -ms-word-break: break-all;
-    word-break: break-all;
-
-    /* Non standard for webkit */
-    word-break: break-word;
-
+    overflow-wrap: break-word;
+    word-wrap: break-word;
     -webkit-hyphens: auto;
+    -ms-hyphens: auto;
     -moz-hyphens: auto;
     hyphens: auto;
 }

--- a/dspace-xmlui-mirage2/src/main/webapp/styles/classic_mirage_color_scheme/_utils.scss
+++ b/dspace-xmlui-mirage2/src/main/webapp/styles/classic_mirage_color_scheme/_utils.scss
@@ -6,9 +6,6 @@
  * http://www.dspace.org/license/
  */
 
-/* Word-break class borrowed from:
-https://justmarkup.com/log/2015/07/dealing-with-long-words-in-css/ */
-
 .word-break {
     overflow-wrap: break-word;
     word-wrap: break-word;


### PR DESCRIPTION
… and Opera mini
This CSS class change creates hyphens in Firefox / Opera mini when breaking words.