### PR TITLE
DS-4379 Stop adding relations as metadata for new items

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -402,13 +402,15 @@ public class MetadataImport {
 
                         // Add the metadata to the item
                         for (BulkEditMetadataValue dcv : whatHasChanged.getAdds()) {
-                            itemService.addMetadata(c, item, dcv.getSchema(),
-                                                    dcv.getElement(),
-                                                    dcv.getQualifier(),
-                                                    dcv.getLanguage(),
-                                                    dcv.getValue(),
-                                                    dcv.getAuthority(),
-                                                    dcv.getConfidence());
+                            if (!StringUtils.equals(dcv.getSchema(), MetadataSchemaEnum.RELATION.getName())) {
+                                itemService.addMetadata(c, item, dcv.getSchema(),
+                                        dcv.getElement(),
+                                        dcv.getQualifier(),
+                                        dcv.getLanguage(),
+                                        dcv.getValue(),
+                                        dcv.getAuthority(),
+                                        dcv.getConfidence());
+                            }
                         }
                         //Add relations after all metadata has been processed
                         for (BulkEditMetadataValue dcv : whatHasChanged.getAdds()) {


### PR DESCRIPTION
This fixes a bug where metadatavalue rows were incorrectly added on CSV import, when the item was new, and it had relationships to another item. The relationships should only be persisted in the database relationship table, not metadatavalue.

https://jira.duraspace.org/browse/DS-4379