### PR TITLE
[HIGH PRIORITY] Fix Maven build where restlet dependency not found for solr-cell

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1781,6 +1781,14 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+        <!-- Currently NEEDED for Solr 7.x, as the solr-parent POM has an old, invalid URL for this repository.
+             The URL is corrected (to the below value) as of Solr 8.3.x, but has not yet been backported to 7.x.
+             Once we upgrade to Solr 8+, we should be able to remove this repository. -->
+        <repository>
+            <id>maven-restlet</id>
+            <name>Public online Restlet repository</name>
+            <url>https://maven.restlet.com</url>
+        </repository>
     </repositories>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1772,7 +1772,7 @@
     <repositories>
         <repository>
             <id>maven-snapshots</id>
-            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
             <layout>default</layout>
             <releases>
                 <enabled>false</enabled>


### PR DESCRIPTION
Recent Maven builds in Travis all fail with the following error:

```
[ERROR] Failed to execute goal on project dspace-api: Could not resolve dependencies for project org.dspace:dspace-api:jar:7.0-SNAPSHOT: Failed to collect dependencies at org.apache.solr:solr-cell:jar:7.3.1 -> org.restlet.jee:org.restlet:jar:2.3.0: Failed to read artifact descriptor for org.restlet.jee:org.restlet:jar:2.3.0: Could not transfer artifact org.restlet.jee:org.restlet:pom:2.3.0 from/to maven-restlet (http://maven.restlet.org): Access denied to: http://maven.restlet.org/org/restlet/jee/org.restlet/2.3.0/org.restlet-2.3.0.pom , ReasonPhrase:Forbidden. -> [Help 1]
```

This is also reproducible in local builds if you have *not* previously downloaded `restlet` (e.g. during a fresh install).

It seems that the old location where `restlet` was available no longer works.  As you can see from the error above, this dependency is pulled in via `solr-cell`, and `solr-cell` attempts to download `restlet` from http://maven.restlet.org/org/restlet/jee/org.restlet/2.3.0/org.restlet-2.3.0.pom which throws a 403 error.

Instead, `restlet` now seems to be available at https://maven.restlet.com (and most recent versions of `solr-parent` now use that `<repository>` location in the POM, for example: https://repo1.maven.org/maven2/org/apache/solr/solr-parent/8.3.0/solr-parent-8.3.0.pom

As we currently are running Solr 7, I'm just copying that repository into our Parent POM to fix this error.  Once we upgrade to Solr 8, this likely can be removed.

I've also updated all our POM `repositories` to use HTTPS, per https://blog.sonatype.com/central-repository-moving-to-https

(SIDENOTE: I haven't had a chance to determine whether this fix needs to be backported to DSpace 6.  But, if anyone else runs into this, let us know or quickly create a backport PR)