### PR TITLE
[Docker] Fix Solr Dockerfile. Pull DSpace Solr configs from 'dspace' image

### DIFF
--- a/dspace/src/main/docker/README.md
+++ b/dspace/src/main/docker/README.md
@@ -2,12 +2,12 @@
 
 ## Dockerfile.dependencies
 
-This dockerfile is used to pre-cache maven downloads that will be used in subsequent DSpace docker builds.
+This Dockerfile is used to pre-cache Maven dependency downloads that will be used in subsequent DSpace docker builds.
 ```
 docker build -t dspace/dspace-dependencies:dspace-7_x -f Dockerfile.dependencies .
 ```
 
-This image is built manually.  It should be rebuilt each year or after each major release in order to refresh the cache of jars.  
+**This image is built manually.**  It should be rebuilt each year or after each major release in order to refresh the cache of jars.
 
 A corresponding image exists for DSpace 4-6.
 
@@ -18,13 +18,16 @@ docker push dspace/dspace-dependencies:dspace-7_x
 
 ## Dockerfile.jdk8-test
 
-This dockefile builds a DSpace 7 tomcat image.  The legacy REST api will be deployed without requiring https access.
+This Dockerfile builds a DSpace 7 Tomcat image (for testing/development).
+This image deploys two DSpace webapps:
+1. The DSpace 7 REST API (at `http://localhost:8080/server`)
+2. The legacy (v6) REST API (at `http://localhost:8080//rest`), deployed without requiring HTTPS access.
 
 ```
 docker build -t dspace/dspace:dspace-7_x-jdk8-test -f Dockerfile.jdk8-test .
 ```
 
-This image is built automatically after each commit is made to the master branch.
+This image is built *automatically* after each commit is made to the `master` branch.
 
 A corresponding image exists for DSpace 4-6.
 
@@ -35,12 +38,15 @@ docker push dspace/dspace:dspace-7_x-jdk8-test
 
 ## Dockerfile.jdk8
 
-This dockefile builds a DSpace 7 tomcat image.
+This Dockerfile builds a DSpace 7 tomcat image.
+This image deploys two DSpace webapps:
+1. The DSpace 7 REST API (at `http://localhost:8080/server`)
+2. The legacy (v6) REST API (at `http://localhost:8080//rest`), deployed *requiring* HTTPS access.
 ```
 docker build -t dspace/dspace:dspace-7_x-jdk8 -f Dockerfile.jdk8 .
 ```
 
-This image is built automatically after each commit is made to the master branch.
+This image is built *automatically* after each commit is made to the `master` branch.
 
 A corresponding image exists for DSpace 4-6.
 
@@ -51,12 +57,12 @@ docker push dspace/dspace:dspace-7_x-jdk8
 
 ## Dockefile.cli.jdk8
 
-This dockerfile builds a DSpace 7 CLI image.
+This Dockerfile builds a DSpace 7 CLI image, which can be used to run commandline tools via Docker.
 ```
 docker build -t dspace/dspace-cli:dspace-7_x -f Dockerfile.cli.jdk8 .
 ```
 
-This image is built automatically after each commit is made to the master branch.
+This image is built *automatically* after each commit is made to the master branch.
 
 A corresponding image exists for DSpace 6.
 
@@ -67,13 +73,13 @@ docker push dspace/dspace-cli:dspace-7_x
 
 ## dspace/src/main/docker/dspace-postgres-pgcrypto/Dockerfile
 
-This is a postgres docker image containing the pgcrypto extension used in DSpace 6 and DSpace 7.
+This is a PostgreSQL Docker image containing the `pgcrypto` extension required by DSpace 6+.
 ```
 cd dspace/src/main/docker/dspace-postgres-pgcrypto
 docker build -t dspace/dspace-postgres-pgcrypto .
 ```
 
-This image is built manually.  It should be rebuilt as needed.
+**This image is built manually.**  It should be rebuilt as needed.
 
 A copy of this file exists in the DSpace 6 branch.  A specialized version of this file exists for DSpace 4 in DSpace-Docker-Images.
 
@@ -84,14 +90,14 @@ docker push dspace/dspace-postgres-pgcrypto
 
 ## dspace/src/main/docker/dspace-postgres-pgcrypto-curl/Dockerfile
 
-This is a postgres docker image containing the pgcrypto extension used in DSpace 6 and DSpace 7.
-This image also contains curl.  The image is pre-configured to load a postgres database dump on initialization.
+This is a PostgreSQL Docker image containing the `pgcrypto` extension required by DSpace 6+.
+This image also contains `curl`.  The image is pre-configured to load a Postgres database dump on initialization.
 ```
 cd dspace/src/main/docker/dspace-postgres-pgcrypto-curl
 docker build -t dspace/dspace-postgres-pgcrypto:loadsql .
 ```
 
-This image is built manually.  It should be rebuilt as needed.
+**This image is built manually.**   It should be rebuilt as needed.
 
 A copy of this file exists in the DSpace 6 branch.
 
@@ -102,13 +108,22 @@ docker push dspace/dspace-postgres-pgcrypto:loadsql
 
 ## dspace/src/main/docker/solr/Dockerfile
 
-This is a standalone solr image containing DSpace solr schemas used in DSpace 7.
+This is a standalone Solr image containing DSpace Solr cores & schemas required by DSpace 7.
+
+**WARNING:** Rebuilding this image first **requires** rebuilding `dspace-7_x-jdk8` (i.e. `Dockerfile.jdk8` listed above),
+as this Solr image copies the latest DSpace-specific Solr schemas & settings from that other image.
+
 ```
+# First, rebuild dspace-7_x-jdk8 to grab the latest Solr configs
+cd [src]
+docker build -t dspace/dspace:dspace-7_x-jdk8 -f Dockerfile.jdk8 .
+
+# Then, rebuild dspace-solr based on that build of DSpace 7.
 cd dspace/src/main/docker/solr
 docker build -t dspace/dspace-solr .
 ```
 
