### PR TITLE
[Docker Fix] Ensure the "server" webapp runs on ONLY one path in Docker

### DIFF
--- a/Dockerfile.jdk8
+++ b/Dockerfile.jdk8
@@ -54,7 +54,13 @@ EXPOSE 8080 8009
 
 ENV JAVA_OPTS=-Xmx2000m
 
-RUN mv /usr/local/tomcat/webapps/ROOT /usr/local/tomcat/webapps/ROOT.bk && \
-    ln -s $DSPACE_INSTALL/webapps/server   /usr/local/tomcat/webapps/ROOT && \
-    ln -s $DSPACE_INSTALL/webapps/server   /usr/local/tomcat/webapps/server   && \
+# Run the "server" webapp off the /server path (e.g. http://localhost:8080/server/)
+# and the v6.x (deprecated) REST API off the "/rest" path
+RUN ln -s $DSPACE_INSTALL/webapps/server   /usr/local/tomcat/webapps/server   && \
     ln -s $DSPACE_INSTALL/webapps/rest          /usr/local/tomcat/webapps/rest
+# If you wish to run "server" webapp off the ROOT path, then comment out the above RUN, and uncomment the below RUN.
+# You also MUST update the URL in dspace/src/main/docker/local.cfg
+# Please note that server webapp should only run on one path at a time.
+#RUN mv /usr/local/tomcat/webapps/ROOT /usr/local/tomcat/webapps/ROOT.bk && \
+#    ln -s $DSPACE_INSTALL/webapps/server   /usr/local/tomcat/webapps/ROOT && \
+#    ln -s $DSPACE_INSTALL/webapps/rest          /usr/local/tomcat/webapps/rest

--- a/Dockerfile.jdk8-test
+++ b/Dockerfile.jdk8-test
@@ -54,11 +54,17 @@ EXPOSE 8080 8009
 
 ENV JAVA_OPTS=-Xmx2000m
 
-RUN mv /usr/local/tomcat/webapps/ROOT /usr/local/tomcat/webapps/ROOT.bk && \
-    ln -s $DSPACE_INSTALL/webapps/server   /usr/local/tomcat/webapps/ROOT && \
-    ln -s $DSPACE_INSTALL/webapps/server   /usr/local/tomcat/webapps/server   && \
+# Run the "server" webapp off the /server path (e.g. http://localhost:8080/server/)
+# and the v6.x (deprecated) REST API off the "/rest" path
+RUN ln -s $DSPACE_INSTALL/webapps/server   /usr/local/tomcat/webapps/server   && \
     ln -s $DSPACE_INSTALL/webapps/rest          /usr/local/tomcat/webapps/rest
+# If you wish to run "server" webapp off the ROOT path, then comment out the above RUN, and uncomment the below RUN.
+# You also MUST update the URL in dspace/src/main/docker/local.cfg
+# Please note that server webapp should only run on one path at a time.
+#RUN mv /usr/local/tomcat/webapps/ROOT /usr/local/tomcat/webapps/ROOT.bk && \
+#    ln -s $DSPACE_INSTALL/webapps/server   /usr/local/tomcat/webapps/ROOT && \
+#    ln -s $DSPACE_INSTALL/webapps/rest          /usr/local/tomcat/webapps/rest
 
+# Overwrite the v6.x (deprecated) REST API's web.xml, so that we can run it on HTTP (defaults to requiring HTTPS)
 COPY dspace/src/main/docker/test/rest_web.xml $DSPACE_INSTALL/webapps/rest/WEB-INF/web.xml
-
 RUN sed -i -e "s|\${dspace.dir}|$DSPACE_INSTALL|" $DSPACE_INSTALL/webapps/rest/WEB-INF/web.xml


### PR DESCRIPTION
This PR changes our Dockerfiles to ensure the "server" webapp only deploys to a single path: http://localhost:8080/server/.  

Currently, on `master`, this webapp deploys to *two* locations...the ROOT path (e.g. http://localhost:8080/) *and* the default `/server` path (e.g. http://localhost:8080/server/).

Unfortunately, in using Docker for testing PRs, I've found this double deployment makes endpoints (especially any requiring authentication) appear to behave oddly.  The reason is that, when you authenticate via REST, you are *only authenticated on one of the two paths*.  

So, if you authenticate via http://localhost:8080/ .. then access restricted paths using that deployment will work (e.g. http://localhost:8080/api/core/items).  However, ones accessed via `/server` will throw authentication errors (e.g. http://localhost:8080/server/api/core/items), as you are *not* considered authenticated via that app.   

To make things worse, when using the HAL Browser, all paths returned via the HAL Browser will use the `/server` endpoint, as this is what is defined in the local.cfg used by Docker: https://github.com/DSpace/DSpace/blob/master/dspace/src/main/docker/local.cfg

This has caused me a lot of confusion today, as I continually tried to authenticate via http://localhost:8080/ only to be redirected (by the HAL Browser) on my next button click to http://localhost:8080/server/ (where I was not logged in).

To fix this issue, I've decided to only deploy the "server" webapp on the `/server` endpoint.  I added in comments to describe how to deploy it on the ROOT endpoint for anyone desiring to do so at a later date.