### PR TITLE
[DS-4355] 6x: Re-scope .dockerignore excludes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,5 +4,7 @@
 */target/
 dspace/modules/*/target/
 Dockerfile.*
-dspace/modules/src/main/docker
-dspace/modules/src/main/docker-compose
+dspace/src/main/docker/dspace-postgres-pgcrypto
+dspace/src/main/docker/dspace-postgres-pgcrypto-curl
+dspace/src/main/docker/README.md
+dspace/src/main/docker-compose/


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-4355