### PR TITLE
DS-3891: fixes minor security issue with HTML opened in a separate tab

### DIFF
--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -599,7 +599,7 @@ jsp.home.search1                                                = Search
 jsp.home.search2                                                = Enter some text in the box below to search DSpace.
 jsp.home.title                                                  = Home
 jsp.layout.footer-default.feedback                              = Feedback
-jsp.layout.footer-default.text                                  = <a target="_blank" href="http://www.dspace.org/">DSpace Software</a> Copyright&nbsp;&copy;&nbsp;2002-2013&nbsp; <a target="_blank" href="http://www.duraspace.org/">Duraspace</a>
+jsp.layout.footer-default.text                                  = <a target="_blank" rel="noopener" href="http://www.dspace.org/">DSpace Software</a> Copyright&nbsp;&copy;&nbsp;2002-2013&nbsp; <a target="_blank" rel="noopener" href="http://www.duraspace.org/">Duraspace</a>
 jsp.layout.footer-default.theme-by								= Theme by
 jsp.layout.header-default.about                                 = About DSpace Software
 jsp.layout.header-default.alt                                   = DSpace
@@ -901,18 +901,18 @@ jsp.search.filter.original_bundle_filenames                      = Filename
 jsp.search.filter.original_bundle_descriptions                   = File description
 jsp.sherpa.title = SHERPA/RoMEO Publisher Policy Database
 jsp.sherpa.loading = <p>Fetching policy information from the SHERPA/RoMEO database</p><img alt="loading" src="{0}/sherpa/image/ajax-loader-big.gif" />
-jsp.sherpa.heading = <p class="sherpaDisclaimer"><a href="https://v2.sherpa.ac.uk/romeo/" target="_blank"><img align="left" src="{0}/sherpa/image/romeosmall.gif" width="100" height="54" alt="SHERPA/RoMEO Database" border="0"></a> All SHERPA/RoMEO information is correct to the best of our knowledge but should not be relied upon for legal advice. SHERPA cannot be held responsible for the re-use of RoMEO data, or for alternative interpretations which are derived from this information.</p>
-jsp.sherpa.error = <p class="sherpaError">Sorry, we have had trouble querying the SHERPA/RoMEO Database. No data is available, try later or check directly at the <a href="https://v2.sherpa.ac.uk/romeo/" target="_blank">SHERPA/RoMEO WebSite</a>.</p>
-jsp.sherpa.noresult = <p class="sherpaNoResult">Sorry, there is no data in the <a href="http://www.sherpa.ac.uk/romeo.php" target="_blank">SHERPA/RoMEO Database</a> for the ISSNs that you have entered.</p>
-jsp.sherpa.oneresult = <p>The <a href="https://v2.sherpa.ac.uk/romeo/" target="_blank">SHERPA/RoMEO</a> database provides the following data for the journal that you have entered.</p>
+jsp.sherpa.heading = <p class="sherpaDisclaimer"><a href="https://v2.sherpa.ac.uk/romeo/" target="_blank" rel="noopener"><img align="left" src="{0}/sherpa/image/romeosmall.gif" width="100" height="54" alt="SHERPA/RoMEO Database" border="0"></a> All SHERPA/RoMEO information is correct to the best of our knowledge but should not be relied upon for legal advice. SHERPA cannot be held responsible for the re-use of RoMEO data, or for alternative interpretations which are derived from this information.</p>
+jsp.sherpa.error = <p class="sherpaError">Sorry, we have had trouble querying the SHERPA/RoMEO Database. No data is available, try later or check directly at the <a href="https://v2.sherpa.ac.uk/romeo/" target="_blank" rel="noopener">SHERPA/RoMEO WebSite</a>.</p>
+jsp.sherpa.noresult = <p class="sherpaNoResult">Sorry, there is no data in the <a href="http://www.sherpa.ac.uk/romeo.php" target="_blank" rel="noopener">SHERPA/RoMEO Database</a> for the ISSNs that you have entered.</p>
+jsp.sherpa.oneresult = <p>The <a href="https://v2.sherpa.ac.uk/romeo/" target="_blank" rel="noopener">SHERPA/RoMEO</a> database provides the following data for the journal that you have entered.</p>
 jsp.sherpa.moreresults = <p>The ISSNs that you have entered match with multiple journals, please review them. You can find the publisher policy for these journals below.</p>
 jsp.sherpa.some-errors = <p>This item contains multiple ISSNs, and at least one ISSN did not return a valid result. Please review the successful results below.</p>
 jsp.sherpa.jornaltitle = <p><b>Journal:</b> {0}
 jsp.sherpa.jornalissn = (ISSN\: {0})</p> 
