### PR TITLE
[DS-4393] Discovery clean index fix DSpace 6

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -461,32 +461,45 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                 // Query for all indexed Items, Collections and Communities,
                 // returning just their handle
                 query.setFields(HANDLE_FIELD);
+                query.addSort(HANDLE_FIELD, SolrQuery.ORDER.asc);
                 query.setQuery(RESOURCE_TYPE_FIELD + ":[2 TO 4]");
-                QueryResponse rsp = getSolr().query(query, SolrRequest.METHOD.POST);
-                SolrDocumentList docs = rsp.getResults();
 
-                Iterator iter = docs.iterator();
-                while (iter.hasNext())
-                {
+                // Get the total amount of results
+                QueryResponse totalResponse = getSolr().query(query);
+                long total = totalResponse.getResults().getNumFound();
 
-                 SolrDocument doc = (SolrDocument) iter.next();
+                int start = 0;
+                int batch = 100;
 
-                String handle = (String) doc.getFieldValue(HANDLE_FIELD);
+                query.setRows(batch);
+                while (start < total) {
+                    query.setStart(start);
+                    QueryResponse rsp = getSolr().query(query, SolrRequest.METHOD.POST);
+                    SolrDocumentList docs = rsp.getResults();
 
-                DSpaceObject o = handleService.resolveToObject(context, handle);
+                    Iterator iter = docs.iterator();
+                    while (iter.hasNext()) {
 
-                if (o == null)
-                {
-                    log.info("Deleting: " + handle);
-                    /*
-                          * Use IndexWriter to delete, its easier to manage
-                          * write.lock
-                          */
-                    unIndexContent(context, handle);
-                } else {
-                    log.debug("Keeping: " + handle);
+                        SolrDocument doc = (SolrDocument) iter.next();
+
+                        String handle = (String) doc.getFieldValue(HANDLE_FIELD);
+
+                        DSpaceObject o = handleService.resolveToObject(context, handle);
+
+                        if (o == null) {
+                            log.info("Deleting: " + handle);
+                            /*
+                             * Use IndexWriter to delete, its easier to manage
+                             * write.lock
+                             */
+                            unIndexContent(context, handle);
+                        } else {
+                            log.debug("Keeping: " + handle);
+                        }
+                    }
+
+                    start += batch;
                 }
-            }
             }
         } catch(Exception e)
         {

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -477,11 +477,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                     QueryResponse rsp = getSolr().query(query, SolrRequest.METHOD.POST);
                     SolrDocumentList docs = rsp.getResults();
 
-                    Iterator iter = docs.iterator();
-                    while (iter.hasNext()) {
-
-                        SolrDocument doc = (SolrDocument) iter.next();
-
+                    for (SolrDocument doc : docs) {
                         String handle = (String) doc.getFieldValue(HANDLE_FIELD);
 
                         DSpaceObject o = handleService.resolveToObject(context, handle);


### PR DESCRIPTION
Fixes #7731

The "index-discovery" command when run without argument or with "-c" will retrieve all documents from the solr index, check if they are still in the database & if not remove them.

There is a bug in this process however, the retrieval of "all" the documents will only retrieve the first 10 check those & then stop.

