### PR TITLE
Avoid setting the virtual metadata language to ANY (*)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/RelationshipMetadataServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/RelationshipMetadataServiceImpl.java
@@ -240,7 +240,6 @@ public class RelationshipMetadataServiceImpl implements RelationshipMetadataServ
             return null;
         }
         metadataValue.setMetadataField(metadataField);
-        //metadataValue.setLanguage(Item.ANY);
         return metadataValue;
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/RelationshipMetadataServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/RelationshipMetadataServiceImpl.java
@@ -240,7 +240,7 @@ public class RelationshipMetadataServiceImpl implements RelationshipMetadataServ
             return null;
         }
         metadataValue.setMetadataField(metadataField);
-        metadataValue.setLanguage(Item.ANY);
+        //metadataValue.setLanguage(Item.ANY);
         return metadataValue;
     }
 


### PR DESCRIPTION
This is a minor change to the virtual metadata

This used to create:
```
"dc.contributor.author": [
      {
        "value": "Demirguc-Kunt, Asli",
        "language": "*",
        "authority": "virtual::399",
        "confidence": -1,
        "place": 0
      },
      {
        "value": "Maksimovic, Vojislav",
        "language": null,
        "authority": null,
        "confidence": -1,
        "place": 1
      }
    ]
```

The `"language": "*"` will now become `"language": null`