### PR TITLE
Minor dependency updates for `master` (pre-7.0)

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -450,14 +450,6 @@
             <artifactId>fontbox</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcmail-jdk15</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
         </dependency>

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFBoxThumbnail.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFBoxThumbnail.java
@@ -11,6 +11,7 @@ import java.awt.image.BufferedImage;
 import java.io.InputStream;
 import javax.imageio.ImageIO;
 
+import org.apache.logging.log4j.Logger;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.rendering.PDFRenderer;
 import org.dspace.content.Item;
@@ -26,6 +27,8 @@ import org.dspace.content.Item;
  * @author Jason Sherman jsherman@usao.edu
  */
 public class PDFBoxThumbnail extends MediaFilter implements SelfRegisterInputFormats {
+    private static Logger log = org.apache.logging.log4j.LogManager.getLogger(PDFBoxThumbnail.class);
+
     @Override
     public String getFilteredName(String oldFilename) {
         return oldFilename + ".jpg";
@@ -66,6 +69,10 @@ public class PDFBoxThumbnail extends MediaFilter implements SelfRegisterInputFor
     public InputStream getDestinationStream(Item currentItem, InputStream source, boolean verbose)
         throws Exception {
         PDDocument doc = PDDocument.load(source);
+        if (doc.isEncrypted()) {
+            log.error("PDF is encrypted. Cannot create thumbnail (item: " + currentItem.getHandle() + ")");
+            return null;
+        }
         PDFRenderer renderer = new PDFRenderer(doc);
         BufferedImage buf = renderer.renderImage(0);
 //        ImageIO.write(buf, "PNG", new File("custom-render.png"));

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFFilter.java
@@ -94,6 +94,10 @@ public class PDFFilter extends MediaFilter {
 
             try {
                 pdfDoc = PDDocument.load(source);
+                if (pdfDoc.isEncrypted()) {
+                    log.error("PDF is encrypted. Cannot extract text (item: " + currentItem.getHandle() + ")");
+                    return null;
+                }
                 pts.writeText(pdfDoc, writer);
             } finally {
                 try {

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <jena.version>2.13.0</jena.version>
         <log4j.version>2.6.2</log4j.version>
         <slf4j.version>1.7.22</slf4j.version>
+        <!-- NOTE: when updating jackson.version, also sync jackson-databind dependency below -->
         <jackson.version>2.8.11</jackson.version>
         <jersey.version>2.26</jersey.version>
         <hibernate.version>5.2.8.Final</hibernate.version>
@@ -1521,7 +1522,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.8.11.1</version> <!-- TODO sync. with jackson.version -->
+                <version>2.8.11.2</version> <!-- TODO sync. with jackson.version -->
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <!-- PIN Solr to 7.3.x until SOLR-12858 is fixed. This bug affects all integration tests that use Solr
              https://issues.apache.org/jira/browse/SOLR-12858 -->
         <solr.client.version>7.3.1</solr.client.version>
-        <spring.version>4.3.6.RELEASE</spring.version>
+        <spring.version>4.3.24.RELEASE</spring.version>
         <spring-boot.version>1.4.4.RELEASE</spring-boot.version>
         <!-- 'root.basedir' is the path to the root [dspace-src] dir. It must be redefined by each child POM,
              as it is used to reference the LICENSE_HEADER and *.properties file(s) in that directory. -->

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
+        <pdfbox-version>2.0.15</pdfbox-version>
         <poi-version>3.17</poi-version>
         <postgresql.driver.version>42.2.1</postgresql.driver.version>
         <!-- PIN Jena to 2.x until both RDF and SWORDv2 can be updated to Jena 3. Requires package renaming, see
@@ -638,8 +639,6 @@
                                         <licenseMerge>Eclipse Public License|Common Public License Version 1.0</licenseMerge>
                                         <licenseMerge>GNU Lesser General Public License (LGPL)|The GNU Lesser General Public License, Version 2.1|GNU Lesser General Public License (LGPL), Version 2.1|GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1|GNU Lesser General Public License, version 2.1|GNU LESSER GENERAL PUBLIC LICENSE|GNU Lesser General Public License|GNU Lesser Public License|GNU Lesser General Public License, Version 2.1|Lesser General Public License (LGPL) v 2.1|LGPL 2.1|LGPL 2.1 license|LGPL 3.0 license|LGPL, v2.1 or later|LGPL</licenseMerge>
                                         <licenseMerge>MIT License|The MIT License|MIT LICENSE</licenseMerge>
-                                        <!-- BouncyCastle uses a modified MIT License: http://www.bouncycastle.org/license.html -->
-                                        <licenseMerge>MIT License|Bouncy Castle Licence</licenseMerge>
                                         <licenseMerge>Mozilla Public License|Mozilla Public License version 1.1|Mozilla Public License 1.1 (MPL 1.1)|MPL 1.1</licenseMerge>
                                         <!-- H2 Database claims this license, but for our purposes it's MPL: http://www.h2database.com -->
                                         <licenseMerge>Mozilla Public License|MPL 2.0, and EPL 1.0</licenseMerge>
@@ -1259,23 +1258,13 @@
             <dependency>
                 <groupId>org.apache.pdfbox</groupId>
                 <artifactId>pdfbox</artifactId>
-                <version>2.0.2</version>
+                <version>${pdfbox-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.pdfbox</groupId>
                 <artifactId>fontbox</artifactId>
-                <version>2.0.2</version>
+                <version>${pdfbox-version}</version>
             </dependency>
-            <dependency>
-	        <groupId>org.bouncycastle</groupId>
-	        <artifactId>bcprov-jdk15</artifactId>
-	        <version>1.46</version>
-	    </dependency>
-	    <dependency>
-	        <groupId>org.bouncycastle</groupId>
-	        <artifactId>bcmail-jdk15</artifactId>
-	        <version>1.46</version>
-	    </dependency>
             <dependency>
                 <groupId>org.apache.poi</groupId>
                 <artifactId>poi</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>8.8</version>
+                            <version>8.18</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
This PR updates dependencies on `master` based on security notices from GitHub (viewable at https://github.com/DSpace/DSpace/network/alerts for GitHub project admins).

It upgrades the following dependencies:
* jackson-databind (from 2.8.11.1 to 2.8.11.2)
* checkstyle (from 8.8 to 8.18)
* PDFBox (from 2.0.2 to 2.0.15)
    * *Removes* Bouncycastle entirely (required only for PDFBox if dealing with encrypted PDFs), and replaces with basic error checking for encrypted PDFs.  **Resolves [DS-2375](https://jira.duraspace.org/browse/DS-2375)**
* Spring Core (from 4.3.6 to 4.3.24)

Build process & unit/integrations tests all succeed.  I've not manually tested the code yet. At a minimum, likely some basic tests of the Filter Media process (for PDFs) should be done prior to merger (since I'm upgrading PDFBox and removing Bouncycastle).