### PR TITLE
Entities submission config

### DIFF
--- a/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
@@ -52,7 +52,7 @@
             <row>
                 <relation-field>
                     <relationship-type>isAuthorOfPublication</relationship-type>
-                    <search-configuration>personConfiguration</search-configuration>
+                    <search-configuration>person</search-configuration>
                     <repeatable>true</repeatable>
                     <name-variants>true</name-variants>
                     <label>Author</label>

--- a/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
@@ -238,7 +238,7 @@ it, please enter the types and the actual numbers or codes.</hint>
      <row>
        <relation-field>
          <relationship-type>isVolumeOfJournal</relationship-type>
-         <search-configuration>periodicalConfiguration</search-configuration>
+         <search-configuration>periodical</search-configuration>
          <filter>creativework.publisher:somepublishername</filter>
          <label>Journal</label>
          <hint>Select the journal related to this volume.</hint>

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionFormsControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionFormsControllerIT.java
@@ -116,7 +116,7 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
                             SubmissionFormFieldMatcher.matchFormOpenRelationshipFieldDefinition("name",
                         "Author", null, true,"Add an author",
                     "dc.contributor.author", "isAuthorOfPublication", null,
-            "personConfiguration", true))))
+            "person", true))))
         ;
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionFormsControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionFormsControllerIT.java
@@ -139,7 +139,7 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
                         .andExpect(jsonPath("$.rows[0].fields", contains(
                             SubmissionFormFieldMatcher.matchFormClosedRelationshipFieldDefinition("Journal", null,
                     false,"Select the journal related to this volume.", "isVolumeOfJournal",
-                        "creativework.publisher:somepublishername", "periodicalConfiguration", false))))
+                        "creativework.publisher:somepublishername", "periodical", false))))
         ;
     }
 }

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -200,6 +200,7 @@
                 <relation-field>
                     <relationship-type>isOrgUnitOfPublication</relationship-type>
                     <search-configuration>organization</search-configuration>
+                    <repeatable>true</repeatable>
                     <label>Organization</label>
                     <hint>Select the Organizational Unit related to this publication.</hint>
                 </relation-field>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -189,6 +189,22 @@
 
         <form name="traditionalpagetwo">
             <row>
+                <relation-field>
+                    <relationship-type>isJournalIssueOfPublication</relationship-type>
+                    <search-configuration>publicationIssue</search-configuration>
+                    <label>Journal Issue</label>
+                    <hint>Select the journal issue related to this publication.</hint>
+                </relation-field>
+            </row>
+            <row>
+                <relation-field>
+                    <relationship-type>isOrgUnitOfPublication</relationship-type>
+                    <search-configuration>organization</search-configuration>
+                    <label>Organization</label>
+                    <hint>Select the Organizational Unit related to this publication.</hint>
+                </relation-field>
+            </row>
+            <row>
                 <field>
                     <dc-schema>dc</dc-schema>
                     <dc-element>subject</dc-element>
@@ -305,6 +321,14 @@
                     <input-type>onebox</input-type>
                     <hint>Enter the job title of the person</hint>
                 </field>
+            </row>
+            <row>
+                <relation-field>
+                    <relationship-type>isOrgUnitOfPerson</relationship-type>
+                    <search-configuration>organization</search-configuration>
+                    <label>Organization</label>
+                    <hint>Select the Organizational Unit this is part of.</hint>
+                </relation-field>
             </row>
         </form>
 
@@ -491,7 +515,7 @@
             <row>
                 <relation-field>
                     <relationship-type>isVolumeOfJournal</relationship-type>
-                    <search-configuration>periodicalConfiguration</search-configuration>
+                    <search-configuration>periodical</search-configuration>
                     <filter>creativework.publisher:somepublishername</filter>
                     <label>Journal</label>
                     <hint>Select the journal related to this volume.</hint>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -51,7 +51,7 @@
             <row>
                 <relation-field>
                     <relationship-type>isAuthorOfPublication</relationship-type>
-                    <search-configuration>personConfiguration</search-configuration>
+                    <search-configuration>person</search-configuration>
                     <repeatable>true</repeatable>
                     <label>Author</label>
                     <hint>Add an author</hint>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -189,23 +189,6 @@
 
         <form name="traditionalpagetwo">
             <row>
-                <relation-field>
-                    <relationship-type>isJournalIssueOfPublication</relationship-type>
-                    <search-configuration>publicationIssue</search-configuration>
-                    <label>Journal Issue</label>
-                    <hint>Select the journal issue related to this publication.</hint>
-                </relation-field>
-            </row>
-            <row>
-                <relation-field>
-                    <relationship-type>isOrgUnitOfPublication</relationship-type>
-                    <search-configuration>organization</search-configuration>
-                    <repeatable>true</repeatable>
-                    <label>Organization</label>
-                    <hint>Select the Organizational Unit related to this publication.</hint>
-                </relation-field>
-            </row>
-            <row>
                 <field>
                     <dc-schema>dc</dc-schema>
                     <dc-element>subject</dc-element>
@@ -322,14 +305,6 @@
                     <input-type>onebox</input-type>
                     <hint>Enter the job title of the person</hint>
                 </field>
-            </row>
-            <row>
-                <relation-field>
-                    <relationship-type>isOrgUnitOfPerson</relationship-type>
-                    <search-configuration>organization</search-configuration>
-                    <label>Organization</label>
-                    <hint>Select the Organizational Unit this is part of.</hint>
-                </relation-field>
             </row>
         </form>
 


### PR DESCRIPTION
This PR contains some sensible default configuration for the submission of a publication with relationships to authors, journal issues and org units.
It also fixes an incorrect use of a discovery config (was renamed in discovery)