### PR TITLE
DS-4327 Configurable workflow: Provenance metadata lacking submitter details

### DIFF
--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowManager.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowManager.java
@@ -7,36 +7,13 @@
  */
 package org.dspace.xmlworkflow;
 
-import java.io.IOException;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.MissingResourceException;
-import javax.mail.MessagingException;
-import javax.servlet.http.HttpServletRequest;
-
 import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.AuthorizeManager;
 import org.dspace.authorize.ResourcePolicy;
-import org.dspace.content.Bitstream;
-import org.dspace.content.Bundle;
+import org.dspace.content.*;
 import org.dspace.content.Collection;
-import org.dspace.content.DCDate;
-import org.dspace.content.InstallItem;
-import org.dspace.content.Item;
-import org.dspace.content.MetadataSchema;
-import org.dspace.content.Metadatum;
-import org.dspace.content.WorkspaceItem;
-import org.dspace.core.ConfigurationManager;
-import org.dspace.core.Constants;
-import org.dspace.core.Context;
-import org.dspace.core.Email;
-import org.dspace.core.I18nUtil;
-import org.dspace.core.LogManager;
+import org.dspace.core.*;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.handle.HandleManager;
@@ -46,13 +23,16 @@ import org.dspace.usage.UsageWorkflowEvent;
 import org.dspace.utils.DSpace;
 import org.dspace.xmlworkflow.state.Step;
 import org.dspace.xmlworkflow.state.Workflow;
-import org.dspace.xmlworkflow.state.actions.Action;
-import org.dspace.xmlworkflow.state.actions.ActionResult;
-import org.dspace.xmlworkflow.state.actions.WorkflowActionConfig;
-import org.dspace.xmlworkflow.storedcomponents.ClaimedTask;
-import org.dspace.xmlworkflow.storedcomponents.PoolTask;
-import org.dspace.xmlworkflow.storedcomponents.WorkflowItemRole;
+import org.dspace.xmlworkflow.state.actions.*;
+import org.dspace.xmlworkflow.storedcomponents.*;
 import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
+
+import javax.mail.MessagingException;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.*;
+
 
 /**
  * When an item is submitted and is somewhere in a workflow, it has a row in the


### PR DESCRIPTION
The DSpace 5 version fix for the issue mentioned here:
https://jira.duraspace.org/browse/DS-4327

The recordStart method has been changed to also allow a null 'action'. When no actual workflow steps are enabled, this provenance is now also created, where previously, this was skipped.