### PR TITLE
NPE by uploading unregistered format file with embargo because of conflicting error code number

### DIFF
--- a/dspace-api/src/main/java/org/dspace/submit/step/UploadStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/UploadStep.java
@@ -78,7 +78,7 @@ public class UploadStep extends AbstractProcessingStep
     public static final int STATUS_NO_FILES_ERROR = 5;
 
     // format of uploaded file is unknown
-    public static final int STATUS_UNKNOWN_FORMAT = 10;
+    public static final int STATUS_UNKNOWN_FORMAT = 11;
 
     // virus checker unavailable ?
     public static final int STATUS_VIRUS_CHECKER_UNAVAILABLE = 14;


### PR DESCRIPTION
By uploading a file with a unregistered format in submission it will throws a NullPointException, if I use the uploading with the embargo feature. After processing of upload it returns an error code of unknown format with digit 10, but the class UploadWithEmbargo in XMLUI checks it with the error code for edit item policy as well, the same digit, then it calls AccessStep later and throws an NullPointException.