### PR TITLE
[DS-4409] Remove GeoIP download Ant target, reconfigure for external provision

### DIFF
--- a/dspace-api/src/test/java/org/dspace/statistics/MockSolrLoggerServiceImpl.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/MockSolrLoggerServiceImpl.java
@@ -10,9 +10,7 @@ package org.dspace.statistics;
 import java.io.File;
 
 import com.maxmind.geoip2.DatabaseReader;
-import org.dspace.services.ConfigurationService;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Mock service that uses an embedded SOLR server for the statistics core.
@@ -20,9 +18,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class MockSolrLoggerServiceImpl
         extends SolrLoggerServiceImpl
         implements InitializingBean {
-
-    @Autowired(required = true)
-    private ConfigurationService configurationService;
 
     public MockSolrLoggerServiceImpl() {
     }
@@ -34,9 +29,8 @@ public class MockSolrLoggerServiceImpl
 
         new FakeDatabaseReader(); // Activate fake
         new FakeDatabaseReader.Builder(); // Activate fake
-        String locationDbPath = configurationService.getProperty("usage-statistics.dbfile");
-        File locationDb = new File(locationDbPath);
-        locationDb.createNewFile();
+        File locationDb = File.createTempFile("GeoIP", ".db");
+        locationDb.deleteOnExit();
         locationService = new DatabaseReader.Builder(locationDb).build();
     }
 

--- a/dspace-api/src/test/java/org/dspace/statistics/MockSolrLoggerServiceImpl.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/MockSolrLoggerServiceImpl.java
@@ -14,6 +14,11 @@ import org.springframework.beans.factory.InitializingBean;
 
 /**
  * Mock service that uses an embedded SOLR server for the statistics core.
+ * <p>
+ * <strong>NOTE:</strong>  this class is overridden by one <em>of the same name</em>
+ * defined in dspace-server-webapp and declared as a bean there.
+ * See {@code config/spring/api/Z-mock-services.xml}.  Some kind of classpath
+ * magic makes this work.
  */
 public class MockSolrLoggerServiceImpl
         extends SolrLoggerServiceImpl

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -72,6 +72,7 @@ import org.dspace.core.Constants;
 import org.dspace.disseminate.CitationDocumentServiceImpl;
 import org.dspace.eperson.Group;
 import org.dspace.services.ConfigurationService;
+import org.dspace.statistics.FakeDatabaseReader;
 import org.dspace.statistics.ObjectCount;
 import org.dspace.statistics.SolrLoggerServiceImpl;
 import org.dspace.statistics.factory.StatisticsServiceFactory;
@@ -116,6 +117,13 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
         // To ensure these tests start "fresh", clear out any existing statistics data.
         // NOTE: this is committed immediately in removeIndex()
         StatisticsServiceFactory.getInstance().getSolrLoggerService().removeIndex("*:*");
+    }
+
+    @BeforeClass
+    public static void mockGeoIP()
+            throws IOException {
+        // Set up a mock GeoIP implementation so we don't need to d/l a database.
+        new FakeDatabaseReader.Builder(); // Activate fake
     }
 
     @Before

--- a/dspace-server-webapp/src/test/java/org/dspace/statistics/FakeDatabaseReader.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/statistics/FakeDatabaseReader.java
@@ -9,6 +9,7 @@ package org.dspace.statistics;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -28,6 +29,8 @@ import com.maxmind.geoip2.record.Traits;
 import mockit.Deencapsulation;
 import mockit.Mock;
 import mockit.MockUp;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Mock service to mock the location Lookup Service used by the SOLR statistics
