### PR TITLE
DS-4230 - PUT contract in relationships

### DIFF
--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RelationshipRestController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RelationshipRestController.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.app.rest;
 
+import java.sql.SQLException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
@@ -19,6 +20,7 @@ import org.dspace.app.rest.link.HalLinkService;
 import org.dspace.app.rest.model.RelationshipRest;
 import org.dspace.app.rest.model.RelationshipRestWrapper;
 import org.dspace.app.rest.model.hateoas.RelationshipResourceWrapper;
+import org.dspace.app.rest.repository.RelationshipRestRepository;
 import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.app.rest.utils.Utils;
 import org.dspace.content.Item;
@@ -52,8 +54,16 @@ public class RelationshipRestController {
     private static final String REGEX_REQUESTMAPPING_LABEL = "/{label:^(?!^\\d+$)" +
         "(?!^[0-9a-fxA-FX]{8}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{12}$)[\\w+\\-]+$+}";
 
+    /**
+     * Regular expression in the request mapping to accept number as identifier
+     */
+    private static final String REGEX_REQUESTMAPPING_IDENTIFIER_AS_DIGIT = "/{id:\\d+}";
+
     @Autowired
     private RelationshipTypeService relationshipTypeService;
+
+    @Autowired
+    private RelationshipRestRepository relationshipRestRepository;
 
     @Autowired
     private RelationshipService relationshipService;
@@ -130,4 +140,29 @@ public class RelationshipRestController {
         return relationshipResourceWrapper;
     }
 
+    /**
+     * Method to change the left item of a relationship with a given item in the body
+     * @return The modified relationship
+     */
+    @RequestMapping(method = RequestMethod.PUT, value = REGEX_REQUESTMAPPING_IDENTIFIER_AS_DIGIT + "/leftItem",
+            consumes = {"text/uri-list"})
+    public RelationshipRest updateRelationshipLeft(@PathVariable Integer id, HttpServletResponse response,
+                                                              HttpServletRequest request) throws SQLException {
+        Context context = ContextUtil.obtainContext(request);
+        return relationshipRestRepository.put(context,"/api/core/relationships/", id,
+                utils.getStringListFromRequest(request), false);
+    }
+
+    /**
+     * Method to change the right item of a relationship with a given item in the body
+     * @return The modified relationship
+     */
+    @RequestMapping(method = RequestMethod.PUT, value = REGEX_REQUESTMAPPING_IDENTIFIER_AS_DIGIT + "/rightItem",
+            consumes = {"text/uri-list"})
+    public RelationshipRest updateRelationshipRight(@PathVariable Integer id, HttpServletResponse response,
+                                                               HttpServletRequest request) throws SQLException {
+        Context context = ContextUtil.obtainContext(request);
+        return relationshipRestRepository.put(context,"/api/core/relationships/", id,
+                utils.getStringListFromRequest(request), true);
+    }
 }

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RelationshipRestController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RelationshipRestController.java
@@ -52,7 +52,7 @@ public class RelationshipRestController {
      * identifier (digits or uuid)
      */
     private static final String REGEX_REQUESTMAPPING_LABEL = "/{label:^(?!^\\d+$)" +
-            "(?!^[0-9a-fxA-FX]{8}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{12}$)[\\w+\\-]+$+}";
+        "(?!^[0-9a-fxA-FX]{8}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{12}$)[\\w+\\-]+$+}";
 
     /**
      * Regular expression in the request mapping to accept number as identifier
@@ -99,7 +99,7 @@ public class RelationshipRestController {
                                                        HttpServletRequest request, @PathVariable String label,
                                                        @RequestParam(name = "dso", required = false) String dsoId,
                                                        Pageable pageable)
-            throws Exception {
+        throws Exception {
 
         Context context = ContextUtil.obtainContext(request);
 
@@ -115,7 +115,7 @@ public class RelationshipRestController {
             }
             for (RelationshipType relationshipType : relationshipTypeList) {
                 relationships.addAll(relationshipService.findByItemAndRelationshipType(context,
-                        item, relationshipType));
+                                                                                       item, relationshipType));
             }
         } else {
             for (RelationshipType relationshipType : relationshipTypeList) {
@@ -134,7 +134,7 @@ public class RelationshipRestController {
         relationshipRestWrapper.setRelationshipRestList(relationshipRests);
 
         RelationshipResourceWrapper relationshipResourceWrapper = new RelationshipResourceWrapper(
-                relationshipRestWrapper, utils, relationshipRests.size(), pageable);
+            relationshipRestWrapper, utils, relationshipRests.size(), pageable);
 
         halLinkService.addLinks(relationshipResourceWrapper, pageable);
         return relationshipResourceWrapper;

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RelationshipRestController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RelationshipRestController.java
@@ -52,7 +52,7 @@ public class RelationshipRestController {
      * identifier (digits or uuid)
      */
     private static final String REGEX_REQUESTMAPPING_LABEL = "/{label:^(?!^\\d+$)" +
-        "(?!^[0-9a-fxA-FX]{8}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{12}$)[\\w+\\-]+$+}";
+            "(?!^[0-9a-fxA-FX]{8}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{12}$)[\\w+\\-]+$+}";
 
     /**
      * Regular expression in the request mapping to accept number as identifier
@@ -99,7 +99,7 @@ public class RelationshipRestController {
                                                        HttpServletRequest request, @PathVariable String label,
                                                        @RequestParam(name = "dso", required = false) String dsoId,
                                                        Pageable pageable)
-        throws Exception {
+            throws Exception {
 
         Context context = ContextUtil.obtainContext(request);
 
@@ -115,7 +115,7 @@ public class RelationshipRestController {
             }
             for (RelationshipType relationshipType : relationshipTypeList) {
                 relationships.addAll(relationshipService.findByItemAndRelationshipType(context,
-                                                                                       item, relationshipType));
+                        item, relationshipType));
             }
         } else {
             for (RelationshipType relationshipType : relationshipTypeList) {
@@ -134,7 +134,7 @@ public class RelationshipRestController {
         relationshipRestWrapper.setRelationshipRestList(relationshipRests);
 
         RelationshipResourceWrapper relationshipResourceWrapper = new RelationshipResourceWrapper(
-            relationshipRestWrapper, utils, relationshipRests.size(), pageable);
+                relationshipRestWrapper, utils, relationshipRests.size(), pageable);
 
         halLinkService.addLinks(relationshipResourceWrapper, pageable);
         return relationshipResourceWrapper;

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/RelationshipRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/RelationshipRestRepository.java
@@ -94,7 +94,7 @@ public class RelationshipRestRepository extends DSpaceRestRepository<Relationshi
 
     @Override
     protected RelationshipRest createAndReturn(Context context, List<String> stringList)
-            throws AuthorizeException, SQLException, RepositoryMethodNotImplementedException {
+        throws AuthorizeException, SQLException, RepositoryMethodNotImplementedException {
 
         HttpServletRequest req = getRequestService().getCurrentRequest().getHttpServletRequest();
         List<DSpaceObject> list = utils.constructDSpaceObjectList(context, stringList);
@@ -102,13 +102,13 @@ public class RelationshipRestRepository extends DSpaceRestRepository<Relationshi
             Item leftItem = (Item) list.get(0);
             Item rightItem = (Item) list.get(1);
             RelationshipType relationshipType = relationshipTypeService
-                    .find(context, Integer.parseInt(req.getParameter("relationshipType")));
+                .find(context, Integer.parseInt(req.getParameter("relationshipType")));
 
             EPerson ePerson = context.getCurrentUser();
             if (authorizeService.authorizeActionBoolean(context, leftItem, Constants.WRITE) ||
-                    authorizeService.authorizeActionBoolean(context, rightItem, Constants.WRITE)) {
+                authorizeService.authorizeActionBoolean(context, rightItem, Constants.WRITE)) {
                 Relationship relationship = relationshipService.create(context, leftItem, rightItem,
-                        relationshipType, 0, 0);
+                                                                       relationshipType, 0, 0);
                 // The above if check deals with the case that a Relationship can be created if the user has write
                 // rights on one of the two items. The following updateItem calls can however call the
                 // ItemService.update() functions which would fail if the user doesn't have permission on both items.
@@ -206,10 +206,10 @@ public class RelationshipRestRepository extends DSpaceRestRepository<Relationshi
     private boolean isAllowedToModifyRelationship(Context context, Relationship relationship, Item leftItem,
                                                   Item rightItem) throws SQLException {
         return (authorizeService.authorizeActionBoolean(context, leftItem, Constants.WRITE) ||
-                authorizeService.authorizeActionBoolean(context, rightItem, Constants.WRITE)) &&
-                (authorizeService.authorizeActionBoolean(context, relationship.getLeftItem(), Constants.WRITE) ||
-                        authorizeService.authorizeActionBoolean(context, relationship.getRightItem(), Constants.WRITE)
-                );
+            authorizeService.authorizeActionBoolean(context, rightItem, Constants.WRITE)) &&
+            (authorizeService.authorizeActionBoolean(context, relationship.getLeftItem(), Constants.WRITE) ||
+            authorizeService.authorizeActionBoolean(context, relationship.getRightItem(), Constants.WRITE)
+            );
     }
 
     @Override

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/RelationshipRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/RelationshipRestRepository.java
@@ -34,6 +34,7 @@ import org.dspace.eperson.EPerson;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Component;
 
@@ -93,7 +94,7 @@ public class RelationshipRestRepository extends DSpaceRestRepository<Relationshi
 
     @Override
     protected RelationshipRest createAndReturn(Context context, List<String> stringList)
-        throws AuthorizeException, SQLException, RepositoryMethodNotImplementedException {
+            throws AuthorizeException, SQLException, RepositoryMethodNotImplementedException {
 
         HttpServletRequest req = getRequestService().getCurrentRequest().getHttpServletRequest();
         List<DSpaceObject> list = utils.constructDSpaceObjectList(context, stringList);
@@ -101,13 +102,13 @@ public class RelationshipRestRepository extends DSpaceRestRepository<Relationshi
             Item leftItem = (Item) list.get(0);
             Item rightItem = (Item) list.get(1);
             RelationshipType relationshipType = relationshipTypeService
-                .find(context, Integer.parseInt(req.getParameter("relationshipType")));
+                    .find(context, Integer.parseInt(req.getParameter("relationshipType")));
 
             EPerson ePerson = context.getCurrentUser();
             if (authorizeService.authorizeActionBoolean(context, leftItem, Constants.WRITE) ||
-                authorizeService.authorizeActionBoolean(context, rightItem, Constants.WRITE)) {
+                    authorizeService.authorizeActionBoolean(context, rightItem, Constants.WRITE)) {
                 Relationship relationship = relationshipService.create(context, leftItem, rightItem,
-                                                                       relationshipType, 0, 0);
+                        relationshipType, 0, 0);
                 // The above if check deals with the case that a Relationship can be created if the user has write
                 // rights on one of the two items. The following updateItem calls can however call the
                 // ItemService.update() functions which would fail if the user doesn't have permission on both items.
@@ -128,29 +129,60 @@ public class RelationshipRestRepository extends DSpaceRestRepository<Relationshi
 
     }
 
-    /*
-     * Disabled the put until https://jira.duraspace.org/browse/DS-4230 is discussed
-    @Override
-    protected RelationshipRest put(Context context, HttpServletRequest request, String apiCategory, String model,
-                                   Integer id, List<String> stringList)
-        throws RepositoryMethodNotImplementedException, SQLException, AuthorizeException {
+    /**
+     * Method to replace either the right or left item of a relationship with a given new item
+     * Called by request mappings in RelationshipRestController
+     * - For replace right item (itemToReplaceIsRight = true)
+     *      => Newly proposed changed relationship: left = old-left; right = new-item
+     * - For replace left item (itemToReplaceIsRight = false)
+     *      => Newly proposed changed relationship: left = new-item; right = old-right
+     * @param context
+     * @param contextPath           What API call was made to get here
+     * @param id                    ID of the relationship we wish to modify
+     * @param stringList            Item to replace either right or left item of relationship with
+     * @param itemToReplaceIsRight  Boolean to decide whether to replace right item (true) or left item (false)
+     * @return  The (modified) relationship
+     * @throws SQLException
+     */
+    public RelationshipRest put(Context context, String contextPath, Integer id, List<String> stringList,
+                                Boolean itemToReplaceIsRight) throws SQLException {
 
-        Relationship relationship = relationshipService.find(context, id);
-        if (relationship == null) {
-            throw new ResourceNotFoundException(apiCategory + "." + model + " with id: " + id + " not found");
+        Relationship relationship;
+        try {
+            relationship = relationshipService.find(context, id);
+        } catch (SQLException e) {
+            throw new ResourceNotFoundException(contextPath + " with id: " + id + " not found");
         }
+        if (relationship == null) {
+            throw new ResourceNotFoundException(contextPath + " with id: " + id + " not found");
+        }
+
         List<DSpaceObject> dSpaceObjects = utils.constructDSpaceObjectList(context, stringList);
-        if (dSpaceObjects.size() == 2 && dSpaceObjects.get(0).getType() == Constants.ITEM
-            && dSpaceObjects.get(1).getType() == Constants.ITEM) {
-            Item leftItem = (Item) dSpaceObjects.get(0);
-            Item rightItem = (Item) dSpaceObjects.get(1);
+        if (dSpaceObjects.size() == 1 && dSpaceObjects.get(0).getType() == Constants.ITEM) {
+
+            Item replacementItemInRelationship = (Item) dSpaceObjects.get(0);
+            Item leftItem;
+            Item rightItem;
+            if (itemToReplaceIsRight) {
+                leftItem = relationship.getLeftItem();
+                rightItem = replacementItemInRelationship;
+            } else {
+                leftItem = replacementItemInRelationship;
+                rightItem = relationship.getRightItem();
+            }
 
             if (isAllowedToModifyRelationship(context, relationship, leftItem, rightItem)) {
                 relationship.setLeftItem(leftItem);
                 relationship.setRightItem(rightItem);
 
-                relationshipService.updatePlaceInRelationship(context, relationship, false);
-                relationshipService.update(context, relationship);
+                try {
+                    relationshipService.updatePlaceInRelationship(context, relationship, false);
+                    relationshipService.update(context, relationship);
+                    context.commit();
+                    context.reloadEntity(relationship);
+                } catch (AuthorizeException e) {
+                    throw new AccessDeniedException("You do not have write rights on this relationship's items");
+                }
 
                 return relationshipConverter.fromModel(relationship);
             } else {
@@ -159,9 +191,7 @@ public class RelationshipRestRepository extends DSpaceRestRepository<Relationshi
         } else {
             throw new UnprocessableEntityException("The given items in the request were not valid");
         }
-
     }
-    */
 
     /**
      * This method will check with the current user has write rights on both one of the original items and one of the
@@ -176,10 +206,10 @@ public class RelationshipRestRepository extends DSpaceRestRepository<Relationshi
     private boolean isAllowedToModifyRelationship(Context context, Relationship relationship, Item leftItem,
                                                   Item rightItem) throws SQLException {
         return (authorizeService.authorizeActionBoolean(context, leftItem, Constants.WRITE) ||
-            authorizeService.authorizeActionBoolean(context, rightItem, Constants.WRITE)) &&
-            (authorizeService.authorizeActionBoolean(context, relationship.getLeftItem(), Constants.WRITE) ||
-            authorizeService.authorizeActionBoolean(context, relationship.getRightItem(), Constants.WRITE)
-            );
+                authorizeService.authorizeActionBoolean(context, rightItem, Constants.WRITE)) &&
+                (authorizeService.authorizeActionBoolean(context, relationship.getLeftItem(), Constants.WRITE) ||
+                        authorizeService.authorizeActionBoolean(context, relationship.getRightItem(), Constants.WRITE)
+                );
     }
 
     @Override

--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/RelationshipRestRepository.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/repository/RelationshipRestRepository.java
@@ -156,7 +156,6 @@ public class RelationshipRestRepository extends DSpaceRestRepository<Relationshi
         if (relationship == null) {
             throw new ResourceNotFoundException(contextPath + " with id: " + id + " not found");
         }
-
         List<DSpaceObject> dSpaceObjects = utils.constructDSpaceObjectList(context, stringList);
         if (dSpaceObjects.size() == 1 && dSpaceObjects.get(0).getType() == Constants.ITEM) {
 
@@ -191,6 +190,7 @@ public class RelationshipRestRepository extends DSpaceRestRepository<Relationshi
         } else {
             throw new UnprocessableEntityException("The given items in the request were not valid");
         }
+
     }
 
     /**

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/RelationshipRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/RelationshipRestRepositoryIT.java
@@ -45,7 +45,6 @@ import org.dspace.content.service.RelationshipTypeService;
 import org.dspace.core.Constants;
 import org.dspace.core.I18nUtil;
 import org.dspace.eperson.EPerson;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -72,113 +71,113 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item auhor1 = ItemBuilder.createItem(context, col1)
-                                 .withTitle("Author1")
-                                 .withIssueDate("2017-10-17")
-                                 .withAuthor("Smith, Donald")
-                                 .withRelationshipType("Person")
-                                 .build();
+                .withTitle("Author1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald")
+                .withRelationshipType("Person")
+                .build();
 
         Item author2 = ItemBuilder.createItem(context, col2)
-                                  .withTitle("Author2")
-                                  .withIssueDate("2016-02-13")
-                                  .withAuthor("Smith, Maria")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author2")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Smith, Maria")
+                .withRelationshipType("Person")
+                .build();
 
         Item author3 = ItemBuilder.createItem(context, col2)
-                                  .withTitle("Author3")
-                                  .withIssueDate("2016-02-13")
-                                  .withAuthor("Maybe, Maybe")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author3")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Maybe, Maybe")
+                .withRelationshipType("Person")
+                .build();
 
         Item orgUnit1 = ItemBuilder.createItem(context, col3)
-                                   .withTitle("OrgUnit1")
-                                   .withAuthor("Testy, TEst")
-                                   .withIssueDate("2015-01-01")
-                                   .withRelationshipType("OrgUnit")
-                                   .build();
+                .withTitle("OrgUnit1")
+                .withAuthor("Testy, TEst")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("OrgUnit")
+                .build();
 
         Item project1 = ItemBuilder.createItem(context, col3)
-                                   .withTitle("Project1")
-                                   .withAuthor("Testy, TEst")
-                                   .withIssueDate("2015-01-01")
-                                   .withRelationshipType("Project")
-                                   .build();
+                .withTitle("Project1")
+                .withAuthor("Testy, TEst")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("Project")
+                .build();
 
         Item publication = ItemBuilder.createItem(context, col3)
-                                      .withTitle("Publication1")
-                                      .withAuthor("Testy, TEst")
-                                      .withIssueDate("2015-01-01")
-                                      .withRelationshipType("Publication")
-                                      .build();
+                .withTitle("Publication1")
+                .withAuthor("Testy, TEst")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("Publication")
+                .build();
 
 
         RelationshipType isOrgUnitOfPersonRelationshipType = relationshipTypeService
-            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Person"),
-                                  entityTypeService.findByEntityType(context, "OrgUnit"),
-                                  "isOrgUnitOfPerson", "isPersonOfOrgUnit");
+                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Person"),
+                        entityTypeService.findByEntityType(context, "OrgUnit"),
+                        "isOrgUnitOfPerson", "isPersonOfOrgUnit");
         RelationshipType isOrgUnitOfProjectRelationshipType = relationshipTypeService
-            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Project"),
-                                  entityTypeService.findByEntityType(context, "OrgUnit"),
-                                  "isOrgUnitOfProject", "isProjectOfOrgUnit");
+                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Project"),
+                        entityTypeService.findByEntityType(context, "OrgUnit"),
+                        "isOrgUnitOfProject", "isProjectOfOrgUnit");
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                                  entityTypeService.findByEntityType(context, "Person"),
-                                  "isAuthorOfPublication", "isPublicationOfAuthor");
+                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                        entityTypeService.findByEntityType(context, "Person"),
+                        "isAuthorOfPublication", "isPublicationOfAuthor");
 
         Relationship relationship1 = RelationshipBuilder
-            .createRelationshipBuilder(context, auhor1, orgUnit1, isOrgUnitOfPersonRelationshipType).build();
+                .createRelationshipBuilder(context, auhor1, orgUnit1, isOrgUnitOfPersonRelationshipType).build();
 
         Relationship relationship2 = RelationshipBuilder
-            .createRelationshipBuilder(context, project1, orgUnit1, isOrgUnitOfProjectRelationshipType).build();
+                .createRelationshipBuilder(context, project1, orgUnit1, isOrgUnitOfProjectRelationshipType).build();
 
         Relationship relationship3 = RelationshipBuilder
-            .createRelationshipBuilder(context, publication, auhor1, isAuthorOfPublicationRelationshipType).build();
+                .createRelationshipBuilder(context, publication, auhor1, isAuthorOfPublicationRelationshipType).build();
 
         context.restoreAuthSystemState();
 
         getClient().perform(get("/api/core/relationships"))
 
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$.page",
-                                       is(PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 3))))
-                   .andExpect(jsonPath("$._embedded.relationships", containsInAnyOrder(
-                       RelationshipMatcher.matchRelationship(relationship1),
-                       RelationshipMatcher.matchRelationship(relationship2),
-                       RelationshipMatcher.matchRelationship(relationship3)
-                   )))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page",
+                        is(PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 3))))
+                .andExpect(jsonPath("$._embedded.relationships", containsInAnyOrder(
+                        RelationshipMatcher.matchRelationship(relationship1),
+                        RelationshipMatcher.matchRelationship(relationship2),
+                        RelationshipMatcher.matchRelationship(relationship3)
+                )))
         ;
 
         getClient().perform(get("/api/core/relationships").param("size", "2"))
 
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$.page",
-                                       is(PageMatcher.pageEntryWithTotalPagesAndElements(0, 2, 2, 3))))
-                   .andExpect(jsonPath("$._embedded.relationships", containsInAnyOrder(
-                       RelationshipMatcher.matchRelationship(relationship1),
-                       RelationshipMatcher.matchRelationship(relationship2)
-                   )))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page",
+                        is(PageMatcher.pageEntryWithTotalPagesAndElements(0, 2, 2, 3))))
+                .andExpect(jsonPath("$._embedded.relationships", containsInAnyOrder(
+                        RelationshipMatcher.matchRelationship(relationship1),
+                        RelationshipMatcher.matchRelationship(relationship2)
+                )))
         ;
 
         getClient().perform(get("/api/core/relationships").param("size", "2").param("page", "1"))
 
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$.page",
-                                       is(PageMatcher.pageEntryWithTotalPagesAndElements(1, 2, 2, 3))))
-                   .andExpect(jsonPath("$._embedded.relationships", contains(
-                       RelationshipMatcher.matchRelationship(relationship3)
-                   )))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page",
+                        is(PageMatcher.pageEntryWithTotalPagesAndElements(1, 2, 2, 3))))
+                .andExpect(jsonPath("$._embedded.relationships", contains(
+                        RelationshipMatcher.matchRelationship(relationship3)
+                )))
         ;
 
     }
@@ -189,40 +188,39 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
-        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                                  .withTitle("Author1")
-                                  .withIssueDate("2017-10-17")
-                                  .withAuthor("Smith, Donald")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald")
+                .withRelationshipType("Person")
+                .build();
 
         Item publication = ItemBuilder.createItem(context, col3)
-                                      .withTitle("Publication1")
-                                      .withAuthor("Testy, TEst")
-                                      .withIssueDate("2015-01-01")
-                                      .withRelationshipType("Publication")
-                                      .build();
+                .withTitle("Publication1")
+                .withAuthor("Testy, TEst")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("Publication")
+                .build();
 
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                                  entityTypeService.findByEntityType(context, "Person"),
-                                  "isAuthorOfPublication", "isPublicationOfAuthor");
+                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                        entityTypeService.findByEntityType(context, "Person"),
+                        "isAuthorOfPublication", "isPublicationOfAuthor");
 
         EPerson user = EPersonBuilder.createEPerson(context)
-                                    .withNameInMetadata("first", "last")
-                                    .withEmail("testaze@gmail.com")
-                                    .withPassword(password)
-                                    .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
-                                    .build();
+                .withNameInMetadata("first", "last")
+                .withEmail("testaze@gmail.com")
+                .withPassword(password)
+                .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
+                .build();
         context.setCurrentUser(user);
 
         authorizeService.addPolicy(context, publication, Constants.WRITE, user);
@@ -232,17 +230,17 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String token = getAuthToken(user.getEmail(), password);
 
         MvcResult mvcResult = getClient(token).perform(post("/api/core/relationships")
-                                                           .param("relationshipType",
-                                                                  isAuthorOfPublicationRelationshipType.getID()
-                                                                                                       .toString())
-                                                           .contentType(MediaType.parseMediaType
-                                                               (org.springframework.data.rest.webmvc.RestMediaTypes
-                                                                    .TEXT_URI_LIST_VALUE))
-                                                           .content(
-                                                               "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                                                   "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                                              .andExpect(status().isCreated())
-                                              .andReturn();
+                .param("relationshipType",
+                        isAuthorOfPublicationRelationshipType.getID()
+                                .toString())
+                .contentType(MediaType.parseMediaType
+                        (org.springframework.data.rest.webmvc.RestMediaTypes
+                                .TEXT_URI_LIST_VALUE))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
 
         ObjectMapper mapper = new ObjectMapper();
 
@@ -251,9 +249,9 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String firstRelationshipIdString = String.valueOf(map.get("id"));
 
         getClient().perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$.leftId", is(publication.getID().toString())))
-                   .andExpect(jsonPath("$.rightId", is(author1.getID().toString())));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.leftId", is(publication.getID().toString())))
+                .andExpect(jsonPath("$.rightId", is(author1.getID().toString())));
 
     }
 
@@ -263,40 +261,39 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
-        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                                  .withTitle("Author1")
-                                  .withIssueDate("2017-10-17")
-                                  .withAuthor("Smith, Donald")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald")
+                .withRelationshipType("Person")
+                .build();
 
         Item publication = ItemBuilder.createItem(context, col3)
-                                      .withTitle("Publication1")
-                                      .withAuthor("Testy, TEst")
-                                      .withIssueDate("2015-01-01")
-                                      .withRelationshipType("Publication")
-                                      .build();
+                .withTitle("Publication1")
+                .withAuthor("Testy, TEst")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("Publication")
+                .build();
 
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                                  entityTypeService.findByEntityType(context, "Person"),
-                                  "isAuthorOfPublication", "isPublicationOfAuthor");
+                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                        entityTypeService.findByEntityType(context, "Person"),
+                        "isAuthorOfPublication", "isPublicationOfAuthor");
 
         EPerson user = EPersonBuilder.createEPerson(context)
-                                     .withNameInMetadata("first", "last")
-                                     .withEmail("testaze@gmail.com")
-                                     .withPassword(password)
-                                     .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
-                                     .build();
+                .withNameInMetadata("first", "last")
+                .withEmail("testaze@gmail.com")
+                .withPassword(password)
+                .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
+                .build();
         context.setCurrentUser(user);
 
         authorizeService.addPolicy(context, author1, Constants.WRITE, user);
@@ -305,17 +302,17 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String token = getAuthToken(user.getEmail(), password);
 
         MvcResult mvcResult = getClient(token).perform(post("/api/core/relationships")
-                                                           .param("relationshipType",
-                                                                  isAuthorOfPublicationRelationshipType.getID()
-                                                                                                       .toString())
-                                                           .contentType(MediaType.parseMediaType
-                                                               (org.springframework.data.rest.webmvc.RestMediaTypes
-                                                                    .TEXT_URI_LIST_VALUE))
-                                                           .content(
-                                                               "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                                                   "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                                              .andExpect(status().isCreated())
-                                              .andReturn();
+                .param("relationshipType",
+                        isAuthorOfPublicationRelationshipType.getID()
+                                .toString())
+                .contentType(MediaType.parseMediaType
+                        (org.springframework.data.rest.webmvc.RestMediaTypes
+                                .TEXT_URI_LIST_VALUE))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
 
         ObjectMapper mapper = new ObjectMapper();
 
@@ -324,9 +321,9 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String firstRelationshipIdString = String.valueOf(map.get("id"));
 
         getClient().perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$.leftId", is(publication.getID().toString())))
-                   .andExpect(jsonPath("$.rightId", is(author1.getID().toString())));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.leftId", is(publication.getID().toString())))
+                .andExpect(jsonPath("$.rightId", is(author1.getID().toString())));
     }
 
 
@@ -336,63 +333,64 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                                  .withTitle("Author1")
-                                  .withIssueDate("2017-10-17")
-                                  .withAuthor("Smith, Donald")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald")
+                .withRelationshipType("Person")
+                .build();
 
         Item publication = ItemBuilder.createItem(context, col3)
-                                      .withTitle("Publication1")
-                                      .withAuthor("Testy, TEst")
-                                      .withIssueDate("2015-01-01")
-                                      .withRelationshipType("Publication")
-                                      .build();
+                .withTitle("Publication1")
+                .withAuthor("Testy, TEst")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("Publication")
+                .build();
 
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                                  entityTypeService.findByEntityType(context, "Person"),
-                                  "isAuthorOfPublication", "isPublicationOfAuthor");
+                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                        entityTypeService.findByEntityType(context, "Person"),
+                        "isAuthorOfPublication", "isPublicationOfAuthor");
 
         EPerson user = EPersonBuilder.createEPerson(context)
-                                     .withNameInMetadata("first", "last")
-                                     .withEmail("testaze@gmail.com")
-                                     .withPassword(password)
-                                     .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
-                                     .build();
+                .withNameInMetadata("first", "last")
+                .withEmail("testaze@gmail.com")
+                .withPassword(password)
+                .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
+                .build();
         context.setCurrentUser(user);
         context.restoreAuthSystemState();
 
         String token = getAuthToken(user.getEmail(), password);
 
         MvcResult mvcResult = getClient(token).perform(post("/api/core/relationships")
-                                                           .param("relationshipType",
-                                                                  isAuthorOfPublicationRelationshipType.getID()
-                                                                                                       .toString())
-                                                           .contentType(MediaType.parseMediaType
-                                                               (org.springframework.data.rest.webmvc.RestMediaTypes
-                                                                    .TEXT_URI_LIST_VALUE))
-                                                           .content(
-                                                               "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                                                   "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                                              .andExpect(status().isForbidden())
-                                              .andReturn();
+                .param("relationshipType",
+                        isAuthorOfPublicationRelationshipType.getID()
+                                .toString())
+                .contentType(MediaType.parseMediaType
+                        (org.springframework.data.rest.webmvc.RestMediaTypes
+                                .TEXT_URI_LIST_VALUE))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                .andExpect(status().isForbidden())
+                .andReturn();
 
     }
 
     /**
      * This method will test the addition of a mixture of plain-text metadatavalues and relationships to then
      * verify that the place property is still being handled correctly.
+     *
      * @throws Exception
      */
     @Test
@@ -401,48 +399,48 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                                  .withTitle("Author1")
-                                  .withIssueDate("2017-10-17")
-                                  .withPersonIdentifierFirstName("Donald")
-                                  .withPersonIdentifierLastName("Smith")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author1")
+                .withIssueDate("2017-10-17")
+                .withPersonIdentifierFirstName("Donald")
+                .withPersonIdentifierLastName("Smith")
+                .withRelationshipType("Person")
+                .build();
 
         Item author2 = ItemBuilder.createItem(context, col2)
-                                  .withTitle("Author2")
-                                  .withIssueDate("2016-02-13")
-                                  .withPersonIdentifierFirstName("Maria")
-                                  .withPersonIdentifierLastName("Smith")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author2")
+                .withIssueDate("2016-02-13")
+                .withPersonIdentifierFirstName("Maria")
+                .withPersonIdentifierLastName("Smith")
+                .withRelationshipType("Person")
+                .build();
 
         Item author3 = ItemBuilder.createItem(context, col2)
-                                  .withTitle("Author3")
-                                  .withIssueDate("2016-02-13")
-                                  .withPersonIdentifierFirstName("Maybe")
-                                  .withPersonIdentifierLastName("Maybe")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author3")
+                .withIssueDate("2016-02-13")
+                .withPersonIdentifierFirstName("Maybe")
+                .withPersonIdentifierLastName("Maybe")
+                .withRelationshipType("Person")
+                .build();
 
         Item publication = ItemBuilder.createItem(context, col3)
-                                      .withTitle("Publication1")
-                                      .withIssueDate("2015-01-01")
-                                      .withRelationshipType("Publication")
-                                      .build();
+                .withTitle("Publication1")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("Publication")
+                .build();
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                                  entityTypeService.findByEntityType(context, "Person"),
-                                  "isAuthorOfPublication", "isPublicationOfAuthor");
+                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                        entityTypeService.findByEntityType(context, "Person"),
+                        "isAuthorOfPublication", "isPublicationOfAuthor");
 
         String adminToken = getAuthToken(admin.getEmail(), password);
 
@@ -450,17 +448,17 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         // Here we create our first Relationship to the Publication to give it a dc.contributor.author virtual
         // metadata field.
         MvcResult mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                                                                .param("relationshipType",
-                                                                       isAuthorOfPublicationRelationshipType.getID()
-                                                                                                            .toString())
-                                                                .contentType(MediaType.parseMediaType
-                                                                    (org.springframework.data.rest.webmvc.RestMediaTypes
-                                                                         .TEXT_URI_LIST_VALUE))
-                                                                .content(
-                                                                    "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                                                        "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                                                   .andExpect(status().isCreated())
-                                                   .andReturn();
+                .param("relationshipType",
+                        isAuthorOfPublicationRelationshipType.getID()
+                                .toString())
+                .contentType(MediaType.parseMediaType
+                        (org.springframework.data.rest.webmvc.RestMediaTypes
+                                .TEXT_URI_LIST_VALUE))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
         ObjectMapper mapper = new ObjectMapper();
 
         String content = mvcResult.getResponse().getContentAsString();
@@ -469,8 +467,8 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
         // Here we call the relationship and verify that the relationship's leftplace is 0
         getClient(adminToken).perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("leftPlace", is(0)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("leftPlace", is(0)));
 
         context.turnOffAuthorisationSystem();
 
@@ -501,22 +499,22 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.restoreAuthSystemState();
         // Verfiy the leftPlace of our relationship is still 0.
         getClient(adminToken).perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("leftPlace", is(0)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("leftPlace", is(0)));
 
         // Create another Relationship for the Publication, thus creating a third dc.contributor.author mdv
         mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                                                      .param("relationshipType",
-                                                             isAuthorOfPublicationRelationshipType.getID()
-                                                                                                  .toString())
-                                                      .contentType(MediaType.parseMediaType
-                                                          (org.springframework.data.rest.webmvc.RestMediaTypes
-                                                               .TEXT_URI_LIST_VALUE))
-                                                      .content(
-                                                          "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                                              "https://localhost:8080/spring-rest/api/core/items/" + author2.getID()))
-                                         .andExpect(status().isCreated())
-                                         .andReturn();
+                .param("relationshipType",
+                        isAuthorOfPublicationRelationshipType.getID()
+                                .toString())
+                .contentType(MediaType.parseMediaType
+                        (org.springframework.data.rest.webmvc.RestMediaTypes
+                                .TEXT_URI_LIST_VALUE))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + author2.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
 
         content = mvcResult.getResponse().getContentAsString();
         map = mapper.readValue(content, Map.class);
@@ -531,8 +529,8 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         // Relationship. Note that leftPlace 1 was skipped due to the dc.contributor.author plain text value and
         // This is expected behaviour and should be tested
         getClient(adminToken).perform(get("/api/core/relationships/" + secondRelationshipIdString))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("leftPlace", is(2)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("leftPlace", is(2)));
 
         author0MD = list.get(0);
         assertEquals("Smith, Donald", author0MD.getValue());
@@ -572,17 +570,17 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
         // Create the third Relationship thus adding a fifth dc.contributor.author mdv
         mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                                                      .param("relationshipType",
-                                                             isAuthorOfPublicationRelationshipType.getID()
-                                                                                                  .toString())
-                                                      .contentType(MediaType.parseMediaType
-                                                          (org.springframework.data.rest.webmvc.RestMediaTypes
-                                                               .TEXT_URI_LIST_VALUE))
-                                                      .content(
-                                                          "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                                              "https://localhost:8080/spring-rest/api/core/items/" + author3.getID()))
-                                         .andExpect(status().isCreated())
-                                         .andReturn();
+                .param("relationshipType",
+                        isAuthorOfPublicationRelationshipType.getID()
+                                .toString())
+                .contentType(MediaType.parseMediaType
+                        (org.springframework.data.rest.webmvc.RestMediaTypes
+                                .TEXT_URI_LIST_VALUE))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + author3.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
 
         content = mvcResult.getResponse().getContentAsString();
         map = mapper.readValue(content, Map.class);
@@ -595,8 +593,8 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         // Assert that the third Relationship has leftPlace 4, even though 3 relationships were created.
         // This is because the plain text values 'occupy' place 1 and 3.
         getClient(adminToken).perform(get("/api/core/relationships/" + thirdRelationshipIdString))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("leftPlace", is(4)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("leftPlace", is(4)));
 
         // Assert that the list is of size 5 and in the following order:
         // "Smith, Donald", "plain text", "Smith, Maria", "plain text two", "Maybe, Maybe"
@@ -703,6 +701,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
     /**
      * This method will test the deletion of a plain-text metadatavalue to then
      * verify that the place property is still being handled correctly.
+     *
      * @throws Exception
      */
     @Test
@@ -711,48 +710,48 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                                  .withTitle("Author1")
-                                  .withIssueDate("2017-10-17")
-                                  .withPersonIdentifierFirstName("Donald")
-                                  .withPersonIdentifierLastName("Smith")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author1")
+                .withIssueDate("2017-10-17")
+                .withPersonIdentifierFirstName("Donald")
+                .withPersonIdentifierLastName("Smith")
+                .withRelationshipType("Person")
+                .build();
 
         Item author2 = ItemBuilder.createItem(context, col2)
-                                  .withTitle("Author2")
-                                  .withIssueDate("2016-02-13")
-                                  .withPersonIdentifierFirstName("Maria")
-                                  .withPersonIdentifierLastName("Smith")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author2")
+                .withIssueDate("2016-02-13")
+                .withPersonIdentifierFirstName("Maria")
+                .withPersonIdentifierLastName("Smith")
+                .withRelationshipType("Person")
+                .build();
 
         Item author3 = ItemBuilder.createItem(context, col2)
-                                  .withTitle("Author3")
-                                  .withIssueDate("2016-02-13")
-                                  .withPersonIdentifierFirstName("Maybe")
-                                  .withPersonIdentifierLastName("Maybe")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author3")
+                .withIssueDate("2016-02-13")
+                .withPersonIdentifierFirstName("Maybe")
+                .withPersonIdentifierLastName("Maybe")
+                .withRelationshipType("Person")
+                .build();
 
         Item publication = ItemBuilder.createItem(context, col3)
-                                      .withTitle("Publication1")
-                                      .withIssueDate("2015-01-01")
-                                      .withRelationshipType("Publication")
-                                      .build();
+                .withTitle("Publication1")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("Publication")
+                .build();
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                                  entityTypeService.findByEntityType(context, "Person"),
-                                  "isAuthorOfPublication", "isPublicationOfAuthor");
+                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                        entityTypeService.findByEntityType(context, "Person"),
+                        "isAuthorOfPublication", "isPublicationOfAuthor");
 
         String adminToken = getAuthToken(admin.getEmail(), password);
 
@@ -761,17 +760,17 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         // This post request will add a first relationship to the publiction and thus create a first set of metadata
         // For the author values, namely "Donald Smith"
         MvcResult mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                                                                .param("relationshipType",
-                                                                       isAuthorOfPublicationRelationshipType.getID()
-                                                                                                            .toString())
-                                                                .contentType(MediaType.parseMediaType
-                                                                    (org.springframework.data.rest.webmvc.RestMediaTypes
-                                                                         .TEXT_URI_LIST_VALUE))
-                                                                .content(
-                                                                    "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                                                        "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                                                   .andExpect(status().isCreated())
-                                                   .andReturn();
+                .param("relationshipType",
+                        isAuthorOfPublicationRelationshipType.getID()
+                                .toString())
+                .contentType(MediaType.parseMediaType
+                        (org.springframework.data.rest.webmvc.RestMediaTypes
+                                .TEXT_URI_LIST_VALUE))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
         ObjectMapper mapper = new ObjectMapper();
 
         String content = mvcResult.getResponse().getContentAsString();
@@ -780,8 +779,8 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
         // This test will double check that the leftPlace for this relationship is indeed 0
         getClient(adminToken).perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("leftPlace", is(0)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("leftPlace", is(0)));
 
 
         context.turnOffAuthorisationSystem();
@@ -804,22 +803,22 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         // This test checks again that the first relationship is still on leftplace 0 and not altered
         // Because of the MetadataValue addition
         getClient(adminToken).perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("leftPlace", is(0)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("leftPlace", is(0)));
 
         // Creates another Relationship for the Publication and thus adding a third metadata value for the author
         mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                                                      .param("relationshipType",
-                                                             isAuthorOfPublicationRelationshipType.getID()
-                                                                                                  .toString())
-                                                      .contentType(MediaType.parseMediaType
-                                                          (org.springframework.data.rest.webmvc.RestMediaTypes
-                                                               .TEXT_URI_LIST_VALUE))
-                                                      .content(
-                                                          "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                                              "https://localhost:8080/spring-rest/api/core/items/" + author2.getID()))
-                                         .andExpect(status().isCreated())
-                                         .andReturn();
+                .param("relationshipType",
+                        isAuthorOfPublicationRelationshipType.getID()
+                                .toString())
+                .contentType(MediaType.parseMediaType
+                        (org.springframework.data.rest.webmvc.RestMediaTypes
+                                .TEXT_URI_LIST_VALUE))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + author2.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
 
         content = mvcResult.getResponse().getContentAsString();
         map = mapper.readValue(content, Map.class);
@@ -828,8 +827,8 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         // This test verifies that the newly created Relationship is on leftPlace 2, because the first relationship
         // is on leftPlace 0 and the plain text metadataValue occupies the place 1
         getClient(adminToken).perform(get("/api/core/relationships/" + secondRelationshipIdString))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("leftPlace", is(2)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("leftPlace", is(2)));
         context.turnOffAuthorisationSystem();
         // Get the publication from the DB again to ensure that we have the latest object
         publication = itemService.find(context, publication.getID());
@@ -850,17 +849,17 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
         // This creates a third relationship for the publication and thus adding a fifth value for author metadatavalues
         mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                                                      .param("relationshipType",
-                                                             isAuthorOfPublicationRelationshipType.getID()
-                                                                                                  .toString())
-                                                      .contentType(MediaType.parseMediaType
-                                                          (org.springframework.data.rest.webmvc.RestMediaTypes
-                                                               .TEXT_URI_LIST_VALUE))
-                                                      .content(
-                                                          "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                                              "https://localhost:8080/spring-rest/api/core/items/" + author3.getID()))
-                                         .andExpect(status().isCreated())
-                                         .andReturn();
+                .param("relationshipType",
+                        isAuthorOfPublicationRelationshipType.getID()
+                                .toString())
+                .contentType(MediaType.parseMediaType
+                        (org.springframework.data.rest.webmvc.RestMediaTypes
+                                .TEXT_URI_LIST_VALUE))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + author3.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
 
         content = mvcResult.getResponse().getContentAsString();
         map = mapper.readValue(content, Map.class);
@@ -868,8 +867,8 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
         // This verifies that the newly created third relationship is on leftPlace 4.
         getClient(adminToken).perform(get("/api/core/relationships/" + thirdRelationshipIdString))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("leftPlace", is(4)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("leftPlace", is(4)));
 
         context.turnOffAuthorisationSystem();
         publication = itemService.find(context, publication.getID());
@@ -919,20 +918,21 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         }
 
         getClient(adminToken).perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("leftPlace", is(0)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("leftPlace", is(0)));
         getClient(adminToken).perform(get("/api/core/relationships/" + secondRelationshipIdString))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("leftPlace", is(2)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("leftPlace", is(2)));
         getClient(adminToken).perform(get("/api/core/relationships/" + thirdRelationshipIdString))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("leftPlace", is(3)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("leftPlace", is(3)));
 
     }
 
     /**
      * This method will test the deletion of a Relationship to then
      * verify that the place property is still being handled correctly.
+     *
      * @throws Exception
      */
     @Test
@@ -942,48 +942,48 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                                  .withTitle("Author1")
-                                  .withIssueDate("2017-10-17")
-                                  .withPersonIdentifierFirstName("Donald")
-                                  .withPersonIdentifierLastName("Smith")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author1")
+                .withIssueDate("2017-10-17")
+                .withPersonIdentifierFirstName("Donald")
+                .withPersonIdentifierLastName("Smith")
+                .withRelationshipType("Person")
+                .build();
 
         Item author2 = ItemBuilder.createItem(context, col2)
-                                  .withTitle("Author2")
-                                  .withIssueDate("2016-02-13")
-                                  .withPersonIdentifierFirstName("Maria")
-                                  .withPersonIdentifierLastName("Smith")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author2")
+                .withIssueDate("2016-02-13")
+                .withPersonIdentifierFirstName("Maria")
+                .withPersonIdentifierLastName("Smith")
+                .withRelationshipType("Person")
+                .build();
 
         Item author3 = ItemBuilder.createItem(context, col2)
-                                  .withTitle("Author3")
-                                  .withIssueDate("2016-02-13")
-                                  .withPersonIdentifierFirstName("Maybe")
-                                  .withPersonIdentifierLastName("Maybe")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author3")
+                .withIssueDate("2016-02-13")
+                .withPersonIdentifierFirstName("Maybe")
+                .withPersonIdentifierLastName("Maybe")
+                .withRelationshipType("Person")
+                .build();
 
         Item publication = ItemBuilder.createItem(context, col3)
-                                      .withTitle("Publication1")
-                                      .withIssueDate("2015-01-01")
-                                      .withRelationshipType("Publication")
-                                      .build();
+                .withTitle("Publication1")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("Publication")
+                .build();
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                                  entityTypeService.findByEntityType(context, "Person"),
-                                  "isAuthorOfPublication", "isPublicationOfAuthor");
+                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                        entityTypeService.findByEntityType(context, "Person"),
+                        "isAuthorOfPublication", "isPublicationOfAuthor");
 
         String adminToken = getAuthToken(admin.getEmail(), password);
 
@@ -992,17 +992,17 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         // This post request will add a first relationship to the publiction and thus create a first set of metadata
         // For the author values, namely "Donald Smith"
         MvcResult mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                                                                .param("relationshipType",
-                                                                       isAuthorOfPublicationRelationshipType.getID()
-                                                                                                            .toString())
-                                                                .contentType(MediaType.parseMediaType
-                                                                    (org.springframework.data.rest.webmvc.RestMediaTypes
-                                                                         .TEXT_URI_LIST_VALUE))
-                                                                .content(
-                                                                    "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                                                        "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                                                   .andExpect(status().isCreated())
-                                                   .andReturn();
+                .param("relationshipType",
+                        isAuthorOfPublicationRelationshipType.getID()
+                                .toString())
+                .contentType(MediaType.parseMediaType
+                        (org.springframework.data.rest.webmvc.RestMediaTypes
+                                .TEXT_URI_LIST_VALUE))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
         ObjectMapper mapper = new ObjectMapper();
 
         String content = mvcResult.getResponse().getContentAsString();
@@ -1011,8 +1011,8 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
         // This test will double check that the leftPlace for this relationship is indeed 0
         getClient(adminToken).perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("leftPlace", is(0)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("leftPlace", is(0)));
 
 
         context.turnOffAuthorisationSystem();
@@ -1035,22 +1035,22 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         // This test checks again that the first relationship is still on leftplace 0 and not altered
         // Because of the MetadataValue addition
         getClient(adminToken).perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("leftPlace", is(0)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("leftPlace", is(0)));
 
         // Creates another Relationship for the Publication and thus adding a third metadata value for the author
         mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                                                      .param("relationshipType",
-                                                             isAuthorOfPublicationRelationshipType.getID()
-                                                                                                  .toString())
-                                                      .contentType(MediaType.parseMediaType
-                                                          (org.springframework.data.rest.webmvc.RestMediaTypes
-                                                               .TEXT_URI_LIST_VALUE))
-                                                      .content(
-                                                          "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                                              "https://localhost:8080/spring-rest/api/core/items/" + author2.getID()))
-                                         .andExpect(status().isCreated())
-                                         .andReturn();
+                .param("relationshipType",
+                        isAuthorOfPublicationRelationshipType.getID()
+                                .toString())
+                .contentType(MediaType.parseMediaType
+                        (org.springframework.data.rest.webmvc.RestMediaTypes
+                                .TEXT_URI_LIST_VALUE))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + author2.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
 
         content = mvcResult.getResponse().getContentAsString();
         map = mapper.readValue(content, Map.class);
@@ -1059,8 +1059,8 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         // This test verifies that the newly created Relationship is on leftPlace 2, because the first relationship
         // is on leftPlace 0 and the plain text metadataValue occupies the place 1
         getClient(adminToken).perform(get("/api/core/relationships/" + secondRelationshipIdString))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("leftPlace", is(2)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("leftPlace", is(2)));
         context.turnOffAuthorisationSystem();
         // Get the publication from the DB again to ensure that we have the latest object
         publication = itemService.find(context, publication.getID());
@@ -1081,17 +1081,17 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
         // This creates a third relationship for the publication and thus adding a fifth value for author metadatavalues
         mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                                                      .param("relationshipType",
-                                                             isAuthorOfPublicationRelationshipType.getID()
-                                                                                                  .toString())
-                                                      .contentType(MediaType.parseMediaType
-                                                          (org.springframework.data.rest.webmvc.RestMediaTypes
-                                                               .TEXT_URI_LIST_VALUE))
-                                                      .content(
-                                                          "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                                              "https://localhost:8080/spring-rest/api/core/items/" + author3.getID()))
-                                         .andExpect(status().isCreated())
-                                         .andReturn();
+                .param("relationshipType",
+                        isAuthorOfPublicationRelationshipType.getID()
+                                .toString())
+                .contentType(MediaType.parseMediaType
+                        (org.springframework.data.rest.webmvc.RestMediaTypes
+                                .TEXT_URI_LIST_VALUE))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + author3.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
 
         content = mvcResult.getResponse().getContentAsString();
         map = mapper.readValue(content, Map.class);
@@ -1099,8 +1099,8 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
         // This verifies that the newly created third relationship is on leftPlace 4.
         getClient(adminToken).perform(get("/api/core/relationships/" + thirdRelationshipIdString))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("leftPlace", is(4)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("leftPlace", is(4)));
 
         context.turnOffAuthorisationSystem();
         publication = itemService.find(context, publication.getID());
@@ -1127,8 +1127,8 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         getClient(adminToken).perform(delete("/api/core/relationships/" + secondRelationshipIdString));
 
         getClient(adminToken).perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("leftPlace", is(0)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("leftPlace", is(0)));
 
         publication = itemService.find(context, publication.getID());
         list = itemService.getMetadata(publication, "dc", "contributor", "author", Item.ANY);
@@ -1157,8 +1157,8 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
 
         getClient(adminToken).perform(get("/api/core/relationships/" + thirdRelationshipIdString))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("leftPlace", is(3)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("leftPlace", is(3)));
 
     }
 
@@ -1166,6 +1166,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
      * This test will simply add Relationships between Items with a useForPlace attribute set to false for the
      * RelationshipType. We want to test that the Relationships that are created will still have their place
      * attributes handled in a correct way
+     *
      * @throws Exception
      */
     @Test
@@ -1174,63 +1175,63 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                                  .withTitle("Author1")
-                                  .withIssueDate("2017-10-17")
-                                  .withAuthor("Smith, Donald")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald")
+                .withRelationshipType("Person")
+                .build();
 
         Item author2 = ItemBuilder.createItem(context, col2)
-                                  .withTitle("Author2")
-                                  .withIssueDate("2016-02-13")
-                                  .withAuthor("Smith, Maria")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author2")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Smith, Maria")
+                .withRelationshipType("Person")
+                .build();
 
         Item author3 = ItemBuilder.createItem(context, col2)
-                                  .withTitle("Author3")
-                                  .withIssueDate("2016-02-13")
-                                  .withAuthor("Maybe, Maybe")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author3")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Maybe, Maybe")
+                .withRelationshipType("Person")
+                .build();
 
         Item orgUnit1 = ItemBuilder.createItem(context, col3)
-                                   .withTitle("OrgUnit1")
-                                   .withIssueDate("2015-01-01")
-                                   .withRelationshipType("OrgUnit")
-                                   .build();
+                .withTitle("OrgUnit1")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("OrgUnit")
+                .build();
 
         RelationshipType isOrgUnitOfPersonRelationshipType = relationshipTypeService
-            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Person"),
-                                  entityTypeService.findByEntityType(context, "OrgUnit"),
-                                  "isOrgUnitOfPerson", "isPersonOfOrgUnit");
+                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Person"),
+                        entityTypeService.findByEntityType(context, "OrgUnit"),
+                        "isOrgUnitOfPerson", "isPersonOfOrgUnit");
         context.restoreAuthSystemState();
         String adminToken = getAuthToken(admin.getEmail(), password);
 
         // This is essentially a sequence of adding Relationships by POST and then checking with GET to see
         // if the place is being set properly.
         MvcResult mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                                                                .param("relationshipType",
-                                                                       isOrgUnitOfPersonRelationshipType.getID()
-                                                                                                        .toString())
-                                                                .contentType(MediaType.parseMediaType
-                                                                    (org.springframework.data.rest.webmvc.RestMediaTypes
-                                                                         .TEXT_URI_LIST_VALUE))
-                                                                .content(
-                                                                    "https://localhost:8080/spring-rest/api/core/items/" + author1.getID() + "\n" +
-                                                                        "https://localhost:8080/spring-rest/api/core/items/" + orgUnit1.getID()))
-                                                   .andExpect(status().isCreated())
-                                                   .andReturn();
+                .param("relationshipType",
+                        isOrgUnitOfPersonRelationshipType.getID()
+                                .toString())
+                .contentType(MediaType.parseMediaType
+                        (org.springframework.data.rest.webmvc.RestMediaTypes
+                                .TEXT_URI_LIST_VALUE))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + author1.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + orgUnit1.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
         ObjectMapper mapper = new ObjectMapper();
 
         String content = mvcResult.getResponse().getContentAsString();
