### PR TITLE
OpenAIRE4 missing relationships on registries

### DIFF
--- a/dspace/config/registries/relationship-formats.xml
+++ b/dspace/config/registries/relationship-formats.xml
@@ -121,4 +121,29 @@
         <element>isPublicationOfJournalIssue</element>
         <scope_note></scope_note>
     </dc-type>
+
+    <!--
+      OpenAIRE4 Guidelines
+      required relationships -->  
+    <dc-type>
+        <schema>relation</schema>
+        <element>isContributorOfPublication</element>
+        <scope_note></scope_note>
+    </dc-type>
+    <dc-type>
+        <schema>relation</schema>
+        <element>isPublicationOfContributor</element>
+        <scope_note></scope_note>
+    </dc-type>
+    <dc-type>
+        <schema>relation</schema>
+        <element>isFundingAgencyOfProject</element>
+        <scope_note></scope_note>
+    </dc-type>
+    <dc-type>
+        <schema>relation</schema>
+        <element>isProjectOfFundingAgency</element>
+        <scope_note></scope_note>
+    </dc-type>
+
 </dspace-dc-types>


### PR DESCRIPTION
OpenAIRE4 proposes some new relationship types like `Contributor <-> Publication` or `Project <-> OrgUnit/FundingAgency` . This PR changes the default relationships-formats.xml and proposes to add this new relationship names.