### PR TITLE
[DS-4356] Document Dockerfile Manual Build Steps (README change)

### DIFF
--- a/dspace/src/main/docker/README.md
+++ b/dspace/src/main/docker/README.md
@@ -69,7 +69,8 @@ docker push dspace/dspace-cli:dspace-7_x
 
 This is a postgres docker image containing the pgcrypto extension used in DSpace 6 and DSpace 7.
 ```
-docker build -t dspace/dspace-postgres-pgcrypto -f dspace/src/main/docker/dspace-postgres-pgcrypto/Dockerfile .
+cd dspace/src/main/docker/dspace-postgres-pgcrypto
+docker build -t dspace/dspace-postgres-pgcrypto .
 ```
 
 This image is built manually.  It should be rebuilt as needed.
@@ -86,7 +87,8 @@ docker push dspace/dspace-postgres-pgcrypto
 This is a postgres docker image containing the pgcrypto extension used in DSpace 6 and DSpace 7.
 This image also contains curl.  The image is pre-configured to load a postgres database dump on initialization.
 ```
-docker build -t dspace/dspace-postgres-pgcrypto:loadsql -f dspace/src/main/docker/dspace-postgres-pgcrypto-curl/Dockerfile .
+cd dspace/src/main/docker/dspace-postgres-pgcrypto-curl
+docker build -t dspace/dspace-postgres-pgcrypto:loadsql .
 ```
 
 This image is built manually.  It should be rebuilt as needed.
@@ -102,7 +104,8 @@ docker push dspace/dspace-postgres-pgcrypto:loadsql
 
 This is a standalone solr image containing DSpace solr schemas used in DSpace 7.
 ```
-docker build -t dspace/dspace-solr -f dspace/src/main/docker/solr/Dockerfile .
+cd dspace/src/main/docker/solr
+docker build -t dspace/dspace-solr .
 ```
 
 This image is built manually.  It should be rebuilt as solr schemas change or as new releases of solr are incorporated.

--- a/dspace/src/main/docker/README.md
+++ b/dspace/src/main/docker/README.md
@@ -1,23 +1,118 @@
 # Docker images supporting DSpace
 
-## dspace-postgres-pgcrypto/Dockerfile
+## Dockerfile.dependencies
 
-_dspace/dspace-postgres-pgcrypto:latest_
+This dockerfile is used to pre-cache maven downloads that will be used in subsequent DSpace docker builds.
+```
+docker build -t dspace/dspace-dependencies:dspace-7_x -f Dockerfile.dependencies .
+```
+
+This image is built manually.  It should be rebuilt each year or after each major release in order to refresh the cache of jars.  
+
+A corresponding image exists for DSpace 4-6.
+
+Admins to our DockerHub repo can publish with the following command.
+```
+docker push dspace/dspace-dependencies:dspace-7_x
+```
+
+## Dockerfile.jdk8-test
+
+This dockefile builds a DSpace 7 tomcat image.  The legacy REST api will be deployed without requiring https access.
+
+```
+docker build -t dspace/dspace:dspace-7_x-jdk8-test -f Dockerfile.jdk8-test .
+```
+
+This image is built automatically after each commit is made to the master branch.
+
+A corresponding image exists for DSpace 4-6.
+
+Admins to our DockerHub repo can publish with the following command.
+```
+docker push dspace/dspace:dspace-7_x-jdk8-test
+```
+
+## Dockerfile.jdk8
+
+This dockefile builds a DSpace 7 tomcat image.
+```
+docker build -t dspace/dspace:dspace-7_x-jdk8 -f Dockerfile.jdk8 .
+```
+
+This image is built automatically after each commit is made to the master branch.
+
+A corresponding image exists for DSpace 4-6.
+
+Admins to our DockerHub repo can publish with the following command.
+```
+docker push dspace/dspace:dspace-7_x-jdk8
+```
+
+## Dockefile.cli.jdk8
+
+This dockerfile builds a DSpace 7 CLI image.
+```
+docker build -t dspace/dspace-cli:dspace-7_x -f Dockerfile.cli.jdk8 .
+```
+
+This image is built automatically after each commit is made to the master branch.
+
+A corresponding image exists for DSpace 6.
+
+Admins to our DockerHub repo can publish with the following command.
+```
+docker push dspace/dspace-cli:dspace-7_x
+```
+
+## dspace/src/main/docker/dspace-postgres-pgcrypto/Dockerfile
 
 This is a postgres docker image containing the pgcrypto extension used in DSpace 6 and DSpace 7.
+```
+docker build -t dspace/dspace-postgres-pgcrypto -f dspace/src/main/docker/dspace-postgres-pgcrypto/Dockerfile .
+```
 
-## dspace-postgres-pgcrypto-curl/Dockerfile
+This image is built manually.  It should be rebuilt as needed.
 
-_dspace/dspace-postgres-pgcrypto:loadsql_
+A copy of this file exists in the DSpace 6 branch.  A specialized version of this file exists for DSpace 4 in DSpace-Docker-Images.
+
+Admins to our DockerHub repo can publish with the following command.
+```
+docker push dspace/dspace-postgres-pgcrypto
+```
+
+## dspace/src/main/docker/dspace-postgres-pgcrypto-curl/Dockerfile
 
 This is a postgres docker image containing the pgcrypto extension used in DSpace 6 and DSpace 7.
 This image also contains curl.  The image is pre-configured to load a postgres database dump on initialization.
+```
+docker build -t dspace/dspace-postgres-pgcrypto:loadsql -f dspace/src/main/docker/dspace-postgres-pgcrypto-curl/Dockerfile .
+```
 
-## solr
+This image is built manually.  It should be rebuilt as needed.
 
-_dspace/dspace-solr_
+A copy of this file exists in the DSpace 6 branch.
+
+Admins to our DockerHub repo can publish with the following command.
+```
+docker push dspace/dspace-postgres-pgcrypto:loadsql
+```
+
+## dspace/src/main/docker/solr/Dockerfile
 
 This is a standalone solr image containing DSpace solr schemas used in DSpace 7.
+```
+docker build -t dspace/dspace-solr -f dspace/src/main/docker/solr/Dockerfile .
+```
+
+This image is built manually.  It should be rebuilt as solr schemas change or as new releases of solr are incorporated.
+
+This file was introduced for DSpace 7.
+
+Admins to our DockerHub repo can publish with the following command.
+```
+docker push dspace/dspace-solr
+```
 
 ## local.cfg and test/ folder
 


### PR DESCRIPTION
Now that the Dockerfiles have migrated to the DSpace/DSpace repo, this file describes how to build each one individually.

https://jira.duraspace.org/browse/DS-4356

This README could be modified and contextualized for 6x as well.