### PR TITLE
(HIGH PRIORITY) Ensure test-jar is only a dependency if tests are enabled

### DIFF
--- a/dspace/modules/additions/pom.xml
+++ b/dspace/modules/additions/pom.xml
@@ -154,7 +154,17 @@
                </plugin>
             </plugins>
          </build>
-
+         <dependencies>
+            <!-- When running tests, also include test classes from dspace-api
+                     (this test-jar is only built when tests are enabled). -->
+            <dependency>
+               <groupId>org.dspace</groupId>
+               <artifactId>dspace-api</artifactId>
+               <version>7.0-SNAPSHOT</version>
+               <type>test-jar</type>
+               <scope>test</scope>
+            </dependency>
+         </dependencies>
       </profile>
    </profiles>
 
@@ -187,13 +197,6 @@
          </exclusions>
       </dependency>
 
-      <dependency>
-         <groupId>org.dspace</groupId>
-         <artifactId>dspace-api</artifactId>
-         <version>7.0-SNAPSHOT</version>
-         <type>test-jar</type>
-         <scope>test</scope>
-      </dependency>
       <!-- Keep jmockit before junit -->
       <dependency>
          <groupId>org.jmockit</groupId>


### PR DESCRIPTION
Another fix for #2553.  This appends another fix onto #2571 (which was merged a bit earlier).  In some environments, #2571 worked fine...in others, this additional fix seems to be needed.

This simply ensures that the `test-jar` for dspace-api is ONLY referenced as a dependency when tests are enabled.  In some environments, it looks like this `test-jar` is only built (i.e. only exists) when tests are enabled.