### PR TITLE
[DS-4325]: Rename Discovery configuration for Entities

### DIFF
--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -54,12 +54,12 @@
                    <entry key="workspace" value-ref="workspaceConfiguration" />
                 <entry key="workflow" value-ref="workflowConfiguration" />
 
-                <entry key="publicationConfiguration" value-ref="publicationConfiguration"/>
-                <entry key="personConfiguration" value-ref="personConfiguration"/>
-                <entry key="organizationConfiguration" value-ref="organizationConfiguration"/>
-                <entry key="publicationIssueConfiguration" value-ref="publicationIssueConfiguration"/>
-                <entry key="publicationVolumeConfiguration" value-ref="publicationVolumeConfiguration"/>
-                <entry key="periodicalConfiguration" value-ref="periodicalConfiguration"/>
+                <entry key="publication" value-ref="publication"/>
+                <entry key="person" value-ref="person"/>
+                <entry key="organization" value-ref="organization"/>
+                <entry key="publicationIssue" value-ref="publicationIssue"/>
+                <entry key="publicationVolume" value-ref="publicationVolume"/>
+                <entry key="periodical" value-ref="periodical"/>
             </map>
         </property>
         <property name="toIgnoreMetadataFields">
@@ -514,7 +514,8 @@
         <property name="spellCheckEnabled" value="true"/>
     </bean>
 
-    <bean id="publicationConfiguration" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
+    <bean id="publication" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
+        <property name="id" value="publication"/>
         <!--Which sidebar facets are to be displayed-->
         <property name="sidebarFacets">
             <list>
@@ -565,7 +566,7 @@
         <property name="defaultFilterQueries">
             <list>
                 <!--Only find items, communities and collections-->
-                <value>search.resourcetype:2 AND relationship.type:Publication</value>
+                <value>search.resourcetype:2 AND entityType_keyword:Publication</value>
             </list>
         </property>
         <!--The configuration for the recent submissions-->
@@ -583,7 +584,8 @@
         <property name="spellCheckEnabled" value="true"/>
     </bean>
 
-    <bean id="personConfiguration" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
+    <bean id="person" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
+        <property name="id" value="person"/>
         <!--Which sidebar facets are to be displayed-->
         <property name="sidebarFacets">
             <list>
@@ -626,7 +628,7 @@
         <property name="defaultFilterQueries">
             <list>
                 <!--Only find items, communities and collections-->
-                <value>search.resourcetype:2 AND relationship.type:Person</value>
+                <value>search.resourcetype:2 AND entityType_keyword:Person</value>
             </list>
         </property>
         <!--Default result per page  -->
@@ -644,8 +646,9 @@
         <property name="spellCheckEnabled" value="true"/>
     </bean>
 
-    <bean id="organizationConfiguration" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
+    <bean id="organization" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
           scope="prototype">
+        <property name="id" value="organization"/>
         <!--Which sidebar facets are to be displayed-->
         <property name="sidebarFacets">
             <list>
@@ -688,7 +691,7 @@
         <property name="defaultFilterQueries">
             <list>
                 <!--Only find items, communities and collections-->
-                <value>search.resourcetype:2 AND relationship.type:OrgUnit</value>
+                <value>search.resourcetype:2 AND entityType_keyword:OrgUnit</value>
             </list>
         </property>
         <!--The configuration for the recent submissions-->
@@ -707,8 +710,9 @@
         <property name="spellCheckEnabled" value="true"/>
     </bean>
 
-    <bean id="publicationIssueConfiguration" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
+    <bean id="publicationIssue" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
           scope="prototype">
+        <property name="id" value="publicationIssue"/>
         <!--Which sidebar facets are to be displayed-->
         <property name="sidebarFacets">
             <list>
@@ -747,7 +751,7 @@
         <property name="defaultFilterQueries">
             <list>
                 <!--Only find items, communities and collections-->
-                <value>search.resourcetype:2 AND relationship.type:JournalIssue</value>
+                <value>search.resourcetype:2 AND entityType_keyword:JournalIssue</value>
             </list>
         </property>
         <!--The configuration for the recent submissions-->
@@ -766,8 +770,9 @@
         <property name="spellCheckEnabled" value="true"/>
     </bean>
 
-    <bean id="publicationVolumeConfiguration" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
+    <bean id="publicationVolume" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
           scope="prototype">
+        <property name="id" value="publicationVolume"/>
         <!--Which sidebar facets are to be displayed-->
         <property name="sidebarFacets">
             <list>
@@ -805,7 +810,7 @@
         <property name="defaultFilterQueries">
             <list>
                 <!--Only find items, communities and collections-->
-                <value>search.resourcetype:2 AND relationship.type:JournalVolume</value>
+                <value>search.resourcetype:2 AND entityType_keyword:JournalVolume</value>
             </list>
         </property>
         <!--The configuration for the recent submissions-->
@@ -824,8 +829,9 @@
         <property name="spellCheckEnabled" value="true"/>
     </bean>
 
-    <bean id="periodicalConfiguration" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
+    <bean id="periodical" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
           scope="prototype">
+        <property name="id" value="periodical"/>
         <!--Which sidebar facets are to be displayed-->
         <property name="sidebarFacets">
             <list>
@@ -863,7 +869,7 @@
         <property name="defaultFilterQueries">
             <list>
                 <!--Only find items, communities and collections-->
-                <value>search.resourcetype:2 AND relationship.type:Journal</value>
+                <value>search.resourcetype:2 AND entityType_keyword:Journal</value>
             </list>
         </property>
         <!--The configuration for the recent submissions-->


### PR DESCRIPTION
As detailed in https://jira.duraspace.org/browse/DS-4325, this PR changes the name of the configurations.

It also contains an ID property because the configuration doesn't work correctly without this property.
The bug which requires an ID per configuration should still be solved

The `defaultFilterQueries` have also been modified to search in `entityType_keyword` instead of `relationship.type`. This the indexed field for relationship.type as defined in https://github.com/DSpace/DSpace/blob/master/dspace/config/spring/api/discovery.xml#L1061
This avoid that the filter `relationship.type:Journal` also contains items with value JournalVolume and JournalIssue.