@@ -35,14 +38,17 @@ import mockit.MockUp;
  */
 public class FakeDatabaseReader
         extends MockUp<DatabaseReader> {
+    private static final Logger LOG = LogManager.getLogger();
 
     FakeDatabaseReader() {
     }
 
-    public FakeDatabaseReader(Object object) {
+    private FakeDatabaseReader(Builder builder) {
+        LOG.debug("constructor({})", () -> builder.toString());
     }
 
     public FakeDatabaseReader $init(Builder builder) {
+        LOG.debug("$init({})", () -> builder.toString());
         return this;
     }
 
@@ -67,6 +73,8 @@ public class FakeDatabaseReader
 
     @Mock
     public CityResponse city(InetAddress address) {
+        LOG.debug("city({})", () -> address.toString());
+
         List<String> names = new ArrayList<>(1);
 
         names.add("New York");
@@ -103,15 +111,30 @@ public class FakeDatabaseReader
 
         /**
          * Fake constructor.
+         * @param stream ignored.
+         */
+        @Mock
+        public void $init(InputStream stream) {
+            LOG.debug("Builder.$init(\"{}\")", () -> stream.toString());
+        }
+
+        /**
+         * Fake constructor.
          * @param file ignored.
          */
         @Mock
         public void $init(File file) {
+            try {
+                LOG.debug("Builder.$init(\"{}\")", file.getCanonicalPath());
+            } catch (IOException e) {
+                LOG.warn("Cannot getCanonicalPath(file):  {}", e.getMessage(), e);
+            }
         }
 
         @Mock
         public DatabaseReader build()
                 throws IOException {
+            LOG.debug("build");
             return Deencapsulation.newUninitializedInstance(DatabaseReader.class);
         }
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/statistics/MockSolrLoggerServiceImpl.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/statistics/MockSolrLoggerServiceImpl.java
@@ -8,6 +8,7 @@
 package org.dspace.statistics;
 
 import java.io.File;
+import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
 
@@ -18,12 +19,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.content.DSpaceObject;
 import org.dspace.eperson.EPerson;
-import org.dspace.services.ConfigurationService;
 import org.dspace.solr.MockSolrServer;
 import org.dspace.usage.UsageWorkflowEvent;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 /**
@@ -43,9 +42,6 @@ public class MockSolrLoggerServiceImpl
     private static final Logger log = LogManager.getLogger();
 
     private MockSolrServer mockSolrServer;
-
-    @Autowired(required = true)
-    private ConfigurationService configurationService;
 
     public MockSolrLoggerServiceImpl() {
     }
@@ -112,11 +108,10 @@ public class MockSolrLoggerServiceImpl
         try {
             new FakeDatabaseReader(); // Activate fake
             new FakeDatabaseReader.Builder(); // Activate fake
-            String locationDbPath = configurationService.getProperty("usage-statistics.dbfile");
-            File locationDb = new File(locationDbPath);
-            locationDb.createNewFile();
+            File locationDb = File.createTempFile("GeoIP", ".mmdb");
+            locationDb.deleteOnExit();
             locationService = new DatabaseReader.Builder(locationDb).build();
-        } catch (Exception e) {
+        } catch (IOException e) {
             log.error("Unable to load FakeDatabaseReader", e);
         }
     }

--- a/dspace/config/modules/usage-statistics.cfg
+++ b/dspace/config/modules/usage-statistics.cfg
@@ -7,8 +7,9 @@
 #---------------------------------------------------------------#
 
 # The location for the database used to map client addresses to approximate
-# physical locations.
-usage-statistics.dbfile = /usr/share/GeoIP/GeoLite2-City.mmdb
+# physical locations.  This MUST BE CONFIGURED if you want statistics with
+# location data.  A typical path is shown:
+#usage-statistics.dbfile = /usr/share/GeoIP/GeoLite2-City.mmdb
 
 # Timeout for the resolver in the DNS lookup
 # Time in milliseconds, defaults to 200 for backward compatibility

--- a/dspace/config/modules/usage-statistics.cfg
+++ b/dspace/config/modules/usage-statistics.cfg
@@ -1,13 +1,14 @@
 #---------------------------------------------------------------#
 #--------------USAGE STATISTICS CONFIGURATIONS------------------#
 #---------------------------------------------------------------#
-# These configs are only used by the DSpace interfaces which    #
-# track usage statistics (Solr)                                 #
+# These properties are only used by the DSpace interfaces which #
+# track usage statistics (Solr).                                #
 # See also: solr-statistics.cfg                                 #
 #---------------------------------------------------------------#
 
-# The location for the Geo Database retrieved on update/installation
-usage-statistics.dbfile = ${dspace.dir}/config/GeoLite2-City.mmdb
+# The location for the database used to map client addresses to approximate
+# physical locations.
+usage-statistics.dbfile = /usr/share/GeoIP/GeoLite2-City.mmdb
 
 # Timeout for the resolver in the DNS lookup
 # Time in milliseconds, defaults to 200 for backward compatibility

--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -79,9 +79,6 @@ Common usage:
         <format property="build.date" pattern="yyyyMMdd-HHmmss" />
     </tstamp>
 
-    <!-- Default location of GeoLite2 City database to download. This may be overridden, if URL path changes. -->
-    <property name="geolite" value="http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz" />
-
 
     <!-- ============================================================= -->
     <!-- The DSpace class path for executing installation targets      -->
@@ -104,7 +101,7 @@ Common usage:
     <taskdef resource="net/sf/antcontrib/antlib.xml" classpathref="class.path"/>
 
     <!-- ============================================================= -->
-    <!-- Print some useful help text                                  -->
+    <!-- Print some useful help text.                                  -->
     <!-- ============================================================= -->
     <target name="help">
 
@@ -117,7 +114,6 @@ Common usage:
         <echo message="update          --> Update ${dspace.dir} config, etc, lib and web applications without " />
         <echo message="                    touching your data" />
     	<echo message="update_configs  --> Update your configs directory with new configuration files"/>
-    	<echo message="update_geolite  --> Dowload and install GeoCity database into ${dspace.dir}/config" />
         <echo message="update_code     --> Update compiled code (bin, lib, and etc directories)" />
         <echo message="update_webapps  --> Update web applications" />
         <echo message="" />
@@ -147,7 +143,7 @@ Common usage:
 
 
     <!-- ============================================================= -->
-    <!-- clean out backup directories                  -->
+    <!-- clean out backup directories                                  -->
     <!-- ============================================================= -->
     <target name="clean_backups">
         <delete includeemptydirs="true">
@@ -176,10 +172,11 @@ Common usage:
     <!-- ============================================================= -->
     <!-- Update the config dir, only adds files, if a file is altered  -->
     <!-- in the target directory, the new file is suffixed wth *.new   -->
-    <!-- and should be hand updated afterward                .          -->
+    <!-- and should be hand updated afterward.                         -->
     <!-- ============================================================= -->
-    <target name="update_configs" depends="overwrite_configs,overwrite_solr_configs" description="Updates the Configuration Directory">
-    	<antcall target="init_geolite" />
+    <target name="update_configs"
+            depends="overwrite_configs,overwrite_solr_configs"
+            description="Updates the Configuration Directory">
     </target>
 
     <target name="overwrite_configs" description="Overwrites a configuration directory." if="${overwrite}" depends="copy_configs_keep">
@@ -832,8 +829,6 @@ Common usage:
 
         <antcall target="copy_webapps" />
 
-    	<antcall target="init_geolite" />
-
         <echo>
 ====================================================================
  The DSpace code has been installed.
@@ -861,63 +856,6 @@ Common usage:
 ====================================================================
         </echo>
 
-    </target>
-
-	<!-- installs GeoCity resolution database -->
-    <target name="update_geolite">
-        <echo>Downloading: ${geolite}</echo>
-        <trycatch property="geolite.error">
-            <try>
-                <get src="${geolite}"
-                     dest="${dspace.dir}/config/GeoLite2-City.tar.gz"
-                     verbose="true"/>
-                <untar src="${dspace.dir}/config/GeoLite2-City.tar.gz"
-                       dest="${dspace.dir}/config/"
-                       compression='gzip'>
-                    <patternset>
-                        <include name='**/GeoLite2-City.mmdb'/>
-                    </patternset>
-                    <mapper type='flatten'/>
-                </untar>
-                <delete file="${dspace.dir}/config/GeoLite2-City.tar.gz"/>
-            </try>
-            <catch>
-                <echo>
-====================================================================
-WARNING : FAILED TO DOWNLOAD GEOLITE DATABASE FILE
-          (Used for DSpace Solr Usage Statistics)
-
-Underlying Error: ${geolite.error}
-
-In order to use DSpace Solr Usage Statistics, you will need to
-manually re-run:
-
-ant update_geolite
-
-OR
-
-You may manually install this file by following these steps:
-(1) Download the latest database archive from ${geolite}
-(2) Unpack it.'
-(3) Copy the file 'GeoLite2-City.mmdb' to '${usage-statistics.dbfile}'.
-
-====================================================================
-                </echo>
-            </catch>
-        </trycatch>
-
-    </target>
-
-    <target name="check_geolite">
-        <condition property="need.geolite">
-            <not>
-                <available file="${usage-statistics.dbfile}" />
-            </not>
-        </condition>
-    </target>
-
-    <target name="init_geolite" depends="check_geolite" if="need.geolite">
-        <antcall target="update_geolite" />
     </target>
 
 </project>


### PR DESCRIPTION
https://jira.lyrasis.org/browse/DS-4409
MaxMind is changing the way that they make their GeoLite database available.  Rather than chase that with our own code, this patch removes our update code in favor of using MaxMind's updater externally.  This will require revising the install, update and configuration guides to explain the new process.

Additionally, the DSpace configuration for the GeoLite database is altered to point to a typical location outside of the installed instance.  Installers should check this property's value and adjust it as needed to suit their local environment.