@@ -1238,20 +1239,20 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String firstRelationshipIdString = String.valueOf(map.get("id"));
 
         getClient(adminToken).perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("rightPlace", is(0)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("rightPlace", is(0)));
 
         mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                                                      .param("relationshipType",
-                                                             isOrgUnitOfPersonRelationshipType.getID().toString())
-                                                      .contentType(MediaType.parseMediaType
-                                                          (org.springframework.data.rest.webmvc.RestMediaTypes
-                                                               .TEXT_URI_LIST_VALUE))
-                                                      .content(
-                                                          "https://localhost:8080/spring-rest/api/core/items/" + author2.getID() + "\n" +
-                                                              "https://localhost:8080/spring-rest/api/core/items/" + orgUnit1.getID()))
-                                         .andExpect(status().isCreated())
-                                         .andReturn();
+                .param("relationshipType",
+                        isOrgUnitOfPersonRelationshipType.getID().toString())
+                .contentType(MediaType.parseMediaType
+                        (org.springframework.data.rest.webmvc.RestMediaTypes
+                                .TEXT_URI_LIST_VALUE))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + author2.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + orgUnit1.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
         mapper = new ObjectMapper();
 
         content = mvcResult.getResponse().getContentAsString();
@@ -1259,20 +1260,20 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String secondRelationshipIdString = String.valueOf(map.get("id"));
 
         getClient(adminToken).perform(get("/api/core/relationships/" + secondRelationshipIdString))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("rightPlace", is(1)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("rightPlace", is(1)));
 
         mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                                                      .param("relationshipType",
-                                                             isOrgUnitOfPersonRelationshipType.getID().toString())
-                                                      .contentType(MediaType.parseMediaType
-                                                          (org.springframework.data.rest.webmvc.RestMediaTypes
-                                                               .TEXT_URI_LIST_VALUE))
-                                                      .content(
-                                                          "https://localhost:8080/spring-rest/api/core/items/" + author3.getID() + "\n" +
-                                                              "https://localhost:8080/spring-rest/api/core/items/" + orgUnit1.getID()))
-                                         .andExpect(status().isCreated())
-                                         .andReturn();
+                .param("relationshipType",
+                        isOrgUnitOfPersonRelationshipType.getID().toString())
+                .contentType(MediaType.parseMediaType
+                        (org.springframework.data.rest.webmvc.RestMediaTypes
+                                .TEXT_URI_LIST_VALUE))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + author3.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + orgUnit1.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
         mapper = new ObjectMapper();
 
         content = mvcResult.getResponse().getContentAsString();
