### PR TITLE
Ds 4295 create new item error rest

### DIFF
--- a/dspace-rest/src/main/java/org/dspace/rest/Resource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/Resource.java
@@ -249,13 +249,24 @@ public class Resource
      */
     protected static EPerson getUser(HttpHeaders headers)
     {
-        List<String> list = headers.getRequestHeader(TokenHolder.TOKEN_HEADER);
-        String token = null;
-        if ((list != null) && (list.size() > 0))
-        {
-            token = list.get(0);
-            return TokenHolder.getEPerson(token);
+        Context context = null;
+        try {
+            context = new Context();
+
+            List<String> list = headers.getRequestHeader(TokenHolder.TOKEN_HEADER);
+            String token = null;
+            if ((list != null) && (list.size() > 0))
+            {
+                token = list.get(0);
+                int ePersonId = TokenHolder.getEPersonId(token);
+                EPerson ePerson = EPerson.find(context, ePersonId);
+                return ePerson;
+            }
+        } catch (SQLException e) {
+            Resource.processException("Status eperson db lookup error: " + e.getMessage(), context);
         }
+
+
         return null;
     }
 

--- a/dspace-rest/src/main/java/org/dspace/rest/Resource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/Resource.java
@@ -258,9 +258,10 @@ public class Resource
             if ((list != null) && (list.size() > 0))
             {
                 token = list.get(0);
-                int ePersonId = TokenHolder.getEPersonId(token);
-                EPerson ePerson = EPerson.find(context, ePersonId);
-                return ePerson;
+                Integer ePersonId = TokenHolder.getEPersonId(token);
+                if (ePersonId != null) {
+                    return EPerson.find(context, ePersonId);
+                }
             }
         } catch (SQLException e) {
             Resource.processException("Status eperson db lookup error: " + e.getMessage(), context);

--- a/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
@@ -169,16 +169,26 @@ public class RestIndex {
     @Consumes({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
     public Response logout(@Context HttpHeaders headers)
     {
+        org.dspace.core.Context context = null;
         List<String> list = headers.getRequestHeader(TokenHolder.TOKEN_HEADER);
         String token = null;
         boolean logout = false;
         EPerson ePerson = null;
-        if (list != null)
-        {
-            token = list.get(0);
-            ePerson = TokenHolder.getEPerson(token);
-            logout = TokenHolder.logout(token);
+
+        try {
+            if (list != null)
+            {
+                context = new org.dspace.core.Context();
+                token = list.get(0);
+                int ePersonId = TokenHolder.getEPersonId(token);
+                ePerson = EPerson.find(context, ePersonId);
+                logout = TokenHolder.logout(context, token);
+            }
+        } catch (SQLException e) {
+            Resource.processException("Status eperson db lookup error: " + e.getMessage(), context);
         }
+
+
         if ((token == null) || (!logout))
         {
             return Response.status(Response.Status.BAD_REQUEST).build();

--- a/dspace-rest/src/main/java/org/dspace/rest/TokenHolder.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/TokenHolder.java
@@ -115,7 +115,7 @@ public class TokenHolder
      * 
      * @param token
      *            Token under which is stored eperson.
-     * @return Return instance of EPerson if is token right, otherwise it
+     * @return Return EPerson id if token is right, otherwise it
      *         returns NULL.
      */
     public static synchronized Integer getEPersonId(String token)


### PR DESCRIPTION
This PR handles the problem where the initially created context while logging in was lost on the following call (For example when submitting an item)

Previously, EPerson objects were kept (Attached to their respective token), which would have contained an 'invalid' context.
This has been changed to simply keep the EPerson ID, and subsequent calls will retrieve this EPerson based on that information (Resulting in having the latest relevant context being attached to that EPerson)

https://jira.duraspace.org/browse/DS-4295

Fixes #7635