### PR TITLE
Collection item template updates

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/CollectionItemtemplateController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/CollectionItemtemplateController.java
@@ -124,7 +124,7 @@ public class CollectionItemtemplateController {
             collectionRestRepository.createTemplateItem(context, collection, inputTemplateItemRest);
         context.commit();
 
-        return ControllerUtils.toResponseEntity(HttpStatus.CREATED, null,
+        return ControllerUtils.toResponseEntity(HttpStatus.CREATED, new HttpHeaders(),
                 converter.toResource(templateItem));
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/CollectionItemtemplateController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/CollectionItemtemplateController.java
@@ -17,6 +17,7 @@ import javax.ws.rs.BadRequestException;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.dspace.app.rest.converter.ConverterService;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.CollectionRest;
 import org.dspace.app.rest.model.ItemRest;
@@ -59,6 +60,9 @@ public class CollectionItemtemplateController {
 
     @Autowired
     private CollectionService collectionService;
+
+    @Autowired
+    private ConverterService converter;
 
     /**
      * This method will create an Item and add it as a template to a Collection.
@@ -147,7 +151,7 @@ public class CollectionItemtemplateController {
         Collection collection = getCollection(context, uuid);
         ItemRest templateItem = collectionRestRepository.getTemplateItem(collection);
 
-        return new ItemResource(templateItem, utils);
+        return converter.toResource(templateItem);
     }
 
     private Collection getCollection(Context context, UUID uuid) throws SQLException {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/CollectionItemtemplateController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/CollectionItemtemplateController.java
@@ -20,8 +20,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dspace.app.rest.converter.ConverterService;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.CollectionRest;
-import org.dspace.app.rest.model.ItemRest;
-import org.dspace.app.rest.model.hateoas.ItemResource;
+import org.dspace.app.rest.model.TemplateItemRest;
+import org.dspace.app.rest.model.hateoas.TemplateItemResource;
 import org.dspace.app.rest.repository.CollectionRestRepository;
 import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.app.rest.utils.Utils;
@@ -112,19 +112,20 @@ public class CollectionItemtemplateController {
         Context context = ContextUtil.obtainContext(request);
         Collection collection = getCollection(context, uuid);
 
-        ItemRest inputItemRest;
+        TemplateItemRest inputTemplateItemRest;
         try {
             ObjectMapper mapper = new ObjectMapper();
-            inputItemRest = mapper.readValue(itemBody.toString(), ItemRest.class);
+            inputTemplateItemRest = mapper.readValue(itemBody.toString(), TemplateItemRest.class);
         } catch (IOException e1) {
             throw new UnprocessableEntityException("Error parsing request body", e1);
         }
 
-        ItemRest templateItem = collectionRestRepository.createTemplateItem(context, collection, inputItemRest);
+        TemplateItemRest templateItem =
+            collectionRestRepository.createTemplateItem(context, collection, inputTemplateItemRest);
         context.commit();
 
-        return ControllerUtils.toResponseEntity(HttpStatus.CREATED, new HttpHeaders(),
-                new ItemResource(templateItem, utils));
+        return ControllerUtils.toResponseEntity(HttpStatus.CREATED, null,
+                converter.toResource(templateItem));
     }
 
     /**
@@ -144,12 +145,12 @@ public class CollectionItemtemplateController {
      */
     @PreAuthorize("hasPermission(#uuid, 'COLLECTION', 'READ')")
     @RequestMapping(method = RequestMethod.GET)
-    public ItemResource getTemplateItem(HttpServletRequest request, @PathVariable UUID uuid)
+    public TemplateItemResource getTemplateItem(HttpServletRequest request, @PathVariable UUID uuid)
             throws SQLException {
 
         Context context = ContextUtil.obtainContext(request);
         Collection collection = getCollection(context, uuid);
-        ItemRest templateItem = collectionRestRepository.getTemplateItem(collection);
+        TemplateItemRest templateItem = collectionRestRepository.getTemplateItem(collection);
 
         return converter.toResource(templateItem);
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ItemtemplateRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ItemtemplateRestController.java
@@ -12,21 +12,17 @@ import static org.dspace.app.rest.utils.RegexUtils.REGEX_REQUESTMAPPING_IDENTIFI
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.UUID;
-
 import javax.servlet.http.HttpServletRequest;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.dspace.app.rest.converter.ConverterService;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
-import org.dspace.app.rest.model.ItemRest;
 import org.dspace.app.rest.model.TemplateItemRest;
-import org.dspace.app.rest.model.hateoas.ItemResource;
 import org.dspace.app.rest.model.hateoas.TemplateItemResource;
 import org.dspace.app.rest.model.wrapper.TemplateItem;
-import org.dspace.app.rest.projection.Projection;
-import org.dspace.app.rest.repository.ItemRestRepository;
 import org.dspace.app.rest.repository.ItemTemplateItemOfLinkRepository;
+import org.dspace.app.rest.repository.TemplateItemRestRepository;
 import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.app.rest.utils.Utils;
 import org.dspace.authorize.AuthorizeException;
@@ -83,7 +79,7 @@ public class ItemtemplateRestController {
      * </pre>
      * @param request
      * @param uuid      A UUID of a template item
-     * @return          The template item corresponding to the UUID above
+     * @return The template item corresponding to the UUID above
      */
     @PreAuthorize("hasPermission(#uuid, 'COLLECTION', 'READ')")
     @RequestMapping(method = RequestMethod.GET)
@@ -120,14 +116,14 @@ public class ItemtemplateRestController {
      * @param request
      * @param uuid          The UUID of the template item to be modified
      * @param jsonNode      The data as shown above
-     * @return              The modified item
+     * @return The modified item
      * @throws SQLException
      * @throws AuthorizeException
      */
     @PreAuthorize("hasPermission(#uuid, 'ITEM', 'WRITE')")
     @RequestMapping(method = RequestMethod.PATCH)
     public ResponseEntity<ResourceSupport> patch(HttpServletRequest request, @PathVariable UUID uuid,
-                                                               @RequestBody(required = true) JsonNode jsonNode)
+                                                 @RequestBody(required = true) JsonNode jsonNode)
         throws SQLException, AuthorizeException {
 
         Context context = ContextUtil.obtainContext(request);
@@ -136,7 +132,7 @@ public class ItemtemplateRestController {
         context.commit();
 
         return ControllerUtils.toResponseEntity(HttpStatus.OK, new HttpHeaders(),
-            converter.toResource(templateItemRest));
+                                                converter.toResource(templateItemRest));
     }
 
     /**
@@ -152,7 +148,7 @@ public class ItemtemplateRestController {
      * </pre>
      * @param request
      * @param uuid
-     * @return          Status code 204 is returned if the deletion was successful
+     * @return Status code 204 is returned if the deletion was successful
      * @throws SQLException
      * @throws AuthorizeException
      * @throws IOException

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ItemtemplateRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ItemtemplateRestController.java
@@ -90,7 +90,7 @@ public class ItemtemplateRestController {
     public TemplateItemResource getTemplateItem(HttpServletRequest request, @PathVariable UUID uuid) {
 
         Context context = ContextUtil.obtainContext(request);
-        TemplateItemRest templateItem = templateItemRestRepository.findOne(context, uuid.toString());
+        TemplateItemRest templateItem = templateItemRestRepository.findOne(context, uuid);
 
         if (templateItem == null) {
             throw new ResourceNotFoundException("Item with id: " + uuid + " not found");

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ItemtemplateRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ItemtemplateRestController.java
@@ -135,7 +135,7 @@ public class ItemtemplateRestController {
         TemplateItemRest templateItemRest = templateItemRestRepository.patchTemplateItem(templateItem, jsonNode);
         context.commit();
 
-        return ControllerUtils.toResponseEntity(HttpStatus.OK, null,
+        return ControllerUtils.toResponseEntity(HttpStatus.OK, new HttpHeaders(),
             converter.toResource(templateItemRest));
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/TemplateItemConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/TemplateItemConverter.java
@@ -39,8 +39,8 @@ public class TemplateItemConverter
         TemplateItemRest templateItemRest = new TemplateItemRest();
         templateItemRest.setProjection(projection);
         if (templateItem.getID() != null) {
-            templateItemRest.setId(templateItem.getID().toString());
-            templateItemRest.setUuid(templateItem.getID().toString());
+            templateItemRest.setId(templateItem.getID());
+            templateItemRest.setUuid(templateItem.getID());
         }
 
         templateItemRest.setLastModified(templateItem.getLastModified());

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/TemplateItemConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/TemplateItemConverter.java
@@ -1,0 +1,63 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.converter;
+
+import java.util.List;
+
+import org.dspace.app.rest.model.MetadataValueList;
+import org.dspace.app.rest.model.TemplateItemRest;
+import org.dspace.app.rest.model.wrapper.TemplateItem;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.service.ItemService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * This is the converter from/to the TemplateItem in the DSpace API data model and the
+ * REST data model
+ */
+@Component
+public class TemplateItemConverter
+    implements DSpaceConverter<TemplateItem, TemplateItemRest> {
+
+    @Autowired
+    ConverterService converter;
+
+    @Autowired
+    private ItemService itemService;
+
+    @Override
+    public TemplateItemRest convert(TemplateItem templateItem, Projection projection) {
+        TemplateItemRest templateItemRest = new TemplateItemRest();
+        templateItemRest.setProjection(projection);
+        if (templateItem.getID() != null) {
+            templateItemRest.setId(templateItem.getID().toString());
+        }
+
+        templateItemRest.setLastModified(templateItem.getLastModified());
+        Collection templateItemOf = templateItem.getTemplateItemOf();
+        if (templateItemOf != null) {
+            templateItemRest.setTemplateItemOf(converter.toRest(templateItemOf, projection));
+        }
+
+        List<MetadataValue> fullList =
+            itemService.getMetadata(templateItem.getItem(), Item.ANY, Item.ANY, Item.ANY, Item.ANY, true);
+        MetadataValueList metadataValues = new MetadataValueList(fullList);
+        templateItemRest.setMetadata(converter.toRest(metadataValues, projection));
+
+        return templateItemRest;
+    }
+
+    @Override
+    public Class<TemplateItem> getModelClass() {
+        return TemplateItem.class;
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/TemplateItemConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/TemplateItemConverter.java
@@ -40,6 +40,7 @@ public class TemplateItemConverter
         templateItemRest.setProjection(projection);
         if (templateItem.getID() != null) {
             templateItemRest.setId(templateItem.getID().toString());
+            templateItemRest.setUuid(templateItem.getID().toString());
         }
 
         templateItemRest.setLastModified(templateItem.getLastModified());

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/TemplateItemRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/TemplateItemRest.java
@@ -1,0 +1,66 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.dspace.app.rest.RestResourceController;
+
+/**
+ * The TemplateItem REST Resource
+ */
+public class TemplateItemRest extends BaseObjectRest<String> {
+    public static final String NAME = "templateItem";
+    public static final String CATEGORY = RestAddressableModel.CORE;
+    @JsonIgnore
+    private CollectionRest templateItemOf;
+    MetadataRest metadata = new MetadataRest();
+    private Date lastModified = new Date();
+
+    public Date getLastModified() {
+        return lastModified;
+    }
+
+    public void setLastModified(Date lastModified) {
+        this.lastModified = lastModified;
+    }
+
+    public CollectionRest getTemplateItemOf() {
+        return templateItemOf;
+    }
+
+    public void setTemplateItemOf(CollectionRest templateItemOf) {
+        this.templateItemOf = templateItemOf;
+    }
+
+    public void setMetadata(MetadataRest metadata) {
+        this.metadata = metadata;
+    }
+
+    public MetadataRest getMetadata() {
+        return this.metadata;
+    }
+
+    @Override
+    public String getCategory() {
+        return CATEGORY;
+    }
+
+    @Override
+    public Class getController() {
+        return RestResourceController.class;
+    }
+
+    @Override
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    public String getType() {
+        return NAME;
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/TemplateItemRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/TemplateItemRest.java
@@ -8,6 +8,7 @@
 package org.dspace.app.rest.model;
 
 import java.util.Date;
+import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -16,8 +17,8 @@ import org.dspace.app.rest.RestResourceController;
 /**
  * The TemplateItem REST Resource
  */
-public class TemplateItemRest extends BaseObjectRest<String> {
-    private String uuid;
+public class TemplateItemRest extends BaseObjectRest<UUID> {
+    private UUID uuid;
 
     public static final String NAME = "itemtemplate";
     public static final String CATEGORY = RestAddressableModel.CORE;
@@ -67,15 +68,15 @@ public class TemplateItemRest extends BaseObjectRest<String> {
     }
 
     @Override
-    public String getId() {
+    public UUID getId() {
         return uuid;
     }
 
-    public String getUuid() {
+    public UUID getUuid() {
         return uuid;
     }
 
-    public void setUuid(String uuid) {
+    public void setUuid(UUID uuid) {
         this.uuid = uuid;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/TemplateItemRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/TemplateItemRest.java
@@ -17,7 +17,9 @@ import org.dspace.app.rest.RestResourceController;
  * The TemplateItem REST Resource
  */
 public class TemplateItemRest extends BaseObjectRest<String> {
-    public static final String NAME = "templateItem";
+    private String uuid;
+
+    public static final String NAME = "itemtemplate";
     public static final String CATEGORY = RestAddressableModel.CORE;
     @JsonIgnore
     private CollectionRest templateItemOf;
@@ -63,4 +65,18 @@ public class TemplateItemRest extends BaseObjectRest<String> {
     public String getType() {
         return NAME;
     }
+
+    @Override
+    public String getId() {
+        return uuid;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/TemplateItemResource.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/TemplateItemResource.java
@@ -12,10 +12,9 @@ import org.dspace.app.rest.model.hateoas.annotations.RelNameDSpaceResource;
 import org.dspace.app.rest.utils.Utils;
 
 /**
- * Item Rest HAL Resource. The HAL Resource wraps the REST Resource
+ * TemplateItem Rest HAL Resource. The HAL Resource wraps the REST Resource
  * adding support for the links and embedded resources
  *
- * @author Andrea Bollini (andrea.bollini at 4science.it)
  */
 @RelNameDSpaceResource(TemplateItemRest.NAME)
 public class TemplateItemResource extends DSpaceResource<TemplateItemRest> {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/TemplateItemResource.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/TemplateItemResource.java
@@ -1,0 +1,26 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model.hateoas;
+
+import org.dspace.app.rest.model.TemplateItemRest;
+import org.dspace.app.rest.model.hateoas.annotations.RelNameDSpaceResource;
+import org.dspace.app.rest.utils.Utils;
+
+/**
+ * Item Rest HAL Resource. The HAL Resource wraps the REST Resource
+ * adding support for the links and embedded resources
+ *
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ */
+@RelNameDSpaceResource(TemplateItemRest.NAME)
+public class TemplateItemResource extends DSpaceResource<TemplateItemRest> {
+
+    public TemplateItemResource(TemplateItemRest data, Utils utils) {
+        super(data, utils);
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/wrapper/TemplateItem.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/wrapper/TemplateItem.java
@@ -1,0 +1,47 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model.wrapper;
+
+import java.util.Date;
+import java.util.List;
+
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataValue;
+
+public class TemplateItem {
+    private Item item;
+
+    public TemplateItem(Item item) {
+        if (item.getTemplateItemOf() == null) {
+            throw new IllegalArgumentException("Cannot create a TemplateItem from an item that isn't a template item");
+        }
+
+        this.item = item;
+    }
+
+    public Item getItem() {
+        return this.item;
+    }
+
+    public List<MetadataValue> getMetadata() {
+        return item.getMetadata();
+    }
+
+    public Object getID() {
+        return item.getID();
+    }
+
+    public Date getLastModified() {
+        return item.getLastModified();
+    }
+
+    public Collection getTemplateItemOf() {
+        return item.getTemplateItemOf();
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/wrapper/TemplateItem.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/wrapper/TemplateItem.java
@@ -9,6 +9,7 @@ package org.dspace.app.rest.model.wrapper;
 
 import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
@@ -33,7 +34,7 @@ public class TemplateItem {
         return item.getMetadata();
     }
 
-    public Object getID() {
+    public UUID getID() {
         return item.getID();
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/wrapper/TemplateItem.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/wrapper/TemplateItem.java
@@ -15,6 +15,10 @@ import org.dspace.content.Collection;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataValue;
 
+/**
+ * This class represents a Collection's Item Template. It acts as a wrapper for an {@link Item} object to differentiate
+ * between actual Items and TemplateItems
+ */
 public class TemplateItem {
     private Item item;
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
@@ -24,8 +24,9 @@ import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.BitstreamRest;
 import org.dspace.app.rest.model.CollectionRest;
 import org.dspace.app.rest.model.CommunityRest;
-import org.dspace.app.rest.model.ItemRest;
+import org.dspace.app.rest.model.TemplateItemRest;
 import org.dspace.app.rest.model.patch.Patch;
+import org.dspace.app.rest.model.wrapper.TemplateItem;
 import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.repository.patch.DSpaceObjectPatch;
 import org.dspace.app.rest.utils.CollectionRestEqualityUtils;
@@ -73,7 +74,8 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
     private ItemService itemService;
 
     public CollectionRestRepository(CollectionService dsoService) {
-        super(dsoService, new DSpaceObjectPatch<CollectionRest>() {});
+        super(dsoService, new DSpaceObjectPatch<CollectionRest>() {
+        });
     }
 
     @Override
@@ -105,13 +107,13 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
 
     @SearchRestMethod(name = "findAuthorizedByCommunity")
     public Page<CollectionRest> findAuthorizedByCommunity(
-            @Parameter(value = "uuid", required = true) UUID communityUuid, Pageable pageable) {
+        @Parameter(value = "uuid", required = true) UUID communityUuid, Pageable pageable) {
         try {
             Context context = obtainContext();
             Community com = communityService.find(context, communityUuid);
             if (com == null) {
                 throw new ResourceNotFoundException(
-                        CommunityRest.CATEGORY + "." + CommunityRest.NAME + " with id: " + communityUuid
+                    CommunityRest.CATEGORY + "." + CommunityRest.NAME + " with id: " + communityUuid
                         + " not found");
             }
             List<Collection> collections = cs.findAuthorized(context, com, Constants.ADD);
@@ -155,7 +157,7 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
 
         if (id == null) {
             throw new DSpaceBadRequestException("Parent Community UUID is null. " +
-                "Cannot create a Collection without providing a parent Community");
+                                                    "Cannot create a Collection without providing a parent Community");
         }
 
         HttpServletRequest req = getRequestService().getCurrentRequest().getHttpServletRequest();
@@ -173,7 +175,7 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
             Community parent = communityService.find(context, id);
             if (parent == null) {
                 throw new UnprocessableEntityException("Parent community for id: "
-                    + id + " not found");
+                                                           + id + " not found");
             }
             collection = cs.create(context, parent);
             cs.update(context, collection);
@@ -188,7 +190,7 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
     @Override
     @PreAuthorize("hasPermission(#id, 'COLLECTION', 'WRITE')")
     protected CollectionRest put(Context context, HttpServletRequest request, String apiCategory, String model, UUID id,
-                                JsonNode jsonNode)
+                                 JsonNode jsonNode)
         throws RepositoryMethodNotImplementedException, SQLException, AuthorizeException {
         CollectionRest collectionRest;
         try {
@@ -210,6 +212,7 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
         }
         return converter.toRest(collection, Projection.DEFAULT);
     }
+
     @Override
     @PreAuthorize("hasPermission(#id, 'COLLECTION', 'DELETE')")
     protected void delete(Context context, UUID id) throws AuthorizeException {
@@ -233,7 +236,7 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
      * @param context
      * @param collection    The collection on which to install the logo
      * @param uploadfile    The new logo
-     * @return              The created bitstream containing the new logo
+     * @return The created bitstream containing the new logo
      * @throws IOException
      * @throws AuthorizeException
      * @throws SQLException
@@ -257,48 +260,46 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
      * @param context
      * @param collection    The collection for which to make the item
      * @param inputItemRest The new item
-     * @return              The created item
+     * @return The created item
      * @throws SQLException
      * @throws AuthorizeException
      */
-    public ItemRest createTemplateItem(Context context, Collection collection, ItemRest inputItemRest)
+    public TemplateItemRest createTemplateItem(Context context, Collection collection, TemplateItemRest inputItemRest)
         throws SQLException, AuthorizeException {
         if (collection.getTemplateItem() != null) {
             throw new UnprocessableEntityException("Collection with ID " + collection.getID()
-                + " already contains a template item");
+                                                       + " already contains a template item");
         }
-
-        if (inputItemRest.getInArchive() || inputItemRest.getDiscoverable() || inputItemRest.getWithdrawn()) {
-            throw new UnprocessableEntityException(
-                    "The template item should not be archived, discoverable or withdrawn");
-        }
-
         cs.createTemplateItem(context, collection);
-        Item templateItem = collection.getTemplateItem();
-        metadataConverter.setMetadata(context, templateItem, inputItemRest.getMetadata());
-        templateItem.setDiscoverable(false);
+        Item item = collection.getTemplateItem();
+        metadataConverter.setMetadata(context, item, inputItemRest.getMetadata());
+        item.setDiscoverable(false);
 
         cs.update(context, collection);
-        itemService.update(context, templateItem);
+        itemService.update(context, item);
 
-        return converter.toRest(templateItem, Projection.DEFAULT);
+        return converter.toRest(new TemplateItem(item), Projection.DEFAULT);
     }
 
     /**
      * This method looks up the template Item associated with a Collection
      *
      * @param collection    The Collection for which to find the template
-     * @return              The template Item from the Collection
+     * @return The template Item from the Collection
      * @throws SQLException
      */
-    public ItemRest getTemplateItem(Collection collection) throws SQLException {
+    public TemplateItemRest getTemplateItem(Collection collection) throws SQLException {
         Item item = collection.getTemplateItem();
         if (item == null) {
             throw new ResourceNotFoundException(
-                    "TemplateItem from " + CollectionRest.CATEGORY + "." + CollectionRest.NAME + " with id: "
-                            + collection.getID() + " not found");
+                "TemplateItem from " + CollectionRest.CATEGORY + "." + CollectionRest.NAME + " with id: "
+                    + collection.getID() + " not found");
         }
 
-        return converter.toRest(item, Projection.DEFAULT);
+        try {
+            return converter.toRest(new TemplateItem(item), Projection.DEFAULT);
+        } catch (IllegalArgumentException e) {
+            throw new UnprocessableEntityException("The item with id " + item.getID() + " is not a template item");
+        }
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
@@ -260,7 +260,7 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
      * @param context
      * @param collection    The collection for which to make the item
      * @param inputItemRest The new item
-     * @return The created item
+     * @return The created TemplateItem
      * @throws SQLException
      * @throws AuthorizeException
      */

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemRestRepository.java
@@ -148,7 +148,7 @@ public class ItemRestRepository extends DSpaceObjectRestRepository<Item, ItemRes
         if (item.getTemplateItemOf() != null) {
             throw new DSpaceBadRequestException("The given ID resolved to a template item");
         }
-        ItemRest itemRest = dsoPatch.patch(findOne(id), patch.getOperations());
+        ItemRest itemRest = dsoPatch.patch(findOne(context, id), patch.getOperations());
         updateDSpaceObject(item, itemRest);
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemRestRepository.java
@@ -146,7 +146,7 @@ public class ItemRestRepository extends DSpaceObjectRestRepository<Item, ItemRes
             throw new ResourceNotFoundException(apiCategory + "." + model + " with id: " + id + " not found");
         }
         if (item.getTemplateItemOf() != null) {
-            throw new DSpaceBadRequestException("The given ID resolved to a template item");
+            throw new DSpaceBadRequestException("The ID: " + id + " resolved to a template item");
         }
         ItemRest itemRest = dsoPatch.patch(findOne(context, id), patch.getOperations());
         updateDSpaceObject(item, itemRest);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemRestRepository.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
-import org.dspace.app.rest.converter.JsonPatchConverter;
 import org.dspace.app.rest.converter.MetadataConverter;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
 import org.dspace.app.rest.exception.RepositoryMethodNotImplementedException;
@@ -114,6 +113,9 @@ public class ItemRestRepository extends DSpaceObjectRestRepository<Item, ItemRes
         if (item == null) {
             return null;
         }
+        if (item.getTemplateItemOf() != null) {
+            throw new DSpaceBadRequestException("Item with id: " + id + " is a template item.");
+        }
         return converter.toRest(item, utils.obtainProjection());
     }
 
@@ -138,14 +140,31 @@ public class ItemRestRepository extends DSpaceObjectRestRepository<Item, ItemRes
     @PreAuthorize("hasPermission(#id, 'ITEM', #patch)")
     protected void patch(Context context, HttpServletRequest request, String apiCategory, String model, UUID id,
                          Patch patch) throws AuthorizeException, SQLException {
-        patchDSpaceObject(apiCategory, model, id, patch);
+
+        Item item = itemService.find(obtainContext(), id);
+        if (item == null) {
+            throw new ResourceNotFoundException(apiCategory + "." + model + " with id: " + id + " not found");
+        }
+        if (item.getTemplateItemOf() != null) {
+            throw new DSpaceBadRequestException("The given ID resolved to a template item");
+        }
+        ItemRest itemRest = dsoPatch.patch(findOne(id), patch.getOperations());
+        updateDSpaceObject(item, itemRest);
     }
 
     @Override
     protected void updateDSpaceObject(Item item, ItemRest itemRest)
         throws AuthorizeException, SQLException {
         super.updateDSpaceObject(item, itemRest);
-
+        if (item.getTemplateItemOf() != null) {
+            if (itemRest.getWithdrawn() != item.isWithdrawn()) {
+                throw new UnprocessableEntityException("Cannot apply a withdrawn patch to a templateItem");
+            }
+            if (itemRest.getDiscoverable() != item.isDiscoverable()) {
+                throw new UnprocessableEntityException("Cannot apply a discoverable patch to a templateItem");
+            }
+            return;
+        }
         Context context = obtainContext();
         if (itemRest.getWithdrawn() != item.isWithdrawn()) {
             if (itemRest.getWithdrawn()) {
@@ -372,45 +391,6 @@ public class ItemRestRepository extends DSpaceObjectRestRepository<Item, ItemRes
         context.commit();
 
         return bundle;
-    }
-
-    /**
-     * Modify a template Item which is a template Item
-     * @param item          The Item to be modified
-     * @param jsonNode      The patch to be applied
-     * @return              The Item as it is after applying the patch
-     * @throws SQLException
-     * @throws AuthorizeException
-     */
-    public ItemRest patchTemplateItem(Item item, JsonNode jsonNode)
-        throws SQLException, AuthorizeException {
-
-        ObjectMapper mapper = new ObjectMapper();
-        JsonPatchConverter patchConverter = new JsonPatchConverter(mapper);
-        Patch patch = patchConverter.convert(jsonNode);
-
-        ItemRest patchedItemRest = dsoPatch.patch(converter.toRest(item, Projection.DEFAULT), patch.getOperations());
-        updateDSpaceObject(item, patchedItemRest);
-
-        return converter.toRest(item, Projection.DEFAULT);
-    }
-
-    /**
-     * Remove an Item which is a template for a Collection.
-     *
-     * Note: The caller is responsible for checking that this item is in fact a template item.
-     *
-     * @param context
-     * @param item          The item to be removed
-     * @throws SQLException
-     * @throws IOException
-     * @throws AuthorizeException
-     */
-    public void removeTemplateItem(Context context, Item item) throws SQLException, IOException, AuthorizeException {
-
-        Collection collection = item.getTemplateItemOf();
-        collectionService.removeTemplateItem(context, collection);
-        collectionService.update(context, collection);
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/TemplateItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/TemplateItemRestRepository.java
@@ -32,6 +32,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.stereotype.Component;
 
+/**
+ * This is the repository class that is responsible for handling {@link TemplateItemRest} objects
+ */
 @Component(TemplateItemRest.CATEGORY + "." + TemplateItemRest.NAME)
 public class TemplateItemRestRepository extends DSpaceRestRepository<TemplateItemRest, UUID> {
 
@@ -47,6 +50,7 @@ public class TemplateItemRestRepository extends DSpaceRestRepository<TemplateIte
     @Autowired
     private CollectionService collectionService;
 
+    @Override
     public TemplateItemRest findOne(Context context, UUID uuid) {
         Item item = null;
         try {
@@ -65,10 +69,12 @@ public class TemplateItemRestRepository extends DSpaceRestRepository<TemplateIte
         }
     }
 
+    @Override
     public Page<TemplateItemRest> findAll(Context context, Pageable pageable) {
         return null;
     }
 
+    @Override
     public Class<TemplateItemRest> getDomainClass() {
         return TemplateItemRest.class;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/TemplateItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/TemplateItemRestRepository.java
@@ -33,7 +33,7 @@ import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.stereotype.Component;
 
 @Component(TemplateItemRest.CATEGORY + "." + TemplateItemRest.NAME)
-public class TemplateItemRestRepository extends DSpaceRestRepository<TemplateItemRest, String> {
+public class TemplateItemRestRepository extends DSpaceRestRepository<TemplateItemRest, UUID> {
 
     @Autowired
     private ItemService itemService;
@@ -47,10 +47,10 @@ public class TemplateItemRestRepository extends DSpaceRestRepository<TemplateIte
     @Autowired
     private CollectionService collectionService;
 
-    public TemplateItemRest findOne(Context context, String s) {
+    public TemplateItemRest findOne(Context context, UUID uuid) {
         Item item = null;
         try {
-            item = itemService.find(context, UUID.fromString(s));
+            item = itemService.find(context, uuid);
         } catch (SQLException e) {
             throw new RuntimeException(e.getMessage(), e);
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/TemplateItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/TemplateItemRestRepository.java
@@ -1,0 +1,117 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.repository;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.dspace.app.rest.converter.JsonPatchConverter;
+import org.dspace.app.rest.model.ItemRest;
+import org.dspace.app.rest.model.TemplateItemRest;
+import org.dspace.app.rest.model.patch.Patch;
+import org.dspace.app.rest.model.wrapper.TemplateItem;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.app.rest.repository.patch.ItemPatch;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.content.service.CollectionService;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.stereotype.Component;
+
+@Component(TemplateItemRest.CATEGORY + "." + TemplateItemRest.NAME)
+public class TemplateItemRestRepository extends DSpaceRestRepository<TemplateItemRest, String> {
+
+    @Autowired
+    private ItemService itemService;
+
+    @Autowired
+    private ItemRestRepository itemRestRepository;
+
+    @Autowired
+    private ItemPatch itemPatch;
+
+    @Autowired
+    private CollectionService collectionService;
+
+    public TemplateItemRest findOne(Context context, String s) {
+        Item item = null;
+        try {
+            item = itemService.find(context, UUID.fromString(s));
+        } catch (SQLException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+        if (item == null) {
+            return null;
+        }
+
+        try {
+            return converter.toRest(new TemplateItem(item), Projection.DEFAULT);
+        } catch (IllegalArgumentException e) {
+            throw new ResourceNotFoundException("The item with id " + item.getID() + " is not a template item");
+        }
+    }
+
+    public Page<TemplateItemRest> findAll(Context context, Pageable pageable) {
+        return null;
+    }
+
+    public Class<TemplateItemRest> getDomainClass() {
+        return TemplateItemRest.class;
+    }
+
+    /**
+     * Modify a template Item which is a template Item
+     * @param templateItem          The Item to be modified
+     * @param jsonNode      The patch to be applied
+     * @return The Item as it is after applying the patch
+     * @throws SQLException
+     * @throws AuthorizeException
+     */
+    public TemplateItemRest patchTemplateItem(TemplateItem templateItem, JsonNode jsonNode)
+        throws SQLException, AuthorizeException {
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonPatchConverter patchConverter = new JsonPatchConverter(mapper);
+        Patch patch = patchConverter.convert(jsonNode);
+
+        ItemRest patchedItemRest =
+            itemPatch.patch(converter.toRest(templateItem.getItem(), Projection.DEFAULT), patch.getOperations());
+        itemRestRepository.updateDSpaceObject(templateItem.getItem(), patchedItemRest);
+
+        return converter.toRest(templateItem, Projection.DEFAULT);
+    }
+
+    /**
+     * Remove an Item which is a template for a Collection.
+     *
+     * Note: The caller is responsible for checking that this item is in fact a template item.
+     *
+     * @param context
+     * @param templateItem          The item to be removed
+     * @throws SQLException
+     * @throws IOException
+     * @throws AuthorizeException
+     */
+    public void removeTemplateItem(Context context, TemplateItem templateItem)
+        throws SQLException, IOException, AuthorizeException {
+
+        Collection collection = templateItem.getItem().getTemplateItemOf();
+        collectionService.removeTemplateItem(context, collection);
+        collectionService.update(context, collection);
+    }
+
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -1200,9 +1200,9 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         getClient(token).perform(delete("/api/core/items/" + templateItem.getID()))
                     .andExpect(status().is(422));
 
-        //Check templateItem is available after failed deletion
+        //Check templateItem is not deleted
         getClient(token).perform(get("/api/core/items/" + templateItem.getID()))
-                   .andExpect(status().isOk());
+                   .andExpect(status().isBadRequest());
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemTemplateRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemTemplateRestControllerIT.java
@@ -150,7 +150,8 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
                                  .andExpect(status().isOk())
                                  .andExpect(jsonPath("$", Matchers.allOf(
                                      hasJsonPath("$.id", is(itemUuidString)),
-                                     hasJsonPath("$.type", is("templateItem")),
+                                     hasJsonPath("$.uuid", is(itemUuidString)),
+                                     hasJsonPath("$.type", is("itemtemplate")),
                                      hasJsonPath("$.metadata", Matchers.allOf(
                                          MetadataMatcher.matchMetadata("dc.description",
                                                                        "dc description content"),
@@ -168,7 +169,8 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
                                  .andExpect(status().isOk())
                                  .andExpect(jsonPath("$", Matchers.allOf(
                                      hasJsonPath("$.id", is(itemUuidString)),
-                                     hasJsonPath("$.type", is("templateItem")),
+                                     hasJsonPath("$.uuid", is(itemUuidString)),
+                                     hasJsonPath("$.type", is("itemtemplate")),
                                      hasJsonPath("$.metadata", Matchers.allOf(
                                          MetadataMatcher.matchMetadata("dc.description",
                                                                        "dc description content"),
@@ -200,7 +202,7 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
                                               .contentType(contentType))
                                  .andExpect(status().isOk())
                                  .andExpect(jsonPath("$", Matchers.allOf(
-                                     hasJsonPath("$.type", is("templateItem")),
+                                     hasJsonPath("$.type", is("itemtemplate")),
                                      hasJsonPath("$.metadata", Matchers.allOf(
                                          MetadataMatcher.matchMetadata("dc.description",
                                                                        "dc description content"),
@@ -213,7 +215,7 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
         getClient(adminAuthToken).perform(get(getCollectionTemplateItemUrlTemplate(childCollection.getID().toString())))
                                  .andExpect(status().isOk())
                                  .andExpect(jsonPath("$", Matchers.allOf(
-                                     hasJsonPath("$.type", is("templateItem")),
+                                     hasJsonPath("$.type", is("itemtemplate")),
                                      hasJsonPath("$.metadata", Matchers.allOf(
                                          MetadataMatcher.matchMetadata("dc.description",
                                                                        "dc description content"),

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemTemplateRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemTemplateRestControllerIT.java
@@ -191,8 +191,9 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
                     MetadataMatcher.matchMetadata("dc.description",
                         "dc description content"),
                     MetadataMatcher.matchMetadata("dc.description.abstract",
-                        "dc description abstract content")
-                )))));
+                        "dc description abstract content"))),
+                hasJsonPath("$._links.mappedCollections")
+            )));
     }
 
     @Test
@@ -213,8 +214,9 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
                     MetadataMatcher.matchMetadata("dc.description",
                         "dc description content"),
                     MetadataMatcher.matchMetadata("dc.description.abstract",
-                        "dc description abstract content")
-                )))));
+                        "dc description abstract content"))),
+                hasJsonPath("$._links.mappedCollections")
+            )));
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemTemplateRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemTemplateRestControllerIT.java
@@ -25,9 +25,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dspace.app.rest.builder.CollectionBuilder;
 import org.dspace.app.rest.builder.CommunityBuilder;
 import org.dspace.app.rest.matcher.MetadataMatcher;
-import org.dspace.app.rest.model.ItemRest;
 import org.dspace.app.rest.model.MetadataRest;
 import org.dspace.app.rest.model.MetadataValueRest;
+import org.dspace.app.rest.model.TemplateItemRest;
 import org.dspace.app.rest.model.patch.AddOperation;
 import org.dspace.app.rest.model.patch.Operation;
 import org.dspace.app.rest.model.patch.ReplaceOperation;
@@ -43,31 +43,29 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
     private ObjectMapper mapper;
     private String adminAuthToken;
     private Collection childCollection;
-    private ItemRest testTemplateItem;
+    private TemplateItemRest testTemplateItem;
     private String patchBody;
 
     @Before
     public void createStructure() throws Exception {
         context.turnOffAuthorisationSystem();
         parentCommunity = CommunityBuilder.createCommunity(context)
-                .withName("Parent Community")
-                .build();
+                                          .withName("Parent Community")
+                                          .build();
         childCollection = CollectionBuilder.createCollection(context, parentCommunity)
-                .withName("Collection 1").build();
+                                           .withName("Collection 1").build();
         adminAuthToken = getAuthToken(admin.getEmail(), password);
 
         mapper = new ObjectMapper();
     }
 
     private void setupTestTemplate() {
-        testTemplateItem = new ItemRest();
-        testTemplateItem.setInArchive(false);
-        testTemplateItem.setDiscoverable(false);
-        testTemplateItem.setWithdrawn(false);
+        testTemplateItem = new TemplateItemRest();
 
         testTemplateItem.setMetadata(new MetadataRest()
-                .put("dc.description", new MetadataValueRest("dc description content"))
-                .put("dc.description.abstract", new MetadataValueRest("dc description abstract content")));
+                                         .put("dc.description", new MetadataValueRest("dc description content"))
+                                         .put("dc.description.abstract",
+                                              new MetadataValueRest("dc description abstract content")));
 
         List<Operation> ops = new ArrayList<>();
         List<Map<String, String>> values = new ArrayList<>();
@@ -82,13 +80,14 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
     private String installTestTemplate() throws Exception {
         MvcResult mvcResult = getClient(adminAuthToken).perform(post(
             getCollectionTemplateItemUrlTemplate(childCollection.getID().toString()))
-            .content(mapper.writeValueAsBytes(testTemplateItem)).contentType(contentType))
-            .andExpect(status().isCreated())
-            .andReturn();
+                                                                    .content(mapper.writeValueAsBytes(testTemplateItem))
+                                                                    .contentType(contentType))
+                                                       .andExpect(status().isCreated())
+                                                       .andReturn();
 
         String content = mvcResult.getResponse().getContentAsString();
-        Map<String,Object> map = mapper.readValue(content, Map.class);
-        return String.valueOf(map.get("uuid"));
+        Map<String, Object> map = mapper.readValue(content, Map.class);
+        return String.valueOf(map.get("id"));
     }
 
     @Test
@@ -96,9 +95,9 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
         setupTestTemplate();
 
         getClient().perform(post(
-                getCollectionTemplateItemUrlTemplate(childCollection.getID().toString()))
-                .content(mapper.writeValueAsBytes(testTemplateItem)).contentType(contentType))
-                .andExpect(status().isUnauthorized());
+            getCollectionTemplateItemUrlTemplate(childCollection.getID().toString()))
+                                .content(mapper.writeValueAsBytes(testTemplateItem)).contentType(contentType))
+                   .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -108,47 +107,14 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
     }
 
     @Test
-    public void createIllegalInArchiveTemplateItem() throws Exception {
-        setupTestTemplate();
-        testTemplateItem.setInArchive(true);
-
-        getClient(adminAuthToken).perform(post(
-                getCollectionTemplateItemUrlTemplate(childCollection.getID().toString()))
-                .content(mapper.writeValueAsBytes(testTemplateItem)).contentType(contentType))
-                .andExpect(status().isUnprocessableEntity());
-    }
-
-    @Test
-    public void createIllegalDiscoverableTemplateItem() throws Exception {
-        setupTestTemplate();
-        testTemplateItem.setDiscoverable(true);
-
-        getClient(adminAuthToken).perform(post(
-                getCollectionTemplateItemUrlTemplate(childCollection.getID().toString()))
-                .content(mapper.writeValueAsBytes(testTemplateItem)).contentType(contentType))
-                .andExpect(status().isUnprocessableEntity());
-    }
-
-    @Test
-    public void createIllegalWithdrawnTemplateItem() throws Exception {
-        setupTestTemplate();
-        testTemplateItem.setWithdrawn(true);
-
-        getClient(adminAuthToken).perform(post(
-                getCollectionTemplateItemUrlTemplate(childCollection.getID().toString()))
-                .content(mapper.writeValueAsBytes(testTemplateItem)).contentType(contentType))
-                .andExpect(status().isUnprocessableEntity());
-    }
-
-    @Test
     public void createTemplateItemNoRights() throws Exception {
         setupTestTemplate();
 
         String userToken = getAuthToken(eperson.getEmail(), password);
         getClient(userToken).perform(post(
-                getCollectionTemplateItemUrlTemplate(childCollection.getID().toString()))
-                .content(mapper.writeValueAsBytes(testTemplateItem)).contentType(contentType))
-                .andExpect(status().isForbidden());
+            getCollectionTemplateItemUrlTemplate(childCollection.getID().toString()))
+                                         .content(mapper.writeValueAsBytes(testTemplateItem)).contentType(contentType))
+                            .andExpect(status().isForbidden());
     }
 
     @Test
@@ -158,9 +124,10 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
         installTestTemplate();
 
         getClient(adminAuthToken).perform(post(
-                getCollectionTemplateItemUrlTemplate(childCollection.getID().toString()))
-                .content(mapper.writeValueAsBytes(testTemplateItem)).contentType(contentType))
-                .andExpect(status().isUnprocessableEntity());
+            getCollectionTemplateItemUrlTemplate(childCollection.getID().toString()))
+                                              .content(mapper.writeValueAsBytes(testTemplateItem))
+                                              .contentType(contentType))
+                                 .andExpect(status().isUnprocessableEntity());
     }
 
     @Test
@@ -168,9 +135,10 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
         setupTestTemplate();
 
         getClient(adminAuthToken).perform(post(
-                getCollectionTemplateItemUrlTemplate("16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9"))
-                .content(mapper.writeValueAsBytes(testTemplateItem)).contentType(contentType))
-                .andExpect(status().isNotFound());
+            getCollectionTemplateItemUrlTemplate("16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9"))
+                                              .content(mapper.writeValueAsBytes(testTemplateItem))
+                                              .contentType(contentType))
+                                 .andExpect(status().isNotFound());
     }
 
     @Test
@@ -179,21 +147,16 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
         String itemUuidString = installTestTemplate();
 
         getClient(adminAuthToken).perform(get(getCollectionTemplateItemUrlTemplate(childCollection.getID().toString())))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$", Matchers.allOf(
-                hasJsonPath("$.id", is(itemUuidString)),
-                hasJsonPath("$.uuid", is(itemUuidString)),
-                hasJsonPath("$.type", is("item")),
-                hasJsonPath("$.inArchive", is(false)),
-                hasJsonPath("$.discoverable", is(false)),
-                hasJsonPath("$.withdrawn", is(false)),
-                hasJsonPath("$.metadata", Matchers.allOf(
-                    MetadataMatcher.matchMetadata("dc.description",
-                        "dc description content"),
-                    MetadataMatcher.matchMetadata("dc.description.abstract",
-                        "dc description abstract content"))),
-                hasJsonPath("$._links.mappedCollections")
-            )));
+                                 .andExpect(status().isOk())
+                                 .andExpect(jsonPath("$", Matchers.allOf(
+                                     hasJsonPath("$.id", is(itemUuidString)),
+                                     hasJsonPath("$.type", is("templateItem")),
+                                     hasJsonPath("$.metadata", Matchers.allOf(
+                                         MetadataMatcher.matchMetadata("dc.description",
+                                                                       "dc description content"),
+                                         MetadataMatcher.matchMetadata("dc.description.abstract",
+                                                                       "dc description abstract content")))
+                                 )));
     }
 
     @Test
@@ -202,21 +165,16 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
         String itemUuidString = installTestTemplate();
 
         getClient(adminAuthToken).perform(get(getTemplateItemUrlTemplate(itemUuidString)))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$", Matchers.allOf(
-                hasJsonPath("$.id", is(itemUuidString)),
-                hasJsonPath("$.uuid", is(itemUuidString)),
-                hasJsonPath("$.type", is("item")),
-                hasJsonPath("$.inArchive", is(false)),
-                hasJsonPath("$.discoverable", is(false)),
-                hasJsonPath("$.withdrawn", is(false)),
-                hasJsonPath("$.metadata", Matchers.allOf(
-                    MetadataMatcher.matchMetadata("dc.description",
-                        "dc description content"),
-                    MetadataMatcher.matchMetadata("dc.description.abstract",
-                        "dc description abstract content"))),
-                hasJsonPath("$._links.mappedCollections")
-            )));
+                                 .andExpect(status().isOk())
+                                 .andExpect(jsonPath("$", Matchers.allOf(
+                                     hasJsonPath("$.id", is(itemUuidString)),
+                                     hasJsonPath("$.type", is("templateItem")),
+                                     hasJsonPath("$.metadata", Matchers.allOf(
+                                         MetadataMatcher.matchMetadata("dc.description",
+                                                                       "dc description content"),
+                                         MetadataMatcher.matchMetadata("dc.description.abstract",
+                                                                       "dc description abstract content")))
+                                 )));
     }
 
     @Test
@@ -226,9 +184,9 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
         String itemId = installTestTemplate();
 
         getClient().perform(patch(getTemplateItemUrlTemplate(itemId))
-                .content(patchBody)
-                .contentType(contentType))
-                .andExpect(status().isUnauthorized());
+                                .content(patchBody)
+                                .contentType(contentType))
+                   .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -238,38 +196,32 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
         String itemId = installTestTemplate();
 
         getClient(adminAuthToken).perform(patch(getTemplateItemUrlTemplate(itemId))
-                .content(patchBody)
-                .contentType(contentType))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$", Matchers.allOf(
-                        hasJsonPath("$.type", is("item")),
-                        hasJsonPath("$.inArchive", is(false)),
-                        hasJsonPath("$.discoverable", is(false)),
-                        hasJsonPath("$.withdrawn", is(false)),
-                        hasJsonPath("$.metadata", Matchers.allOf(
-                                MetadataMatcher.matchMetadata("dc.description",
-                                        "dc description content"),
-                                MetadataMatcher.matchMetadata("dc.description.abstract",
-                                        "dc description abstract content"),
-                                MetadataMatcher.matchMetadata("dc.description.tableofcontents",
-                                        "table of contents")
-                        )))));
+                                              .content(patchBody)
+                                              .contentType(contentType))
+                                 .andExpect(status().isOk())
+                                 .andExpect(jsonPath("$", Matchers.allOf(
+                                     hasJsonPath("$.type", is("templateItem")),
+                                     hasJsonPath("$.metadata", Matchers.allOf(
+                                         MetadataMatcher.matchMetadata("dc.description",
+                                                                       "dc description content"),
+                                         MetadataMatcher.matchMetadata("dc.description.abstract",
+                                                                       "dc description abstract content"),
+                                         MetadataMatcher.matchMetadata("dc.description.tableofcontents",
+                                                                       "table of contents")
+                                     )))));
 
         getClient(adminAuthToken).perform(get(getCollectionTemplateItemUrlTemplate(childCollection.getID().toString())))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$", Matchers.allOf(
-                        hasJsonPath("$.type", is("item")),
-                        hasJsonPath("$.inArchive", is(false)),
-                        hasJsonPath("$.discoverable", is(false)),
-                        hasJsonPath("$.withdrawn", is(false)),
-                        hasJsonPath("$.metadata", Matchers.allOf(
-                                MetadataMatcher.matchMetadata("dc.description",
-                                        "dc description content"),
-                                MetadataMatcher.matchMetadata("dc.description.abstract",
-                                        "dc description abstract content"),
-                                MetadataMatcher.matchMetadata("dc.description.tableofcontents",
-                                        "table of contents")
-                        )))));
+                                 .andExpect(status().isOk())
+                                 .andExpect(jsonPath("$", Matchers.allOf(
+                                     hasJsonPath("$.type", is("templateItem")),
+                                     hasJsonPath("$.metadata", Matchers.allOf(
+                                         MetadataMatcher.matchMetadata("dc.description",
+                                                                       "dc description content"),
+                                         MetadataMatcher.matchMetadata("dc.description.abstract",
+                                                                       "dc description abstract content"),
+                                         MetadataMatcher.matchMetadata("dc.description.tableofcontents",
+                                                                       "table of contents")
+                                     )))));
     }
 
     @Test
@@ -284,9 +236,9 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
         String illegalPatchBody = getPatchContent(ops);
 
         getClient(adminAuthToken).perform(patch(getTemplateItemUrlTemplate(itemId))
-                .content(illegalPatchBody)
-                .contentType(contentType))
-                .andExpect(status().isBadRequest());
+                                              .content(illegalPatchBody)
+                                              .contentType(contentType))
+                                 .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -301,9 +253,9 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
         String illegalPatchBody = getPatchContent(ops);
 
         getClient(adminAuthToken).perform(patch(getTemplateItemUrlTemplate(itemId))
-                .content(illegalPatchBody)
-                .contentType(contentType))
-                .andExpect(status().isUnprocessableEntity());
+                                              .content(illegalPatchBody)
+                                              .contentType(contentType))
+                                 .andExpect(status().isUnprocessableEntity());
     }
 
     @Test