@@ -1280,8 +1281,8 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String thirdRelationshipIdString = String.valueOf(map.get("id"));
 
         getClient(adminToken).perform(get("/api/core/relationships/" + thirdRelationshipIdString))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("rightPlace", is(2)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("rightPlace", is(2)));
     }
 
     /**
@@ -1289,6 +1290,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
      * RelationshipType. We want to test that the Relationships that are created will still have their place
      * attributes handled in a correct way. It will then delete a Relationship and once again ensure that the place
      * attributes are being handled correctly.
+     *
      * @throws Exception
      */
     @Test
@@ -1297,63 +1299,63 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                                  .withTitle("Author1")
-                                  .withIssueDate("2017-10-17")
-                                  .withAuthor("Smith, Donald")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald")
+                .withRelationshipType("Person")
+                .build();
 
         Item author2 = ItemBuilder.createItem(context, col2)
-                                  .withTitle("Author2")
-                                  .withIssueDate("2016-02-13")
-                                  .withAuthor("Smith, Maria")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author2")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Smith, Maria")
+                .withRelationshipType("Person")
+                .build();
 
         Item author3 = ItemBuilder.createItem(context, col2)
-                                  .withTitle("Author3")
-                                  .withIssueDate("2016-02-13")
-                                  .withAuthor("Maybe, Maybe")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author3")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Maybe, Maybe")
+                .withRelationshipType("Person")
+                .build();
 
         Item orgUnit1 = ItemBuilder.createItem(context, col3)
-                                   .withTitle("OrgUnit1")
-                                   .withIssueDate("2015-01-01")
-                                   .withRelationshipType("OrgUnit")
-                                   .build();
+                .withTitle("OrgUnit1")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("OrgUnit")
+                .build();
 
         RelationshipType isOrgUnitOfPersonRelationshipType = relationshipTypeService
-            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Person"),
-                                  entityTypeService.findByEntityType(context, "OrgUnit"),
-                                  "isOrgUnitOfPerson", "isPersonOfOrgUnit");
+                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Person"),
+                        entityTypeService.findByEntityType(context, "OrgUnit"),
+                        "isOrgUnitOfPerson", "isPersonOfOrgUnit");
         context.restoreAuthSystemState();
         String adminToken = getAuthToken(admin.getEmail(), password);
 
         // This is essentially a sequence of adding Relationships by POST and then checking with GET to see
         // if the place is being set properly.
         MvcResult mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                                                                .param("relationshipType",
-                                                                       isOrgUnitOfPersonRelationshipType.getID()
-                                                                                                        .toString())
-                                                                .contentType(MediaType.parseMediaType
-                                                                    (org.springframework.data.rest.webmvc.RestMediaTypes
-                                                                         .TEXT_URI_LIST_VALUE))
-                                                                .content(
-                                                                    "https://localhost:8080/spring-rest/api/core/items/" + author1.getID() + "\n" +
-                                                                        "https://localhost:8080/spring-rest/api/core/items/" + orgUnit1.getID()))
-                                                   .andExpect(status().isCreated())
-                                                   .andReturn();
+                .param("relationshipType",
+                        isOrgUnitOfPersonRelationshipType.getID()
+                                .toString())
+                .contentType(MediaType.parseMediaType
+                        (org.springframework.data.rest.webmvc.RestMediaTypes
+                                .TEXT_URI_LIST_VALUE))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + author1.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + orgUnit1.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
         ObjectMapper mapper = new ObjectMapper();
 
         String content = mvcResult.getResponse().getContentAsString();
@@ -1361,20 +1363,20 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String firstRelationshipIdString = String.valueOf(map.get("id"));
 
         getClient(adminToken).perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("rightPlace", is(0)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("rightPlace", is(0)));
 
         mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                                                      .param("relationshipType",
-                                                             isOrgUnitOfPersonRelationshipType.getID().toString())
-                                                      .contentType(MediaType.parseMediaType
-                                                          (org.springframework.data.rest.webmvc.RestMediaTypes
-                                                               .TEXT_URI_LIST_VALUE))
-                                                      .content(
-                                                          "https://localhost:8080/spring-rest/api/core/items/" + author2.getID() + "\n" +
-                                                              "https://localhost:8080/spring-rest/api/core/items/" + orgUnit1.getID()))
-                                         .andExpect(status().isCreated())
-                                         .andReturn();
+                .param("relationshipType",
+                        isOrgUnitOfPersonRelationshipType.getID().toString())
+                .contentType(MediaType.parseMediaType
+                        (org.springframework.data.rest.webmvc.RestMediaTypes
+                                .TEXT_URI_LIST_VALUE))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + author2.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + orgUnit1.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
         mapper = new ObjectMapper();
 
         content = mvcResult.getResponse().getContentAsString();
@@ -1382,20 +1384,20 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String secondRelationshipIdString = String.valueOf(map.get("id"));
 
         getClient(adminToken).perform(get("/api/core/relationships/" + secondRelationshipIdString))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("rightPlace", is(1)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("rightPlace", is(1)));
 
         mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                                                      .param("relationshipType",
-                                                             isOrgUnitOfPersonRelationshipType.getID().toString())
-                                                      .contentType(MediaType.parseMediaType
-                                                          (org.springframework.data.rest.webmvc.RestMediaTypes
-                                                               .TEXT_URI_LIST_VALUE))
-                                                      .content(
-                                                          "https://localhost:8080/spring-rest/api/core/items/" + author3.getID() + "\n" +
-                                                              "https://localhost:8080/spring-rest/api/core/items/" + orgUnit1.getID()))
-                                         .andExpect(status().isCreated())
-                                         .andReturn();
+                .param("relationshipType",
+                        isOrgUnitOfPersonRelationshipType.getID().toString())
+                .contentType(MediaType.parseMediaType
+                        (org.springframework.data.rest.webmvc.RestMediaTypes
+                                .TEXT_URI_LIST_VALUE))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + author3.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + orgUnit1.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
         mapper = new ObjectMapper();
 
         content = mvcResult.getResponse().getContentAsString();
@@ -1403,101 +1405,132 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String thirdRelationshipIdString = String.valueOf(map.get("id"));
 
         getClient(adminToken).perform(get("/api/core/relationships/" + thirdRelationshipIdString))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("rightPlace", is(2)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("rightPlace", is(2)));
 
         // Here we will delete the secondRelationship and then verify that the others have their place handled properly
         getClient(adminToken).perform(delete("/api/core/relationships/" + secondRelationshipIdString))
-                             .andExpect(status().isNoContent());
+                .andExpect(status().isNoContent());
 
         getClient(adminToken).perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("rightPlace", is(0)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("rightPlace", is(0)));
 
         getClient(adminToken).perform(get("/api/core/relationships/" + thirdRelationshipIdString))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("rightPlace", is(1)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("rightPlace", is(1)));
 
     }
 
-    @Ignore
+    /**
+     * This test will create a relationship with author 1 - publication 1
+     * Then modify this relationship by changing the left item to author 2 via PUT > Verify
+     * Then modify this relationship by changing the right item to publication 2 via PUT > Verify
+     *
+     * @throws Exception
+     */
+    @Test
     public void putRelationshipAdminAccess() throws Exception {
 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
-        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                                  .withTitle("Author1")
-                                  .withIssueDate("2017-10-17")
-                                  .withAuthor("Smith, Donald")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald")
+                .withRelationshipType("Person")
+                .build();
 
         Item author2 = ItemBuilder.createItem(context, col1)
-                                  .withTitle("Author2")
-                                  .withIssueDate("2017-10-12")
-                                  .withAuthor("Smith, Donalaze")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author2")
+                .withIssueDate("2017-10-12")
+                .withAuthor("Smith, Donalaze")
+                .withRelationshipType("Person")
+                .build();
 
         Item publication = ItemBuilder.createItem(context, col3)
-                                      .withTitle("Publication1")
-                                      .withAuthor("Testy, TEst")
-                                      .withIssueDate("2015-01-01")
-                                      .withRelationshipType("Publication")
-                                      .build();
+                .withTitle("Publication1")
+                .withAuthor("Testy, TEst")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("Publication")
+                .build();
+
+        Item publication2 = ItemBuilder.createItem(context, col3)
+                .withTitle("Publication2")
+                .withAuthor("Testy, TEst")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("Publication")
+                .build();
 
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                                  entityTypeService.findByEntityType(context, "Person"),
-                                  "isAuthorOfPublication", "isPublicationOfAuthor");
-
-
+                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                        entityTypeService.findByEntityType(context, "Person"),
+                        "isAuthorOfPublication", "isPublicationOfAuthor");
 
         context.restoreAuthSystemState();
+
 
         String token = getAuthToken(admin.getEmail(), password);
 
         MvcResult mvcResult = getClient(token).perform(post("/api/core/relationships")
-                                                           .param("relationshipType",
-                                                                  isAuthorOfPublicationRelationshipType.getID()
-                                                                                                       .toString())
-                                                           .contentType(MediaType.parseMediaType
-                                                               (org.springframework.data.rest.webmvc.RestMediaTypes
-                                                                    .TEXT_URI_LIST_VALUE))
-                                                           .content(
-                                                               "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                                                   "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                                              .andExpect(status().isCreated())
-                                              .andReturn();
+                .param("relationshipType",
+                        isAuthorOfPublicationRelationshipType.getID()
+                                .toString())
+                .contentType(MediaType.parseMediaType
+                        (org.springframework.data.rest.webmvc.RestMediaTypes
+                                .TEXT_URI_LIST_VALUE))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
+
 
         ObjectMapper mapper = new ObjectMapper();
         String content = mvcResult.getResponse().getContentAsString();
-        Map<String,Object> map = mapper.readValue(content, Map.class);
+        Map<String, Object> map = mapper.readValue(content, Map.class);
         String id = String.valueOf(map.get("id"));
 
-        MvcResult mvcResult2 = getClient(token).perform(put("/api/core/relationships/" + id)
-                                                            .contentType(MediaType.parseMediaType
-                                                                (org.springframework.data.rest.webmvc.RestMediaTypes
-                                                                     .TEXT_URI_LIST_VALUE))
-                                                            .content(
-                                                                "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                                                    "https://localhost:8080/spring-rest/api/core/items/" + author2.getID()))
-                                               .andExpect(status().isOk())
-                                               .andReturn();
+        //Modify the left item in the relationship publication > publication 2
+        MvcResult mvcResult2 = getClient(token).perform(put("/api/core/relationships/" + id + "/leftItem")
+                .contentType(MediaType.parseMediaType
+                        (org.springframework.data.rest.webmvc.RestMediaTypes
+                                .TEXT_URI_LIST_VALUE))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + publication2.getID()))
+                .andExpect(status().isOk())
+                .andReturn();
 
+        //verify left item change and other not changed
         getClient(token).perform(get("/api/core/relationships/" + id))
-                        .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.rightId", is(author2.getID().toString())));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.leftId", is(publication2.getID().toString())))
+                .andExpect(jsonPath("$.rightId", is(author1.getID().toString())));
+
+        //Modify the right item in the relationship publication > publication 2
+        MvcResult mvcResult3 = getClient(token).perform(put("/api/core/relationships/" + id + "/rightItem")
+                .contentType(MediaType.parseMediaType
+                        (org.springframework.data.rest.webmvc.RestMediaTypes
+                                .TEXT_URI_LIST_VALUE))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + author2.getID()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //verify right item change and other not changed
+        getClient(token).perform(get("/api/core/relationships/" + id))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.rightId", is(author2.getID().toString())))
+                .andExpect(jsonPath("$.leftId", is(publication2.getID().toString())));
 
     }
 
@@ -1506,55 +1539,53 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
      * Change it to a relationship between publication 1 and author 2
      * Verify this is possible for a user with WRITE permissions on author 1 and author 2
      */
-    @Ignore
+    @Test
     public void putRelationshipWriteAccessOnAuthors() throws Exception {
 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
-        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                                  .withTitle("Author1")
-                                  .withIssueDate("2017-10-17")
-                                  .withAuthor("Smith, Donald")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald")
+                .withRelationshipType("Person")
+                .build();
 
         Item author2 = ItemBuilder.createItem(context, col1)
-                                  .withTitle("Author2")
-                                  .withIssueDate("2017-10-12")
-                                  .withAuthor("Smith, Donalaze")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author2")
+                .withIssueDate("2017-10-12")
+                .withAuthor("Smith, Donalaze")
+                .withRelationshipType("Person")
+                .build();
 
         Item publication = ItemBuilder.createItem(context, col3)
-                                      .withTitle("Publication1")
-                                      .withAuthor("Testy, TEst")
-                                      .withIssueDate("2015-01-01")
-                                      .withRelationshipType("Publication")
-                                      .build();
+                .withTitle("Publication1")
+                .withAuthor("Testy, TEst")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("Publication")
+                .build();
 
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                                  entityTypeService.findByEntityType(context, "Person"),
-                                  "isAuthorOfPublication", "isPublicationOfAuthor");
-
+                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                        entityTypeService.findByEntityType(context, "Person"),
+                        "isAuthorOfPublication", "isPublicationOfAuthor");
 
 
         EPerson user = EPersonBuilder.createEPerson(context)
