### PR TITLE
[DS-4187] Tool to dump and restore the 'authority' Solr core

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/authority/Commands.java
+++ b/dspace-api/src/main/java/org/dspace/app/authority/Commands.java
@@ -29,6 +29,7 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.common.SolrDocument;
@@ -96,6 +97,10 @@ public class Commands {
 
         // Locate the 'authority' Solr core.
         String collectionURL = CFG.getProperty("solr.authority.server");
+        if (StringUtils.isBlank(collectionURL)) {
+            System.err.println("Cannot continue:  solr.authority.server is not configured.");
+            System.exit(1);
+        }
 
         // Interpret command.
         if (command.hasOption(OPT_DUMP)) {

--- a/dspace-api/src/main/java/org/dspace/app/authority/Commands.java
+++ b/dspace-api/src/main/java/org/dspace/app/authority/Commands.java
@@ -177,7 +177,7 @@ public class Commands {
                 //      For all field values.
                 for (Object fieldValue : document.getFieldValues(fieldName)) {
                     LOG.debug("fieldValue is a {}",
-                            ()->fieldValue.getClass().getSimpleName());
+                        () -> fieldValue.getClass().getSimpleName());
                     xmlWriter.writeStartElement(ParseEventHandler.ELEMENT_FIELD);
                     xmlWriter.writeAttribute(ParseEventHandler.ATTRIBUTE_NAME, fieldName);
                     String valueString;
@@ -319,7 +319,7 @@ public class Commands {
         public void characters(char[] ch, int start, int length) {
             currentValue.append(ch, start, length);
             LOG.debug("characters:  ch = '{}'; start = {}; length = {}; currentValue = '{}'",
-                    ()->ch, ()->start, ()->length, ()->currentValue.toString());
+                () -> ch, () -> start, () -> length, () -> currentValue.toString());
         }
 
         @Override

--- a/dspace-api/src/main/java/org/dspace/app/authority/Commands.java
+++ b/dspace-api/src/main/java/org/dspace/app/authority/Commands.java
@@ -1,7 +1,10 @@
-/*
- * Copyright 2019 Mark H. Wood.
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
  */
-
 package org.dspace.app.authority;
 
 import java.io.IOException;
@@ -64,9 +67,12 @@ public class Commands {
         final String OPT_HELP    = "h";
 
         OptionGroup verbs = new OptionGroup();
-        verbs.addOption(new Option(OPT_DUMP,    "dump", false, "Export all records as XML on standard out"));
-        verbs.addOption(new Option(OPT_RESTORE, "restore", false, "Import records from XML on standard in"));
-        verbs.addOption(new Option(OPT_HELP,    "help", false, "Describe all options"));
+        verbs.addOption(new Option(OPT_DUMP, "dump", false,
+                "Export all records as XML on standard out"));
+        verbs.addOption(new Option(OPT_RESTORE, "restore", false,
+                "Import records from XML on standard in"));
+        verbs.addOption(new Option(OPT_HELP, "help", false,
+                "Describe all options"));
 
         Options options = new Options();
         options.addOptionGroup(verbs);
@@ -263,7 +269,7 @@ public class Commands {
         @Override
         public void error(SAXParseException e)
                 throws SAXException {
-            throw new SAXException(String.format("At line %d column %d:  %s",
+            throw new SAXException(String.format("Error at line %d column %d:  %s",
                     locator.getLineNumber(), locator.getColumnNumber(),
                     e.getMessage()));
         }
@@ -271,7 +277,7 @@ public class Commands {
         @Override
         public void fatalError(SAXParseException e)
                 throws SAXException {
-            throw new SAXException(String.format("At line %d column %d:  %s",
+            throw new SAXException(String.format("Fatal error at line %d column %d:  %s",
                     locator.getLineNumber(), locator.getColumnNumber(),
                     e.getMessage()));
         }
@@ -279,7 +285,7 @@ public class Commands {
         @Override
         public void warning(SAXParseException e)
                 throws SAXException {
-            throw new SAXException(String.format("At line %d column %d:  %s",
+            throw new SAXException(String.format("Warning at line %d column %d:  %s",
                     locator.getLineNumber(), locator.getColumnNumber(),
                     e.getMessage()));
         }

--- a/dspace-api/src/main/java/org/dspace/app/authority/Commands.java
+++ b/dspace-api/src/main/java/org/dspace/app/authority/Commands.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2019 Mark H. Wood.
+ */
+
+package org.dspace.app.authority;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.OptionGroup;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.dspace.services.ConfigurationService;
+import org.dspace.utils.DSpace;
+import org.xml.sax.Attributes;
+import org.xml.sax.Locator;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * CLI for the authority subsystem.
+ *
+ * @author mhwood
+ */
+public class Commands {
+    private static final ConfigurationService CFG = new DSpace().getConfigurationService();
+
+    /** Null constructor for a CLI class. */
+    private Commands() {}
+
+    public static void main (String[] argv)
+            throws IOException,
+                   SolrServerException,
+                   XMLStreamException,
+                   ParserConfigurationException,
+                   SAXException {
+        // Parse the command
+        final String OPT_DUMP    = "d";
+        final String OPT_RESTORE = "r";
+        final String OPT_HELP    = "h";
+
+        OptionGroup verbs = new OptionGroup();
+        verbs.addOption(new Option(OPT_DUMP,    "dump", false, "Export all records as XML on standard out"));
+        verbs.addOption(new Option(OPT_RESTORE, "restore", false, "Import records from XML on standard in"));
+        verbs.addOption(new Option(OPT_HELP,    "help", false, "Describe all options"));
+
+        Options options = new Options();
+        options.addOptionGroup(verbs);
+
+        CommandLine command = null;
+        try {
+            command = new DefaultParser().parse(options, argv);
+        } catch (ParseException e) {
+            System.err.format("Unrecognized command:%n%s%n", e.getMessage());
+            giveHelp(options);
+            System.exit(1);
+        }
+
+        // Locate the 'authority' Solr core.
+        URI collectionURI = null;
+        try {
+            collectionURI = new URI(CFG.getProperty("solr.server")).resolve("authority");
+        } catch (URISyntaxException ex) {
+            System.err.format("Could not build URL for the authority index:  {}",
+                    ex.getMessage());
+            System.exit(1);
+        }
+
+        // Interpret command.
+        if (command.hasOption(OPT_HELP)) {
+            giveHelp(options);
+            System.exit(0);
+        } else if (command.hasOption(OPT_DUMP)) {
+            try (
+                    HttpSolrClient solr = new HttpSolrClient.Builder(collectionURI.toString()).build();
+                    Writer output = new OutputStreamWriter(System.out, StandardCharsets.UTF_8);
+                    ) {
+                dump(solr, output);
+            }
+        } else if (command.hasOption(OPT_RESTORE)) {
+            try ( HttpSolrClient solr = new HttpSolrClient.Builder(collectionURI.toString()).build(); ) {
+                restore(solr, System.in);
+            }
+        } else {
+            System.err.println("Unknown command");
+            System.exit(1);
+        }
+
+        System.exit(0);
+    }
+
+    private static void giveHelp(Options options) {
+        new HelpFormatter().printHelp("dspace authority [--dump | --restore]", options);
+    }
+
+    /**
+     * Serialize all records from a Solr core to a simple XML document.
+     *
+     * @param solr connection to Solr.  Should be focused on a single core/collection.
+     * @param output XML document written here.
+     * @throws IOException passed through.
+     * @throws SolrServerException passed through.
+     * @throws XMLStreamException passed through.
+     */
+    static private void dump(HttpSolrClient solr, Writer output)
+            throws IOException, SolrServerException, XMLStreamException {
+        // Set up to write XML.
+        XMLStreamWriter xmlWriter = XMLOutputFactory.newInstance()
+                .createXMLStreamWriter(output);
+        xmlWriter.writeStartDocument("1.0", StandardCharsets.UTF_8.name());
+        xmlWriter.writeStartElement("authority-dump");
+
+        // Set up the query
+        ModifiableSolrParams params = new ModifiableSolrParams();
+        params.add("q", "*.*");
+
+        // For all Solr records.
+        for (SolrDocument document : new SolrQueryWindow(solr, params)) {
+            //    Start a record element.
+            xmlWriter.writeStartElement("r");
+            //    For all fields.
+            for (String field : document.getFieldNames()) {
+                //      For all values.
+                for (Object value : document.getFieldValues(field)) {
+                    xmlWriter.writeStartElement("f"); // Field
+                    xmlWriter.writeAttribute("name", field);
+                    xmlWriter.writeCharacters(value.toString());
+                    xmlWriter.writeEndElement(); // Field (f)
+                }
+            }
+            //    End the record element.
+            xmlWriter.writeEndElement(); // Record (r)
+        }
+
+        // Close up XML.
+        xmlWriter.writeEndElement(); // Document ("authority-dump")
+        xmlWriter.close();
+
+        // Finished!
+    }
+
+    /**
+     * Read a valid authority dump document and create Solr records from it.
+     * Uses ContentHandler to update Solr.
+     *
+     * @param solr connection to the authority core.
+     * @param input the dump document.
+     * @throws ParserConfigurationException passed through.
+     * @throws SAXException passed through.
+     * @throws IOException passed through.
+     */
+    private static void restore(HttpSolrClient solr, InputStream input)
+            throws ParserConfigurationException, SAXException, IOException {
+        // Load the schema.
+        SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        Schema schema = schemaFactory.newSchema(Commands.class.getResource("authority-dump.xsd"));
+
+        // Configure a parser factory.
+        SAXParserFactory parserFactory = SAXParserFactory.newInstance();
+        parserFactory.setSchema(schema);
+        parserFactory.setValidating(true);
+
+        // Create and run a parser.  ContentHandler will update Solr.
+        SAXParser parser = parserFactory.newSAXParser();
+        parser.parse(input, new ParseEventHandler(solr));
+    }
+
+    /**
+     * Handle SAX content events and errors.
+     */
+    private static class ParseEventHandler
+            extends DefaultHandler {
+        private final HttpSolrClient solr;
+        private final StringBuilder currentValue = new StringBuilder();
+        private Locator locator;
+        private SolrInputDocument solrInputDocument;
+        private String currentField;
+
+        /*
+         * ContentHandler
+         */
+
+        /**
+         * Save a reference to a connection to a Solr core/collection.
+         *
+         * @param solr Connection to Solr.
+         */
+        ParseEventHandler(HttpSolrClient solr) {
+            this.solr = solr;
+        }
+
+        @Override
+        public void setDocumentLocator(Locator locator) {
+            this.locator = locator;
+        }
+
+        @Override
+        public void startElement(String uri, String localName, String qName, Attributes atts) {
+            if ("f".equals(localName)) {
+                currentField = atts.getValue("name");
+            }
+        }
+
+        @Override
+        public void endElement(String uri, String localName, String qName)
+                throws SAXException {
+            if ("r".equals(localName)) {
+                try {
+                    solr.add(solrInputDocument);
+                } catch (SolrServerException | IOException ex) {
+                    throw new SAXException("Could not add a record", ex);
+                }
+            } else if ("f".equals(localName)) {
+                solrInputDocument.addField(currentField, currentValue);
+                currentValue.delete(0, currentValue.length());
+                solrInputDocument.clear();
+            }
+        }
+
+        @Override
+        public void characters(char[] ch, int start, int length) {
+            currentValue.append(ch, start, length);
+        }
+
+        @Override
+        public void endDocument()
+                throws SAXException {
+            try {
+                solr.commit();
+            } catch (SolrServerException | IOException ex) {
+                throw new SAXException("Could not commit final documents", ex);
+            }
+        }
+
+        /*
+         * ErrorHandler
+         */
+
+        @Override
+        public void error(SAXParseException e)
+                throws SAXException {
+            throw new SAXException(String.format("At line %d column %d:  %s",
+                    locator.getLineNumber(), locator.getColumnNumber(),
+                    e.getMessage()));
+        }
+
+        @Override
+        public void fatalError(SAXParseException e)
+                throws SAXException {
+            throw new SAXException(String.format("At line %d column %d:  %s",
+                    locator.getLineNumber(), locator.getColumnNumber(),
+                    e.getMessage()));
+        }
+
+        @Override
+        public void warning(SAXParseException e)
+                throws SAXException {
+            throw new SAXException(String.format("At line %d column %d:  %s",
+                    locator.getLineNumber(), locator.getColumnNumber(),
+                    e.getMessage()));
+        }
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/app/authority/Commands.java
+++ b/dspace-api/src/main/java/org/dspace/app/authority/Commands.java
@@ -237,19 +237,23 @@ public class Commands {
      */
     private static class ParseEventHandler
             extends DefaultHandler {
-        private final HttpSolrClient solr;
         Logger LOG = LogManager.getLogger(ParseEventHandler.class);
-
-        private final StringBuilder currentValue = new StringBuilder();
-        private final SolrInputDocument solrInputDocument = new SolrInputDocument();
-        private Locator locator;
-        private String currentField;
-        private long nRecords = 0;
 
         private static final String ELEMENT_ROOT = "authority-dump";
         private static final String ELEMENT_RECORD = "r";
         private static final String ELEMENT_FIELD = "f";
         private static final String ATTRIBUTE_NAME = "name";
+
+        private final HttpSolrClient solr;
+        private final SolrInputDocument solrInputDocument = new SolrInputDocument();
+        private Locator locator;
+        private long nRecords = 0;
+
+        /** Name of the field being parsed. */
+        private String currentField;
+
+        /** Value of the field being parsed. */
+        private final StringBuilder currentValue = new StringBuilder();
 
         /**
          * Save a reference to a connection to a Solr core/collection.

--- a/dspace-api/src/main/java/org/dspace/app/authority/SolrQueryWindow.java
+++ b/dspace-api/src/main/java/org/dspace/app/authority/SolrQueryWindow.java
@@ -94,7 +94,7 @@ class SolrQueryWindow
     @Override
     public boolean hasNext() {
         LOG.debug("hasNext:  results.getNumFound = {}; windowStart = {}; windowPos = {}",
-                ()->results.getNumFound(), ()->windowStart, ()->windowPos);
+            () -> results.getNumFound(), () -> windowStart, () -> windowPos);
         return results.getNumFound() > windowStart + windowPos;
     }
 

--- a/dspace-api/src/main/java/org/dspace/app/authority/SolrQueryWindow.java
+++ b/dspace-api/src/main/java/org/dspace/app/authority/SolrQueryWindow.java
@@ -18,6 +18,8 @@ import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Wrap a Solr query in an Iterator, repeatedly executing the query while moving
@@ -27,6 +29,8 @@ import org.apache.solr.common.params.SolrParams;
  */
 class SolrQueryWindow
         implements Iterable<SolrDocument>, Iterator<SolrDocument> {
+    private static final Logger LOG = LoggerFactory.getLogger(SolrQueryWindow.class);
+
     /** Fetch this many results at a time. */
     private static final int WINDOW_SIZE = 100;
 
@@ -68,6 +72,7 @@ class SolrQueryWindow
             throws SolrServerException, IOException {
         windowStart += WINDOW_SIZE;
         params.set("start", windowStart);
+        LOG.debug("refill:  windowStart = {}", windowStart);
         QueryResponse response = solr.query(params);
         results = response.getResults();
         windowPos = 0;
@@ -88,7 +93,9 @@ class SolrQueryWindow
 
     @Override
     public boolean hasNext() {
-        return results.getNumFound() < windowStart + windowPos;
+        LOG.debug("hasNext:  results.getNumFound = {}; windowStart = {}; windowPos = {}",
+                results.getNumFound(), windowStart, windowPos);
+        return results.getNumFound() > windowStart + windowPos;
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/app/authority/SolrQueryWindow.java
+++ b/dspace-api/src/main/java/org/dspace/app/authority/SolrQueryWindow.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019 Mark H. Wood.
+ */
+
+package org.dspace.app.authority;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrDocumentList;
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.common.params.SolrParams;
+
+/**
+ * Wrap a Solr query in an Iterator, repeatedly executing the query while moving
+ * a fixed-sized window across the results until all have been returned.
+ *
+ * @author mhwood
+ */
+class SolrQueryWindow implements Iterable<SolrDocument>, Iterator<SolrDocument> {
+    /** Fetch this many results at a time. */
+    private static final int WINDOW_SIZE = 100;
+
+    /** Where we send queries and whence we get results. */
+    private final HttpSolrClient solr;
+
+    /** Caller's Solr query parameters, augmented with {@code start} and {@code rows}. */
+    private final ModifiableSolrParams params;
+
+    /** Current offset of the window within the total result set. */
+    private int windowStart = 0;
+
+    /** Current position within the results window. */
+    private int windowPos;
+
+    /** Content of the results window. */
+    private SolrDocumentList results;
+
+    /**
+     * Holds a Solr connection, a query, and the current window of results.
+     *
+     * @param solr connection to a Solr core/collection.
+     * @param params description of the query.  Any {@code start} and
+     *          {@code rows} parameters will be ignored.
+     */
+    SolrQueryWindow(HttpSolrClient solr, SolrParams params)
+            throws SolrServerException, IOException {
+        this.solr = solr;
+        this.params = new ModifiableSolrParams(params);
+
+        // Initialize the results window.
+        this.params.set("start", windowStart);
+        this.params.set("rows", WINDOW_SIZE);
+        refill();
+    }
+
+    /** Position the window, perform partial query, advance the window. */
+    private void refill()
+            throws SolrServerException, IOException {
+        params.set("start", windowStart);
+        QueryResponse response = solr.query(params);
+        results = response.getResults();
+        windowStart += WINDOW_SIZE;
+        windowPos = 0;
+    }
+
+    @Override
+    public Iterator<SolrDocument> iterator() {
+        return this;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return results.getNumFound() < windowStart + windowPos;
+    }
+
+    @Override
+    public SolrDocument next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException("All contents consumed.");
+        }
+        if (windowPos > results.size()) {
+            try {
+                refill();
+            } catch (SolrServerException | IOException ex) {
+                throw new NoSuchElementException("Unable to refill window:  " + ex.getMessage());
+            }
+        }
+        return results.get(windowPos++);
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/app/authority/SolrQueryWindow.java
+++ b/dspace-api/src/main/java/org/dspace/app/authority/SolrQueryWindow.java
@@ -103,7 +103,7 @@ class SolrQueryWindow
         if (!hasNext()) {
             throw new NoSuchElementException("All contents consumed.");
         }
-        if (windowPos > results.size()) {
+        if (windowPos >= results.size()) {
             try {
                 refill();
             } catch (SolrServerException | IOException ex) {

--- a/dspace-api/src/main/java/org/dspace/app/authority/SolrQueryWindow.java
+++ b/dspace-api/src/main/java/org/dspace/app/authority/SolrQueryWindow.java
@@ -11,6 +11,8 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.response.QueryResponse;
@@ -18,8 +20,6 @@ import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Wrap a Solr query in an Iterator, repeatedly executing the query while moving
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 class SolrQueryWindow
         implements Iterable<SolrDocument>, Iterator<SolrDocument> {
-    private static final Logger LOG = LoggerFactory.getLogger(SolrQueryWindow.class);
+    private static final Logger LOG = LogManager.getLogger(SolrQueryWindow.class);
 
     /** Fetch this many results at a time. */
     private static final int WINDOW_SIZE = 100;
@@ -94,7 +94,7 @@ class SolrQueryWindow
     @Override
     public boolean hasNext() {
         LOG.debug("hasNext:  results.getNumFound = {}; windowStart = {}; windowPos = {}",
-                results.getNumFound(), windowStart, windowPos);
+                ()->results.getNumFound(), ()->windowStart, ()->windowPos);
         return results.getNumFound() > windowStart + windowPos;
     }
 

--- a/dspace-api/src/main/java/org/dspace/app/authority/package-info.java
+++ b/dspace-api/src/main/java/org/dspace/app/authority/package-info.java
@@ -1,0 +1,13 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+/**
+ * Command line utilities for working with the authority index.
+ */
+
+package org.dspace.app.authority;

--- a/dspace-api/src/main/resources/org/dspace/app/authority/authority-dump.xsd
+++ b/dspace-api/src/main/resources/org/dspace/app/authority/authority-dump.xsd
@@ -1,18 +1,33 @@
 <?xml version='1.0'  encoding='UTF-8'?>
 <!--
-Copyright 2019 Mark H. Wood.
--->
 
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+-->
 <xs:schema version="1.0"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
            elementFormDefault="qualified">
     <xs:element name="authority-dump">
+        <xs:annotation>
+            <xs:documentation>Snapshot of the content of a DSpace instance's authority records.</xs:documentation>
+        </xs:annotation>
         <xs:complexType>
             <xs:sequence>
                 <xs:element name='r' minOccurs='0' maxOccurs='unbounded'>
+                    <xs:annotation>
+                        <xs:documentation>Record (a Solr document)</xs:documentation>
+                    </xs:annotation>
                     <xs:complexType>
                         <xs:sequence>
-                            <xs:element name='f' type='pcdata' minOccurs='0' maxOccurs='unbounded'/>
+                            <xs:element name='f' type='xs:string' minOccurs='0' maxOccurs='unbounded'>
+                                <xs:annotation>
+                                    <xs:documentation>Field within a Solr document</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
                         </xs:sequence>
                     </xs:complexType>
                 </xs:element>

--- a/dspace-api/src/main/resources/org/dspace/app/authority/authority-dump.xsd
+++ b/dspace-api/src/main/resources/org/dspace/app/authority/authority-dump.xsd
@@ -1,0 +1,22 @@
+<?xml version='1.0'  encoding='UTF-8'?>
+<!--
+Copyright 2019 Mark H. Wood.
+-->
+
+<xs:schema version="1.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified">
+    <xs:element name="authority-dump">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name='r' minOccurs='0' maxOccurs='unbounded'>
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name='f' type='pcdata' minOccurs='0' maxOccurs='unbounded'/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/dspace-api/src/main/resources/org/dspace/app/authority/authority-dump.xsd
+++ b/dspace-api/src/main/resources/org/dspace/app/authority/authority-dump.xsd
@@ -23,10 +23,17 @@
                     </xs:annotation>
                     <xs:complexType>
                         <xs:sequence>
-                            <xs:element name='f' type='xs:string' minOccurs='0' maxOccurs='unbounded'>
-                                <xs:annotation>
-                                    <xs:documentation>Field within a Solr document</xs:documentation>
-                                </xs:annotation>
+                            <xs:element name='f' minOccurs='0' maxOccurs='unbounded'>
+                                <xs:complexType>
+                                    <xs:simpleContent>
+                                        <xs:annotation>
+                                            <xs:documentation>Field within a Solr document</xs:documentation>
+                                        </xs:annotation>
+                                        <xs:extension base='xs:string'>
+                                            <xs:attribute name='name'/>
+                                        </xs:extension>
+                                    </xs:simpleContent>
+                                </xs:complexType>
                             </xs:element>
                         </xs:sequence>
                     </xs:complexType>

--- a/dspace/config/launcher.xml
+++ b/dspace/config/launcher.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0"?>
 <commands>
     <command>
+        <name>authority</name>
+        <description>Dump or restore the authority index</description>
+        <step>
+            <class>org.dspace.app.authority.Commands</class>
+        </step>
+    </command>
+    <command>
         <name>bitstore-migrate</name>
         <description>Assetstore migration tool</description>
         <step>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-4187
WIP because I need to find a way to generate some authority records for testing.  At this moment the tool has been tested only on an empty authority core (and it succeeds).

'dspace authority -d' dumps the core to standard out.
'dspace authority -r' loads a dump from standard in.  Add '-c' to remove all existing authority records first.