### PR TITLE
Discovery indexing: Ensuring discovery configuration is used during indexing

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SearchUtils.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SearchUtils.java
@@ -11,8 +11,10 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.dspace.content.Collection;
 import org.dspace.content.DSpaceObject;
@@ -140,26 +142,26 @@ public class SearchUtils {
     private static List<DiscoveryConfiguration> getAllDiscoveryConfigurations(String prefix,
                                                                               List<Collection> collections, Item item)
         throws SQLException {
-        Map<String, DiscoveryConfiguration> result = new HashMap<String, DiscoveryConfiguration>();
+        Set<DiscoveryConfiguration> result = new HashSet<>();
 
         for (Collection collection : collections) {
             DiscoveryConfiguration configuration = getDiscoveryConfiguration(prefix, collection);
-            if (!result.containsKey(configuration.getId())) {
-                result.put(configuration.getId(), configuration);
-            }
+            result.add(configuration);
         }
+
+        //Add alwaysIndex configurations
+        DiscoveryConfigurationService configurationService = getConfigurationService();
+        result.addAll(configurationService.getIndexAlwaysConfigurations());
 
         //Also add one for the default
         addConfigurationIfExists(result, prefix);
 
-        return Arrays.asList(result.values().toArray(new DiscoveryConfiguration[result.size()]));
+        return Arrays.asList(result.toArray(new DiscoveryConfiguration[result.size()]));
     }
 
-    private static void addConfigurationIfExists(Map<String, DiscoveryConfiguration> result, String confName) {
+    private static void addConfigurationIfExists(Set<DiscoveryConfiguration> result, String confName) {
         DiscoveryConfiguration configurationExtra = getDiscoveryConfigurationByName(confName);
-        if (!result.containsKey(configurationExtra.getId())) {
-            result.put(configurationExtra.getId(), configurationExtra);
-        }
+        result.add(configurationExtra);
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/SearchUtils.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SearchUtils.java
@@ -10,10 +10,8 @@ package org.dspace.discovery;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.dspace.content.Collection;

--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfiguration.java
@@ -53,6 +53,13 @@ public class DiscoveryConfiguration implements InitializingBean {
     private boolean spellCheckEnabled;
     private boolean indexAlways = false;
 
+    /**
+     * The `indexAlways` property determines whether the configuration should always be included when indexing items.
+     * The default value is false which implies the configuration is only used when it matches the collection or if
+     * it's the default configuration
+     * When set to true, the configuration is also used to index an item without a specific collection mapping
+     * This can be used for displaying different facets depending on the type of item instead of the collection
+     */
     public boolean isIndexAlways() {
         return indexAlways;
     }

--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfiguration.java
@@ -51,6 +51,15 @@ public class DiscoveryConfiguration implements InitializingBean {
     private DiscoveryHitHighlightingConfiguration hitHighlightingConfiguration;
     private DiscoveryMoreLikeThisConfiguration moreLikeThisConfiguration;
     private boolean spellCheckEnabled;
+    private boolean indexAlways = false;
+
+    public boolean isIndexAlways() {
+        return indexAlways;
+    }
+
+    public void setIndexAlways(boolean indexAlways) {
+        this.indexAlways = indexAlways;
+    }
 
     public String getId() {
         return id;

--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfigurationService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfigurationService.java
@@ -76,6 +76,11 @@ public class DiscoveryConfigurationService {
         }
     }
 
+    /**
+     * Retrieves a list of all DiscoveryConfiguration objects where
+     * {@link org.dspace.discovery.configuration.DiscoveryConfiguration#isIndexAlways()} is true
+     * These configurations should always be included when indexing
+     */
     public List<DiscoveryConfiguration> getIndexAlwaysConfigurations() {
         List<DiscoveryConfiguration> configs = new ArrayList<>();
         for (String key : map.keySet()) {

--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfigurationService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfigurationService.java
@@ -78,9 +78,9 @@ public class DiscoveryConfigurationService {
 
     public List<DiscoveryConfiguration> getIndexAlwaysConfigurations() {
         List<DiscoveryConfiguration> configs = new ArrayList<>();
-        for(String key : map.keySet()) {
+        for (String key : map.keySet()) {
             DiscoveryConfiguration config = map.get(key);
-            if(config.isIndexAlways()) {
+            if (config.isIndexAlways()) {
                 configs.add(config);
             }
         }

--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfigurationService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfigurationService.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.discovery.configuration;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -73,6 +74,17 @@ public class DiscoveryConfigurationService {
         } else {
             return getDiscoveryConfiguration(dso);
         }
+    }
+
+    public List<DiscoveryConfiguration> getIndexAlwaysConfigurations() {
+        List<DiscoveryConfiguration> configs = new ArrayList<>();
+        for(String key : map.keySet()) {
+            DiscoveryConfiguration config = map.get(key);
+            if(config.isIndexAlways()) {
+                configs.add(config);
+            }
+        }
+        return configs;
     }
 
     public static void main(String[] args) {

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -516,6 +516,7 @@
 
     <bean id="publication" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
         <property name="id" value="publication"/>
+        <property name="indexAlways" value="true"/>
         <!--Which sidebar facets are to be displayed-->
         <property name="sidebarFacets">
             <list>
@@ -586,6 +587,7 @@
 
     <bean id="person" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
         <property name="id" value="person"/>
+        <property name="indexAlways" value="true"/>
         <!--Which sidebar facets are to be displayed-->
         <property name="sidebarFacets">
             <list>
@@ -649,6 +651,7 @@
     <bean id="organization" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
           scope="prototype">
         <property name="id" value="organization"/>
+        <property name="indexAlways" value="true"/>
         <!--Which sidebar facets are to be displayed-->
         <property name="sidebarFacets">
             <list>
@@ -713,6 +716,7 @@
     <bean id="publicationIssue" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
           scope="prototype">
         <property name="id" value="publicationIssue"/>
+        <property name="indexAlways" value="true"/>
         <!--Which sidebar facets are to be displayed-->
         <property name="sidebarFacets">
             <list>
@@ -773,6 +777,7 @@
     <bean id="publicationVolume" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
           scope="prototype">
         <property name="id" value="publicationVolume"/>
+        <property name="indexAlways" value="true"/>
         <!--Which sidebar facets are to be displayed-->
         <property name="sidebarFacets">
             <list>
@@ -832,6 +837,7 @@
     <bean id="periodical" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
           scope="prototype">
         <property name="id" value="periodical"/>
+        <property name="indexAlways" value="true"/>
         <!--Which sidebar facets are to be displayed-->
         <property name="sidebarFacets">
             <list>


### PR DESCRIPTION
We noticed a few problems with the discovery indexing:
* If you create a configuration, link it to a collection, but don't add `<property name="id" value="somevalue"/>` where somevalue is unique per configuration, it will be ignored.
* It's not possible to create a discovery configuration applied to items without linking it to collections. This is however a useful feature to search with a custom discovery configuration and display facets specific to that configuration

This has been solved by:
* Making sure the list of configurations is a HashSet which avoids duplicate configurations (instead of a HashMap which only avoids duplicate ids and only supports one configuration without an id)
* Creating an `indexAlways` property which states the configuration should always be included when indexing items