### PR TITLE
DS-3971: Simple user who are not system administrator, …

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -108,7 +108,15 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
         clonedBitstream.setChecksum(bitstream.getChecksum());
         clonedBitstream.setChecksumAlgorithm(bitstream.getChecksumAlgorithm());
         clonedBitstream.setFormat(bitstream.getBitstreamFormat());
-
+        clonedBitstream.setStoreNumber(bitstream.getStoreNumber());
+        List<MetadataValue> metadataValues = getMetadata(bitstream, Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+        for (MetadataValue metadataValue : metadataValues) 
+        {
+            addMetadata(context, clonedBitstream, metadataValue.getMetadataField(), 
+                        metadataValue.getLanguage(), metadataValue.getValue(), 
+                        metadataValue.getAuthority(), metadataValue.getConfidence());
+        }
+        
         try 
         {
             //Update our bitstream but turn off the authorization system since permissions haven't been set at this point in time.

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
@@ -342,18 +342,7 @@ public class BitstreamStorageServiceImpl implements BitstreamStorageService, Ini
     @Override
     public Bitstream clone(Context context, Bitstream bitstream) throws SQLException, IOException, AuthorizeException 
     {
-        Bitstream clonedBitstream = bitstreamService.clone(context, bitstream);
-        clonedBitstream.setStoreNumber(bitstream.getStoreNumber());
-        
-        List<MetadataValue> metadataValues = bitstreamService.getMetadata(bitstream, Item.ANY, Item.ANY, Item.ANY, Item.ANY);
-        
-        for (MetadataValue metadataValue : metadataValues) 
-        {
-            bitstreamService.addMetadata(context, clonedBitstream, metadataValue.getMetadataField(), metadataValue.getLanguage(), metadataValue.getValue(), metadataValue.getAuthority(), metadataValue.getConfidence());
-        }
-        bitstreamService.update(context, clonedBitstream);
-        return clonedBitstream;
-
+        return bitstreamService.clone(context, bitstream);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/versioning/AbstractVersionProvider.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/AbstractVersionProvider.java
@@ -14,7 +14,6 @@ import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.BundleService;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
-import org.dspace.storage.bitstore.service.BitstreamStorageService;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.IOException;
@@ -38,8 +37,6 @@ public abstract class AbstractVersionProvider {
     protected AuthorizeService authorizeService;
     @Autowired(required = true)
     protected BitstreamService bitstreamService;
-    @Autowired(required = true)
-    protected BitstreamStorageService bitstreamStorageService;
     @Autowired(required = true)
     protected BundleService bundleService;
     @Autowired(required = true)
@@ -79,9 +76,8 @@ public abstract class AbstractVersionProvider {
             for(Bitstream nativeBitstream : nativeBundle.getBitstreams())
             {
                 // Metadata and additional information like internal identifier, 
-                // file size, checksum, and checksum algorithm are set by the bitstreamStorageService.clone(...)
-                // and respectively bitstreamService.clone(...) method.
-                Bitstream bitstreamNew =  bitstreamStorageService.clone(c, nativeBitstream);
+                // file size, checksum, and checksum algorithm are set by the bitstreamService.clone(...) method.
+                Bitstream bitstreamNew =  bitstreamService.clone(c, nativeBitstream);
 
                 bundleService.addBitstream(c, bundleNew, bitstreamNew);
 


### PR DESCRIPTION
can again generate versions of their items without getting authorization failures.To avoid an unpersisted state and authorization failures, all Bitstream's metadata are duplicated in the BitstreamServiceImpl#clone and the BitstreamStorageService#clone does not make any changes on the cloned bitstream

Fixes #7318