### PR TITLE
Entities: Search relationships total fix

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RelationshipRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RelationshipRestRepository.java
@@ -337,7 +337,7 @@ public class RelationshipRestRepository extends DSpaceRestRepository<Relationshi
                 throw new ResourceNotFoundException("The request DSO with id: " + dsoId + " was not found");
             }
             for (RelationshipType relationshipType : relationshipTypeList) {
-                total = relationshipService.countByItemAndRelationshipType(context, item, relationshipType);
+                total += relationshipService.countByItemAndRelationshipType(context, item, relationshipType);
                 relationships.addAll(relationshipService.findByItemAndRelationshipType(context, item, relationshipType,
                         pageable.getPageSize(), pageable.getOffset()));
             }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RelationshipRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RelationshipRestRepository.java
@@ -343,7 +343,7 @@ public class RelationshipRestRepository extends DSpaceRestRepository<Relationshi
             }
         } else {
             for (RelationshipType relationshipType : relationshipTypeList) {
-                total = relationshipService.countByRelationshipType(context, relationshipType);
+                total += relationshipService.countByRelationshipType(context, relationshipType);
                 relationships.addAll(relationshipService.findByRelationshipType(context, relationshipType,
                         pageable.getPageSize(), pageable.getOffset()));
             }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipTypeRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipTypeRestControllerIT.java
@@ -184,6 +184,7 @@ public class RelationshipTypeRestControllerIT extends AbstractEntityIntegrationT
             .createRelationshipBuilder(context, publication2, author3, isAuthorOfPublicationRelationshipType).build();
 
         context.restoreAuthSystemState();
+        //verify results
         getClient().perform(get("/api/core/relationships/search/byLabel?label=isAuthorOfPublication"))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$._embedded.relationships", containsInAnyOrder(
@@ -193,6 +194,12 @@ public class RelationshipTypeRestControllerIT extends AbstractEntityIntegrationT
                        RelationshipMatcher.matchRelationship(relationship4)
                    )));
 
+        //verify paging
+        getClient().perform(get("/api/core/relationships/search/byLabel?label=isAuthorOfPublication&size=2"))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.page.totalElements", is(4)));
+
+        //verify results
         getClient().perform(get("/api/core/relationships/search/byLabel?label=isAuthorOfPublication&dso="
                                     + publication.getID()))
                    .andExpect(status().isOk())
@@ -201,6 +208,13 @@ public class RelationshipTypeRestControllerIT extends AbstractEntityIntegrationT
                        RelationshipMatcher.matchRelationship(relationship2)
                    )));
 
+        //verify paging
+        getClient().perform(get("/api/core/relationships/search/byLabel?label=isAuthorOfPublication&dso="
+                                    + publication.getID()+"&size=1"))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.page.totalElements", is(2)));
+
+        //verify results
         getClient().perform(get("/api/core/relationships/search/byLabel?label=isAuthorOfPublication&dso="
                                     + publication2.getID()))
                    .andExpect(status().isOk())
@@ -208,5 +222,12 @@ public class RelationshipTypeRestControllerIT extends AbstractEntityIntegrationT
                        RelationshipMatcher.matchRelationship(relationship3),
                        RelationshipMatcher.matchRelationship(relationship4)
                    )));
+
+        //verify paging
+        getClient().perform(get("/api/core/relationships/search/byLabel?label=isAuthorOfPublication&dso="
+                                    + publication2.getID()+"&size=1"))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.page.totalElements", is(2)));
+
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipTypeRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipTypeRestControllerIT.java
@@ -210,7 +210,7 @@ public class RelationshipTypeRestControllerIT extends AbstractEntityIntegrationT
 
         //verify paging
         getClient().perform(get("/api/core/relationships/search/byLabel?label=isAuthorOfPublication&dso="
-                                    + publication.getID()+"&size=1"))
+                                    + publication.getID() + "&size=1"))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$.page.totalElements", is(2)));
 
@@ -225,7 +225,7 @@ public class RelationshipTypeRestControllerIT extends AbstractEntityIntegrationT
 
         //verify paging
         getClient().perform(get("/api/core/relationships/search/byLabel?label=isAuthorOfPublication&dso="
-                                    + publication2.getID()+"&size=1"))
+                                    + publication2.getID() + "&size=1"))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$.page.totalElements", is(2)));
 


### PR DESCRIPTION
The totals for the `/api/core/relationships/search/byLabel` endpoint has a problem
If there are multiple relationship types with the requested label, the total is not correct.

This has been tested and ITs have been included to verify this