### PR TITLE
[Docker] Update DSpace 7 Entities sample data SQL and assetstore

### DIFF
--- a/dspace/src/main/docker-compose/cli.assetstore.yml
+++ b/dspace/src/main/docker-compose/cli.assetstore.yml
@@ -11,7 +11,7 @@ version: "3.7"
 services:
   dspace-cli:
     environment:
-      - LOADASSETS=https://www.dropbox.com/s/zv7lj8j2lp3egjs/assetstore.tar.gz?dl=1
+      - LOADASSETS=https://www.dropbox.com/s/v3ahfcuatklbmi0/assetstore-2019-11-28.tar.gz?dl=1
     entrypoint:
       - /bin/bash
       - '-c'

--- a/dspace/src/main/docker-compose/db.entities.yml
+++ b/dspace/src/main/docker-compose/db.entities.yml
@@ -13,4 +13,4 @@ services:
     image: dspace/dspace-postgres-pgcrypto:loadsql
     environment:
       # Double underbars in env names will be replaced with periods for apache commons
-      - LOADSQL=https://www.dropbox.com/s/xh3ack0vg0922p2/configurable-entities-2019-05-08.sql?dl=1
+      - LOADSQL=https://www.dropbox.com/s/4ap1y6deseoc8ws/dspace7-entities-2019-11-28.sql?dl=1


### PR DESCRIPTION
This PR updates the DSpace 7 Entities sample data used by our Docker Compose scripts.  The previous test data was outdated (from May 2019) and recent code changes meant it was no longer fully functional.  This is now updated sample data (SQL & assetstore) from late November 2019.

I've tested this locally and it works much better than the current test data set.  

This simple change can be tested using the "Ingest Entities Test Data" instructions in our Docker README at: https://github.com/DSpace/DSpace/tree/master/dspace/src/main/docker-compose#ingest-option-2-ingest-entities-test-data