-jsp.sherpa.publisher = <p><b>Publisher:</b> <a href="{1}" target="_blank">{0}</a></p>
+jsp.sherpa.publisher = <p><b>Publisher:</b> <a href="{1}" target="_blank" rel="noopener">{0}</a></p>
 jsp.sherpa.publisher.onlyname = <p><b>Publisher:</b> {0}</p>
 jsp.sherpa.publisher.unknow = <p><b>Publisher:</b> Unknown</p>
-jsp.sherpa.publisher.nodata =  <p>Sorry, there are no data about this publisher in the <a href="https://v2.sherpa.ac.uk/romeo/" target="_blank">SHERPA/RoMEO</a> Database. If you know its policies or you want suggest to add the Publisher to the SHERPA/RoMEO Database you can use <a href="http://www.sherpa.ac.uk/romeoupdate.php" target="_blank">this form</a></p>
+jsp.sherpa.publisher.nodata =  <p>Sorry, there are no data about this publisher in the <a href="https://v2.sherpa.ac.uk/romeo/" target="_blank" rel="noopener">SHERPA/RoMEO</a> Database. If you know its policies or you want suggest to add the Publisher to the SHERPA/RoMEO Database you can use <a href="http://www.sherpa.ac.uk/romeoupdate.php" target="_blank" rel="noopener">this form</a></p>
 jsp.sherpa.pre-print.can =  <p><b>Author''s Pre-prints:</b><img src="{0}/sherpa/image/can.gif" alt="can" border="0" /> Author <b>can</b> archive pre-print (ie pre-refereeing)</p>
 jsp.sherpa.pre-print.cannot =  <p><b>Author''s Pre-prints:</b><img src="{0}/sherpa/image/cannot.gif" alt="cannot" border="0" /> Author <b>cannot</b> archive pre-print (ie pre-refereeing)</p>
 jsp.sherpa.pre-print.restricted =  <p><b>Author''s Pre-prints:</b><img src="{0}/sherpa/image/restricted.gif" alt="restricted" border="0" /> <b>Subject to Restrictions below</b>, author <b>can</b> archive pre-print (ie pre-refereeing)</p>
@@ -929,7 +929,7 @@ jsp.sherpa.publisher-version.restricted =  <p><b>Publisher''s Version:</b><img s
 jsp.sherpa.publisher-version.unclear =  <p><b>Publisher''s Version:</b><img src="{0}/sherpa/image/unclear.gif" alt="unclear" border="0" /> Archiving status unclear</p>
 jsp.sherpa.publisher-version.unknown =  <p><b>Publisher''s Version:</b> - No information</p>
 jsp.sherpa.generalconditions = <p><b>General conditions:</b></p>
-jsp.sherpa.paidoption = <p><b>Paid open access:</b> <a href="{1}" target="_blank">{0}</a>. {2}</p>
+jsp.sherpa.paidoption = <p><b>Paid open access:</b> <a href="{1}" target="_blank" rel="noopener">{0}</a>. {2}</p>
 jsp.sherpa.paidoption-label = Paid open access
 jsp.sherpa.paidoption-message = A paid open access option is available for this journal
 jsp.sherpa.copyright = <p><b>Copyright:</b></p>

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/BrowseListTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/BrowseListTag.java
@@ -869,7 +869,7 @@ public class BrowseListTag extends TagSupport
         		Bitstream original = thumbnail.getOriginal();
         		String link = hrq.getContextPath() + "/bitstream/" + item.getHandle() + "/" + original.getSequenceID() + "/" +
         						UIUtil.encodeBitstreamName(original.getName(), Constants.DEFAULT_ENCODING);
-        		thumbFrag.append("<a target=\"_blank\" href=\"").append(link).append("\" />");
+        		thumbFrag.append("<a target=\"_blank\" rel=\"noopener\" href=\"").append(link).append("\" />");
         	}
         	else
         	{

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemListTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemListTag.java
@@ -833,7 +833,7 @@ public class ItemListTag extends TagSupport
                 Bitstream original = thumbnail.getOriginal();
                 String link = hrq.getContextPath() + "/bitstream/" + item.getHandle() + "/" + original.getSequenceID() + "/" +
                                 UIUtil.encodeBitstreamName(original.getName(), Constants.DEFAULT_ENCODING);
-                thumbFrag.append("<a target=\"_blank\" href=\"" + link + "\" />");
+                thumbFrag.append("<a target=\"_blank\" rel=\"noopener\" href=\"" + link + "\" />");
             }
             else
             {

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemTag.java
@@ -926,7 +926,7 @@ public class ItemTag extends TagSupport
             		}
 
             		out.print("<tr><td headers=\"t1\" class=\"standard break-all\">");
