### PR TITLE
DS-4291 Properly show results for 0-9 link in browse

### DIFF
--- a/dspace-api/src/main/java/org/dspace/browse/BrowseInfo.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseInfo.java
@@ -482,6 +482,10 @@ public class BrowseInfo
         return results;
     }
 
+	public void setResults(List results) {
+		this.results = results;
+	}
+
     /**
      * Return the results of the Browse as an array of String array.
      * The first element (i.e. index 0) is the value, the second is the authority key
@@ -542,6 +546,10 @@ public class BrowseInfo
     {
         return total;
     }
+
+	public void setTotal(int total) {
+		this.total = total;
+	}
 
     /**
      * Return the position of the requested item or value in the set of results.

--- a/dspace-api/src/main/java/org/dspace/browse/SolrBrowseDAO.java
+++ b/dspace-api/src/main/java/org/dspace/browse/SolrBrowseDAO.java
@@ -494,6 +494,7 @@ public class SolrBrowseDAO implements BrowseDAO
 
     @Override
     public void setStartsWith(String startsWith) {
+        sResponse = null;
         this.startsWith = startsWith;
     }
 

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ConfigurableBrowse.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ConfigurableBrowse.java
@@ -24,9 +24,11 @@ import org.dspace.app.xmlui.utils.*;
 import org.dspace.app.xmlui.wing.Message;
 import org.dspace.app.xmlui.wing.WingException;
 import org.dspace.app.xmlui.wing.element.*;
+import org.dspace.app.xmlui.wing.element.List;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.browse.*;
 import org.dspace.content.*;
+import org.dspace.content.Collection;
 import org.dspace.content.Item;
 import org.dspace.content.authority.factory.ContentAuthorityServiceFactory;
 import org.dspace.content.authority.service.ChoiceAuthorityService;
@@ -41,10 +43,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.Serializable;
 import java.sql.SQLException;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Implements all the browse functionality (browse by title, subject, authors,
@@ -1099,6 +1098,9 @@ class BrowseParams
         paramMap.put(BrowseParams.RESULTS_PER_PAGE, Integer
                 .toString(this.scope.getResultsPerPage()));
         paramMap.put(BrowseParams.ETAL, Integer.toString(this.etAl));
+        if (this.scope.hasStartsWith()) {
+            paramMap.put(BrowseParams.STARTS_WITH, this.scope.getStartsWith());
+        }
 
         return paramMap;
     }


### PR DESCRIPTION
When browsing by Author, if you click the "0-9" link at the top, it is only showing results for 0 instead of 0-9.

Currently, only a facet query prefix for "0" is being used, so no other results are shown. Because facet query prefixes don't support ranges, the simplest solution is to perform separate queries and combine the results for 0-9. This fix performs the additional queries and combines their results and totals.

This is the 6.x version of #2696 