### PR TITLE
[DS-4197] StatisticsDataVisits: Use dso length value

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
@@ -781,6 +781,7 @@ public class StatisticsDataVisits extends StatisticsData {
         public void setDso(DSpaceObject dso, int dsoType, int length) {
             this.dsoType = dsoType;
             this.dso = dso;
+            this.dsoLength = length;
         }
 
         public void setDsoType(int dsoType) {


### PR DESCRIPTION
The supplied length was unused before and always got initialized with 0.

https://jira.duraspace.org/browse/DS-4197
Fixes #7537 

_(I will backport this fix to dspace-6_x once merged in master. A backport to dspace-5_x is not required because this bug was introduced in dspace-6_x.)_