### PR TITLE
[DS-3849] REST API items resource returns items in non-deterministic order (master port)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
@@ -306,6 +306,8 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
                 criteriaBuilder.notEqual(itemRoot.get(Item_.owningCollection), collection),
                 criteriaBuilder.isMember(collection, itemRoot.get(Item_.collections)),
                 criteriaBuilder.isTrue(itemRoot.get(Item_.inArchive))));
+        criteriaQuery.orderBy(criteriaBuilder.asc(itemRoot.get(Item_.id)));
+        criteriaQuery.groupBy(itemRoot.get(Item_.id));
         return list(context, criteriaQuery, false, Item.class, limit, offset).iterator();
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
@@ -320,6 +320,7 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
                 criteriaBuilder.isMember(collection, itemRoot.get(Item_.collections)),
                 criteriaBuilder.isTrue(itemRoot.get(Item_.inArchive))));
         criteriaQuery.orderBy(criteriaBuilder.asc(itemRoot.get(Item_.id)));
+        criteriaQuery.groupBy(itemRoot.get(Item_.id));
         return count(context, criteriaQuery, criteriaBuilder, itemRoot);
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
@@ -319,8 +319,6 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
                 criteriaBuilder.notEqual(itemRoot.get(Item_.owningCollection), collection),
                 criteriaBuilder.isMember(collection, itemRoot.get(Item_.collections)),
                 criteriaBuilder.isTrue(itemRoot.get(Item_.inArchive))));
-        criteriaQuery.orderBy(criteriaBuilder.asc(itemRoot.get(Item_.id)));
-        criteriaQuery.groupBy(itemRoot.get(Item_.id));
         return count(context, criteriaQuery, criteriaBuilder, itemRoot);
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
@@ -32,6 +32,7 @@ import org.dspace.eperson.EPerson;
 import org.hibernate.Criteria;
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.DetachedCriteria;
+import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Property;
 import org.hibernate.criterion.Restrictions;
@@ -54,14 +55,14 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
 
     @Override
     public Iterator<Item> findAll(Context context, boolean archived) throws SQLException {
-        Query query = createQuery(context, "FROM Item WHERE inArchive= :in_archive");
+        Query query = createQuery(context, "FROM Item WHERE inArchive= :in_archive order by id");
         query.setParameter("in_archive", archived);
         return iterate(query);
     }
 
     @Override
     public Iterator<Item> findAll(Context context, boolean archived, int limit, int offset) throws SQLException {
-        Query query = createQuery(context, "FROM Item WHERE inArchive= :in_archive");
+        Query query = createQuery(context, "FROM Item WHERE inArchive= :in_archive order by id");
         query.setParameter("in_archive", archived);
         query.setFirstResult(offset);
         query.setMaxResults(limit);
@@ -71,7 +72,8 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
 
     @Override
     public Iterator<Item> findAll(Context context, boolean archived, boolean withdrawn) throws SQLException {
-        Query query = createQuery(context, "FROM Item WHERE inArchive= :in_archive or withdrawn = :withdrawn");
+        Query query = createQuery(context, "FROM Item WHERE inArchive= :in_archive or withdrawn = :withdrawn " +
+            "order by id");
         query.setParameter("in_archive", archived);
         query.setParameter("withdrawn", withdrawn);
         return iterate(query);
@@ -90,6 +92,8 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
             queryStr.append(" AND last_modified > :last_modified");
         }
 
+        queryStr.append(" order by id");
+
         Query query = createQuery(context, queryStr.toString());
         query.setParameter("in_archive", archived);
         query.setParameter("withdrawn", withdrawn);
@@ -102,7 +106,8 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
 
     @Override
     public Iterator<Item> findBySubmitter(Context context, EPerson eperson) throws SQLException {
-        Query query = createQuery(context, "FROM Item WHERE inArchive= :in_archive and submitter= :submitter");
+        Query query = createQuery(context, "FROM Item WHERE inArchive= :in_archive and submitter= :submitter " +
+            "order by id");
         query.setParameter("in_archive", true);
         query.setParameter("submitter", eperson);
         return iterate(query);
@@ -135,7 +140,7 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
         if (value != null) {
             hqlQueryString += " AND STR(metadatavalue.value) = :text_value";
         }
-        Query query = createQuery(context, hqlQueryString);
+        Query query = createQuery(context, hqlQueryString + " order by item.id");
 
         query.setParameter("in_archive", inArchive);
         query.setParameter("metadata_field", metadataField);
@@ -251,6 +256,9 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
                 criteria.add(Subqueries.notExists(subcriteria));
             }
         }
