### PR TITLE
[DS-4153] Added repository createAndReturn that accepts parent id

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -391,14 +392,17 @@ public class RestResourceController implements InitializingBean {
      * @param request       The relevant request
      * @param apiCategory   The apiCategory to be used
      * @param model         The model to be used
+     * @param parent        Optional parent identifier
      * @return              The relevant ResponseEntity for this request
      * @throws HttpRequestMethodNotSupportedException   If something goes wrong
      */
     @RequestMapping(method = RequestMethod.POST, consumes = {"application/json", "application/hal+json"})
-    public ResponseEntity<ResourceSupport> post(HttpServletRequest request, @PathVariable String apiCategory,
-                                                @PathVariable String model)
+    public ResponseEntity<ResourceSupport> post(HttpServletRequest request,
+                                                @PathVariable String apiCategory,
+                                                @PathVariable String model,
+                                                @RequestParam(required = false) String parent)
         throws HttpRequestMethodNotSupportedException {
-        return postJsonInternal(request, apiCategory, model);
+        return postJsonInternal(request, apiCategory, model, parent);
     }
 
     /**
@@ -433,21 +437,21 @@ public class RestResourceController implements InitializingBean {
      * @param request       The relevant request
      * @param apiCategory   The apiCategory to be used
      * @param model         The model to be used
+     * @param parent        The parent object id (optional)
      * @return              The relevant ResponseEntity for this request
      * @throws HttpRequestMethodNotSupportedException   If something goes wrong
      */
     public <ID extends Serializable> ResponseEntity<ResourceSupport> postJsonInternal(HttpServletRequest request,
                                                                                   String apiCategory,
-                                                                                  String model)
+                                                                                  String model, String parent)
         throws HttpRequestMethodNotSupportedException {
         checkModelPluralForm(apiCategory, model);
         DSpaceRestRepository<RestAddressableModel, ID> repository = utils.getResourceRepository(apiCategory, model);
 
-        String parentCommunityString = request.getParameter("parent");
         RestAddressableModel modelObject;
-        if (parentCommunityString != null) {
-            UUID parentCommunityUuid = UUIDUtils.fromString(parentCommunityString);
-            modelObject = repository.createAndReturn(parentCommunityUuid);
+        if (parent != null) {
+            UUID parentUuid = UUIDUtils.fromString(parent);
+            modelObject = repository.createAndReturn(parentUuid);
         } else {
             modelObject = repository.createAndReturn();
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -51,6 +51,7 @@ import org.dspace.app.rest.repository.LinkRestRepository;
 import org.dspace.app.rest.utils.RestRepositoryUtils;
 import org.dspace.app.rest.utils.Utils;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.util.UUIDUtils;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -441,7 +442,15 @@ public class RestResourceController implements InitializingBean {
         throws HttpRequestMethodNotSupportedException {
         checkModelPluralForm(apiCategory, model);
         DSpaceRestRepository<RestAddressableModel, ID> repository = utils.getResourceRepository(apiCategory, model);
-        RestAddressableModel modelObject = repository.createAndReturn();
+
+        String parentCommunityString = request.getParameter("parent");
+        RestAddressableModel modelObject;
+        if (parentCommunityString != null) {
+            UUID parentCommunityUuid = UUIDUtils.fromString(parentCommunityString);
+            modelObject = repository.createAndReturn(parentCommunityUuid);
+        } else {
+            modelObject = repository.createAndReturn();
+        }
         if (modelObject == null) {
             return ControllerUtils.toEmptyResponse(HttpStatus.CREATED);
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
@@ -168,7 +168,7 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
 
     @Override
     protected CollectionRest createAndReturn(Context context) throws AuthorizeException {
-        throw new DSpaceBadRequestException("Missing parent parameter.");
+        throw new DSpaceBadRequestException("Cannot create a Collection without providing a parent Community.");
     }
 
     @Override
@@ -176,8 +176,8 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
     protected CollectionRest createAndReturn(Context context, UUID id) throws AuthorizeException {
 
         if (id == null) {
-            throw new DSpaceBadRequestException("The given parent parameter was invalid: "
-                + id);
+            throw new DSpaceBadRequestException("Parent Community UUID is null. " +
+                "Cannot create a Collection without providing a parent Community");
         }
 
         HttpServletRequest req = getRequestService().getCurrentRequest().getHttpServletRequest();
@@ -187,8 +187,9 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
             ServletInputStream input = req.getInputStream();
             collectionRest = mapper.readValue(input, CollectionRest.class);
         } catch (IOException e1) {
-            throw new UnprocessableEntityException("Error parsing request body: " + e1.toString());
+            throw new UnprocessableEntityException("Error parsing request body.", e1);
         }
+
         Collection collection;
         try {
             Community parent = communityService.find(context, id);
@@ -200,8 +201,7 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
             cs.update(context, collection);
             metadataConverter.setMetadata(context, collection, collectionRest.getMetadata());
         } catch (SQLException e) {
-            throw new RuntimeException("Unable to create new Collection under parent Community " +
-                                           id, e);
+            throw new RuntimeException("Unable to create new Collection under parent Community " + id, e);
         }
         return converter.convert(collection);
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
@@ -17,7 +17,6 @@ import javax.servlet.http.HttpServletRequest;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.rest.Parameter;
 import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.converter.CollectionConverter;
@@ -38,7 +37,6 @@ import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.CommunityService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.util.UUIDUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -169,8 +167,19 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
     }
 
     @Override
-    @PreAuthorize("hasAuthority('ADMIN')")
     protected CollectionRest createAndReturn(Context context) throws AuthorizeException {
+        throw new DSpaceBadRequestException("Missing parent parameter.");
+    }
+
+    @Override
+    @PreAuthorize("hasPermission(#id, 'COMMUNITY', 'ADD')")
+    protected CollectionRest createAndReturn(Context context, UUID id) throws AuthorizeException {
+
+        if (id == null) {
+            throw new DSpaceBadRequestException("The given parent parameter was invalid: "
+                + id);
+        }
+
         HttpServletRequest req = getRequestService().getCurrentRequest().getHttpServletRequest();
         ObjectMapper mapper = new ObjectMapper();
         CollectionRest collectionRest;
@@ -180,36 +189,19 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
         } catch (IOException e1) {
             throw new UnprocessableEntityException("Error parsing request body: " + e1.toString());
         }
-
         Collection collection;
-
-
-        String parentCommunityString = req.getParameter("parent");
         try {
-            Community parent = null;
-            if (StringUtils.isNotBlank(parentCommunityString)) {
-
-                UUID parentCommunityUuid = UUIDUtils.fromString(parentCommunityString);
-                if (parentCommunityUuid == null) {
-                    throw new DSpaceBadRequestException("The given parent was invalid: "
-                            + parentCommunityString);
-                }
-
-                parent = communityService.find(context, parentCommunityUuid);
-                if (parent == null) {
-                    throw new UnprocessableEntityException("Parent community for id: "
-                            + parentCommunityUuid + " not found");
-                }
-            } else {
-                throw new DSpaceBadRequestException("The parent parameter cannot be left empty," +
-                                                  "collections require a parent community.");
+            Community parent = communityService.find(context, id);
+            if (parent == null) {
+                throw new UnprocessableEntityException("Parent community for id: "
+                    + id + " not found");
             }
             collection = cs.create(context, parent);
             cs.update(context, collection);
             metadataConverter.setMetadata(context, collection, collectionRest.getMetadata());
         } catch (SQLException e) {
             throw new RuntimeException("Unable to create new Collection under parent Community " +
-                                           parentCommunityString, e);
+                                           id, e);
         }
         return converter.convert(collection);
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
@@ -17,7 +17,6 @@ import javax.servlet.http.HttpServletRequest;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.rest.Parameter;
 import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.converter.CommunityConverter;
@@ -34,7 +33,6 @@ import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Community;
 import org.dspace.content.service.CommunityService;
 import org.dspace.core.Context;
-import org.dspace.util.UUIDUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -83,25 +81,45 @@ public class CommunityRestRepository extends DSpaceObjectRestRepository<Communit
         }
 
         Community community;
-
-
         try {
-            Community parent = null;
-            String parentCommunityString = req.getParameter("parent");
-            if (StringUtils.isNotBlank(parentCommunityString)) {
+            // top-level community
+            community = cs.create(null, context);
+            cs.update(context, community);
+            metadataConverter.setMetadata(context, community, communityRest.getMetadata());
+        } catch (SQLException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
 
-                UUID parentCommunityUuid = UUIDUtils.fromString(parentCommunityString);
-                if (parentCommunityUuid == null) {
-                    throw new DSpaceBadRequestException("The given parent parameter was invalid: "
-                            + parentCommunityString);
-                }
+        return dsoConverter.convert(community);
+    }
 
-                parent = cs.find(context, parentCommunityUuid);
-                if (parent == null) {
-                    throw new UnprocessableEntityException("Parent community for id: "
-                            + parentCommunityUuid + " not found");
-                }
+    @Override
+    @PreAuthorize("hasPermission(#id, 'COMMUNITY', 'ADD')")
+    protected CommunityRest createAndReturn(Context context, UUID id) throws AuthorizeException {
+
+        if (id == null) {
+            throw new DSpaceBadRequestException("The given parent parameter was invalid: "
+                + id);
+        }
+
+        HttpServletRequest req = getRequestService().getCurrentRequest().getHttpServletRequest();
+        ObjectMapper mapper = new ObjectMapper();
+        CommunityRest communityRest;
+        try {
+            ServletInputStream input = req.getInputStream();
+            communityRest = mapper.readValue(input, CommunityRest.class);
+        } catch (IOException e1) {
+            throw new UnprocessableEntityException("Error parsing request body: " + e1.toString());
+        }
+
+        Community community;
+        try {
+            Community parent = cs.find(context, id);
+            if (parent == null) {
+                throw new UnprocessableEntityException("Parent community for id: "
+                    + id + " not found");
             }
+            // sub-community
             community = cs.create(parent, context);
             cs.update(context, community);
             metadataConverter.setMetadata(context, community, communityRest.getMetadata());

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
@@ -98,8 +98,8 @@ public class CommunityRestRepository extends DSpaceObjectRestRepository<Communit
     protected CommunityRest createAndReturn(Context context, UUID id) throws AuthorizeException {
 
         if (id == null) {
-            throw new DSpaceBadRequestException("The given parent parameter was invalid: "
-                + id);
+            throw new DSpaceBadRequestException("Parent Community UUID is null. " +
+                "Cannot create a SubCommunity without providing a parent Community.");
         }
 
         HttpServletRequest req = getRequestService().getCurrentRequest().getHttpServletRequest();
@@ -109,7 +109,7 @@ public class CommunityRestRepository extends DSpaceObjectRestRepository<Communit
             ServletInputStream input = req.getInputStream();
             communityRest = mapper.readValue(input, CommunityRest.class);
         } catch (IOException e1) {
-            throw new UnprocessableEntityException("Error parsing request body: " + e1.toString());
+            throw new UnprocessableEntityException("Error parsing request body.", e1);
         }
 
         Community community;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/DSpaceRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/DSpaceRestRepository.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.UUID;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -260,6 +261,46 @@ public abstract class DSpaceRestRepository<T extends RestAddressableModel, ID ex
     public abstract DSpaceResource<T> wrapResource(T model, String... rels);
 
     /**
+     * Create and return a new instance. Data are usually retrieved from the thread bound http request
+     *
+     * @return the created REST object
+     */
+    public T createAndReturn() {
+        Context context = null;
+        try {
+            context = obtainContext();
+            T entity = thisRepository.createAndReturn(context);
+            context.commit();
+            return entity;
+        } catch (AuthorizeException e) {
+            throw new RESTAuthorizationException(e);
+        } catch (SQLException ex) {
+            throw new RuntimeException(ex.getMessage(), ex);
+        }
+    }
+
+    /**
+     * Create and return a new instance after adding to the parent. Data are usually retrieved from
+     * the thread bound http request.
+     *
+     * @param uuid the id of the parent object
+     * @return the created REST object
+     */
+    public T createAndReturn(UUID uuid) {
+        Context context = null;
+        try {
+            context = obtainContext();
+            T entity = thisRepository.createAndReturn(context, uuid);
+            context.commit();
+            return entity;
+        } catch (AuthorizeException e) {
+            throw new RESTAuthorizationException(e);
+        } catch (SQLException ex) {
+            throw new RuntimeException(ex.getMessage(), ex);
+        }
+    }
+
+    /**
      * Create and return a new instance. Data is recovered from the thread bound HTTP request and the list
      * of DSpaceObjects provided in the uri-list body
      *
@@ -281,22 +322,22 @@ public abstract class DSpaceRestRepository<T extends RestAddressableModel, ID ex
     }
 
     /**
-     * Create and return a new instance. Data are usually retrieved from the thread bound http request
+     * Method to implement to support the creation of a new instance. Usually require to retrieve the http request from
+     * the thread bound attribute
      *
+     * @param context
+     *            the dspace context
+     * @param uuid
+     *            The uuid of the parent object retrieved from the query param.
      * @return the created REST object
+     * @throws AuthorizeException
+     * @throws SQLException
+     * @throws RepositoryMethodNotImplementedException
+     *             returned by the default implementation when the operation is not supported for the entity
      */
-    public T createAndReturn() {
-        Context context = null;
-        try {
-            context = obtainContext();
-            T entity = thisRepository.createAndReturn(context);
-            context.commit();
-            return entity;
-        } catch (AuthorizeException e) {
-            throw new RESTAuthorizationException(e);
-        } catch (SQLException ex) {
-            throw new RuntimeException(ex.getMessage(), ex);
-        }
+    protected T createAndReturn(Context context, UUID uuid)
+        throws AuthorizeException, SQLException, RepositoryMethodNotImplementedException {
+        throw new RepositoryMethodNotImplementedException("No implementation found; Method not allowed!", "");
     }
 
     /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/EPersonRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/EPersonRestPermissionEvaluatorPlugin.java
@@ -30,8 +30,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 /**
- * An authenicated user is allowed to view, update or delete his or her own data. This {@link RestPermissionEvaluatorPlugin}
- * implemenents that requirement.
+ * An authenticated user is allowed to view, update or delete his or her own data. This {@link RestPermissionEvaluatorPlugin}
+ * implements that requirement.
  */
 @Component
 public class EPersonRestPermissionEvaluatorPlugin extends RestObjectPermissionEvaluatorPlugin {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
@@ -473,6 +473,7 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
                                           .withName("Parent Community")
                                           .withLogo("ThisIsSomeDummyText")
                                           .build();
+        context.restoreAuthSystemState();
 
         ObjectMapper mapper = new ObjectMapper();
         CollectionRest collectionRest = new CollectionRest();
@@ -551,6 +552,7 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
         // ADD authorization on parent community
         context.setCurrentUser(eperson);
         authorizeService.addPolicy(context, parentCommunity, Constants.ADD, eperson);
+        context.restoreAuthSystemState();
 
         String authToken = getAuthToken(eperson.getEmail(), password);
 
@@ -611,6 +613,8 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
                 new MetadataValueRest("Title Text")));
 
         context.setCurrentUser(eperson);
+        context.restoreAuthSystemState();
+
         // User doesn't have add permission on the collection.
         String authToken = getAuthToken(eperson.getEmail(), password);
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
@@ -98,6 +98,7 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child2).withName("Collection 2").build();
 
+        context.restoreAuthSystemState();
 
         getClient().perform(get("/api/core/collections")
                                 .param("size", "1"))
@@ -147,6 +148,7 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child2).withName("Collection 2").build();
 
+        context.restoreAuthSystemState();
 
         getClient().perform(get("/api/core/collections/" + col1.getID()))
                    .andExpect(status().isOk())
@@ -179,6 +181,8 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1")
                                            .withLogo("TestingContentForLogo").build();
         Collection col2 = CollectionBuilder.createCollection(context, child2).withName("Collection 2").build();
+
+        context.restoreAuthSystemState();
 
         getClient().perform(get("/api/core/collections/" + col1.getID()))
                    .andExpect(status().isOk())
@@ -225,6 +229,8 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child2).withName("Collection 2").build();
 
+        context.restoreAuthSystemState();
+
         getClient().perform(get("/api/core/collections/search/findAuthorized"))
                    .andExpect(status().isOk())
                    .andExpect(content().contentType(contentType))
@@ -253,6 +259,8 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
                                            .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child2).withName("Collection 2").build();
+
+        context.restoreAuthSystemState();
 
         getClient().perform(get("/api/core/collections/search/findAuthorizedByCommunity")
                                 .param("uuid", parentCommunity.getID().toString()))
@@ -294,6 +302,7 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child2).withName("Collection 2").build();
 
+        context.restoreAuthSystemState();
 
         getClient().perform(get("/api/core/collections/" + UUID.randomUUID()))
                    .andExpect(status().isNotFound());
@@ -317,6 +326,8 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
                                            .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
         Collection col2 = CollectionBuilder.createCollection(context, child2).withName("Collection 2").build();
+
+        context.restoreAuthSystemState();
 
         getClient().perform(get("/api/core/collections/" + col1.getID()))
                    .andExpect(status().isOk())
@@ -363,6 +374,8 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
         collectionRest.setMetadata(new MetadataRest()
                 .put("dc.title", new MetadataValueRest("Electronic theses and dissertations")));
 
+        context.restoreAuthSystemState();
+
         getClient(token).perform(put("/api/core/collections/" + col1.getID().toString())
                                      .contentType(MediaType.APPLICATION_JSON)
                                      .content(mapper.writeValueAsBytes(collectionRest)))
@@ -408,6 +421,8 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
 
         String token = getAuthToken(admin.getEmail(), password);
 
+        context.restoreAuthSystemState();
+
         getClient(token).perform(get("/api/core/collections/" + col1.getID().toString()))
                         .andExpect(status().isOk())
                         .andExpect(content().contentType(contentType))
@@ -448,6 +463,8 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
         Collection col1 = CollectionBuilder.createCollection(context, parentCommunityChild1)
                                            .withName("Collection 1")
                                            .build();
+
+        context.restoreAuthSystemState();
 
         getClient().perform(get("/api/core/collections/" + col1.getID().toString()))
                         .andExpect(status().isOk())
@@ -658,6 +675,8 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
 
         String token = getAuthToken(eperson.getEmail(), password);
 
+        context.restoreAuthSystemState();
+
         getClient(token).perform(get("/api/core/collections/" + col1.getID().toString()))
                         .andExpect(status().isOk())
                         .andExpect(content().contentType(contentType))
@@ -705,6 +724,8 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
 
         context.setCurrentUser(eperson);
         authorizeService.addPolicy(context, col1, Constants.WRITE, eperson);
+
+        context.restoreAuthSystemState();
 
         String token = getAuthToken(eperson.getEmail(), password);
         ObjectMapper mapper = new ObjectMapper();
@@ -783,6 +804,9 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
                                             new MetadataValueRest("Title Text")));
 
         String authToken = getAuthToken(admin.getEmail(), password);
