### PR TITLE
DS-4337 implement bitstream-bitstreamformat relation endpoints

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/BitstreamFormat.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamFormat.java
@@ -275,7 +275,7 @@ public class BitstreamFormat implements Serializable, ReloadableEntity<Integer> 
             return false;
         }
         final BitstreamFormat otherBitstreamFormat = (BitstreamFormat) other;
-        if (this.getID() != otherBitstreamFormat.getID()) {
+        if (!this.getID().equals(otherBitstreamFormat.getID())) {
             return false;
         }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -208,7 +208,7 @@ public class BitstreamRestController {
      *
      * @param uuid The UUID of the bitstream for which to update the bitstream format
      * @param request  The request object
-     * @return The wrapped resource containing the new bitstream format or null when the bitstream format wasn't changed
+     * @return The wrapped resource containing the bitstream which in turn contains the bitstream format
      * @throws SQLException       If something goes wrong in the database
      */
     @RequestMapping(method = PUT, consumes = {"text/uri-list"}, value = "format")

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -7,9 +7,13 @@
  */
 package org.dspace.app.rest;
 
+import static org.dspace.app.rest.utils.ContextUtil.obtainContext;
+import static org.springframework.web.bind.annotation.RequestMethod.PUT;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -18,12 +22,17 @@ import javax.ws.rs.core.Response;
 import org.apache.catalina.connector.ClientAbortException;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.Logger;
+import org.dspace.app.rest.converter.BitstreamConverter;
+import org.dspace.app.rest.exception.DSpaceBadRequestException;
 import org.dspace.app.rest.model.BitstreamRest;
+import org.dspace.app.rest.model.hateoas.BitstreamResource;
 import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.app.rest.utils.MultipartFileSender;
+import org.dspace.app.rest.utils.Utils;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bitstream;
 import org.dspace.content.BitstreamFormat;
+import org.dspace.content.service.BitstreamFormatService;
 import org.dspace.content.service.BitstreamService;
 import org.dspace.core.Context;
 import org.dspace.disseminate.service.CitationDocumentService;
@@ -31,6 +40,8 @@ import org.dspace.services.ConfigurationService;
 import org.dspace.services.EventService;
 import org.dspace.usage.UsageEvent;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.security.access.prepost.PostAuthorize;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -54,17 +65,20 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/api/" + BitstreamRest.CATEGORY + "/" + BitstreamRest.PLURAL_NAME
-    + "/{uuid:[0-9a-fxA-FX]{8}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{12}}/content")
-public class BitstreamContentRestController {
+    + "/{uuid:[0-9a-fxA-FX]{8}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{4}-[0-9a-fxA-FX]{12}}")
+public class BitstreamRestController {
 
     private static final Logger log = org.apache.logging.log4j.LogManager
-            .getLogger(BitstreamContentRestController.class);
+            .getLogger(BitstreamRestController.class);
 
     //Most file systems are configured to use block sizes of 4096 or 8192 and our buffer should be a multiple of that.
     private static final int BUFFER_SIZE = 4096 * 10;
 
     @Autowired
     private BitstreamService bitstreamService;
+
+    @Autowired
+    BitstreamFormatService bitstreamFormatService;
 
     @Autowired
     private EventService eventService;
@@ -75,8 +89,14 @@ public class BitstreamContentRestController {
     @Autowired
     private ConfigurationService configurationService;
 
+    @Autowired
+    BitstreamConverter converter;
+
+    @Autowired
+    Utils utils;
+
     @PreAuthorize("hasPermission(#uuid, 'BITSTREAM', 'READ')")
-    @RequestMapping(method = {RequestMethod.GET, RequestMethod.HEAD})
+    @RequestMapping( method = {RequestMethod.GET, RequestMethod.HEAD}, value = "content")
     public void retrieve(@PathVariable UUID uuid, HttpServletResponse response,
                          HttpServletRequest request) throws IOException, SQLException, AuthorizeException {
 
@@ -181,5 +201,47 @@ public class BitstreamContentRestController {
         Response.Status.Family responseCode = Response.Status.Family.familyOf(response.getStatus());
         return responseCode.equals(Response.Status.Family.SUCCESSFUL)
             || responseCode.equals(Response.Status.Family.REDIRECTION);
+    }
+
+    /**
+     * This method will update the bitstream format of the bitstream that corresponds to the provided bitstream uuid.
+     *
+     * @param uuid The UUID of the bitstream for which to update the bitstream format
+     * @param request  The request object
+     * @return The wrapped resource containing the new bitstream format or null when the bitstream format wasn't changed
+     * @throws SQLException       If something goes wrong in the database
+     */
+    @RequestMapping(method = PUT, consumes = {"text/uri-list"}, value = "format")
+    @PreAuthorize("hasPermission(#uuid, 'BITSTREAM','WRITE')")
+    @PostAuthorize("returnObject != null")
+    public BitstreamResource updateBitstreamFormat(@PathVariable UUID uuid,
+                                                   HttpServletRequest request) throws SQLException {
+
+        Context context = obtainContext(request);
+
+        List<BitstreamFormat> bitstreamFormats = utils.constructBitstreamFormatList(request, context);
+
+        if (bitstreamFormats.size() > 1) {
+            throw new DSpaceBadRequestException("Only one bitstream format is allowed");
+        }
+
+        BitstreamFormat bitstreamFormat = bitstreamFormats.stream().findFirst()
+                .orElseThrow(() -> new DSpaceBadRequestException("No valid bitstream format was provided"));
+
+        Bitstream bitstream = bitstreamService.find(context, uuid);
+
+        if (bitstream == null) {
+            throw new ResourceNotFoundException("Bitstream with id: " + uuid + " not found");
+        }
+        if (bitstreamFormat.equals(bitstream.getFormat(context))) {
+            throw new DSpaceBadRequestException("The provided bitstream format is already the bitstream format");
+        }
+
+        bitstream.setFormat(context, bitstreamFormat);
+
+        context.commit();
+
+        return (BitstreamResource) utils.getResourceRepository(BitstreamRest.CATEGORY, BitstreamRest.NAME)
+                .wrapResource(converter.fromModel(context.reloadEntity(bitstream)));
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -233,9 +233,6 @@ public class BitstreamRestController {
         if (bitstream == null) {
             throw new ResourceNotFoundException("Bitstream with id: " + uuid + " not found");
         }
-        if (bitstreamFormat.equals(bitstream.getFormat(context))) {
-            throw new DSpaceBadRequestException("The provided bitstream format is already the bitstream format");
-        }
 
         bitstream.setFormat(context, bitstreamFormat);
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/Utils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/Utils.java
@@ -249,9 +249,9 @@ public class Utils {
      * This method will construct a List of BitstreamFormats out of a request.
      * It will call the {@link Utils#getStringListFromRequest(HttpServletRequest)} method to retrieve a list of links
      * out of the request.
-     * The method will iterate over this list of links and parse the links to retrieve the UUID from it.
-     * It will then look through all the DSpaceObjectServices to try and match this UUID to a DSpaceObject.
-     * If one is found, this DSpaceObject is added to the List of DSpaceObjects that we will return.
+     * The method will iterate over this list of links and parse the links to retrieve the integer ID from it.
+     * It will then retrieve the BitstreamFormat corresponding to this ID.
+     * If one is found, this BitstreamFormat is added to the List of BitstreamFormats that we will return.
      *
      * @param request   The request out of which we'll create the List of BitstreamFormats
      * @param context   The relevant DSpace context

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/Utils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/Utils.java
@@ -7,6 +7,9 @@
  */
 package org.dspace.app.rest.utils;
 
+import static java.lang.Integer.parseInt;
+import static java.util.stream.Collectors.toList;
+
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 
 import java.io.BufferedInputStream;
@@ -19,6 +22,7 @@ import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Scanner;
 
 import javax.servlet.http.HttpServletRequest;
@@ -36,7 +40,9 @@ import org.dspace.app.rest.model.RestAddressableModel;
 import org.dspace.app.rest.model.hateoas.DSpaceResource;
 import org.dspace.app.rest.repository.DSpaceRestRepository;
 import org.dspace.app.rest.repository.LinkRestRepository;
+import org.dspace.content.BitstreamFormat;
 import org.dspace.content.DSpaceObject;
+import org.dspace.content.service.BitstreamFormatService;
 import org.dspace.content.service.DSpaceObjectService;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
@@ -67,6 +73,8 @@ public class Utils {
     @Autowired(required = true)
     private List<DSpaceObjectService<? extends DSpaceObject>> dSpaceObjectServices;
 
+    @Autowired
+    private BitstreamFormatService bitstreamFormatService;
 
     public <T> Page<T> getPage(List<T> fullContents, Pageable pageable) {
         int total = fullContents.size();
@@ -235,6 +243,39 @@ public class Utils {
         } else {
             return multipartFile.getName();
         }
+    }
+
+    /**
+     * This method will construct a List of BitstreamFormats out of a request.
+     * It will call the {@link Utils#getStringListFromRequest(HttpServletRequest)} method to retrieve a list of links
+     * out of the request.
+     * The method will iterate over this list of links and parse the links to retrieve the UUID from it.
+     * It will then look through all the DSpaceObjectServices to try and match this UUID to a DSpaceObject.
+     * If one is found, this DSpaceObject is added to the List of DSpaceObjects that we will return.
+     *
+     * @param request   The request out of which we'll create the List of BitstreamFormats
+     * @param context   The relevant DSpace context
+     * @return          The resulting list of BitstreamFormats that we parsed out of the request
+     */
+    public List<BitstreamFormat> constructBitstreamFormatList(HttpServletRequest request, Context context) {
+
+        return getStringListFromRequest(request).stream()
+                .map(link -> {
+                    if (link.endsWith("/")) {
+                        link = link.substring(0, link.length() - 1);
+                    }
+                    return link.substring(link.lastIndexOf('/') + 1);
+                })
+                .map(id -> {
+                    try {
+                        return bitstreamFormatService.find(context, parseInt(id));
+                    } catch (SQLException | NumberFormatException e) {
+                        log.error("Could not find bitstream format for id: " + id, e);
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .collect(toList());
     }
 
     /**

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -7,14 +7,35 @@
  */
 package org.dspace.app.rest;
 
+import static java.util.UUID.randomUUID;
+
+import static org.apache.commons.collections.CollectionUtils.isEmpty;
+import static org.dspace.app.rest.builder.BitstreamBuilder.createBitstream;
+import static org.dspace.app.rest.builder.BitstreamFormatBuilder.createBitstreamFormat;
+import static org.dspace.app.rest.builder.CollectionBuilder.createCollection;
+import static org.dspace.app.rest.builder.CommunityBuilder.createCommunity;
+import static org.dspace.app.rest.builder.ItemBuilder.createItem;
+import static org.dspace.app.rest.builder.ResourcePolicyBuilder.createResourcePolicy;
+import static org.dspace.app.rest.matcher.BitstreamFormatMatcher.matchBitstreamFormat;
+import static org.dspace.content.BitstreamFormat.KNOWN;
+import static org.dspace.content.BitstreamFormat.SUPPORTED;
+import static org.dspace.content.BitstreamFormat.UNKNOWN;
+import static org.dspace.core.Constants.READ;
+import static org.dspace.core.Constants.WRITE;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.springframework.data.rest.webmvc.RestMediaTypes.TEXT_URI_LIST_VALUE;
+import static org.springframework.http.MediaType.parseMediaType;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.head;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.io.ByteArrayInputStream;
@@ -26,11 +47,10 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.UUID;
 
+import com.amazonaws.util.StringInputStream;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.CharEncoding;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -40,9 +60,13 @@ import org.dspace.app.rest.builder.CommunityBuilder;
 import org.dspace.app.rest.builder.GroupBuilder;
 import org.dspace.app.rest.builder.ItemBuilder;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.authorize.service.ResourcePolicyService;
 import org.dspace.content.Bitstream;
+import org.dspace.content.BitstreamFormat;
 import org.dspace.content.Collection;
+import org.dspace.content.Community;
 import org.dspace.content.Item;
+import org.dspace.content.service.BitstreamService;
 import org.dspace.core.Constants;
 import org.dspace.disseminate.CitationDocumentServiceImpl;
 import org.dspace.eperson.Group;
@@ -57,23 +81,31 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * Integration test to test the /api/core/bitstreams/[id]/content endpoint
+ * Integration test to test the /api/core/bitstreams/[id]/* endpoints
  *
  * @author Tom Desair (tom dot desair at atmire dot com)
  * @author Frederic Van Reet (frederic dot vanreet at atmire dot com)
  */
-public class BitstreamContentRestControllerIT extends AbstractControllerIntegrationTest {
+public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest {
 
     protected SolrLoggerService solrLoggerService = StatisticsServiceFactory.getInstance().getSolrLoggerService();
-
-    private static final Logger log = LogManager
-        .getLogger(BitstreamContentRestControllerIT.class);
 
     @Autowired
     private ConfigurationService configurationService;
 
     @Autowired
     private CitationDocumentServiceImpl citationDocumentService;
+
+    @Autowired
+    private BitstreamService bitstreamService;
+
+    @Autowired
+    private ResourcePolicyService resourcePolicyService;
+
+    private Bitstream bitstream;
+    private BitstreamFormat supportedFormat;
+    private BitstreamFormat knownFormat;
+    private BitstreamFormat unknownFormat;
 
     @BeforeClass
     public static void clearStatistics() throws Exception {
@@ -83,10 +115,45 @@ public class BitstreamContentRestControllerIT extends AbstractControllerIntegrat
     }
 
     @Before
-    public void setup() throws Exception {
+    @Override
+    public void setUp() throws Exception {
+
         super.setUp();
 
         configurationService.setProperty("citation-page.enable_globally", false);
+
+        context.turnOffAuthorisationSystem();
+
+        Community community = createCommunity(context).build();
+        Collection collection = createCollection(context, community).build();
+        Item item = createItem(context, collection).build();
+
+        bitstream = createBitstream(context, item, new StringInputStream("test")).build();
+
+        unknownFormat = createBitstreamFormat(context)
+                .withMimeType("unknown test mime type")
+                .withDescription("unknown test description")
+                .withShortDescription("unknown test short description")
+                .withSupportLevel(UNKNOWN)
+                .build();
+
+        knownFormat = createBitstreamFormat(context)
+                .withMimeType("known test mime type")
+                .withDescription("known test description")
+                .withShortDescription("known test short description")
+                .withSupportLevel(KNOWN)
+                .build();
+
+        supportedFormat = createBitstreamFormat(context)
+                .withMimeType("supported mime type")
+                .withDescription("supported description")
+                .withShortDescription("supported short description")
+                .withSupportLevel(SUPPORTED)
+                .build();
+
+        bitstream.setFormat(context, supportedFormat);
+
+        context.restoreAuthSystemState();
     }
 
     @Test
@@ -425,5 +492,152 @@ public class BitstreamContentRestControllerIT extends AbstractControllerIntegrat
         }
     }
 
+    @Test
+    public void getBitstreamFormatUnauthorized() throws Exception {
 
+        resourcePolicyService.removePolicies(context, bitstream, READ);
+
+        getClient()
+                .perform(get("/api/core/bitstreams/" + bitstream.getID() + "/format"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void getBitstreamFormatForbidden() throws Exception {
+
+        resourcePolicyService.removePolicies(context, bitstream, READ);
+
+        getClient(getAuthToken(eperson.getEmail(), password))
+                .perform(get("/api/core/bitstreams/" + bitstream.getID() + "/format"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void getBitstreamFormat() throws Exception {
+
+        getClient()
+                .perform(get("/api/core/bitstreams/" + bitstream.getID() + "/format"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", matchBitstreamFormat(
+                        supportedFormat.getID(),
+                        supportedFormat.getMIMEType(),
+                        supportedFormat.getDescription(),
+                        supportedFormat.getShortDescription(),
+                        "SUPPORTED"
+                )));
+    }
+
+    @Test
+    public void updateBitstreamFormatBadRequest() throws Exception {
+
+        getClient(getAuthToken(admin.getEmail(), password)).perform(
+                put("/api/core/bitstreams/" + bitstream.getID() + "/format")
+                        .contentType(parseMediaType(TEXT_URI_LIST_VALUE))
+                        .content(
+                                REST_SERVER_URL + "/api/core/bitstreamformat/-1"
+                        )
+        ).andExpect(status().isBadRequest());
+
+        getClient(getAuthToken(admin.getEmail(), password)).perform(
+                put("/api/core/bitstreams/" + bitstream.getID() + "/format")
+                        .contentType(parseMediaType(TEXT_URI_LIST_VALUE))
+                        .content(
+                                REST_SERVER_URL + "/api/core/bitstreamformat/" + knownFormat.getID()
+                                        + "\n https://localhost:8080/spring-rest/api/core/bitstreamformat/"
+                                        + supportedFormat.getID()
+                        )
+        ).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void updateBitstreamFormatNotFound() throws Exception {
+
+        getClient(getAuthToken(admin.getEmail(), password)).perform(
+                put("/api/core/bitstreams/" + randomUUID() + "/format")
+                        .contentType(parseMediaType(TEXT_URI_LIST_VALUE))
+                        .content(
+                                REST_SERVER_URL + "/api/core/bitstreamformat/" + unknownFormat.getID()
+                        )
+        ).andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void updateBitstreamFormatUnauthorized() throws Exception {
+
+        getClient().perform(
+                put("/api/core/bitstreams/" + bitstream.getID() + "/format")
+                        .contentType(parseMediaType(TEXT_URI_LIST_VALUE))
+                        .content(
+                                REST_SERVER_URL + "/api/core/bitstreamformat/" + knownFormat.getID()
+                        )
+        ).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void updateBitstreamFormatForbidden() throws Exception {
+
+        getClient(getAuthToken(eperson.getEmail(), password)).perform(
+                put("/api/core/bitstreams/" + bitstream.getID() + "/format")
+                        .contentType(parseMediaType(TEXT_URI_LIST_VALUE))
+                        .content(
+                                REST_SERVER_URL + "/api/core/bitstreamformat/" + knownFormat.getID()
+                        )
+        ).andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void updateBitstreamFormatEPerson() throws Exception {
+
+        context.turnOffAuthorisationSystem();
+
+        createResourcePolicy(context)
+                .withUser(eperson)
+                .withAction(WRITE)
+                .withDspaceObject(bitstream)
+                .build();
+
+        bitstreamService.addMetadata(context, bitstream, "dc", "format", null, null, "test format");
+
+        context.restoreAuthSystemState();
+
+        getClient(getAuthToken(eperson.getEmail(), password)).perform(
+                put("/api/core/bitstreams/" + bitstream.getID() + "/format")
+                        .contentType(parseMediaType(TEXT_URI_LIST_VALUE))
+                        .content(
+                                REST_SERVER_URL + "/api/core/bitstreamformat/" + knownFormat.getID()
+                        )
+        ).andExpect(status().isOk());
+
+        bitstream = context.reloadEntity(bitstream);
+
+        assertThat(knownFormat, equalTo(bitstream.getFormat(context)));
+        assertTrue(isEmpty(
+                bitstreamService.getMetadataByMetadataString(bitstream, "dc.format")
+        ));
+    }
+
+    @Test
+    public void updateBitstreamFormatAdmin() throws Exception {
+
+        context.turnOffAuthorisationSystem();
+
+        bitstreamService.addMetadata(context, bitstream, "dc", "format", null, null, "another test format");
+
+        context.restoreAuthSystemState();
+
+        getClient(getAuthToken(admin.getEmail(), password)).perform(
+                put("/api/core/bitstreams/" + bitstream.getID() + "/format")
+                        .contentType(parseMediaType(TEXT_URI_LIST_VALUE))
+                        .content(
+                                REST_SERVER_URL + "/api/core/bitstreamformat/" + unknownFormat.getID()
+                        )
+        ).andExpect(status().isOk());
+
+        bitstream = context.reloadEntity(bitstream);
+
+        assertThat(unknownFormat, equalTo(bitstream.getFormat(context)));
+        assertTrue(isEmpty(
+                bitstreamService.getMetadataByMetadataString(bitstream, "dc.format")
+        ));
+    }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -21,7 +21,6 @@ import static org.dspace.app.rest.builder.ResourcePolicyBuilder.createResourcePo
 import static org.dspace.app.rest.matcher.BitstreamFormatMatcher.matchBitstreamFormat;
 import static org.dspace.content.BitstreamFormat.KNOWN;
 import static org.dspace.content.BitstreamFormat.SUPPORTED;
-import static org.dspace.content.BitstreamFormat.UNKNOWN;
 import static org.dspace.core.Constants.READ;
 import static org.dspace.core.Constants.WRITE;
 import static org.hamcrest.CoreMatchers.not;
@@ -133,7 +132,9 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
         Collection collection = createCollection(context, community).build();
         Item item = createItem(context, collection).build();
 
-        bitstream = createBitstream(context, item, toInputStream("test", UTF_8)).build();
+        bitstream = createBitstream(context, item, toInputStream("test", UTF_8))
+                .withFormat("test format")
+                .build();
 
         unknownFormat = bitstreamFormatService.findUnknown(context);
 
@@ -596,8 +597,6 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
                 .withDspaceObject(bitstream)
                 .build();
 
-        bitstreamService.addMetadata(context, bitstream, "dc", "format", null, null, "test format");
-
         context.restoreAuthSystemState();
 
         getClient(getAuthToken(eperson.getEmail(), password)).perform(
@@ -620,8 +619,6 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
     public void updateBitstreamFormatAdmin() throws Exception {
 
         context.turnOffAuthorisationSystem();
-
-        bitstreamService.addMetadata(context, bitstream, "dc", "format", null, null, "another test format");
 
         context.restoreAuthSystemState();
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/builder/BitstreamBuilder.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/builder/BitstreamBuilder.java
@@ -75,6 +75,13 @@ public class BitstreamBuilder extends AbstractDSpaceObjectBuilder<Bitstream> {
         return this;
     }
 
+    public BitstreamBuilder withFormat(String format) throws SQLException {
+
+        bitstreamService.addMetadata(context, bitstream, "dc", "format", null, null, format);
+
+        return this;
+    }
+
     private Bundle getOriginalBundle(Item item) throws SQLException, AuthorizeException {
         List<Bundle> bundles = itemService.getBundles(item, ORIGINAL);
         Bundle targetBundle = null;


### PR DESCRIPTION
This PR provides GET & PUT endpoints for the bitstream format of a bitstream, as described in these changes to the REST contract:

https://github.com/DSpace/Rest7Contract/pull/68

The GET endpoint was already functioning by this endpoint:

https://github.com/DSpace/DSpace/blob/master/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java#L324

But an IT for this wasn't added yet.

see https://jira.duraspace.org/browse/DS-4337