### PR TITLE
Docker bug fix: Ensure database is initialized before starting Tomcat

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,13 @@ services:
     volumes:
     - assetstore:/dspace/assetstore
     - ./dspace/src/main/docker-compose/local.cfg:/dspace/config/local.cfg
+    # Ensure that the database is ready before starting tomcat
+    entrypoint:
+    - /bin/bash
+    - '-c'
+    - |
+      /dspace/bin/dspace database migrate
+      catalina.sh run
   dspacedb:
     container_name: dspacedb
     environment:


### PR DESCRIPTION
This is a tiny PR to solve what seems to be a timing issue in fresh Docker startups.  If you are running `docker-compose` for the first time, or have deleted your volumes & are now running `docker-compose`  again, you might hit errors where Tomcat attempts to start up before the Database finishes initializing.

I'm able to reproduce this reliably (at least 2 times in a row) by doing this:

1. Shut down Docker containers: `docker-compose -p d7 down`
2. Delete all existing volumes: `docker volume rm $(docker volume ls -q)`
3. Recreate all Docker containers (and volumes): `docker-compose -p d7 up -d`

I've borrowed this fix from the `dspace-angular` project where it's already in place: https://github.com/DSpace/dspace-angular/blob/master/docker/docker-compose-rest.yml#L19-L25