### PR TITLE
DS-4292  Fix Browse pagination with starts-with

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ConfigurableBrowse.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ConfigurableBrowse.java
@@ -1099,6 +1099,7 @@ class BrowseParams
         paramMap.put(BrowseParams.RESULTS_PER_PAGE, Integer
                 .toString(this.scope.getResultsPerPage()));
         paramMap.put(BrowseParams.ETAL, Integer.toString(this.etAl));
+        paramMap.put(BrowseParams.STARTS_WITH, this.scope.getStartsWith());
 
         return paramMap;
     }


### PR DESCRIPTION
Currently, if you're browsing by Author, select a starts-with link and then click the next page, it brings you to the 2nd page of all results rather than the 2nd page of those _starts_with results.

This fix adds the starts-with parameter to `getControlParameters()` so that pagination forward _and_ backwards work with starts-with