### PR TITLE
[Docker Build Fix]: Ensure bin scripts ALWAYS have correct line endings

### DIFF
--- a/dspace/bin/.gitattributes
+++ b/dspace/bin/.gitattributes
@@ -1,0 +1,9 @@
+# Ensure Unix files in this folder always keep Unix line endings
+dspace text eol=lf
+dspace-info.pl text eol=lf
+log-reporter text eol=lf
+make-handle-config text eol=lf
+start-handle-server text eol=lf
+
+# Ensure Windows files in this folder always keep Windows line endings
+*.bat text eol=crlf


### PR DESCRIPTION
This PR adds in a new `[src]/dspace/bin/.gitattributes` configuration that tells Git to *always keep the OS-specific line endings* for all our scripts in `[dspace]/bin/`.

Currently, on `master`, the scripts in `[dspace]/bin/` simply have the line endings of whatever OS you are working on.  So, on Windows, they all have CRLF endings, and on Linux, they all have LF endings.  This behavior is fine in most scenarios, but causes issues if you build a Docker container from *Windows* (as our Docker containers all use Linux).

Here's the specific behavior I saw.  Keep in mind, I'm working on Windows 10
1. If I checkout our GitHub repo, all scripts in `[src]/dspace/bin/` end up with CRLF line endings
2. Using our Docker compose instructions, I rebuilt the `dspace/dspace-cli` image on my local machine.  See these instructions: https://github.com/DSpace/DSpace/blob/master/dspace/src/main/docker-compose/README.md
3. I then started my (locally built) Docker images. (again see above instructions)
4. Then, I tried running the `create-administrator` command (again see above instructions) and saw this error: `standard_init_linux.go:175: exec user process caused "no such file or directory"`

After digging around a bit, I realized what had occurred is that the `[src]/dspace/bin/dspace` script was checked out with CRLF line endings, and then copied to my locally built `dspace/dspace-cli` Docker image with those same CRLF line endings.  This resulted in the above error because the Docker image could not execute a script on Linux with CRLF line endings.  See for example: https://willi.am/blog/2016/08/11/docker-for-windows-dealing-with-windows-line-endings/

Rather than changing our Docker build process to ensure these corrected line endings, I realized we could just tell Git to always retain the proper line endings for these scripts.  That's exactly what this PR does. (This fix works for me, as after it is applied & I checkout the scripts again, the above steps succeed)

This PR should be backported to 6.x, as it also uses the `dspace/dspace-cli` image, which is the image where the issue became evident.