### PR TITLE
DS-4222: Make sure locale is used for CCLicense-link

### DIFF
--- a/dspace-api/src/main/java/org/dspace/license/CC4LocaleConverter.java
+++ b/dspace-api/src/main/java/org/dspace/license/CC4LocaleConverter.java
@@ -1,0 +1,68 @@
+package org.dspace.license;
+
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Logger;
+import org.jaxen.JaxenException;
+import org.jaxen.jdom.JDOMXPath;
+import org.jdom.Attribute;
+import org.jdom.Document;
+import org.jdom.Element;
+import org.jdom.JDOMException;
+import org.jdom.input.SAXBuilder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+class CC4LocaleConverter {
+
+    private static Logger log = Logger.getLogger(CC4LocaleConverter.class);
+
+    private final Document license_doc;
+
+    private CC4LocaleConverter(Document license_doc) {
+        this.license_doc =  (Document)license_doc.clone();
+    }
+
+    private CC4LocaleConverter(InputStream in) throws JDOMException, IOException {
+        SAXBuilder parser = new SAXBuilder();
+        license_doc = parser.build(in);
+    }
+
+    public static CC4LocaleConverter builder(Document license_doc) {
+        return new CC4LocaleConverter(license_doc);
+    }
+
+    public static CC4LocaleConverter builder(InputStream in) throws JDOMException, IOException {
+        return new CC4LocaleConverter(in);
+    }
+
+    public Document build(String locale) {
+        try {
+            JDOMXPath xp_licenseUri = new JDOMXPath("//result/license-uri");
+            Element licenseUri = (Element) xp_licenseUri.selectSingleNode(license_doc);
+
+            if (StringUtils.containsIgnoreCase(licenseUri.getText(), "4.")) {
+
+                JDOMXPath xp_licenseUriAttributes = new JDOMXPath(String.format("(//result//@rdf:* | //result//@href)[.='%s']", licenseUri.getText()));
+                xp_licenseUriAttributes.addNamespace("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#");
+                @SuppressWarnings("unchecked")
+                List<Attribute> licenseAttributes = (List<Attribute>)xp_licenseUriAttributes.selectNodes(license_doc);
+
+                String cc_baseUri = StringUtils.substringBeforeLast(licenseUri.getText(), "/");
+                String localeLicenseUri = String.format("%s/deed.%s", cc_baseUri, StringUtils.isEmpty(locale) ? "en" : locale);
+                licenseUri.setText(localeLicenseUri);
+                for (Attribute attribute : licenseAttributes) {
+                    attribute.setValue(localeLicenseUri);
+                }
+            } else {
+                log.warn("Creative Commons license " + licenseUri.getText() +  " is not version 4");
+            }
+        } catch (JaxenException e) {
+            log.warn(e.getMessage());
+            return null;
+        }
+        return this.license_doc;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/license/CCLookup.java
+++ b/dspace-api/src/main/java/org/dspace/license/CCLookup.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.dspace.license.factory.LicenseServiceFactory;
 import org.dspace.license.service.CreativeCommonsService;
@@ -306,9 +307,11 @@ public class CCLookup {
 		try {
 			// parsing document from input stream
 			java.io.InputStream stream = connection.getInputStream();
-			this.license_doc = this.parser.build(stream);
+			this.license_doc = StringUtils.isEmpty((String)answers.get("jurisdiction"))
+					? CC4LocaleConverter.builder(stream).build(lang)
+					: this.parser.build(stream);
 		} catch (JDOMException jde) {
-                        log.warn(jde.getMessage());
+			log.warn(jde.getMessage());
 		} catch (Exception e) {
 			log.warn(e.getCause());
 		}

--- a/dspace-api/src/test/java/org/dspace/license/CC4LocaleConverterTest.java
+++ b/dspace-api/src/test/java/org/dspace/license/CC4LocaleConverterTest.java
@@ -1,0 +1,51 @@
+package org.dspace.license;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jdom.Document;
+import org.jdom.input.SAXBuilder;
+import org.jdom.output.XMLOutputter;
+import org.junit.Test;
+
+import java.io.FileInputStream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+
+public class CC4LocaleConverterTest {
+
+    @Test
+    public void cc3ConvertTest() throws Exception {
+        String cc3_path = "src/test/resources/cc3license.xml";
+
+        SAXBuilder saxBuilder = new SAXBuilder();
+        Document expectedDocument = saxBuilder.build(new FileInputStream(cc3_path));
+        String expectedString = new XMLOutputter().outputString(expectedDocument);
+
+        Document resultDocument = CC4LocaleConverter.builder(new FileInputStream(cc3_path)).build("no");
+        String resultString = new XMLOutputter().outputString(resultDocument);
+
+        assertThat("CC3 license not modified", resultString, equalTo(expectedString));
+    }
+
+    @Test
+    public void cc4ConvertTest() throws Exception {
+        String cc4_path = "src/test/resources/cc4license.xml";
+
+        Document resultDocument = CC4LocaleConverter.builder(new FileInputStream(cc4_path)).build("no");
+        String resultString = new XMLOutputter().outputString(resultDocument);
+
+        assertThat("CC4 license modified", StringUtils.countMatches(resultString, "http://creativecommons.org/licenses/by/4.0/deed.no"), is(6));
+    }
+
+    @Test
+    public void cc4ConvertTestDefaultLocale() throws Exception {
+        String cc4_path = "src/test/resources/cc4license.xml";
+
+        Document resultDocument = CC4LocaleConverter.builder(new FileInputStream(cc4_path)).build("");
+        String resultString = new XMLOutputter().outputString(resultDocument);
+
+        assertThat("CC4 license modified", StringUtils.countMatches(resultString, "http://creativecommons.org/licenses/by/4.0/deed.en"), is(6));
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/license/CCLookupIT.java
+++ b/dspace-api/src/test/java/org/dspace/license/CCLookupIT.java
@@ -1,0 +1,141 @@
+package org.dspace.license;
+
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+
+public class CCLookupIT {
+
+    private static ConfigurationService config = null;
+    private CCLookup ccLookup = new CCLookup();
+    private static final String LICENSE_ID = "standard";
+
+    @BeforeClass
+    public static void setUpClass()
+            throws Exception
+    {
+        // Find the configuration service
+        config = DSpaceServicesFactory.getInstance().getConfigurationService();
+        config.setProperty("cc.api.rooturl","http://api.creativecommons.org/rest/1.5");
+    }
+
+    @Test
+    public void noLocaleCC4Link() throws Exception {
+        String lang = "no";
+        Map<String, String> answers = new HashMap<>();
+        answers.put("commercial", "y");
+        answers.put("derivatives", "y");
+        answers.put("jurisdiction", "");
+
+        ccLookup.issue(LICENSE_ID, answers, lang);
+
+        assertThat("Operation success", ccLookup.isSuccess(), is(true));
+        assertThat("License document exists", ccLookup.getLicenseDocument(), notNullValue());
+        assertThat("CC version 4", ccLookup.getLicenseUrl(), containsString("4."));
+        assertThat("CC locale language link", ccLookup.getLicenseUrl(), endsWith("deed."+lang));
+        assertThat("CC licence name", ccLookup.getLicenseName().length(), not(0));
+    }
+
+    @Test
+    public void defaultLocaleCC4Link() throws Exception {
+        Map<String, String> answers = new HashMap<>();
+        answers.put("commercial", "y");
+        answers.put("derivatives", "y");
+        answers.put("jurisdiction", "");
+
+        ccLookup.issue(LICENSE_ID, answers, null);
+
+        assertThat("Operation success", ccLookup.isSuccess(), is(true));
+        assertThat("License document exists", ccLookup.getLicenseDocument(), notNullValue());
+        assertThat("CC version 4", ccLookup.getLicenseUrl(), containsString("4."));
+        assertThat("CC locale language link", ccLookup.getLicenseUrl(), endsWith("deed.en"));
+        assertThat("CC licence name", ccLookup.getLicenseName().length(), not(0));
+    }
+
+    @Test
+    public void noLocaleCC3Link() throws Exception {
+        String lang = "no";
+        Map<String, String> answers = new HashMap<>();
+        answers.put("commercial", "y");
+        answers.put("derivatives", "y");
+        answers.put("jurisdiction", "no");
+
+        ccLookup.issue(LICENSE_ID, answers, lang);
+
+        assertThat("Operation success", ccLookup.isSuccess(), is(true));
+        assertThat("License document exists", ccLookup.getLicenseDocument(), notNullValue());
+        assertThat("CC version 3", ccLookup.getLicenseUrl(), containsString("3."));
+        assertThat("CC locale language link", ccLookup.getLicenseUrl(), not(endsWith("deed."+lang)));
+        assertThat("CC licence name", ccLookup.getLicenseName().length(), not(0));
+    }
+
+    @Test
+    public void defaultLocaleCC3Link() throws Exception {
+        Map<String, String> answers = new HashMap<>();
+        answers.put("commercial", "y");
+        answers.put("derivatives", "y");
+        answers.put("jurisdiction", "no");
+
+        ccLookup.issue(LICENSE_ID, answers, null);
+
+        assertThat("Operation success", ccLookup.isSuccess(), is(true));
+        assertThat("License document exists", ccLookup.getLicenseDocument(), notNullValue());
+        assertThat("CC version 3", ccLookup.getLicenseUrl(), containsString("3."));
+        assertThat("CC locale language link", ccLookup.getLicenseUrl(), not(containsString("deed.")));
+        assertThat("CC licence name", ccLookup.getLicenseName().length(), not(0));
+    }
+
+    @Test
+    public void lookupNoLocale4Link() throws Exception {
+        String licenseUri = "http://creativecommons.org/licenses/by/4.0/";
+        String localeLicenseUri = licenseUri + "deed.no";
+
+        ccLookup.issue(localeLicenseUri);
+
+        assertThat("Operation success", ccLookup.isSuccess(), is(true));
+        assertThat("License document exists", ccLookup.getLicenseDocument(), notNullValue());
+        assertThat("This CC operation does not support locale", ccLookup.getLicenseUrl(), equalTo(licenseUri));
+        assertThat("CC licence name", ccLookup.getLicenseName().length(), not(0));
+    }
+
+    @Test
+    public void lookupDefaultLocale4Link() throws Exception {
+        String licenseUri = "http://creativecommons.org/licenses/by/4.0/";
+        ccLookup.issue(licenseUri);
+
+        assertThat("Operation success", ccLookup.isSuccess(), is(true));
+        assertThat("License document exists", ccLookup.getLicenseDocument(), notNullValue());
+        assertThat("This CC operation does not support locale", ccLookup.getLicenseUrl(), equalTo(licenseUri));
+        assertThat("CC licence name", ccLookup.getLicenseName().length(), not(0));
+    }
+
+    @Test
+    public void lookupNoLocale3Link() throws Exception {
+        String licenseUri = "http://creativecommons.org/licenses/by/3.0/no/";
+        ccLookup.issue(licenseUri);
+
+        assertThat("Operation success", ccLookup.isSuccess(), is(true));
+        assertThat("License document exists", ccLookup.getLicenseDocument(), notNullValue());
+        assertThat("This CC operation does not support locale", ccLookup.getLicenseUrl(), equalTo(licenseUri));
+        assertThat("CC licence name", ccLookup.getLicenseName().length(), not(0));
+    }
+
+    @Test
+    public void lookupDefaultLocale3Link() throws Exception {
+        String licenseUri = "http://creativecommons.org/licenses/by/3.0/";
+        ccLookup.issue(licenseUri);
+
+        assertThat("Operation success", ccLookup.isSuccess(), is(true));
+        assertThat("License document exists", ccLookup.getLicenseDocument(), notNullValue());
+        assertThat("This CC operation does not support locale", ccLookup.getLicenseUrl(), equalTo(licenseUri));
+        assertThat("CC licence name", ccLookup.getLicenseName().length(), not(0));
+    }
+}

--- a/dspace-api/src/test/resources/cc3license.xml
+++ b/dspace-api/src/test/resources/cc3license.xml
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='utf-8'?>
+<result>
+    <license-uri>http://creativecommons.org/licenses/by/3.0/no/</license-uri>
+    <license-name>Navngivelse 3.0 Norge</license-name>
+    <deprecated>false</deprecated>
+    <rdf>
+        <rdf:RDF xmlns="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+            <Work xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:about=""><license rdf:resource="http://creativecommons.org/licenses/by/3.0/no/"/></Work><License rdf:about="http://creativecommons.org/licenses/by/3.0/no/">
+            <permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks"/>
+            <permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
+            <permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
+            <requires rdf:resource="http://creativecommons.org/ns#Attribution"/>
+            <requires rdf:resource="http://creativecommons.org/ns#Notice"/>
+        </License>
+        </rdf:RDF>
+    </rdf>
+    <licenserdf>
+        <rdf:RDF xmlns="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+            <License rdf:about="http://creativecommons.org/licenses/by/3.0/no/">
+                <permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks"/>
+                <permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
+                <permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
+                <requires rdf:resource="http://creativecommons.org/ns#Attribution"/>
+                <requires rdf:resource="http://creativecommons.org/ns#Notice"/>
+            </License>
+        </rdf:RDF>
+    </licenserdf>
+    <html><a rel="license" href="http://creativecommons.org/licenses/by/3.0/no/"><img alt="Creative Commons-lisens" style="border-width:0" src="http://i.creativecommons.org/l/by/3.0/no/88x31.png"/></a><br/>Dette verk er lisensieret under en <a rel="license" href="http://creativecommons.org/licenses/by/3.0/no/">Creative Commons Navngivelse 3.0 Norge lisens</a>.</html>
+</result>

--- a/dspace-api/src/test/resources/cc4license.xml
+++ b/dspace-api/src/test/resources/cc4license.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+    <license-uri>http://creativecommons.org/licenses/by/4.0/</license-uri>
+    <license-name>Navngivelse 4.0 Internasjonal</license-name>
+    <deprecated>false</deprecated>
+    <rdf>
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://creativecommons.org/ns#">
+            <Work xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:about="">
+                <license rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
+            </Work>
+            <License rdf:about="http://creativecommons.org/licenses/by/4.0/">
+            <permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+            <permits rdf:resource="http://creativecommons.org/ns#Distribution" />
+            <permits rdf:resource="http://creativecommons.org/ns#Reproduction" />
+            <requires rdf:resource="http://creativecommons.org/ns#Attribution" />
+            <requires rdf:resource="http://creativecommons.org/ns#Notice" />
+        </License>
+        </rdf:RDF>
+    </rdf>
+    <licenserdf>
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://creativecommons.org/ns#">
+            <License rdf:about="http://creativecommons.org/licenses/by/4.0/">
+                <permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+                <permits rdf:resource="http://creativecommons.org/ns#Distribution" />
+                <permits rdf:resource="http://creativecommons.org/ns#Reproduction" />
+                <requires rdf:resource="http://creativecommons.org/ns#Attribution" />
+                <requires rdf:resource="http://creativecommons.org/ns#Notice" />
+            </License>
+        </rdf:RDF>
+    </licenserdf>
+    <html>
+        <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">
+            <img alt="Creative Commons-lisens" style="border-width:0" src="http://i.creativecommons.org/l/by/4.0/88x31.png" />
+        </a>
+        <br />
+        Dette verk er lisensieret under en <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">
+        Creative Commons Navngivelse 4.0 Internasjonal lisens</a>.
+    </html>
+</result>

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -853,7 +853,7 @@ cc.license.classfilter = recombo, mark
 # http://api.creativecommons.org/rest/1.5/support/jurisdictions
 # Commented out means the license is unported.
 # (e.g. nz = New Zealand, uk = England and Wales, jp = Japan)
-cc.license.jurisdiction = us
+#cc.license.jurisdiction = us
 
 # Locale for CC dialogs
 # A locale in the form language or language-country.


### PR DESCRIPTION
Make sure that the locale from dspace.cfg (cc.license.locale = no) is read and used to generate the link to creativecommons lisens (https://creativecommons.org/licenses/by-nd/4.0/deed.no).

Fixes #7562 