### PR TITLE
DS-4293 Fix Known/Supported labels in UploadStep/UploadWithEmbargoStep

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/UploadStep.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/UploadStep.java
@@ -332,13 +332,13 @@ public class UploadStep extends AbstractSubmissionStep
                     cell.addContent(" ");
                     switch (support)
                     {
-                        case 1:
-                            cell.addContent(T_supported);
-                            break;
-                        case 2:
+                        case BitstreamFormat.KNOWN:
                             cell.addContent(T_known);
                             break;
-                        case 3:
+                        case BitstreamFormat.SUPPORTED:
+                            cell.addContent(T_supported);
+                            break;
+                        case BitstreamFormat.UNKNOWN:
                             cell.addContent(T_unsupported);
                             break;
                     }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/UploadWithEmbargoStep.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/UploadWithEmbargoStep.java
@@ -333,13 +333,13 @@ public class UploadWithEmbargoStep extends UploadStep
 	            	cell.addContent(" ");
 	            	switch (support)
 	            	{
-	            	case 1:
-	            		cell.addContent(T_supported);
+	            	case BitstreamFormat.KNOWN:
+                        cell.addContent(T_known);
 	            		break;
-	            	case 2:
-	            		cell.addContent(T_known);
+	            	case BitstreamFormat.SUPPORTED:
+                        cell.addContent(T_supported);
 	            		break;
-	            	case 3:
+	            	case BitstreamFormat.UNKNOWN:
 	            		cell.addContent(T_unsupported);
 	            		break;
 	            	}


### PR DESCRIPTION
Currently in UploadStep/UploadWithEmbargoStep, "Supported" file types are mislabeled as "Known" and "Known" file types are mislabeled as "Supported". Support levels are shown correctly in the Review Step.

This fix fixes the switch statement to choose the correct labels (and use enum values)