### PR TITLE
DS-304, DS-1922: METS generator should check for READ permissions

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/DSpaceMETSGenerator.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/DSpaceMETSGenerator.java
@@ -15,6 +15,7 @@ import org.apache.cocoon.ProcessingException;
 import org.apache.cocoon.ResourceNotFoundException;
 import org.apache.cocoon.environment.ObjectModelHelper;
 import org.apache.cocoon.environment.Request;
+import org.apache.cocoon.environment.Response;
 import org.apache.cocoon.generation.AbstractGenerator;
 import org.dspace.app.xmlui.objectmanager.AbstractAdapter;
 import org.dspace.app.xmlui.objectmanager.ContainerAdapter;
@@ -107,14 +108,21 @@ public class DSpaceMETSGenerator extends AbstractGenerator
                 throw new ResourceNotFoundException("Unable to locate object.");
             }
             
-            // Configure the adapter for this request.
-            configureAdapter(adapter);
-            
-			// Generate the METS document
-			contentHandler.startDocument();
-			adapter.renderMETS(context, contentHandler,lexicalHandler);
-			contentHandler.endDocument();
-			
+			if (adapter.isAuthorized())
+			{
+				// Configure the adapter for this request.
+				configureAdapter(adapter);
+
+				// Generate the METS document
+				contentHandler.startDocument();
+				adapter.renderMETS(context, contentHandler, lexicalHandler);
+				contentHandler.endDocument();
+			}
+			else
+			{
+				Response response = ObjectModelHelper.getResponse(objectModel);
+				response.setStatus(403);
+			}
 		} catch (WingException we) {
 			throw new ProcessingException(we);
 		} catch (CrosswalkException ce) {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/DSpaceOREGenerator.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/DSpaceOREGenerator.java
@@ -13,15 +13,20 @@ import java.util.UUID;
 
 import org.apache.cocoon.ProcessingException;
 import org.apache.cocoon.ResourceNotFoundException;
+import org.apache.cocoon.environment.ObjectModelHelper;
+import org.apache.cocoon.environment.Response;
 import org.apache.cocoon.generation.AbstractGenerator;
 import org.dspace.app.xmlui.utils.ContextUtil;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.factory.AuthorizeServiceFactory;
+import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.crosswalk.CrosswalkException;
 import org.dspace.content.crosswalk.DisseminationCrosswalk;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.ItemService;
+import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.factory.CoreServiceFactory;
 import org.dspace.handle.factory.HandleServiceFactory;
@@ -43,6 +48,7 @@ public class DSpaceOREGenerator extends AbstractGenerator
 
 	protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();
 	protected HandleService handleService = HandleServiceFactory.getInstance().getHandleService();
+	protected AuthorizeService authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();
 
 	/**
 	 * Generate the ORE Aggregation.
@@ -59,13 +65,23 @@ public class DSpaceOREGenerator extends AbstractGenerator
                 throw new ResourceNotFoundException("Unable to locate object.");
             }
             
-            
-            // Instantiate and execute the ORE plugin
-            SAXOutputter out = new SAXOutputter(contentHandler);
-            DisseminationCrosswalk xwalk = (DisseminationCrosswalk)CoreServiceFactory.getInstance().getPluginService().getNamedPlugin(DisseminationCrosswalk.class,"ore");
-            
-            Element ore = xwalk.disseminateElement(context, item);
-            out.output(ore);
+			if (authorizeService.authorizeActionBoolean(context, item,
+					Constants.READ))
+			{
+				// Instantiate and execute the ORE plugin
+				SAXOutputter out = new SAXOutputter(contentHandler);
+				DisseminationCrosswalk xwalk = (DisseminationCrosswalk) CoreServiceFactory
+						.getInstance().getPluginService()
+						.getNamedPlugin(DisseminationCrosswalk.class, "ore");
+
+				Element ore = xwalk.disseminateElement(context, item);
+				out.output(ore);
+			}
+			else
+			{
+				Response response = ObjectModelHelper.getResponse(objectModel);
+				response.setStatus(403);
+			}
 		} catch (JDOMException je) {
 			throw new ProcessingException(je);
 		} catch (AuthorizeException ae) {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/DSpaceOREGenerator.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/DSpaceOREGenerator.java
@@ -66,12 +66,6 @@ public class DSpaceOREGenerator extends AbstractGenerator
             
             Element ore = xwalk.disseminateElement(context, item);
             out.output(ore);
-            
-			/* Generate the METS document
-			contentHandler.startDocument();
-			adapter.renderMETS(contentHandler,lexicalHandler);
-			contentHandler.endDocument();*/
-			
 		} catch (JDOMException je) {
 			throw new ProcessingException(je);
 		} catch (AuthorizeException ae) {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/AbstractAdapter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/AbstractAdapter.java
@@ -19,6 +19,9 @@ import org.dspace.app.util.Util;
 import org.dspace.app.xmlui.wing.AttributeMap;
 import org.dspace.app.xmlui.wing.Namespace;
 import org.dspace.app.xmlui.wing.WingException;
+import org.dspace.authenticate.factory.AuthenticateServiceFactory;
+import org.dspace.authorize.factory.AuthorizeServiceFactory;
+import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Bitstream;
 import org.dspace.content.BitstreamFormat;
 import org.dspace.content.Item;
@@ -85,6 +88,8 @@ public abstract class AbstractAdapter
     protected ContentHandler contentHandler;
     protected LexicalHandler lexicalHandler;
     protected NamespaceSupport namespaces;
+
+    protected AuthorizeService authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();
     
     /**
      * Construct a new adapter, implementers must call this method so
@@ -628,6 +633,14 @@ public abstract class AbstractAdapter
        return false;
     }
     
+    /**
+     * Check if the current user is allowed to read the contents
+     * of the adapter.
+     *
+     * @return True if the user has sufficient permissions
+     * @throws SQLException passed through.
+     */
+    abstract public boolean isAuthorized() throws SQLException;
     
     
     

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/ContainerAdapter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/ContainerAdapter.java
@@ -820,4 +820,10 @@ public class ContainerAdapter extends AbstractAdapter
         // Close out field
         endElement(DIM,"field");
     }  
