### PR TITLE
[DS-3823] Our extensive EHCache configuration is ignored

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/CacheSnooper.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/CacheSnooper.java
@@ -1,0 +1,49 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+package org.dspace.app.util;
+
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheManager;
+import org.dspace.core.Context;
+import org.dspace.servicemanager.DSpaceKernelImpl;
+import org.dspace.servicemanager.DSpaceKernelInit;
+import org.dspace.services.CachingService;
+
+/**
+ * List all EhCache CacheManager and Cache instances.
+ *
+ * @author Mark H. Wood <mwood@iupui.edu>
+ */
+public class CacheSnooper {
+    private CacheSnooper() { }
+
+    public static void main(String[] argv) {
+        // Ensure that the DSpace kernel is started.
+        DSpaceKernelImpl kernel = DSpaceKernelInit.getKernel(null);
+
+        // Ensure that the services cache manager is started.
+        CachingService serviceCaches = kernel.getServiceManager()
+                .getServiceByName(null, CachingService.class);
+
+        // Ensure that the database layer is started.
+        Context ctx = new Context();
+
+        // List those caches!
+        for (CacheManager manager : CacheManager.ALL_CACHE_MANAGERS) {
+            System.out.format("CacheManager:  %s%n", manager);
+            for (String cacheName : manager.getCacheNames()) {
+                Cache cache = manager.getCache(cacheName);
+                System.out.format("       Cache:  '%s'; maxHeap:  %d; maxDisk:  %d%n",
+                        cacheName,
+                        cache.getCacheConfiguration().getMaxEntriesLocalHeap(),
+                        cache.getCacheConfiguration().getMaxEntriesLocalDisk());
+            }
+        }
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/app/util/CacheSnooper.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/CacheSnooper.java
@@ -18,6 +18,15 @@ import org.dspace.services.CachingService;
 /**
  * List all EhCache CacheManager and Cache instances.
  *
+ * <p>This is a debugging tool, not used in the daily operation of DSpace.
+ * Just run it from the installed instance using
+ * {@code bin/dspace dsrun org.dspace.app.util.CacheSnooper}
+ * to check that the cache configuration is what you expect it to be,
+ * given your configuration.
+ *
+ * <p>This was created to prove a specific cache configuration patch,
+ * but I leave it here in the hope that it may be useful to others.
+ *
  * @author Mark H. Wood <mwood@iupui.edu>
  */
 public class CacheSnooper {

--- a/dspace-services/src/main/resources/spring/spring-dspace-core-services.xml
+++ b/dspace-services/src/main/resources/spring/spring-dspace-core-services.xml
@@ -39,7 +39,8 @@
     <bean id="org.dspace.caching.ehcache.CacheManager"
           class="org.springframework.cache.ehcache.EhCacheManagerFactoryBean">
         <property name="configLocation">
-            <bean class="org.dspace.servicemanager.spring.ResourceFinder" factory-method="getResourceFromPaths">
+            <bean class="org.dspace.servicemanager.spring.ResourceFinder"
+                  factory-method="getResourceFromPaths">
                 <constructor-arg>
                     <list>
                         <value>ehcache-config.xml</value>
@@ -48,7 +49,8 @@
                 </constructor-arg>
             </bean>
         </property>
-        <property name="shared" value="true"/>
+        <property name='acceptExisting' value='true'/>
+        <property name='cacheManagerName' value='org.dspace.services'/>
     </bean>
     <!-- CACHING end beans -->
 

--- a/dspace/config/hibernate-ehcache-config.xml
+++ b/dspace/config/hibernate-ehcache-config.xml
@@ -10,7 +10,8 @@
 -->
 <ehcache xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="ehcache.xsd"
-         updateCheck='false'>
+         updateCheck='false'
+         name='org.dspace.hibernate'>
 
     <diskStore path="java.io.tmpdir"/>
 

--- a/dspace/config/hibernate.cfg.xml
+++ b/dspace/config/hibernate.cfg.xml
@@ -21,7 +21,7 @@
         <!--Second level cache configuration-->
         <property name="hibernate.cache.use_query_cache">true</property>
         <property name="hibernate.cache.use_second_level_cache">true</property>
-        <property name="hibernate.cache.region.factory_class">org.hibernate.cache.ehcache.SingletonEhCacheRegionFactory</property>
+        <property name="hibernate.cache.region.factory_class">org.hibernate.cache.ehcache.EhCacheRegionFactory</property>
         <property name="hibernate.cache.use_structured_entries">true</property>
         <property name="javax.persistence.sharedCache.mode">ENABLE_SELECTIVE</property>
         <!-- Set in config/spring/api/core-hibernate.xml -->


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3823
This patch is meant to give dspace-services and Hibernate distinct EhCache ``CacheManager``s so that they can have different configurations.  EhCache has been ignoring our carefully detailed Hibernate cache configuration because it already had a CacheManager with the default name and was re-using it.  That could have performance implications.