### PR TITLE
[DS-4404] Upgrade Mets crosswalk for oai to xslt 2.0 

### DIFF
--- a/dspace/config/crosswalks/oai/metadataFormats/mets.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/mets.xsl
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- http://www.loc.gov/standards/mets/mets.xsd -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-	xmlns:doc="http://www.lyncode.com/xoai" 
-    xmlns:date="http://exslt.org/dates-and-times" 
-    extension-element-prefixes="date" version="1.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
     
 	<xsl:output omit-xml-declaration="yes" method="xml" indent="yes" />
 
@@ -20,7 +17,7 @@
 			</xsl:attribute>
 			<metsHdr>
 				<xsl:attribute name="CREATEDATE">
-					<xsl:value-of select="concat(date:format-date(date:date(), 'yyyy-MM-dd'), 'T' , date:format-date(date:time(), 'HH:mm:ss'), 'Z')"/>
+					<xsl:value-of select="concat(format-date(current-date(), 'yyyy-MM-dd'), 'T' , format-time(current-time(), 'HH:mm:ss'), 'Z')"/>
 				</xsl:attribute>
 				<agent ROLE="CUSTODIAN" TYPE="ORGANIZATION">
 					<name><xsl:value-of select="doc:metadata/doc:element[@name='repository']/doc:field[@name='name']/text()" /></name>

--- a/dspace/config/crosswalks/oai/metadataFormats/mets.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/mets.xsl
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- http://www.loc.gov/standards/mets/mets.xsd -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+				xmlns:doc="http://www.lyncode.com/xoai" version="2.0">
     
 	<xsl:output omit-xml-declaration="yes" method="xml" indent="yes" />
 


### PR DESCRIPTION
This removes the exslt functions and uses xslt 2.0 native ones for dates and times. This is not compatible with Xalan-J, so needs some consideration for backporting.

Related: https://github.com/DSpace/xoai/pull/68