### PR TITLE
Travis CI: Continue to use Ubuntu Trusty 14.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 sudo: false
+dist: trusty
 
 env: 
   # Give Maven 1GB of memory to work with


### PR DESCRIPTION
Ubuntu Xenial 16.04 does not support OracleJDK8 anymore.