-                                     .withNameInMetadata("first", "last")
-                                     .withEmail("testaze@gmail.com")
-                                     .withPassword(password)
-                                     .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
-                                     .build();
+                .withNameInMetadata("first", "last")
+                .withEmail("testaze@gmail.com")
+                .withPassword(password)
+                .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
+                .build();
         context.setCurrentUser(user);
 
         authorizeService.addPolicy(context, author1, Constants.WRITE, user);
@@ -1565,32 +1596,32 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String token = getAuthToken(user.getEmail(), password);
 
         MvcResult mvcResult = getClient(token).perform(post("/api/core/relationships")
-                                                           .param("relationshipType",
-                                                                  isAuthorOfPublicationRelationshipType.getID()
-                                                                                                       .toString())
-                                                           .contentType(MediaType.parseMediaType("text/uri-list"))
-                                                           .content(
-                                                               "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                                                   "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                                              .andExpect(status().isCreated())
-                                              .andReturn();
+                .param("relationshipType",
+                        isAuthorOfPublicationRelationshipType.getID()
+                                .toString())
+                .contentType(MediaType.parseMediaType("text/uri-list"))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
 
         ObjectMapper mapper = new ObjectMapper();
         String content = mvcResult.getResponse().getContentAsString();
-        Map<String,Object> map = mapper.readValue(content, Map.class);
+        Map<String, Object> map = mapper.readValue(content, Map.class);
         String id = String.valueOf(map.get("id"));
 
-        MvcResult mvcResult2 = getClient(token).perform(put("/api/core/relationships/" + id)
-                                                            .contentType(MediaType.parseMediaType("text/uri-list"))
-                                                            .content(
-                                                                "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                                                    "https://localhost:8080/spring-rest/api/core/items/" + author2.getID()))
-                                               .andExpect(status().isOk())
-                                               .andReturn();
-
+        //change right item from author 1 > author 2
+        MvcResult mvcResult2 = getClient(token).perform(put("/api/core/relationships/" + id + "/rightItem")
+                .contentType(MediaType.parseMediaType("text/uri-list"))
+                .content("https://localhost:8080/spring-rest/api/core/items/" + author2.getID()))
+                .andExpect(status().isOk())
+                .andReturn();
+        //verify change  and other not changed
         getClient(token).perform(get("/api/core/relationships/" + id))
-                        .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.rightId", is(author2.getID().toString())));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.rightId", is(author2.getID().toString())))
+                .andExpect(jsonPath("$.leftId", is(publication.getID().toString())));
 
     }
 
@@ -1599,55 +1630,53 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
      * Change it to a relationship between publication 1 and author 2
      * Verify this is possible for a user with WRITE permissions on publication 1
      */
-    @Ignore
+    @Test
     public void putRelationshipWriteAccessOnPublication() throws Exception {
 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
-        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                                  .withTitle("Author1")
-                                  .withIssueDate("2017-10-17")
-                                  .withAuthor("Smith, Donald")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald")
+                .withRelationshipType("Person")
+                .build();
 
         Item author2 = ItemBuilder.createItem(context, col1)
-                                  .withTitle("Author2")
-                                  .withIssueDate("2017-10-12")
-                                  .withAuthor("Smith, Donalaze")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author2")
+                .withIssueDate("2017-10-12")
+                .withAuthor("Smith, Donalaze")
+                .withRelationshipType("Person")
+                .build();
 
         Item publication = ItemBuilder.createItem(context, col3)
-                                      .withTitle("Publication1")
-                                      .withAuthor("Testy, TEst")
-                                      .withIssueDate("2015-01-01")
-                                      .withRelationshipType("Publication")
-                                      .build();
+                .withTitle("Publication1")
+                .withAuthor("Testy, TEst")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("Publication")
+                .build();
 
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                                  entityTypeService.findByEntityType(context, "Person"),
-                                  "isAuthorOfPublication", "isPublicationOfAuthor");
-
+                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                        entityTypeService.findByEntityType(context, "Person"),
+                        "isAuthorOfPublication", "isPublicationOfAuthor");
 
 
         EPerson user = EPersonBuilder.createEPerson(context)
-                                     .withNameInMetadata("first", "last")
-                                     .withEmail("testaze@gmail.com")
-                                     .withPassword(password)
-                                     .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
-                                     .build();
+                .withNameInMetadata("first", "last")
+                .withEmail("testaze@gmail.com")
+                .withPassword(password)
+                .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
+                .build();
         context.setCurrentUser(user);
 
         authorizeService.addPolicy(context, publication, Constants.WRITE, user);
@@ -1657,32 +1686,31 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String token = getAuthToken(user.getEmail(), password);
 
         MvcResult mvcResult = getClient(token).perform(post("/api/core/relationships")
-                                                           .param("relationshipType",
-                                                                  isAuthorOfPublicationRelationshipType.getID()
-                                                                                                       .toString())
-                                                           .contentType(MediaType.parseMediaType("text/uri-list"))
-                                                           .content(
-                                                               "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                                                   "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                                              .andExpect(status().isCreated())
-                                              .andReturn();
+                .param("relationshipType",
+                        isAuthorOfPublicationRelationshipType.getID()
+                                .toString())
+                .contentType(MediaType.parseMediaType("text/uri-list"))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
 
         ObjectMapper mapper = new ObjectMapper();
         String content = mvcResult.getResponse().getContentAsString();
-        Map<String,Object> map = mapper.readValue(content, Map.class);
+        Map<String, Object> map = mapper.readValue(content, Map.class);
         String id = String.valueOf(map.get("id"));
-
-        MvcResult mvcResult2 = getClient(token).perform(put("/api/core/relationships/" + id)
-                                                            .contentType(MediaType.parseMediaType("text/uri-list"))
-                                                            .content(
-                                                                "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                                                    "https://localhost:8080/spring-rest/api/core/items/" + author2.getID()))
-                                               .andExpect(status().isOk())
-                                               .andReturn();
-
+        //change rightItem from author1 > author2
+        MvcResult mvcResult2 = getClient(token).perform(put("/api/core/relationships/" + id + "/rightItem")
+                .contentType(MediaType.parseMediaType("text/uri-list"))
+                .content("https://localhost:8080/spring-rest/api/core/items/" + author2.getID()))
+                .andExpect(status().isOk())
+                .andReturn();
+        //verify right item change and other not changed
         getClient(token).perform(get("/api/core/relationships/" + id))
-                        .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.rightId", is(author2.getID().toString())));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.rightId", is(author2.getID().toString())))
+                .andExpect(jsonPath("$.leftId", is(publication.getID().toString())));
 
     }
 
@@ -1692,61 +1720,52 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
      * Change it to a relationship between publication 2 and author 1
      * Verify this is possible for a user with WRITE permissions on publication 1 and publication 2
      */
-    @Ignore
+    @Test
     public void putRelationshipWriteAccessOnPublications() throws Exception {
 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
-        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                                  .withTitle("Author1")
-                                  .withIssueDate("2017-10-17")
-                                  .withAuthor("Smith, Donald")
-                                  .withRelationshipType("Person")
-                                  .build();
-
-        Item author2 = ItemBuilder.createItem(context, col1)
-                                  .withTitle("Author2")
-                                  .withIssueDate("2017-10-12")
-                                  .withAuthor("Smith, Donalaze")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald")
+                .withRelationshipType("Person")
+                .build();
 
         Item publication1 = ItemBuilder.createItem(context, col3)
-                                      .withTitle("Publication1")
-                                      .withAuthor("Testy, TEst")
-                                      .withIssueDate("2015-01-01")
-                                      .withRelationshipType("Publication")
-                                      .build();
+                .withTitle("Publication1")
+                .withAuthor("Testy, TEst")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("Publication")
+                .build();
         Item publication2 = ItemBuilder.createItem(context, col3)
-                                      .withTitle("Publication2")
-                                      .withAuthor("Testy, TEstzeaze")
-                                      .withIssueDate("2015-01-01")
-                                      .withRelationshipType("Publication")
-                                      .build();
+                .withTitle("Publication2")
+                .withAuthor("Testy, TEstzeaze")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("Publication")
+                .build();
 
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                                  entityTypeService.findByEntityType(context, "Person"),
-                                  "isAuthorOfPublication", "isPublicationOfAuthor");
-
+                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                        entityTypeService.findByEntityType(context, "Person"),
+                        "isAuthorOfPublication", "isPublicationOfAuthor");
 
 
         EPerson user = EPersonBuilder.createEPerson(context)
-                                     .withNameInMetadata("first", "last")
-                                     .withEmail("testaze@gmail.com")
-                                     .withPassword(password)
-                                     .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
-                                     .build();
+                .withNameInMetadata("first", "last")
+                .withEmail("testaze@gmail.com")
+                .withPassword(password)
+                .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
+                .build();
         context.setCurrentUser(user);
 
         authorizeService.addPolicy(context, publication1, Constants.WRITE, user);