+
+        context.restoreAuthSystemState();
+
         getClient(authToken).perform(post("/api/core/collections")
                                          .content(mapper.writeValueAsBytes(collectionRest))
                                          .param("parent", "123")
@@ -822,6 +846,9 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
                                             new MetadataValueRest("Title Text")));
 
         String authToken = getAuthToken(admin.getEmail(), password);
+
+        context.restoreAuthSystemState();
+
         getClient(authToken).perform(post("/api/core/collections")
                                          .content(mapper.writeValueAsBytes(collectionRest))
                                          .contentType(contentType))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -258,6 +258,8 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
 
         comm.setMetadata(metadataRest);
 
+        context.restoreAuthSystemState();
+
         // Anonymous user tries to create a community.
         // Should fail because user is not authenticated. Error 401.
         getClient().perform(post("/api/core/communities")
@@ -293,6 +295,8 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                                            .withLogo("Test Logo")
                                            .build();
 
+        context.restoreAuthSystemState();
+
         getClient().perform(get("/api/core/communities"))
                    .andExpect(status().isOk())
                    .andExpect(content().contentType(contentType))
@@ -323,6 +327,8 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                                            .withName("Sub Community")
                                            .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+
+        context.restoreAuthSystemState();
 
         getClient().perform(get("/api/core/communities")
                                 .param("size", "1"))
@@ -375,6 +381,8 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                                            .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
 
+        context.restoreAuthSystemState();
+
         getClient().perform(get("/api/core/communities/" + parentCommunity.getID().toString()))
                    .andExpect(status().isOk())
                    .andExpect(content().contentType(contentType))
@@ -406,6 +414,8 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                                            .withName("Sub Community")
                                            .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+
+        context.restoreAuthSystemState();
 
         getClient().perform(get("/api/core/communities/" + parentCommunity.getID().toString()))
                    .andExpect(status().isOk())
@@ -484,6 +494,7 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                                             .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
 
+        context.restoreAuthSystemState();
 
         getClient().perform(get("/api/core/communities/search/top"))
                    .andExpect(status().isOk())
@@ -543,6 +554,8 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
         Collection col1 = CollectionBuilder.createCollection(context, parentCommunityChild1)
                                            .withName("Collection 1")
                                            .build();
+
+        context.restoreAuthSystemState();
 
         getClient().perform(get("/api/core/communities/search/subCommunities")
                 .param("parent", parentCommunity.getID().toString()))
@@ -651,6 +664,8 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                                            .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
 
+        context.restoreAuthSystemState();
+
         getClient().perform(get("/api/core/communities/" + UUID.randomUUID())).andExpect(status().isNotFound());
     }
 
