### PR TITLE
DS-2376: Catch exception from encrypted PDF instead of expecting to test for it. (Bug fix follow-up)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFFilter.java
@@ -18,6 +18,7 @@ import java.io.Writer;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.encryption.InvalidPasswordException;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.dspace.content.Item;
 import org.dspace.core.ConfigurationManager;
@@ -94,11 +95,11 @@ public class PDFFilter extends MediaFilter {
 
             try {
                 pdfDoc = PDDocument.load(source);
-                if (pdfDoc.isEncrypted()) {
-                    log.error("PDF is encrypted. Cannot extract text (item: " + currentItem.getHandle() + ")");
-                    return null;
-                }
                 pts.writeText(pdfDoc, writer);
+            } catch (InvalidPasswordException ex) {
+                log.error("PDF is encrypted. Cannot extract text (item: {})",
+                    () -> currentItem.getHandle());
+                return null;
             } finally {
                 try {
                     if (pdfDoc != null) {


### PR DESCRIPTION
This is an immediate follow-up to a PR #2425 that I just merged, which related directly to DS-2376.  After merger, I noticed that an important contribution to this PR from @mwoodiupui had somehow been lost (likely during a force commit after a recent rebase).  This contributions was originally a part of PR#2425, and was submitted here:  https://github.com/tdonohue/DSpace/pull/10

So, this is a tiny, one-commit PR to correct my rebase mistake.  Once Travis approves, I will merge it immediately, as all prior testing of #2425 was done with this code change in place.