### PR TITLE
Rename virtual bean virtual metadata configuration

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -44,7 +44,7 @@ import org.dspace.content.service.ItemService;
 import org.dspace.content.service.MetadataSchemaService;
 import org.dspace.content.service.RelationshipService;
 import org.dspace.content.service.WorkspaceItemService;
-import org.dspace.content.virtual.VirtualMetadataPopularConfiguration;
+import org.dspace.content.virtual.VirtualMetadataConfiguration;
 import org.dspace.content.virtual.VirtualMetadataPopulator;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
@@ -1424,7 +1424,7 @@ prevent the generation of resource policy entry values with null dspace_object a
         throws SQLException {
         List<RelationshipMetadataValue> resultingMetadataValueList = new LinkedList<>();
         RelationshipType relationshipType = relationship.getRelationshipType();
-        HashMap<String, VirtualMetadataPopularConfiguration> hashMaps;
+        HashMap<String, VirtualMetadataConfiguration> hashMaps;
         String relationName = "";
         Item otherItem = null;
         int place = 0;
@@ -1460,14 +1460,14 @@ prevent the generation of resource policy entry values with null dspace_object a
     //hashmaps parameter. The beans will be used to retrieve the values for the RelationshipMetadataValue objects
     //and the keys of the hashmap will be used to construct the RelationshipMetadataValue object.
     private List<RelationshipMetadataValue> handleRelationshipTypeMetadataMapping(Context context, Item item,
-                                                HashMap<String, VirtualMetadataPopularConfiguration> hashMaps,
+                                                HashMap<String, VirtualMetadataConfiguration> hashMaps,
                                                                                   Item otherItem, String relationName,
                                                                                   Integer relationshipId, int place)
         throws SQLException {
         List<RelationshipMetadataValue> resultingMetadataValueList = new LinkedList<>();
-        for (Map.Entry<String, VirtualMetadataPopularConfiguration> entry : hashMaps.entrySet()) {
+        for (Map.Entry<String, VirtualMetadataConfiguration> entry : hashMaps.entrySet()) {
             String key = entry.getKey();
-            VirtualMetadataPopularConfiguration virtualBean = entry.getValue();
+            VirtualMetadataConfiguration virtualBean = entry.getValue();
 
             for (String value : virtualBean.getValues(context, otherItem)) {
                 RelationshipMetadataValue metadataValue = constructMetadataValue(context, key);

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -1460,8 +1460,7 @@ prevent the generation of resource policy entry values with null dspace_object a
     //hashmaps parameter. The beans will be used to retrieve the values for the RelationshipMetadataValue objects
     //and the keys of the hashmap will be used to construct the RelationshipMetadataValue object.
     private List<RelationshipMetadataValue> handleRelationshipTypeMetadataMapping(Context context, Item item,
-                                                                                  HashMap<String, VirtualMetadataPopularConfiguration>
-                                                                                      hashMaps,
+                                                HashMap<String, VirtualMetadataPopularConfiguration> hashMaps,
                                                                                   Item otherItem, String relationName,
                                                                                   Integer relationshipId, int place)
         throws SQLException {

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -44,7 +44,7 @@ import org.dspace.content.service.ItemService;
 import org.dspace.content.service.MetadataSchemaService;
 import org.dspace.content.service.RelationshipService;
 import org.dspace.content.service.WorkspaceItemService;
-import org.dspace.content.virtual.VirtualBean;
+import org.dspace.content.virtual.VirtualMetadataPopularConfiguration;
 import org.dspace.content.virtual.VirtualMetadataPopulator;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
@@ -1424,7 +1424,7 @@ prevent the generation of resource policy entry values with null dspace_object a
         throws SQLException {
         List<RelationshipMetadataValue> resultingMetadataValueList = new LinkedList<>();
         RelationshipType relationshipType = relationship.getRelationshipType();
-        HashMap<String, VirtualBean> hashMaps;
+        HashMap<String, VirtualMetadataPopularConfiguration> hashMaps;
         String relationName = "";
         Item otherItem = null;
         int place = 0;
@@ -1460,15 +1460,15 @@ prevent the generation of resource policy entry values with null dspace_object a
     //hashmaps parameter. The beans will be used to retrieve the values for the RelationshipMetadataValue objects
     //and the keys of the hashmap will be used to construct the RelationshipMetadataValue object.
     private List<RelationshipMetadataValue> handleRelationshipTypeMetadataMapping(Context context, Item item,
-                                                                                  HashMap<String, VirtualBean>
+                                                                                  HashMap<String, VirtualMetadataPopularConfiguration>
                                                                                       hashMaps,
                                                                                   Item otherItem, String relationName,
                                                                                   Integer relationshipId, int place)
         throws SQLException {
         List<RelationshipMetadataValue> resultingMetadataValueList = new LinkedList<>();
-        for (Map.Entry<String, VirtualBean> entry : hashMaps.entrySet()) {
+        for (Map.Entry<String, VirtualMetadataPopularConfiguration> entry : hashMaps.entrySet()) {
             String key = entry.getKey();
-            VirtualBean virtualBean = entry.getValue();
+            VirtualMetadataPopularConfiguration virtualBean = entry.getValue();
 
             for (String value : virtualBean.getValues(context, otherItem)) {
                 RelationshipMetadataValue metadataValue = constructMetadataValue(context, key);

--- a/dspace-api/src/main/java/org/dspace/content/virtual/Collected.java
+++ b/dspace-api/src/main/java/org/dspace/content/virtual/Collected.java
@@ -18,13 +18,13 @@ import org.dspace.core.Context;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * A bean implementing the {@link VirtualMetadataPopularConfiguration} interface to achieve the generation of Virtual
+ * A bean implementing the {@link VirtualMetadataConfiguration} interface to achieve the generation of Virtual
  * metadata
  * The Collected bean will take all the values of each metadata field defined in the list and it'll
  * create a list of virtual metadata fields defined by the map in which it's defined.
  * All values from the metadata fields will returned as separate elements
  */
-public class Collected implements VirtualMetadataPopularConfiguration {
+public class Collected implements VirtualMetadataConfiguration {
 
     @Autowired
     private ItemService itemService;

--- a/dspace-api/src/main/java/org/dspace/content/virtual/Collected.java
+++ b/dspace-api/src/main/java/org/dspace/content/virtual/Collected.java
@@ -18,12 +18,13 @@ import org.dspace.core.Context;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * A bean implementing the {@link VirtualBean} interface to achieve the generation of Virtual metadata
+ * A bean implementing the {@link VirtualMetadataPopularConfiguration} interface to achieve the generation of Virtual
+ * metadata
  * The Collected bean will take all the values of each metadata field defined in the list and it'll
  * create a list of virtual metadata fields defined by the map in which it's defined.
  * All values from the metadata fields will returned as separate elements
  */
-public class Collected implements VirtualBean {
+public class Collected implements VirtualMetadataPopularConfiguration {
 
     @Autowired
     private ItemService itemService;

--- a/dspace-api/src/main/java/org/dspace/content/virtual/Concatenate.java
+++ b/dspace-api/src/main/java/org/dspace/content/virtual/Concatenate.java
@@ -18,14 +18,14 @@ import org.dspace.core.Context;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * A bean implementing the {@link VirtualMetadataPopularConfiguration} interface to achieve the generation of Virtual
+ * A bean implementing the {@link VirtualMetadataConfiguration} interface to achieve the generation of Virtual
  * metadata
  * The Concatenate bean will take all the values of each metadata field configured in the list
  * and it will join all of these together with the separator defined in this bean. This means that whichever
  * entry this bean belongs to, that metadata field will have the value of the related item's metadata values
  * joined together with this separator. Only one value will be returned
  */
-public class Concatenate implements VirtualMetadataPopularConfiguration {
+public class Concatenate implements VirtualMetadataConfiguration {
 
     @Autowired
     private ItemService itemService;

--- a/dspace-api/src/main/java/org/dspace/content/virtual/Concatenate.java
+++ b/dspace-api/src/main/java/org/dspace/content/virtual/Concatenate.java
@@ -18,13 +18,14 @@ import org.dspace.core.Context;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * A bean implementing the {@link VirtualBean} interface to achieve the generation of Virtual metadata
+ * A bean implementing the {@link VirtualMetadataPopularConfiguration} interface to achieve the generation of Virtual
+ * metadata
  * The Concatenate bean will take all the values of each metadata field configured in the list
  * and it will join all of these together with the separator defined in this bean. This means that whichever
  * entry this bean belongs to, that metadata field will have the value of the related item's metadata values
  * joined together with this separator. Only one value will be returned
  */
-public class Concatenate implements VirtualBean {
+public class Concatenate implements VirtualMetadataPopularConfiguration {
 
     @Autowired
     private ItemService itemService;

--- a/dspace-api/src/main/java/org/dspace/content/virtual/Related.java
+++ b/dspace-api/src/main/java/org/dspace/content/virtual/Related.java
@@ -108,9 +108,11 @@ public class Related implements VirtualMetadataPopularConfiguration {
 
     /**
      * Generic setter for the virtualMetadataPopularConfiguration property of this class
-     * @param virtualMetadataPopularConfiguration   The VirtualBean to which the virtualMetadataPopularConfiguration property will be set to
+     * @param virtualMetadataPopularConfiguration   The VirtualBean to which the
+     *                                             virtualMetadataPopularConfiguration property will be set to
      */
-    public void setVirtualMetadataPopularConfiguration(VirtualMetadataPopularConfiguration virtualMetadataPopularConfiguration) {
+    public void setVirtualMetadataPopularConfiguration(VirtualMetadataPopularConfiguration
+                                                               virtualMetadataPopularConfiguration) {
         this.virtualMetadataPopularConfiguration = virtualMetadataPopularConfiguration;
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/virtual/Related.java
+++ b/dspace-api/src/main/java/org/dspace/content/virtual/Related.java
@@ -25,16 +25,16 @@ import org.dspace.core.Context;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * A bean implementing the {@link VirtualBean} interface to achieve the generation of Virtual metadata
- * by traversing the path of relation specified in the config for this bean
+ * A bean implementing the {@link VirtualMetadataPopularConfiguration} interface to achieve the generation of
+ * Virtual metadata by traversing the path of relation specified in the config for this bean
  * The Related bean will find the relationshiptype defined in the relationshipTypeString property on
- * the current item and it'll use the related item from that relationship to pass it along to the virtualBean
- * property which in turn refers to another VirtualBean instance and it continues the chain until it reaches
- * either a Concatenate or Collected bean to retrieve the values. It will then return that value through the chain
- * again and it'll fill the values into the virtual metadata fields that are defined in the map for the first
- * Related bean.
+ * the current item and it'll use the related item from that relationship to pass it along to the
+ * virtualMetadataPopularConfiguration property which in turn refers to another VirtualBean instance and it continues
+ * the chain until it reaches either a Concatenate or Collected bean to retrieve the values. It will then return
+ * that value through the chain again and it'll fill the values into the virtual metadata fields that are defined
+ * in the map for the first Related bean.
  */
-public class Related implements VirtualBean {
+public class Related implements VirtualMetadataPopularConfiguration {
 
     @Autowired
     private RelationshipTypeService relationshipTypeService;
@@ -59,7 +59,7 @@ public class Related implements VirtualBean {
     /**
      * The next bean to call its getValues() method on
      */
-    private VirtualBean virtualBean;
+    private VirtualMetadataPopularConfiguration virtualMetadataPopularConfiguration;
 
     /**
      * The boolean value indicating whether this field should be used for place or not
@@ -99,19 +99,19 @@ public class Related implements VirtualBean {
     }
 
     /**
-     * Generic getter for the virtualBean property of this class
-     * @return  The virtualBean property
+     * Generic getter for the virtualMetadataPopularConfiguration property of this class
+     * @return  The virtualMetadataPopularConfiguration property
      */
-    public VirtualBean getVirtualBean() {
-        return virtualBean;
+    public VirtualMetadataPopularConfiguration getVirtualMetadataPopularConfiguration() {
+        return virtualMetadataPopularConfiguration;
     }
 
     /**
-     * Generic setter for the virtualBean property of this class
-     * @param virtualBean   The VirtualBean to which the virtualBean property will be set to
+     * Generic setter for the virtualMetadataPopularConfiguration property of this class
+     * @param virtualMetadataPopularConfiguration   The VirtualBean to which the virtualMetadataPopularConfiguration property will be set to
      */
-    public void setVirtualBean(VirtualBean virtualBean) {
-        this.virtualBean = virtualBean;
+    public void setVirtualMetadataPopularConfiguration(VirtualMetadataPopularConfiguration virtualMetadataPopularConfiguration) {
+        this.virtualMetadataPopularConfiguration = virtualMetadataPopularConfiguration;
     }
 
     /**
@@ -162,12 +162,12 @@ public class Related implements VirtualBean {
             if (relationship.getRelationshipType().getLeftType() == entityType) {
                 if (relationship.getLeftPlace() == place) {
                     Item otherItem = relationship.getRightItem();
-                    return virtualBean.getValues(context, otherItem);
+                    return virtualMetadataPopularConfiguration.getValues(context, otherItem);
                 }
             } else if (relationship.getRelationshipType().getRightType() == entityType) {
                 if (relationship.getRightPlace() == place) {
                     Item otherItem = relationship.getLeftItem();
-                    return virtualBean.getValues(context, otherItem);
+                    return virtualMetadataPopularConfiguration.getValues(context, otherItem);
                 }
             }
         }

--- a/dspace-api/src/main/java/org/dspace/content/virtual/Related.java
+++ b/dspace-api/src/main/java/org/dspace/content/virtual/Related.java
@@ -25,16 +25,16 @@ import org.dspace.core.Context;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * A bean implementing the {@link VirtualMetadataPopularConfiguration} interface to achieve the generation of
+ * A bean implementing the {@link VirtualMetadataConfiguration} interface to achieve the generation of
  * Virtual metadata by traversing the path of relation specified in the config for this bean
  * The Related bean will find the relationshiptype defined in the relationshipTypeString property on
  * the current item and it'll use the related item from that relationship to pass it along to the
- * virtualMetadataPopularConfiguration property which in turn refers to another VirtualBean instance and it continues
+ * virtualMetadataConfiguration property which in turn refers to another VirtualBean instance and it continues
  * the chain until it reaches either a Concatenate or Collected bean to retrieve the values. It will then return
  * that value through the chain again and it'll fill the values into the virtual metadata fields that are defined
  * in the map for the first Related bean.
  */
-public class Related implements VirtualMetadataPopularConfiguration {
+public class Related implements VirtualMetadataConfiguration {
 
     @Autowired
     private RelationshipTypeService relationshipTypeService;
@@ -59,7 +59,7 @@ public class Related implements VirtualMetadataPopularConfiguration {
     /**
      * The next bean to call its getValues() method on
      */
-    private VirtualMetadataPopularConfiguration virtualMetadataPopularConfiguration;
+    private VirtualMetadataConfiguration virtualMetadataConfiguration;
 
     /**
      * The boolean value indicating whether this field should be used for place or not
@@ -99,21 +99,21 @@ public class Related implements VirtualMetadataPopularConfiguration {
     }
 
     /**
-     * Generic getter for the virtualMetadataPopularConfiguration property of this class
-     * @return  The virtualMetadataPopularConfiguration property
+     * Generic getter for the virtualMetadataConfiguration property of this class
+     * @return  The virtualMetadataConfiguration property
      */
-    public VirtualMetadataPopularConfiguration getVirtualMetadataPopularConfiguration() {
-        return virtualMetadataPopularConfiguration;
+    public VirtualMetadataConfiguration getVirtualMetadataConfiguration() {
+        return virtualMetadataConfiguration;
     }
 
     /**
-     * Generic setter for the virtualMetadataPopularConfiguration property of this class
-     * @param virtualMetadataPopularConfiguration   The VirtualBean to which the
-     *                                             virtualMetadataPopularConfiguration property will be set to
+     * Generic setter for the virtualMetadataConfiguration property of this class
+     * @param virtualMetadataConfiguration   The VirtualBean to which the
+     *                                             virtualMetadataConfiguration property will be set to
      */
-    public void setVirtualMetadataPopularConfiguration(VirtualMetadataPopularConfiguration
-                                                               virtualMetadataPopularConfiguration) {
-        this.virtualMetadataPopularConfiguration = virtualMetadataPopularConfiguration;
+    public void setVirtualMetadataConfiguration(VirtualMetadataConfiguration
+                                                        virtualMetadataConfiguration) {
+        this.virtualMetadataConfiguration = virtualMetadataConfiguration;
     }
 
     /**
@@ -164,12 +164,12 @@ public class Related implements VirtualMetadataPopularConfiguration {
             if (relationship.getRelationshipType().getLeftType() == entityType) {
                 if (relationship.getLeftPlace() == place) {
                     Item otherItem = relationship.getRightItem();
-                    return virtualMetadataPopularConfiguration.getValues(context, otherItem);
+                    return virtualMetadataConfiguration.getValues(context, otherItem);
                 }
             } else if (relationship.getRelationshipType().getRightType() == entityType) {
                 if (relationship.getRightPlace() == place) {
                     Item otherItem = relationship.getLeftItem();
-                    return virtualMetadataPopularConfiguration.getValues(context, otherItem);
+                    return virtualMetadataConfiguration.getValues(context, otherItem);
                 }
             }
         }

--- a/dspace-api/src/main/java/org/dspace/content/virtual/UUIDValue.java
+++ b/dspace-api/src/main/java/org/dspace/content/virtual/UUIDValue.java
@@ -18,7 +18,7 @@ import org.dspace.core.Context;
  * This class is used by the VirtualMetadataPopulator. It will simply take the ID of the item that's passed along
  * to this and return that as it's value
  */
-public class UUIDValue implements VirtualBean {
+public class UUIDValue implements VirtualMetadataPopularConfiguration {
 
     private boolean useForPlace;
 

--- a/dspace-api/src/main/java/org/dspace/content/virtual/UUIDValue.java
+++ b/dspace-api/src/main/java/org/dspace/content/virtual/UUIDValue.java
@@ -18,7 +18,7 @@ import org.dspace.core.Context;
  * This class is used by the VirtualMetadataPopulator. It will simply take the ID of the item that's passed along
  * to this and return that as it's value
  */
-public class UUIDValue implements VirtualMetadataPopularConfiguration {
+public class UUIDValue implements VirtualMetadataConfiguration {
 
     private boolean useForPlace;
 

--- a/dspace-api/src/main/java/org/dspace/content/virtual/VirtualMetadataConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/content/virtual/VirtualMetadataConfiguration.java
@@ -18,7 +18,7 @@ import org.dspace.core.Context;
  * The config is located in core-services.xml whilst the actual code implementation is located in
  * {@link org.dspace.content.ItemServiceImpl}
  */
-public interface VirtualMetadataPopularConfiguration {
+public interface VirtualMetadataConfiguration {
 
     /**
      * This method will return a list filled with String values which will be determine by the bean that's responsible

--- a/dspace-api/src/main/java/org/dspace/content/virtual/VirtualMetadataPopularConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/content/virtual/VirtualMetadataPopularConfiguration.java
@@ -18,7 +18,7 @@ import org.dspace.core.Context;
  * The config is located in core-services.xml whilst the actual code implementation is located in
  * {@link org.dspace.content.ItemServiceImpl}
  */
-public interface VirtualBean {
+public interface VirtualMetadataPopularConfiguration {
 
     /**
      * This method will return a list filled with String values which will be determine by the bean that's responsible

--- a/dspace-api/src/main/java/org/dspace/content/virtual/VirtualMetadataPopulator.java
+++ b/dspace-api/src/main/java/org/dspace/content/virtual/VirtualMetadataPopulator.java
@@ -22,13 +22,13 @@ public class VirtualMetadataPopulator {
     /**
      * The map that holds this representation
      */
-    private Map<String, HashMap<String, VirtualBean>> map;
+    private Map<String, HashMap<String, VirtualMetadataPopularConfiguration>> map;
 
     /**
      * Standard setter for the map
      * @param map   The map to be used in the VirtualMetadataPopulator
      */
-    public void setMap(Map<String, HashMap<String, VirtualBean>> map) {
+    public void setMap(Map<String, HashMap<String, VirtualMetadataPopularConfiguration>> map) {
         this.map = map;
     }
 
@@ -36,7 +36,7 @@ public class VirtualMetadataPopulator {
      * Standard getter for the map
      * @return  The map that is used in the VirtualMetadataPopulator
      */
-    public Map<String, HashMap<String, VirtualBean>> getMap() {
+    public Map<String, HashMap<String, VirtualMetadataPopularConfiguration>> getMap() {
         return map;
     }
 
@@ -48,15 +48,15 @@ public class VirtualMetadataPopulator {
      * @return                  A boolean indicating whether the useForPlace is true or not for the given parameters
      */
     public boolean isUseForPlaceTrueForRelationshipType(RelationshipType relationshipType, boolean isLeft) {
-        HashMap<String, VirtualBean> hashMaps;
+        HashMap<String, VirtualMetadataPopularConfiguration> hashMaps;
         if (isLeft) {
             hashMaps = this.getMap().get(relationshipType.getLeftLabel());
         } else {
             hashMaps = this.getMap().get(relationshipType.getRightLabel());
         }
         if (hashMaps != null) {
-            for (Map.Entry<String, VirtualBean> entry : hashMaps.entrySet()) {
-                VirtualBean virtualBean = entry.getValue();
+            for (Map.Entry<String, VirtualMetadataPopularConfiguration> entry : hashMaps.entrySet()) {
+                VirtualMetadataPopularConfiguration virtualBean = entry.getValue();
                 boolean useForPlace = virtualBean.getUseForPlace();
                 if (useForPlace) {
                     return true;

--- a/dspace-api/src/main/java/org/dspace/content/virtual/VirtualMetadataPopulator.java
+++ b/dspace-api/src/main/java/org/dspace/content/virtual/VirtualMetadataPopulator.java
@@ -22,13 +22,13 @@ public class VirtualMetadataPopulator {
     /**
      * The map that holds this representation
      */
-    private Map<String, HashMap<String, VirtualMetadataPopularConfiguration>> map;
+    private Map<String, HashMap<String, VirtualMetadataConfiguration>> map;
 
     /**
      * Standard setter for the map
      * @param map   The map to be used in the VirtualMetadataPopulator
      */
-    public void setMap(Map<String, HashMap<String, VirtualMetadataPopularConfiguration>> map) {
+    public void setMap(Map<String, HashMap<String, VirtualMetadataConfiguration>> map) {
         this.map = map;
     }
 
@@ -36,7 +36,7 @@ public class VirtualMetadataPopulator {
      * Standard getter for the map
      * @return  The map that is used in the VirtualMetadataPopulator
      */
-    public Map<String, HashMap<String, VirtualMetadataPopularConfiguration>> getMap() {
+    public Map<String, HashMap<String, VirtualMetadataConfiguration>> getMap() {
         return map;
     }
 
@@ -48,15 +48,15 @@ public class VirtualMetadataPopulator {
      * @return                  A boolean indicating whether the useForPlace is true or not for the given parameters
      */
     public boolean isUseForPlaceTrueForRelationshipType(RelationshipType relationshipType, boolean isLeft) {
-        HashMap<String, VirtualMetadataPopularConfiguration> hashMaps;
+        HashMap<String, VirtualMetadataConfiguration> hashMaps;
         if (isLeft) {
             hashMaps = this.getMap().get(relationshipType.getLeftLabel());
         } else {
             hashMaps = this.getMap().get(relationshipType.getRightLabel());
         }
         if (hashMaps != null) {
-            for (Map.Entry<String, VirtualMetadataPopularConfiguration> entry : hashMaps.entrySet()) {
-                VirtualMetadataPopularConfiguration virtualBean = entry.getValue();
+            for (Map.Entry<String, VirtualMetadataConfiguration> entry : hashMaps.entrySet()) {
+                VirtualMetadataConfiguration virtualBean = entry.getValue();
                 boolean useForPlace = virtualBean.getUseForPlace();
                 if (useForPlace) {
                     return true;

--- a/dspace/config/spring/api/virtual-metadata.xml
+++ b/dspace/config/spring/api/virtual-metadata.xml
@@ -37,7 +37,7 @@
 
     <!-- Config like this will tell our VirtualMetadataPopulator to include the virtual metadata field
          'dc.contributor.author' on the appropriate item with the values defined in the value-ref.
-          This value-ref should be a bean of type VirtualBean -->
+          This value-ref should be a bean of type VirtualMetadataPopularConfiguration -->
     <util:map id="isAuthorOfPublicationMap">
         <entry key="dc.contributor.author" value-ref="publicationAuthor_author"/>
     </util:map>
@@ -62,7 +62,7 @@
 
     <!-- Config like this will tell our VirtualMetadataPopulator to include the virtual metadata field
      'dc.contributor.other' on the appropriate item with the values defined in the value-ref.
-      This value-ref should be a bean of type VirtualBean -->
+      This value-ref should be a bean of type VirtualMetadataPopularConfiguration -->
     <util:map id="isOrgUnitOfPublicationMap">
         <entry key="dc.contributor.other" value-ref="publicationOrgUnit_name"/>
     </util:map>
@@ -154,18 +154,18 @@
          alone, we need to pass this call higher up the chain to the journalvolume's relationships to find the journal.
          Therefore we've created this Related bean which will look at the journalvolume's relationships with type
          'isJournalOfVolume' to find the journal that this journalvolume is related to and it'll then call the next
-         VirtualBean with that journal to retrieve the value. This will leave the retrieving of the values to the
-         next bean in the chain -->
+         VirtualMetadataPopularConfiguration with that journal to retrieve the value. This will leave the retrieving
+         of the values to the next bean in the chain -->
     <bean class="org.dspace.content.virtual.Related" id="volumeJournal_issn_related">
         <property name="relationshipTypeString" value="isJournalOfVolume"/>
         <property name="place" value="1"/>
-        <property name="virtualBean" ref="volumeJournal_issn"/>
+        <property name="virtualMetadataPopularConfiguration" ref="volumeJournal_issn"/>
     </bean>
 
     <bean class="org.dspace.content.virtual.Related" id="volumeJournal_title_related">
         <property name="relationshipTypeString" value="isJournalOfVolume"/>
         <property name="place" value="1"/>
-        <property name="virtualBean" ref="volumeJournal_title"/>
+        <property name="virtualMetadataPopularConfiguration" ref="volumeJournal_title"/>
     </bean>
 
     <util:map id="isJournalOfVolumeMap">
@@ -224,39 +224,39 @@
      alone, we need to pass this call higher up the chain to the journalissue's relationships to find the journal.
      Therefore we've created this Related bean which will look at the journalissue's relationships with type
      'isJournalVolumeOfIssue' to find the journalvolume that this journalissue is related to and it'll then call the next
-     VirtualBean with that journalvolume to retrieve the value. This will leave the retrieving of the values to the
-     next bean in the chain.
+     VirtualMetadataPopularConfiguration with that journalvolume to retrieve the value. This will leave the retrieving
+     of the values to the next bean in the chain.
      In this specific case, it'll call another Related bean to retrieve the journal for the journalvolume and it'll
      then retrieve the volume. This example has 2 Related beans chained to eachother to finally chain to a Collected
      bean to retrieve the final value -->
     <bean class="org.dspace.content.virtual.Related" id="issueVolumeJournal_issn_related">
         <property name="relationshipTypeString" value="isJournalVolumeOfIssue"/>
         <property name="place" value="1"/>
-        <property name="virtualBean" ref="volumeJournal_issn_related"/>
+        <property name="virtualMetadataPopularConfiguration" ref="volumeJournal_issn_related"/>
     </bean>
 
     <bean class="org.dspace.content.virtual.Related" id="issueVolumeJournal_title_related">
         <property name="relationshipTypeString" value="isJournalVolumeOfIssue"/>
         <property name="place" value="1"/>
-        <property name="virtualBean" ref="volumeJournal_title_related"/>
+        <property name="virtualMetadataPopularConfiguration" ref="volumeJournal_title_related"/>
     </bean>
 
     <bean class="org.dspace.content.virtual.Related" id="issueVolume_title_related">
         <property name="relationshipTypeString" value="isJournalVolumeOfIssue"/>
         <property name="place" value="1"/>
-        <property name="virtualBean" ref="issueVolume_title"/>
+        <property name="virtualMetadataPopularConfiguration" ref="issueVolume_title"/>
     </bean>
 
     <bean class="org.dspace.content.virtual.Related" id="issueVolumeJournal_uuid_related">
         <property name="relationshipTypeString" value="isJournalVolumeOfIssue"/>
         <property name="place" value="1"/>
-        <property name="virtualBean" ref="volumeJournal_uuid_related"/>
+        <property name="virtualMetadataPopularConfiguration" ref="volumeJournal_uuid_related"/>
     </bean>
 
     <bean class="org.dspace.content.virtual.Related" id="volumeJournal_uuid_related">
         <property name="relationshipTypeString" value="isJournalOfVolume"/>
         <property name="place" value="1"/>
-        <property name="virtualBean" ref="volumeJournal_uuid"/>
+        <property name="virtualMetadataPopularConfiguration" ref="volumeJournal_uuid"/>
     </bean>
     <bean class="org.dspace.content.virtual.UUIDValue" id="volumeJournal_uuid"/>
 </beans>

--- a/dspace/config/spring/api/virtual-metadata.xml
+++ b/dspace/config/spring/api/virtual-metadata.xml
@@ -37,7 +37,7 @@
 
     <!-- Config like this will tell our VirtualMetadataPopulator to include the virtual metadata field
          'dc.contributor.author' on the appropriate item with the values defined in the value-ref.
-          This value-ref should be a bean of type VirtualMetadataPopularConfiguration -->
+          This value-ref should be a bean of type VirtualMetadataConfiguration -->
     <util:map id="isAuthorOfPublicationMap">
         <entry key="dc.contributor.author" value-ref="publicationAuthor_author"/>
     </util:map>
@@ -62,7 +62,7 @@
 
     <!-- Config like this will tell our VirtualMetadataPopulator to include the virtual metadata field
      'dc.contributor.other' on the appropriate item with the values defined in the value-ref.
-      This value-ref should be a bean of type VirtualMetadataPopularConfiguration -->
+      This value-ref should be a bean of type VirtualMetadataConfiguration -->
     <util:map id="isOrgUnitOfPublicationMap">
         <entry key="dc.contributor.other" value-ref="publicationOrgUnit_name"/>
     </util:map>
@@ -154,18 +154,18 @@
          alone, we need to pass this call higher up the chain to the journalvolume's relationships to find the journal.
          Therefore we've created this Related bean which will look at the journalvolume's relationships with type
          'isJournalOfVolume' to find the journal that this journalvolume is related to and it'll then call the next
-         VirtualMetadataPopularConfiguration with that journal to retrieve the value. This will leave the retrieving
+         VirtualMetadataConfiguration with that journal to retrieve the value. This will leave the retrieving
          of the values to the next bean in the chain -->
     <bean class="org.dspace.content.virtual.Related" id="volumeJournal_issn_related">
         <property name="relationshipTypeString" value="isJournalOfVolume"/>
         <property name="place" value="1"/>
-        <property name="virtualMetadataPopularConfiguration" ref="volumeJournal_issn"/>
+        <property name="virtualMetadataConfiguration" ref="volumeJournal_issn"/>
     </bean>
 
     <bean class="org.dspace.content.virtual.Related" id="volumeJournal_title_related">
         <property name="relationshipTypeString" value="isJournalOfVolume"/>
         <property name="place" value="1"/>
-        <property name="virtualMetadataPopularConfiguration" ref="volumeJournal_title"/>
+        <property name="virtualMetadataConfiguration" ref="volumeJournal_title"/>
     </bean>
 
     <util:map id="isJournalOfVolumeMap">
@@ -224,7 +224,7 @@
      alone, we need to pass this call higher up the chain to the journalissue's relationships to find the journal.
      Therefore we've created this Related bean which will look at the journalissue's relationships with type
      'isJournalVolumeOfIssue' to find the journalvolume that this journalissue is related to and it'll then call the next
-     VirtualMetadataPopularConfiguration with that journalvolume to retrieve the value. This will leave the retrieving
+     VirtualMetadataConfiguration with that journalvolume to retrieve the value. This will leave the retrieving
      of the values to the next bean in the chain.
      In this specific case, it'll call another Related bean to retrieve the journal for the journalvolume and it'll
      then retrieve the volume. This example has 2 Related beans chained to eachother to finally chain to a Collected
@@ -232,31 +232,31 @@
     <bean class="org.dspace.content.virtual.Related" id="issueVolumeJournal_issn_related">
         <property name="relationshipTypeString" value="isJournalVolumeOfIssue"/>
         <property name="place" value="1"/>
-        <property name="virtualMetadataPopularConfiguration" ref="volumeJournal_issn_related"/>
+        <property name="virtualMetadataConfiguration" ref="volumeJournal_issn_related"/>
     </bean>
 
     <bean class="org.dspace.content.virtual.Related" id="issueVolumeJournal_title_related">
         <property name="relationshipTypeString" value="isJournalVolumeOfIssue"/>
         <property name="place" value="1"/>
-        <property name="virtualMetadataPopularConfiguration" ref="volumeJournal_title_related"/>
+        <property name="virtualMetadataConfiguration" ref="volumeJournal_title_related"/>
     </bean>
 
     <bean class="org.dspace.content.virtual.Related" id="issueVolume_title_related">
         <property name="relationshipTypeString" value="isJournalVolumeOfIssue"/>
         <property name="place" value="1"/>
-        <property name="virtualMetadataPopularConfiguration" ref="issueVolume_title"/>
+        <property name="virtualMetadataConfiguration" ref="issueVolume_title"/>
     </bean>
 
     <bean class="org.dspace.content.virtual.Related" id="issueVolumeJournal_uuid_related">
         <property name="relationshipTypeString" value="isJournalVolumeOfIssue"/>
         <property name="place" value="1"/>
-        <property name="virtualMetadataPopularConfiguration" ref="volumeJournal_uuid_related"/>
+        <property name="virtualMetadataConfiguration" ref="volumeJournal_uuid_related"/>
     </bean>
 
     <bean class="org.dspace.content.virtual.Related" id="volumeJournal_uuid_related">
         <property name="relationshipTypeString" value="isJournalOfVolume"/>
         <property name="place" value="1"/>
-        <property name="virtualMetadataPopularConfiguration" ref="volumeJournal_uuid"/>
+        <property name="virtualMetadataConfiguration" ref="volumeJournal_uuid"/>
     </bean>
     <bean class="org.dspace.content.virtual.UUIDValue" id="volumeJournal_uuid"/>
 </beans>


### PR DESCRIPTION
Based on https://github.com/DSpace/DSpace/pull/2376#discussion_r266166731, I've 
renamed VirtualBean to VirtualMetadataConfiguration