### PR TITLE
Default webui.submit.upload.required

### DIFF
--- a/dspace-api/src/main/java/org/dspace/submit/model/UploadConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/submit/model/UploadConfiguration.java
@@ -53,7 +53,8 @@ public class UploadConfiguration {
 
     public Boolean isRequired() {
         if (required == null) {
-            required = configurationService.getBooleanProperty("webui.submit.upload.required");
+            //defaults to true
+            required = configurationService.getBooleanProperty("webui.submit.upload.required", true);
         }
         return required;
     }

--- a/dspace-api/src/main/java/org/dspace/submit/model/UploadConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/submit/model/UploadConfiguration.java
@@ -54,7 +54,8 @@ public class UploadConfiguration {
     public Boolean isRequired() {
         if (required == null) {
             //defaults to true
-            required = configurationService.getBooleanProperty("webui.submit.upload.required", true);
+            //don't store a local copy of the configuration property
+            return configurationService.getBooleanProperty("webui.submit.upload.required", true);
         }
         return required;
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowItemRestRepositoryIT.java
@@ -52,8 +52,6 @@ import org.dspace.content.Item;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.eperson.EPerson;
 import org.dspace.services.ConfigurationService;
-import org.dspace.submit.model.UploadConfiguration;
-import org.dspace.submit.model.UploadConfigurationService;
 import org.dspace.xmlworkflow.storedcomponents.ClaimedTask;
 import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 import org.hamcrest.Matchers;
@@ -72,8 +70,6 @@ public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationT
     @Autowired
     private ConfigurationService configurationService;
 
-    @Autowired
-    private UploadConfigurationService uploadConfigurationService;
 
     @Before
     @Override
@@ -83,13 +79,6 @@ public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationT
 
         //disable file upload mandatory
         configurationService.setProperty("webui.submit.upload.required", false);
-
-        //reset config
-        for (String key : uploadConfigurationService.getMap().keySet()) {
-            UploadConfiguration uploadConfig = uploadConfigurationService.getMap().get(key);
-            uploadConfig.setRequired(null);
-        }
-
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowItemRestRepositoryIT.java
@@ -51,11 +51,14 @@ import org.dspace.content.Community;
 import org.dspace.content.Item;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.eperson.EPerson;
+import org.dspace.services.ConfigurationService;
 import org.dspace.xmlworkflow.storedcomponents.ClaimedTask;
 import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 import org.hamcrest.Matchers;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Test suite for the WorkflowItem endpoint
@@ -63,6 +66,20 @@ import org.junit.Test;
  *
  */
 public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private ConfigurationService configurationService;
+
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+
+        super.setUp();
+
+        //disable file upload mandatory
+        configurationService.setProperty("webui.submit.upload.required", false);
+    }
 
     @Test
     /**
@@ -1517,4 +1534,11 @@ public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationT
         ;
     }
 
+    @Override
+    public void destroy() throws Exception {
+        //reinstate file upload mandatory
+        configurationService.setProperty("webui.submit.upload.required", null);
+
+        super.destroy();
+    }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowItemRestRepositoryIT.java
@@ -52,6 +52,8 @@ import org.dspace.content.Item;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.eperson.EPerson;
 import org.dspace.services.ConfigurationService;
+import org.dspace.submit.model.UploadConfiguration;
+import org.dspace.submit.model.UploadConfigurationService;
 import org.dspace.xmlworkflow.storedcomponents.ClaimedTask;
 import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 import org.hamcrest.Matchers;
@@ -70,6 +72,8 @@ public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationT
     @Autowired
     private ConfigurationService configurationService;
 
+    @Autowired
+    private UploadConfigurationService uploadConfigurationService;
 
     @Before
     @Override
@@ -79,6 +83,13 @@ public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationT
 
         //disable file upload mandatory
         configurationService.setProperty("webui.submit.upload.required", false);
+
+        //reset config
+        for (String key : uploadConfigurationService.getMap().keySet()) {
+            UploadConfiguration uploadConfig = uploadConfigurationService.getMap().get(key);
+            uploadConfig.setRequired(null);
+        }
+
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowItemRestRepositoryIT.java
@@ -1533,12 +1533,4 @@ public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationT
             .andExpect(jsonPath("$.sections.traditionalpagetwo['dc.subject'][5].value", is("Final Subject")))
         ;
     }
-
-    @Override
-    public void destroy() throws Exception {
-        //reinstate file upload mandatory
-        configurationService.setProperty("webui.submit.upload.required", null);
-
-        super.destroy();
-    }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
@@ -51,8 +51,11 @@ import org.dspace.content.Community;
 import org.dspace.content.Item;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.eperson.EPerson;
+import org.dspace.services.ConfigurationService;
 import org.hamcrest.Matchers;
+import org.junit.Before;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -62,6 +65,19 @@ import org.springframework.test.web.servlet.MvcResult;
  *
  */
 public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private ConfigurationService configurationService;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+
+        super.setUp();
+
+        //disable file upload mandatory
+        configurationService.setProperty("webui.submit.upload.required", false);
+    }
 
     @Test
     /**
@@ -1628,6 +1644,83 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
             .andExpect(jsonPath("$.sections.upload.files[0].metadata['dc.source'][0].value",
                     is("/local/path/simple-article.pdf")))
         ;
+    }
+
+    @Test
+    public void createWorkspaceWithFiles_UploadRequired() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+            .withName("Sub Community")
+            .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+
+        String authToken = getAuthToken(admin.getEmail(), password);
+
+        WorkspaceItem witem = WorkspaceItemBuilder.createWorkspaceItem(context, col1)
+            .withTitle("Test WorkspaceItem")
+            .withIssueDate("2017-10-17")
+            .build();
+
+        configurationService.setProperty("webui.submit.upload.required", true);
+
+        InputStream pdf = getClass().getResourceAsStream("simple-article.pdf");
+        final MockMultipartFile pdfFile = new MockMultipartFile("file", "/local/path/simple-article.pdf",
+            "application/pdf", pdf);
+
+        // upload the file in our workspaceitem
+        getClient(authToken).perform(fileUpload("/api/submission/workspaceitems/" + witem.getID())
+            .file(pdfFile))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.sections.upload.files[0].metadata['dc.title'][0].value",
+                is("simple-article.pdf")))
+            .andExpect(jsonPath("$.sections.upload.files[0].metadata['dc.source'][0].value",
+                is("/local/path/simple-article.pdf")))
+        ;
+
+        //Verify there are no errors since file was uploaded (with upload required set to true)
+        getClient(authToken).perform(get("/api/submission/workspaceitems/" + witem.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.errors").doesNotExist());
+    }
+
+    @Test
+    public void createWorkspaceWithoutFiles_UploadRequired() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+            .withName("Sub Community")
+            .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+
+        String authToken = getAuthToken(admin.getEmail(), password);
+
+        WorkspaceItem witem = WorkspaceItemBuilder.createWorkspaceItem(context, col1)
+            .withTitle("Test WorkspaceItem")
+            .withIssueDate("2017-10-17")
+            .build();
+
+        configurationService.setProperty("webui.submit.upload.required", true);
+
+        //Verify there is an error since no file was uploaded (with upload required set to true)
+        getClient(authToken).perform(get("/api/submission/workspaceitems/" + witem.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.errors").isNotEmpty())
+            .andExpect(jsonPath("$.errors[?(@.message=='error.validation.filerequired')]",
+                Matchers.contains(
+                    hasJsonPath("$.paths", Matchers.contains(
+                        hasJsonPath("$", Matchers.is("/sections/upload"))
+                    )))));
     }
 
     @Test


### PR DESCRIPTION
Configuring whether the file upload is required used an incorrect default value
https://github.com/DSpace/DSpace/blob/master/dspace/config/dspace.cfg#L838 states webui.submit.upload.required defaults to true, and this is also the default in DSpace 6. It was however implemented to default to false

This PR also includes ITs to verify this parameter works