### PR TITLE
DS-1977: hides "private" items from Google Sitemaps

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
+++ b/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
@@ -211,7 +211,7 @@ public class GenerateSitemaps
             c.uncacheEntity(coll);
         }
 
-        Iterator<Item> allItems = itemService.findAll(c);
+        Iterator<Item> allItems = itemService.findInArchiveOrWithdrawnDiscoverable(c);
         int itemCount = 0;
 
         while (allItems.hasNext())

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -243,6 +243,13 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
     }
 
     @Override
+    public Iterator<Item> findInArchiveOrWithdrawnDiscoverable(Context context)
+            throws SQLException
+    {
+        return itemDAO.findAll(context, true, true, true, null);
+    }
+
+    @Override
     public Iterator<Item> findInArchiveOrWithdrawnDiscoverableModifiedSince(Context context, Date since)
             throws SQLException
     {

--- a/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
@@ -127,6 +127,15 @@ public interface ItemService extends DSpaceObjectService<Item>, DSpaceObjectLega
     public Iterator<Item> findByCollection(Context context, Collection collection, Integer limit, Integer offset) throws SQLException;
 
     /**
+     * Get all Items installed or withdrawn, and discoverable.
+     * @param context context
+     * @return an iterator over the items in the collection.
+     * @throws SQLException if database error
+     */
+    public Iterator<Item> findInArchiveOrWithdrawnDiscoverable(Context context)
+            throws SQLException;
+
+    /**
      * Get all Items installed or withdrawn, discoverable, and modified since a Date.
      * @param context context
      * @param since earliest interesting last-modified date, or null for no date test.

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -219,6 +219,91 @@ public class ItemTest extends AbstractDSpaceObjectTest
     }
 
     /**
+     * Test of findInArchiveOrWithdrawnDiscoverable method, of class Item.
+     */
+    @Test
+    public void testFindInArchiveOrWithdrawnDiscoverable() throws Exception {
+        // Init item to be both withdrawn and discoverable
+        it.setWithdrawn(true);
+        it.setArchived(false);
+        it.setDiscoverable(true);
+
+        // Test 0: With withdrawn = true, archived = false and discoverable = true we should get non-null list with our item
+        Iterator<Item> all = itemService.findInArchiveOrWithdrawnDiscoverable(context);
+        assertThat("Returned list should not be null", all, notNullValue());
+
+        boolean added = false;
+        while(all.hasNext()) {
+            Item tmp = all.next();
+            if(tmp.equals(it)) {
+                added = true;
+            }
+        }
+
+        // Test 1: we should find our item in this list
+        assertTrue("List should contain item when discoverable is true", added);
+
+        // Repeat Tests 0, 1 with withdrawn = false and archived = true as this should result in same behaviour
+        it.setWithdrawn(false);
+        it.setArchived(true);
+
+        // Test 2: With withdrawn = false, archived = true and discoverable = true we should get non-null list with our item
+        all = itemService.findInArchiveOrWithdrawnDiscoverable(context);
+        assertThat("Returned list should not be null", all, notNullValue());
+
+        added = false;
+        while(all.hasNext()) {
+            Item tmp = all.next();
+            if(tmp.equals(it)) {
+                added = true;
+            }
+        }
+
+        // Test 3: we should find our item in this list
+        assertTrue("List should contain item when discoverable is true", added);
+
+
+        // Repeat Tests 0-3 with discoverable set to false
+        it.setWithdrawn(true);
+        it.setArchived(false);
+        it.setDiscoverable(false);
+
+        // Test 4: With withdrawn = true, archived = false and discoverable = true we should get non-null list with our item
+        all = itemService.findInArchiveOrWithdrawnDiscoverable(context);
+        assertThat("Returned list should not be null", all, notNullValue());
+
+        added = false;
+        while(all.hasNext()) {
+            Item tmp = all.next();
+            if(tmp.equals(it)) {
+                added = true;
+            }
+        }
+
+        // Test 5: we should not find our item in this list
+        assertFalse("List should not contain item when discoverable is false", added);
+
+        // Repeat Tests 4, 5 with withdrawn = false and archived = true as this should result in same behaviour
+        it.setWithdrawn(false);
+        it.setArchived(true);
+
+        // Test 6: With withdrawn = false, archived = true and discoverable = true we should get non-null list with our item
+        all = itemService.findInArchiveOrWithdrawnDiscoverable(context);
+        assertThat("Returned list should not be null", all, notNullValue());
+
+        added = false;
+        while(all.hasNext()) {
+            Item tmp = all.next();
+            if(tmp.equals(it)) {
+                added = true;
+            }
+        }
+
+        // Test 7: we should not find our item in this list
+        assertFalse("List should not contain item when discoverable is false", added);
+    }
+
+    /**
      * Test of findInArchiveOrWithdrawnDiscoverableModifiedSince method, of class Item.
      */
     @Test


### PR DESCRIPTION
Creates new method in ItemServiceImpl.java that returns discoverable items for the Google Sitemap generator.

Jira issue: https://jira.duraspace.org/browse/DS-1977