### PR TITLE
DS-4219 Fix filter-media solr exception

### DIFF
--- a/dspace/solr/search/conf/solrconfig.xml
+++ b/dspace/solr/search/conf/solrconfig.xml
@@ -25,11 +25,11 @@
 <config>
   <luceneMatchVersion>7.2.1</luceneMatchVersion>
 
-  <!-- Include contributed analyzers that we use in DSpace. -->
-  <lib dir='${solr.install.dir}/contrib/analysis-extras/lib/'
-       regex='icu4j-.*\.jar'/>
-  <lib dir='${solr.install.dir}/contrib/analysis-extras/lucene-libs/'
-       regex='lucene-analyzers-icu-.*\.jar'/>
+  <!-- Include libraries that we use in DSpace. -->
+  <lib dir='${solr.install.dir}/contrib/analysis-extras/lib/' regex='icu4j-.*\.jar'/>
+  <lib dir='${solr.install.dir}/contrib/analysis-extras/lucene-libs/' regex='lucene-analyzers-icu-.*\.jar'/>
+  <lib dir="${solr.install.dir}/contrib/extraction/lib" />
+  <lib dir="${solr.install.dir}/dist/" regex="solr-cell-\d.*\.jar" />
   
   <dataDir>${solr.data.dir:}</dataDir>
 


### PR DESCRIPTION
This PR addresses [DS-4219](https://jira.duraspace.org/browse/DS-4219)

In DSpace 7, running `filter-media` currently fails due to `solr.extraction.ExtractingRequestHandler ClassNotFoundException`. This is because of missing libraries that weren't included in the solr config.

The fix for this issue was included in #2393 (and [DS-3695](https://jira.duraspace.org/browse/DS-3695)), but since that PR includes fixes for other issues and hasn't received much attention, I decided to make a smaller PR just to get `filter-media` working again.