### PR TITLE
Some minor code cleanup in the tests

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/FullTextContentStreams.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/FullTextContentStreams.java
@@ -25,7 +25,6 @@ import javax.annotation.Nullable;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.io.Charsets;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.solr.common.util.ContentStreamBase;
@@ -209,7 +208,7 @@ public class FullTextContentStreams extends ContentStreamBase {
             }
 
             return inputStream == null ? null : new SequenceInputStream(
-                new ByteArrayInputStream("\n".getBytes(Charsets.UTF_8)), inputStream);
+                new ByteArrayInputStream("\n".getBytes(StandardCharsets.UTF_8)), inputStream);
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/eperson/dao/impl/GroupDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/dao/impl/GroupDAOImpl.java
@@ -167,7 +167,7 @@ public class GroupDAOImpl extends AbstractHibernateDSODAO<Group> implements Grou
     @Override
     public void delete(Context context, Group group) throws SQLException {
         Query query = getHibernateSession(context)
-            .createSQLQuery("DELETE FROM group2group WHERE parent_id=:groupId or child_id=:groupId");
+            .createNativeQuery("DELETE FROM group2group WHERE parent_id=:groupId or child_id=:groupId");
         query.setParameter("groupId", group.getID());
         query.executeUpdate();
         super.delete(context, group);

--- a/dspace-api/src/test/java/org/dspace/app/util/GoogleBitstreamComparatorTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/GoogleBitstreamComparatorTest.java
@@ -380,6 +380,7 @@ public class GoogleBitstreamComparatorTest extends AbstractUnitTest {
     }
 
     @After
+    @Override
     public void destroy() {
         settings = null;
         super.destroy();

--- a/dspace-api/src/test/java/org/dspace/app/util/GoogleMetadataTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/GoogleMetadataTest.java
@@ -12,9 +12,9 @@ import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 
-import org.apache.commons.io.Charsets;
 import org.apache.logging.log4j.Logger;
 import org.dspace.AbstractUnitTest;
 import org.dspace.authorize.AuthorizeException;
@@ -98,20 +98,20 @@ public class GoogleMetadataTest extends AbstractUnitTest {
     public void testGetPDFURLDifferentMimeTypes() throws Exception {
         context.turnOffAuthorisationSystem();
         Bundle bundle = ContentServiceFactory.getInstance().getBundleService().create(context, it, "ORIGINAL");
-        Bitstream b = bitstreamService
-            .create(context, new ByteArrayInputStream("Bitstream 1".getBytes(Charsets.UTF_8)));
+        Bitstream b = bitstreamService.create(
+            context, new ByteArrayInputStream("Bitstream 1".getBytes(StandardCharsets.UTF_8)));
         b.setName(context, "Word");
         b.setFormat(context, bitstreamFormatService.create(context));
         b.getFormat(context).setMIMEType("application/msword");
         bundleService.addBitstream(context, bundle, b);
-        Bitstream b2 = bitstreamService
-            .create(context, new ByteArrayInputStream("Bitstream 2".getBytes(Charsets.UTF_8)));
+        Bitstream b2 = bitstreamService.create(
+            context, new ByteArrayInputStream("Bitstream 2".getBytes(StandardCharsets.UTF_8)));
         b2.setName(context, "Pdf");
         b2.setFormat(context, bitstreamFormatService.create(context));
         b2.getFormat(context).setMIMEType("application/pdf");
         bundleService.addBitstream(context, bundle, b2);
-        Bitstream b3 = bitstreamService
-            .create(context, new ByteArrayInputStream("Bitstream 3".getBytes(Charsets.UTF_8)));
+        Bitstream b3 = bitstreamService.create(
+            context, new ByteArrayInputStream("Bitstream 3".getBytes(StandardCharsets.UTF_8)));
         b3.setName(context, "Rtf");
         b3.setFormat(context, bitstreamFormatService.create(context));
         b3.getFormat(context).setMIMEType("text/richtext");
@@ -132,18 +132,21 @@ public class GoogleMetadataTest extends AbstractUnitTest {
     public void testGetPDFURLSameMimeTypes() throws Exception {
         context.turnOffAuthorisationSystem();
         Bundle bundle = ContentServiceFactory.getInstance().getBundleService().create(context, it, "ORIGINAL");
-        ;
-        Bitstream b = bitstreamService.create(context, new ByteArrayInputStream("123456789".getBytes(Charsets.UTF_8)));
+
+        Bitstream b = bitstreamService.create(
+            context, new ByteArrayInputStream("123456789".getBytes(StandardCharsets.UTF_8)));
         b.setName(context, "size9");
         b.setFormat(context, bitstreamFormatService.create(context));
         b.getFormat(context).setMIMEType("application/pdf");
         bundleService.addBitstream(context, bundle, b);
-        Bitstream b2 = bitstreamService.create(context, new ByteArrayInputStream("1".getBytes(Charsets.UTF_8)));
+        Bitstream b2 = bitstreamService.create(
+            context, new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
         b2.setName(context, "size1");
         b2.setFormat(context, bitstreamFormatService.create(context));
         b2.getFormat(context).setMIMEType("application/pdf");
         bundleService.addBitstream(context, bundle, b2);
-        Bitstream b3 = bitstreamService.create(context, new ByteArrayInputStream("12345".getBytes(Charsets.UTF_8)));
+        Bitstream b3 = bitstreamService.create(
+            context, new ByteArrayInputStream("12345".getBytes(StandardCharsets.UTF_8)));
         b3.setName(context, "size5");
         b3.setFormat(context, bitstreamFormatService.create(context));
         b3.getFormat(context).setMIMEType("text/richtext");
@@ -164,18 +167,21 @@ public class GoogleMetadataTest extends AbstractUnitTest {
     public void testGetPDFURLSameMimeTypesSameSize() throws Exception {
         context.turnOffAuthorisationSystem();
         Bundle bundle = ContentServiceFactory.getInstance().getBundleService().create(context, it, "ORIGINAL");
-        ;
-        Bitstream b = bitstreamService.create(context, new ByteArrayInputStream("1".getBytes(Charsets.UTF_8)));
+
+        Bitstream b = bitstreamService.create(
+            context, new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
         b.setName(context, "first");
         b.setFormat(context, bitstreamFormatService.create(context));
         b.getFormat(context).setMIMEType("application/pdf");
         bundleService.addBitstream(context, bundle, b);
-        Bitstream b2 = bitstreamService.create(context, new ByteArrayInputStream("1".getBytes(Charsets.UTF_8)));
+        Bitstream b2 = bitstreamService.create(
+            context, new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
         b2.setName(context, "second");
         b2.setFormat(context, bitstreamFormatService.create(context));
         b2.getFormat(context).setMIMEType("application/pdf");
         bundleService.addBitstream(context, bundle, b2);
-        Bitstream b3 = bitstreamService.create(context, new ByteArrayInputStream("1".getBytes(Charsets.UTF_8)));
+        Bitstream b3 = bitstreamService.create(
+            context, new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
         b3.setName(context, "third");
         b3.setFormat(context, bitstreamFormatService.create(context));
         b3.getFormat(context).setMIMEType("application/pdf");
@@ -196,20 +202,21 @@ public class GoogleMetadataTest extends AbstractUnitTest {
     public void testGetPDFURLWithPrimaryBitstream() throws Exception {
         context.turnOffAuthorisationSystem();
         Bundle bundle = ContentServiceFactory.getInstance().getBundleService().create(context, it, "ORIGINAL");
-        ;
-        Bitstream b = bitstreamService
-            .create(context, new ByteArrayInputStream("Larger file than primary".getBytes(Charsets.UTF_8)));
+
+        Bitstream b = bitstreamService.create(
+            context, new ByteArrayInputStream("Larger file than primary".getBytes(StandardCharsets.UTF_8)));
         b.setName(context, "first");
         b.setFormat(context, bitstreamFormatService.create(context));
         b.getFormat(context).setMIMEType("unknown");
         bundleService.addBitstream(context, bundle, b);
         Bitstream b2 = bitstreamService.create(context, new ByteArrayInputStream(
-            "Bitstream with more prioritized mimetype than primary".getBytes(Charsets.UTF_8)));
+            "Bitstream with more prioritized mimetype than primary".getBytes(StandardCharsets.UTF_8)));
         b2.setName(context, "second");
         b2.setFormat(context, bitstreamFormatService.create(context));
         b2.getFormat(context).setMIMEType("application/pdf");
         bundleService.addBitstream(context, bundle, b2);
-        Bitstream b3 = bitstreamService.create(context, new ByteArrayInputStream("1".getBytes(Charsets.UTF_8)));
+        Bitstream b3 = bitstreamService.create(
+            context, new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
         b3.setName(context, "primary");
         b3.setFormat(context, bitstreamFormatService.create(context));
         b3.getFormat(context).setMIMEType("Primary");
@@ -232,19 +239,21 @@ public class GoogleMetadataTest extends AbstractUnitTest {
     public void testGetPDFURLWithUndefinedMimeTypes() throws Exception {
         context.turnOffAuthorisationSystem();
         Bundle bundle = ContentServiceFactory.getInstance().getBundleService().create(context, it, "ORIGINAL");
-        ;
-        Bitstream b = bitstreamService.create(context, new ByteArrayInputStream("12".getBytes(Charsets.UTF_8)));
+
+        Bitstream b = bitstreamService.create(
+            context, new ByteArrayInputStream("12".getBytes(StandardCharsets.UTF_8)));
         b.setName(context, "small");
         b.setFormat(context, bitstreamFormatService.create(context));
         b.getFormat(context).setMIMEType("unknown type 1");
         bundleService.addBitstream(context, bundle, b);
-        Bitstream b2 = bitstreamService.create(context, new ByteArrayInputStream("12121212".getBytes(Charsets.UTF_8)));
+        Bitstream b2 = bitstreamService.create(
+            context, new ByteArrayInputStream("12121212".getBytes(StandardCharsets.UTF_8)));
         b2.setName(context, "medium");
         b2.setFormat(context, bitstreamFormatService.create(context));
         b2.getFormat(context).setMIMEType("unknown type 2");
         bundleService.addBitstream(context, bundle, b2);
-        Bitstream b3 = bitstreamService
-            .create(context, new ByteArrayInputStream("12121212121212".getBytes(Charsets.UTF_8)));
+        Bitstream b3 = bitstreamService.create(
+            context, new ByteArrayInputStream("12121212121212".getBytes(StandardCharsets.UTF_8)));
         b3.setName(context, "large");
         b3.setFormat(context, bitstreamFormatService.create(context));
         b3.getFormat(context).setMIMEType("unknown type 3");
@@ -277,7 +286,7 @@ public class GoogleMetadataTest extends AbstractUnitTest {
     public void testGetPDFURLWithNoBitstreams() throws Exception {
         context.turnOffAuthorisationSystem();
         Bundle bundle = ContentServiceFactory.getInstance().getBundleService().create(context, it, "ORIGINAL");
-        ;
+
         context.restoreAuthSystemState();
         context.commit();
         GoogleMetadata gm = new GoogleMetadata(this.context, it);
@@ -291,18 +300,18 @@ public class GoogleMetadataTest extends AbstractUnitTest {
     public void testGetPDFURLWithEmptyBitstreams() throws Exception {
         context.turnOffAuthorisationSystem();
         Bundle bundle = ContentServiceFactory.getInstance().getBundleService().create(context, it, "ORIGINAL");
-        ;
-        Bitstream b = bitstreamService.create(context, new ByteArrayInputStream("".getBytes(Charsets.UTF_8)));
+
+        Bitstream b = bitstreamService.create(context, new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
         b.setName(context, "small");
         b.setFormat(context, bitstreamFormatService.create(context));
         b.getFormat(context).setMIMEType("unknown type 1");
         bundleService.addBitstream(context, bundle, b);
-        Bitstream b2 = bitstreamService.create(context, new ByteArrayInputStream("".getBytes(Charsets.UTF_8)));
+        Bitstream b2 = bitstreamService.create(context, new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
         b2.setName(context, "medium");
         b2.setFormat(context, bitstreamFormatService.create(context));
         b2.getFormat(context).setMIMEType("unknown type 2");
         bundleService.addBitstream(context, bundle, b2);
-        Bitstream b3 = bitstreamService.create(context, new ByteArrayInputStream("".getBytes(Charsets.UTF_8)));
+        Bitstream b3 = bitstreamService.create(context, new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
         b3.setName(context, "large");
         b3.setFormat(context, bitstreamFormatService.create(context));
         b3.getFormat(context).setMIMEType("unknown type 3");

--- a/dspace-api/src/test/java/org/dspace/app/util/IndexVersionTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/IndexVersionTest.java
@@ -46,25 +46,25 @@ public class IndexVersionTest {
         // 4.1 < 4.4 < 4.5 < 4.10 < 4.21 < 4.51
 
         // less than tests (return -1)
-        assertEquals(IndexVersion.compareSoftwareVersions("5", "6"), -1);
-        assertEquals(IndexVersion.compareSoftwareVersions("4.1", "6"), -1);
-        assertEquals(IndexVersion.compareSoftwareVersions("4.1", "4.4"), -1);
-        assertEquals(IndexVersion.compareSoftwareVersions("4.1", "4.10"), -1);
-        assertEquals(IndexVersion.compareSoftwareVersions("4.4", "4.10"), -1);
-        assertEquals(IndexVersion.compareSoftwareVersions("4.4", "5.1"), -1);
+        assertEquals(-1, IndexVersion.compareSoftwareVersions("5", "6"));
+        assertEquals(-1, IndexVersion.compareSoftwareVersions("4.1", "6"));
+        assertEquals(-1, IndexVersion.compareSoftwareVersions("4.1", "4.4"));
+        assertEquals(-1, IndexVersion.compareSoftwareVersions("4.1", "4.10"));
+        assertEquals(-1, IndexVersion.compareSoftwareVersions("4.4", "4.10"));
+        assertEquals(-1, IndexVersion.compareSoftwareVersions("4.4", "5.1"));
 
         // greater than tests (return 1)
-        assertEquals(IndexVersion.compareSoftwareVersions("6", "5"), 1);
-        assertEquals(IndexVersion.compareSoftwareVersions("6.10", "6.4"), 1);
-        assertEquals(IndexVersion.compareSoftwareVersions("6.10", "6.1"), 1);
-        assertEquals(IndexVersion.compareSoftwareVersions("5.3", "2.4"), 1);
+        assertEquals(1, IndexVersion.compareSoftwareVersions("6", "5"));
+        assertEquals(1, IndexVersion.compareSoftwareVersions("6.10", "6.4"));
+        assertEquals(1, IndexVersion.compareSoftwareVersions("6.10", "6.1"));
+        assertEquals(1, IndexVersion.compareSoftwareVersions("5.3", "2.4"));
 
         // equality tests (return 0)
-        assertEquals(IndexVersion.compareSoftwareVersions("5", "5.0"), 0);
-        assertEquals(IndexVersion.compareSoftwareVersions("6", "6"), 0);
-        assertEquals(IndexVersion.compareSoftwareVersions("4.2", "4.2"), 0);
+        assertEquals(0, IndexVersion.compareSoftwareVersions("5", "5.0"));
+        assertEquals(0, IndexVersion.compareSoftwareVersions("6", "6"));
+        assertEquals(0, IndexVersion.compareSoftwareVersions("4.2", "4.2"));
         // we ignore subminor versions, so these should be "equal"
-        assertEquals(IndexVersion.compareSoftwareVersions("4.2.1", "4.2"), 0);
+        assertEquals(0, IndexVersion.compareSoftwareVersions("4.2.1", "4.2"));
     }
 
 }

--- a/dspace-api/src/test/java/org/dspace/checker/dao/impl/ChecksumHistoryDAOImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/checker/dao/impl/ChecksumHistoryDAOImplTest.java
@@ -70,7 +70,7 @@ public class ChecksumHistoryDAOImplTest
 
         // Create two older rows
         HibernateDBConnection dbc = (HibernateDBConnection) CoreHelpers.getDBConnection(context);
-        Query qry = dbc.getSession().createSQLQuery(
+        Query qry = dbc.getSession().createNativeQuery(
             "INSERT INTO checksum_history"
                 + "(check_id, process_end_date, result, bitstream_id)"
                 + " VALUES (:id, :date, :result, :bitstream)");

--- a/dspace-api/src/test/java/org/dspace/checker/dao/impl/ChecksumHistoryDAOImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/checker/dao/impl/ChecksumHistoryDAOImplTest.java
@@ -127,17 +127,17 @@ public class ChecksumHistoryDAOImplTest
 
         qry.setParameter("date", matchDate);
         count = (Long) qry.getSingleResult();
-        assertEquals("Should find no row at matchDate", count, 0);
+        assertEquals("Should find no row at matchDate", 0, count);
 
         // See if nonmatching old row is still present.
         qry.setParameter("date", noMatchDate);
         count = (Long) qry.getSingleResult();
-        assertEquals("Should find one row at noMatchDate", count, 1);
+        assertEquals("Should find one row at noMatchDate", 1, count);
 
         // See if new row is still present.
         qry.setParameter("date", futureDate);
         count = (Long) qry.getSingleResult();
-        assertEquals("Should find one row at futureDate", count, 1);
+        assertEquals("Should find one row at futureDate", 1, count);
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/content/BundleTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/BundleTest.java
@@ -12,7 +12,6 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -169,7 +168,7 @@ public class BundleTest extends AbstractDSpaceObjectTest {
         assertThat("testCreate 0", created, notNullValue());
         assertTrue("testCreate 1", created.getID() != null);
         assertTrue("testCreate 2", created.getBitstreams().size() == 0);
-        assertEquals("testCreate 3", created.getName(), "testCreateBundle");
+        assertThat("testCreate 3", created.getName(), equalTo("testCreateBundle"));
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/content/CommunityTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/CommunityTest.java
@@ -12,7 +12,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -752,7 +751,7 @@ public class CommunityTest extends AbstractDSpaceObjectTest {
         }};
 
         //null by default
-        assertEquals("testGetParentCommunity 0", c.getParentCommunities().size(), 0);
+        assertThat("testGetParentCommunity 0", c.getParentCommunities().size(), equalTo(0));
 
         //community with  parent
         Community son = communityService.create(c, context);

--- a/dspace-api/src/test/java/org/dspace/content/LicenseUtilsTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/LicenseUtilsTest.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -259,7 +260,7 @@ public class LicenseUtilsTest extends AbstractUnitTest {
         StringWriter writer = new StringWriter();
         IOUtils.copy(
             bitstreamService.retrieve(context, itemService.getBundles(item, "LICENSE").get(0).getBitstreams().get(0)),
-            writer);
+            writer, StandardCharsets.UTF_8);
         String license = writer.toString();
 
         assertThat("testGrantLicense 0", license, equalTo(defaultLicense));

--- a/dspace-api/src/test/java/org/dspace/content/packager/ITDSpaceAIP.java
+++ b/dspace-api/src/test/java/org/dspace/content/packager/ITDSpaceAIP.java
@@ -28,7 +28,6 @@ import org.dspace.AbstractUnitTest;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.ResourcePolicy;
 import org.dspace.authorize.factory.AuthorizeServiceFactory;
-import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.authorize.service.ResourcePolicyService;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
@@ -95,7 +94,6 @@ public class ITDSpaceAIP extends AbstractUnitTest {
     protected ResourcePolicyService resourcePolicyService = AuthorizeServiceFactory.getInstance()
                                                                                    .getResourcePolicyService();
     protected GroupService groupService = EPersonServiceFactory.getInstance().getGroupService();
-    protected AuthorizeService authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();
 
     /**
      * InfoMap multiple value separator (see saveObjectInfo() and assertObject* methods)
@@ -110,7 +108,6 @@ public class ITDSpaceAIP extends AbstractUnitTest {
     private static String testItemHandle = null;
     private static String testMappedItemHandle = null;
     private static String submitterEmail = "aip-test@dspace.org";
-    private Context context;
 
     /**
      * Create a global temporary upload folder which will be cleaned up automatically by JUnit.

--- a/dspace-api/src/test/java/org/dspace/core/ContextTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/ContextTest.java
@@ -22,8 +22,6 @@ import java.util.UUID;
 import mockit.NonStrictExpectations;
 import org.dspace.AbstractUnitTest;
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.authorize.factory.AuthorizeServiceFactory;
-import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.factory.EPersonServiceFactory;
@@ -37,7 +35,6 @@ import org.junit.Test;
  * @author tdonohue
  */
 public class ContextTest extends AbstractUnitTest {
-    protected AuthorizeService authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();
     protected EPersonService ePersonService = EPersonServiceFactory.getInstance().getEPersonService();
     protected GroupService groupService = EPersonServiceFactory.getInstance().getGroupService();
 

--- a/dspace-api/src/test/java/org/dspace/curate/ITCurator.java
+++ b/dspace-api/src/test/java/org/dspace/curate/ITCurator.java
@@ -168,7 +168,7 @@ public class ITCurator
     /**
      * Absorb report strings into a sequential collection.
      */
-    class ListReporter
+    static class ListReporter
             implements Appendable {
         private final List<String> report = new ArrayList<>();
 

--- a/dspace-api/src/test/java/org/dspace/discovery/FullTextContentStreamsTest.java
+++ b/dspace-api/src/test/java/org/dspace/discovery/FullTextContentStreamsTest.java
@@ -16,9 +16,9 @@ import static org.mockito.Mockito.when;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
-import org.apache.commons.io.Charsets;
 import org.apache.commons.io.IOUtils;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
@@ -77,11 +77,11 @@ public class FullTextContentStreamsTest {
         when(textBitstream3.getSizeBytes()).thenReturn(3L);
 
         when(bitstreamService.retrieve(null, textBitstream1))
-            .thenReturn(new ByteArrayInputStream("This is text 1".getBytes(Charsets.UTF_8)));
+            .thenReturn(new ByteArrayInputStream("This is text 1".getBytes(StandardCharsets.UTF_8)));
         when(bitstreamService.retrieve(null, textBitstream2))
-            .thenReturn(new ByteArrayInputStream("This is text 2".getBytes(Charsets.UTF_8)));
+            .thenReturn(new ByteArrayInputStream("This is text 2".getBytes(StandardCharsets.UTF_8)));
         when(bitstreamService.retrieve(null, textBitstream3))
-            .thenReturn(new ByteArrayInputStream("This is text 3".getBytes(Charsets.UTF_8)));
+            .thenReturn(new ByteArrayInputStream("This is text 3".getBytes(StandardCharsets.UTF_8)));
 
         streams.bitstreamService = bitstreamService;
     }
@@ -150,7 +150,7 @@ public class FullTextContentStreamsTest {
         InputStream inputStream = streams.getStream();
         assertNotNull(inputStream);
         assertEquals("The data in the input stream should match the text of the bitstream", "\nThis is text 1",
-                     IOUtils.toString(inputStream, Charsets.UTF_8));
+                     IOUtils.toString(inputStream, StandardCharsets.UTF_8));
     }
 
     @Test
@@ -169,7 +169,7 @@ public class FullTextContentStreamsTest {
         InputStream inputStream = streams.getStream();
         assertNotNull(inputStream);
         assertEquals("The data in the input stream should match 'This is text 1'", "\nThis is text 1" +
-            "\nThis is text 2\nThis is text 3", IOUtils.toString(inputStream, Charsets.UTF_8));
+            "\nThis is text 2\nThis is text 3", IOUtils.toString(inputStream, StandardCharsets.UTF_8));
     }
 
     @Test
@@ -188,7 +188,7 @@ public class FullTextContentStreamsTest {
         assertFalse("Content stream should not be empty", streams.isEmpty());
         InputStream inputStream = streams.getStream();
         assertNotNull(inputStream);
-        String content = IOUtils.toString(inputStream, Charsets.UTF_8);
+        String content = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
         assertTrue("The data should contain data of the first bitstream that is not corrupt",
                    content.contains("This is text 1"));
         assertFalse("The data should NOT contain data of the second bitstream that is corrupt",

--- a/dspace-api/src/test/java/org/dspace/eperson/GroupTest.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/GroupTest.java
@@ -7,8 +7,8 @@
  */
 package org.dspace.eperson;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -143,7 +143,7 @@ public class GroupTest extends AbstractUnitTest {
         topGroup.setName("new name");
         groupService.update(context, topGroup);
         assertThat("setGroupName 1", topGroup.getName(), notNullValue());
-        assertEquals("setGroupName 2", topGroup.getName(), "new name");
+        assertThat("setGroupName 2", topGroup.getName(), equalTo("new name"));
     }
 
     @Test
@@ -153,7 +153,7 @@ public class GroupTest extends AbstractUnitTest {
         topGroup.setName("new name");
         groupService.update(context, topGroup);
         assertThat("setGroupName 1", topGroup.getName(), notNullValue());
-        assertEquals("setGroupName 2", topGroup.getName(), "topGroup");
+        assertThat("setGroupName 2", topGroup.getName(), equalTo("topGroup"));
 
         topGroup.setPermanent(false);
         groupService.update(context, topGroup);
@@ -164,7 +164,7 @@ public class GroupTest extends AbstractUnitTest {
         Group group = groupService.findByName(context, "topGroup");
         assertThat("findByName 1", group, notNullValue());
         assertThat("findByName 2", group.getName(), notNullValue());
-        assertEquals("findByName 2", group.getName(), "topGroup");
+        assertThat("findByName 2", group.getName(), equalTo("topGroup"));
     }
 
     @Test
@@ -219,7 +219,7 @@ public class GroupTest extends AbstractUnitTest {
         Collections.sort(sortedNames);
 
         // Verify the sorted arraylist is still equal to the original (unsorted) one
-        assertEquals("findAllNameSort compareLists", sortedNames, names);
+        assertThat("findAllNameSort compareLists", names, equalTo(sortedNames));
     }
 
     @Test
@@ -227,14 +227,14 @@ public class GroupTest extends AbstractUnitTest {
         //We can find 2 groups so attempt to retrieve with offset 0 and a max of one
         List<Group> groups = groupService.search(context, "level", 0, 1);
         assertThat("search 1", groups, notNullValue());
-        assertEquals("search 2", groups.size(), 1);
+        assertThat("search 2", groups.size(), equalTo(1));
         String firstGroupName = groups.iterator().next().getName();
         assertTrue("search 3", firstGroupName.equals("level1Group") || firstGroupName.equals("level2Group"));
 
         //Retrieve the second group
         groups = groupService.search(context, "level", 1, 2);
         assertThat("search 1", groups, notNullValue());
-        assertEquals("search 2", groups.size(), 1);
+        assertThat("search 2", groups.size(), equalTo(1));
         String secondGroupName = groups.iterator().next().getName();
         assertTrue("search 3", secondGroupName.equals("level1Group") || secondGroupName.equals("level2Group"));
     }
@@ -242,14 +242,14 @@ public class GroupTest extends AbstractUnitTest {
     @Test
     public void searchByID() throws SQLException {
         List<Group> searchResult = groupService.search(context, String.valueOf(topGroup.getID()), 0, 10);
-        assertEquals("searchID 1", searchResult.size(), 1);
-        assertEquals("searchID 2", searchResult.iterator().next(), topGroup);
+        assertThat("searchID 1", searchResult.size(), equalTo(1));
+        assertThat("searchID 2", searchResult.iterator().next(), equalTo(topGroup));
     }
 
 
     @Test
     public void searchResultCount() throws SQLException {
-        assertEquals("searchResultCount", groupService.searchResultCount(context, "level"), 2);
+        assertThat("searchResultCount", groupService.searchResultCount(context, "level"), equalTo(2));
     }
 
     @Test
@@ -259,7 +259,7 @@ public class GroupTest extends AbstractUnitTest {
             ePerson = createEPersonAndAddToGroup("addMemberEPerson@dspace.org", topGroup);
             groupService.update(context, topGroup);
 
-            assertEquals("addMemberEPerson 1", topGroup.getMembers().size(), 1);
+            assertThat("addMemberEPerson 1", topGroup.getMembers().size(), equalTo(1));
             assertTrue("addMemberEPerson 2", topGroup.getMembers().contains(ePerson));
         } finally {
             if (ePerson != null) {
@@ -295,7 +295,7 @@ public class GroupTest extends AbstractUnitTest {
             groupService.addMember(context, toDeleteGroup, ePerson);
             groupService.update(context, toDeleteGroup);
             groupService.delete(context, toDeleteGroup);
-            assertEquals("deleteGroupEPersonMembers", ePerson.getGroups().size(), 0);
+            assertThat("deleteGroupEPersonMembers", ePerson.getGroups().size(), equalTo(0));
         } finally {
             if (ePerson != null) {
                 ePersonService.delete(context, ePerson);

--- a/dspace-api/src/test/java/org/dspace/statistics/util/TestLocationUtils.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/util/TestLocationUtils.java
@@ -30,7 +30,7 @@ public class TestLocationUtils extends AbstractDSpaceTest {
      */
     @Test
     public void testGetContinentCode() {
-        assertEquals(LocationUtils.getContinentCode("US"), "NA");
+        assertEquals("NA", LocationUtils.getContinentCode("US"));
         assertTrue(LocationUtils.getContinentCode(null).length() > 2); // message
         assertTrue(LocationUtils.getContinentCode("xyz").length() > 2); // message
     }

--- a/dspace-spring-rest/src/test/java/org/dspace/app/rest/test/AbstractControllerIntegrationTest.java
+++ b/dspace-spring-rest/src/test/java/org/dspace/app/rest/test/AbstractControllerIntegrationTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
@@ -18,7 +19,6 @@ import javax.servlet.Filter;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.io.Charsets;
 import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.rest.Application;
 import org.dspace.app.rest.model.patch.Operation;
@@ -80,7 +80,7 @@ public class AbstractControllerIntegrationTest extends AbstractIntegrationTestWi
     public static final String BASE_REST_SERVER_URL = "http://localhost";
 
     protected MediaType contentType = new MediaType(MediaTypes.HAL_JSON.getType(),
-                                                    MediaTypes.HAL_JSON.getSubtype(), Charsets.UTF_8);
+                                                    MediaTypes.HAL_JSON.getSubtype(), StandardCharsets.UTF_8);
 
     protected MediaType textUriContentType = RestMediaTypes.TEXT_URI_LIST;
 


### PR DESCRIPTION
This is mainly some code cleanup in the tests:

* Fix the order of the arguments of `assertEquals` (or replaces it with `assertThat` if it is already used in the TestCase)
* Add a missing override annotation
* Replace the deprecated `org.apache.commons.io.Charsets` with `java.nio.charset.StandardCharsets` (this is fixed in `org.dspace.discovery.FullTextContentStreams`, too)
* Remove member variables that are already declared in the `AbstractUnitTest`
* Replace deprecated (in hibernate-5.2) `createSQLQuery` with `createNativeQuery` (this is replaced in `org.dspace.eperson.dao.impl.GroupDAOImpl`, too)
* Add a charset to `IOUtils.copy`, because using the default charset is deprecated
* Make an inner class static, because it does not reference the enclosing class. This fixes a warning during compilation.