@@ -318,9 +270,9 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
         String illegalPatchBody = getPatchContent(ops);
 
         getClient(adminAuthToken).perform(patch(getTemplateItemUrlTemplate(itemId))
-                .content(illegalPatchBody)
-                .contentType(contentType))
-                .andExpect(status().isUnprocessableEntity());
+                                              .content(illegalPatchBody)
+                                              .contentType(contentType))
+                                 .andExpect(status().isUnprocessableEntity());
     }
 
     @Test
@@ -331,9 +283,9 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
 
         String userToken = getAuthToken(eperson.getEmail(), password);
         getClient(userToken).perform(patch(getTemplateItemUrlTemplate(itemId))
-                .content(patchBody)
-                .contentType(contentType))
-                .andExpect(status().isForbidden());
+                                         .content(patchBody)
+                                         .contentType(contentType))
+                            .andExpect(status().isForbidden());
     }
 
     @Test
@@ -341,9 +293,9 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
         setupTestTemplate();
 
         getClient(adminAuthToken).perform(patch(getTemplateItemUrlTemplate("16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9"))
-                .content(patchBody)
-                .contentType(contentType))
-                .andExpect(status().isNotFound());
+                                              .content(patchBody)
+                                              .contentType(contentType))
+                                 .andExpect(status().isNotFound());
     }
 
     @Test
