### PR TITLE
DS-4194 Use lazy fetching iterator for long query results

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/AbstractHibernateDAO.java
+++ b/dspace-api/src/main/java/org/dspace/core/AbstractHibernateDAO.java
@@ -12,12 +12,14 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Stream;
 import javax.persistence.Query;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.Root;
 
+import com.google.common.collect.AbstractIterator;
 import org.apache.commons.collections.CollectionUtils;
 import org.hibernate.Session;
 
@@ -269,8 +271,19 @@ public abstract class AbstractHibernateDAO<T> implements GenericDAO<T> {
      */
     public Iterator<T> iterate(Query query) {
         @SuppressWarnings("unchecked")
-        Iterator<T> result = (Iterator<T>) query.getResultList().iterator();
-        return result;
+        org.hibernate.query.Query hquery = query.unwrap(org.hibernate.query.Query.class);
+        Stream<T> stream = hquery.stream();
+        Iterator<T> iter = stream.iterator();
+        return new AbstractIterator<T> () {
+            @Override
+            protected T computeNext() {
+                return iter.hasNext() ? iter.next() : endOfData();
+            }
+            @Override
+            public void finalize() {
+                stream.close();
+            }
+        };
     }
 
     /**


### PR DESCRIPTION
Solves: [DS-4194](https://jira.duraspace.org/browse/DS-4194)

This moves away from reading every result into memory during the Discovery indexing process.