### PR TITLE
[DS-4298] changed the PathVariable for the upload method with uuid to…

### DIFF
--- a/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-spring-rest/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -572,8 +572,8 @@ public class RestResourceController implements InitializingBean {
      *            the api category
      * @param model
      *            the rest model that identify the REST resource collection
-     * @param id
-     *            the id of the specific rest resource
+     * @param uuid
+     *            the uuid of the specific rest resource
      * @param uploadfile
      *            the file to upload
      * @return the created resource
@@ -584,11 +584,11 @@ public class RestResourceController implements InitializingBean {
     public <ID extends Serializable> ResponseEntity<ResourceSupport> upload(HttpServletRequest request,
                                                                             @PathVariable String apiCategory,
                                                                             @PathVariable String model,
-                                                                            @PathVariable UUID id,
+                                                                            @PathVariable UUID uuid,
                                                                             @RequestParam("file") MultipartFile
                                                                                 uploadfile)
         throws HttpRequestMethodNotSupportedException {
-        return uploadInternal(request, apiCategory, model, id, uploadfile);
+        return uploadInternal(request, apiCategory, model, uuid, uploadfile);
     }
 
     /**


### PR DESCRIPTION
This PR solves the jira issue: https://jira.duraspace.org/browse/DS-4298
This PR renames the PathVariable for the Upload method with UUID from 'id' to 'uuid' to match the regex that's used for the value in the RequestMapping