### PR TITLE
Clarify purpose of Bitstream's Sequence ID

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/Bitstream.java
+++ b/dspace-api/src/main/java/org/dspace/content/Bitstream.java
@@ -99,8 +99,12 @@ public class Bitstream extends DSpaceObject implements DSpaceObjectLegacySupport
     }
 
     /**
-     * Get the sequence ID of this bitstream
+     * Get the sequence ID of this bitstream. The sequence ID is a unique (within an Item) integer that references
+     * this bitstream. It acts as a "persistent" identifier within the Item for this Bitstream (as Bitstream names
+     * are not persistent). Because it is unique within an Item, sequence IDs are assigned by the ItemService.update()
+     * method.
      *
+     * @see org.dspace.content.ItemServiceImpl#update(Context, Item)
      * @return the sequence ID
      */
     public int getSequenceID() {
@@ -112,8 +116,12 @@ public class Bitstream extends DSpaceObject implements DSpaceObjectLegacySupport
     }
 
     /**
-     * Set the sequence ID of this bitstream
+     * Set the sequence ID of this bitstream. The sequence ID is a unique (within an Item) integer that references
+     * this bitstream. While this method is public, it should only be used by ItemService.update() or other methods
+     * which validate the uniqueness of the ID within the associated Item. This method itself does not validate
+     * uniqueness of the ID, nor does the underlying database table.
      *
+     * @see org.dspace.content.ItemServiceImpl#update(Context, Item)
      * @param sid the ID
      */
     public void setSequenceID(int sid) {

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -496,7 +496,8 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
 
         super.update(context, item);
 
-        // Set sequence IDs for bitstreams in item
+        // Set sequence IDs for bitstreams in Item. To guarantee uniqueness,
+        // sequence IDs are assigned in sequential order (starting with 1)
         int sequence = 0;
         List<Bundle> bunds = item.getBundles();
 
@@ -513,8 +514,6 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
 
         // start sequencing bitstreams without sequence IDs
         sequence++;
-
-
         for (Bundle bund : bunds) {
             List<Bitstream> streams = bund.getBitstreams();
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/BitstreamRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/BitstreamRest.java
@@ -28,6 +28,7 @@ public class BitstreamRest extends DSpaceObjectRest {
     private BitstreamFormatRest format;
     private Long sizeBytes;
     private CheckSumRest checkSum;
+    // sequenceId is READ_ONLY because it is assigned by the ItemService (as it must be unique within an Item)
     @JsonProperty(access = Access.READ_ONLY)
     private Integer sequenceId;
 


### PR DESCRIPTION
Per discussion in today's [DSpace 7 meeting](https://wiki.duraspace.org/display/DSPACE/2019-08-22+DSpace+7+Working+Group+Meeting) and in #2473 and https://github.com/DSpace/Rest7Contract/pull/68, I dug a bit deeper on why we have a "sequence_id" for Bitstreams.

@abollini was correct that the "sequence_id" seems to have been envisioned as a "unique" identifier for a Bitstream within an Item (and the ID is only unique within an Item).  I've also discovered that our ItemService actually **does assign the "sequence_id" via a simple integer sequence** (hence the name) here: https://github.com/DSpace/DSpace/blob/master/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java#L499-L529

Therefore, I believe we were correct today to decide that a "sequence_id" should be **READ ONLY** from the REST API layer, as it is assigned in the API layer.

To clarify this decision & the purpose of this field, I've enhanced the comments on methods around sequence_id.  Hopefully these will better explain (in the future) why this idea exists.  (as a sidenote: I no longer feel it should be deprecated at this time).

Please give this a quick review @benbosman and @abollini and let me know what you think!  (I will note that I did attempt to make `Bitstream.setSequenceId()` a protected method, but unfortunately it is also used by our AIP restore process to restore sequence IDs from an AIP backup.)