### PR TITLE
[DS-4144] Update node and npm versions for mirage 2 (6.x)

### DIFF
--- a/dspace/modules/xmlui-mirage2/pom.xml
+++ b/dspace/modules/xmlui-mirage2/pom.xml
@@ -26,8 +26,8 @@
         <!-- These versions should be kept in sync with ./.travis.yml -->
         <sass.version>3.4.25</sass.version>
         <compass.version>1.0.1</compass.version>
-        <node.version>6.5.0</node.version>
-        <npm.version>3.10.8</npm.version>
+        <node.version>8.10.0</node.version>
+        <npm.version>6.5.0</npm.version>
         <!-- Override version of JRuby that gem-maven-plugin installs when "mirage2.deps.included=true" -->
         <jruby.version>9.1.17.0</jruby.version>
     </properties>


### PR DESCRIPTION
JIRA: https://jira.duraspace.org/browse/DS-4144
This small change brings node and npm versions up to date as per the fix for DSpace 5.x -- the 6.x mirage2 builds aren't actually failing currently, but we might as well bring the versions up to date and get them matched up.