### PR TITLE
DS-4328

### DIFF
--- a/dspace-api/src/main/java/org/dspace/submit/step/InitialQuestionsStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/InitialQuestionsStep.java
@@ -227,6 +227,9 @@ public class InitialQuestionsStep extends AbstractProcessingStep
                 subInfo.getSubmissionItem().getItem().addDC("date", "issued", null, "today");
             }
         }
+        else {
+            subInfo.getSubmissionItem().getItem().clearMetadata("dc", "date", "issued", Item.ANY);
+        }
 
         // commit all changes to DB
         subInfo.getSubmissionItem().update();


### PR DESCRIPTION
This change will clear the dc.date.issued item metadata field when published is selected during the initial questions submission step.

Jira ticket: https://jira.duraspace.org/browse/DS-4328