### PR TITLE
[Docker] Ensure dspace container waits until db is accepting connections before starting Tomcat

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,11 +20,15 @@ services:
     volumes:
     - assetstore:/dspace/assetstore
     - ./dspace/src/main/docker-compose/local.cfg:/dspace/config/local.cfg
-    # Ensure that the database is ready before starting tomcat
+    # Ensure that the database is ready BEFORE starting tomcat
+    # 1. While TCP connection to dspacedb port is not available, continue to sleep
+    # 2. Then, run database migration to init database tables
+    # 3. Finally, start Tomcat
     entrypoint:
     - /bin/bash
     - '-c'
     - |
+      while !</dev/tcp/dspacedb/5432; do sleep 1; done;
       /dspace/bin/dspace database migrate
       catalina.sh run
   dspacedb:
@@ -34,6 +38,9 @@ services:
     image: dspace/dspace-postgres-pgcrypto
     networks:
       dspacenet:
+    ports:
+    - published: 5432
+      target: 5432
     stdin_open: true
     tty: true
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,14 +21,14 @@ services:
     - assetstore:/dspace/assetstore
     - ./dspace/src/main/docker-compose/local.cfg:/dspace/config/local.cfg
     # Ensure that the database is ready BEFORE starting tomcat
-    # 1. While TCP connection to dspacedb port is not available, continue to sleep
+    # 1. While a TCP connection to dspacedb port 5432 is not available, continue to sleep
     # 2. Then, run database migration to init database tables
     # 3. Finally, start Tomcat
     entrypoint:
     - /bin/bash
     - '-c'
     - |
-      while !</dev/tcp/dspacedb/5432; do sleep 1; done;
+      while (!</dev/tcp/dspacedb/5432) > /dev/null 2>&1; do sleep 1; done;
       /dspace/bin/dspace database migrate
       catalina.sh run
   dspacedb:


### PR DESCRIPTION
This is a minor change to our default `docker-compose.yml` for DSpace 7 (master) which ensures that the main `dspace` container (which runs Tomcat) waits for the `dspacedb` container (which runs Postgres) to _completely initialize_.

Currently, we have a "race condition" when running Docker for the first time.  While our compose file always starts the `dspacedb` container _first_ (see `depends_on`), it **doesn't wait for that DB container to complete its initialization**.  Instead, it just keeps moving along and starts the `dspace` container. 

Unfortunately, this means that sometimes the `dspace` contain starts Tomcat *before* the `dspacedb` container finishes its initialization, resulting in Hibernate errors (as that database hasn't initialized all the tables and the `dspace database migrate` command errors out).

I've been able to reliably reproduce these Hibernate errors by simply doing a fresh startup:

1. Stop all containers: `docker-compose -p d7 down`
2. Remove all existing volumes: `docker volume rm $(docker volume ls -q)`
3. Restart all containers: `docker-compose -p d7 up`
4. Watch the logs, you'll see that the Tomcat container fails to start cause of Hibernate errors...these are because it didn't wait on the database container to complete all its initialization.


This PR adds a simple check to the `dspace` container to ensure it continually pings the `dspacedb` container and waits until the `dspacedb` container responds to TCP connections.

Additionally, I added a semi-related improvement which makes the database available on port 5432...this makes debugging database issues easier as you can use postgres client tools (like pgAdmin or similar) to connect to the database to see what its status is.


