### PR TITLE
DS-4367 remove unnecessary dspace.restUrl and fix default configuration

### DIFF
--- a/dspace-api/src/test/data/dspaceFolder/config/local.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/local.cfg
@@ -25,6 +25,9 @@
 # SERVER CONFIGURATION   #
 ##########################
 
+# Spring boot test by default mock the server on the localhost (80)
+dspace.baseUrl = http://localhost
+
 # DSpace installation directory.
 # This is the location where you want to install DSpace.
 # Windows note: Please remember to use forward slashes for all paths (e.g. C:/dspace)

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/MappedCollectionRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/MappedCollectionRestController.java
@@ -73,12 +73,12 @@ public class MappedCollectionRestController {
      * The owning collection is not included in this list. It will transform the list of Collections to a list of
      * CollectionRest objects and it'll then encapsulate these into a MappedCollectionResourceWrapper object
      *
-     * curl -X GET http://<dspace.restUrl>/api/core/item/{uuid}/mappedCollections
+     * curl -X GET http://<dspace.baseUrl>/api/core/item/{uuid}/mappedCollections
      *
      * Example:
      * <pre>
      * {@code
-     *      curl -X GET http://<dspace.restUrl>/api/core/items/8b632938-77c2-487c-81f0-e804f63e68e6/mappedCollections
+     *      curl -X GET http://<dspace.baseUrl>/api/core/items/8b632938-77c2-487c-81f0-e804f63e68e6/mappedCollections
      * }
      * </pre>
      *
@@ -121,14 +121,14 @@ public class MappedCollectionRestController {
      * This method will add an Item to a Collection. The Collection object is encapsulated in the request due to the
      * text/uri-list consumer and the Item UUID comes from the path in the URL
      *
-     * curl -X POST http://<dspace.restUrl>/api/core/item/{uuid}/mappedCollections
+     * curl -X POST http://<dspace.baseUrl>/api/core/item/{uuid}/mappedCollections
      *  -H "Content-Type:text/uri-list"
      *  --data $'https://{url}/rest/api/core/collections/{uuid}'
      *
      * Example:
      * <pre>
      * {@code
-     * curl -X POST http://<dspace.restUrl>/api/core/item/{uuid}/mappedCollections
+     * curl -X POST http://<dspace.baseUrl>/api/core/item/{uuid}/mappedCollections
      *  -H "Content-Type:text/uri-list"
      *  --data $'https://{url}/rest/api/core/collections/506a7e54-8d7c-4d5b-8636-d5f6411483de'
      * }
@@ -176,12 +176,12 @@ public class MappedCollectionRestController {
      * This method will delete a Collection to Item relation. It will remove an Item with UUID given in the request
      * URL from the Collection with UUID given in the request URL.
      *
-     * curl -X DELETE http://<dspace.restUrl>/api/core/item/{uuid}/mappedCollections/{collectionUuid}
+     * curl -X DELETE http://<dspace.baseUrl>/api/core/item/{uuid}/mappedCollections/{collectionUuid}
      *
      * Example:
      * <pre>
      * {@code
-     * curl -X DELETE http://<dspace.restUrl>/api/core/item/{uuid}/mappedCollections/{collectionUuid}
+     * curl -X DELETE http://<dspace.baseUrl>/api/core/item/{uuid}/mappedCollections/{collectionUuid}
      * }
      * </pre>
      *

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/MappedItemRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/MappedItemRestController.java
@@ -67,12 +67,12 @@ public class MappedItemRestController {
      * returning only items that belong to a different collection but are mapped to the given one.
      * These Items are then encapsulated in a MappedItemResourceWrapper and returned
      *
-     * curl -X GET http://<dspace.restUrl>/api/core/collections/{uuid}/mappedItems
+     * curl -X GET http://<dspace.baseUrl>/api/core/collections/{uuid}/mappedItems
      *
      * Example:
      * <pre>
      * {@code
-     *      curl -X GET http://<dspace.restUrl>/api/core/collections/8b632938-77c2-487c-81f0-e804f63e68e6/mappedItems
+     *      curl -X GET http://<dspace.baseUrl>/api/core/collections/8b632938-77c2-487c-81f0-e804f63e68e6/mappedItems
      * }
      * </pre>
      *

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -1095,12 +1095,12 @@ public class RestResourceController implements InitializingBean {
     /**
      * Execute a PUT request for an entity with id of type UUID;
      *
-     * curl -X PUT http://<dspace.restUrl>/api/{apiCategory}/{model}/{uuid}
+     * curl -X PUT http://<dspace.baseUrl>/api/{apiCategory}/{model}/{uuid}
      *
      * Example:
      * <pre>
      * {@code
-     *      curl -X PUT http://<dspace.restUrl>/api/core/collection/8b632938-77c2-487c-81f0-e804f63e68e6
+     *      curl -X PUT http://<dspace.baseUrl>/api/core/collection/8b632938-77c2-487c-81f0-e804f63e68e6
      * }
      * </pre>
      *

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/RootConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/RootConverter.java
@@ -13,7 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
- * This class converts the restUrl and constructs a RootRest instance to return
+ * This class read the core configuration properties and constructs a RootRest instance to return
  */
 @Component
 public class RootConverter {
@@ -25,7 +25,7 @@ public class RootConverter {
         RootRest rootRest = new RootRest();
         rootRest.setDspaceName(configurationService.getProperty("dspace.name"));
         rootRest.setDspaceURL(configurationService.getProperty("dspace.url"));
-        rootRest.setDspaceRest(configurationService.getProperty("dspace.restUrl"));
+        rootRest.setDspaceRest(configurationService.getProperty("dspace.baseUrl"));
         return rootRest;
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RootRestResourceControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RootRestResourceControllerIT.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
@@ -23,6 +24,20 @@ import org.junit.Test;
  * @author Tom Desair (tom dot desair at atmire dot com)
  */
 public class RootRestResourceControllerIT extends AbstractControllerIntegrationTest {
+
+    @Test
+    public void serverPropertiesTest() throws Exception {
+      //When we call the root endpoint
+        getClient().perform(get("/api"))
+                   //The status has to be 200 OK
+                   .andExpect(status().isOk())
+                   //We expect the content type to be "application/hal+json;charset=UTF-8"
+                   .andExpect(content().contentType(contentType))
+                   .andExpect(jsonPath("$.dspaceURL", Matchers.is("http://localhost:3000")))
+                   .andExpect(jsonPath("$.dspaceName", Matchers.is("DSpace at My University")))
+                   .andExpect(jsonPath("$.dspaceRest", Matchers.is(BASE_REST_SERVER_URL)))
+                   .andExpect(jsonPath("$.type", Matchers.is("root")));
+    }
 
     @Test
     public void listDefinedEndpoint() throws Exception {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/converter/RootConverterTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/converter/RootConverterTest.java
@@ -36,7 +36,7 @@ public class RootConverterTest {
     public void setUp() throws Exception {
         when(configurationService.getProperty("dspace.url")).thenReturn("dspaceurl");
         when(configurationService.getProperty("dspace.name")).thenReturn("dspacename");
-        when(configurationService.getProperty("dspace.restUrl")).thenReturn("rest");
+        when(configurationService.getProperty("dspace.baseUrl")).thenReturn("rest");
     }
 
     @Test

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -25,19 +25,11 @@ dspace.dir = /dspace
 # DSpace host name - should match base URL.  Do not include port number.
 dspace.hostname = localhost
 
-# DSpace base host URL.  Include port number etc.
-dspace.baseUrl = http://localhost:8080
+# DSpace server backend webapp URL.  Include port number etc.
+dspace.baseUrl = http://localhost:8080/server
 
-# Full link your end users will use to access DSpace. In most cases, this will be the baseurl followed by
-# the context path to the UI you are using.
-#
-# Alternatively, you can use a url redirect or deploy the web application under the servlet container root.
-# This is the URL that the front-end will be served on
-dspace.url = ${dspace.baseUrl}
-
-# This is the URL that will be used for the REST endpoints to be served on.
-# This will typically be followed by /api to determine the root endpoints.
-dspace.restUrl = ${dspace.baseUrl}/server
+# Full link your end users will use to access DSpace. This is the URL of your angular UI
+dspace.url = http://localhost:3000
 
 # Optional: DSpace URL for mobile access
 # This
@@ -53,11 +45,9 @@ assetstore.dir = ${dspace.dir}/assetstore
 default.language = en_US
 
 # Solr server/webapp.
-# DSpace uses Solr for all search/browse capability (and for usage statistics by default).
-# The included 'solr' webapp MUST be deployed to Tomcat for DSpace to function.
-# Usually it will be available via port 8080 and the 'solr' context path. But,
-# But, you may need to modify this if you are running DSpace on a custom port, etc.
-solr.server = http://localhost:8080/solr
+# DSpace uses Solr for all search/browse capability (and for usage statistics).
+# since DSpace 7, SOLR must be installed as a stand-alone service
+solr.server = http://localhost:8983/solr
 
 ##### Database settings #####
 # DSpace only supports two database types: PostgreSQL or Oracle

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -33,14 +33,11 @@ dspace.dir=/dspace
 # DSpace host name - should match base URL.  Do not include port number
 dspace.hostname = localhost
 
-# DSpace base host URL.  Include port number etc.
-dspace.baseUrl = http://localhost:8080
+# DSpace server backend webapp URL.  Include port number etc.
+dspace.baseUrl = http://localhost:8080/server
 
-# Full link your end users will use to access DSpace. In most cases, this will be the baseurl followed by
-# the context path to the UI you are using.
-#
-# Alternatively, you can use a url redirect or deploy the web application under the servlet container root.
-#dspace.url = ${dspace.baseUrl}
+# Full link your end users will use to access DSpace. This is the URL of your angular UI
+dspace.url = http://localhost:3000
 
 # Name of the site
 dspace.name = DSpace at My University
@@ -53,11 +50,9 @@ dspace.name = DSpace at My University
 #default.language = en_US
 
 # Solr server/webapp.
-# DSpace uses Solr for all search/browse capability (and for usage statistics by default).
-# The included 'solr' webapp MUST be deployed to Tomcat for DSpace to function.
-# Usually it will be available via port 8080 and the 'solr' context path. But,
-# But, you may need to modify this if you are running DSpace on a custom port, etc.
-solr.server = http://localhost:8080/solr
+# DSpace uses Solr for all search/browse capability (and for usage statistics).
+# since DSpace 7, SOLR must be installed as a stand-alone service
+#solr.server = http://localhost:8983/solr
 
 ##########################
 # DATABASE CONFIGURATION #

--- a/dspace/config/modules/oai.cfg
+++ b/dspace/config/modules/oai.cfg
@@ -12,7 +12,7 @@
 
 # Path where OAI module is available
 # Defaults to "oai", which means the OAI module would be available
-# at ${dspace.restURL}/oai/
+# at ${dspace.baseURL}/oai/
 # (Requires reboot of servlet container, e.g. Tomcat, to reload)
 oai.path = oai
 

--- a/dspace/config/modules/rdf.cfg
+++ b/dspace/config/modules/rdf.cfg
@@ -12,9 +12,9 @@
 # (Requires reboot of servlet container, e.g. Tomcat, to reload)
 #rdf.enabled = true
 
-# Path where RDF module is available (in the Spring REST webapp)
+# Path where RDF module is available (in the Spring Server webapp)
 # Defaults to "rdf", which means the RDF module would be available
-# at ${dspace.restURL}/rdf/
+# at ${dspace.baseURL}/rdf/
 # (Requires reboot of servlet container, e.g. Tomcat, to reload)
 rdf.path = rdf
 

--- a/dspace/config/modules/sword-server.cfg
+++ b/dspace/config/modules/sword-server.cfg
@@ -12,9 +12,9 @@
 # (Requires reboot of servlet container, e.g. Tomcat, to reload)
 #sword-server.enabled = true
 
-# Path where SWORD v1 module is available (in the Spring REST webapp)
+# Path where SWORD v1 module is available (in the Spring Server webapp)
 # Defaults to "sword", which means the SWORD mould would be available
-# at ${dspace.restURL}/sword/
+# at ${dspace.baseUrl}/sword/
 # (Requires reboot of servlet container, e.g. Tomcat, to reload)
 #sword-server.path = sword
 
@@ -46,7 +46,7 @@
 # which DSpace will construct the deposit location urls for
 # collections.
 #
-# The default is ${dspace.url}/sword/deposit
+# The default is ${dspace.baseUrl}/sword/deposit
 #
 # In the event that you are not deploying DSpace as the ROOT
 # application in the servlet container, this will generate
@@ -59,7 +59,7 @@
 # URL from which DSpace will construct the service document
 # location urls for the site, and for individual collections
 #
-# The default is {dspace.url}/sword/servicedocument
+# The default is {dspace.baseUrl}/sword/servicedocument
 #
 # In the event that you are not deploying DSpace as the ROOT
 # application in the servlet container, this will generate
@@ -72,7 +72,7 @@
 # which DSpace will use to construct the media link urls
 # for items which are deposited via sword
 #
-# The default is {dspace.url}/sword/media-link
+# The default is {dspace.baseUrl}/sword/media-link
 #
 # In the event that you are not deploying DSpace as the ROOT
 # application in the servlet container, this will generate

--- a/dspace/config/modules/swordv2-server.cfg
+++ b/dspace/config/modules/swordv2-server.cfg
@@ -12,15 +12,15 @@
 # (Requires reboot of servlet container, e.g. Tomcat, to reload)
 #swordv2-server.enabled = true
 
- # Path where SWORD v2 module is available (in the Spring REST webapp)
+ # Path where SWORD v2 module is available (in the Spring Server webapp)
 # Defaults to "swordv2", which means the SWORD v2 module would be available
-# at ${dspace.restURL}/swordv2/
+# at ${dspace.baseURL}/swordv2/
 # (Requires reboot of servlet container, e.g. Tomcat, to reload)
 #swordv2-server.path = swordv2
 
 # the base url of the sword 2.0  system
 #
-# the default if {dspace.url}/swordv2
+# the default if {dspace.baseUrl}/swordv2
 #
 #swordv2-server.url = http://www.myu.ac.uk/swordv2
 
@@ -28,7 +28,7 @@
 # which DSpace will construct the deposit location urls for
 # collections.
 #
-# The default is {dspace.url}/swordv2/collection
+# The default is {dspace.baseUrl}/swordv2/collection
 #
 # In the event that you are not deploying DSpace as the ROOT
 # application in the servlet container, this will generate
@@ -41,7 +41,7 @@
 # URL from which DSpace will construct the service document
 # location urls for the site, and for individual collections
 #
-# The default is {dspace.url}/swordv2/servicedocument
+# The default is {dspace.baseUrl}/swordv2/servicedocument
 #
 # In the event that you are not deploying DSpace as the ROOT
 # application in the servlet container, this will generate

--- a/dspace/src/main/docker-compose/local.cfg
+++ b/dspace/src/main/docker-compose/local.cfg
@@ -1,6 +1,6 @@
 dspace.dir=/dspace
 db.url=jdbc:postgresql://dspacedb:5432/dspace
 dspace.hostname=dspace
-dspace.baseUrl=http://localhost:8080
+dspace.baseUrl=http://localhost:8080/server
 dspace.name=DSpace Started with Docker Compose
 solr.server=http://dspacesolr:8983/solr

--- a/dspace/src/main/docker/local.cfg
+++ b/dspace/src/main/docker/local.cfg
@@ -5,5 +5,5 @@
 dspace.dir = /dspace
 db.url = jdbc:postgresql://dspacedb:5432/dspace
 dspace.hostname = localhost
-dspace.baseUrl = http://localhost:8080
+dspace.baseUrl = http://localhost:8080/server
 solr.server=http://dspacesolr:8983/solr


### PR DESCRIPTION
Now that we have a single webapp it is no longer necessary to have a base url and separate url for each webapp, including rest.
I have updated the dspace.cfg, the local.cfg and the spring rest code to reflect that.