### PR TITLE
[DS-4251] made sure that the test.csv file gets deleted

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/csv/CsvImportIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/csv/CsvImportIT.java
@@ -16,6 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.io.BufferedWriter;
+import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.sql.SQLException;
@@ -233,5 +234,10 @@ public class CsvImportIT extends AbstractEntityIntegrationTest {
         out = null;
 
         runDSpaceScript("metadata-import", "-f", "test.csv", "-e", "admin@email.com", "-s");
+
+        File file = new File(filename);
+        if (file.exists()) {
+            file.delete();
+        }
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/csv/CsvImportIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/csv/CsvImportIT.java
@@ -233,7 +233,7 @@ public class CsvImportIT extends AbstractEntityIntegrationTest {
         out.close();
         out = null;
 
-        runDSpaceScript("metadata-import", "-f", "test.csv", "-e", "admin@email.com", "-s");
+        runDSpaceScript("metadata-import", "-f", filename, "-e", "admin@email.com", "-s");
 
         File file = new File(filename);
         if (file.exists()) {


### PR DESCRIPTION
After running the test suite in DSpace 7, a file named test.csv would be created and ended up in the project structure because of a test in the CsvImportIT class that would create this file to run a script and not delete it afterwards.
I've now made sure that this file gets deleted after the script has ran and thus it won't stay lingering around in the project structure afterwards.