### PR TITLE
Fix build - spring-expression is required at runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1113,7 +1113,6 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-expression</artifactId>
                 <version>${spring.version}</version>
-                <scope>test</scope>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Build of the dspace demo server fails with

```
2:40:03 test_database:
22:40:05      [java] Exception in thread "main" java.lang.NoClassDefFoundError: org/springframework/expression/PropertyAccessor
22:40:05      [java] 	at org.springframework.context.support.AbstractApplicationContext.prepareBeanFactory(AbstractApplicationContext.java:630)
22:40:05      [java] 	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:517)
22:40:05      [java] 	at org.dspace.servicemanager.spring.SpringServiceManager.startup(SpringServiceManager.java:196)
22:40:05      [java] 	at org.dspace.servicemanager.DSpaceServiceManager.startup(DSpaceServiceManager.java:231)
22:40:05      [java] 	at org.dspace.servicemanager.DSpaceKernelImpl.start(DSpaceKernelImpl.java:153)
22:40:05      [java] 	at org.dspace.servicemanager.DSpaceKernelImpl.start(DSpaceKernelImpl.java:128)
22:40:05      [java] 	at org.dspace.app.launcher.ScriptLauncher.main(ScriptLauncher.java:53)
22:40:05      [java] Caused by: java.lang.ClassNotFoundException: org.springframework.expression.PropertyAccessor
22:40:05      [java] 	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
22:40:05      [java] 	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
22:40:05      [java] 	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
22:40:05      [java] 	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
22:40:05      [java] 	... 7 more
```