-This image is built manually.  It should be rebuilt as solr schemas change or as new releases of solr are incorporated.
+**This image is built manually.**  It should be rebuilt when Solr schemas change or as new releases of Solr are incorporated.
 
 This file was introduced for DSpace 7.
 
@@ -119,4 +134,4 @@ docker push dspace/dspace-solr
 
 ## local.cfg and test/ folder
 
-These resources are bundled into the _dspace/dspace_ image at build time.
+These resources are bundled into the `dspace/dspace` image at build time.

--- a/dspace/src/main/docker/solr/Dockerfile
+++ b/dspace/src/main/docker/solr/Dockerfile
@@ -13,11 +13,13 @@ FROM dspace/dspace:dspace-7_x-jdk8 as dspace
 FROM solr:7
 # Directory on 'dspace' image (see above) where DSpace is installed
 ENV DSPACE_INSTALL=/dspace
+# Solr user
+ENV SOLR_USER=solr
 # Expose Solr on localhost:8983
 EXPOSE 8983 8983
 
 WORKDIR /opt/solr/server/solr
-USER solr
+USER $SOLR_USER
 # Create DSpace-specific Solr cores (based on default configset provided by Solr)
 RUN \
     cp -r configsets/_default authority && \
@@ -31,7 +33,7 @@ RUN \
 
 # Copy the DSpace-specific Solr schemas & configs (from our 'dspace' image)
 # into corresponding Solr core directory
-COPY --from=dspace $DSPACE_INSTALL/solr/authority authority/
-COPY --from=dspace $DSPACE_INSTALL/solr/oai oai/
-COPY --from=dspace $DSPACE_INSTALL/solr/search search/
-COPY --from=dspace $DSPACE_INSTALL/solr/statistics statistics/
+COPY --from=dspace --chown=$SOLR_USER:$SOLR_USER $DSPACE_INSTALL/solr/authority authority/
+COPY --from=dspace --chown=$SOLR_USER:$SOLR_USER $DSPACE_INSTALL/solr/oai oai/
+COPY --from=dspace --chown=$SOLR_USER:$SOLR_USER $DSPACE_INSTALL/solr/search search/
+COPY --from=dspace --chown=$SOLR_USER:$SOLR_USER $DSPACE_INSTALL/solr/statistics statistics/

--- a/dspace/src/main/docker/solr/Dockerfile
+++ b/dspace/src/main/docker/solr/Dockerfile
@@ -6,11 +6,19 @@
 # http://www.dspace.org/license/
 #
 
-FROM solr:latest
+# Define a 'dspace' alias for our latest v7 image
+FROM dspace/dspace:dspace-7_x-jdk8 as dspace
+
+# Pin to Solr v7 (v8 currently has build issues)
+FROM solr:7
+# Directory on 'dspace' image (see above) where DSpace is installed
+ENV DSPACE_INSTALL=/dspace
+# Expose Solr on localhost:8983
 EXPOSE 8983 8983
 
 WORKDIR /opt/solr/server/solr
 USER solr
+# Create DSpace-specific Solr cores (based on default configset provided by Solr)
 RUN \
     cp -r configsets/_default authority && \
     mkdir authority/data &&\
@@ -21,7 +29,9 @@ RUN \
     cp -r configsets/_default statistics && \
     mkdir statistics/data
 
-COPY dspace/solr/authority authority/
-COPY dspace/solr/oai oai/
-COPY dspace/solr/search search/
-COPY dspace/solr/statistics statistics/
+# Copy the DSpace-specific Solr schemas & configs (from our 'dspace' image)
+# into corresponding Solr core directory
+COPY --from=dspace $DSPACE_INSTALL/solr/authority authority/
+COPY --from=dspace $DSPACE_INSTALL/solr/oai oai/
+COPY --from=dspace $DSPACE_INSTALL/solr/search search/
+COPY --from=dspace $DSPACE_INSTALL/solr/statistics statistics/

--- a/dspace/src/main/docker/solr/Dockerfile
+++ b/dspace/src/main/docker/solr/Dockerfile
@@ -9,7 +9,9 @@
 # Define a 'dspace' alias for our latest v7 image
 FROM dspace/dspace:dspace-7_x-jdk8 as dspace
 
-# Pin to Solr v7 (v8 currently has build issues)
+# Pin to Solr v7
+# Note: The WORKDIR changes to /var/solr in v8 and directory layout is different
+# See README at https://github.com/docker-solr/docker-solr/pull/210
 FROM solr:7
 # Directory on 'dspace' image (see above) where DSpace is installed
 ENV DSPACE_INSTALL=/dspace


### PR DESCRIPTION
Currently, the Dockerfile we use to build a custom Solr image is broken, as the `COPY` commands have incorrect paths: https://github.com/DSpace/DSpace/blob/master/dspace/src/main/docker/solr/Dockerfile#L24-L27

I've updated these `COPY` commands to pull the Solr configuration files from our latest `dspace-7_x-jdk8` image to ensure this Solr image is always synced with the latest configuration files.  This fixes the issue, but requires updating the `dspace-7_x-jdk8` image *first*.  Therefore, I've updated/enhanced the README to describe this process.

I've lightly tested this and it seems to work.  Will give it a more thorough test soon, as we need to update our Solr image with updated Solr schema from recently merged #2612 