### PR TITLE
Another attempt at fixing Date test in `OAIpmhIT` integration test

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/oai/OAIpmhIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/oai/OAIpmhIT.java
@@ -9,6 +9,7 @@
 package org.dspace.app.oai;
 
 import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
@@ -147,8 +148,8 @@ public class OAIpmhIT extends AbstractControllerIntegrationTest {
         // Get current date/time and store as "now", then round to nearest second (as OAI-PMH ignores milliseconds)
         Date now = new Date();
         Date nowToNearestSecond = DateUtils.round(now, Calendar.SECOND);
-        // Return "now" when "getEarliestDate()" is called for the currently loaded EarliestDateResolver bean
-        doReturn(now).when(earliestDateResolver).getEarliestDate(context);
+        // Return "nowToNearestSecond" when "getEarliestDate()" is called for currently loaded EarliestDateResolver bean
+        doReturn(nowToNearestSecond).when(earliestDateResolver).getEarliestDate(any());
 
         // Attempt to make an Identify request to root context
         getClient().perform(get(DEFAULT_CONTEXT).param("verb", "Identify"))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/oai/OAIpmhIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/oai/OAIpmhIT.java
@@ -18,6 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.xpath;
 
+import java.util.Calendar;
 import java.util.Date;
 
 import com.lyncode.xoai.dataprovider.core.XOAIManager;
@@ -27,6 +28,7 @@ import com.lyncode.xoai.dataprovider.services.impl.BaseDateProvider;
 import com.lyncode.xoai.dataprovider.xml.xoaiconfig.Configuration;
 import com.lyncode.xoai.dataprovider.xml.xoaiconfig.ContextConfiguration;
 
+import org.apache.commons.lang3.time.DateUtils;
 import org.dspace.app.rest.builder.CollectionBuilder;
 import org.dspace.app.rest.builder.CommunityBuilder;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
@@ -142,8 +144,9 @@ public class OAIpmhIT extends AbstractControllerIntegrationTest {
     @Test
     public void requestForIdentifyShouldReturnTheConfiguredValues() throws Exception {
 
-        // Get current date/time and store as "now"
+        // Get current date/time and store as "now", then round to nearest second (as OAI-PMH ignores milliseconds)
         Date now = new Date();
+        Date nowToNearestSecond = DateUtils.round(now, Calendar.SECOND);
         // Return "now" when "getEarliestDate()" is called for the currently loaded EarliestDateResolver bean
         doReturn(now).when(earliestDateResolver).getEarliestDate(context);
 
@@ -168,7 +171,7 @@ public class OAIpmhIT extends AbstractControllerIntegrationTest {
                                   .string(configurationService.getProperty("oai.url") + "/" + DEFAULT_CONTEXT_PATH))
                    // Expect earliestDatestamp to be "now", i.e. current date, (as mocked above)
                    .andExpect(xpath("OAI-PMH/Identify/earliestDatestamp")
-                                  .string(baseDateProvider.format(now)))
+                                  .string(baseDateProvider.format(nowToNearestSecond)))
         ;
     }
 


### PR DESCRIPTION
I've noticed again that the Date test in `OAIpmhIT` fails randomly, and when it fails it is always off by a second.  

This is a new attempt to make this test more stable by ensuring that the mock date is pre-rounded to the nearest second (to avoid any rounding errors), and ensure that the mock date is always returned (regardless of current Context object).

I've run this test through Travis CI (in my private repo) 5 times in a row today with no failures.  So, I'm hoping it's now stabilized (previously it seemed to fail randomly every few builds).  But, let's see how Travis behaves here.