### PR TITLE
(HIGH PRIORITY) Fix broken master builds

### DIFF
--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -155,9 +155,6 @@
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
                     <attachClasses>true</attachClasses>
-                    <!-- In version 2.1-alpha-1, this was incorrectly named warSourceExcludes -->
-                    <packagingExcludes>WEB-INF/lib/*.jar</packagingExcludes>
-                    <warSourceExcludes>WEB-INF/lib/*.jar</warSourceExcludes>
                     <!-- Filter the web.xml (needed for IDE compatibility/debugging) -->
                     <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
                 </configuration>
@@ -170,10 +167,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.2</version>
                 <executions>
                     <execution>
                         <goals>
+                            <!-- Builds a *-tests.jar of all test classes -->
                             <goal>test-jar</goal>
                         </goals>
                     </execution>

--- a/dspace/modules/additions/pom.xml
+++ b/dspace/modules/additions/pom.xml
@@ -190,6 +190,7 @@
       <dependency>
          <groupId>org.dspace</groupId>
          <artifactId>dspace-api</artifactId>
+         <version>7.0-SNAPSHOT</version>
          <type>test-jar</type>
          <scope>test</scope>
       </dependency>

--- a/dspace/modules/server/pom.xml
+++ b/dspace/modules/server/pom.xml
@@ -96,7 +96,6 @@ just adding new jar in the classloader</description>
                          install of DSpace, against which Tests can be run. -->
                     <plugin>
                         <artifactId>maven-dependency-plugin</artifactId>
-                        <version>2.8</version>
                         <configuration>
                             <outputDirectory>${project.build.directory}/testing</outputDirectory>
                             <artifactItems>
@@ -140,7 +139,6 @@ just adding new jar in the classloader</description>
                     <plugin>
                         <groupId>org.codehaus.gmaven</groupId>
                         <artifactId>groovy-maven-plugin</artifactId>
-                        <version>2.0</version>
                         <executions>
                             <execution>
                                 <id>setproperty</id>
@@ -189,7 +187,17 @@ just adding new jar in the classloader</description>
                     </plugin>
                 </plugins>
             </build>
-
+            <dependencies>
+                <!-- When running tests, also include test classes from dspace-server-webapp
+                     (this test-jar is only built when tests are enabled). -->
+                <dependency>
+                    <groupId>org.dspace</groupId>
+                    <artifactId>dspace-server-webapp</artifactId>
+                    <version>7.0-SNAPSHOT</version>
+                    <type>test-jar</type>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>oracle-support</id>
@@ -230,13 +238,6 @@ just adding new jar in the classloader</description>
             <artifactId>spring-boot-starter-tomcat</artifactId>
             <scope>provided</scope>
             <version>${spring-boot.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.dspace</groupId>
-            <artifactId>dspace-server-webapp</artifactId>
-            <type>test-jar</type>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -938,12 +938,6 @@
                 <version>7.0-SNAPSHOT</version>
             </dependency>
             <dependency>
-                <groupId>org.dspace</groupId>
-                <artifactId>dspace-api</artifactId>
-                <type>test-jar</type>
-                <version>7.0-SNAPSHOT</version>
-            </dependency>
-            <dependency>
                 <groupId>org.dspace.modules</groupId>
                 <artifactId>additions</artifactId>
                 <version>7.0-SNAPSHOT</version>
@@ -990,14 +984,9 @@
             <dependency>
                 <groupId>org.dspace</groupId>
                 <artifactId>dspace-server-webapp</artifactId>
-                <type>test-jar</type>
                 <version>7.0-SNAPSHOT</version>
-            </dependency>
-            <dependency>
-                <groupId>org.dspace</groupId>
-                <artifactId>dspace-server-webapp</artifactId>
+                <type>jar</type>
                 <classifier>classes</classifier>
-                <version>7.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.dspace</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -994,17 +994,11 @@
                 <version>7.0-SNAPSHOT</version>
                 <type>war</type>
             </dependency>
-            <!-- DSpace Localization Packages -->
+            <!-- DSpace API Localization Packages -->
             <dependency>
                 <groupId>org.dspace</groupId>
                 <artifactId>dspace-api-lang</artifactId>
                 <version>[6.0.0,7.0.0)</version>
-            </dependency>
-            <dependency>
-                <groupId>org.dspace</groupId>
-                <artifactId>dspace-xmlui-lang</artifactId>
-                <version>[6.0.0,7.0.0)</version>
-                <type>war</type>
             </dependency>
 
             <!-- DSpace third Party Dependencies -->


### PR DESCRIPTION
Fixes to #2553 (merged earlier today) which broke the ability to build DSpace on `master` *without tests*.  Currently, master only builds fine if you enable unit & integration tests.  

However, if you run a simple `mvn package`, build failures occur as the two new `test-jar` dependencies (added in #2553 ) are not found.

This PR fixes the build errors by correctly scoping the `test-jar` dependencies & ensuring that the `server` module only pulls in the `dspace-server-webapp` test-jar when tests are enabled.

I also removed an unused dependency on `dspace-xmlui-lang` that I stumbled across.  This PR succeeds a `mvn package` and also succeeds with tests enabled.