### PR TITLE
DS-4198: Create On-Demand build of Docker Image for a PR

### DIFF
--- a/Dockerfile.jdk8-test
+++ b/Dockerfile.jdk8-test
@@ -11,6 +11,8 @@
 # Step 1 - Run Maven Build
 FROM dspace/dspace-dependencies:dspace-7_x as build
 ARG TARGET_DIR=dspace-installer
+# The docker hub build will set the following environment variable
+ARG DOCKER_TAG=${DOCKER_TAG}
 WORKDIR /app
 
 # The dspace-install directory will be written to /install
@@ -23,6 +25,14 @@ USER dspace
 # Copy the DSpace source code into the workdir (excluding .dockerignore contents)
 ADD --chown=dspace . /app/
 COPY dspace/src/main/docker/local.cfg /app/local.cfg
+
+# if DOCKER_TAG is in the format prNNNN then merge code for that PR on top of the current branch
+RUN PRNUM=`echo ${DOCKER_TAG}| egrep "^pr([0-9]+)$" | sed -e s/pr//` && \
+    if [ -n $PRNUM ]; \ 
+    then echo "Merging $PRNUM"; \
+      curl -o /tmp/pr.patch -L https://github.com/DSpace/DSpace/pull/$PRNUM.diff; \
+      git apply /tmp/pr.patch; \
+    fi
 
 # Build DSpace.  Copy the dspace-install directory to /install.  Clean up the build to keep the docker image small
 RUN mvn package && \

--- a/Dockerfile.jdk8-test
+++ b/Dockerfile.jdk8-test
@@ -26,7 +26,7 @@ USER dspace
 ADD --chown=dspace . /app/
 COPY dspace/src/main/docker/local.cfg /app/local.cfg
 
-RUN echo "****** DOCKER_TAG=${DOCKER_TAG}"
+RUN env
 RUN zzzz #force fail
 
 # if DOCKER_TAG is in the format prNNNN then merge code for that PR on top of the current branch

--- a/Dockerfile.jdk8-test
+++ b/Dockerfile.jdk8-test
@@ -26,9 +26,6 @@ USER dspace
 ADD --chown=dspace . /app/
 COPY dspace/src/main/docker/local.cfg /app/local.cfg
 
-RUN env
-RUN zzzz #force fail
-
 # if DOCKER_TAG is in the format prNNNN then merge code for that PR on top of the current branch
 RUN PRNUM=`echo ${DOCKER_TAG}| egrep "^pr([0-9]+)$" | sed -e s/pr//` && \
     if [ -n "$PRNUM" ]; \ 

--- a/Dockerfile.jdk8-test
+++ b/Dockerfile.jdk8-test
@@ -27,7 +27,7 @@ ADD --chown=dspace . /app/
 COPY dspace/src/main/docker/local.cfg /app/local.cfg
 
 RUN echo "****** DOCKER_TAG=${DOCKER_TAG}"
-zzzz #force fail
+RUN zzzz #force fail
 
 # if DOCKER_TAG is in the format prNNNN then merge code for that PR on top of the current branch
 RUN PRNUM=`echo ${DOCKER_TAG}| egrep "^pr([0-9]+)$" | sed -e s/pr//` && \

--- a/Dockerfile.jdk8-test
+++ b/Dockerfile.jdk8-test
@@ -26,6 +26,9 @@ USER dspace
 ADD --chown=dspace . /app/
 COPY dspace/src/main/docker/local.cfg /app/local.cfg
 
+RUN echo "****** DOCKER_TAG=${DOCKER_TAG}"
+zzzz #force fail
+
 # if DOCKER_TAG is in the format prNNNN then merge code for that PR on top of the current branch
 RUN PRNUM=`echo ${DOCKER_TAG}| egrep "^pr([0-9]+)$" | sed -e s/pr//` && \
     if [ -n "$PRNUM" ]; \ 

--- a/Dockerfile.jdk8-test
+++ b/Dockerfile.jdk8-test
@@ -28,7 +28,7 @@ COPY dspace/src/main/docker/local.cfg /app/local.cfg
 
 # if DOCKER_TAG is in the format prNNNN then merge code for that PR on top of the current branch
 RUN PRNUM=`echo ${DOCKER_TAG}| egrep "^pr([0-9]+)$" | sed -e s/pr//` && \
-    if [ -n $PRNUM ]; \ 
+    if [ -n "$PRNUM" ]; \ 
     then echo "Merging $PRNUM"; \
       curl -o /tmp/pr.patch -L https://github.com/DSpace/DSpace/pull/$PRNUM.diff; \
       git apply /tmp/pr.patch; \

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,1 @@
+docker build --build-arg DOCKER_TAG=$DOCKER_TAG -f $DOCKERFILE_PATH -t $IMAGE_NAME .

--- a/hooks/build
+++ b/hooks/build
@@ -1,1 +1,2 @@
+#!/bin/bash
 docker build --build-arg DOCKER_TAG=$DOCKER_TAG -f $DOCKERFILE_PATH -t $IMAGE_NAME .


### PR DESCRIPTION
### Background Links
- https://github.com/DSpace-Labs/DSpace-Docker-Images/issues/103
- https://jira.duraspace.org/browse/DS-4198

The automated builds could be configured as follows

![image](https://user-images.githubusercontent.com/1111057/54958696-d818fd00-4f13-11e9-82cb-641efb0694f2.png)

A committer or contributor with DockerHub build rights could trigger the build the of image.

When the tag name is in the form prNNNN, the appropriate PR code will be merged before the maven build.  See the following sample output.

```
Step 9/28 : RUN PRNUM=`echo ${DOCKER_TAG}| egrep "^pr([0-9]+)$" | sed -e s/pr//` && if [ -n "$PRNUM" ]; then echo "Merging $PRNUM"; curl -o /tmp/pr.patch -L https://github.com/DSpace/DSpace/pull/$PRNUM.diff; git apply /tmp/pr.patch; fi
---> Running in 326e043de993
Merging 2379
% Total % Received % Xferd Average Speed Time Time Time Current
Dload Upload Total Spent Left Speed
0 0 0 0 0 0 0 0 --:--:-- --:--:-- --:--:-- 0 100 139 0 139 0 0 583 0 --:--:-- --:--:-- --:--:-- 584
100 1593 0 1593 0 0 3520 0 --:--:-- --:--:-- --:--:-- 3520
Removing intermediate container 326e043de993
```
## Note that a dockerhub build hook is needed to pass the tag to the build

- The build hook must be relative to the dockerfile
- ~~Is it time to move all the Dockerfiles to dspace/src/main/docker?~~
  - The old dockerhub build system did not permit this