### PR TITLE
[DS-4144] Update node and npm versions for mirage 2 (5.x)

### DIFF
--- a/dspace/modules/xmlui-mirage2/pom.xml
+++ b/dspace/modules/xmlui-mirage2/pom.xml
@@ -26,8 +26,8 @@
         <!-- These versions should be kept in sync with ./.travis.yml -->
         <sass.version>3.4.25</sass.version>
         <compass.version>1.0.1</compass.version>
-        <node.version>0.10.31</node.version>
-        <npm.version>1.4.23</npm.version>
+        <node.version>8.10.0</node.version>
+        <npm.version>6.5.0</npm.version>
         <!-- Override version of JRuby that gem-maven-plugin installs when "mirage2.deps.included=true" -->
         <jruby.version>9.1.17.0</jruby.version>
     </properties>


### PR DESCRIPTION
JIRA: https://jira.duraspace.org/browse/DS-4144
This small change brings node and npm versions up to date in DSpace 5.x
This fixes an issue where mirage2 is failing to build in some versions of DSpace 5.