-                    out.print("<a target=\"_blank\" href=\"");
+                    out.print("<a target=\"_blank\" rel=\"noopener\" href=\"");
                     out.print(request.getContextPath());
                     out.print("/html/");
                     out.print(handle + "/");
@@ -951,7 +951,7 @@ public class ItemTag extends TagSupport
                     out.print("</td><td headers=\"t4\" class=\"standard\">");
             		out.print(primaryBitstream.getFormatDescription(context));
             		out
-                        .print("</td><td class=\"standard\"><a class=\"btn btn-primary\" target=\"_blank\" href=\"");
+                        .print("</td><td class=\"standard\"><a class=\"btn btn-primary\" target=\"_blank\" rel=\"noopener\" href=\"");
             		out.print(request.getContextPath());
             		out.print("/html/");
             		out.print(handle + "/");
@@ -993,7 +993,7 @@ public class ItemTag extends TagSupport
                                 // Work out what the bitstream link should be
                                 // (persistent
                                 // ID if item has Handle)
-                                String bsLink = "target=\"_blank\" href=\""
+                                String bsLink = "target=\"_blank\" rel=\"noopener\" href=\""
                                         + request.getContextPath();
 
                                 if ((handle != null)
@@ -1224,7 +1224,7 @@ public class ItemTag extends TagSupport
             for (Bitstream b : bitstreams)
             {
                 out.print("<div align=\"center\" class=\"standard\">");
-                out.print("<strong><a class=\"btn btn-primary\" target=\"_blank\" href=\"");
+                out.print("<strong><a class=\"btn btn-primary\" target=\"_blank\" rel=\"noopener\" href=\"");
                 out.print(request.getContextPath());
                 out.print("/retrieve/");
                 out.print(b.getID() + "/");

--- a/dspace-jspui/src/main/webapp/layout/legacy/header-default.jsp
+++ b/dspace-jspui/src/main/webapp/layout/legacy/header-default.jsp
@@ -111,7 +111,7 @@
                 <td>
                     <a href="<%= request.getContextPath() %>/"><img src="<%= request.getContextPath() %>/image/dspace-blue.gif" alt="<fmt:message key="jsp.layout.header-default.alt"/>" width="198" height="79" border="0"/></a></td>
                     <td class="tagLine" width="99%"> <%-- Make as wide as possible. cellpadding repeated for broken NS 4.x --%>
-                    <a class="tagLineText" target="_blank" href="http://www.dspace.org/"><fmt:message key="jsp.layout.header-default.about"/></a>
+                    <a class="tagLineText" target="_blank" rel="noopener" href="http://www.dspace.org/"><fmt:message key="jsp.layout.header-default.about"/></a>
                 </td>
                 <td nowrap="nowrap" valign="middle">
                 </td>

--- a/dspace-jspui/src/main/webapp/sherpa/sherpa-policy.jsp
+++ b/dspace-jspui/src/main/webapp/sherpa/sherpa-policy.jsp
@@ -177,7 +177,7 @@
 									<div class="sherpaPaid">
 										<p>
 											<strong><fmt:message key="jsp.sherpa.paidoption-label"/>: </strong>
-											<a href='<c:out value="${publisher.paidAccessUrl}"/>' target="_blank">
+											<a href='<c:out value="${publisher.paidAccessUrl}"/>' target="_blank" rel="noopener">
 												<c:out value="${publisher.paidAccessDescription}"/>
 											</a>. <fmt:message key="jsp.sherpa.paidoption-message"/>.
 										</p>
@@ -191,7 +191,7 @@
 										<fmt:message key="jsp.sherpa.copyright" />
 										<ul class="sherpa-copyright-links">
 											<c:forEach var="copyright_url" items="${policy.urls}">
-												<li><a href="${copyright_url.key}" target="_blank">${copyright_url.value}</a></li>
+												<li><a href="${copyright_url.key}" target="_blank" rel="noopener">${copyright_url.value}</a></li>
 											</c:forEach>
 										</ul>
 									</div>

--- a/dspace-jspui/src/main/webapp/submit/review-upload.jsp
+++ b/dspace-jspui/src/main/webapp/submit/review-upload.jsp
@@ -85,7 +85,7 @@
 	            downloadLink = "html/db-id/" + item.getID();
 	        }
 %>
-	                                            <a href="<%= request.getContextPath() %>/<%= downloadLink %>/<%= UIUtil.encodeBitstreamName(bitstreams.get(i).getName()) %>" target="_blank"><%= bitstreams.get(i).getName() %></a> - <%= bitstreams.get(i).getFormatDescription(context) %>
+	                                            <a href="<%= request.getContextPath() %>/<%= downloadLink %>/<%= UIUtil.encodeBitstreamName(bitstreams.get(i).getName()) %>" target="_blank" rel="noopener"><%= bitstreams.get(i).getName() %></a> - <%= bitstreams.get(i).getFormatDescription(context) %>
 <%
 	        switch (format.getSupportLevel())
 	        {

--- a/dspace-jspui/src/main/webapp/submit/show-uploaded-file.jsp
+++ b/dspace-jspui/src/main/webapp/submit/show-uploaded-file.jsp
@@ -123,7 +123,7 @@
             </tr>
             <tr>
                 <td headers="t1" class="evenRowOddCol">
-                	<a href="<%= request.getContextPath() %>/retrieve/<%= bitstream.getID() %>/<%= org.dspace.app.webui.util.UIUtil.encodeBitstreamName(bitstream.getName()) %>" target="_blank"><%= bitstream.getName() %></a>
+                	<a href="<%= request.getContextPath() %>/retrieve/<%= bitstream.getID() %>/<%= org.dspace.app.webui.util.UIUtil.encodeBitstreamName(bitstream.getName()) %>" target="_blank" rel="noopener"><%= bitstream.getName() %></a>
                 	<%-- <input type="submit" name="submit_remove_<%= bitstream.getID() %>" value="Click here if this is the wrong file"> --%>
 					<input class="btn btn-danger pull-right" type="submit" name="submit_remove_<%= bitstream.getID() %>" value="<fmt:message key="jsp.submit.show-uploaded-file.click2.button"/>" />
                 </td>

--- a/dspace-jspui/src/main/webapp/submit/upload-file-list.jsp
+++ b/dspace-jspui/src/main/webapp/submit/upload-file-list.jsp
@@ -177,7 +177,7 @@
 			      } %> />
 		</td>
                 <td headers="t2" class="<%= row %>RowOddCol break-all">
-                	<a href="<%= request.getContextPath() %>/retrieve/<%= bitstreams.get(i).getID() %>/<%= org.dspace.app.webui.util.UIUtil.encodeBitstreamName(bitstreams.get(i).getName()) %>" target="_blank"><%= bitstreams.get(i).getName() %></a>
+                	<a href="<%= request.getContextPath() %>/retrieve/<%= bitstreams.get(i).getID() %>/<%= org.dspace.app.webui.util.UIUtil.encodeBitstreamName(bitstreams.get(i).getName()) %>" target="_blank" rel="noopener"><%= bitstreams.get(i).getName() %></a>
             <%      // Don't display "remove" button in workflow mode
 			        if (allowFileEditing)
 			        {

--- a/dspace-jspui/src/main/webapp/tools/edit-item-form.jsp
+++ b/dspace-jspui/src/main/webapp/tools/edit-item-form.jsp
@@ -579,8 +579,8 @@
 %>
             <tr id="<%="row_" + bundles.get(i).getName() + "_" + bitstream.getID()%>">
             	<td headers="t10" class="<%= row %>RowEvenCol" align="center">
-                	<%-- <a target="_blank" href="<%= request.getContextPath() %>/retrieve/<%= bitstream.getID() %>">View</a>&nbsp;<input type="submit" name="submit_delete_bitstream_<%= key %>" value="Remove"> --%>
-					<a class="btn btn-info" target="_blank" href="<%= request.getContextPath() %>/retrieve/<%= bitstream.getID() %>"><fmt:message key="jsp.tools.general.view"/></a>&nbsp;
+                	<%-- <a target="_blank" rel="noopener" href="<%= request.getContextPath() %>/retrieve/<%= bitstream.getID() %>">View</a>&nbsp;<input type="submit" name="submit_delete_bitstream_<%= key %>" value="Remove"> --%>
+					<a class="btn btn-info" target="_blank" rel="noopener" href="<%= request.getContextPath() %>/retrieve/<%= bitstream.getID() %>"><fmt:message key="jsp.tools.general.view"/></a>&nbsp;
 				</td>
                 <% if (bundles.get(i).getName().equals("ORIGINAL"))
                    { %>

--- a/dspace-xmlui-mirage2/src/main/webapp/scripts/person-lookup.js
+++ b/dspace-xmlui-mirage2/src/main/webapp/scripts/person-lookup.js
@@ -153,7 +153,7 @@ function AuthorLookup(url, authorityInput, collectionID) {
                         '<label>' + label + ': </label>';
 
                     if(key == 'orcid'){
-                        dataString +='<span><a target="_blank" href="http://orcid.org/' + aData[key] + '">' + aData[key] + '</a></span>';
+                        dataString +='<span><a target="_blank" rel="noopener" href="http://orcid.org/' + aData[key] + '">' + aData[key] + '</a></span>';
                     } else {
                         dataString += '<span>' + aData[key] + '</span>';
                     }

--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/core/page-structure.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/core/page-structure.xsl
@@ -708,7 +708,7 @@
                     <hr/>
                     <div class="col-xs-7 col-sm-8">
                         <div>
-                            <a href="http://www.dspace.org/" target="_blank">DSpace software</a> copyright&#160;&#169;&#160;2002-2016&#160; <a href="http://www.duraspace.org/" target="_blank">DuraSpace</a>
+                            <a href="http://www.dspace.org/" target="_blank" rel="noopener">DSpace software</a> copyright&#160;&#169;&#160;2002-2016&#160; <a href="http://www.duraspace.org/" target="_blank" rel="noopener">DuraSpace</a>
                         </div>
                         <div class="hidden-print">
                             <a>
@@ -734,7 +734,7 @@
                         <div class="pull-right">
                             <span class="theme-by">Theme by&#160;</span>
                             <br/>
-                            <a title="Atmire NV" target="_blank" href="http://atmire.com">
+                            <a title="Atmire NV" target="_blank" rel="noopener" href="http://atmire.com">
                                 <img alt="Atmire NV" src="{concat($theme-path, 'images/atmire-logo-small.svg')}"/>
                             </a>
                         </div>

--- a/dspace-xmlui/src/main/webapp/static/js/person-lookup.js
+++ b/dspace-xmlui/src/main/webapp/static/js/person-lookup.js
@@ -137,7 +137,7 @@ function AuthorLookup(url, authorityInput, collectionID) {
                         '<label>' + label + ': </label>';
 
                     if(key == 'orcid'){
-                        dataString +='<span><a target="_blank" href="http://orcid.org/' + aData[key] + '">' + aData[key] + '</a></span>';
+                        dataString +='<span><a target="_blank" rel="noopener" href="http://orcid.org/' + aData[key] + '">' + aData[key] + '</a></span>';
                     } else {
                         dataString += '<span>' + aData[key] + '</span>';
                     }

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
@@ -589,11 +589,11 @@
         <div id="ds-footer-wrapper">
             <div id="ds-footer">
                 <div id="ds-footer-left">
-                    <a href="http://www.dspace.org/" target="_blank">DSpace software</a> copyright&#160;&#169;&#160;2002-2016&#160; <a href="http://www.duraspace.org/" target="_blank">DuraSpace</a>
+                    <a href="http://www.dspace.org/" target="_blank" rel="noopener">DSpace software</a> copyright&#160;&#169;&#160;2002-2016&#160; <a href="http://www.duraspace.org/" target="_blank" rel="noopener">DuraSpace</a>
                 </div>
                 <div id="ds-footer-right">
                     <span class="theme-by">Theme by&#160;</span>
-                    <a title="Atmire NV" target="_blank" href="http://atmire.com" id="ds-footer-logo-link">
+                    <a title="Atmire NV" target="_blank" rel="noopener" href="http://atmire.com" id="ds-footer-logo-link">
                     <span id="ds-footer-logo">&#160;</span>
                     </a>
                 </div>

--- a/dspace-xmlui/src/main/webapp/themes/mobile/mobile.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/mobile/mobile.xsl
@@ -577,11 +577,14 @@
                                 <xsl:variable name="v1" select="translate($v1,' ', '+')"/>
                                 <a>
                                     <xsl:attribute name="href">
-                                    <xsl:text>http://scholar.google.com/scholar?q=</xsl:text>
-                                    <xsl:value-of select="$v1"/>
+                                        <xsl:text>https://scholar.google.com/scholar?q=</xsl:text>
+                                        <xsl:value-of select="$v1"/>
                                     </xsl:attribute>
                                     <xsl:attribute name="target">
-                                    <xsl:text>_blank</xsl:text>
+                                        <xsl:text>_blank</xsl:text>
+                                    </xsl:attribute>
+                                    <xsl:attribute name="rel">
+                                        <xsl:text>noopener</xsl:text>
                                     </xsl:attribute>
                                     <i18n:text>xmlui.mobile.items_in_google_scholar</i18n:text>
                                 </a>


### PR DESCRIPTION
I think I found all of the instances that needed to be changed, both external links and cases where HTML bitstreams are opened in a separate tab (mostly JSPUI).

Jira issue: https://jira.duraspace.org/browse/DS-3891

Fixes #7238