### PR TITLE
[DS-4359] added nullcheck in EntityServiceImpl#getAllRelationshipTypes

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/EntityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/EntityServiceImpl.java
@@ -8,6 +8,7 @@
 package org.dspace.content;
 
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
@@ -94,6 +95,9 @@ public class EntityServiceImpl implements EntityService {
     @Override
     public List<RelationshipType> getAllRelationshipTypes(Context context, Entity entity) throws SQLException {
         EntityType entityType = this.getType(context, entity);
+        if (entityType == null) {
+            return Collections.emptyList();
+        }
         List<RelationshipType> listToReturn = new LinkedList<>();
         for (RelationshipType relationshipType : relationshipTypeService.findAll(context)) {
             if (relationshipType.getLeftType().getID() == entityType.getID() ||


### PR DESCRIPTION
Fixed the issue described at: https://jira.duraspace.org/browse/DS-4359

This PR simply adds a nullcheck around the EntityType and returns an empty list if it's null. This solves the issue as a nullcheck was needed.
This does not cause any issue since it's not possible to get a RelationshipType that is defined by a null EntityType; therefor it'll always need to return an empty list if the EntityType is null