### PR TITLE
Bug in ViewEvents

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ViewEventRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ViewEventRest.java
@@ -9,6 +9,7 @@ package org.dspace.app.rest.model;
 
 import java.util.UUID;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.dspace.app.rest.RestResourceController;
 
@@ -22,6 +23,12 @@ public class ViewEventRest extends BaseObjectRest<UUID> {
 
     private UUID targetId;
     private String targetType;
+
+    @Override
+    @JsonIgnore
+    public UUID getId() {
+        return id;
+    }
 
     public UUID getTargetId() {
         return targetId;


### PR DESCRIPTION
Based on the following angular related issue/comment:
https://github.com/DSpace/dspace-angular/pull/532#issuecomment-566167627

The rest response contained a property: id: null
1. The ID is not relevant in this case
2. A null ID should not be returned.

This PR handles the following:
- Remove 'id' field from the ViewEventRest response

Similar to HarvesterMetadataRest, this has been ignored, so REST does not return that id (without changing any other functionality)