### PR TITLE
DS-4342 improve performance when retrieving items from a collection

### DIFF
--- a/dspace-rest/src/main/java/org/dspace/rest/CollectionsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/CollectionsResource.java
@@ -273,19 +273,17 @@ public class CollectionsResource extends Resource
                     headers, request, context);
 
             items = new ArrayList<Item>();
-            Iterator<org.dspace.content.Item> dspaceItems = itemService.findByCollection(context, dspaceCollection);
-            for (int i = 0; (dspaceItems.hasNext()) && (i < (limit + offset)); i++)
-            {
+            Iterator<org.dspace.content.Item> dspaceItems = itemService.findByCollection(context, dspaceCollection,
+                                                                                         limit, offset);
+
+            while (dspaceItems.hasNext()) {
                 org.dspace.content.Item dspaceItem = dspaceItems.next();
 
-                if (i >= offset)
+                if (itemService.isItemListedForUser(context, dspaceItem))
                 {
-                    if (itemService.isItemListedForUser(context, dspaceItem))
-                    {
-                        items.add(new Item(dspaceItem, servletContext, expand, context));
-                        writeStats(dspaceItem, UsageEvent.Action.VIEW, user_ip, user_agent, xforwardedfor,
-                                headers, request, context);
-                    }
+                    items.add(new Item(dspaceItem, servletContext, expand, context));
+                    writeStats(dspaceItem, UsageEvent.Action.VIEW, user_ip, user_agent, xforwardedfor,
+                               headers, request, context);
                 }
             }
 


### PR DESCRIPTION
Fixes #7682
This PR updates the CollectionsResource.getCollectionItems method to include the limit and offset parameters when retrieving items for a collection, instead of retrieving al items for a collection.

This should improve the performance of the collections/collection_id/items REST endpoint.
