### PR TITLE
DS-4353: Fix exception when using UUID on Harvesting

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/harvest/Harvest.java
+++ b/dspace-api/src/main/java/org/dspace/app/harvest/Harvest.java
@@ -295,7 +295,8 @@ public class Harvest
                 // database ID
                 else
                 {
-                    System.out.println("Looking up by id: " + collectionID + ", parsed as '" + Integer.parseInt(collectionID) + "', " + "in context: " + context);
+                    // not a handle, try and treat it as an collection database UUID
+                    System.out.println("Looking up by UUID: " + collectionID + ", " + "in context: " + context);
                     targetCollection = collectionService.find(context, UUID.fromString(collectionID));
                 }
             }


### PR DESCRIPTION
Fixing issue reported on https://jira.duraspace.org/browse/DS-4353 (that also affects DS6) when the user tries to run the harvesting process with the collection parameter as an UUID:
/dspace/bin/dspace harvest -r -e EPERSON -c 29a3b9d7-607b-4a15-a796-60b329d483c1

(This patch was already merged into master branch on https://github.com/DSpace/DSpace/pull/2536)