### PR TITLE
[DS-4360] fixed construction of the SearchEvents link on the statistics endpoint

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/link/statistics/StatisticsSupportHalLinkFactory.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/link/statistics/StatisticsSupportHalLinkFactory.java
@@ -24,7 +24,7 @@ public class StatisticsSupportHalLinkFactory
 
         list.add(buildLink(Link.REL_SELF, getMethodOn().getStatisticsSupport()));
         list.add(buildLink("viewevents", getMethodOn().getViewEvents()));
-        list.add(buildLink("searchevents", getMethodOn().getViewEvents()));
+        list.add(buildLink("searchevents", getMethodOn().getSearchEvents()));
     }
 
     protected Class<StatisticsRestController> getControllerClass() {


### PR DESCRIPTION
This PR fixes the issue described in: https://jira.duraspace.org/browse/DS-4360

The construction of the SearchEvents link has been altered to the correct method call