### PR TITLE
[DS-4346] 6x: Add default docker-compose file to code base

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 */target/
 dspace/modules/*/target/
 Dockerfile.*
+dspace/modules/src/main/docker-compose

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 
 [![Build Status](https://travis-ci.org/DSpace/DSpace.png?branch=master)](https://travis-ci.org/DSpace/DSpace)
 
-[DSpace Documentation](https://wiki.duraspace.org/display/DSDOC/) | 
+[DSpace Documentation](https://wiki.duraspace.org/display/DSDOC/) |
 [DSpace Releases](https://github.com/DSpace/DSpace/releases) |
-[DSpace Wiki](https://wiki.duraspace.org/display/DSPACE/Home) | 
+[DSpace Wiki](https://wiki.duraspace.org/display/DSPACE/Home) |
 [Support](https://wiki.duraspace.org/display/DSPACE/Support)
 
-DSpace open source software is a turnkey repository application used by more than 
+DSpace open source software is a turnkey repository application used by more than
 1000+ organizations and institutions worldwide to provide durable access to digital resources.
 For more information, visit http://www.dspace.org/
 
@@ -20,18 +20,21 @@ Past releases are all available via GitHub at https://github.com/DSpace/DSpace/r
 
 ## Documentation / Installation
 
-Documentation for each release may be viewed online or downloaded via our [Documentation Wiki](https://wiki.duraspace.org/display/DSDOC/). 
+Documentation for each release may be viewed online or downloaded via our [Documentation Wiki](https://wiki.duraspace.org/display/DSDOC/).
 
 The latest DSpace Installation instructions are available at:
 https://wiki.duraspace.org/display/DSDOC6x/Installing+DSpace
 
-Please be aware that, as a Java web application, DSpace requires a database (PostgreSQL or Oracle) 
+Please be aware that, as a Java web application, DSpace requires a database (PostgreSQL or Oracle)
 and a servlet container (usually Tomcat) in order to function.
 More information about these and all other prerequisites can be found in the Installation instructions above.
 
+## Running DSpace 6 in Docker
+See [Running DSpace 6 with Docker Compose](dspace/src/main/docker-compose/README.md)
+
 ## Contributing
 
-DSpace is a community built and supported project. We do not have a centralized development or support team, 
+DSpace is a community built and supported project. We do not have a centralized development or support team,
 but have a dedicated group of volunteers who help us improve the software, documentation, resources, etc.
 
 We welcome contributions of any type. Here's a few basic guides that provide suggestions for contributing to DSpace:
@@ -55,8 +58,8 @@ We welcome everyone to participate in these lists:
 
 Additional support options are listed at https://wiki.duraspace.org/display/DSPACE/Support
 
-DSpace also has an active service provider network. If you'd rather hire a service provider to 
-install, upgrade, customize or host DSpace, then we recommend getting in touch with one of our 
+DSpace also has an active service provider network. If you'd rather hire a service provider to
+install, upgrade, customize or host DSpace, then we recommend getting in touch with one of our
 [Registered Service Providers](http://www.dspace.org/service-providers).
 
 ## Issue Tracker

--- a/docker-compose-cli.yml
+++ b/docker-compose-cli.yml
@@ -1,3 +1,11 @@
+#
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
+#
+# http://www.dspace.org/license/
+#
+
 version: "3.7"
 
 services:

--- a/docker-compose-cli.yml
+++ b/docker-compose-cli.yml
@@ -1,0 +1,25 @@
+version: "3.7"
+
+services:
+  dspace-cli:
+    image: dspace/dspace-cli:local-branch
+    container_name: dspace-cli
+    build:
+      context: .
+      dockerfile: Dockerfile.cli.jdk8
+    #environment:
+    volumes:
+    - ./dspace/src/main/docker-compose/local.cfg:/dspace/config/local.cfg
+    - assetstore:/dspace/assetstore
+    entrypoint: /dspace/bin/dspace
+    command: help
+    networks:
+      - dspacenet
+    tty: true
+    stdin_open: true
+
+volumes:
+  assetstore:
+
+networks:
+  dspacenet:

--- a/docker-compose-cli.yml
+++ b/docker-compose-cli.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   dspace-cli:
-    image: dspace/dspace-cli:local-branch
+    image: "dspace/dspace-cli:${DSPACE_VER:-dspace-6_x}"
     container_name: dspace-cli
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,11 @@
+#
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
+#
+# http://www.dspace.org/license/
+#
+
 version: '3.7'
 networks:
   dspacenet:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '3.7'
+networks:
+  dspacenet:
+services:
+  dspace:
+    container_name: dspace
+    depends_on:
+    - dspacedb
+    image: "${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-dspace-6_x-jdk8-test}"
+    build:
+      context: .
+      dockerfile: Dockerfile.jdk8-test
+    networks:
+      dspacenet:
+    ports:
+    - published: 8080
+      target: 8080
+    stdin_open: true
+    tty: true
+    volumes:
+    - ./dspace/src/main/docker-compose/local.cfg:/dspace/config/local.cfg
+    - ./dspace/src/main/docker-compose/xmlui.xconf:/dspace/config/xmlui.xconf
+    - assetstore:/dspace/assetstore
+    - solr_authority:/dspace/solr/authority/data
+    - solr_oai:/dspace/solr/oai/data
+    - solr_search:/dspace/solr/search/data
+    - solr_statistics:/dspace/solr/statistics/data
+  dspacedb:
+    container_name: dspacedb
+    environment:
+      PGDATA: /pgdata
+    image: dspace/dspace-postgres-pgcrypto
+    networks:
+      dspacenet:
+    stdin_open: true
+    tty: true
+    volumes:
+    - pgdata:/pgdata
+volumes:
+  assetstore:
+  pgdata:
+  solr_authority:
+  solr_oai:
+  solr_search:
+  solr_statistics:

--- a/dspace/src/main/docker-compose/README.md
+++ b/dspace/src/main/docker-compose/README.md
@@ -1,0 +1,36 @@
+# Docker Compose Resources
+
+- cli.ingest.yml
+  - Docker compose file that will run an AIP ingest into DSpace 6.
+- local.cfg
+  - Sets the environment used across containers run with docker-compose
+- xmlui.xconf
+  - Brings up the XMLUI Mirage2 theme by default.
+
+## To run a published DSpace image from your branch
+
+```
+docker-compose -p d6 up -d
+```
+
+## To build start DSpace from your branch
+```
+docker-compose -p d6 up --build -d
+```
+
+## Ingesting test content
+
+Compile your local changes for the DSpace CLI container
+```
+docker-compose -p d6 -f docker-compose-cli.yml build
+```
+
+Create an admin account.  By default, the dspace-cli container runs the dspace command.
+```
+docker-compose -p d6 -f docker-compose-cli.yml run dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
+```
+
+Download a Zip file of AIP content and ingest test data
+```
+docker-compose -p d6 -f docker-compose-cli.yml -f dspace/src/main/docker-compose/cli.ingest.yml run dspace-cli
+```

--- a/dspace/src/main/docker-compose/README.md
+++ b/dspace/src/main/docker-compose/README.md
@@ -1,5 +1,13 @@
 # Docker Compose Resources
 
+## Root directory
+- docker-compose.yml
+  - Docker compose file to orchestrate DSpace 6 components
+- docker-compose-cli
+  - Docker compose file to run DSpace CLI tasks within a running DSpace instance in Docker
+
+## dspace/src/main/docker-compose
+
 - cli.ingest.yml
   - Docker compose file that will run an AIP ingest into DSpace 6.
 - local.cfg

--- a/dspace/src/main/docker-compose/README.md
+++ b/dspace/src/main/docker-compose/README.md
@@ -15,23 +15,23 @@
 - xmlui.xconf
   - Brings up the XMLUI Mirage2 theme by default.
 
-## To run a published DSpace image from your branch
+## To refresh / pull DSpace images from Dockerhub
+```
+docker-compose -f docker-compose.yml -f docker-compose-cli.yml pull
+```
+
+## To build DSpace images using code in your branch
+```
+docker-compose -f docker-compose.yml -f docker-compose-cli.yml build
+```
+
+## To run DSpace from your branch
 
 ```
 docker-compose -p d6 up -d
 ```
 
-## To build start DSpace from your branch
-```
-docker-compose -p d6 up --build -d
-```
-
 ## Ingesting test content
-
-Compile your local changes for the DSpace CLI container
-```
-docker-compose -p d6 -f docker-compose-cli.yml build
-```
 
 Create an admin account.  By default, the dspace-cli container runs the dspace command.
 ```

--- a/dspace/src/main/docker-compose/cli.ingest.yml
+++ b/dspace/src/main/docker-compose/cli.ingest.yml
@@ -1,0 +1,26 @@
+version: "3.7"
+
+services:
+  dspace-cli:
+    environment:
+    - AIPZIP=https://github.com/DSpace-Labs/AIP-Files/raw/master/dogAndReport.zip
+    - ADMIN_EMAIL=test@test.edu
+    - AIPDIR=/tmp/aip-dir
+    entrypoint:
+      - /bin/bash
+      - '-c'
+      - |
+          rm -rf $${AIPDIR}
+          mkdir $${AIPDIR} /dspace/upload
+          cd $${AIPDIR}
+          pwd
+          curl $${AIPZIP} -L -s --output aip.zip
+          unzip aip.zip
+          cd $${AIPDIR}
+
+          /dspace/bin/dspace packager -r -a -t AIP -e $${ADMIN_EMAIL} -f -u SITE*.zip
+          /dspace/bin/dspace database update-sequences
+          touch /dspace/solr/search/conf/reindex.flag
+
+          /dspace/bin/dspace oai import
+          /dspace/bin/dspace oai clean-cache

--- a/dspace/src/main/docker-compose/cli.ingest.yml
+++ b/dspace/src/main/docker-compose/cli.ingest.yml
@@ -5,6 +5,7 @@
 #
 # http://www.dspace.org/license/
 #
+
 version: "3.7"
 
 services:

--- a/dspace/src/main/docker-compose/cli.ingest.yml
+++ b/dspace/src/main/docker-compose/cli.ingest.yml
@@ -1,3 +1,10 @@
+#
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
+#
+# http://www.dspace.org/license/
+#
 version: "3.7"
 
 services:

--- a/dspace/src/main/docker-compose/local.cfg
+++ b/dspace/src/main/docker-compose/local.cfg
@@ -1,0 +1,6 @@
+dspace.dir=/dspace
+db.url=jdbc:postgresql://dspacedb:5432/dspace
+dspace.hostname=localhost
+dspace.baseUrl=http://localhost:8080
+dspace.name=DSpace Started with Docker Compose
+solr.server=http://dspace:8080/solr

--- a/dspace/src/main/docker-compose/xmlui.xconf
+++ b/dspace/src/main/docker-compose/xmlui.xconf
@@ -1,0 +1,176 @@
+<?xml version="1.0"?>
+<!DOCTYPE xmlui SYSTEM "xmlui.dtd">
+
+<!--
+    - xmlui.xconf
+    -
+    - Copyright (c) 2002-2009, The DSpace Foundation.  All rights reserved.
+    -
+    - Redistribution and use in source and binary forms, with or without
+    - modification, are permitted provided that the following conditions are
+    - met:
+    -
+    - - Redistributions of source code must retain the above copyright
+    - notice, this list of conditions and the following disclaimer.
+    -
+    - - Redistributions in binary form must reproduce the above copyright
+    - notice, this list of conditions and the following disclaimer in the
+    - documentation and/or other materials provided with the distribution.
+    -
+    - Neither the name of the DSpace Foundation nor the names of its
+    - contributors may be used to endorse or promote products derived from
+    - this software without specific prior written permission.
+    -
+    - THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    - ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    - LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    - A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    - HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    - INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    - BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+    - OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+    - ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+    - TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+    - USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+    - DAMAGE.
+-->
+
+
+<!--
+    - The XMLUI (Manakin Release) configuration file
+    -
+    - Authors: Scott Phillips
+    - Version: $Revision$
+    - Date:    $Date$
+-->
+
+<xmlui>
+    <!--
+        This section configures the Aspect "chain". An Aspect provides a set
+        of coupled features for the system. All Aspects are chained together
+        such that together they form the complete DSpace website. This is where
+        the chain is defined, the order in which each aspect is declared
+        determines it's order in the chain. Aspects at the top are invoked
+        first.
+
+        The <aspect> element has two attributes, name & path. The name is used
+        to identify the Aspect, while the path determines the directory. The
+        path attribute should be listed exactly as it is found in the
+        /xmlui/cocoon/aspects/ directory followed by a slash.
+    -->
+    <aspects>
+        <!-- =====================
+             Item Level Versioning
+             ===================== -->
+        <!--
+             To enable Item Level Versioning features, uncomment this aspect.
+             This is currently disabled by default because of one known issue:
+             DS-1382. Please, review them to see whether they apply
+             to you before enabling versioning.
+        -->
+        <!--<aspect name="Versioning Aspect" path="resource://aspects/Versioning/" />-->
+
+        <!-- =====================
+             Base Features/Aspects
+             ===================== -->
+        <!-- Base DSpace XMLUI Aspects for Display, Browse, Search, Admin, Login and Submission -->
+        <aspect name="Displaying Artifacts" path="resource://aspects/ViewArtifacts/" />
+        <aspect name="Browsing Artifacts" path="resource://aspects/BrowseArtifacts/" />
+        <aspect name="Discovery" path="resource://aspects/Discovery/" />
+        <aspect name="Administration" path="resource://aspects/Administrative/" />
+        <aspect name="E-Person" path="resource://aspects/EPerson/" />
+        <aspect name="Submission and Workflow" path="resource://aspects/Submission/" />
+
+        <!-- ========================
+             Usage Statistics Engines
+             ======================== -->
+        <!-- By default, DSpace uses a Statistics engine based on SOLR -->
+        <aspect name="Statistics" path="resource://aspects/Statistics/" />
+
+        <!--
+             If you prefer to use "Elastic Search" Statistics, you can uncomment the below
+             aspect and COMMENT OUT the default "Statistics" aspect above.
+             You must also enable the ElasticSearchLoggerEventListener.
+        -->
+        <!-- <aspect name="Statistics - Elastic Search" path="resource://aspects/StatisticsElasticSearch/" /> -->
+
+        <!-- Additionally you may choose to expose your Google Analytics statistics in DSpace -->
+        <!-- <aspect name="StatisticsGoogleAnalytics" path="resource://aspects/StatisticsGoogleAnalytics/" /> -->
+
+        <!-- =========================
+             Approval Workflow Systems
+             ========================= -->
+        <!-- By default, DSpace uses a legacy 3-step approval workflow for new submissions -->
+        <aspect name="Original Workflow" path="resource://aspects/Workflow/" />
+
+        <!-- If you prefer, a Configurable XML-based Workflow is available. To enable it, you can
+             uncomment the below aspect and comment out the "Original Workflow" aspect above.
+             PLEASE NOTE: in order to use the configurable workflow you must also run the
+             database migration scripts as detailed in the DSpace Documentation -->
+        <!-- <aspect name="XMLWorkflow" path="resource://aspects/XMLWorkflow/" /> -->
+
+        <!-- ==============
+             SWORDv1 Client
+             ============== -->
+        <!-- DSpace also comes with an option SWORD Client aspect, which allows
+             you to submit content FROM your DSpace TO another SWORD-enabled repository.
+             To enable this feature, uncomment the aspect below. -->
+        <!-- <aspect name="SwordClient" path="resource://aspects/SwordClient/" /> -->
+
+        <!--
+            This demo aspect tests the various possible DRI features.
+            It may be useful to developers in developing new aspects or themes.
+            It's accessible for admins in the XMLTest menu or via the /XMLTest/ URL.
+        -->
+        <!-- <aspect name="XML Tests" path="resource://aspects/XMLTest/"/> -->
+    </aspects>
+
+    <!--
+        This section configures which Theme should apply to a particular URL.
+        Themes stylize an abstract DRI document (generated by the Aspect
+        chain from above) and produce XHTML (or possibly another format) for
+        display to the user. Each theme rule is processed in the order that it
+        is listed below, the first rule that matches is the theme that is applied.
+
+        The <theme> element has several attributes including: name, id, regex,
+        handle, and path. The name attribute is used to identify the theme, while
+        the path determines the directory. The path attribute should be listed
+        exactly as it is found in the /xmlui/cocoon/themes/ directory. Both the
+        regex and handle attributes determine if the theme rule matches the URL.
+        If either the pattern or handle attribute is left off then the only the
+        other component is used to determine matching.
+
+        Keep in mind that the order of <theme> elements matters in the case of
+        overlapping matching rules. For example, a theme rule with a very broad
+        matching rule (like regex=".*") will override a more specific theme
+        declaration (like handle="1234/23") if placed before it.
+
+        Finally, theme application also "cascades" down to pages derived from the
+        one that the theme directly applies to. Thus, a theme applied to a
+        specific community will also apply to that community's collections and
+        their respective items.
+    -->
+    <themes>
+        <!-- Example configuration -->
+
+        <!-- <theme name="Test Theme 1" handle="123456789/1" path="theme1/"/>    -->
+        <!-- <theme name="Test Theme 2" regex="community-list" path="theme2/"/> -->
+
+        <!-- Mirage theme, @mire contributed theme, default since DSpace 3.0 -->
+        <theme name="Atmire Mirage Theme" regex=".*" path="Mirage2/" />
+
+        <!-- Reference theme, the default Manakin XMLUI layout up to DSpace 1.8 -->
+        <!-- <theme name="Default Reference Theme" regex=".*" path="Reference/" /> -->
+
+        <!-- Classic theme, inspired by the JSP UI -->
+        <!-- <theme name="Classic" regex=".*" path="Classic/" /> -->
+
+        <!-- The Kubrick theme -->
+        <!-- <theme name="Kubrick" regex=".*" path="Kubrick/" /> -->
+
+        <!--
+             For information on configuring the mobile theme, see:
+             dspace-xmlui/src/main/webapp/themes/mobile/readme.txt
+        -->
+    </themes>
+</xmlui>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-4346

- https://wiki.duraspace.org/display/~terrywbrady/Docker+Compose+Refactoring

## To refresh / pull DSpace images from Dockerhub
```
docker-compose -f docker-compose.yml -f docker-compose-cli.yml pull
```

## To build DSpace images using code in your branch
```
docker-compose -f docker-compose.yml -f docker-compose-cli.yml build
```

## To run DSpace from your branch

```
docker-compose -p d6 up -d
```

## Ingesting test content

Create an admin account.  By default, the dspace-cli container runs the dspace command.
```
docker-compose -p d6 -f docker-compose-cli.yml run dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
```

Download a Zip file of AIP content and ingest test data
```
docker-compose -p d6 -f docker-compose-cli.yml -f dspace/src/main/docker-compose/cli.ingest.yml run dspace-cli
```