+
+        criteria.addOrder(Order.asc("item.id"));
+
         log.debug(String.format("Running custom query with %d filters", index));
 
         return ((List<Item>) criteria.list()).iterator();
@@ -263,7 +271,7 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
         Query query = createQuery(context,
                   "SELECT item FROM Item as item join item.metadata metadatavalue " +
                   "WHERE item.inArchive=:in_archive AND metadatavalue.metadataField = :metadata_field AND " +
-                      "metadatavalue.authority = :authority");
+                      "metadatavalue.authority = :authority order by item.id");
         query.setParameter("in_archive", inArchive);
         query.setParameter("metadata_field", metadataField);
         query.setParameter("authority", authority);
@@ -275,7 +283,7 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
                                                    Integer offset) throws SQLException {
         Query query = createQuery(context,
               "select i from Item i join i.collections c " +
-              "WHERE :collection IN c AND i.inArchive=:in_archive");
+              "WHERE :collection IN c AND i.inArchive=:in_archive  order by i.id");
         query.setParameter("collection", collection);
         query.setParameter("in_archive", true);
         if (offset != null) {
@@ -311,12 +319,14 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
                 criteriaBuilder.notEqual(itemRoot.get(Item_.owningCollection), collection),
                 criteriaBuilder.isMember(collection, itemRoot.get(Item_.collections)),
                 criteriaBuilder.isTrue(itemRoot.get(Item_.inArchive))));
+        criteriaQuery.orderBy(criteriaBuilder.asc(itemRoot.get(Item_.id)));
         return count(context, criteriaQuery, criteriaBuilder, itemRoot);
     }
 
     @Override
     public Iterator<Item> findAllByCollection(Context context, Collection collection) throws SQLException {
-        Query query = createQuery(context, "select i from Item i join i.collections c WHERE :collection IN c");
+        Query query = createQuery(context, "select i from Item i join i.collections c WHERE :collection IN c " +
+            "order by i.id");
         query.setParameter("collection", collection);
 
         return iterate(query);
@@ -325,7 +335,8 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
     @Override
     public Iterator<Item> findAllByCollection(Context context, Collection collection, Integer limit, Integer offset)
         throws SQLException {
-        Query query = createQuery(context, "select i from Item i join i.collections c WHERE :collection IN c");
+        Query query = createQuery(context, "select i from Item i join i.collections c WHERE :collection IN c " +
+            "order by i.id");
         query.setParameter("collection", collection);
 
         if (offset != null) {
@@ -370,7 +381,7 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
     @Override
     public Iterator<Item> findByLastModifiedSince(Context context, Date since)
         throws SQLException {
-        Query query = createQuery(context, "SELECT i FROM item i WHERE last_modified > :last_modified");
+        Query query = createQuery(context, "SELECT i FROM item i WHERE last_modified > :last_modified order by id");
         query.setParameter("last_modified", since, TemporalType.TIMESTAMP);
         return iterate(query);
     }


### PR DESCRIPTION
This PR updates the ItemDAOImpl class to make sure all item lists returned by this class will now be in a deterministic order.

Jira Issue: https://jira.duraspace.org/browse/DS-3849

Fixes #7196 