### PR TITLE
Entities: configuring whether name variants should be used

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
@@ -90,6 +90,11 @@ public class DCInput {
     private boolean repeatable = false;
 
     /**
+     * should name-variants be used?
+     */
+    private boolean nameVariants = false;
+
+    /**
      * 'hint' text to display
      */
     private String hint = null;
@@ -183,6 +188,9 @@ public class DCInput {
         String repStr = fieldMap.get("repeatable");
         repeatable = "true".equalsIgnoreCase(repStr)
             || "yes".equalsIgnoreCase(repStr);
+        String nameVariantsString = fieldMap.get("name-variants");
+        nameVariants = (StringUtils.isNotBlank(nameVariantsString)) ?
+                nameVariantsString.equalsIgnoreCase("true") : false;
         label = fieldMap.get("label");
         inputType = fieldMap.get("input-type");
         // these types are list-controlled
@@ -267,6 +275,15 @@ public class DCInput {
      */
     public boolean getRepeatable() {
         return isRepeatable();
+    }
+
+    /**
+     * Get the nameVariants flag for this row
+     *
+     * @return the nameVariants flag
+     */
+    public boolean areNameVariantsAllowed() {
+        return nameVariants;
     }
 
     /**

--- a/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
@@ -18,7 +18,7 @@
  <!-- displayed label, a text string prompt which is called a hint, and    -->
  <!-- an input-type. Each field also may hold optional elements: DC        -->
  <!-- qualifier name, a repeatable flag, an optional name-variants allowed -->
- <!-- flag, and a text string whose presence  &ndash;&gt; serves as a      -->
+ <!-- flag, and a text string whose presence serves as a                   -->
  <!-- 'this field is required' flag.                                       -->
 
  <form-definitions>

--- a/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
@@ -14,11 +14,12 @@
  <!-- Each form set contains an ordered set of pages; each page defines    -->
  <!-- one submission metadata entry screen. Each page has an ordered list  -->
  <!-- of field definitions, Each field definition corresponds to one       -->
- <!-- metadata entry (a so-called row), which has a DC element name, a    -->
+ <!-- metadata entry (a so-called row), which has a DC element name, a     -->
  <!-- displayed label, a text string prompt which is called a hint, and    -->
  <!-- an input-type. Each field also may hold optional elements: DC        -->
- <!-- qualifier name, a repeatable flag, and a text string whose presence  -->
- <!-- serves as a 'this field is required' flag.                           -->
+ <!-- qualifier name, a repeatable flag, an optional name-variants allowed -->
+ <!-- flag, and a text string whose presence  &ndash;&gt; serves as a      -->
+ <!-- 'this field is required' flag.                                       -->
 
  <form-definitions>
     <form name="bitstream-metadata">
@@ -53,6 +54,7 @@
                     <relationship-type>isAuthorOfPublication</relationship-type>
                     <search-configuration>personConfiguration</search-configuration>
                     <repeatable>true</repeatable>
+                    <name-variants>true</name-variants>
                     <label>Author</label>
                     <hint>Add an author</hint>
                     <linked-metadata-field>

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionFormConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionFormConverter.java
@@ -170,6 +170,7 @@ public class SubmissionFormConverter implements DSpaceConverter<DCInputSet, Subm
         selectableRelationship.setRelationshipType(dcinput.getRelationshipType());
         selectableRelationship.setFilter(dcinput.getFilter());
         selectableRelationship.setSearchConfiguration(dcinput.getSearchConfiguration());
+        selectableRelationship.setNameVariants(String.valueOf(dcinput.areNameVariantsAllowed()));
         return selectableRelationship;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/submit/SelectableRelationship.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/submit/SelectableRelationship.java
@@ -23,6 +23,7 @@ public class SelectableRelationship {
     private String relationshipType;
     private String filter;
     private String searchConfiguration;
+    private String nameVariants;
 
     public void setRelationshipType(String relationshipType) {
         this.relationshipType = relationshipType;
@@ -46,5 +47,13 @@ public class SelectableRelationship {
 
     public String getSearchConfiguration() {
         return searchConfiguration;
+    }
+
+    public void setNameVariants(String nameVariants) {
+        this.nameVariants = nameVariants;
+    }
+
+    public String getNameVariants() {
+        return nameVariants;
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionFormsControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionFormsControllerIT.java
@@ -78,7 +78,7 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
                    // check the first two rows
                    .andExpect(jsonPath("$.rows[0].fields", contains(
                         SubmissionFormFieldMatcher.matchFormFieldDefinition("name", "Author",
-                null, true, "Add an author", "dc.contributor.author"))))
+                null, true,"Add an author", "dc.contributor.author"))))
                    .andExpect(jsonPath("$.rows[1].fields", contains(
                         SubmissionFormFieldMatcher.matchFormFieldDefinition("onebox", "Title",
                                 "You must enter a main title for this item.", false,
@@ -90,9 +90,9 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
                                         "You must enter at least the year.", false,
                                         "Please give the date", "col-sm-4",
                                         "dc.date.issued"),
-                                SubmissionFormFieldMatcher.matchFormFieldDefinition("onebox", "Publisher", null, false,
-                                        "Enter the name of", "col-sm-8",
-                                        "dc.publisher"))))
+                                SubmissionFormFieldMatcher.matchFormFieldDefinition("onebox", "Publisher",
+                                        null, false,"Enter the name of",
+                                        "col-sm-8","dc.publisher"))))
         ;
     }
 
@@ -114,9 +114,9 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
                         // check the first two rows
                         .andExpect(jsonPath("$.rows[0].fields", contains(
                             SubmissionFormFieldMatcher.matchFormOpenRelationshipFieldDefinition("name",
-                        "Author", null, true, "Add an author",
+                        "Author", null, true,"Add an author",
                     "dc.contributor.author", "isAuthorOfPublication", null,
-            "personConfiguration"))))
+            "personConfiguration", true))))
         ;
     }
 
@@ -138,8 +138,8 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
                         // check the first two rows
                         .andExpect(jsonPath("$.rows[0].fields", contains(
                             SubmissionFormFieldMatcher.matchFormClosedRelationshipFieldDefinition("Journal", null,
-                    false, "Select the journal related to this volume.", "isVolumeOfJournal",
-                        "creativework.publisher:somepublishername", "periodicalConfiguration"))))
+                    false,"Select the journal related to this volume.", "isVolumeOfJournal",
+                        "creativework.publisher:somepublishername", "periodicalConfiguration", false))))
         ;
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/SubmissionFormFieldMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/SubmissionFormFieldMatcher.java
@@ -13,6 +13,8 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
+import javax.annotation.Nullable;
+
 import org.hamcrest.Matcher;
 
 /**
@@ -47,7 +49,8 @@ public class SubmissionFormFieldMatcher {
      * @return a Matcher for all the condition above
      */
     public static Matcher<? super Object> matchFormFieldDefinition(String type, String label, String mandatoryMessage,
-                                                                   boolean repeatable, String hints, String metadata) {
+                                                                   boolean repeatable,
+                                                                   String hints, String metadata) {
         return matchFormFieldDefinition(type, label, mandatoryMessage, repeatable, hints, null, metadata);
     }
 
@@ -73,8 +76,8 @@ public class SubmissionFormFieldMatcher {
      * @return a Matcher for all the condition above
      */
     public static Matcher<? super Object> matchFormFieldDefinition(String type, String label, String mandatoryMessage,
-                                                                   boolean repeatable, String hints, String style,
-                                                                   String metadata) {
+                                                                   boolean repeatable,
+                                                                   String hints, String style, String metadata) {
         return allOf(
             // check each field definition
             hasJsonPath("$.input.type", is(type)),
@@ -113,19 +116,26 @@ public class SubmissionFormFieldMatcher {
      *            the optional filter to be used for the lookup
      * @param searchConfiguration
      *            the searchConfiguration to be used for the lookup
+     * @param nameVariants
+     *            the optional name variants allowed flag
      * @return a Matcher for all the condition above
      */
     public static Matcher<? super Object> matchFormOpenRelationshipFieldDefinition(String type, String label,
                                                                                    String mandatoryMessage,
-                                                                                   boolean repeatable, String hints,
+                                                                                   boolean repeatable,
+                                                                                   String hints,
                                                                                    String metadata,
                                                                                    String relationshipType,
                                                                                    String filter,
-                                                                                   String searchConfiguration) {
+                                                                                   String searchConfiguration,
+                                                                                   @Nullable Boolean nameVariants) {
         return allOf(
             hasJsonPath("$.selectableRelationship.relationshipType", is(relationshipType)),
             hasJsonPath("$.selectableRelationship.filter", is(filter)),
             hasJsonPath("$.selectableRelationship.searchConfiguration", is(searchConfiguration)),
+                nameVariants != null ?
+                        hasJsonPath("$.selectableRelationship.nameVariants", is(nameVariants.toString()))
+                        : hasNoJsonPath("$.selectableRelationship.nameVariants"),
             matchFormFieldDefinition(type, label, mandatoryMessage, repeatable, hints, metadata));
     }
 
@@ -148,18 +158,25 @@ public class SubmissionFormFieldMatcher {
      *            the optional filter to be used for the lookup
      * @param searchConfiguration
      *            the searchConfiguration to be used for the lookup
+     * @param nameVariants
+     *            the optional name variants allowed flag
      * @return a Matcher for all the condition above
      */
     public static Matcher<? super Object> matchFormClosedRelationshipFieldDefinition(String label,
                                                                                      String mandatoryMessage,
-                                                                                     boolean repeatable, String hints,
+                                                                                     boolean repeatable,
+                                                                                     String hints,
                                                                                      String relationshipType,
                                                                                      String filter,
-                                                                                     String searchConfiguration) {
+                                                                                     String searchConfiguration,
+                                                                                     @Nullable Boolean nameVariants) {
         return allOf(
             hasJsonPath("$.selectableRelationship.relationshipType", is(relationshipType)),
             hasJsonPath("$.selectableRelationship.filter", is(filter)),
             hasJsonPath("$.selectableRelationship.searchConfiguration", is(searchConfiguration)),
+                nameVariants != null ?
+                        hasJsonPath("$.selectableRelationship.nameVariants", is(nameVariants.toString()))
+                        : hasNoJsonPath("$.selectableRelationship.nameVariants"),
             hasJsonPath("$.label", is(label)),
             mandatoryMessage != null ? hasJsonPath("$.mandatoryMessage", containsString(mandatoryMessage)) :
                 hasNoJsonPath("$.mandatoryMessage"),

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/SubmissionFormFieldMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/SubmissionFormFieldMatcher.java
@@ -13,8 +13,6 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
-import javax.annotation.Nullable;
-
 import org.hamcrest.Matcher;
 
 /**
@@ -128,14 +126,12 @@ public class SubmissionFormFieldMatcher {
                                                                                    String relationshipType,
                                                                                    String filter,
                                                                                    String searchConfiguration,
-                                                                                   @Nullable Boolean nameVariants) {
+                                                                                   boolean nameVariants) {
         return allOf(
             hasJsonPath("$.selectableRelationship.relationshipType", is(relationshipType)),
             hasJsonPath("$.selectableRelationship.filter", is(filter)),
             hasJsonPath("$.selectableRelationship.searchConfiguration", is(searchConfiguration)),
-                nameVariants != null ?
-                        hasJsonPath("$.selectableRelationship.nameVariants", is(nameVariants.toString()))
-                        : hasNoJsonPath("$.selectableRelationship.nameVariants"),
+            hasJsonPath("$.selectableRelationship.nameVariants", is(String.valueOf(nameVariants))),
             matchFormFieldDefinition(type, label, mandatoryMessage, repeatable, hints, metadata));
     }
 
@@ -169,14 +165,12 @@ public class SubmissionFormFieldMatcher {
                                                                                      String relationshipType,
                                                                                      String filter,
                                                                                      String searchConfiguration,
-                                                                                     @Nullable Boolean nameVariants) {
+                                                                                     boolean nameVariants) {
         return allOf(
             hasJsonPath("$.selectableRelationship.relationshipType", is(relationshipType)),
             hasJsonPath("$.selectableRelationship.filter", is(filter)),
             hasJsonPath("$.selectableRelationship.searchConfiguration", is(searchConfiguration)),
-                nameVariants != null ?
-                        hasJsonPath("$.selectableRelationship.nameVariants", is(nameVariants.toString()))
-                        : hasNoJsonPath("$.selectableRelationship.nameVariants"),
+            hasJsonPath("$.selectableRelationship.nameVariants", is(String.valueOf(nameVariants))),
             hasJsonPath("$.label", is(label)),
             mandatoryMessage != null ? hasJsonPath("$.mandatoryMessage", containsString(mandatoryMessage)) :
                 hasNoJsonPath("$.mandatoryMessage"),

--- a/dspace/config/submission-forms.dtd
+++ b/dspace/config/submission-forms.dtd
@@ -22,6 +22,7 @@
   
  <!ELEMENT hint (#PCDATA) >
  <!ELEMENT required (#PCDATA)>
+ <!ELEMENT name-variants (#PCDATA)>
  <!ELEMENT regex (#PCDATA) >
 
  <!ELEMENT form-value-pairs (value-pairs)* >
@@ -59,5 +60,5 @@
 <!ELEMENT relationship-type (#PCDATA) >
 <!ELEMENT search-configuration (#PCDATA) >
 <!ELEMENT filter (#PCDATA) >
-<!ELEMENT relation-field (relationship-type, search-configuration, filter?, repeatable?, label, type-bind?, hint, linked-metadata-field?, required?, visibility?)>
+<!ELEMENT relation-field (relationship-type, search-configuration, filter?, repeatable?, name-variants?, label, type-bind?, hint, linked-metadata-field?, required?, visibility?)>
 <!ELEMENT linked-metadata-field (dc-schema, dc-element, dc-qualifier?, input-type)>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -14,7 +14,7 @@
     <!-- Each form set contains an ordered set of pages; each page defines    -->
     <!-- one submission metadata entry screen. Each page has an ordered list  -->
     <!-- of field definitions, Each field definition corresponds to one       -->
-    <!-- metadata entry (a so-called row), which has a DC element name, a    -->
+    <!-- metadata entry (a so-called row), which has a DC element name, a     -->
     <!-- displayed label, a text string prompt which is called a hint, and    -->
     <!-- an input-type. Each field also may hold optional elements: DC        -->
     <!-- qualifier name, a repeatable flag, and a text string whose presence  -->


### PR DESCRIPTION
This is the REST implementation of https://github.com/DSpace/Rest7Contract/pull/77

It allows for configuration specifying whether the entities lookup should present the dropdown to enter name variants