@@ -1757,33 +1776,31 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String token = getAuthToken(user.getEmail(), password);
 
         MvcResult mvcResult = getClient(token).perform(post("/api/core/relationships")
-                                                           .param("relationshipType",
-                                                                  isAuthorOfPublicationRelationshipType.getID()
-                                                                                                       .toString())
-                                                           .contentType(MediaType.parseMediaType("text/uri-list"))
-                                                           .content(
-                                                               "https://localhost:8080/spring-rest/api/core/items/" + publication1.getID() + "\n" +
-                                                                   "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                                              .andExpect(status().isCreated())
-                                              .andReturn();
+                .param("relationshipType",
+                        isAuthorOfPublicationRelationshipType.getID()
+                                .toString())
+                .contentType(MediaType.parseMediaType("text/uri-list"))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + publication1.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
 
         ObjectMapper mapper = new ObjectMapper();
         String content = mvcResult.getResponse().getContentAsString();
-        Map<String,Object> map = mapper.readValue(content, Map.class);
+        Map<String, Object> map = mapper.readValue(content, Map.class);
         String id = String.valueOf(map.get("id"));
-
-        MvcResult mvcResult2 = getClient(token).perform(put("/api/core/relationships/" + id)
-                                                            .contentType(MediaType.parseMediaType("text/uri-list"))
-                                                            .content(
-                                                                "https://localhost:8080/spring-rest/api/core/items/" + publication2.getID() + "\n" +
-                                                                    "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                                               .andExpect(status().isOk())
-                                               .andReturn();
-
+        //change leftItem
+        MvcResult mvcResult2 = getClient(token).perform(put("/api/core/relationships/" + id + "/leftItem")
+                .contentType(MediaType.parseMediaType("text/uri-list"))
+                .content("https://localhost:8080/spring-rest/api/core/items/" + publication2.getID()))
+                .andExpect(status().isOk())
+                .andReturn();
+        //verify change  and other not changed
         getClient(token).perform(get("/api/core/relationships/" + id))
-                        .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.leftId", is(publication2.getID().toString())));
-
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.leftId", is(publication2.getID().toString())))
+                .andExpect(jsonPath("$.rightId", is(author1.getID().toString())));
     }
 
 
@@ -1792,62 +1809,53 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
      * Change it to a relationship between publication 2 and author 1
      * Verify this is possible for a user with WRITE permissions on author 1
      */
-    @Ignore
+    @Test
     public void putRelationshipWriteAccessOnAuthor() throws Exception {
 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
-        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                                  .withTitle("Author1")
-                                  .withIssueDate("2017-10-17")
-                                  .withAuthor("Smith, Donald")
-                                  .withRelationshipType("Person")
-                                  .build();
-
-        Item author2 = ItemBuilder.createItem(context, col1)
-                                  .withTitle("Author2")
-                                  .withIssueDate("2017-10-12")
-                                  .withAuthor("Smith, Donalaze")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald")
+                .withRelationshipType("Person")
+                .build();
 
         Item publication1 = ItemBuilder.createItem(context, col3)
-                                      .withTitle("Publication1")
-                                      .withAuthor("Testy, TEst")
-                                      .withIssueDate("2015-01-01")
-                                      .withRelationshipType("Publication")
-                                      .build();
+                .withTitle("Publication1")
+                .withAuthor("Testy, TEst")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("Publication")
+                .build();
 
         Item publication2 = ItemBuilder.createItem(context, col3)
-                                      .withTitle("Publication2")
-                                      .withAuthor("Testy, TEstzea")
-                                      .withIssueDate("2015-01-01")
-                                      .withRelationshipType("Publication")
-                                      .build();
+                .withTitle("Publication2")
+                .withAuthor("Testy, TEstzea")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("Publication")
+                .build();
 
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                                  entityTypeService.findByEntityType(context, "Person"),
-                                  "isAuthorOfPublication", "isPublicationOfAuthor");
-
+                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                        entityTypeService.findByEntityType(context, "Person"),
+                        "isAuthorOfPublication", "isPublicationOfAuthor");
 
 
         EPerson user = EPersonBuilder.createEPerson(context)
-                                     .withNameInMetadata("first", "last")
-                                     .withEmail("testaze@gmail.com")
-                                     .withPassword(password)
-                                     .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
-                                     .build();
+                .withNameInMetadata("first", "last")
+                .withEmail("testaze@gmail.com")
+                .withPassword(password)
+                .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
+                .build();
         context.setCurrentUser(user);
 
         authorizeService.addPolicy(context, author1, Constants.WRITE, user);
@@ -1857,34 +1865,32 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String token = getAuthToken(user.getEmail(), password);
 
         MvcResult mvcResult = getClient(getAuthToken(admin.getEmail(), password))
-            .perform(post("/api/core/relationships")
-                       .param("relationshipType",
-                              isAuthorOfPublicationRelationshipType.getID()
-                                                                   .toString())
-                       .contentType(MediaType.parseMediaType("text/uri-list"))
-                       .content(
-                           "https://localhost:8080/spring-rest/api/core/items/" + publication1.getID() + "\n" +
-                               "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-          .andExpect(status().isCreated())
-          .andReturn();
+                .perform(post("/api/core/relationships")
+                        .param("relationshipType",
+                                isAuthorOfPublicationRelationshipType.getID()
+                                        .toString())
+                        .contentType(MediaType.parseMediaType("text/uri-list"))
+                        .content(
+                                "https://localhost:8080/spring-rest/api/core/items/" + publication1.getID() + "\n" +
+                                        "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
 
         ObjectMapper mapper = new ObjectMapper();
         String content = mvcResult.getResponse().getContentAsString();
-        Map<String,Object> map = mapper.readValue(content, Map.class);
+        Map<String, Object> map = mapper.readValue(content, Map.class);
         String id = String.valueOf(map.get("id"));
-
-        MvcResult mvcResult2 = getClient(token).perform(put("/api/core/relationships/" + id)
-                                                            .contentType(MediaType.parseMediaType("text/uri-list"))
-                                                            .content(
-                                                                "https://localhost:8080/spring-rest/api/core/items/" + publication2.getID() + "\n" +
-                                                                    "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                                               .andExpect(status().isOk())
-                                               .andReturn();
-
+        //change left item
+        MvcResult mvcResult2 = getClient(token).perform(put("/api/core/relationships/" + id + "/leftItem")
+                .contentType(MediaType.parseMediaType("text/uri-list"))
+                .content("https://localhost:8080/spring-rest/api/core/items/" + publication2.getID()))
+                .andExpect(status().isOk())
+                .andReturn();
+        //verify change and other not changed
         getClient(token).perform(get("/api/core/relationships/" + id))
-                        .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.leftId", is(publication2.getID().toString())));
-
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.leftId", is(publication2.getID().toString())))
+                .andExpect(jsonPath("$.rightId", is(author1.getID().toString())));
     }
 
 
@@ -1893,55 +1899,53 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
      * Change it to a relationship between publication 1 and author 2
      * Verify this is NOT possible for a user without WRITE permissions
      */
-    @Ignore
+    @Test
     public void putRelationshipNoAccess() throws Exception {
 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
-        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                                  .withTitle("Author1")
-                                  .withIssueDate("2017-10-17")
-                                  .withAuthor("Smith, Donald")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald")
+                .withRelationshipType("Person")
+                .build();
 
         Item author2 = ItemBuilder.createItem(context, col1)
-                                  .withTitle("Author2")
-                                  .withIssueDate("2017-10-12")
-                                  .withAuthor("Smith, Donalaze")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author2")
+                .withIssueDate("2017-10-12")
+                .withAuthor("Smith, Donalaze")
+                .withRelationshipType("Person")
+                .build();
 
         Item publication = ItemBuilder.createItem(context, col3)
-                                      .withTitle("Publication1")
-                                      .withAuthor("Testy, TEst")
-                                      .withIssueDate("2015-01-01")
-                                      .withRelationshipType("Publication")
-                                      .build();
+                .withTitle("Publication1")
+                .withAuthor("Testy, TEst")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("Publication")
+                .build();
 
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                                  entityTypeService.findByEntityType(context, "Person"),
-                                  "isAuthorOfPublication", "isPublicationOfAuthor");
-
+                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                        entityTypeService.findByEntityType(context, "Person"),
+                        "isAuthorOfPublication", "isPublicationOfAuthor");
 
 
         EPerson user = EPersonBuilder.createEPerson(context)
-                                     .withNameInMetadata("first", "last")
-                                     .withEmail("testaze@gmail.com")
-                                     .withPassword(password)
-                                     .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
-                                     .build();
+                .withNameInMetadata("first", "last")
+                .withEmail("testaze@gmail.com")
+                .withPassword(password)
+                .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
+                .build();
         context.setCurrentUser(user);
 
         context.restoreAuthSystemState();
@@ -1949,30 +1953,32 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String token = getAuthToken(admin.getEmail(), password);
 
         MvcResult mvcResult = getClient(token).perform(post("/api/core/relationships")
-                                                           .param("relationshipType",
-                                                                  isAuthorOfPublicationRelationshipType.getID()
-                                                                                                       .toString())
-                                                           .contentType(MediaType.parseMediaType("text/uri-list"))
-                                                           .content(
-                                                               "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                                                   "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                                              .andExpect(status().isCreated())
-                                              .andReturn();
+                .param("relationshipType",
+                        isAuthorOfPublicationRelationshipType.getID()
+                                .toString())
+                .contentType(MediaType.parseMediaType("text/uri-list"))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
 
         ObjectMapper mapper = new ObjectMapper();
         String content = mvcResult.getResponse().getContentAsString();
-        Map<String,Object> map = mapper.readValue(content, Map.class);
+        Map<String, Object> map = mapper.readValue(content, Map.class);
         String id = String.valueOf(map.get("id"));
         token = getAuthToken(user.getEmail(), password);
-
-        MvcResult mvcResult2 = getClient(token).perform(put("/api/core/relationships/" + id)
-                                                            .contentType(MediaType.parseMediaType("text/uri-list"))
-                                                            .content(
-                                                                "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                                                    "https://localhost:8080/spring-rest/api/core/items/" + author2.getID()))
-                                               .andExpect(status().isForbidden())
-                                               .andReturn();
-
+        //attempt change, expect not allowed
+        MvcResult mvcResult2 = getClient(token).perform(put("/api/core/relationships/" + id + "/rightItem")
+                .contentType(MediaType.parseMediaType("text/uri-list"))
+                .content("https://localhost:8080/spring-rest/api/core/items/" + author2.getID()))
+                .andExpect(status().isForbidden())
+                .andReturn();
+        //verify nothing changed
+        getClient(token).perform(get("/api/core/relationships/" + id))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.leftId", is(publication.getID().toString())))
+                .andExpect(jsonPath("$.rightId", is(author1.getID().toString())));
     }
 
     /**
@@ -1980,55 +1986,54 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
      * Change it to a relationship between publication 1 and author 2
      * Verify this is NOT possible for a user with WRITE permissions on author 1
      */
-    @Ignore
+    @Test
     public void putRelationshipOnlyAccessOnOneAuthor() throws Exception {
 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                                  .withTitle("Author1")
-                                  .withIssueDate("2017-10-17")
-                                  .withAuthor("Smith, Donald")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald")
+                .withRelationshipType("Person")
+                .build();
 
         Item author2 = ItemBuilder.createItem(context, col1)
-                                  .withTitle("Author2")
-                                  .withIssueDate("2017-10-12")
-                                  .withAuthor("Smith, Donalaze")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author2")
+                .withIssueDate("2017-10-12")
+                .withAuthor("Smith, Donalaze")
+                .withRelationshipType("Person")
+                .build();
 
         Item publication = ItemBuilder.createItem(context, col3)
-                                      .withTitle("Publication1")
-                                      .withAuthor("Testy, TEst")
-                                      .withIssueDate("2015-01-01")
-                                      .withRelationshipType("Publication")
-                                      .build();
+                .withTitle("Publication1")
+                .withAuthor("Testy, TEst")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("Publication")
+                .build();
 
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                                  entityTypeService.findByEntityType(context, "Person"),
-                                  "isAuthorOfPublication", "isPublicationOfAuthor");
-
+                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                        entityTypeService.findByEntityType(context, "Person"),
+                        "isAuthorOfPublication", "isPublicationOfAuthor");
 
 
         EPerson user = EPersonBuilder.createEPerson(context)
-                                     .withNameInMetadata("first", "last")
-                                     .withEmail("testaze@gmail.com")
-                                     .withPassword(password)
-                                     .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
-                                     .build();
+                .withNameInMetadata("first", "last")
+                .withEmail("testaze@gmail.com")
+                .withPassword(password)
+                .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
+                .build();
         context.setCurrentUser(user);
 
         authorizeService.addPolicy(context, author1, Constants.WRITE, user);
@@ -2038,30 +2043,32 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String token = getAuthToken(admin.getEmail(), password);
 
         MvcResult mvcResult = getClient(token).perform(post("/api/core/relationships")
-                                                           .param("relationshipType",
-                                                                  isAuthorOfPublicationRelationshipType.getID()
-                                                                                                       .toString())
-                                                           .contentType(MediaType.parseMediaType("text/uri-list"))
-                                                           .content(
-                                                               "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                                                   "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                                              .andExpect(status().isCreated())
-                                              .andReturn();
+                .param("relationshipType",
+                        isAuthorOfPublicationRelationshipType.getID()
+                                .toString())
+                .contentType(MediaType.parseMediaType("text/uri-list"))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
 
         ObjectMapper mapper = new ObjectMapper();
         String content = mvcResult.getResponse().getContentAsString();
-        Map<String,Object> map = mapper.readValue(content, Map.class);
+        Map<String, Object> map = mapper.readValue(content, Map.class);
         String id = String.valueOf(map.get("id"));
         token = getAuthToken(user.getEmail(), password);
-
-        MvcResult mvcResult2 = getClient(token).perform(put("/api/core/relationships/" + id)
-                                                            .contentType(MediaType.parseMediaType("text/uri-list"))
-                                                            .content(
-                                                                "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                                                    "https://localhost:8080/spring-rest/api/core/items/" + author2.getID()))
-                                               .andExpect(status().isForbidden())
-                                               .andReturn();
-
+        //attempt right item change, expect not allowed
+        MvcResult mvcResult2 = getClient(token).perform(put("/api/core/relationships/" + id + "/rightItem")
+                .contentType(MediaType.parseMediaType("text/uri-list"))
+                .content("https://localhost:8080/spring-rest/api/core/items/" + author2.getID()))
+                .andExpect(status().isForbidden())
+                .andReturn();
+        //verify not changed
+        getClient(token).perform(get("/api/core/relationships/" + id))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.leftId", is(publication.getID().toString())))
+                .andExpect(jsonPath("$.rightId", is(author1.getID().toString())));
     }
 
     /**
@@ -2069,61 +2076,52 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
      * Change it to a relationship between publication 2 and author 1
      * Verify this is NOT possible for a user with WRITE permissions on publication 1
      */
-    @Ignore
+    @Test
     public void putRelationshipOnlyAccessOnOnePublication() throws Exception {
 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+                .withName("Parent Community")
+                .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+                .withName("Sub Community")
+                .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
-        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                                  .withTitle("Author1")
-                                  .withIssueDate("2017-10-17")
-                                  .withAuthor("Smith, Donald")
-                                  .withRelationshipType("Person")
-                                  .build();
-
-        Item author2 = ItemBuilder.createItem(context, col1)
-                                  .withTitle("Author2")
-                                  .withIssueDate("2017-10-12")
-                                  .withAuthor("Smith, Donalaze")
-                                  .withRelationshipType("Person")
-                                  .build();
+                .withTitle("Author1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald")
+                .withRelationshipType("Person")
+                .build();
 
         Item publication1 = ItemBuilder.createItem(context, col3)
-                                       .withTitle("Publication1")
-                                       .withAuthor("Testy, TEst")
-                                       .withIssueDate("2015-01-01")
-                                       .withRelationshipType("Publication")
-                                       .build();
+                .withTitle("Publication1")
+                .withAuthor("Testy, TEst")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("Publication")
+                .build();
         Item publication2 = ItemBuilder.createItem(context, col3)
-                                       .withTitle("Publication2")
-                                       .withAuthor("Testy, TEstzeaze")
-                                       .withIssueDate("2015-01-01")
-                                       .withRelationshipType("Publication")
-                                       .build();
+                .withTitle("Publication2")
+                .withAuthor("Testy, TEstzeaze")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("Publication")
+                .build();
 
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                                  entityTypeService.findByEntityType(context, "Person"),
-                                  "isAuthorOfPublication", "isPublicationOfAuthor");
-
+                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                        entityTypeService.findByEntityType(context, "Person"),
+                        "isAuthorOfPublication", "isPublicationOfAuthor");
 
 
         EPerson user = EPersonBuilder.createEPerson(context)
-                                     .withNameInMetadata("first", "last")
-                                     .withEmail("testaze@gmail.com")
-                                     .withPassword(password)
-                                     .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
-                                     .build();
+                .withNameInMetadata("first", "last")
+                .withEmail("testaze@gmail.com")
+                .withPassword(password)
+                .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
+                .build();
         context.setCurrentUser(user);
 
         authorizeService.addPolicy(context, publication1, Constants.WRITE, user);
@@ -2133,32 +2131,123 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.restoreAuthSystemState();
 
         MvcResult mvcResult = getClient(token).perform(post("/api/core/relationships")
-                                                           .param("relationshipType",
-                                                                  isAuthorOfPublicationRelationshipType.getID()
-                                                                                                       .toString())
-                                                           .contentType(MediaType.parseMediaType("text/uri-list"))
-                                                           .content(
-                                                               "https://localhost:8080/spring-rest/api/core/items/" + publication1.getID() + "\n" +
-                                                                   "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                                              .andExpect(status().isCreated())
-                                              .andReturn();
+                .param("relationshipType",
+                        isAuthorOfPublicationRelationshipType.getID()
+                                .toString())
+                .contentType(MediaType.parseMediaType("text/uri-list"))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + publication1.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
 
         ObjectMapper mapper = new ObjectMapper();
         String content = mvcResult.getResponse().getContentAsString();
-        Map<String,Object> map = mapper.readValue(content, Map.class);
+        Map<String, Object> map = mapper.readValue(content, Map.class);
+        String id = String.valueOf(map.get("id"));
+        //attempt left item change, expect not allowed
+        MvcResult mvcResult2 = getClient(token).perform(put("/api/core/relationships/" + id + "/leftItem")
+                .contentType(MediaType.parseMediaType("text/uri-list"))
+                .content("https://localhost:8080/spring-rest/api/core/items/" + publication2.getID()))
+                .andExpect(status().isForbidden())
+                .andReturn();
+        //verify not changed
+        getClient(token).perform(get("/api/core/relationships/" + id))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.leftId", is(publication1.getID().toString())))
+                .andExpect(jsonPath("$.rightId", is(author1.getID().toString())));
+
+    }
+
+    @Test
+    public void putRelationshipWithNonexistentID() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+        Item publication1 = ItemBuilder.createItem(context, col1)
+                .withTitle("Publication1")
+                .withAuthor("Testy, TEst")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("Publication")
+                .build();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        context.restoreAuthSystemState();
+
+        int nonexistentRelationshipID = 404404404;
+        //attempt left item change on non-existent relationship
+        MvcResult mvcResult = getClient(token).perform(
+                put("/api/core/relationships/" + nonexistentRelationshipID + "/leftItem")
+                .contentType(MediaType.parseMediaType("text/uri-list"))
+                .content("https://localhost:8080/spring-rest/api/core/items/" + publication1.getID()))
+                .andExpect(status().isNotFound())
+                .andReturn();
+
+    }
+
+    @Test
+    public void putRelationshipWithInvalidItemIDInBody() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+        Item author1 = ItemBuilder.createItem(context, col1)
+                .withTitle("Author1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald")
+                .withRelationshipType("Person")
+                .build();
+        Item publication1 = ItemBuilder.createItem(context, col1)
+                .withTitle("Publication1")
+                .withAuthor("Testy, TEst")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("Publication")
+                .build();
+
+        RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
+                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                        entityTypeService.findByEntityType(context, "Person"),
+                        "isAuthorOfPublication", "isPublicationOfAuthor");
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        context.restoreAuthSystemState();
+
+        MvcResult mvcResult = getClient(token).perform(post("/api/core/relationships")
+                .param("relationshipType",
+                        isAuthorOfPublicationRelationshipType.getID()
+                                .toString())
+                .contentType(MediaType.parseMediaType("text/uri-list"))
+                .content(
+                        "https://localhost:8080/spring-rest/api/core/items/" + publication1.getID() + "\n" +
+                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        ObjectMapper mapper = new ObjectMapper();
+        String content = mvcResult.getResponse().getContentAsString();
+        Map<String, Object> map = mapper.readValue(content, Map.class);
         String id = String.valueOf(map.get("id"));
 
-        MvcResult mvcResult2 = getClient(token).perform(put("/api/core/relationships/" + id)
-                                                            .contentType(MediaType.parseMediaType("text/uri-list"))
-                                                            .content(
-                                                                "https://localhost:8080/spring-rest/api/core/items/" + publication2.getID() + "\n" +
-                                                                    "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                                               .andExpect(status().isForbidden())
-                                               .andReturn();
-
-        getClient(token).perform(get("/api/core/relationships/" + id))
-                        .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.leftId", is(publication1.getID().toString())));
+        int nonexistentItemID = 404404404;
+        //attempt left item change on non-existent relationship
+        MvcResult mvcResult2 = getClient(token).perform(put("/api/core/relationships/" + id + "/leftItem")
+                .contentType(MediaType.parseMediaType("text/uri-list"))
+                .content("https://localhost:8080/spring-rest/api/core/items/" + nonexistentItemID))
+                .andExpect(status().isUnprocessableEntity())
+                .andReturn();
 
     }
 }

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/RelationshipRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/RelationshipRestRepositoryIT.java
@@ -71,113 +71,113 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                .withName("Parent Community")
-                .build();
+                                          .withName("Parent Community")
+                                          .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                .withName("Sub Community")
-                .build();
+                                           .withName("Sub Community")
+                                           .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item auhor1 = ItemBuilder.createItem(context, col1)
-                .withTitle("Author1")
-                .withIssueDate("2017-10-17")
-                .withAuthor("Smith, Donald")
-                .withRelationshipType("Person")
-                .build();
+                                 .withTitle("Author1")
+                                 .withIssueDate("2017-10-17")
+                                 .withAuthor("Smith, Donald")
+                                 .withRelationshipType("Person")
+                                 .build();
 
         Item author2 = ItemBuilder.createItem(context, col2)
-                .withTitle("Author2")
-                .withIssueDate("2016-02-13")
-                .withAuthor("Smith, Maria")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author2")
+                                  .withIssueDate("2016-02-13")
+                                  .withAuthor("Smith, Maria")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item author3 = ItemBuilder.createItem(context, col2)
-                .withTitle("Author3")
-                .withIssueDate("2016-02-13")
-                .withAuthor("Maybe, Maybe")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author3")
+                                  .withIssueDate("2016-02-13")
+                                  .withAuthor("Maybe, Maybe")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item orgUnit1 = ItemBuilder.createItem(context, col3)
-                .withTitle("OrgUnit1")
-                .withAuthor("Testy, TEst")
-                .withIssueDate("2015-01-01")
-                .withRelationshipType("OrgUnit")
-                .build();
+                                   .withTitle("OrgUnit1")
+                                   .withAuthor("Testy, TEst")
+                                   .withIssueDate("2015-01-01")
+                                   .withRelationshipType("OrgUnit")
+                                   .build();
 
         Item project1 = ItemBuilder.createItem(context, col3)
-                .withTitle("Project1")
-                .withAuthor("Testy, TEst")
-                .withIssueDate("2015-01-01")
-                .withRelationshipType("Project")
-                .build();
+                                   .withTitle("Project1")
+                                   .withAuthor("Testy, TEst")
+                                   .withIssueDate("2015-01-01")
+                                   .withRelationshipType("Project")
+                                   .build();
 
         Item publication = ItemBuilder.createItem(context, col3)
-                .withTitle("Publication1")
-                .withAuthor("Testy, TEst")
-                .withIssueDate("2015-01-01")
-                .withRelationshipType("Publication")
-                .build();
+                                      .withTitle("Publication1")
+                                      .withAuthor("Testy, TEst")
+                                      .withIssueDate("2015-01-01")
+                                      .withRelationshipType("Publication")
+                                      .build();
 
 
         RelationshipType isOrgUnitOfPersonRelationshipType = relationshipTypeService
-                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Person"),
-                        entityTypeService.findByEntityType(context, "OrgUnit"),
-                        "isOrgUnitOfPerson", "isPersonOfOrgUnit");
+            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Person"),
+                                  entityTypeService.findByEntityType(context, "OrgUnit"),
+                                  "isOrgUnitOfPerson", "isPersonOfOrgUnit");
         RelationshipType isOrgUnitOfProjectRelationshipType = relationshipTypeService
-                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Project"),
-                        entityTypeService.findByEntityType(context, "OrgUnit"),
-                        "isOrgUnitOfProject", "isProjectOfOrgUnit");
+            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Project"),
+                                  entityTypeService.findByEntityType(context, "OrgUnit"),
+                                  "isOrgUnitOfProject", "isProjectOfOrgUnit");
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                        entityTypeService.findByEntityType(context, "Person"),
-                        "isAuthorOfPublication", "isPublicationOfAuthor");
+            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                                  entityTypeService.findByEntityType(context, "Person"),
+                                  "isAuthorOfPublication", "isPublicationOfAuthor");
 
         Relationship relationship1 = RelationshipBuilder
-                .createRelationshipBuilder(context, auhor1, orgUnit1, isOrgUnitOfPersonRelationshipType).build();
+            .createRelationshipBuilder(context, auhor1, orgUnit1, isOrgUnitOfPersonRelationshipType).build();
 
         Relationship relationship2 = RelationshipBuilder
-                .createRelationshipBuilder(context, project1, orgUnit1, isOrgUnitOfProjectRelationshipType).build();
+            .createRelationshipBuilder(context, project1, orgUnit1, isOrgUnitOfProjectRelationshipType).build();
 
         Relationship relationship3 = RelationshipBuilder
-                .createRelationshipBuilder(context, publication, auhor1, isAuthorOfPublicationRelationshipType).build();
+            .createRelationshipBuilder(context, publication, auhor1, isAuthorOfPublicationRelationshipType).build();
 
         context.restoreAuthSystemState();
 
         getClient().perform(get("/api/core/relationships"))
 
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.page",
-                        is(PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 3))))
-                .andExpect(jsonPath("$._embedded.relationships", containsInAnyOrder(
-                        RelationshipMatcher.matchRelationship(relationship1),
-                        RelationshipMatcher.matchRelationship(relationship2),
-                        RelationshipMatcher.matchRelationship(relationship3)
-                )))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.page",
+                                       is(PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 3))))
+                   .andExpect(jsonPath("$._embedded.relationships", containsInAnyOrder(
+                       RelationshipMatcher.matchRelationship(relationship1),
+                       RelationshipMatcher.matchRelationship(relationship2),
+                       RelationshipMatcher.matchRelationship(relationship3)
+                   )))
         ;
 
         getClient().perform(get("/api/core/relationships").param("size", "2"))
 
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.page",
-                        is(PageMatcher.pageEntryWithTotalPagesAndElements(0, 2, 2, 3))))
-                .andExpect(jsonPath("$._embedded.relationships", containsInAnyOrder(
-                        RelationshipMatcher.matchRelationship(relationship1),
-                        RelationshipMatcher.matchRelationship(relationship2)
-                )))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.page",
+                                       is(PageMatcher.pageEntryWithTotalPagesAndElements(0, 2, 2, 3))))
+                   .andExpect(jsonPath("$._embedded.relationships", containsInAnyOrder(
+                       RelationshipMatcher.matchRelationship(relationship1),
+                       RelationshipMatcher.matchRelationship(relationship2)
+                   )))
         ;
 
         getClient().perform(get("/api/core/relationships").param("size", "2").param("page", "1"))
 
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.page",
-                        is(PageMatcher.pageEntryWithTotalPagesAndElements(1, 2, 2, 3))))
-                .andExpect(jsonPath("$._embedded.relationships", contains(
-                        RelationshipMatcher.matchRelationship(relationship3)
-                )))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.page",
+                                       is(PageMatcher.pageEntryWithTotalPagesAndElements(1, 2, 2, 3))))
+                   .andExpect(jsonPath("$._embedded.relationships", contains(
+                       RelationshipMatcher.matchRelationship(relationship3)
+                   )))
         ;
 
     }
@@ -188,39 +188,39 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                .withName("Parent Community")
-                .build();
+                                          .withName("Parent Community")
+                                          .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                .withName("Sub Community")
-                .build();
+                                           .withName("Sub Community")
+                                           .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                .withTitle("Author1")
-                .withIssueDate("2017-10-17")
-                .withAuthor("Smith, Donald")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author1")
+                                  .withIssueDate("2017-10-17")
+                                  .withAuthor("Smith, Donald")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item publication = ItemBuilder.createItem(context, col3)
-                .withTitle("Publication1")
-                .withAuthor("Testy, TEst")
-                .withIssueDate("2015-01-01")
-                .withRelationshipType("Publication")
-                .build();
+                                      .withTitle("Publication1")
+                                      .withAuthor("Testy, TEst")
+                                      .withIssueDate("2015-01-01")
+                                      .withRelationshipType("Publication")
+                                      .build();
 
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                        entityTypeService.findByEntityType(context, "Person"),
-                        "isAuthorOfPublication", "isPublicationOfAuthor");
+            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                                  entityTypeService.findByEntityType(context, "Person"),
+                                  "isAuthorOfPublication", "isPublicationOfAuthor");
 
         EPerson user = EPersonBuilder.createEPerson(context)
-                .withNameInMetadata("first", "last")
-                .withEmail("testaze@gmail.com")
-                .withPassword(password)
-                .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
-                .build();
+                                    .withNameInMetadata("first", "last")
+                                    .withEmail("testaze@gmail.com")
+                                    .withPassword(password)
+                                    .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
+                                    .build();
         context.setCurrentUser(user);
 
         authorizeService.addPolicy(context, publication, Constants.WRITE, user);
@@ -230,17 +230,17 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String token = getAuthToken(user.getEmail(), password);
 
         MvcResult mvcResult = getClient(token).perform(post("/api/core/relationships")
-                .param("relationshipType",
-                        isAuthorOfPublicationRelationshipType.getID()
-                                .toString())
-                .contentType(MediaType.parseMediaType
-                        (org.springframework.data.rest.webmvc.RestMediaTypes
-                                .TEXT_URI_LIST_VALUE))
-                .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                .andExpect(status().isCreated())
-                .andReturn();
+                                                           .param("relationshipType",
+                                                                  isAuthorOfPublicationRelationshipType.getID()
+                                                                                                       .toString())
+                                                           .contentType(MediaType.parseMediaType
+                                                               (org.springframework.data.rest.webmvc.RestMediaTypes
+                                                                    .TEXT_URI_LIST_VALUE))
+                                                           .content(
+                                                               "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                                                   "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                                              .andExpect(status().isCreated())
+                                              .andReturn();
 
         ObjectMapper mapper = new ObjectMapper();
 
@@ -249,9 +249,9 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String firstRelationshipIdString = String.valueOf(map.get("id"));
 
         getClient().perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.leftId", is(publication.getID().toString())))
-                .andExpect(jsonPath("$.rightId", is(author1.getID().toString())));
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.leftId", is(publication.getID().toString())))
+                   .andExpect(jsonPath("$.rightId", is(author1.getID().toString())));
 
     }
 
@@ -261,39 +261,39 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                .withName("Parent Community")
-                .build();
+                                          .withName("Parent Community")
+                                          .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                .withName("Sub Community")
-                .build();
+                                           .withName("Sub Community")
+                                           .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                .withTitle("Author1")
-                .withIssueDate("2017-10-17")
-                .withAuthor("Smith, Donald")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author1")
+                                  .withIssueDate("2017-10-17")
+                                  .withAuthor("Smith, Donald")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item publication = ItemBuilder.createItem(context, col3)
-                .withTitle("Publication1")
-                .withAuthor("Testy, TEst")
-                .withIssueDate("2015-01-01")
-                .withRelationshipType("Publication")
-                .build();
+                                      .withTitle("Publication1")
+                                      .withAuthor("Testy, TEst")
+                                      .withIssueDate("2015-01-01")
+                                      .withRelationshipType("Publication")
+                                      .build();
 
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                        entityTypeService.findByEntityType(context, "Person"),
-                        "isAuthorOfPublication", "isPublicationOfAuthor");
+            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                                  entityTypeService.findByEntityType(context, "Person"),
+                                  "isAuthorOfPublication", "isPublicationOfAuthor");
 
         EPerson user = EPersonBuilder.createEPerson(context)
-                .withNameInMetadata("first", "last")
-                .withEmail("testaze@gmail.com")
-                .withPassword(password)
-                .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
-                .build();
+                                     .withNameInMetadata("first", "last")
+                                     .withEmail("testaze@gmail.com")
+                                     .withPassword(password)
+                                     .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
+                                     .build();
         context.setCurrentUser(user);
 
         authorizeService.addPolicy(context, author1, Constants.WRITE, user);
@@ -302,17 +302,17 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String token = getAuthToken(user.getEmail(), password);
 
         MvcResult mvcResult = getClient(token).perform(post("/api/core/relationships")
-                .param("relationshipType",
-                        isAuthorOfPublicationRelationshipType.getID()
-                                .toString())
-                .contentType(MediaType.parseMediaType
-                        (org.springframework.data.rest.webmvc.RestMediaTypes
-                                .TEXT_URI_LIST_VALUE))
-                .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                .andExpect(status().isCreated())
-                .andReturn();
+                                                           .param("relationshipType",
+                                                                  isAuthorOfPublicationRelationshipType.getID()
+                                                                                                       .toString())
+                                                           .contentType(MediaType.parseMediaType
+                                                               (org.springframework.data.rest.webmvc.RestMediaTypes
+                                                                    .TEXT_URI_LIST_VALUE))
+                                                           .content(
+                                                               "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                                                   "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                                              .andExpect(status().isCreated())
+                                              .andReturn();
 
         ObjectMapper mapper = new ObjectMapper();
 
@@ -321,9 +321,9 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String firstRelationshipIdString = String.valueOf(map.get("id"));
 
         getClient().perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.leftId", is(publication.getID().toString())))
-                .andExpect(jsonPath("$.rightId", is(author1.getID().toString())));
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.leftId", is(publication.getID().toString())))
+                   .andExpect(jsonPath("$.rightId", is(author1.getID().toString())));
     }
 
 
@@ -333,57 +333,57 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                .withName("Parent Community")
-                .build();
+                                          .withName("Parent Community")
+                                          .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                .withName("Sub Community")
-                .build();
+                                           .withName("Sub Community")
+                                           .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                .withTitle("Author1")
-                .withIssueDate("2017-10-17")
-                .withAuthor("Smith, Donald")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author1")
+                                  .withIssueDate("2017-10-17")
+                                  .withAuthor("Smith, Donald")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item publication = ItemBuilder.createItem(context, col3)
-                .withTitle("Publication1")
-                .withAuthor("Testy, TEst")
-                .withIssueDate("2015-01-01")
-                .withRelationshipType("Publication")
-                .build();
+                                      .withTitle("Publication1")
+                                      .withAuthor("Testy, TEst")
+                                      .withIssueDate("2015-01-01")
+                                      .withRelationshipType("Publication")
+                                      .build();
 
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                        entityTypeService.findByEntityType(context, "Person"),
-                        "isAuthorOfPublication", "isPublicationOfAuthor");
+            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                                  entityTypeService.findByEntityType(context, "Person"),
+                                  "isAuthorOfPublication", "isPublicationOfAuthor");
 
         EPerson user = EPersonBuilder.createEPerson(context)
