### PR TITLE
DS-1980: Adds meta tag to prevent robots from indexing the item if it is private

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemViewer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemViewer.java
@@ -307,6 +307,16 @@ public class ItemViewer extends AbstractDSpaceTransformer implements CacheablePr
 
             XMLOutputter xmlo = new XMLOutputter();
             xmlo.output(new Text("\n"), sw);
+
+            // Include noindex tag for robots if item is not discoverable
+            if (!item.isDiscoverable()) {
+                Element noindex = new Element("meta");
+                noindex.setAttribute("name", "robots");
+                noindex.setAttribute("content", "noindex");
+                xmlo.output(noindex, sw);
+                xmlo.output(new Text("\n"), sw);
+            }
+
             for (int i = 0; i < l.size(); i++)
             {
                 Element e = (Element) l.get(i);


### PR DESCRIPTION
Fixes #5346 
If the item is not discoverable then the following tag is added to the header:

`<meta name="robots" content="noindex">`