### PR TITLE
Use findByCollection method to retrieve only archived item in ItemMapServlet (6.x)

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/ItemMapServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/ItemMapServlet.java
@@ -129,7 +129,7 @@ public class ItemMapServlet extends DSpaceServlet
     		Map<UUID, Integer> myCounts = new HashMap<>(); // counts for each collection
     		
     		// get all items from that collection, add them to a hash
-    		Iterator<Item> i = itemService.findAllByCollection(context, myCollection);
+    		Iterator<Item> i = itemService.findByCollection(context, myCollection);
             // iterate through the items in this collection, and count how many
             // are native, and how many are imports, and which collections they
             // came from


### PR DESCRIPTION
This PR replace findAllByCollection with findByCollection method in ItemMapServlet to fix an issue with not archived item