### PR TITLE
[DS-4215] - ItemCounter loads from database unnecessarily communities and collections

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -2244,7 +2244,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
     protected String transformDisplayedValue(Context context, String field, String value) throws SQLException {
         if(field.equals("location.comm") || field.equals("location.coll"))
         {
-            value = locationToName(context, field, value);
+            return value;
         }
         else if (field.endsWith("_filter") || field.endsWith("_ac")
           || field.endsWith("_acid"))
@@ -2312,7 +2312,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
     protected String transformSortValue(Context context, String field, String value) throws SQLException {
         if(field.equals("location.comm") || field.equals("location.coll"))
         {
-            value = locationToName(context, field, value);
+            return value;
         }
         else if (field.endsWith("_filter") || field.endsWith("_ac")
                 || field.endsWith("_acid"))


### PR DESCRIPTION
This is a quick PR for DS-4215 for testing the performance of the change. It removes the calls to the function that gets the name of the community/collection from database (function locationToName). 

It is not intended to be included directly in the source code because removes code that could be useful for creating a facet of communities/collections. If this fix improves the performance could be refactored to not remove this part of code.