-                .withNameInMetadata("first", "last")
-                .withEmail("testaze@gmail.com")
-                .withPassword(password)
-                .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
-                .build();
+                                     .withNameInMetadata("first", "last")
+                                     .withEmail("testaze@gmail.com")
+                                     .withPassword(password)
+                                     .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
+                                     .build();
         context.setCurrentUser(user);
         context.restoreAuthSystemState();
 
         String token = getAuthToken(user.getEmail(), password);
 
         MvcResult mvcResult = getClient(token).perform(post("/api/core/relationships")
-                .param("relationshipType",
-                        isAuthorOfPublicationRelationshipType.getID()
-                                .toString())
-                .contentType(MediaType.parseMediaType
-                        (org.springframework.data.rest.webmvc.RestMediaTypes
-                                .TEXT_URI_LIST_VALUE))
-                .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                .andExpect(status().isForbidden())
-                .andReturn();
+                                                           .param("relationshipType",
+                                                                  isAuthorOfPublicationRelationshipType.getID()
+                                                                                                       .toString())
+                                                           .contentType(MediaType.parseMediaType
+                                                               (org.springframework.data.rest.webmvc.RestMediaTypes
+                                                                    .TEXT_URI_LIST_VALUE))
+                                                           .content(
+                                                               "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                                                   "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                                              .andExpect(status().isForbidden())
+                                              .andReturn();
 
     }
 
@@ -398,48 +398,48 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                .withName("Parent Community")
-                .build();
+                                          .withName("Parent Community")
+                                          .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                .withName("Sub Community")
-                .build();
+                                           .withName("Sub Community")
+                                           .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                .withTitle("Author1")
-                .withIssueDate("2017-10-17")
-                .withPersonIdentifierFirstName("Donald")
-                .withPersonIdentifierLastName("Smith")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author1")
+                                  .withIssueDate("2017-10-17")
+                                  .withPersonIdentifierFirstName("Donald")
+                                  .withPersonIdentifierLastName("Smith")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item author2 = ItemBuilder.createItem(context, col2)
-                .withTitle("Author2")
-                .withIssueDate("2016-02-13")
-                .withPersonIdentifierFirstName("Maria")
-                .withPersonIdentifierLastName("Smith")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author2")
+                                  .withIssueDate("2016-02-13")
+                                  .withPersonIdentifierFirstName("Maria")
+                                  .withPersonIdentifierLastName("Smith")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item author3 = ItemBuilder.createItem(context, col2)
-                .withTitle("Author3")
-                .withIssueDate("2016-02-13")
-                .withPersonIdentifierFirstName("Maybe")
-                .withPersonIdentifierLastName("Maybe")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author3")
+                                  .withIssueDate("2016-02-13")
+                                  .withPersonIdentifierFirstName("Maybe")
+                                  .withPersonIdentifierLastName("Maybe")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item publication = ItemBuilder.createItem(context, col3)
-                .withTitle("Publication1")
-                .withIssueDate("2015-01-01")
-                .withRelationshipType("Publication")
-                .build();
+                                      .withTitle("Publication1")
+                                      .withIssueDate("2015-01-01")
+                                      .withRelationshipType("Publication")
+                                      .build();
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                        entityTypeService.findByEntityType(context, "Person"),
-                        "isAuthorOfPublication", "isPublicationOfAuthor");
+            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                                  entityTypeService.findByEntityType(context, "Person"),
+                                  "isAuthorOfPublication", "isPublicationOfAuthor");
 
         String adminToken = getAuthToken(admin.getEmail(), password);
 
@@ -447,17 +447,17 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         // Here we create our first Relationship to the Publication to give it a dc.contributor.author virtual
         // metadata field.
         MvcResult mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                .param("relationshipType",
-                        isAuthorOfPublicationRelationshipType.getID()
-                                .toString())
-                .contentType(MediaType.parseMediaType
-                        (org.springframework.data.rest.webmvc.RestMediaTypes
-                                .TEXT_URI_LIST_VALUE))
-                .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                .andExpect(status().isCreated())
-                .andReturn();
+                                                                .param("relationshipType",
+                                                                       isAuthorOfPublicationRelationshipType.getID()
+                                                                                                            .toString())
+                                                                .contentType(MediaType.parseMediaType
+                                                                    (org.springframework.data.rest.webmvc.RestMediaTypes
+                                                                         .TEXT_URI_LIST_VALUE))
+                                                                .content(
+                                                                    "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                                                        "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                                                   .andExpect(status().isCreated())
+                                                   .andReturn();
         ObjectMapper mapper = new ObjectMapper();
 
         String content = mvcResult.getResponse().getContentAsString();
@@ -466,8 +466,8 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
         // Here we call the relationship and verify that the relationship's leftplace is 0
         getClient(adminToken).perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("leftPlace", is(0)));
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("leftPlace", is(0)));
 
         context.turnOffAuthorisationSystem();
 
@@ -498,22 +498,22 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.restoreAuthSystemState();
         // Verfiy the leftPlace of our relationship is still 0.
         getClient(adminToken).perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("leftPlace", is(0)));
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("leftPlace", is(0)));
 
         // Create another Relationship for the Publication, thus creating a third dc.contributor.author mdv
         mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                .param("relationshipType",
-                        isAuthorOfPublicationRelationshipType.getID()
-                                .toString())
-                .contentType(MediaType.parseMediaType
-                        (org.springframework.data.rest.webmvc.RestMediaTypes
-                                .TEXT_URI_LIST_VALUE))
-                .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                "https://localhost:8080/spring-rest/api/core/items/" + author2.getID()))
-                .andExpect(status().isCreated())
-                .andReturn();
+                                                      .param("relationshipType",
+                                                             isAuthorOfPublicationRelationshipType.getID()
+                                                                                                  .toString())
+                                                      .contentType(MediaType.parseMediaType
+                                                          (org.springframework.data.rest.webmvc.RestMediaTypes
+                                                               .TEXT_URI_LIST_VALUE))
+                                                      .content(
+                                                          "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                                              "https://localhost:8080/spring-rest/api/core/items/" + author2.getID()))
+                                         .andExpect(status().isCreated())
+                                         .andReturn();
 
         content = mvcResult.getResponse().getContentAsString();
         map = mapper.readValue(content, Map.class);
@@ -528,8 +528,8 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         // Relationship. Note that leftPlace 1 was skipped due to the dc.contributor.author plain text value and
         // This is expected behaviour and should be tested
         getClient(adminToken).perform(get("/api/core/relationships/" + secondRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("leftPlace", is(2)));
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("leftPlace", is(2)));
 
         author0MD = list.get(0);
         assertEquals("Smith, Donald", author0MD.getValue());
@@ -569,17 +569,17 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
         // Create the third Relationship thus adding a fifth dc.contributor.author mdv
         mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                .param("relationshipType",
-                        isAuthorOfPublicationRelationshipType.getID()
-                                .toString())
-                .contentType(MediaType.parseMediaType
-                        (org.springframework.data.rest.webmvc.RestMediaTypes
-                                .TEXT_URI_LIST_VALUE))
-                .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                "https://localhost:8080/spring-rest/api/core/items/" + author3.getID()))
-                .andExpect(status().isCreated())
-                .andReturn();
+                                                      .param("relationshipType",
+                                                             isAuthorOfPublicationRelationshipType.getID()
+                                                                                                  .toString())
+                                                      .contentType(MediaType.parseMediaType
+                                                          (org.springframework.data.rest.webmvc.RestMediaTypes
+                                                               .TEXT_URI_LIST_VALUE))
+                                                      .content(
+                                                          "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                                              "https://localhost:8080/spring-rest/api/core/items/" + author3.getID()))
+                                         .andExpect(status().isCreated())
+                                         .andReturn();
 
         content = mvcResult.getResponse().getContentAsString();
         map = mapper.readValue(content, Map.class);
@@ -592,8 +592,8 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         // Assert that the third Relationship has leftPlace 4, even though 3 relationships were created.
         // This is because the plain text values 'occupy' place 1 and 3.
         getClient(adminToken).perform(get("/api/core/relationships/" + thirdRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("leftPlace", is(4)));
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("leftPlace", is(4)));
 
         // Assert that the list is of size 5 and in the following order:
         // "Smith, Donald", "plain text", "Smith, Maria", "plain text two", "Maybe, Maybe"
@@ -708,48 +708,48 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                .withName("Parent Community")
-                .build();
+                                          .withName("Parent Community")
+                                          .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                .withName("Sub Community")
-                .build();
+                                           .withName("Sub Community")
+                                           .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                .withTitle("Author1")
-                .withIssueDate("2017-10-17")
-                .withPersonIdentifierFirstName("Donald")
-                .withPersonIdentifierLastName("Smith")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author1")
+                                  .withIssueDate("2017-10-17")
+                                  .withPersonIdentifierFirstName("Donald")
+                                  .withPersonIdentifierLastName("Smith")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item author2 = ItemBuilder.createItem(context, col2)
-                .withTitle("Author2")
-                .withIssueDate("2016-02-13")
-                .withPersonIdentifierFirstName("Maria")
-                .withPersonIdentifierLastName("Smith")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author2")
+                                  .withIssueDate("2016-02-13")
+                                  .withPersonIdentifierFirstName("Maria")
+                                  .withPersonIdentifierLastName("Smith")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item author3 = ItemBuilder.createItem(context, col2)
-                .withTitle("Author3")
-                .withIssueDate("2016-02-13")
-                .withPersonIdentifierFirstName("Maybe")
-                .withPersonIdentifierLastName("Maybe")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author3")
+                                  .withIssueDate("2016-02-13")
+                                  .withPersonIdentifierFirstName("Maybe")
+                                  .withPersonIdentifierLastName("Maybe")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item publication = ItemBuilder.createItem(context, col3)
-                .withTitle("Publication1")
-                .withIssueDate("2015-01-01")
-                .withRelationshipType("Publication")
-                .build();
+                                      .withTitle("Publication1")
+                                      .withIssueDate("2015-01-01")
+                                      .withRelationshipType("Publication")
+                                      .build();
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                        entityTypeService.findByEntityType(context, "Person"),
-                        "isAuthorOfPublication", "isPublicationOfAuthor");
+            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                                  entityTypeService.findByEntityType(context, "Person"),
+                                  "isAuthorOfPublication", "isPublicationOfAuthor");
 
         String adminToken = getAuthToken(admin.getEmail(), password);
 
@@ -758,17 +758,17 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         // This post request will add a first relationship to the publiction and thus create a first set of metadata
         // For the author values, namely "Donald Smith"
         MvcResult mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                .param("relationshipType",
-                        isAuthorOfPublicationRelationshipType.getID()
-                                .toString())
-                .contentType(MediaType.parseMediaType
-                        (org.springframework.data.rest.webmvc.RestMediaTypes
-                                .TEXT_URI_LIST_VALUE))
-                .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                .andExpect(status().isCreated())
-                .andReturn();
+                                                                .param("relationshipType",
+                                                                       isAuthorOfPublicationRelationshipType.getID()
+                                                                                                            .toString())
+                                                                .contentType(MediaType.parseMediaType
+                                                                    (org.springframework.data.rest.webmvc.RestMediaTypes
+                                                                         .TEXT_URI_LIST_VALUE))
+                                                                .content(
+                                                                    "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                                                        "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                                                   .andExpect(status().isCreated())
+                                                   .andReturn();
         ObjectMapper mapper = new ObjectMapper();
 
         String content = mvcResult.getResponse().getContentAsString();
@@ -777,8 +777,8 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
         // This test will double check that the leftPlace for this relationship is indeed 0
         getClient(adminToken).perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("leftPlace", is(0)));
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("leftPlace", is(0)));
 
 
         context.turnOffAuthorisationSystem();
@@ -801,22 +801,22 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         // This test checks again that the first relationship is still on leftplace 0 and not altered
         // Because of the MetadataValue addition
         getClient(adminToken).perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("leftPlace", is(0)));
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("leftPlace", is(0)));
 
         // Creates another Relationship for the Publication and thus adding a third metadata value for the author
         mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                .param("relationshipType",
-                        isAuthorOfPublicationRelationshipType.getID()
-                                .toString())
-                .contentType(MediaType.parseMediaType
-                        (org.springframework.data.rest.webmvc.RestMediaTypes
-                                .TEXT_URI_LIST_VALUE))
-                .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                "https://localhost:8080/spring-rest/api/core/items/" + author2.getID()))
-                .andExpect(status().isCreated())
-                .andReturn();
+                                                      .param("relationshipType",
+                                                             isAuthorOfPublicationRelationshipType.getID()
+                                                                                                  .toString())
+                                                      .contentType(MediaType.parseMediaType
+                                                          (org.springframework.data.rest.webmvc.RestMediaTypes
+                                                               .TEXT_URI_LIST_VALUE))
+                                                      .content(
+                                                          "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                                              "https://localhost:8080/spring-rest/api/core/items/" + author2.getID()))
+                                         .andExpect(status().isCreated())
+                                         .andReturn();
 
         content = mvcResult.getResponse().getContentAsString();
         map = mapper.readValue(content, Map.class);
@@ -825,8 +825,8 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         // This test verifies that the newly created Relationship is on leftPlace 2, because the first relationship
         // is on leftPlace 0 and the plain text metadataValue occupies the place 1
         getClient(adminToken).perform(get("/api/core/relationships/" + secondRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("leftPlace", is(2)));
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("leftPlace", is(2)));
         context.turnOffAuthorisationSystem();
         // Get the publication from the DB again to ensure that we have the latest object
         publication = itemService.find(context, publication.getID());
@@ -847,17 +847,17 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
         // This creates a third relationship for the publication and thus adding a fifth value for author metadatavalues
         mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                .param("relationshipType",
-                        isAuthorOfPublicationRelationshipType.getID()
-                                .toString())
-                .contentType(MediaType.parseMediaType
-                        (org.springframework.data.rest.webmvc.RestMediaTypes
-                                .TEXT_URI_LIST_VALUE))
-                .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                "https://localhost:8080/spring-rest/api/core/items/" + author3.getID()))
-                .andExpect(status().isCreated())
-                .andReturn();
+                                                      .param("relationshipType",
+                                                             isAuthorOfPublicationRelationshipType.getID()
+                                                                                                  .toString())
+                                                      .contentType(MediaType.parseMediaType
+                                                          (org.springframework.data.rest.webmvc.RestMediaTypes
+                                                               .TEXT_URI_LIST_VALUE))
+                                                      .content(
+                                                          "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                                              "https://localhost:8080/spring-rest/api/core/items/" + author3.getID()))
+                                         .andExpect(status().isCreated())
+                                         .andReturn();
 
         content = mvcResult.getResponse().getContentAsString();
         map = mapper.readValue(content, Map.class);
@@ -865,8 +865,8 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
         // This verifies that the newly created third relationship is on leftPlace 4.
         getClient(adminToken).perform(get("/api/core/relationships/" + thirdRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("leftPlace", is(4)));
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("leftPlace", is(4)));
 
         context.turnOffAuthorisationSystem();
         publication = itemService.find(context, publication.getID());
@@ -916,14 +916,14 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         }
 
         getClient(adminToken).perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("leftPlace", is(0)));
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("leftPlace", is(0)));
         getClient(adminToken).perform(get("/api/core/relationships/" + secondRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("leftPlace", is(2)));
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("leftPlace", is(2)));
         getClient(adminToken).perform(get("/api/core/relationships/" + thirdRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("leftPlace", is(3)));
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("leftPlace", is(3)));
 
     }
 
@@ -939,48 +939,48 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                .withName("Parent Community")
-                .build();
+                                          .withName("Parent Community")
+                                          .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                .withName("Sub Community")
-                .build();
+                                           .withName("Sub Community")
+                                           .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                .withTitle("Author1")
-                .withIssueDate("2017-10-17")
-                .withPersonIdentifierFirstName("Donald")
-                .withPersonIdentifierLastName("Smith")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author1")
+                                  .withIssueDate("2017-10-17")
+                                  .withPersonIdentifierFirstName("Donald")
+                                  .withPersonIdentifierLastName("Smith")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item author2 = ItemBuilder.createItem(context, col2)
-                .withTitle("Author2")
-                .withIssueDate("2016-02-13")
-                .withPersonIdentifierFirstName("Maria")
-                .withPersonIdentifierLastName("Smith")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author2")
+                                  .withIssueDate("2016-02-13")
+                                  .withPersonIdentifierFirstName("Maria")
+                                  .withPersonIdentifierLastName("Smith")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item author3 = ItemBuilder.createItem(context, col2)
-                .withTitle("Author3")
-                .withIssueDate("2016-02-13")
-                .withPersonIdentifierFirstName("Maybe")
-                .withPersonIdentifierLastName("Maybe")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author3")
+                                  .withIssueDate("2016-02-13")
+                                  .withPersonIdentifierFirstName("Maybe")
+                                  .withPersonIdentifierLastName("Maybe")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item publication = ItemBuilder.createItem(context, col3)
-                .withTitle("Publication1")
-                .withIssueDate("2015-01-01")
-                .withRelationshipType("Publication")
-                .build();
+                                      .withTitle("Publication1")
+                                      .withIssueDate("2015-01-01")
+                                      .withRelationshipType("Publication")
+                                      .build();
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                        entityTypeService.findByEntityType(context, "Person"),
-                        "isAuthorOfPublication", "isPublicationOfAuthor");
+            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                                  entityTypeService.findByEntityType(context, "Person"),
+                                  "isAuthorOfPublication", "isPublicationOfAuthor");
 
         String adminToken = getAuthToken(admin.getEmail(), password);
 
@@ -989,17 +989,17 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         // This post request will add a first relationship to the publiction and thus create a first set of metadata
         // For the author values, namely "Donald Smith"
         MvcResult mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                .param("relationshipType",
-                        isAuthorOfPublicationRelationshipType.getID()
-                                .toString())
-                .contentType(MediaType.parseMediaType
-                        (org.springframework.data.rest.webmvc.RestMediaTypes
-                                .TEXT_URI_LIST_VALUE))
-                .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                .andExpect(status().isCreated())
-                .andReturn();
+                                                                .param("relationshipType",
+                                                                       isAuthorOfPublicationRelationshipType.getID()
+                                                                                                            .toString())
+                                                                .contentType(MediaType.parseMediaType
+                                                                    (org.springframework.data.rest.webmvc.RestMediaTypes
+                                                                         .TEXT_URI_LIST_VALUE))
+                                                                .content(
+                                                                    "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                                                        "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                                                   .andExpect(status().isCreated())
+                                                   .andReturn();
         ObjectMapper mapper = new ObjectMapper();
 
         String content = mvcResult.getResponse().getContentAsString();
@@ -1008,8 +1008,8 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
         // This test will double check that the leftPlace for this relationship is indeed 0
         getClient(adminToken).perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("leftPlace", is(0)));
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("leftPlace", is(0)));
 
 
         context.turnOffAuthorisationSystem();
@@ -1032,22 +1032,22 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         // This test checks again that the first relationship is still on leftplace 0 and not altered
         // Because of the MetadataValue addition
         getClient(adminToken).perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("leftPlace", is(0)));
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("leftPlace", is(0)));
 
         // Creates another Relationship for the Publication and thus adding a third metadata value for the author
         mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                .param("relationshipType",
-                        isAuthorOfPublicationRelationshipType.getID()
-                                .toString())
-                .contentType(MediaType.parseMediaType
-                        (org.springframework.data.rest.webmvc.RestMediaTypes
-                                .TEXT_URI_LIST_VALUE))
-                .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                "https://localhost:8080/spring-rest/api/core/items/" + author2.getID()))
-                .andExpect(status().isCreated())
-                .andReturn();
+                                                      .param("relationshipType",
+                                                             isAuthorOfPublicationRelationshipType.getID()
+                                                                                                  .toString())
+                                                      .contentType(MediaType.parseMediaType
+                                                          (org.springframework.data.rest.webmvc.RestMediaTypes
+                                                               .TEXT_URI_LIST_VALUE))
+                                                      .content(
+                                                          "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                                              "https://localhost:8080/spring-rest/api/core/items/" + author2.getID()))
+                                         .andExpect(status().isCreated())
+                                         .andReturn();
 
         content = mvcResult.getResponse().getContentAsString();
         map = mapper.readValue(content, Map.class);
@@ -1056,8 +1056,8 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         // This test verifies that the newly created Relationship is on leftPlace 2, because the first relationship
         // is on leftPlace 0 and the plain text metadataValue occupies the place 1
         getClient(adminToken).perform(get("/api/core/relationships/" + secondRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("leftPlace", is(2)));
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("leftPlace", is(2)));
         context.turnOffAuthorisationSystem();
         // Get the publication from the DB again to ensure that we have the latest object
         publication = itemService.find(context, publication.getID());
@@ -1078,17 +1078,17 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
         // This creates a third relationship for the publication and thus adding a fifth value for author metadatavalues
         mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                .param("relationshipType",
-                        isAuthorOfPublicationRelationshipType.getID()
-                                .toString())
-                .contentType(MediaType.parseMediaType
-                        (org.springframework.data.rest.webmvc.RestMediaTypes
-                                .TEXT_URI_LIST_VALUE))
-                .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                "https://localhost:8080/spring-rest/api/core/items/" + author3.getID()))
-                .andExpect(status().isCreated())
-                .andReturn();
+                                                      .param("relationshipType",
+                                                             isAuthorOfPublicationRelationshipType.getID()
+                                                                                                  .toString())
+                                                      .contentType(MediaType.parseMediaType
+                                                          (org.springframework.data.rest.webmvc.RestMediaTypes
+                                                               .TEXT_URI_LIST_VALUE))
+                                                      .content(
+                                                          "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                                              "https://localhost:8080/spring-rest/api/core/items/" + author3.getID()))
+                                         .andExpect(status().isCreated())
+                                         .andReturn();
 
         content = mvcResult.getResponse().getContentAsString();
         map = mapper.readValue(content, Map.class);
@@ -1096,8 +1096,8 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
         // This verifies that the newly created third relationship is on leftPlace 4.
         getClient(adminToken).perform(get("/api/core/relationships/" + thirdRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("leftPlace", is(4)));
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("leftPlace", is(4)));
 
         context.turnOffAuthorisationSystem();
         publication = itemService.find(context, publication.getID());
@@ -1124,8 +1124,8 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         getClient(adminToken).perform(delete("/api/core/relationships/" + secondRelationshipIdString));
 
         getClient(adminToken).perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("leftPlace", is(0)));
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("leftPlace", is(0)));
 
         publication = itemService.find(context, publication.getID());
         list = itemService.getMetadata(publication, "dc", "contributor", "author", Item.ANY);
@@ -1154,8 +1154,8 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
 
         getClient(adminToken).perform(get("/api/core/relationships/" + thirdRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("leftPlace", is(3)));
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("leftPlace", is(3)));
 
     }
 
@@ -1171,63 +1171,63 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                .withName("Parent Community")
-                .build();
+                                          .withName("Parent Community")
+                                          .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                .withName("Sub Community")
-                .build();
+                                           .withName("Sub Community")
+                                           .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                .withTitle("Author1")
-                .withIssueDate("2017-10-17")
-                .withAuthor("Smith, Donald")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author1")
+                                  .withIssueDate("2017-10-17")
+                                  .withAuthor("Smith, Donald")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item author2 = ItemBuilder.createItem(context, col2)
-                .withTitle("Author2")
-                .withIssueDate("2016-02-13")
-                .withAuthor("Smith, Maria")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author2")
+                                  .withIssueDate("2016-02-13")
+                                  .withAuthor("Smith, Maria")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item author3 = ItemBuilder.createItem(context, col2)
-                .withTitle("Author3")
-                .withIssueDate("2016-02-13")
-                .withAuthor("Maybe, Maybe")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author3")
+                                  .withIssueDate("2016-02-13")
+                                  .withAuthor("Maybe, Maybe")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item orgUnit1 = ItemBuilder.createItem(context, col3)
-                .withTitle("OrgUnit1")
-                .withIssueDate("2015-01-01")
-                .withRelationshipType("OrgUnit")
-                .build();
+                                   .withTitle("OrgUnit1")
+                                   .withIssueDate("2015-01-01")
+                                   .withRelationshipType("OrgUnit")
+                                   .build();
 
         RelationshipType isOrgUnitOfPersonRelationshipType = relationshipTypeService
