### PR TITLE
DS-4271: Replaced brackets with double quotes in SolrServiceImpl.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -2107,7 +2107,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                 if(!value.matches("\\[.*TO.*\\]"))
                 {
                     value = ClientUtils.escapeQueryChars(value);
-                    filterQuery.append("(").append(value).append(")");
+                    filterQuery.append("\"").append(value).append("\"");
                 }
                 else
                 {


### PR DESCRIPTION
DSpace 6 versions of the fix provided in:
https://jira.duraspace.org/browse/DS-4271 
Fixes #7611 

Quite a small fix, but it has been open for a little while now, so took the liberty to create a quick PR
(More information is present in the JIRA ticket itself)