+
+    @Override
+    public boolean isAuthorized() throws SQLException
+    {
+        return authorizeService.authorizeActionBoolean(dspaceContext, dso, Constants.READ);
+    }
 }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/ItemAdapter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/ItemAdapter.java
@@ -984,6 +984,12 @@ public class ItemAdapter extends AbstractAdapter
         }
     }
 
+    @Override
+    public boolean isAuthorized() throws SQLException
+    {
+        return authorizeService.authorizeActionBoolean(context, item, Constants.READ);
+    }
+
 
     /**
      * Checks which Bundles of current item a user has requested.

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/RepositoryAdapter.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/objectmanager/RepositoryAdapter.java
@@ -280,6 +280,12 @@ public class RepositoryAdapter extends AbstractAdapter
         
     }
 
+    @Override
+    public boolean isAuthorized()
+    {
+        return true;
+    }
+
     /**
      * 
      * 


### PR DESCRIPTION
This is a replacement for #2364. _(I can port it to dspace-5_x if it is merged. Then it would replace #2363, too.)_

This is a fix for [DS-304](https://jira.duraspace.org/browse/DS-304) and [DS-1922](https://jira.duraspace.org/browse/DS-1922).

The `DSpaceMETSGenerator` should check, that the current user has `READ` permission on the object. This pull request adds a new method to the `AbstractAdapter` to check for this permissions (#2364 only handles the `ItemAdapter` via an instanceof check and a cast).

This pull request also handles a similar case for the `DSpaceOREGenerator`. The `ore.xml` does not contain all metadata, but at least the title and the authors are visible even if the current user does not have the permission to view the item.

If a user does not have the `READ` permission, an empty response with a 403 response code is returned. (We could throw an `AuthorizeException`, but clients expect plain XML on both endpoints and could be confused with a HTML response.)