### PR TITLE
[DS-4200] IPMatcher: Fix netmask conversion

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/IPMatcher.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/IPMatcher.java
@@ -87,13 +87,16 @@ public class IPMatcher {
                                                          + ipSpec);
                     }
 
-                    int maskBytes = maskBits / 8;
-                    for (int i = 0; i < maskBytes; i++) {
-                        netmask[i] = (byte) 0Xff;
-                    }
-                    netmask[maskBytes] = (byte) ((byte) 0Xff << 8 - (maskBits % 8)); // FIXME test!
-                    for (int i = maskBytes + 1; i < (128 / 8); i++) {
-                        netmask[i] = 0;
+                    for (int i = 0; i < netmask.length; i++) {
+                        if (maskBits <= 0) {
+                            netmask[i] = 0;
+                        } else if (maskBits > 8) {
+                            netmask[i] = (byte) 0Xff;
+                        } else {
+                            netmask[i] = (byte) ((byte) 0Xff << 8 - maskBits);
+                        }
+
+                        maskBits = maskBits - 8;
                     }
                     break;
                 case 1: // No explicit mask:  fill the mask with 1s

--- a/dspace-api/src/test/java/org/dspace/authenticate/IPMatcherTest.java
+++ b/dspace-api/src/test/java/org/dspace/authenticate/IPMatcherTest.java
@@ -153,6 +153,14 @@ public class IPMatcherTest {
         assertFalse(ipMatcher.match("0:0:0:0:0:0:0:1"));
     }
 
+    @Test
+    public void testIPv6FullMaskMatching() throws Exception {
+        final IPMatcher ipMatcher = new IPMatcher("::2/128");
+
+        assertTrue(ipMatcher.match("0:0:0:0:0:0:0:2"));
+        assertFalse(ipMatcher.match("0:0:0:0:0:0:0:1"));
+    }
+
 
     @Test
     public void testAsteriskMatchingSuccess() throws Exception {


### PR DESCRIPTION
The old netmask conversion code (from prefix length to a bitmask) did not work for a 128 prefix.

https://jira.duraspace.org/browse/DS-4200

_(I will backport this fix to dspace-6_x and dspace-5_x once merged into master.)_