-                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Person"),
-                        entityTypeService.findByEntityType(context, "OrgUnit"),
-                        "isOrgUnitOfPerson", "isPersonOfOrgUnit");
+            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Person"),
+                                  entityTypeService.findByEntityType(context, "OrgUnit"),
+                                  "isOrgUnitOfPerson", "isPersonOfOrgUnit");
         context.restoreAuthSystemState();
         String adminToken = getAuthToken(admin.getEmail(), password);
 
         // This is essentially a sequence of adding Relationships by POST and then checking with GET to see
         // if the place is being set properly.
         MvcResult mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                .param("relationshipType",
-                        isOrgUnitOfPersonRelationshipType.getID()
-                                .toString())
-                .contentType(MediaType.parseMediaType
-                        (org.springframework.data.rest.webmvc.RestMediaTypes
-                                .TEXT_URI_LIST_VALUE))
-                .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + author1.getID() + "\n" +
-                                "https://localhost:8080/spring-rest/api/core/items/" + orgUnit1.getID()))
-                .andExpect(status().isCreated())
-                .andReturn();
+                                                                .param("relationshipType",
+                                                                       isOrgUnitOfPersonRelationshipType.getID()
+                                                                                                        .toString())
+                                                                .contentType(MediaType.parseMediaType
+                                                                    (org.springframework.data.rest.webmvc.RestMediaTypes
+                                                                         .TEXT_URI_LIST_VALUE))
+                                                                .content(
+                                                                    "https://localhost:8080/spring-rest/api/core/items/" + author1.getID() + "\n" +
+                                                                        "https://localhost:8080/spring-rest/api/core/items/" + orgUnit1.getID()))
+                                                   .andExpect(status().isCreated())
+                                                   .andReturn();
         ObjectMapper mapper = new ObjectMapper();
 
         String content = mvcResult.getResponse().getContentAsString();
@@ -1235,20 +1235,20 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String firstRelationshipIdString = String.valueOf(map.get("id"));
 
         getClient(adminToken).perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("rightPlace", is(0)));
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("rightPlace", is(0)));
 
         mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                .param("relationshipType",
-                        isOrgUnitOfPersonRelationshipType.getID().toString())
-                .contentType(MediaType.parseMediaType
-                        (org.springframework.data.rest.webmvc.RestMediaTypes
-                                .TEXT_URI_LIST_VALUE))
-                .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + author2.getID() + "\n" +
-                                "https://localhost:8080/spring-rest/api/core/items/" + orgUnit1.getID()))
-                .andExpect(status().isCreated())
-                .andReturn();
+                                                      .param("relationshipType",
+                                                             isOrgUnitOfPersonRelationshipType.getID().toString())
+                                                      .contentType(MediaType.parseMediaType
+                                                          (org.springframework.data.rest.webmvc.RestMediaTypes
+                                                               .TEXT_URI_LIST_VALUE))
+                                                      .content(
+                                                          "https://localhost:8080/spring-rest/api/core/items/" + author2.getID() + "\n" +
+                                                              "https://localhost:8080/spring-rest/api/core/items/" + orgUnit1.getID()))
+                                         .andExpect(status().isCreated())
+                                         .andReturn();
         mapper = new ObjectMapper();
 
         content = mvcResult.getResponse().getContentAsString();
@@ -1256,20 +1256,20 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String secondRelationshipIdString = String.valueOf(map.get("id"));
 
         getClient(adminToken).perform(get("/api/core/relationships/" + secondRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("rightPlace", is(1)));
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("rightPlace", is(1)));
 
         mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                .param("relationshipType",
-                        isOrgUnitOfPersonRelationshipType.getID().toString())
-                .contentType(MediaType.parseMediaType
-                        (org.springframework.data.rest.webmvc.RestMediaTypes
-                                .TEXT_URI_LIST_VALUE))
-                .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + author3.getID() + "\n" +
-                                "https://localhost:8080/spring-rest/api/core/items/" + orgUnit1.getID()))
-                .andExpect(status().isCreated())
-                .andReturn();
+                                                      .param("relationshipType",
+                                                             isOrgUnitOfPersonRelationshipType.getID().toString())
+                                                      .contentType(MediaType.parseMediaType
+                                                          (org.springframework.data.rest.webmvc.RestMediaTypes
+                                                               .TEXT_URI_LIST_VALUE))
+                                                      .content(
+                                                          "https://localhost:8080/spring-rest/api/core/items/" + author3.getID() + "\n" +
+                                                              "https://localhost:8080/spring-rest/api/core/items/" + orgUnit1.getID()))
+                                         .andExpect(status().isCreated())
+                                         .andReturn();
         mapper = new ObjectMapper();
 
         content = mvcResult.getResponse().getContentAsString();
@@ -1277,8 +1277,8 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String thirdRelationshipIdString = String.valueOf(map.get("id"));
 
         getClient(adminToken).perform(get("/api/core/relationships/" + thirdRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("rightPlace", is(2)));
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("rightPlace", is(2)));
     }
 
     /**
@@ -1294,63 +1294,63 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                .withName("Parent Community")
-                .build();
+                                          .withName("Parent Community")
+                                          .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                .withName("Sub Community")
-                .build();
+                                           .withName("Sub Community")
+                                           .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                .withTitle("Author1")
-                .withIssueDate("2017-10-17")
-                .withAuthor("Smith, Donald")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author1")
+                                  .withIssueDate("2017-10-17")
+                                  .withAuthor("Smith, Donald")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item author2 = ItemBuilder.createItem(context, col2)
-                .withTitle("Author2")
-                .withIssueDate("2016-02-13")
-                .withAuthor("Smith, Maria")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author2")
+                                  .withIssueDate("2016-02-13")
+                                  .withAuthor("Smith, Maria")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item author3 = ItemBuilder.createItem(context, col2)
-                .withTitle("Author3")
-                .withIssueDate("2016-02-13")
-                .withAuthor("Maybe, Maybe")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author3")
+                                  .withIssueDate("2016-02-13")
+                                  .withAuthor("Maybe, Maybe")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item orgUnit1 = ItemBuilder.createItem(context, col3)
-                .withTitle("OrgUnit1")
-                .withIssueDate("2015-01-01")
-                .withRelationshipType("OrgUnit")
-                .build();
+                                   .withTitle("OrgUnit1")
+                                   .withIssueDate("2015-01-01")
+                                   .withRelationshipType("OrgUnit")
+                                   .build();
 
         RelationshipType isOrgUnitOfPersonRelationshipType = relationshipTypeService
-                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Person"),
-                        entityTypeService.findByEntityType(context, "OrgUnit"),
-                        "isOrgUnitOfPerson", "isPersonOfOrgUnit");
+            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Person"),
+                                  entityTypeService.findByEntityType(context, "OrgUnit"),
+                                  "isOrgUnitOfPerson", "isPersonOfOrgUnit");
         context.restoreAuthSystemState();
         String adminToken = getAuthToken(admin.getEmail(), password);
 
         // This is essentially a sequence of adding Relationships by POST and then checking with GET to see
         // if the place is being set properly.
         MvcResult mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                .param("relationshipType",
-                        isOrgUnitOfPersonRelationshipType.getID()
-                                .toString())
-                .contentType(MediaType.parseMediaType
-                        (org.springframework.data.rest.webmvc.RestMediaTypes
-                                .TEXT_URI_LIST_VALUE))
-                .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + author1.getID() + "\n" +
-                                "https://localhost:8080/spring-rest/api/core/items/" + orgUnit1.getID()))
-                .andExpect(status().isCreated())
-                .andReturn();
+                                                                .param("relationshipType",
+                                                                       isOrgUnitOfPersonRelationshipType.getID()
+                                                                                                        .toString())
+                                                                .contentType(MediaType.parseMediaType
+                                                                    (org.springframework.data.rest.webmvc.RestMediaTypes
+                                                                         .TEXT_URI_LIST_VALUE))
+                                                                .content(
+                                                                    "https://localhost:8080/spring-rest/api/core/items/" + author1.getID() + "\n" +
+                                                                        "https://localhost:8080/spring-rest/api/core/items/" + orgUnit1.getID()))
+                                                   .andExpect(status().isCreated())
+                                                   .andReturn();
         ObjectMapper mapper = new ObjectMapper();
 
         String content = mvcResult.getResponse().getContentAsString();
@@ -1358,20 +1358,20 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String firstRelationshipIdString = String.valueOf(map.get("id"));
 
         getClient(adminToken).perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("rightPlace", is(0)));
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("rightPlace", is(0)));
 
         mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                .param("relationshipType",
-                        isOrgUnitOfPersonRelationshipType.getID().toString())
-                .contentType(MediaType.parseMediaType
-                        (org.springframework.data.rest.webmvc.RestMediaTypes
-                                .TEXT_URI_LIST_VALUE))
-                .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + author2.getID() + "\n" +
-                                "https://localhost:8080/spring-rest/api/core/items/" + orgUnit1.getID()))
-                .andExpect(status().isCreated())
-                .andReturn();
+                                                      .param("relationshipType",
+                                                             isOrgUnitOfPersonRelationshipType.getID().toString())
+                                                      .contentType(MediaType.parseMediaType
+                                                          (org.springframework.data.rest.webmvc.RestMediaTypes
+                                                               .TEXT_URI_LIST_VALUE))
+                                                      .content(
+                                                          "https://localhost:8080/spring-rest/api/core/items/" + author2.getID() + "\n" +
+                                                              "https://localhost:8080/spring-rest/api/core/items/" + orgUnit1.getID()))
+                                         .andExpect(status().isCreated())
+                                         .andReturn();
         mapper = new ObjectMapper();
 
         content = mvcResult.getResponse().getContentAsString();
@@ -1379,20 +1379,20 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String secondRelationshipIdString = String.valueOf(map.get("id"));
 
         getClient(adminToken).perform(get("/api/core/relationships/" + secondRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("rightPlace", is(1)));
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("rightPlace", is(1)));
 
         mvcResult = getClient(adminToken).perform(post("/api/core/relationships")
-                .param("relationshipType",
-                        isOrgUnitOfPersonRelationshipType.getID().toString())
-                .contentType(MediaType.parseMediaType
-                        (org.springframework.data.rest.webmvc.RestMediaTypes
-                                .TEXT_URI_LIST_VALUE))
-                .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + author3.getID() + "\n" +
-                                "https://localhost:8080/spring-rest/api/core/items/" + orgUnit1.getID()))
-                .andExpect(status().isCreated())
-                .andReturn();
+                                                      .param("relationshipType",
+                                                             isOrgUnitOfPersonRelationshipType.getID().toString())
+                                                      .contentType(MediaType.parseMediaType
+                                                          (org.springframework.data.rest.webmvc.RestMediaTypes
+                                                               .TEXT_URI_LIST_VALUE))
+                                                      .content(
+                                                          "https://localhost:8080/spring-rest/api/core/items/" + author3.getID() + "\n" +
+                                                              "https://localhost:8080/spring-rest/api/core/items/" + orgUnit1.getID()))
+                                         .andExpect(status().isCreated())
+                                         .andReturn();
         mapper = new ObjectMapper();
 
         content = mvcResult.getResponse().getContentAsString();
@@ -1400,20 +1400,20 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String thirdRelationshipIdString = String.valueOf(map.get("id"));
 
         getClient(adminToken).perform(get("/api/core/relationships/" + thirdRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("rightPlace", is(2)));
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("rightPlace", is(2)));
 
         // Here we will delete the secondRelationship and then verify that the others have their place handled properly
         getClient(adminToken).perform(delete("/api/core/relationships/" + secondRelationshipIdString))
-                .andExpect(status().isNoContent());
+                             .andExpect(status().isNoContent());
 
         getClient(adminToken).perform(get("/api/core/relationships/" + firstRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("rightPlace", is(0)));
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("rightPlace", is(0)));
 
         getClient(adminToken).perform(get("/api/core/relationships/" + thirdRelationshipIdString))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("rightPlace", is(1)));
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("rightPlace", is(1)));
 
     }
 
@@ -1430,34 +1430,34 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                .withName("Parent Community")
-                .build();
+                                          .withName("Parent Community")
+                                          .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                .withName("Sub Community")
-                .build();
+                                           .withName("Sub Community")
+                                           .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                .withTitle("Author1")
-                .withIssueDate("2017-10-17")
-                .withAuthor("Smith, Donald")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author1")
+                                  .withIssueDate("2017-10-17")
+                                  .withAuthor("Smith, Donald")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item author2 = ItemBuilder.createItem(context, col1)
-                .withTitle("Author2")
-                .withIssueDate("2017-10-12")
-                .withAuthor("Smith, Donalaze")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author2")
+                                  .withIssueDate("2017-10-12")
+                                  .withAuthor("Smith, Donalaze")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item publication = ItemBuilder.createItem(context, col3)
-                .withTitle("Publication1")
-                .withAuthor("Testy, TEst")
-                .withIssueDate("2015-01-01")
-                .withRelationshipType("Publication")
-                .build();
+                                      .withTitle("Publication1")
+                                      .withAuthor("Testy, TEst")
+                                      .withIssueDate("2015-01-01")
+                                      .withRelationshipType("Publication")
+                                      .build();
 
         Item publication2 = ItemBuilder.createItem(context, col3)
                 .withTitle("Publication2")
@@ -1467,9 +1467,9 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                 .build();
 
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                        entityTypeService.findByEntityType(context, "Person"),
-                        "isAuthorOfPublication", "isPublicationOfAuthor");
+            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                                  entityTypeService.findByEntityType(context, "Person"),
+                                  "isAuthorOfPublication", "isPublicationOfAuthor");
 
 
 
@@ -1478,17 +1478,17 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String token = getAuthToken(admin.getEmail(), password);
 
         MvcResult mvcResult = getClient(token).perform(post("/api/core/relationships")
-                .param("relationshipType",
-                        isAuthorOfPublicationRelationshipType.getID()
-                                .toString())
-                .contentType(MediaType.parseMediaType
-                        (org.springframework.data.rest.webmvc.RestMediaTypes
-                                .TEXT_URI_LIST_VALUE))
-                .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                .andExpect(status().isCreated())
-                .andReturn();
+                                                           .param("relationshipType",
+                                                                  isAuthorOfPublicationRelationshipType.getID()
+                                                                                                       .toString())
+                                                           .contentType(MediaType.parseMediaType
+                                                               (org.springframework.data.rest.webmvc.RestMediaTypes
+                                                                    .TEXT_URI_LIST_VALUE))
+                                                           .content(
+                                                               "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                                                   "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                                              .andExpect(status().isCreated())
+                                              .andReturn();
 
         ObjectMapper mapper = new ObjectMapper();
         String content = mvcResult.getResponse().getContentAsString();
@@ -1540,48 +1540,48 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                .withName("Parent Community")
-                .build();
+                                          .withName("Parent Community")
+                                          .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                .withName("Sub Community")
-                .build();
+                                           .withName("Sub Community")
+                                           .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                .withTitle("Author1")
-                .withIssueDate("2017-10-17")
-                .withAuthor("Smith, Donald")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author1")
+                                  .withIssueDate("2017-10-17")
+                                  .withAuthor("Smith, Donald")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item author2 = ItemBuilder.createItem(context, col1)
-                .withTitle("Author2")
-                .withIssueDate("2017-10-12")
-                .withAuthor("Smith, Donalaze")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author2")
+                                  .withIssueDate("2017-10-12")
+                                  .withAuthor("Smith, Donalaze")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item publication = ItemBuilder.createItem(context, col3)
-                .withTitle("Publication1")
-                .withAuthor("Testy, TEst")
-                .withIssueDate("2015-01-01")
-                .withRelationshipType("Publication")
-                .build();
+                                      .withTitle("Publication1")
+                                      .withAuthor("Testy, TEst")
+                                      .withIssueDate("2015-01-01")
+                                      .withRelationshipType("Publication")
+                                      .build();
 
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                        entityTypeService.findByEntityType(context, "Person"),
-                        "isAuthorOfPublication", "isPublicationOfAuthor");
+            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                                  entityTypeService.findByEntityType(context, "Person"),
+                                  "isAuthorOfPublication", "isPublicationOfAuthor");
 
 
 
         EPerson user = EPersonBuilder.createEPerson(context)
-                .withNameInMetadata("first", "last")
-                .withEmail("testaze@gmail.com")
-                .withPassword(password)
-                .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
-                .build();
+                                     .withNameInMetadata("first", "last")
+                                     .withEmail("testaze@gmail.com")
+                                     .withPassword(password)
+                                     .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
+                                     .build();
         context.setCurrentUser(user);
 
         authorizeService.addPolicy(context, author1, Constants.WRITE, user);
@@ -1592,15 +1592,15 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String token = getAuthToken(user.getEmail(), password);
 
         MvcResult mvcResult = getClient(token).perform(post("/api/core/relationships")
-                .param("relationshipType",
-                        isAuthorOfPublicationRelationshipType.getID()
-                                .toString())
-                .contentType(MediaType.parseMediaType("text/uri-list"))
-                .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                .andExpect(status().isCreated())
-                .andReturn();
+                                                           .param("relationshipType",
+                                                                  isAuthorOfPublicationRelationshipType.getID()
+                                                                                                       .toString())
+                                                           .contentType(MediaType.parseMediaType("text/uri-list"))
+                                                           .content(
+                                                               "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                                                   "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                                              .andExpect(status().isCreated())
+                                              .andReturn();
 
         ObjectMapper mapper = new ObjectMapper();
         String content = mvcResult.getResponse().getContentAsString();
@@ -1615,9 +1615,9 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                 .andReturn();
         //verify change  and other not changed
         getClient(token).perform(get("/api/core/relationships/" + id))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.rightId", is(author2.getID().toString())))
-                .andExpect(jsonPath("$.leftId", is(publication.getID().toString())));
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.rightId", is(author2.getID().toString())))
+                        .andExpect(jsonPath("$.leftId", is(publication.getID().toString())));
 
     }
 
@@ -1632,48 +1632,48 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                .withName("Parent Community")
-                .build();
+                                          .withName("Parent Community")
+                                          .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                .withName("Sub Community")
-                .build();
+                                           .withName("Sub Community")
+                                           .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                .withTitle("Author1")
-                .withIssueDate("2017-10-17")
-                .withAuthor("Smith, Donald")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author1")
+                                  .withIssueDate("2017-10-17")
+                                  .withAuthor("Smith, Donald")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item author2 = ItemBuilder.createItem(context, col1)
-                .withTitle("Author2")
-                .withIssueDate("2017-10-12")
-                .withAuthor("Smith, Donalaze")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author2")
+                                  .withIssueDate("2017-10-12")
+                                  .withAuthor("Smith, Donalaze")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item publication = ItemBuilder.createItem(context, col3)
-                .withTitle("Publication1")
-                .withAuthor("Testy, TEst")
-                .withIssueDate("2015-01-01")
-                .withRelationshipType("Publication")
-                .build();
+                                      .withTitle("Publication1")
+                                      .withAuthor("Testy, TEst")
+                                      .withIssueDate("2015-01-01")
+                                      .withRelationshipType("Publication")
+                                      .build();
 
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                        entityTypeService.findByEntityType(context, "Person"),
-                        "isAuthorOfPublication", "isPublicationOfAuthor");
+            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                                  entityTypeService.findByEntityType(context, "Person"),
+                                  "isAuthorOfPublication", "isPublicationOfAuthor");
 
 
 
         EPerson user = EPersonBuilder.createEPerson(context)
-                .withNameInMetadata("first", "last")
-                .withEmail("testaze@gmail.com")
-                .withPassword(password)
-                .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
-                .build();
+                                     .withNameInMetadata("first", "last")
+                                     .withEmail("testaze@gmail.com")
+                                     .withPassword(password)
+                                     .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
+                                     .build();
         context.setCurrentUser(user);
 
         authorizeService.addPolicy(context, publication, Constants.WRITE, user);
@@ -1683,15 +1683,15 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String token = getAuthToken(user.getEmail(), password);
 
         MvcResult mvcResult = getClient(token).perform(post("/api/core/relationships")
-                .param("relationshipType",
-                        isAuthorOfPublicationRelationshipType.getID()
-                                .toString())
-                .contentType(MediaType.parseMediaType("text/uri-list"))
-                .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                .andExpect(status().isCreated())
-                .andReturn();
+                                                           .param("relationshipType",
+                                                                  isAuthorOfPublicationRelationshipType.getID()
+                                                                                                       .toString())
+                                                           .contentType(MediaType.parseMediaType("text/uri-list"))
+                                                           .content(
+                                                               "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                                                   "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                                              .andExpect(status().isCreated())
+                                              .andReturn();
 
         ObjectMapper mapper = new ObjectMapper();
         String content = mvcResult.getResponse().getContentAsString();
@@ -1705,9 +1705,9 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                 .andReturn();
         //verify right item change and other not changed
         getClient(token).perform(get("/api/core/relationships/" + id))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.rightId", is(author2.getID().toString())))
-                .andExpect(jsonPath("$.leftId", is(publication.getID().toString())));
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.rightId", is(author2.getID().toString())))
+                        .andExpect(jsonPath("$.leftId", is(publication.getID().toString())));
 
     }
 
@@ -1723,47 +1723,47 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                .withName("Parent Community")
-                .build();
+                                          .withName("Parent Community")
+                                          .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                .withName("Sub Community")
-                .build();
+                                           .withName("Sub Community")
+                                           .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                .withTitle("Author1")
-                .withIssueDate("2017-10-17")
-                .withAuthor("Smith, Donald")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author1")
+                                  .withIssueDate("2017-10-17")
+                                  .withAuthor("Smith, Donald")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item publication1 = ItemBuilder.createItem(context, col3)
-                .withTitle("Publication1")
-                .withAuthor("Testy, TEst")
-                .withIssueDate("2015-01-01")
-                .withRelationshipType("Publication")
-                .build();
+                                      .withTitle("Publication1")
+                                      .withAuthor("Testy, TEst")
+                                      .withIssueDate("2015-01-01")
+                                      .withRelationshipType("Publication")
+                                      .build();
         Item publication2 = ItemBuilder.createItem(context, col3)
-                .withTitle("Publication2")
-                .withAuthor("Testy, TEstzeaze")
-                .withIssueDate("2015-01-01")
-                .withRelationshipType("Publication")
-                .build();
+                                      .withTitle("Publication2")
+                                      .withAuthor("Testy, TEstzeaze")
+                                      .withIssueDate("2015-01-01")
+                                      .withRelationshipType("Publication")
+                                      .build();
 
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                        entityTypeService.findByEntityType(context, "Person"),
-                        "isAuthorOfPublication", "isPublicationOfAuthor");
+            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                                  entityTypeService.findByEntityType(context, "Person"),
+                                  "isAuthorOfPublication", "isPublicationOfAuthor");
 
 
 
         EPerson user = EPersonBuilder.createEPerson(context)
-                .withNameInMetadata("first", "last")
-                .withEmail("testaze@gmail.com")
-                .withPassword(password)
-                .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
-                .build();
+                                     .withNameInMetadata("first", "last")
+                                     .withEmail("testaze@gmail.com")
+                                     .withPassword(password)
+                                     .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
+                                     .build();
         context.setCurrentUser(user);
 
         authorizeService.addPolicy(context, publication1, Constants.WRITE, user);
@@ -1774,15 +1774,15 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String token = getAuthToken(user.getEmail(), password);
 
         MvcResult mvcResult = getClient(token).perform(post("/api/core/relationships")
-                .param("relationshipType",
-                        isAuthorOfPublicationRelationshipType.getID()
-                                .toString())
-                .contentType(MediaType.parseMediaType("text/uri-list"))
-                .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + publication1.getID() + "\n" +
-                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                .andExpect(status().isCreated())
-                .andReturn();
+                                                           .param("relationshipType",
+                                                                  isAuthorOfPublicationRelationshipType.getID()
+                                                                                                       .toString())
+                                                           .contentType(MediaType.parseMediaType("text/uri-list"))
+                                                           .content(
+                                                               "https://localhost:8080/spring-rest/api/core/items/" + publication1.getID() + "\n" +
+                                                                   "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                                              .andExpect(status().isCreated())
+                                              .andReturn();
 
         ObjectMapper mapper = new ObjectMapper();
         String content = mvcResult.getResponse().getContentAsString();
@@ -1796,9 +1796,9 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                 .andReturn();
         //verify change  and other not changed
         getClient(token).perform(get("/api/core/relationships/" + id))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.leftId", is(publication2.getID().toString())))
-                .andExpect(jsonPath("$.rightId", is(author1.getID().toString())));
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.leftId", is(publication2.getID().toString())))
+                        .andExpect(jsonPath("$.rightId", is(author1.getID().toString())));
     }
 
 
@@ -1813,48 +1813,48 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                .withName("Parent Community")
-                .build();
+                                          .withName("Parent Community")
+                                          .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                .withName("Sub Community")
-                .build();
+                                           .withName("Sub Community")
+                                           .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                .withTitle("Author1")
-                .withIssueDate("2017-10-17")
-                .withAuthor("Smith, Donald")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author1")
+                                  .withIssueDate("2017-10-17")
+                                  .withAuthor("Smith, Donald")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item publication1 = ItemBuilder.createItem(context, col3)
-                .withTitle("Publication1")
-                .withAuthor("Testy, TEst")
-                .withIssueDate("2015-01-01")
-                .withRelationshipType("Publication")
-                .build();
+                                      .withTitle("Publication1")
+                                      .withAuthor("Testy, TEst")
+                                      .withIssueDate("2015-01-01")
+                                      .withRelationshipType("Publication")
+                                      .build();
 
         Item publication2 = ItemBuilder.createItem(context, col3)
-                .withTitle("Publication2")
-                .withAuthor("Testy, TEstzea")
-                .withIssueDate("2015-01-01")
-                .withRelationshipType("Publication")
-                .build();
+                                      .withTitle("Publication2")
+                                      .withAuthor("Testy, TEstzea")
+                                      .withIssueDate("2015-01-01")
+                                      .withRelationshipType("Publication")
+                                      .build();
 
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                        entityTypeService.findByEntityType(context, "Person"),
-                        "isAuthorOfPublication", "isPublicationOfAuthor");
+            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                                  entityTypeService.findByEntityType(context, "Person"),
+                                  "isAuthorOfPublication", "isPublicationOfAuthor");
 
 
 
         EPerson user = EPersonBuilder.createEPerson(context)
-                .withNameInMetadata("first", "last")
-                .withEmail("testaze@gmail.com")
-                .withPassword(password)
-                .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
-                .build();
+                                     .withNameInMetadata("first", "last")
+                                     .withEmail("testaze@gmail.com")
+                                     .withPassword(password)
+                                     .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
+                                     .build();
         context.setCurrentUser(user);
 
         authorizeService.addPolicy(context, author1, Constants.WRITE, user);
@@ -1864,16 +1864,16 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String token = getAuthToken(user.getEmail(), password);
 
         MvcResult mvcResult = getClient(getAuthToken(admin.getEmail(), password))
-                .perform(post("/api/core/relationships")
-                        .param("relationshipType",
-                                isAuthorOfPublicationRelationshipType.getID()
-                                        .toString())
-                        .contentType(MediaType.parseMediaType("text/uri-list"))
-                        .content(
-                                "https://localhost:8080/spring-rest/api/core/items/" + publication1.getID() + "\n" +
-                                        "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                .andExpect(status().isCreated())
-                .andReturn();
+            .perform(post("/api/core/relationships")
+                       .param("relationshipType",
+                              isAuthorOfPublicationRelationshipType.getID()
+                                                                   .toString())
+                       .contentType(MediaType.parseMediaType("text/uri-list"))
+                       .content(
+                           "https://localhost:8080/spring-rest/api/core/items/" + publication1.getID() + "\n" +
+                               "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+          .andExpect(status().isCreated())
+          .andReturn();
 
         ObjectMapper mapper = new ObjectMapper();
         String content = mvcResult.getResponse().getContentAsString();
@@ -1887,9 +1887,9 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                 .andReturn();
         //verify change and other not changed
         getClient(token).perform(get("/api/core/relationships/" + id))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.leftId", is(publication2.getID().toString())))
-                .andExpect(jsonPath("$.rightId", is(author1.getID().toString())));
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.leftId", is(publication2.getID().toString())))
+                        .andExpect(jsonPath("$.rightId", is(author1.getID().toString())));
     }
 
 
@@ -1904,48 +1904,48 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                .withName("Parent Community")
-                .build();
+                                          .withName("Parent Community")
+                                          .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                .withName("Sub Community")
-                .build();
+                                           .withName("Sub Community")
+                                           .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                .withTitle("Author1")
-                .withIssueDate("2017-10-17")
-                .withAuthor("Smith, Donald")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author1")
+                                  .withIssueDate("2017-10-17")
+                                  .withAuthor("Smith, Donald")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item author2 = ItemBuilder.createItem(context, col1)
-                .withTitle("Author2")
-                .withIssueDate("2017-10-12")
-                .withAuthor("Smith, Donalaze")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author2")
+                                  .withIssueDate("2017-10-12")
+                                  .withAuthor("Smith, Donalaze")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item publication = ItemBuilder.createItem(context, col3)
-                .withTitle("Publication1")
-                .withAuthor("Testy, TEst")
-                .withIssueDate("2015-01-01")
-                .withRelationshipType("Publication")
-                .build();
+                                      .withTitle("Publication1")
+                                      .withAuthor("Testy, TEst")
+                                      .withIssueDate("2015-01-01")
+                                      .withRelationshipType("Publication")
+                                      .build();
 
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                        entityTypeService.findByEntityType(context, "Person"),
-                        "isAuthorOfPublication", "isPublicationOfAuthor");
+            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                                  entityTypeService.findByEntityType(context, "Person"),
+                                  "isAuthorOfPublication", "isPublicationOfAuthor");
 
 
 
         EPerson user = EPersonBuilder.createEPerson(context)
-                .withNameInMetadata("first", "last")
-                .withEmail("testaze@gmail.com")
-                .withPassword(password)
-                .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
-                .build();
+                                     .withNameInMetadata("first", "last")
+                                     .withEmail("testaze@gmail.com")
+                                     .withPassword(password)
+                                     .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
+                                     .build();
         context.setCurrentUser(user);
 
         context.restoreAuthSystemState();
@@ -1953,15 +1953,15 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String token = getAuthToken(admin.getEmail(), password);
 
         MvcResult mvcResult = getClient(token).perform(post("/api/core/relationships")
-                .param("relationshipType",
-                        isAuthorOfPublicationRelationshipType.getID()
-                                .toString())
-                .contentType(MediaType.parseMediaType("text/uri-list"))
-                .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                .andExpect(status().isCreated())
-                .andReturn();
+                                                           .param("relationshipType",
+                                                                  isAuthorOfPublicationRelationshipType.getID()
+                                                                                                       .toString())
+                                                           .contentType(MediaType.parseMediaType("text/uri-list"))
+                                                           .content(
+                                                               "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                                                   "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                                              .andExpect(status().isCreated())
+                                              .andReturn();
 
         ObjectMapper mapper = new ObjectMapper();
         String content = mvcResult.getResponse().getContentAsString();
@@ -1992,49 +1992,49 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                .withName("Parent Community")
-                .build();
+                                          .withName("Parent Community")
+                                          .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                .withName("Sub Community")
-                .build();
+                                           .withName("Sub Community")
+                                           .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                .withTitle("Author1")
-                .withIssueDate("2017-10-17")
-                .withAuthor("Smith, Donald")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author1")
+                                  .withIssueDate("2017-10-17")
+                                  .withAuthor("Smith, Donald")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item author2 = ItemBuilder.createItem(context, col1)
-                .withTitle("Author2")
-                .withIssueDate("2017-10-12")
-                .withAuthor("Smith, Donalaze")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author2")
+                                  .withIssueDate("2017-10-12")
+                                  .withAuthor("Smith, Donalaze")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item publication = ItemBuilder.createItem(context, col3)
-                .withTitle("Publication1")
-                .withAuthor("Testy, TEst")
-                .withIssueDate("2015-01-01")
-                .withRelationshipType("Publication")
-                .build();
+                                      .withTitle("Publication1")
+                                      .withAuthor("Testy, TEst")
+                                      .withIssueDate("2015-01-01")
+                                      .withRelationshipType("Publication")
+                                      .build();
 
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                        entityTypeService.findByEntityType(context, "Person"),
-                        "isAuthorOfPublication", "isPublicationOfAuthor");
+            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                                  entityTypeService.findByEntityType(context, "Person"),
+                                  "isAuthorOfPublication", "isPublicationOfAuthor");
 
 
 
         EPerson user = EPersonBuilder.createEPerson(context)
-                .withNameInMetadata("first", "last")
-                .withEmail("testaze@gmail.com")
-                .withPassword(password)
-                .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
-                .build();
+                                     .withNameInMetadata("first", "last")
+                                     .withEmail("testaze@gmail.com")
+                                     .withPassword(password)
+                                     .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
+                                     .build();
         context.setCurrentUser(user);
 
         authorizeService.addPolicy(context, author1, Constants.WRITE, user);
@@ -2044,15 +2044,15 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         String token = getAuthToken(admin.getEmail(), password);
 
         MvcResult mvcResult = getClient(token).perform(post("/api/core/relationships")
-                .param("relationshipType",
-                        isAuthorOfPublicationRelationshipType.getID()
-                                .toString())
-                .contentType(MediaType.parseMediaType("text/uri-list"))
-                .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
-                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                .andExpect(status().isCreated())
-                .andReturn();
+                                                           .param("relationshipType",
+                                                                  isAuthorOfPublicationRelationshipType.getID()
+                                                                                                       .toString())
+                                                           .contentType(MediaType.parseMediaType("text/uri-list"))
+                                                           .content(
+                                                               "https://localhost:8080/spring-rest/api/core/items/" + publication.getID() + "\n" +
+                                                                   "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                                              .andExpect(status().isCreated())
+                                              .andReturn();
 
         ObjectMapper mapper = new ObjectMapper();
         String content = mvcResult.getResponse().getContentAsString();
@@ -2083,47 +2083,47 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                .withName("Parent Community")
-                .build();
+                                          .withName("Parent Community")
+                                          .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                .withName("Sub Community")
-                .build();
+                                           .withName("Sub Community")
+                                           .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                .withTitle("Author1")
-                .withIssueDate("2017-10-17")
-                .withAuthor("Smith, Donald")
-                .withRelationshipType("Person")
-                .build();
+                                  .withTitle("Author1")
+                                  .withIssueDate("2017-10-17")
+                                  .withAuthor("Smith, Donald")
+                                  .withRelationshipType("Person")
+                                  .build();
 
         Item publication1 = ItemBuilder.createItem(context, col3)
-                .withTitle("Publication1")
-                .withAuthor("Testy, TEst")
-                .withIssueDate("2015-01-01")
-                .withRelationshipType("Publication")
-                .build();
+                                       .withTitle("Publication1")
+                                       .withAuthor("Testy, TEst")
+                                       .withIssueDate("2015-01-01")
+                                       .withRelationshipType("Publication")
+                                       .build();
         Item publication2 = ItemBuilder.createItem(context, col3)
-                .withTitle("Publication2")
-                .withAuthor("Testy, TEstzeaze")
-                .withIssueDate("2015-01-01")
-                .withRelationshipType("Publication")
-                .build();
+                                       .withTitle("Publication2")
+                                       .withAuthor("Testy, TEstzeaze")
+                                       .withIssueDate("2015-01-01")
+                                       .withRelationshipType("Publication")
+                                       .build();
 
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
-                .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
-                        entityTypeService.findByEntityType(context, "Person"),
-                        "isAuthorOfPublication", "isPublicationOfAuthor");
+            .findbyTypesAndLabels(context, entityTypeService.findByEntityType(context, "Publication"),
+                                  entityTypeService.findByEntityType(context, "Person"),
+                                  "isAuthorOfPublication", "isPublicationOfAuthor");
 
 
 
         EPerson user = EPersonBuilder.createEPerson(context)
-                .withNameInMetadata("first", "last")
-                .withEmail("testaze@gmail.com")
-                .withPassword(password)
-                .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
-                .build();
+                                     .withNameInMetadata("first", "last")
+                                     .withEmail("testaze@gmail.com")
+                                     .withPassword(password)
+                                     .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
+                                     .build();
         context.setCurrentUser(user);
 
         authorizeService.addPolicy(context, publication1, Constants.WRITE, user);
@@ -2133,15 +2133,15 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.restoreAuthSystemState();
 
         MvcResult mvcResult = getClient(token).perform(post("/api/core/relationships")
-                .param("relationshipType",
-                        isAuthorOfPublicationRelationshipType.getID()
-                                .toString())
-                .contentType(MediaType.parseMediaType("text/uri-list"))
-                .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + publication1.getID() + "\n" +
-                                "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
-                .andExpect(status().isCreated())
-                .andReturn();
+                                                           .param("relationshipType",
+                                                                  isAuthorOfPublicationRelationshipType.getID()
+                                                                                                       .toString())
+                                                           .contentType(MediaType.parseMediaType("text/uri-list"))
+                                                           .content(
+                                                               "https://localhost:8080/spring-rest/api/core/items/" + publication1.getID() + "\n" +
+                                                                   "https://localhost:8080/spring-rest/api/core/items/" + author1.getID()))
+                                              .andExpect(status().isCreated())
+                                              .andReturn();
 
         ObjectMapper mapper = new ObjectMapper();
         String content = mvcResult.getResponse().getContentAsString();
@@ -2155,9 +2155,9 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                 .andReturn();
         //verify not changed
         getClient(token).perform(get("/api/core/relationships/" + id))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.leftId", is(publication1.getID().toString())))
-                .andExpect(jsonPath("$.rightId", is(author1.getID().toString())));
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.leftId", is(publication1.getID().toString())))
+                        .andExpect(jsonPath("$.rightId", is(author1.getID().toString())));
 
     }
 

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/RelationshipRestRepositoryIT.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/RelationshipRestRepositoryIT.java
@@ -390,7 +390,6 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
     /**
      * This method will test the addition of a mixture of plain-text metadatavalues and relationships to then
      * verify that the place property is still being handled correctly.
-     *
      * @throws Exception
      */
     @Test