@@ -353,7 +305,7 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
         String itemId = installTestTemplate();
 
         getClient().perform(delete(getTemplateItemUrlTemplate(itemId)))
-                .andExpect(status().isUnauthorized());
+                   .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -363,7 +315,7 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
         String itemId = installTestTemplate();
 
         getClient(adminAuthToken).perform(delete(getTemplateItemUrlTemplate(itemId)))
-                .andExpect(status().isNoContent());
+                                 .andExpect(status().isNoContent());
     }
 
     @Test
@@ -374,13 +326,13 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
 
         String userToken = getAuthToken(eperson.getEmail(), password);
         getClient(userToken).perform(delete(getTemplateItemUrlTemplate(itemId)))
-                .andExpect(status().isForbidden());
+                            .andExpect(status().isForbidden());
     }
 
     @Test
     public void deleteTemplateItemForNonexisting() throws Exception {
         getClient(adminAuthToken).perform(delete(getTemplateItemUrlTemplate("16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9")))
-                .andExpect(status().isNotFound());
+                                 .andExpect(status().isNotFound());
     }
 
     private String getCollectionTemplateItemUrlTemplate(String uuid) {


### PR DESCRIPTION
At the moment, the itemtemplate information at:
* api/core/collections/{UUID}/itemtemplate 

contains too much detail:

* inArchive
* discoverable
* withdrawn
* ...

These need to be removed, because for an item template, these properties etc don’t actually MEAN anything. A template item can never be archived for example, should never be discoverable, and the like.

Where previously an 'ItemTemplate' was basically just an instance of an Item, the removal of the superfluous information now has differentiated the actual usages of an item vs an item template.
Since these differences have now occurred, a split has been made so that the TemplateItemRest is an object in and of itself that can be used in the appropriate related code.

In the future, this also allows us to do more fine-grained tweaking to either object without altering the other object
