### PR TITLE
Minor dependency updates to resolve GitHub security alerts

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -306,7 +306,7 @@
             <artifactId>hibernate-jpamodelgen</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator-cdi</artifactId>
             <version>${hibernate-validator.version}</version>
         </dependency>

--- a/dspace-rest/pom.xml
+++ b/dspace-rest/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <!-- This is the path to the root [dspace-src] directory. -->
         <root.basedir>${basedir}/..</root.basedir>
-        <spring-security.version>3.2.9.RELEASE</spring-security.version>
+        <spring-security.version>5.1.3.RELEASE</spring-security.version>
     </properties>
     <build>
         <plugins>

--- a/dspace-rest/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/dspace-rest/src/main/webapp/WEB-INF/applicationContext.xml
@@ -11,7 +11,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-	http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	http://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <!-- Acquires the DSpace Utility Class with initialized Service Manager -->
     <bean id="dspace" class="org.dspace.utils.DSpace"/>
@@ -27,8 +27,8 @@
     </bean>
 
     <!-- Inject the SolrLoggerUsageEventListener into the EventService  -->
-    <!-- 
-    Temporarily commented out SolrLoggerUsageEventListener to get REST API working on master. 
+    <!--
+    Temporarily commented out SolrLoggerUsageEventListener to get REST API working on master.
     This should be uncommented again once DS-3815 is resolved.
 
     <bean class="org.dspace.statistics.SolrLoggerUsageEventListener">

--- a/dspace-rest/src/main/webapp/WEB-INF/security-applicationContext.xml
+++ b/dspace-rest/src/main/webapp/WEB-INF/security-applicationContext.xml
@@ -13,7 +13,7 @@
        xmlns:security="http://www.springframework.org/schema/security"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-  http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+  http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
     <context:annotation-config/>
 
@@ -21,7 +21,7 @@
         Every url in the rest will pass through these filters, login & shibboleth-login will trigger an authentication attempt.
      -->
     <bean id="springSecurityFilterChain" class="org.springframework.security.web.FilterChainProxy">
-        <security:filter-chain-map path-type="ant">
+        <security:filter-chain-map request-matcher="ant">
             <security:filter-chain pattern="/login" filters="sif,passwordLoginAuthenticationFilter"/>
             <security:filter-chain pattern="/shibboleth-login" filters="sif,passwordLoginAuthenticationFilter"/>
             <security:filter-chain pattern="/logout" filters="sif,logoutFilter"/>

--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -28,7 +28,7 @@
         <!-- Define our starting class for our Spring Boot Application -->
         <start-class>org.dspace.app.rest.Application</start-class>
         <!-- Library for managing JSON Web Tokens (JWT): https://bitbucket.org/connect2id/nimbus-jose-jwt/wiki/Home -->
-        <nimbus-jose-jwt.version>6.2</nimbus-jose-jwt.version>
+        <nimbus-jose-jwt.version>7.9</nimbus-jose-jwt.version>
     </properties>
 
     <profiles>

--- a/dspace/modules/server/pom.xml
+++ b/dspace/modules/server/pom.xml
@@ -139,6 +139,7 @@ just adding new jar in the classloader</description>
                     <plugin>
                         <groupId>org.codehaus.gmaven</groupId>
                         <artifactId>groovy-maven-plugin</artifactId>
+                        <version>2.0</version>
                         <executions>
                             <execution>
                                 <id>setproperty</id>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <url>https://github.com/dspace/DSpace</url>
 
     <organization>
-        <name>DuraSpace</name>
+        <name>LYRASIS</name>
         <url>http://www.dspace.org</url>
     </organization>
 
@@ -29,7 +29,7 @@
         <log4j.version>2.11.2</log4j.version>
         <slf4j.version>1.7.25</slf4j.version>
         <!-- NOTE: when updating jackson.version, also sync jackson-databind dependency below -->
-        <jackson.version>2.9.9</jackson.version>
+        <jackson.version>2.10.2</jackson.version>
         <jersey.version>2.28</jersey.version>
         <hibernate.version>5.3.11.Final</hibernate.version>
         <hibernate-validator.version>6.0.17.Final</hibernate-validator.version>
@@ -1007,7 +1007,7 @@
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
-                <version>3.4.11</version>
+                <version>3.4.14</version>
             </dependency>
 
             <!-- solr-cell and axiom-api disagree on versions -->


### PR DESCRIPTION
This PR provides minor dependency updates to resolve the security alerts listed at https://github.com/DSpace/DSpace/network/alerts (may only be accessible to Committers).

Individual commits link to the CVE report which they resolve (see commit list in this PR).  In some scenarios I did *not* update to the latest version of the dependency, as doing so caused other dependency conflicts.  So, I chose to simply upgrade to a version where the security issue was resolved.

Also includes a few other minor fixes:
* Resolves two minor Maven build warnings
* Updates the (deprecated) REST API Spring config files for Spring Security v5.

I've tested this locally (in Docker) and everything still seems to work fine (including the old, deprecated REST API). However, as always, another set of eyes is welcome.