### PR TITLE
DS-4401 Enforce relational place ordering when place direction is known

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/RelationshipDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/RelationshipDAOImpl.java
@@ -145,11 +145,13 @@ public class RelationshipDAOImpl extends AbstractHibernateDAO<Relationship> impl
                     .where(criteriaBuilder.equal(relationshipRoot.get(Relationship_.relationshipType),
                             relationshipType),
                            criteriaBuilder.equal(relationshipRoot.get(Relationship_.leftItem), item));
+            criteriaQuery.orderBy(criteriaBuilder.asc(relationshipRoot.get(Relationship_.leftPlace)));
         } else {
             criteriaQuery
                     .where(criteriaBuilder.equal(relationshipRoot.get(Relationship_.relationshipType),
                             relationshipType),
                             criteriaBuilder.equal(relationshipRoot.get(Relationship_.rightItem), item));
+            criteriaQuery.orderBy(criteriaBuilder.asc(relationshipRoot.get(Relationship_.rightPlace)));
         }
         return list(context, criteriaQuery, true, Relationship.class, limit, offset);
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RelationshipRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RelationshipRestRepository.java
@@ -351,9 +351,13 @@ public class RelationshipRestRepository extends DSpaceRestRepository<Relationshi
                 throw new ResourceNotFoundException("The request DSO with id: " + dsoId + " was not found");
             }
             for (RelationshipType relationshipType : relationshipTypeList) {
+                boolean isLeft = false;
+                if (relationshipType.getLeftwardType().equalsIgnoreCase(label)) {
+                    isLeft = true;
+                }
                 total += relationshipService.countByItemAndRelationshipType(context, item, relationshipType);
                 relationships.addAll(relationshipService.findByItemAndRelationshipType(context, item, relationshipType,
-                        pageable.getPageSize(), pageable.getOffset()));
+                        isLeft, pageable.getPageSize(), pageable.getOffset()));
             }
         } else {
             for (RelationshipType relationshipType : relationshipTypeList) {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipRestRepositoryIT.java
@@ -86,6 +86,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
     private Item author3;
 
     private Item orgUnit1;
+    private Item orgUnit2;
     private Item project1;
 
     private Item publication1;
@@ -156,6 +157,13 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                               .withIssueDate("2015-01-01")
                               .withRelationshipType("OrgUnit")
                               .build();
+
+        orgUnit2 = ItemBuilder.createItem(context, col3)
+                .withTitle("OrgUnit2")
+                .withAuthor("Testy, TEst")
+                .withIssueDate("2015-01-01")
+                .withRelationshipType("OrgUnit")
+                .build();
 
         project1 = ItemBuilder.createItem(context, col3)
                               .withTitle("Project1")
@@ -2161,6 +2169,9 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         Relationship relationship1 = RelationshipBuilder
             .createRelationshipBuilder(context, author1, orgUnit1, isOrgUnitOfPersonRelationshipType).build();
 
+        Relationship relationshipOrgunitExtra = RelationshipBuilder
+                .createRelationshipBuilder(context, author1, orgUnit2, isOrgUnitOfPersonRelationshipType).build();
+
         // We're creating a Relationship of type isOrgUnitOfPerson between a different author and the same orgunit
         Relationship relationshipAuthorExtra = RelationshipBuilder
             .createRelationshipBuilder(context, author2, orgUnit1, isOrgUnitOfPersonRelationshipType).build();
@@ -2186,10 +2197,16 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$.page",
-                                       is(PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 1))))
+                                       is(PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 2))))
                    .andExpect(jsonPath("$._embedded.relationships", hasItem(
                        RelationshipMatcher.matchRelationship(relationship1)
-                   )))
+                   ))) //check ordering
+                   .andExpect(jsonPath("$._embedded.relationships[0]._links.rightItem.href",
+                       containsString(orgUnit1.getID().toString())
+                   ))
+                   .andExpect(jsonPath("$._embedded.relationships[1]._links.rightItem.href",
+                       containsString(orgUnit2.getID().toString())
+                   ))
         ;
 
         // Perform a GET request to the searchByLabel endpoint, asking for Relationships of type isOrgUnitOfPerson
@@ -2201,10 +2218,11 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$.page",
-                                       is(PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 2))))
+                                       is(PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 3))))
                    .andExpect(jsonPath("$._embedded.relationships", containsInAnyOrder(
                        RelationshipMatcher.matchRelationship(relationship1),
-                       RelationshipMatcher.matchRelationship(relationshipAuthorExtra)
+                       RelationshipMatcher.matchRelationship(relationshipAuthorExtra),
+                       RelationshipMatcher.matchRelationship(relationshipOrgunitExtra)
                    )))
         ;
     }


### PR DESCRIPTION
From: https://jira.lyrasis.org/browse/DS-4401

Small improvement to enforce ascending order by leftward or rightward place when calling `findByItemAndRelationshipType` with the `isLeft` param.

The need for this fix came about when I requested the relationships from an item that had around 1,800~ relationships and received them in an mixed order which would cause a bad user experience when you're dependent on relational ordering.