### PR TITLE
DS-4340 Duplicate Headers when bitstream has a comma in the title

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/util/UIUtil.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/util/UIUtil.java
@@ -587,7 +587,7 @@ public class UIUtil extends Util
 		}
 		finally
 		{
-			response.setHeader("Content-Disposition", "attachment;filename=" + name);
+			response.setHeader("Content-Disposition", "attachment;filename=" + '"' + name + '"');
 		}
 	}
 	


### PR DESCRIPTION
Fixes #7680
The original issue DS-1422 (#4791) was fixed only in the XMLUI