### PR TITLE
[DS-4257] dspace.url and dspace.baseUrl config cleanup

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
@@ -929,7 +929,7 @@ public class ItemExportServiceImpl implements ItemExportService {
             Locale supportedLocale = I18nUtil.getEPersonLocale(eperson);
             Email email = Email.getEmail(I18nUtil.getEmailFilename(supportedLocale, "export_success"));
             email.addRecipient(eperson.getEmail());
-            email.addArgument(ConfigurationManager.getProperty("dspace.url") + "/exportdownload/" + fileName);
+            email.addArgument(ConfigurationManager.getProperty("dspace.ui.url") + "/exportdownload/" + fileName);
             email.addArgument(ConfigurationManager.getProperty("org.dspace.app.itemexport.life.span.hours"));
 
             email.send();
@@ -947,7 +947,7 @@ public class ItemExportServiceImpl implements ItemExportService {
             Email email = Email.getEmail(I18nUtil.getEmailFilename(supportedLocale, "export_error"));
             email.addRecipient(eperson.getEmail());
             email.addArgument(error);
-            email.addArgument(ConfigurationManager.getProperty("dspace.url") + "/feedback");
+            email.addArgument(ConfigurationManager.getProperty("dspace.ui.url") + "/feedback");
 
             email.send();
         } catch (Exception e) {

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -1797,7 +1797,7 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
             Email email = Email.getEmail(I18nUtil.getEmailFilename(supportedLocale, "bte_batch_import_error"));
             email.addRecipient(eperson.getEmail());
             email.addArgument(error);
-            email.addArgument(ConfigurationManager.getProperty("dspace.url") + "/feedback");
+            email.addArgument(ConfigurationManager.getProperty("dspace.ui.url") + "/feedback");
 
             email.send();
         } catch (Exception e) {

--- a/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
+++ b/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
@@ -152,11 +152,11 @@ public class GenerateSitemaps {
      */
     public static void generateSitemaps(boolean makeHTMLMap,
                                         boolean makeSitemapOrg) throws SQLException, IOException {
-        String sitemapStem = configurationService.getProperty("dspace.url")
+        String sitemapStem = configurationService.getProperty("dspace.ui.url")
             + "/sitemap";
-        String htmlMapStem = configurationService.getProperty("dspace.url")
+        String htmlMapStem = configurationService.getProperty("dspace.ui.url")
             + "/htmlmap";
-        String handleURLStem = configurationService.getProperty("dspace.url")
+        String handleURLStem = configurationService.getProperty("dspace.ui.url")
             + "/handle/";
 
         File outputDir = new File(configurationService.getProperty("sitemap.dir"));
@@ -293,7 +293,7 @@ public class GenerateSitemaps {
                 .getProperty("http.proxy.port"));
         }
 
-        String sitemapURL = configurationService.getProperty("dspace.url")
+        String sitemapURL = configurationService.getProperty("dspace.ui.url")
             + "/sitemap";
 
         URL url = new URL(engineURL + URLEncoder.encode(sitemapURL, "UTF-8"));

--- a/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
@@ -33,6 +33,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 import org.dspace.core.LogManager;
+import org.dspace.core.Utils;
 import org.dspace.discovery.DiscoverQuery;
 import org.dspace.discovery.SearchServiceException;
 import org.dspace.discovery.SearchUtils;
@@ -581,7 +582,7 @@ public class LogAnalyser {
         }
 
         // now do the host name and url lookup
-        hostName = ConfigurationManager.getProperty("dspace.ui.hostname").trim();
+        hostName = Utils.getHostName(ConfigurationManager.getProperty("dspace.ui.url"));
         name = ConfigurationManager.getProperty("dspace.name").trim();
         url = ConfigurationManager.getProperty("dspace.ui.url").trim();
         if ((url != null) && (!url.endsWith("/"))) {

--- a/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
@@ -581,7 +581,7 @@ public class LogAnalyser {
         }
 
         // now do the host name and url lookup
-        hostName = ConfigurationManager.getProperty("dspace.hostname").trim();
+        hostName = ConfigurationManager.getProperty("dspace.ui.hostname").trim();
         name = ConfigurationManager.getProperty("dspace.name").trim();
         url = ConfigurationManager.getProperty("dspace.ui.url").trim();
         if ((url != null) && (!url.endsWith("/"))) {

--- a/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
@@ -583,7 +583,7 @@ public class LogAnalyser {
         // now do the host name and url lookup
         hostName = ConfigurationManager.getProperty("dspace.hostname").trim();
         name = ConfigurationManager.getProperty("dspace.name").trim();
-        url = ConfigurationManager.getProperty("dspace.url").trim();
+        url = ConfigurationManager.getProperty("dspace.ui.url").trim();
         if ((url != null) && (!url.endsWith("/"))) {
             url = url + "/";
         }

--- a/dspace-api/src/main/java/org/dspace/app/util/AbstractDSpaceWebapp.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/AbstractDSpaceWebapp.java
@@ -50,16 +50,16 @@ abstract public class AbstractDSpaceWebapp
     /**
      * Construct a particular kind of DSpace application.
      *
-     * @param kind what kind of application is this?  (XMLUI, JSPUI, etc.)
+     * @param kind what kind of application is this?
      */
     public AbstractDSpaceWebapp(String kind) {
         this.kind = kind;
 
         started = new Date();
 
-        url = ConfigurationManager.getProperty("dspace.url");
+        url = ConfigurationManager.getProperty("dspace.ui.url");
         if (null == url) {
-            throw new IllegalStateException("dspace.url is undefined");
+            throw new IllegalStateException("dspace.ui.url is undefined");
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
@@ -889,7 +889,7 @@ public class GoogleMetadata {
             Bitstream bitstream = findLinkableFulltext(item);
             if (bitstream != null) {
                 StringBuilder path = new StringBuilder();
-                path.append(ConfigurationManager.getProperty("dspace.url"));
+                path.append(ConfigurationManager.getProperty("dspace.ui.url"));
 
                 if (item.getHandle() != null) {
                     path.append("/bitstream/");

--- a/dspace-api/src/main/java/org/dspace/app/util/OpenSearchServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/OpenSearchServiceImpl.java
@@ -89,7 +89,7 @@ public class OpenSearchServiceImpl implements OpenSearchService {
      * Get base search service URL (websvc.opensearch.svccontext)
      */
     protected String getBaseSearchServiceURL() {
-        return configurationService.getProperty("dspace.url") + "/" +
+        return configurationService.getProperty("dspace.server.url") + "/" +
             configurationService.getProperty("websvc.opensearch.svccontext");
     }
 
@@ -97,7 +97,7 @@ public class OpenSearchServiceImpl implements OpenSearchService {
      * Get base search UI URL (websvc.opensearch.uicontext)
      */
     protected String getBaseSearchUIURL() {
-        return configurationService.getProperty("dspace.url") + "/" +
+        return configurationService.getProperty("dspace.server.url") + "/" +
             configurationService.getProperty("websvc.opensearch.uicontext");
     }
 

--- a/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
@@ -531,7 +531,7 @@ public class SyndicationFeed {
         if (dso == null) {
             if (baseURL == null) {
                 if (request == null) {
-                    baseURL = ConfigurationManager.getProperty("dspace.url");
+                    baseURL = ConfigurationManager.getProperty("dspace.ui.url");
                 } else {
                     baseURL = (request.isSecure()) ? "https://" : "http://";
                     baseURL += ConfigurationManager.getProperty("dspace.hostname");

--- a/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
@@ -533,9 +533,7 @@ public class SyndicationFeed {
                 if (request == null) {
                     baseURL = ConfigurationManager.getProperty("dspace.ui.url");
                 } else {
-                    baseURL = (request.isSecure()) ? "https://" : "http://";
-                    baseURL += ConfigurationManager.getProperty("dspace.hostname");
-                    baseURL += ":" + request.getServerPort();
+                    baseURL = ConfigurationManager.getProperty("dspace.ui.url");
                     baseURL += request.getContextPath();
                 }
             }

--- a/dspace-api/src/main/java/org/dspace/checker/DailyReportEmailer.java
+++ b/dspace-api/src/main/java/org/dspace/checker/DailyReportEmailer.java
@@ -62,7 +62,7 @@ public class DailyReportEmailer {
     public void sendReport(File attachment, int numberOfBitstreams)
         throws IOException, javax.mail.MessagingException {
         if (numberOfBitstreams > 0) {
-            String hostname = ConfigurationManager.getProperty("dspace.hostname");
+            String hostname = ConfigurationManager.getProperty("dspace.ui.hostname");
             Email email = new Email();
             email.setSubject(
                 "Checksum checker Report - " + numberOfBitstreams + " Bitstreams found with POSSIBLE issues on " +

--- a/dspace-api/src/main/java/org/dspace/checker/DailyReportEmailer.java
+++ b/dspace-api/src/main/java/org/dspace/checker/DailyReportEmailer.java
@@ -27,6 +27,7 @@ import org.dspace.checker.service.SimpleReporterService;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 import org.dspace.core.Email;
+import org.dspace.core.Utils;
 
 /**
  * <p>
@@ -62,7 +63,7 @@ public class DailyReportEmailer {
     public void sendReport(File attachment, int numberOfBitstreams)
         throws IOException, javax.mail.MessagingException {
         if (numberOfBitstreams > 0) {
-            String hostname = ConfigurationManager.getProperty("dspace.ui.hostname");
+            String hostname = Utils.getHostName(ConfigurationManager.getProperty("dspace.ui.url"));
             Email email = new Email();
             email.setSubject(
                 "Checksum checker Report - " + numberOfBitstreams + " Bitstreams found with POSSIBLE issues on " +

--- a/dspace-api/src/main/java/org/dspace/content/Site.java
+++ b/dspace-api/src/main/java/org/dspace/content/Site.java
@@ -56,7 +56,7 @@ public class Site extends DSpaceObject {
     }
 
     public String getURL() {
-        return ConfigurationManager.getProperty("dspace.url");
+        return ConfigurationManager.getProperty("dspace.ui.url");
     }
 
     private SiteService getSiteService() {

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/OREDisseminationCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/OREDisseminationCrosswalk.java
@@ -265,7 +265,7 @@ public class OREDisseminationCrosswalk
         Element pmhMeta = new Element("entry",ATOM_NS);
 
         pUri = new Element("id",ATOM_NS);
-        String oaiId = new String("oai:" + ConfigurationManager.getProperty("dspace.hostname") + ":" + item.getHandle
+        String oaiId = new String("oai:" + ConfigurationManager.getProperty("dspace.ui.hostname") + ":" + item.getHandle
         ());
         pUri.addContent(oaiId + "#oai_dc");
         pmhMeta.addContent(pUri);

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/OREDisseminationCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/OREDisseminationCrosswalk.java
@@ -92,7 +92,7 @@ public class OREDisseminationCrosswalk
     private Element disseminateItem(Context context, Item item)
         throws CrosswalkException, IOException, SQLException, AuthorizeException {
         String oaiUrl = null;
-        String dsUrl = configurationService.getProperty("dspace.url");
+        String dsUrl = configurationService.getProperty("dspace.ui.url");
 
         String remSource = configurationService.getProperty("oai.ore.authoritative.source");
         if (remSource == null || remSource.equalsIgnoreCase("oai")) {

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/OREDisseminationCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/OREDisseminationCrosswalk.java
@@ -265,7 +265,8 @@ public class OREDisseminationCrosswalk
         Element pmhMeta = new Element("entry",ATOM_NS);
 
         pUri = new Element("id",ATOM_NS);
-        String oaiId = new String("oai:" + ConfigurationManager.getProperty("dspace.ui.hostname") + ":" + item.getHandle
+        String hostname = Utils.getHostName(ConfigurationManager.getProperty("dspace.ui.url"));
+        String oaiId = new String("oai:" + hostname + ":" + item.getHandle
         ());
         pUri.addContent(oaiId + "#oai_dc");
         pmhMeta.addContent(pUri);

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/PREMISCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/PREMISCrosswalk.java
@@ -219,7 +219,7 @@ public class PREMISCrosswalk
         //  b. name of bitstream, if any
         //  c. made-up name based on sequence ID and extension.
         String sid = String.valueOf(bitstream.getSequenceID());
-        String baseUrl = ConfigurationManager.getProperty("dspace.url");
+        String baseUrl = ConfigurationManager.getProperty("dspace.ui.url");
         String handle = null;
         // get handle of parent Item of this bitstream, if there is one:
         List<Bundle> bn = bitstream.getBundles();

--- a/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSDisseminator.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSDisseminator.java
@@ -1400,7 +1400,7 @@ public abstract class AbstractMETSDisseminator
                 }
                 if (handle != null) {
                     return configurationService
-                        .getProperty("dspace.url")
+                        .getProperty("dspace.ui.url")
                         + "/bitstream/"
                         + handle
                         + "/"
@@ -1410,7 +1410,7 @@ public abstract class AbstractMETSDisseminator
                 } else {   //no Handle assigned, so persistent(-ish) URI for bitstream is
                     // Format: {site-base-url}/retrieve/{bitstream-internal-id}
                     return configurationService
-                        .getProperty("dspace.url")
+                        .getProperty("dspace.ui.url")
                         + "/retrieve/"
                         + String.valueOf(bitstream.getID());
                 }

--- a/dspace-api/src/main/java/org/dspace/core/Email.java
+++ b/dspace-api/src/main/java/org/dspace/core/Email.java
@@ -497,7 +497,7 @@ public class Email {
         String to = config.getProperty("mail.admin");
         String subject = "DSpace test email";
         String server = config.getProperty("mail.server");
-        String url = config.getProperty("dspace.url");
+        String url = config.getProperty("dspace.ui.url");
         Email message;
         try {
             if (args.length <= 0) {

--- a/dspace-api/src/main/java/org/dspace/core/Utils.java
+++ b/dspace-api/src/main/java/org/dspace/core/Utils.java
@@ -13,6 +13,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.math.BigInteger;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.rmi.dgc.VMID;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -30,7 +32,10 @@ import java.util.regex.Pattern;
 
 import com.coverity.security.Escape;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringSubstitutor;
 import org.apache.logging.log4j.Logger;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
  * Utility functions for DSpace.
@@ -407,5 +412,39 @@ public final class Utils {
         } else {
             return schema + separator + element + separator + qualifier;
         }
+    }
+
+
+    /**
+     * Retrieve the hostname from a given URI string
+     * @param uriString URI string
+     * @return hostname (without any www.) or null (if URI was invalid)
+     */
+    public static String getHostName(String uriString) {
+        try {
+            URI uri = new URI(uriString);
+            String hostname = uri.getHost();
+            // remove the "www." from hostname, if it exists
+            if (hostname != null) {
+                return hostname.startsWith("www.") ? hostname.substring(4) : hostname;
+            }
+            return hostname;
+        } catch (URISyntaxException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Replaces configuration placeholders within a String with the corresponding value
+     * from DSpace's Configuration Service.
+     * <P>
+     * For example, given a String like "My DSpace is installed at ${dspace.dir}", this
+     * method will replace "${dspace.dir}" with the configured value of that property.
+     * @param string source string
+     * @return string with any placeholders replaced with configured values.
+     */
+    public static String interpolateConfigsInString(String string) {
+        ConfigurationService config = DSpaceServicesFactory.getInstance().getConfigurationService();
+        return StringSubstitutor.replace(string, config.getProperties());
     }
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -218,7 +218,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
     /**
      * Unindex a Document in the Lucene index.
-     * 
+     *
      * @param context the dspace context
      * @param searchUniqueID the search uniqueID of the document to be deleted
      * @throws IOException  if IO error
@@ -230,7 +230,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
     /**
      * Unindex a Document in the Lucene Index.
-     * 
+     *
      * @param context the dspace context
      * @param searchUniqueID the search uniqueID of the document to be deleted
      * @throws IOException  if IO error
@@ -465,7 +465,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                         Locale.getDefault(), "internal_error"));
                 email.addRecipient(recipient);
                 email.addArgument(ConfigurationManager
-                                      .getProperty("dspace.url"));
+                                      .getProperty("dspace.ui.url"));
                 email.addArgument(new Date());
 
                 String stackTrace;

--- a/dspace-api/src/main/java/org/dspace/eperson/AccountServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/AccountServiceImpl.java
@@ -228,7 +228,7 @@ public class AccountServiceImpl implements AccountService {
      */
     protected void sendEmail(Context context, String email, boolean isRegister, RegistrationData rd)
         throws MessagingException, IOException, SQLException {
-        String base = ConfigurationManager.getProperty("dspace.url");
+        String base = ConfigurationManager.getProperty("dspace.ui.url");
 
         //  Note change from "key=" to "token="
         String specialLink = new StringBuffer().append(base).append(

--- a/dspace-api/src/main/java/org/dspace/eperson/EPersonConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPersonConsumer.java
@@ -83,7 +83,7 @@ public class EPersonConsumer implements Consumer {
                             adminEmail.addRecipient(notifyRecipient);
 
                             adminEmail.addArgument(ConfigurationManager.getProperty("dspace.name"));
-                            adminEmail.addArgument(ConfigurationManager.getProperty("dspace.url"));
+                            adminEmail.addArgument(ConfigurationManager.getProperty("dspace.ui.url"));
                             adminEmail.addArgument(eperson.getFirstName() + " " + eperson.getLastName()); // Name
                             adminEmail.addArgument(eperson.getEmail());
                             adminEmail.addArgument(new Date());

--- a/dspace-api/src/main/java/org/dspace/handle/HandleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/handle/HandleServiceImpl.java
@@ -72,7 +72,7 @@ public class HandleServiceImpl implements HandleService {
             return null;
         }
 
-        String url = configurationService.getProperty("dspace.url")
+        String url = configurationService.getProperty("dspace.ui.url")
             + "/handle/" + handle;
 
         if (log.isDebugEnabled()) {
@@ -85,7 +85,7 @@ public class HandleServiceImpl implements HandleService {
     @Override
     public String resolveUrlToHandle(Context context, String url)
         throws SQLException {
-        String dspaceUrl = configurationService.getProperty("dspace.url")
+        String dspaceUrl = configurationService.getProperty("dspace.ui.url")
             + "/handle/";
         String handleResolver = configurationService.getProperty("handle.canonical.prefix");
 

--- a/dspace-api/src/main/java/org/dspace/health/InfoCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/InfoCheck.java
@@ -38,7 +38,7 @@ public class InfoCheck extends Check {
         ).append("\n");
 
         sb.append("Url: ").append(
-            ConfigurationManager.getProperty("dspace.url")
+            ConfigurationManager.getProperty("dspace.ui.url")
         ).append("\n");
         sb.append("\n");
 

--- a/dspace-api/src/main/java/org/dspace/identifier/EZIDIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/EZIDIdentifierProvider.java
@@ -583,7 +583,7 @@ public class EZIDIdentifierProvider
             log.warn("{} #{} has no handle -- location not set.",
                      contentServiceFactory.getDSpaceObjectService(dso).getTypeText(dso), dso.getID());
         } else {
-            String url = configurationService.getProperty("dspace.url")
+            String url = configurationService.getProperty("dspace.ui.url")
                 + "/handle/" + item.getHandle();
             log.info("Supplying location:  {}", url);
             mapped.put("_target", url);

--- a/dspace-api/src/main/java/org/dspace/rdf/conversion/SimpleDSORelationsConverterPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/rdf/conversion/SimpleDSORelationsConverterPlugin.java
@@ -473,7 +473,7 @@ public class SimpleDSORelationsConverterPlugin
             // we currently ignore those
             return null;
         }
-        String dspaceURL = configurationService.getProperty("dspace.url");
+        String dspaceURL = configurationService.getProperty("dspace.ui.url");
         String link = "";
         try {
             // this currently (DSpace 4.1) works with xmlui and jspui.

--- a/dspace-api/src/main/java/org/dspace/rdf/negotiation/Negotiator.java
+++ b/dspace-api/src/main/java/org/dspace/rdf/negotiation/Negotiator.java
@@ -249,7 +249,7 @@ public class Negotiator {
         // if html is requested we have to forward to the repositories webui.
         if ("html".equals(lang)) {
             urlBuilder.append(DSpaceServicesFactory.getInstance()
-                                                   .getConfigurationService().getProperty("dspace.url"));
+                                                   .getConfigurationService().getProperty("dspace.ui.url"));
             if (!handle.equals(DSpaceServicesFactory.getInstance()
                                                     .getConfigurationService().getProperty("handle.prefix") + "/0")) {
                 urlBuilder.append("/handle/");

--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
@@ -650,7 +650,7 @@ public class StatisticsDataVisits extends StatisticsData {
                     }
 
 
-                    String url = ConfigurationManager.getProperty("dspace.url") + "/bitstream/" + identifier + "/";
+                    String url = ConfigurationManager.getProperty("dspace.ui.url") + "/bitstream/" + identifier + "/";
 
                     // If we can put the pretty name of the bitstream on the end of the URL
                     try {

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
@@ -92,7 +92,7 @@ public class S3BitStoreService implements BitStoreService {
 
         // bucket name
         if (StringUtils.isEmpty(bucketName)) {
-            bucketName = "dspace-asset-" + ConfigurationManager.getProperty("dspace.hostname");
+            bucketName = "dspace-asset-" + ConfigurationManager.getProperty("dspace.ui.hostname");
             log.warn("S3 BucketName is not configured, setting default: " + bucketName);
         }
 
@@ -343,7 +343,7 @@ public class S3BitStoreService implements BitStoreService {
         store.s3Service.setRegion(usEast1);
 
         //Bucketname should be lowercase
-        store.bucketName = "dspace-asset-" + ConfigurationManager.getProperty("dspace.hostname") + ".s3test";
+        store.bucketName = "dspace-asset-" + ConfigurationManager.getProperty("dspace.ui.hostname") + ".s3test";
         store.s3Service.createBucket(store.bucketName);
 /* Broken in DSpace 6 TODO Refactor
         // time everything, todo, swtich to caliper

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
@@ -92,7 +92,9 @@ public class S3BitStoreService implements BitStoreService {
 
         // bucket name
         if (StringUtils.isEmpty(bucketName)) {
-            bucketName = "dspace-asset-" + ConfigurationManager.getProperty("dspace.ui.hostname");
+            // get hostname of DSpace UI to use to name bucket
+            String hostname = Utils.getHostName(ConfigurationManager.getProperty("dspace.ui.url"));
+            bucketName = "dspace-asset-" + hostname;
             log.warn("S3 BucketName is not configured, setting default: " + bucketName);
         }
 
@@ -342,8 +344,10 @@ public class S3BitStoreService implements BitStoreService {
         Region usEast1 = Region.getRegion(Regions.US_EAST_1);
         store.s3Service.setRegion(usEast1);
 
+        // get hostname of DSpace UI to use to name bucket
+        String hostname = Utils.getHostName(ConfigurationManager.getProperty("dspace.ui.url"));
         //Bucketname should be lowercase
-        store.bucketName = "dspace-asset-" + ConfigurationManager.getProperty("dspace.ui.hostname") + ".s3test";
+        store.bucketName = "dspace-asset-" + hostname + ".s3test";
         store.s3Service.createBucket(store.bucketName);
 /* Broken in DSpace 6 TODO Refactor
         // time everything, todo, swtich to caliper

--- a/dspace-api/src/main/java/org/dspace/workflowbasic/BasicWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/workflowbasic/BasicWorkflowServiceImpl.java
@@ -1041,7 +1041,7 @@ public class BasicWorkflowServiceImpl implements BasicWorkflowService {
 
     @Override
     public String getMyDSpaceLink() {
-        return configurationService.getProperty("dspace.url") + "/mydspace";
+        return configurationService.getProperty("dspace.ui.url") + "/mydspace";
     }
 
     protected void notifyOfReject(Context context, BasicWorkflowItem workflowItem, EPerson e,

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/WorkflowUtils.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/WorkflowUtils.java
@@ -161,7 +161,7 @@ public class WorkflowUtils extends Util {
 
                 email.addRecipient(recipient);
                 email.addArgument(ConfigurationManager
-                                      .getProperty("dspace.url"));
+                                      .getProperty("dspace.ui.url"));
                 email.addArgument(new Date());
                 email.addArgument(request.getSession().getId());
                 email.addArgument(logInfo);

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
@@ -1049,7 +1049,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
             email.addArgument(coll.getName());
             email.addArgument(rejector);
             email.addArgument(reason);
-            email.addArgument(ConfigurationManager.getProperty("dspace.url") + "/mydspace");
+            email.addArgument(ConfigurationManager.getProperty("dspace.ui.url") + "/mydspace");
 
             email.send();
         } catch (Exception ex) {
@@ -1063,7 +1063,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
 
     @Override
     public String getMyDSpaceLink() {
-        return ConfigurationManager.getProperty("dspace.url") + "/mydspace";
+        return ConfigurationManager.getProperty("dspace.ui.url") + "/mydspace";
     }
 
     protected void revokeReviewerPolicies(Context context, Item item) throws SQLException, AuthorizeException {

--- a/dspace-api/src/test/data/dspaceFolder/config/local.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/local.cfg
@@ -25,8 +25,8 @@
 # SERVER CONFIGURATION   #
 ##########################
 
-# Spring boot test by default mock the server on the localhost (80)
-dspace.baseUrl = http://localhost
+# Spring boot test: by default mock the server on the localhost (80)
+dspace.server.url = http://localhost:8080/server
 
 # DSpace installation directory.
 # This is the location where you want to install DSpace.

--- a/dspace-api/src/test/data/dspaceFolder/config/local.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/local.cfg
@@ -26,7 +26,7 @@
 ##########################
 
 # Spring boot test: by default mock the server on the localhost (80)
-dspace.server.url = http://localhost:8080/server
+dspace.server.url = http://localhost
 
 # DSpace installation directory.
 # This is the location where you want to install DSpace.

--- a/dspace-api/src/test/java/org/dspace/content/SiteTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/SiteTest.java
@@ -141,7 +141,7 @@ public class SiteTest extends AbstractUnitTest {
      */
     @Test
     public void testGetURL() {
-        assertThat("testGetURL 0", s.getURL(), equalTo(ConfigurationManager.getProperty("dspace.url")));
+        assertThat("testGetURL 0", s.getURL(), equalTo(ConfigurationManager.getProperty("dspace.ui.url")));
     }
 
 }

--- a/dspace-api/src/test/java/org/dspace/core/UtilsTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/UtilsTest.java
@@ -1,0 +1,71 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.dspace.AbstractUnitTest;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.junit.Test;
+
+/**
+ * Perform some basic unit tests for Utils Class
+ *
+ * @author tdonohue
+ */
+public class UtilsTest extends AbstractUnitTest {
+
+    /**
+     * Test of getHostName method, of class Utils
+     */
+    @Test
+    public void testGetHostName() {
+        assertEquals("Test remove HTTP", "dspace.org",
+                     Utils.getHostName("http://dspace.org"));
+
+        assertEquals("Test remove HTTPS", "dspace.org",
+                     Utils.getHostName("https://dspace.org"));
+
+        assertEquals("Test remove trailing slash", "dspace.org",
+                     Utils.getHostName("https://dspace.org/"));
+
+        assertEquals("Test remove www.", "dspace.org",
+                     Utils.getHostName("https://www.dspace.org"));
+
+        assertEquals("Test keep other prefixes", "demo.dspace.org",
+                     Utils.getHostName("https://demo.dspace.org"));
+
+        // This uses a bunch of reserved URI characters
+        assertNull("Test invalid URI returns null", Utils.getHostName("&+,?/@="));
+    }
+
+    /**
+     * Test of interpolateConfigsInString method, of class Utils
+     */
+    @Test
+    public void testInterpolateConfigsInString() {
+        ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+
+        // Add a new config to test with
+        String configName = "not.a.dspace.config.at.all";
+        String configValue = "demo.dspace.org";
+        configurationService.setProperty(configName, configValue);
+
+        // Create a string where the config is represented by ${variable}
+        String stringWithVariable = "The config " + configName + " has a value of ${" + configName + "}!";
+        String expectedValue = "The config " + configName + " has a value of " + configValue + "!";
+
+        assertEquals("Test config interpolation", expectedValue,
+                     Utils.interpolateConfigsInString(stringWithVariable));
+
+        // remove the config we added
+        configurationService.setProperty(configName, null);
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/identifier/EZIDIdentifierProviderTest.java
+++ b/dspace-api/src/test/java/org/dspace/identifier/EZIDIdentifierProviderTest.java
@@ -449,7 +449,7 @@ public class EZIDIdentifierProviderTest
             // Evaluate
             String target = (String) metadata.get("_target");
             assertEquals("Generates correct _target metadatum",
-                         config.getProperty("dspace.url") + "/handle/" + handle,
+                         config.getProperty("dspace.ui.url") + "/handle/" + handle,
                          target);
             assertTrue("Has title", metadata.containsKey("datacite.title"));
             assertTrue("Has publication year", metadata.containsKey("datacite.publicationyear"));

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/config/DSpaceConfigurationService.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/config/DSpaceConfigurationService.java
@@ -7,22 +7,49 @@
  */
 package org.dspace.xoai.services.impl.config;
 
-import org.dspace.core.ConfigurationManager;
+import org.dspace.core.Utils;
+import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.xoai.services.api.config.ConfigurationService;
 
 public class DSpaceConfigurationService implements ConfigurationService {
+
+    private org.dspace.services.ConfigurationService configurationService =
+        DSpaceServicesFactory.getInstance().getConfigurationService();
+
+    /**
+     * Initialize the OAI Configuration Service
+     */
+    public DSpaceConfigurationService() {
+        // Check the DSpace ConfigurationService for required OAI-PMH settings.
+        // If they do not exist, set sane defaults as needed.
+
+        // Per OAI Spec, "oai.identifier.prefix" should be the hostname / domain name of the site.
+        // This configuration is needed by the [dspace]/config/crosswalks/oai/description.xml template, so if
+        // unspecified we will dynamically set it to the hostname of the "dspace.ui.url" configuration.
+        if (!configurationService.hasProperty("oai.identifier.prefix")) {
+            configurationService.setProperty("oai.identifier.prefix",
+                                             Utils.getHostName(configurationService.getProperty("dspace.ui.url")));
+        }
+    }
+
+
     @Override
     public String getProperty(String key) {
-        return ConfigurationManager.getProperty(key);
+        return configurationService.getProperty(key);
     }
 
     @Override
     public String getProperty(String module, String key) {
-        return ConfigurationManager.getProperty(module, key);
+        return configurationService.getProperty(module, key);
     }
 
     @Override
     public boolean getBooleanProperty(String module, String key, boolean defaultValue) {
-        return ConfigurationManager.getBooleanProperty(module, key, defaultValue);
+        if (module == null) {
+            return configurationService.getBooleanProperty(key, defaultValue);
+        }
+
+        // Assume "module" properties are always prefixed with the module name
+        return configurationService.getBooleanProperty(module + "." + key, defaultValue);
     }
 }

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceRepositoryConfiguration.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceRepositoryConfiguration.java
@@ -9,6 +9,7 @@ package org.dspace.xoai.services.impl.xoai;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Date;
@@ -22,6 +23,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.core.Context;
+import org.dspace.core.Utils;
 import org.dspace.xoai.exceptions.InvalidMetadataFieldException;
 import org.dspace.xoai.services.api.EarliestDateResolver;
 import org.dspace.xoai.services.api.config.ConfigurationService;
@@ -132,13 +134,13 @@ public class DSpaceRepositoryConfiguration implements RepositoryConfiguration {
     @Override
     public List<String> getDescription() {
         List<String> result = new ArrayList<String>();
-        String descriptionFile = configurationService.getProperty("oai", "description.file");
+        String descriptionFile = configurationService.getProperty("oai.description.file");
         if (descriptionFile == null) {
             // Try indexed
             boolean stop = false;
             List<String> descriptionFiles = new ArrayList<String>();
             for (int i = 0; !stop; i++) {
-                String tmp = configurationService.getProperty("oai", "description.file." + i);
+                String tmp = configurationService.getProperty("oai.description.file." + i);
                 if (tmp == null) {
                     stop = true;
                 } else {
@@ -150,7 +152,10 @@ public class DSpaceRepositoryConfiguration implements RepositoryConfiguration {
                 try {
                     File f = new File(path);
                     if (f.exists()) {
-                        result.add(FileUtils.readFileToString(f));
+                        String fileAsString = FileUtils.readFileToString(f, StandardCharsets.UTF_8);
+                        // replace any configuration placeholders (e.g. ${variable}) in string
+                        fileAsString = Utils.interpolateConfigsInString(fileAsString);
+                        result.add(fileAsString);
                     }
                 } catch (IOException e) {
                     log.debug(e.getMessage(), e);
@@ -161,7 +166,10 @@ public class DSpaceRepositoryConfiguration implements RepositoryConfiguration {
             try {
                 File f = new File(descriptionFile);
                 if (f.exists()) {
-                    result.add(FileUtils.readFileToString(f));
+                    String fileAsString = FileUtils.readFileToString(f, StandardCharsets.UTF_8);
+                    // replace any configuration placeholders (e.g. ${variable}) in string
+                    fileAsString = Utils.interpolateConfigsInString(fileAsString);
+                    result.add(fileAsString);
                 }
             } catch (IOException e) {
                 log.debug(e.getMessage(), e);

--- a/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
@@ -176,7 +176,7 @@ public class ItemUtils {
     }
 
     /**
-     * This method will add all sub-elements to a top element, like: dc, or dcterms, ...     * 
+     * This method will add all sub-elements to a top element, like: dc, or dcterms, ...     *
      * @param schema         Element argument passed by reference that will be changed
      * @param val            Metadatavalue that will be processed
      * @throws SQLException
@@ -284,7 +284,7 @@ public class ItemUtils {
 
         // Repository Info
         Element repository = create("repository");
-        repository.getField().add(createValue("url", ConfigurationManager.getProperty("dspace.baseUrl")));
+        repository.getField().add(createValue("url", ConfigurationManager.getProperty("dspace.ui.url")));
         repository.getField().add(createValue("name", ConfigurationManager.getProperty("dspace.name")));
         repository.getField().add(createValue("mail", ConfigurationManager.getProperty("mail.admin")));
         metadata.getElement().add(repository);

--- a/dspace-rdf/src/main/java/org/dspace/rdf/providing/DataProviderServlet.java
+++ b/dspace-rdf/src/main/java/org/dspace/rdf/providing/DataProviderServlet.java
@@ -61,7 +61,7 @@ public class DataProviderServlet extends HttpServlet {
         log.debug("lang = " + lang + ", cType = " + cType + " and pathInfo: " + pathInfo);
         if (StringUtils.isEmpty(pathInfo) || StringUtils.countMatches(pathInfo, "/") < 2) {
             String dspaceURI =
-                DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("dspace.url");
+                DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("dspace.ui.url");
             this.serveNamedGraph(dspaceURI, lang, cType, response);
             return;
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/CollectionLogoController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/CollectionLogoController.java
@@ -65,7 +65,7 @@ public class CollectionLogoController {
     /**
      * This method will add a logo to the collection.
      *
-     * curl -X POST http://<dspace.restUrl>/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb/logo' \
+     * curl -X POST http://<dspace.server.url>/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb/logo' \
      *  -XPOST -H 'Content-Type: multipart/form-data' \
      *  -H 'Authorization: Bearer eyJhbGciOiJI...' \
      *  -F "file=@Downloads/test.png"
@@ -73,7 +73,7 @@ public class CollectionLogoController {
      * Example:
      * <pre>
      * {@code
-     * curl -X POST http://<dspace.restUrl>/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb/logo' \
+     * curl -X POST http://<dspace.server.url>/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb/logo' \
      *  -XPOST -H 'Content-Type: multipart/form-data' \
      *  -H 'Authorization: Bearer eyJhbGciOiJI...' \
      *  -F "file=@Downloads/test.png"

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/CommunityLogoController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/CommunityLogoController.java
@@ -66,7 +66,7 @@ public class CommunityLogoController {
     /**
      * This method will add a logo to the community.
      *
-     * curl -X POST http://<dspace.restUrl>/api/core/communities/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb/logo' \
+     * curl -X POST http://<dspace.server.url>/api/core/communities/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb/logo' \
      *  -XPOST -H 'Content-Type: multipart/form-data' \
      *  -H 'Authorization: Bearer eyJhbGciOiJI...' \
      *  -F "file=@Downloads/test.png"
@@ -74,7 +74,7 @@ public class CommunityLogoController {
      * Example:
      * <pre>
      * {@code
-     * curl -X POST http://<dspace.restUrl>/api/core/communities/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb/logo' \
+     * curl -X POST http://<dspace.server.url>/api/core/communities/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb/logo' \
      *  -XPOST -H 'Content-Type: multipart/form-data' \
      *  -H 'Authorization: Bearer eyJhbGciOiJI...' \
      *  -F "file=@Downloads/test.png"

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ExternalSourcesRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ExternalSourcesRestController.java
@@ -44,7 +44,7 @@ public class ExternalSourcesRestController {
      * This method will retrieve all the ExternalSourceEntries for the ExternalSource for the given externalSourceName
      * param
      *
-     * curl -X GET http://<dspace.restUrl>/api/integration/externalsources/orcidV2/entries
+     * curl -X GET http://<dspace.server.url>/api/integration/externalsources/orcidV2/entries
      *
      * @param externalSourceName The externalSourceName that defines which ExternalDataProvider is used
      * @param query         The query used in the lookup
@@ -74,7 +74,7 @@ public class ExternalSourcesRestController {
      * This method will retrieve one ExternalSourceEntryResource based on the ExternalSource for the given
      * externalSourceName and with the given entryId
      *
-     * curl -X GET http://<dspace.restUrl>/api/integration/externalsources/orcidV2/entries/0000-0000-0000-0000
+     * curl -X GET http://<dspace.server.url>/api/integration/externalsources/orcidV2/entries/0000-0000-0000-0000
      *
      * @param externalSourceName The externalSourceName that defines which ExternalDataProvider is used
      * @param entryId       The entryId used for the lookup

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/MappedCollectionRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/MappedCollectionRestController.java
@@ -60,14 +60,14 @@ public class MappedCollectionRestController {
      * This method will add an Item to a Collection. The Collection object is encapsulated in the request due to the
      * text/uri-list consumer and the Item UUID comes from the path in the URL
      *
-     * curl -X POST http://<dspace.baseUrl>/api/core/item/{uuid}/mappedCollections
+     * curl -X POST http://<dspace.server.url>/api/core/item/{uuid}/mappedCollections
      *  -H "Content-Type:text/uri-list"
      *  --data $'https://{url}/rest/api/core/collections/{uuid}'
      *
      * Example:
      * <pre>
      * {@code
-     * curl -X POST http://<dspace.baseUrl>/api/core/item/{uuid}/mappedCollections
+     * curl -X POST http://<dspace.server.url>/api/core/item/{uuid}/mappedCollections
      *  -H "Content-Type:text/uri-list"
      *  --data $'https://{url}/rest/api/core/collections/506a7e54-8d7c-4d5b-8636-d5f6411483de'
      * }
@@ -116,12 +116,12 @@ public class MappedCollectionRestController {
      * This method will delete a Collection to Item relation. It will remove an Item with UUID given in the request
      * URL from the Collection with UUID given in the request URL.
      *
-     * curl -X DELETE http://<dspace.baseUrl>/api/core/item/{uuid}/mappedCollections/{collectionUuid}
+     * curl -X DELETE http://<dspace.server.url>/api/core/item/{uuid}/mappedCollections/{collectionUuid}
      *
      * Example:
      * <pre>
      * {@code
-     * curl -X DELETE http://<dspace.baseUrl>/api/core/item/{uuid}/mappedCollections/{collectionUuid}
+     * curl -X DELETE http://<dspace.server.url>/api/core/item/{uuid}/mappedCollections/{collectionUuid}
      * }
      * </pre>
      *

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -1058,12 +1058,12 @@ public class RestResourceController implements InitializingBean {
     /**
      * Execute a PUT request for an entity with id of type UUID;
      *
-     * curl -X PUT http://<dspace.baseUrl>/api/{apiCategory}/{model}/{uuid}
+     * curl -X PUT http://<dspace.server.url>/api/{apiCategory}/{model}/{uuid}
      *
      * Example:
      * <pre>
      * {@code
-     *      curl -X PUT http://<dspace.baseUrl>/api/core/collection/8b632938-77c2-487c-81f0-e804f63e68e6
+     *      curl -X PUT http://<dspace.server.url>/api/core/collection/8b632938-77c2-487c-81f0-e804f63e68e6
      * }
      * </pre>
      *

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/RootConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/RootConverter.java
@@ -24,8 +24,8 @@ public class RootConverter {
     public RootRest convert() {
         RootRest rootRest = new RootRest();
         rootRest.setDspaceName(configurationService.getProperty("dspace.name"));
-        rootRest.setDspaceURL(configurationService.getProperty("dspace.url"));
-        rootRest.setDspaceRest(configurationService.getProperty("dspace.baseUrl"));
+        rootRest.setDspaceURL(configurationService.getProperty("dspace.ui.url"));
+        rootRest.setDspaceRest(configurationService.getProperty("dspace.server.url"));
         return rootRest;
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/link/process/ProcessResourceHalLinkFactory.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/link/process/ProcessResourceHalLinkFactory.java
@@ -28,7 +28,7 @@ public class ProcessResourceHalLinkFactory extends HalLinkFactory<ProcessResourc
     private ConfigurationService configurationService;
 
     protected void addLinks(ProcessResource halResource, Pageable pageable, LinkedList<Link> list) throws Exception {
-        String dspaceRestUrl = configurationService.getProperty("dspace.restUrl");
+        String dspaceRestUrl = configurationService.getProperty("dspace.server.url");
         list.add(
             buildLink("script", dspaceRestUrl + "/api/system/scripts/" + halResource.getContent().getScriptName()));
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/factories/impl/BundleMoveOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/factories/impl/BundleMoveOperation.java
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Component;
  * This operation moves bitstreams within a bundle from one index to another.
  *
  * Example: <code>
- * curl -X PATCH http://${dspace.url}/api/bundles/<:id-bundle> -H "
+ * curl -X PATCH http://${dspace.server.url}/api/bundles/<:id-bundle> -H "
  * Content-Type: application/json" -d '[{ "op": "move", "path": "
  * /_links/bitstreams/1/href", "from": "/_links/bitstreams/0/href"]'
  * </code>

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/factories/impl/EPersonCertificateReplaceOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/factories/impl/EPersonCertificateReplaceOperation.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
  * Implementation for EPerson requires certificate patches.
  *
  * Example: <code>
- * curl -X PATCH http://${dspace.url}/api/epersons/eperson/<:id-eperson> -H "
+ * curl -X PATCH http://${dspace.server.url}/api/epersons/eperson/<:id-eperson> -H "
  * Content-Type: application/json" -d '[{ "op": "replace", "path": "
  * /certificate", "value": true|false]'
  * </code>

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/factories/impl/EPersonEmailReplaceOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/factories/impl/EPersonEmailReplaceOperation.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
  * Implementation for EPerson password patches.
  *
  * Example: <code>
- * curl -X PATCH http://${dspace.url}/api/epersons/eperson/<:id-eperson> -H "
+ * curl -X PATCH http://${dspace.server.url}/api/epersons/eperson/<:id-eperson> -H "
  * Content-Type: application/json" -d '[{ "op": "replace", "path": "
  * /email", "value": "new@email"]'
  * </code>

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/factories/impl/EPersonLoginReplaceOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/factories/impl/EPersonLoginReplaceOperation.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
  * Implementation for EPerson canLogin patches.
  *
  * Example: <code>
- * curl -X PATCH http://${dspace.url}/api/epersons/eperson/<:id-eperson> -H "
+ * curl -X PATCH http://${dspace.server.url}/api/epersons/eperson/<:id-eperson> -H "
  * Content-Type: application/json" -d '[{ "op": "replace", "path": "
  * /canLogin", "value": true|false]'
  * </code>

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/factories/impl/EPersonNetidReplaceOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/factories/impl/EPersonNetidReplaceOperation.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
  * Implementation for EPerson netid patches.
  *
  * Example: <code>
- * curl -X PATCH http://${dspace.url}/api/epersons/eperson/<:id-eperson> -H "
+ * curl -X PATCH http://${dspace.server.url}/api/epersons/eperson/<:id-eperson> -H "
  * Content-Type: application/json" -d '[{ "op": "replace", "path": "
  * /netid", "value": "newNetId"]'
  * </code>

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/factories/impl/EPersonPasswordReplaceOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/factories/impl/EPersonPasswordReplaceOperation.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
  * Implementation for EPerson password patches.
  *
  * Example: <code>
- * curl -X PATCH http://${dspace.url}/api/epersons/eperson/<:id-eperson> -H "
+ * curl -X PATCH http://${dspace.server.url}/api/epersons/eperson/<:id-eperson> -H "
  * Content-Type: application/json" -d '[{ "op": "replace", "path": "
  * /password", "value": "newpassword"]'
  * </code>

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/factories/impl/ItemDiscoverableReplaceOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/factories/impl/ItemDiscoverableReplaceOperation.java
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Component;
  * This is the implementation for Item resource patches.
  *
  * Example: <code>
- * curl -X PATCH http://${dspace.url}/api/item/<:id-item> -H "
+ * curl -X PATCH http://${dspace.server.url}/api/item/<:id-item> -H "
  * Content-Type: application/json" -d '[{ "op": "replace", "path": "
  * /discoverable", "value": true|false]'
  * </code>

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/factories/impl/ItemWithdrawReplaceOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/factories/impl/ItemWithdrawReplaceOperation.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Component;
  * This is the implementation for Item resource patches.
  * <p>
  * Example: <code>
- * curl -X PATCH http://${dspace.url}/api/item/<:id-item> -H "
+ * curl -X PATCH http://${dspace.server.url}/api/item/<:id-item> -H "
  * Content-Type: application/json" -d '[{ "op": "replace", "path": "
  * /withdrawn", "value": true|false]'
  * </code>

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/factories/impl/ResourcePolicyDescriptionOperations.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/factories/impl/ResourcePolicyDescriptionOperations.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
  * Implementation for ResourcePolicy name patches.
  *
  * Example: <code>
- * curl -X PATCH http://${dspace.url}/api/authz/resourcepolicies/<:id-resourcepolicy> -H "
+ * curl -X PATCH http://${dspace.server.url}/api/authz/resourcepolicies/<:id-resourcepolicy> -H "
  * Content-Type: application/json" -d '[{ "op": "replace", "path": "
  * /description", "value": "my description"]'
  * </code>
@@ -82,7 +82,7 @@ public class ResourcePolicyDescriptionOperations implements ResourcePatchOperati
      *            the resource to update
      * @param operation
      *            the operation to apply
-     * 
+     *
      */
     void checkModelForExistingValue(ResourcePolicyRest resource, Operation operation) {
         if (resource.getDescription() == null) {
@@ -97,7 +97,7 @@ public class ResourcePolicyDescriptionOperations implements ResourcePatchOperati
      *            the resource to update
      * @param operation
      *            the operation to apply
-     * 
+     *
      */
     void checkModelForNotExistingValue(ResourcePolicyRest resource, Operation operation) {
         if (resource.getDescription() != null) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/factories/impl/ResourcePolicyEndDateOperations.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/factories/impl/ResourcePolicyEndDateOperations.java
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Component;
  * Implementation for ResourcePolicy endDate patches.
  *
  * Example: <code>
- * curl -X PATCH http://${dspace.url}/api/authz/resourcepolicies/<:id-resourcepolicy> -H "
+ * curl -X PATCH http://${dspace.server.url}/api/authz/resourcepolicies/<:id-resourcepolicy> -H "
  * Content-Type: application/json" -d '[{ "op": "replace", "path": "
  * /endDate", "value": "YYYY-MM-DD"]'
  * </code>
@@ -100,7 +100,7 @@ public class ResourcePolicyEndDateOperations implements ResourcePatchOperation<R
      *            the resource to update
      * @param operation
      *            the operation to apply
-     * 
+     *
      */
     void checkModelForExistingValue(ResourcePolicyRest resource, Operation operation) {
         if (resource.getEndDate() == null) {
@@ -115,7 +115,7 @@ public class ResourcePolicyEndDateOperations implements ResourcePatchOperation<R
      *            the resource to update
      * @param operation
      *            the operation to apply
-     * 
+     *
      */
     void checkModelForNotExistingValue(ResourcePolicyRest resource, Operation operation) {
         if (resource.getEndDate() != null) {
@@ -131,7 +131,7 @@ public class ResourcePolicyEndDateOperations implements ResourcePatchOperation<R
      *            the resource to update
      * @param operation
      *            the operation to apply
-     * 
+     *
      */
     void checkModelForConsistentValue(ResourcePolicyRest resource, Operation operation) {
         String dateS = (String) operation.getValue();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/factories/impl/ResourcePolicyNameOperations.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/factories/impl/ResourcePolicyNameOperations.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
  * Implementation for ResourcePolicy name patches.
  *
  * Example: <code>
- * curl -X PATCH http://${dspace.url}/api/authz/resourcepolicies/<:id-resourcepolicy> -H "
+ * curl -X PATCH http://${dspace.server.url}/api/authz/resourcepolicies/<:id-resourcepolicy> -H "
  * Content-Type: application/json" -d '[{ "op": "replace", "path": "
  * /name", "value": "New Name"]'
  * </code>
@@ -82,7 +82,7 @@ public class ResourcePolicyNameOperations implements ResourcePatchOperation<Reso
      *            the resource to update
      * @param operation
      *            the operation to apply
-     * 
+     *
      */
     void checkModelForExistingValue(ResourcePolicyRest resource, Operation operation) {
         if (resource.getName() == null) {
@@ -97,7 +97,7 @@ public class ResourcePolicyNameOperations implements ResourcePatchOperation<Reso
      *            the resource to update
      * @param operation
      *            the operation to apply
-     * 
+     *
      */
     void checkModelForNotExistingValue(ResourcePolicyRest resource, Operation operation) {
         if (resource.getName() != null) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/factories/impl/ResourcePolicyStartDateOperations.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/factories/impl/ResourcePolicyStartDateOperations.java
@@ -20,25 +20,25 @@ import org.springframework.stereotype.Component;
  * Implementation for ResourcePolicy startDate patches.
  *
  * Examples:
- * 
+ *
  * <code>
- * curl -X PATCH http://${dspace.url}/api/authz/resourcepolicies/<:id-resourcepolicy> -H "
+ * curl -X PATCH http://${dspace.server.url}/api/authz/resourcepolicies/<:id-resourcepolicy> -H "
  * Content-Type: application/json" -d '[{ "op": "replace", "path": "
  * /startDate", "value": "YYYY-MM-DD"]'
  * </code>
- * 
+ *
  * <code>
- * curl -X PATCH http://${dspace.url}/api/authz/resourcepolicies/<:id-resourcepolicy> -H "
+ * curl -X PATCH http://${dspace.server.url}/api/authz/resourcepolicies/<:id-resourcepolicy> -H "
  * Content-Type: application/json" -d '[{ "op": "add", "path": "
  * /startDate", "value": "YYYY-MM-DD"]'
  * </code>
  *
  * <code>
- * curl -X PATCH http://${dspace.url}/api/authz/resourcepolicies/<:id-resourcepolicy> -H "
+ * curl -X PATCH http://${dspace.server.url}/api/authz/resourcepolicies/<:id-resourcepolicy> -H "
  * Content-Type: application/json" -d '[{ "op": "delete", "path": "
  * /startDate"]'
  * </code>
- * 
+ *
  * @author Andrea Bollini (andrea.bollini at 4science.it)
  */
 @Component
@@ -114,7 +114,7 @@ public class ResourcePolicyStartDateOperations implements ResourcePatchOperation
      *            the resource to update
      * @param operation
      *            the operation to apply
-     * 
+     *
      */
     void checkModelForExistingValue(ResourcePolicyRest resource, Operation operation) {
         if (resource.getStartDate() == null) {
@@ -129,7 +129,7 @@ public class ResourcePolicyStartDateOperations implements ResourcePatchOperation
      *            the resource to update
      * @param operation
      *            the operation to apply
-     * 
+     *
      */
     void checkModelForNotExistingValue(ResourcePolicyRest resource, Operation operation) {
         if (resource.getStartDate() != null) {
@@ -145,7 +145,7 @@ public class ResourcePolicyStartDateOperations implements ResourcePatchOperation
      *            the resource to update
      * @param operation
      *            the operation to apply
-     * 
+     *
      */
     void checkModelForConsistentValue(ResourcePolicyRest resource, Operation operation) {
         String dateS = (String) operation.getValue();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/SubmissionService.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/SubmissionService.java
@@ -179,8 +179,8 @@ public class SubmissionService {
         checksum.setValue(source.getChecksum());
         data.setCheckSum(checksum);
         data.setSizeBytes(source.getSizeBytes());
-        data.setUrl(configurationService.getProperty("dspace.server.url") + "/api/" + BitstreamRest.CATEGORY + "/" + English
-            .plural(BitstreamRest.NAME) + "/" + source.getID() + "/content");
+        data.setUrl(configurationService.getProperty("dspace.server.url") + "/api/" + BitstreamRest.CATEGORY + "/" +
+                        English.plural(BitstreamRest.NAME) + "/" + source.getID() + "/content");
         return data;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/SubmissionService.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/SubmissionService.java
@@ -80,7 +80,7 @@ public class SubmissionService {
 
     /**
      * Create a workspaceitem using the information in the reqest
-     * 
+     *
      * @param context
      *            the dspace context
      * @param request
@@ -179,14 +179,14 @@ public class SubmissionService {
         checksum.setValue(source.getChecksum());
         data.setCheckSum(checksum);
         data.setSizeBytes(source.getSizeBytes());
-        data.setUrl(configurationService.getProperty("dspace.url") + "/api/" + BitstreamRest.CATEGORY + "/" + English
+        data.setUrl(configurationService.getProperty("dspace.server.url") + "/api/" + BitstreamRest.CATEGORY + "/" + English
             .plural(BitstreamRest.NAME) + "/" + source.getID() + "/content");
         return data;
     }
 
     /**
      * Create a workflowitem using the information in the reqest
-     * 
+     *
      * @param context
      *            the dspace context
      * @param requestUriListString

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/ItemMetadataValueAddPatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/ItemMetadataValueAddPatchOperation.java
@@ -28,7 +28,7 @@ import org.springframework.util.Assert;
  * "/sections/<:name-of-the-form>/<:metadata>/-"
  *
  * Example: <code>
- * curl -X PATCH http://${dspace.url}/api/submission/workspaceitems/<:id-workspaceitem> -H "
+ * curl -X PATCH http://${dspace.server.url}/api/submission/workspaceitems/<:id-workspaceitem> -H "
  * Content-Type: application/json" -d '[{ "op": "add", "path": "
  * /sections/traditionalpageone/dc.title/-", "value": {"value": "Add new
  * title"}}]'
@@ -38,7 +38,7 @@ import org.springframework.util.Assert;
  * "/sections/<:name-of-the-form>/<:metadata>/<:idx-zero-based>"
  *
  * Example: <code>
- * curl -X PATCH http://${dspace.url}/api/submission/workspaceitems/<:id-workspaceitem> -H "
+ * curl -X PATCH http://${dspace.server.url}/api/submission/workspaceitems/<:id-workspaceitem> -H "
  * Content-Type: application/json" -d '[{ "op": "add", "path": "
  * /sections/traditionalpageone/dc.title/1", "value": {"value": "Add new
  * title"}}]'
@@ -48,7 +48,7 @@ import org.springframework.util.Assert;
  * "/sections/<:name-of-the-form>/<:metadata>"
  *
  * Example: <code>
- * curl -X PATCH http://${dspace.url}/api/submission/workspaceitems/<:id-workspaceitem> -H "
+ * curl -X PATCH http://${dspace.server.url}/api/submission/workspaceitems/<:id-workspaceitem> -H "
  * Content-Type: application/json" -d '[{ "op": "add", "path": "
  * /sections/traditionalpageone/dc.title", "value": [{"value": "Add new first
  * title"}, {"value": "Add new second title"}]}]'

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/ItemMetadataValueMovePatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/ItemMetadataValueMovePatchOperation.java
@@ -21,7 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  * instance to put the 3rd author as 1st author you need to run:
  *
  * <code>
- * curl -X PATCH http://${dspace.url}/api/submission/workspaceitems/<:id-workspaceitem> -H "
+ * curl -X PATCH http://${dspace.server.url}/api/submission/workspaceitems/<:id-workspaceitem> -H "
  * Content-Type: application/json" -d '[{ "op": "move", "from": "
  * /sections/traditionalpageone/dc.contributor.author/2", "path": "
  * /sections/traditionalpageone/dc.contributor.author/0"}]'

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/ItemMetadataValueRemovePatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/ItemMetadataValueRemovePatchOperation.java
@@ -21,7 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  * "/sections/<:name-of-the-form>/<:metadata>/<:idx-zero-based>"
  *
  * Example: <code>
- * curl -X PATCH http://${dspace.url}/api/submission/workspaceitems/<:id-workspaceitem> -H "
+ * curl -X PATCH http://${dspace.server.url}/api/submission/workspaceitems/<:id-workspaceitem> -H "
  * Content-Type: application/json" -d '[{ "op": "remove", "path": "
  * /sections/traditionalpageone/dc.title/1"}]'
  * </code>
@@ -30,7 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  * "/sections/<:name-of-the-form>/<:metadata>"
  *
  * Example: <code>
- * curl -X PATCH http://${dspace.url}/api/submission/workspaceitems/<:id-workspaceitem> -H "
+ * curl -X PATCH http://${dspace.server.url}/api/submission/workspaceitems/<:id-workspaceitem> -H "
  * Content-Type: application/json" -d '[{ "op": "remove", "path": "
  * /sections/traditionalpageone/dc.title"}]'
  * </code>

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/ItemMetadataValueReplacePatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/ItemMetadataValueReplacePatchOperation.java
@@ -28,7 +28,7 @@ import org.springframework.util.Assert;
  * must return an error.
  *
  * Example: <code>
- * curl -X PATCH http://${dspace.url}/api/submission/workspaceitems/<:id-workspaceitem> -H "
+ * curl -X PATCH http://${dspace.server.url}/api/submission/workspaceitems/<:id-workspaceitem> -H "
  * Content-Type: application/json" -d '[{ "op": "replace", "path": "
  * /sections/traditionalpageone/dc.title/0", "value": {"value": "Add new
  * title", "language": "en"}}]'
@@ -37,7 +37,7 @@ import org.springframework.util.Assert;
  * It is also possible to change only a single attribute of the {@link MetadataValueRest} (except the "place").
  *
  * Example: <code>
- * curl -X PATCH http://${dspace.url}/api/submission/workspaceitems/<:id-workspaceitem> -H "
+ * curl -X PATCH http://${dspace.server.url}/api/submission/workspaceitems/<:id-workspaceitem> -H "
  * Content-Type: application/json" -d '[{ "op": "replace", "path": "
  * /sections/traditionalpageone/dc.title/0/language", "value": "it"}]'
  * </code>

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/LicenseStep.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/LicenseStep.java
@@ -42,7 +42,7 @@ public class LicenseStep extends org.dspace.submit.step.LicenseStep implements A
             String acceptanceDate = bitstreamService.getMetadata(bitstream, DCTERMS_RIGHTSDATE);
             result.setAcceptanceDate(acceptanceDate);
             result.setUrl(
-                configurationService.getProperty("dspace.url") + "/api/" + BitstreamRest.CATEGORY + "/" + English
+                configurationService.getProperty("dspace.server.url") + "/api/" + BitstreamRest.CATEGORY + "/" + English
                     .plural(BitstreamRest.NAME) + "/" + bitstream.getID() + "/content");
             result.setGranted(true);
         }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rdf/RdfIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rdf/RdfIT.java
@@ -139,8 +139,8 @@ public class RdfIT extends AbstractWebClientIntegrationTest {
         ResponseEntity<String> response = getResponseAsString(REDIRECTION_PATH + "/" + communityHandle);
         // Expect a 303 (See Other) response code, redirecting us to the HTTP URI of the Community
         assertThat(response.getStatusCode(), equalTo(HttpStatus.SEE_OTHER));
-        // Expect location of redirection to be [dspace.url]/handle/[community_handle]
+        // Expect location of redirection to be [dspace.ui.url]/handle/[community_handle]
         assertThat(response.getHeaders().getLocation(), equalTo(
-            URI.create(configurationService.getProperty("dspace.url") + "/handle/" + communityHandle + "/")));
+            URI.create(configurationService.getProperty("dspace.ui.url") + "/handle/" + communityHandle + "/")));
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/converter/RootConverterTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/converter/RootConverterTest.java
@@ -34,9 +34,9 @@ public class RootConverterTest {
 
     @Before
     public void setUp() throws Exception {
-        when(configurationService.getProperty("dspace.url")).thenReturn("dspaceurl");
+        when(configurationService.getProperty("dspace.ui.url")).thenReturn("dspaceurl");
         when(configurationService.getProperty("dspace.name")).thenReturn("dspacename");
-        when(configurationService.getProperty("dspace.baseUrl")).thenReturn("rest");
+        when(configurationService.getProperty("dspace.server.url")).thenReturn("rest");
     }
 
     @Test

--- a/dspace-services/src/main/java/org/dspace/servicemanager/config/DSpaceEnvironmentConfiguration.java
+++ b/dspace-services/src/main/java/org/dspace/servicemanager/config/DSpaceEnvironmentConfiguration.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
  * Bash does not allow environment variables that contain dots in their name.
  * This Configuration loads environment variables that contains two underlines
  * and replaces "__P__" -> "." and "__D__" -> "-"
- * E.g.: dspace__P__baseUrl will be read as dspace.baseUrl.
+ * E.g.: dspace__P__dir will be read as dspace.dir.
  * E.g.: my__D__dspace__P__prop will be read as my-dspace.prop.
  *
  * Most of this file was copied from org.apache.commons.configuration2.EnvironmentConfiguration.

--- a/dspace-sword/src/main/java/org/dspace/sword/BitstreamEntryGenerator.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/BitstreamEntryGenerator.java
@@ -106,7 +106,7 @@ public class BitstreamEntryGenerator extends DSpaceATOMEntry {
         if (this.deposit != null && this.deposit.isNoOp()) {
             // just use the dspace url as the
             // property
-            String cfg = ConfigurationManager.getProperty("dspace.url");
+            String cfg = ConfigurationManager.getProperty("dspace.ui.url");
             entry.setId(cfg);
 
             return;

--- a/dspace-sword/src/main/java/org/dspace/sword/CollectionLocation.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/CollectionLocation.java
@@ -97,9 +97,9 @@ public class CollectionLocation {
      * If the configuration sword.deposit.url is set, this will be returned,
      * but if not, it will construct the url as follows:
      *
-     * [dspace.baseUrl]/sword/deposit
+     * [dspace.server.url]/sword/deposit
      *
-     * where dspace.baseUrl is also in the configuration file.
+     * where dspace.server.url is also in the configuration file.
      *
      * @return the base URL for sword deposit
      * @throws DSpaceSWORDException can be thrown by the internals of the DSpace SWORD implementation
@@ -110,11 +110,11 @@ public class CollectionLocation {
             "sword-server", "deposit.url");
         if (depositUrl == null || "".equals(depositUrl)) {
             String dspaceUrl = ConfigurationManager
-                .getProperty("dspace.baseUrl");
+                .getProperty("dspace.server.url");
             if (dspaceUrl == null || "".equals(dspaceUrl)) {
                 throw new DSpaceSWORDException(
                     "Unable to construct deposit urls, due to missing/invalid config in sword.deposit.url and/or " +
-                        "dspace.baseUrl");
+                        "dspace.server.url");
             }
 
             try {
@@ -123,7 +123,7 @@ public class CollectionLocation {
                                      url.getPort(), "/sword/deposit").toString();
             } catch (MalformedURLException e) {
                 throw new DSpaceSWORDException(
-                    "Unable to construct deposit urls, due to invalid dspace.baseUrl " +
+                    "Unable to construct deposit urls, due to invalid dspace.server.url " +
                         e.getMessage(), e);
             }
 

--- a/dspace-sword/src/main/java/org/dspace/sword/ItemEntryGenerator.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/ItemEntryGenerator.java
@@ -162,7 +162,7 @@ public class ItemEntryGenerator extends DSpaceATOMEntry {
 
         // if we get this far, then we just use the dspace url as the
         // property
-        String cfg = ConfigurationManager.getProperty("dspace.url");
+        String cfg = ConfigurationManager.getProperty("dspace.ui.url");
         entry.setId(cfg);
 
         // FIXME: later on we will maybe have a workflow page supplied
@@ -246,7 +246,7 @@ public class ItemEntryGenerator extends DSpaceATOMEntry {
             return;
         }
 
-        String base = ConfigurationManager.getProperty("dspace.url");
+        String base = ConfigurationManager.getProperty("dspace.ui.url");
 
         // if there's no base URL, we are stuck
         if (base == null) {

--- a/dspace-sword/src/main/java/org/dspace/sword/SWORDUrlManager.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/SWORDUrlManager.java
@@ -421,7 +421,7 @@ public class SWORDUrlManager {
             }
 
             String handle = item.getHandle();
-            String bsLink = ConfigurationManager.getProperty("dspace.url");
+            String bsLink = ConfigurationManager.getProperty("dspace.ui.url");
 
             if (handle != null && !"".equals(handle)) {
                 bsLink = bsLink + "/bitstream/" + handle + "/" +

--- a/dspace-sword/src/main/java/org/dspace/sword/SWORDUrlManager.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/SWORDUrlManager.java
@@ -304,11 +304,11 @@ public class SWORDUrlManager {
             "sword-server", "servicedocument.url");
         if (depositUrl == null || "".equals(depositUrl)) {
             String dspaceUrl = ConfigurationManager.getProperty(
-                "dspace.baseUrl");
+                "dspace.server.url");
             if (dspaceUrl == null || "".equals(dspaceUrl)) {
                 throw new DSpaceSWORDException(
                     "Unable to construct service document urls, due to missing/invalid " +
-                        "config in sword.servicedocument.url and/or dspace.baseUrl");
+                        "config in sword.servicedocument.url and/or dspace.server.url");
             }
 
             try {
@@ -317,7 +317,7 @@ public class SWORDUrlManager {
                                      url.getPort(), "/sword/servicedocument").toString();
             } catch (MalformedURLException e) {
                 throw new DSpaceSWORDException(
-                    "Unable to construct service document urls, due to invalid dspace.baseUrl " +
+                    "Unable to construct service document urls, due to invalid dspace.server.url " +
                         e.getMessage(), e);
             }
 
@@ -334,9 +334,9 @@ public class SWORDUrlManager {
      * If the configuration sword.deposit.url is set, this will be returned,
      * but if not, it will construct the url as follows:
      *
-     * [dspace.baseUrl]/sword/deposit
+     * [dspace.server.url]/sword/deposit
      *
-     * where dspace.baseUrl is also in the configuration file.
+     * where dspace.server.url is also in the configuration file.
      *
      * @return the base URL for SWORD deposit
      * @throws DSpaceSWORDException can be thrown by the internals of the DSpace SWORD implementation
@@ -347,11 +347,11 @@ public class SWORDUrlManager {
             "sword-server", "deposit.url");
         if (depositUrl == null || "".equals(depositUrl)) {
             String dspaceUrl = ConfigurationManager.getProperty(
-                "dspace.baseUrl");
+                "dspace.server.url");
             if (dspaceUrl == null || "".equals(dspaceUrl)) {
                 throw new DSpaceSWORDException(
                     "Unable to construct deposit urls, due to missing/invalid config in " +
-                        "sword.deposit.url and/or dspace.baseUrl");
+                        "sword.deposit.url and/or dspace.server.url");
             }
 
             try {
@@ -360,7 +360,7 @@ public class SWORDUrlManager {
                                      url.getPort(), "/sword/deposit").toString();
             } catch (MalformedURLException e) {
                 throw new DSpaceSWORDException(
-                    "Unable to construct deposit urls, due to invalid dspace.baseUrl " +
+                    "Unable to construct deposit urls, due to invalid dspace.server.url " +
                         e.getMessage(), e);
             }
 
@@ -439,7 +439,7 @@ public class SWORDUrlManager {
     /**
      * Get the base media link URL.  It can be configured using
      * {@code sword-server.media-link.url}.  If not configured, it will be
-     * calculated using {@code dspace.baseUrl} and the constant path
+     * calculated using {@code dspace.server.url} and the constant path
      * {@code /sword/media-link}.
      *
      * @return that URL.
@@ -451,11 +451,11 @@ public class SWORDUrlManager {
             "sword-server", "media-link.url");
         if (StringUtils.isBlank(mlUrl)) {
             String dspaceUrl = ConfigurationManager.getProperty(
-                "dspace.baseUrl");
+                "dspace.server.url");
             if (dspaceUrl == null || "".equals(dspaceUrl)) {
                 throw new DSpaceSWORDException(
                     "Unable to construct media-link urls, due to missing/invalid config in " +
-                        "media-link.url and/or dspace.baseUrl");
+                        "media-link.url and/or dspace.server.url");
             }
 
             try {
@@ -464,7 +464,7 @@ public class SWORDUrlManager {
                                 "/sword/media-link").toString();
             } catch (MalformedURLException e) {
                 throw new DSpaceSWORDException(
-                    "Unable to construct media-link urls, due to invalid dspace.baseUrl " +
+                    "Unable to construct media-link urls, due to invalid dspace.server.url " +
                         e.getMessage(), e);
             }
 

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordUrlManager.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordUrlManager.java
@@ -95,11 +95,11 @@ public class SwordUrlManager {
         String sUrl = ConfigurationManager.getProperty("swordv2-server", "url");
         if (sUrl == null || "".equals(sUrl)) {
             String dspaceUrl = ConfigurationManager
-                .getProperty("dspace.baseUrl");
+                .getProperty("dspace.server.url");
             if (dspaceUrl == null || "".equals(dspaceUrl)) {
                 throw new DSpaceSwordException(
                     "Unable to construct service document urls, due to missing/invalid " +
-                        "config in sword2.url and/or dspace.baseUrl");
+                        "config in sword2.url and/or dspace.server.url");
             }
 
             try {
@@ -108,7 +108,7 @@ public class SwordUrlManager {
                                "/swordv2").toString();
             } catch (MalformedURLException e) {
                 throw new DSpaceSwordException(
-                    "Unable to construct service document urls, due to invalid dspace.baseUrl " +
+                    "Unable to construct service document urls, due to invalid dspace.server.url " +
                         e.getMessage(), e);
             }
         }
@@ -303,11 +303,11 @@ public class SwordUrlManager {
             .getProperty("swordv2-server", "servicedocument.url");
         if (sdUrl == null || "".equals(sdUrl)) {
             String dspaceUrl = ConfigurationManager
-                .getProperty("dspace.baseUrl");
+                .getProperty("dspace.server.url");
             if (dspaceUrl == null || "".equals(dspaceUrl)) {
                 throw new DSpaceSwordException(
                     "Unable to construct service document urls, due to missing/invalid " +
-                        "config in swordv2-server.cfg servicedocument.url and/or dspace.baseUrl");
+                        "config in swordv2-server.cfg servicedocument.url and/or dspace.server.url");
             }
 
             try {
@@ -316,7 +316,7 @@ public class SwordUrlManager {
                                 "/swordv2/servicedocument").toString();
             } catch (MalformedURLException e) {
                 throw new DSpaceSwordException(
-                    "Unable to construct service document urls, due to invalid dspace.baseUrl " +
+                    "Unable to construct service document urls, due to invalid dspace.server.url " +
                         e.getMessage(), e);
             }
         }
@@ -332,9 +332,9 @@ public class SwordUrlManager {
      * If the configuration sword.deposit.url is set, this will be returned,
      * but if not, it will construct the url as follows:
      *
-     * [dspace.baseUrl]/sword/deposit
+     * [dspace.server.url]/sword/deposit
      *
-     * where dspace.baseUrl is also in the configuration file.
+     * where dspace.server.url is also in the configuration file.
      *
      * @return the base URL for SWORD deposit
      * @throws DSpaceSwordException can be thrown by the internals of the DSpace SWORD implementation
@@ -345,11 +345,11 @@ public class SwordUrlManager {
             .getProperty("swordv2-server", "collection.url");
         if (depositUrl == null || "".equals(depositUrl)) {
             String dspaceUrl = ConfigurationManager
-                .getProperty("dspace.baseUrl");
+                .getProperty("dspace.server.url");
             if (dspaceUrl == null || "".equals(dspaceUrl)) {
                 throw new DSpaceSwordException(
                     "Unable to construct deposit urls, due to missing/invalid config in " +
-                        "swordv2-server.cfg deposit.url and/or dspace.baseUrl");
+                        "swordv2-server.cfg deposit.url and/or dspace.server.url");
             }
 
             try {
@@ -358,7 +358,7 @@ public class SwordUrlManager {
                                      url.getPort(), "/swordv2/collection").toString();
             } catch (MalformedURLException e) {
                 throw new DSpaceSwordException(
-                    "Unable to construct deposit urls, due to invalid dspace.baseUrl " +
+                    "Unable to construct deposit urls, due to invalid dspace.server.url " +
                         e.getMessage(), e);
             }
 

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordUrlManager.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordUrlManager.java
@@ -407,7 +407,7 @@ public class SwordUrlManager {
             }
 
             String handle = item.getHandle();
-            String bsLink = ConfigurationManager.getProperty("dspace.url");
+            String bsLink = ConfigurationManager.getProperty("dspace.ui.url");
 
             if (handle != null && !"".equals(handle)) {
                 bsLink = bsLink + "/bitstream/" + handle + "/" +

--- a/dspace/bin/make-handle-config
+++ b/dspace/bin/make-handle-config
@@ -16,8 +16,11 @@ BINDIR=`dirname $0`
 
 echo "Writing simple Handle server configuration"
 
-# Read parameters from DSpace config
-dshostname=`$BINDIR/dspace dsprop --property dspace.ui.hostname`
+# Read server URL from DSpace config
+dsurl=`$BINDIR/dspace dsprop --property dspace.server.url`
+# Parse hostname from URL
+dshostname=`echo $dsurl | awk -F/ '{ print $3; exit }'`
+# Determine IP address from hostname
 dshostip=`host $dshostname | awk '/has address/ { print $4; exit }'`
 if [ "$dshostip" = "127.0.0.1" ]; then
   # Just use default. SimpleSetup will fail when trying to bind to localhost addresses.

--- a/dspace/bin/make-handle-config
+++ b/dspace/bin/make-handle-config
@@ -17,7 +17,7 @@ BINDIR=`dirname $0`
 echo "Writing simple Handle server configuration"
 
 # Read parameters from DSpace config
-dshostname=`$BINDIR/dspace dsprop --property dspace.hostname`
+dshostname=`$BINDIR/dspace dsprop --property dspace.ui.hostname`
 dshostip=`host $dshostname | awk '/has address/ { print $4; exit }'`
 if [ "$dshostip" = "127.0.0.1" ]; then
   # Just use default. SimpleSetup will fail when trying to bind to localhost addresses.

--- a/dspace/config/crosswalks/oai/description.xml
+++ b/dspace/config/crosswalks/oai/description.xml
@@ -1,6 +1,6 @@
 <oai-identifier xmlns="http://www.openarchives.org/OAI/2.0/oai-identifier" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai-identifier http://www.openarchives.org/OAI/2.0/oai-identifier.xsd">
 <scheme>oai</scheme>
-<repositoryIdentifier>${dspace.hostname}</repositoryIdentifier>
+<repositoryIdentifier>${dspace.ui.hostname}</repositoryIdentifier>
 <delimiter>:</delimiter>
-<sampleIdentifier>oai:${dspace.hostname}:${handle.prefix}/1234</sampleIdentifier>
+<sampleIdentifier>oai:${dspace.ui.hostname}:${handle.prefix}/1234</sampleIdentifier>
 </oai-identifier>

--- a/dspace/config/crosswalks/oai/description.xml
+++ b/dspace/config/crosswalks/oai/description.xml
@@ -1,6 +1,6 @@
 <oai-identifier xmlns="http://www.openarchives.org/OAI/2.0/oai-identifier" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai-identifier http://www.openarchives.org/OAI/2.0/oai-identifier.xsd">
 <scheme>oai</scheme>
-<repositoryIdentifier>${dspace.ui.hostname}</repositoryIdentifier>
+<repositoryIdentifier>${oai.identifier.prefix}</repositoryIdentifier>
 <delimiter>:</delimiter>
-<sampleIdentifier>oai:${dspace.ui.hostname}:${handle.prefix}/1234</sampleIdentifier>
+<sampleIdentifier>oai:${oai.identifier.prefix}:${handle.prefix}/1234</sampleIdentifier>
 </oai-identifier>

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -22,14 +22,17 @@
 # Windows note: Please remember to use forward slashes for all paths (e.g. C:/dspace)
 dspace.dir = /dspace
 
-# DSpace host name - should match base URL.  Do not include port number.
-dspace.hostname = localhost
-
-# DSpace server backend webapp URL.  Include port number etc.
+# URL of DSpace backend ('server' webapp). Include port number etc.
+# This is where REST API and all enabled server modules (OAI-PMH, SWORD, SWORDv2, RDF, etc) will respond
 dspace.server.url = http://localhost:8080/server
-#dspace.baseUrl = http://localhost:8080/server
 
-# Full link your end users will use to access DSpace. This is the URL of your angular UI
+# DSpace UI hostname. Should match dspace.ui.url.  Do not include port number.
+# This is used by some modules (e.g. OAI) as an identifier for your site.
+# You also may chose to use this to populate other configurations below.
+dspace.ui.hostname = localhost
+
+# URL of DSpace frontend (Angular UI). Include port number etc
+# This is used by the backend to provide links in emails, RSS feeds, Sitemaps, etc.
 dspace.ui.url = http://localhost:3000
 
 # Name of the site
@@ -43,7 +46,7 @@ default.language = en_US
 
 # Solr server/webapp.
 # DSpace uses Solr for all search/browse capability (and for usage statistics).
-# since DSpace 7, SOLR must be installed as a stand-alone service
+# Since DSpace 7, SOLR must be installed as a stand-alone service
 solr.server = http://localhost:8983/solr
 
 ##### Database settings #####
@@ -135,8 +138,8 @@ alert.recipient = ${mail.admin}
 mail.charset = UTF-8
 
 # A comma-separated list of hostnames that are allowed to refer browsers to email forms.
-# Default behaviour is to accept referrals only from dspace.hostname
-mail.allowed.referrers = ${dspace.hostname}
+# Default behaviour is to accept referrals only from dspace.ui.hostname
+mail.allowed.referrers = ${dspace.ui.hostname}
 
 # Pass extra settings to the Java mail library. Comma-separated, equals sign between
 # the key and the value. For example:
@@ -1827,7 +1830,7 @@ webui.suggest.enable = false
 
 # Force all authenticated connections to use SSL, only non-authenticated
 # connections are allowed over plain http. If set to true, then you need to
-# ensure that the 'dspace.hostname' parameter is set to the correctly.
+# ensure that the 'dspace.ui.hostname' parameter is set to the correctly.
 #xmlui.force.ssl = true
 
 # Determine if new users should be allowed to register or edit their own metadata.

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -26,11 +26,6 @@ dspace.dir = /dspace
 # This is where REST API and all enabled server modules (OAI-PMH, SWORD, SWORDv2, RDF, etc) will respond
 dspace.server.url = http://localhost:8080/server
 
-# DSpace UI hostname. Should match dspace.ui.url.  Do not include port number.
-# This is used by some modules (e.g. OAI) as an identifier for your site.
-# You also may chose to use this to populate other configurations below.
-dspace.ui.hostname = localhost
-
 # URL of DSpace frontend (Angular UI). Include port number etc
 # This is used by the backend to provide links in emails, RSS feeds, Sitemaps, etc.
 dspace.ui.url = http://localhost:3000
@@ -138,8 +133,9 @@ alert.recipient = ${mail.admin}
 mail.charset = UTF-8
 
 # A comma-separated list of hostnames that are allowed to refer browsers to email forms.
-# Default behaviour is to accept referrals only from dspace.ui.hostname
-mail.allowed.referrers = ${dspace.ui.hostname}
+# Default behaviour is to accept referrals only from dspace.hostname
+# TODO: Needs removal/replacement. No longer used in DSpace 7 codebase and dspace.hostname config no longer exists.
+#mail.allowed.referrers = ${dspace.hostname}
 
 # Pass extra settings to the Java mail library. Comma-separated, equals sign between
 # the key and the value. For example:
@@ -1830,7 +1826,7 @@ webui.suggest.enable = false
 
 # Force all authenticated connections to use SSL, only non-authenticated
 # connections are allowed over plain http. If set to true, then you need to
-# ensure that the 'dspace.ui.hostname' parameter is set to the correctly.
+# ensure that the 'dspace.hostname' parameter is set to the correctly.
 #xmlui.force.ssl = true
 
 # Determine if new users should be allowed to register or edit their own metadata.

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -26,14 +26,11 @@ dspace.dir = /dspace
 dspace.hostname = localhost
 
 # DSpace server backend webapp URL.  Include port number etc.
-dspace.baseUrl = http://localhost:8080/server
+dspace.server.url = http://localhost:8080/server
+#dspace.baseUrl = http://localhost:8080/server
 
 # Full link your end users will use to access DSpace. This is the URL of your angular UI
-dspace.url = http://localhost:3000
-
-# Optional: DSpace URL for mobile access
-# This
-#dspace.mobileUrl = http://mobile.example.com
+dspace.ui.url = http://localhost:3000
 
 # Name of the site
 dspace.name = DSpace at My University
@@ -234,7 +231,7 @@ identifier.doi.namespaceseparator = dspace/
 #
 # Items in DSpace receive a unique URL, stored in dc.identifier.uri
 # after it is generated during the submission process.
-handle.canonical.prefix = ${dspace.url}/handle/
+handle.canonical.prefix = ${dspace.ui.url}/handle/
 
 # If you register with CNRI's handle service at http://www.handle.net/,
 # these links can be generated as permalinks using http://hdl.handle.net/
@@ -1349,7 +1346,7 @@ webui.feed.item.author = dc.contributor.author
 
 # Customize the image icon included with the site-wide feeds:
 # Must be an absolute URL, e.g.
-## webui.feed.logo.url = ${dspace.url}/themes/mysite/images/mysite-logo.png
+## webui.feed.logo.url = ${dspace.ui.url}/themes/mysite/images/mysite-logo.png
 
 # iTunes Podcast Enhanced RSS Feed Properties
 # Add all the communities / collections, separated by commas (no spaces) that should

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -34,11 +34,6 @@ dspace.dir=/dspace
 # This is where REST API and all enabled server modules (OAI-PMH, SWORD, SWORDv2, RDF, etc) will respond
 dspace.server.url = http://localhost:8080/server
 
-# DSpace UI hostname. Should match dspace.ui.url.  Do not include port number.
-# This is used by some modules (e.g. OAI) as an identifier for your site.
-# You also may chose to use this to populate other configurations below.
-dspace.ui.hostname = localhost
-
 # URL of DSpace frontend (Angular UI). Include port number etc
 # This is used by the backend to provide links in emails, RSS feeds, Sitemaps, etc.
 dspace.ui.url = http://localhost:3000

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -30,13 +30,17 @@
 # Windows note: Please remember to use forward slashes for all paths (e.g. C:/dspace)
 dspace.dir=/dspace
 
-# DSpace host name - should match base URL.  Do not include port number
-dspace.hostname = localhost
-
-# DSpace server backend webapp URL.  Include port number etc.
+# URL of DSpace backend ('server' webapp). Include port number etc.
+# This is where REST API and all enabled server modules (OAI-PMH, SWORD, SWORDv2, RDF, etc) will respond
 dspace.server.url = http://localhost:8080/server
 
-# Full link your end users will use to access DSpace. This is the URL of your angular UI
+# DSpace UI hostname. Should match dspace.ui.url.  Do not include port number.
+# This is used by some modules (e.g. OAI) as an identifier for your site.
+# You also may chose to use this to populate other configurations below.
+dspace.ui.hostname = localhost
+
+# URL of DSpace frontend (Angular UI). Include port number etc
+# This is used by the backend to provide links in emails, RSS feeds, Sitemaps, etc.
 dspace.ui.url = http://localhost:3000
 
 # Name of the site
@@ -51,7 +55,7 @@ dspace.name = DSpace at My University
 
 # Solr server/webapp.
 # DSpace uses Solr for all search/browse capability (and for usage statistics).
-# since DSpace 7, SOLR must be installed as a stand-alone service
+# Since DSpace 7, SOLR must be installed as a stand-alone service
 #solr.server = http://localhost:8983/solr
 
 ##########################

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -34,10 +34,10 @@ dspace.dir=/dspace
 dspace.hostname = localhost
 
 # DSpace server backend webapp URL.  Include port number etc.
-dspace.baseUrl = http://localhost:8080/server
+dspace.server.url = http://localhost:8080/server
 
 # Full link your end users will use to access DSpace. This is the URL of your angular UI
-dspace.url = http://localhost:3000
+dspace.ui.url = http://localhost:3000
 
 # Name of the site
 dspace.name = DSpace at My University
@@ -138,7 +138,7 @@ db.schema = public
 #
 # Items in DSpace receive a unique URL, stored in dc.identifier.uri
 # after it is generated during the submission process.
-# 
+#
 # If you register with CNRI's handle service at http://www.handle.net/,
 # these links can be generated as permalinks using http://hdl.handle.net/
 # as canonical prefix. Please make sure to change handle.canonical.prefix

--- a/dspace/config/modules/oai.cfg
+++ b/dspace/config/modules/oai.cfg
@@ -12,7 +12,7 @@
 
 # Path where OAI module is available
 # Defaults to "oai", which means the OAI module would be available
-# at ${dspace.baseURL}/oai/
+# at ${dspace.server.url}/oai/
 # (Requires reboot of servlet container, e.g. Tomcat, to reload)
 oai.path = oai
 
@@ -21,7 +21,7 @@ oai.storage=solr
 
 # The base URL of the OAI webapp (do not include the context e.g. /request, /openaire, etc).
 # Note: Comment out if you want to fallback to the request's URL.
-oai.url = ${dspace.baseUrl}/${oai.path}
+oai.url = ${dspace.server.url}/${oai.path}
 
 # Base solr index
 oai.solr.url=${solr.server}/oai
@@ -47,7 +47,7 @@ oai.cache.dir = ${dspace.dir}/var/oai
 #--------------OAI IMPORT CONFIGURATION ------------------------#
 #---------------------------------------------------------------#
 
-# Size of batches to commit to solr at a time 
+# Size of batches to commit to solr at a time
 oai.import.batch.size = 1000
 
 #---------------------------------------------------------------#

--- a/dspace/config/modules/oai.cfg
+++ b/dspace/config/modules/oai.cfg
@@ -8,7 +8,7 @@
 # When "true", the OAI module is accessible on ${oai.path}
 # When "false" or commented out, OAI is disabled/inaccessible.
 # (Requires reboot of servlet container, e.g. Tomcat, to reload)
-#oai.enabled = true
+oai.enabled = true
 
 # Path where OAI module is available
 # Defaults to "oai", which means the OAI module would be available
@@ -25,9 +25,16 @@ oai.url = ${dspace.server.url}/${oai.path}
 
 # Base solr index
 oai.solr.url=${solr.server}/oai
-# OAI persistent identifier prefix.
-# Format - oai:PREFIX:HANDLE
-oai.identifier.prefix = ${dspace.ui.hostname}
+
+# OAI persistent identifier prefix
+# This field is used for two purposes:
+#   1. As your OAI-PMH <repositoryIdentifier>
+#   2. As the prefix for all Identifiers in OAI-PMH (Format is "oai:${oai.identifier.prefix}:${handle.prefix}")
+# The OAI-PMH spec requires this prefix to correspond to your site's hostname. Therefore, by default,
+# DSpace will set this configuration to the hostname from your ${dspace.ui.url} configuration.
+# However, you may override that default value by uncommenting this configuration.
+# oai.identifier.prefix = YOUR_SITE_HOSTNAME
+
 # Base url for bitstreams
 oai.bitstream.baseUrl = ${dspace.ui.url}
 

--- a/dspace/config/modules/oai.cfg
+++ b/dspace/config/modules/oai.cfg
@@ -29,7 +29,7 @@ oai.solr.url=${solr.server}/oai
 # Format - oai:PREFIX:HANDLE
 oai.identifier.prefix = ${dspace.hostname}
 # Base url for bitstreams
-oai.bitstream.baseUrl = ${dspace.url}
+oai.bitstream.baseUrl = ${dspace.ui.url}
 
 # Base Configuration Directory
 oai.config.dir = ${dspace.dir}/config/crosswalks/oai

--- a/dspace/config/modules/oai.cfg
+++ b/dspace/config/modules/oai.cfg
@@ -27,7 +27,7 @@ oai.url = ${dspace.server.url}/${oai.path}
 oai.solr.url=${solr.server}/oai
 # OAI persistent identifier prefix.
 # Format - oai:PREFIX:HANDLE
-oai.identifier.prefix = ${dspace.hostname}
+oai.identifier.prefix = ${dspace.ui.hostname}
 # Base url for bitstreams
 oai.bitstream.baseUrl = ${dspace.ui.url}
 

--- a/dspace/config/modules/rdf.cfg
+++ b/dspace/config/modules/rdf.cfg
@@ -14,7 +14,7 @@
 
 # Path where RDF module is available (in the Spring Server webapp)
 # Defaults to "rdf", which means the RDF module would be available
-# at ${dspace.baseURL}/rdf/
+# at ${dspace.server.url}/rdf/
 # (Requires reboot of servlet container, e.g. Tomcat, to reload)
 rdf.path = rdf
 
@@ -23,7 +23,7 @@ rdf.contentNegotiation.enable = false
 
 # Set the url of the RDF module here. This is necessary to use content
 # negotiation
-rdf.contextPath = ${dspace.baseUrl}/${rdf.path}
+rdf.contextPath = ${dspace.server.url}/${rdf.path}
 
 
 # Address of the public SPARQL endpoint
@@ -41,7 +41,7 @@ rdf.storage.graphstore.authentication = no
 # please set the authentication credentials
 #rdf.storage.graphstore.login = dspace
 #rdf.storage.graphstore.password = ecapsd
-# Address DSpace should use to query the SPARQL endpoint, e.g. the 
+# Address DSpace should use to query the SPARQL endpoint, e.g. the
 # RDFStorageImpl uses this address to determine a list of all stored
 # graphs. The SPARQL endpoint can be read-only, all commands which change
 # data will be performed using the SPARQL 1.1 Graph Store HTTP Protocoll.

--- a/dspace/config/modules/sword-server.cfg
+++ b/dspace/config/modules/sword-server.cfg
@@ -14,7 +14,7 @@
 
 # Path where SWORD v1 module is available (in the Spring Server webapp)
 # Defaults to "sword", which means the SWORD mould would be available
-# at ${dspace.baseUrl}/sword/
+# at ${dspace.server.url}/sword/
 # (Requires reboot of servlet container, e.g. Tomcat, to reload)
 #sword-server.path = sword
 
@@ -46,7 +46,7 @@
 # which DSpace will construct the deposit location urls for
 # collections.
 #
-# The default is ${dspace.baseUrl}/sword/deposit
+# The default is ${dspace.server.url}/sword/deposit
 #
 # In the event that you are not deploying DSpace as the ROOT
 # application in the servlet container, this will generate
@@ -59,7 +59,7 @@
 # URL from which DSpace will construct the service document
 # location urls for the site, and for individual collections
 #
-# The default is {dspace.baseUrl}/sword/servicedocument
+# The default is {dspace.server.url}/sword/servicedocument
 #
 # In the event that you are not deploying DSpace as the ROOT
 # application in the servlet container, this will generate
@@ -72,7 +72,7 @@
 # which DSpace will use to construct the media link urls
 # for items which are deposited via sword
 #
-# The default is {dspace.baseUrl}/sword/media-link
+# The default is {dspace.server.url}/sword/media-link
 #
 # In the event that you are not deploying DSpace as the ROOT
 # application in the servlet container, this will generate

--- a/dspace/config/modules/swordv2-server.cfg
+++ b/dspace/config/modules/swordv2-server.cfg
@@ -14,13 +14,13 @@
 
  # Path where SWORD v2 module is available (in the Spring Server webapp)
 # Defaults to "swordv2", which means the SWORD v2 module would be available
-# at ${dspace.baseURL}/swordv2/
+# at ${dspace.server.url}/swordv2/
 # (Requires reboot of servlet container, e.g. Tomcat, to reload)
 #swordv2-server.path = swordv2
 
 # the base url of the sword 2.0  system
 #
-# the default if {dspace.baseUrl}/swordv2
+# the default if {dspace.server.url}/swordv2
 #
 #swordv2-server.url = http://www.myu.ac.uk/swordv2
 
@@ -28,7 +28,7 @@
 # which DSpace will construct the deposit location urls for
 # collections.
 #
-# The default is {dspace.baseUrl}/swordv2/collection
+# The default is {dspace.server.url}/swordv2/collection
 #
 # In the event that you are not deploying DSpace as the ROOT
 # application in the servlet container, this will generate
@@ -41,7 +41,7 @@
 # URL from which DSpace will construct the service document
 # location urls for the site, and for individual collections
 #
-# The default is {dspace.baseUrl}/swordv2/servicedocument
+# The default is {dspace.server.url}/swordv2/servicedocument
 #
 # In the event that you are not deploying DSpace as the ROOT
 # application in the servlet container, this will generate
@@ -141,7 +141,7 @@ swordv2-server.keep-original-package = true
 # which belongs to the On-Behalf-Of user, which represents a significant
 # security risk.  It is therefore recommended to either disable
 # mediated deposit, or to expressly set a list of accounts which
-# are allowed to mediate on behalf of other users 
+# are allowed to mediate on behalf of other users
 # (see swordv2-server.on-behalf-of.update.mediators)
 #
 # See the SWORD specification for a detailed explanation of deposit
@@ -173,10 +173,9 @@ swordv2-server.verbose-description.error.enable = true
 # The error document can contain an alternate url, which the client
 # can use to follow up any issues.
 #
-# This is the Contact-Us page on the XMLUI (localise the url space
-# first)
+# This is the Contact-Us page on the UI (localise the url space first)
 #
-swordv2-server.error.alternate.url = ${dspace.baseUrl}/contact
+swordv2-server.error.alternate.url = ${dspace.ui.url}/contact
 
 # The URL may have an associated content type; if you know what it
 # is, you can enter it here
@@ -494,13 +493,7 @@ swordv2-server.state.archive.description = The item has been archived
 swordv2-server.state.withdrawn.uri = http://dspace.org/state/withdrawn
 swordv2-server.state.withdrawn.description = The item has been withdrawn from the archive and is no longer available
 
-# URL template for items in the workspace (items in the archive will use
-# the handle)
-#
-# JSPUI
-# swordv2-server.workspace.url-template = ${dspace.baseUrl}/view-workspaceitem?submit_view=Yes&workspace_id=#wsid#
-
-# XMLUI
-swordv2-server.workspace.url-template = ${dspace.baseUrl}/submit?workspaceID=#wsid#
+# URL template for items in the workspace (items in the archive will use the handle)
+swordv2-server.workspace.url-template = ${dspace.ui.url}/workspaceitems/#wsid#/edit
 
 

--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -349,8 +349,6 @@ Common usage:
                      autoconfiguring itself (e.g. see DS-3104). -->
                 <include name="log4j*.properties"/>
                 <include name="log4j2*.xml"/>
-                <!-- Filter OAI-PMH description so it can include hostname and handle prefix -->
-                <include name="crosswalks/oai/description.xml"/>
                 <!-- Filter sample Tomcat context.xml -->
                 <include name="default.context.xml"/>
                 <!-- Filter RDF configs as these are TTL files -->

--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -849,9 +849,9 @@ Common usage:
 
    ${dspace.dir}/bin/dspace create-administrator
 
- You should then be able to access your DSpace's 'home page':
+ You should then be able to access your DSpace's REST API:
 
-   ${dspace.url}
+   ${dspace.server.url}
 
 ====================================================================
         </echo>

--- a/dspace/src/main/docker-compose/local.cfg
+++ b/dspace/src/main/docker-compose/local.cfg
@@ -1,6 +1,6 @@
 dspace.dir=/dspace
 db.url=jdbc:postgresql://dspacedb:5432/dspace
 dspace.hostname=dspace
-dspace.baseUrl=http://localhost:8080/server
+dspace.server.url=http://localhost:8080/server
 dspace.name=DSpace Started with Docker Compose
 solr.server=http://dspacesolr:8983/solr

--- a/dspace/src/main/docker-compose/local.cfg
+++ b/dspace/src/main/docker-compose/local.cfg
@@ -1,6 +1,5 @@
 dspace.dir=/dspace
 db.url=jdbc:postgresql://dspacedb:5432/dspace
-dspace.hostname=dspace
 dspace.server.url=http://localhost:8080/server
 dspace.name=DSpace Started with Docker Compose
 solr.server=http://dspacesolr:8983/solr

--- a/dspace/src/main/docker/local.cfg
+++ b/dspace/src/main/docker/local.cfg
@@ -5,5 +5,5 @@
 dspace.dir = /dspace
 db.url = jdbc:postgresql://dspacedb:5432/dspace
 dspace.hostname = localhost
-dspace.baseUrl = http://localhost:8080/server
+dspace.server.url=http://localhost:8080/server
 solr.server=http://dspacesolr:8983/solr

--- a/dspace/src/main/docker/local.cfg
+++ b/dspace/src/main/docker/local.cfg
@@ -4,6 +4,5 @@
 # ------------------------------------------------------------------------
 dspace.dir = /dspace
 db.url = jdbc:postgresql://dspacedb:5432/dspace
-dspace.hostname = localhost
 dspace.server.url=http://localhost:8080/server
 solr.server=http://dspacesolr:8983/solr


### PR DESCRIPTION
This PR is the final stage of https://jira.lyrasis.org/browse/DS-4257 (Spring Boot webapp refactor).  I finally got back to this.

It refactors our configuration slightly to better differentiate between our URL-based configurations.

Two **new configurations** are added:
* `dspace.server.url` = The URL of the server webapp (i.e. DSpace backend)
* `dspace.ui.url` = The URL of the Angular UI (i.e. DSpace frontend)
* ~~`dspace.ui.hostname` = The hostname of the DSpace UI (This config is only really used as an "identifier" for DSpace in modules like OAI-PMH)~~
    * **UPDATE:** I've updated this PR to refactor out the need for a "hostname" configuration. See notes below under the `dspace.hostname` bullet.

These old URL configurations have been removed (replaced by the above):
* `dspace.baseUrl` is removed and (usually) replaced by `dspace.server.url`.  However, in a few rare cases it was actually referring to the UI and was replaced by `dspace.ui.url`.
* `dspace.url` is removed and (usually) replaced by `dspace.ui.url`. However, in a few rare cases it was actually referring to the backend and was replaced by `dspace.server.url`.
* `dspace.hostname` is **completely removed** (with no replacement).  Instead, I've refactored the code that used `dspace.hostname` to _instead parse the hostname from the appropriate `dspace.*.url` configuration_.
    * Added a new `Utils.getHostName()` utility method to parse the hostname from any URL. Added tests to prove it works.  Refactored Java code that previously used `dspace.hostname` to now use this utility method.
    * Changed OAI-PMH's `description.xml` to use the existing `oai.identifier.prefix` (which previously defaulted to `dspace.hostname`).  Changed `oai.identifier.prefix` to now be set *dynamically* to the hostname of the `dspace.ui.url` (if not specified in the oai.cfg or similar)
    * Refactored OAI-PMH build process to no longer populate the `description.xml` using Ant filters. Instead, any configuration variables in the `description.xml` are now populated *dynamically*.  This ensures it can use the `oai.identifier.prefix` (now populated dynamically).
* `dspace.mobileUrl` is **completely removed** (no longer used anywhere in our codebase and not applicable for Angular UI).

NOTE: Once this PR is merged, we need to ensure all DSpace 7 developers are aware of the new configurations.  Additionally, the REST API demo site must update its local.cfg to use the new configurations (or else errors may occur).