### PR TITLE
6x: Allow virus scanner to work with Embargo Upload step

### DIFF
--- a/dspace-api/src/main/java/org/dspace/submit/step/UploadWithEmbargoStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/UploadWithEmbargoStep.java
@@ -57,7 +57,6 @@ import org.dspace.handle.service.HandleService;
  *
  * @author Tim Donohue
  * @author Keiji Suzuki
- * @version $Revision$
  */
 public class UploadWithEmbargoStep extends UploadStep
 {
@@ -486,7 +485,7 @@ public class UploadWithEmbargoStep extends UploadStep
                 if (configurationService.getBooleanProperty("submission-curation.virus-scan"))
                 {
                     Curator curator = new Curator();
-                    curator.addTask("vscan").curate(item);
+                    curator.addTask("vscan").curate(context, item);
                     int status = curator.getStatus("vscan");
                     if (status == Curator.CURATE_ERROR)
                     {


### PR DESCRIPTION
This pull request allows the work already done in commit
dd4ca00 for DS-3469, "virus scan during submission
attempts to read bitstream as anonymous user, which
fails" to also work with the UploadWithEmbargoStep.


