### PR TITLE
DS-3946: start-handle-server script fails to remove the lock file (master port)

### DIFF
--- a/dspace/bin/start-handle-server
+++ b/dspace/bin/start-handle-server
@@ -37,7 +37,7 @@ if [ "$JAVA_OPTS" = "" ]; then
 fi
 
 # Remove lock file, in case the old Handle server did not shut down properly
-rm -f $handledir/txns/lock
+rm -f $HANDLEDIR/txns/lock
 
 # Start the Handle server, with a special log4j properties file.
 # We cannot simply write to the same logs, since log4j


### PR DESCRIPTION
This PR ports the fix in https://github.com/DSpace/DSpace/pull/2114 to 7.x.

Jira issue: https://jira.duraspace.org/browse/DS-3946