### PR TITLE
DS-4328

### DIFF
--- a/dspace-api/src/main/java/org/dspace/submit/step/InitialQuestionsStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/InitialQuestionsStep.java
@@ -16,6 +16,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.util.SubmissionInfo;
 import org.dspace.app.util.Util;
 import org.dspace.authorize.AuthorizeException;
@@ -230,7 +231,15 @@ public class InitialQuestionsStep extends AbstractProcessingStep
             }
         }
         else {
-            itemService.clearMetadata(context, item, MetadataSchema.DC_SCHEMA, "date", "issued", Item.ANY);
+            List<MetadataValue> metadata = itemService.getMetadata(item, "dc", "date", "issued", Item.ANY);
+            itemService.clearMetadata(context, item,MetadataSchema.DC_SCHEMA, "date", "issued", Item.ANY);
+
+            for (MetadataValue metadataValue : metadata) {
+                if(!StringUtils.equals(metadataValue.getValue(), "today")){
+                    itemService.addMetadata(context, item,MetadataSchema.DC_SCHEMA, "date", "issued", Item.ANY, metadataValue.getValue());
+                }
+            }
+
         }
 
         // commit all changes to DB

--- a/dspace-api/src/main/java/org/dspace/submit/step/InitialQuestionsStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/InitialQuestionsStep.java
@@ -229,6 +229,9 @@ public class InitialQuestionsStep extends AbstractProcessingStep
                 itemService.addMetadata(context, item, MetadataSchema.DC_SCHEMA, "date", "issued", null, "today");
             }
         }
+        else {
+            itemService.clearMetadata(context, item, MetadataSchema.DC_SCHEMA, "date", "issued", Item.ANY);
+        }
 
         // commit all changes to DB
         ContentServiceFactory.getInstance().getInProgressSubmissionService(subInfo.getSubmissionItem()).update(context, subInfo.getSubmissionItem());


### PR DESCRIPTION
This change will clear the dc.date.issued item metadata field when published is selected during the initial questions submission step. 

Jira ticket: https://jira.duraspace.org/browse/DS-4328
Fixes #7668