@@ -701,7 +700,6 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
     /**
      * This method will test the deletion of a plain-text metadatavalue to then
      * verify that the place property is still being handled correctly.
-     *
      * @throws Exception
      */
     @Test
@@ -932,7 +930,6 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
     /**
      * This method will test the deletion of a Relationship to then
      * verify that the place property is still being handled correctly.
-     *
      * @throws Exception
      */
     @Test
@@ -1166,7 +1163,6 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
      * This test will simply add Relationships between Items with a useForPlace attribute set to false for the
      * RelationshipType. We want to test that the Relationships that are created will still have their place
      * attributes handled in a correct way
-     *
      * @throws Exception
      */
     @Test
@@ -1290,7 +1286,6 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
      * RelationshipType. We want to test that the Relationships that are created will still have their place
      * attributes handled in a correct way. It will then delete a Relationship and once again ensure that the place
      * attributes are being handled correctly.
-     *
      * @throws Exception
      */
     @Test
@@ -1476,8 +1471,9 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                         entityTypeService.findByEntityType(context, "Person"),
                         "isAuthorOfPublication", "isPublicationOfAuthor");
 
-        context.restoreAuthSystemState();
 
+
+        context.restoreAuthSystemState();
 
         String token = getAuthToken(admin.getEmail(), password);
 
@@ -1494,10 +1490,9 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                 .andExpect(status().isCreated())
                 .andReturn();
 
-
         ObjectMapper mapper = new ObjectMapper();
         String content = mvcResult.getResponse().getContentAsString();
-        Map<String, Object> map = mapper.readValue(content, Map.class);
+        Map<String,Object> map = mapper.readValue(content, Map.class);
         String id = String.valueOf(map.get("id"));
 
         //Modify the left item in the relationship publication > publication 2
@@ -1522,7 +1517,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                         (org.springframework.data.rest.webmvc.RestMediaTypes
                                 .TEXT_URI_LIST_VALUE))
                 .content(
-                        "https://localhost:8080/spring-rest/api/core/items/" + author2.getID()))
+                                "https://localhost:8080/spring-rest/api/core/items/" + author2.getID()))
                 .andExpect(status().isOk())
                 .andReturn();
 
@@ -1580,6 +1575,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                         "isAuthorOfPublication", "isPublicationOfAuthor");
 
 
+
         EPerson user = EPersonBuilder.createEPerson(context)
                 .withNameInMetadata("first", "last")
                 .withEmail("testaze@gmail.com")
@@ -1608,7 +1604,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
         ObjectMapper mapper = new ObjectMapper();
         String content = mvcResult.getResponse().getContentAsString();
-        Map<String, Object> map = mapper.readValue(content, Map.class);
+        Map<String,Object> map = mapper.readValue(content, Map.class);
         String id = String.valueOf(map.get("id"));
 
         //change right item from author 1 > author 2
@@ -1671,6 +1667,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                         "isAuthorOfPublication", "isPublicationOfAuthor");
 
 
+
         EPerson user = EPersonBuilder.createEPerson(context)
                 .withNameInMetadata("first", "last")
                 .withEmail("testaze@gmail.com")
@@ -1698,7 +1695,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
         ObjectMapper mapper = new ObjectMapper();
         String content = mvcResult.getResponse().getContentAsString();
-        Map<String, Object> map = mapper.readValue(content, Map.class);
+        Map<String,Object> map = mapper.readValue(content, Map.class);
         String id = String.valueOf(map.get("id"));
         //change rightItem from author1 > author2
         MvcResult mvcResult2 = getClient(token).perform(put("/api/core/relationships/" + id + "/rightItem")
@@ -1760,6 +1757,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                         "isAuthorOfPublication", "isPublicationOfAuthor");
 
 
+
         EPerson user = EPersonBuilder.createEPerson(context)
                 .withNameInMetadata("first", "last")
                 .withEmail("testaze@gmail.com")
@@ -1788,7 +1786,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
         ObjectMapper mapper = new ObjectMapper();
         String content = mvcResult.getResponse().getContentAsString();
-        Map<String, Object> map = mapper.readValue(content, Map.class);
+        Map<String,Object> map = mapper.readValue(content, Map.class);
         String id = String.valueOf(map.get("id"));
         //change leftItem
         MvcResult mvcResult2 = getClient(token).perform(put("/api/core/relationships/" + id + "/leftItem")
@@ -1850,6 +1848,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                         "isAuthorOfPublication", "isPublicationOfAuthor");
 
 
+
         EPerson user = EPersonBuilder.createEPerson(context)
                 .withNameInMetadata("first", "last")
                 .withEmail("testaze@gmail.com")
@@ -1878,7 +1877,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
         ObjectMapper mapper = new ObjectMapper();
         String content = mvcResult.getResponse().getContentAsString();
-        Map<String, Object> map = mapper.readValue(content, Map.class);
+        Map<String,Object> map = mapper.readValue(content, Map.class);
         String id = String.valueOf(map.get("id"));
         //change left item
         MvcResult mvcResult2 = getClient(token).perform(put("/api/core/relationships/" + id + "/leftItem")
@@ -1940,6 +1939,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                         "isAuthorOfPublication", "isPublicationOfAuthor");
 
 
+
         EPerson user = EPersonBuilder.createEPerson(context)
                 .withNameInMetadata("first", "last")
                 .withEmail("testaze@gmail.com")
@@ -1965,7 +1965,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
         ObjectMapper mapper = new ObjectMapper();
         String content = mvcResult.getResponse().getContentAsString();
-        Map<String, Object> map = mapper.readValue(content, Map.class);
+        Map<String,Object> map = mapper.readValue(content, Map.class);
         String id = String.valueOf(map.get("id"));
         token = getAuthToken(user.getEmail(), password);
         //attempt change, expect not allowed
@@ -2028,6 +2028,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                         "isAuthorOfPublication", "isPublicationOfAuthor");
 
 
+
         EPerson user = EPersonBuilder.createEPerson(context)
                 .withNameInMetadata("first", "last")
                 .withEmail("testaze@gmail.com")
@@ -2055,7 +2056,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
         ObjectMapper mapper = new ObjectMapper();
         String content = mvcResult.getResponse().getContentAsString();
-        Map<String, Object> map = mapper.readValue(content, Map.class);
+        Map<String,Object> map = mapper.readValue(content, Map.class);
         String id = String.valueOf(map.get("id"));
         token = getAuthToken(user.getEmail(), password);
         //attempt right item change, expect not allowed
@@ -2116,6 +2117,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                         "isAuthorOfPublication", "isPublicationOfAuthor");
 
 
+
         EPerson user = EPersonBuilder.createEPerson(context)
                 .withNameInMetadata("first", "last")
                 .withEmail("testaze@gmail.com")
@@ -2143,7 +2145,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
         ObjectMapper mapper = new ObjectMapper();
         String content = mvcResult.getResponse().getContentAsString();
-        Map<String, Object> map = mapper.readValue(content, Map.class);
+        Map<String,Object> map = mapper.readValue(content, Map.class);
         String id = String.valueOf(map.get("id"));
         //attempt left item change, expect not allowed
         MvcResult mvcResult2 = getClient(token).perform(put("/api/core/relationships/" + id + "/leftItem")


### PR DESCRIPTION
Based on https://jira.duraspace.org/browse/DS-4230 and https://github.com/DSpace/Rest7Contract/pull/60, the PUT contract in the relationships has been updated to use /api/core/relationships/:id/leftItem or /api/core/relationships/:id/rightItem

Since there was already an agreement on the contract, the implementation has been completed as well