@@ -692,6 +707,8 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
 
         communityRest.setMetadata(new MetadataRest()
                 .put("dc.title", new MetadataValueRest("Electronic theses and dissertations")));
+
+        context.restoreAuthSystemState();
 
         getClient(token).perform(put("/api/core/communities/" + parentCommunity.getID().toString())
                                 .contentType(MediaType.APPLICATION_JSON)
@@ -750,6 +767,8 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                                            .build();
 
         String token = getAuthToken(admin.getEmail(), password);
+
+        context.restoreAuthSystemState();
 
         getClient(token).perform(get("/api/core/communities/" + parentCommunity.getID().toString()))
                         .andExpect(status().isOk())
@@ -810,6 +829,7 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                                            .withName("Collection 1")
                                            .build();
 
+        context.restoreAuthSystemState();
 
         getClient().perform(get("/api/core/communities/" + parentCommunity.getID().toString()))
                         .andExpect(status().isOk())
@@ -840,6 +860,8 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
         authorizeService.addPolicy(context, parentCommunity, Constants.DELETE, eperson);
 
         String token = getAuthToken(eperson.getEmail(), password);
+
+        context.restoreAuthSystemState();
 
         getClient(token).perform(get("/api/core/communities/" + parentCommunity.getID().toString()))
                         .andExpect(status().isOk())
@@ -898,6 +920,8 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
 
         context.setCurrentUser(eperson);
         authorizeService.addPolicy(context, parentCommunity, Constants.WRITE, eperson);
+
+        context.restoreAuthSystemState();
 
         String token = getAuthToken(eperson.getEmail(), password);
 
@@ -974,6 +998,8 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
         metadataRest.put("dc.title", title);
 
         comm.setMetadata(metadataRest);
+
+        context.restoreAuthSystemState();
 
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(post("/api/core/communities")

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -179,7 +179,6 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
         // ADD authorization on parent community
         context.setCurrentUser(eperson);
         authorizeService.addPolicy(context, parentCommunity, Constants.ADD, eperson);
-
         context.restoreAuthSystemState();
 
         String authToken = getAuthToken(eperson.getEmail(), password);


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-4153
I decided to add a createAndReturn method that takes the parent id as a parameter since I didn't see a better approach. The parent id is retrieved in the controller.  I'm using the id to check permissions on the parent object when adding collections and sub-communities.



