### PR TITLE
Fix issue with bulkedit.ignore-on-export parameter on DSpaceCSV

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSV.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSV.java
@@ -273,8 +273,8 @@ public class DSpaceCSV implements Serializable
         ignore = new HashMap<>();
 
         // Specify default values
-        String[] defaultValues = new String[]{"dc.date.accessioned, dc.date.available, " +
-                                              "dc.date.updated, dc.description.provenance"};
+        String[] defaultValues = new String[]{"dc.date.accessioned", "dc.date.available", 
+                                              "dc.date.updated", "dc.description.provenance"};
         String[] toIgnoreArray = DSpaceServicesFactory.getInstance().getConfigurationService().getArrayProperty("bulkedit.ignore-on-export", defaultValues);
         for (String toIgnoreString : toIgnoreArray)
         {

--- a/dspace/config/modules/bulkedit.cfg
+++ b/dspace/config/modules/bulkedit.cfg
@@ -20,8 +20,10 @@
 
 # Metadata elements to exclude when exporting via the user interfaces, or when using the
 # command line version and not using the -a (all) option.
-# bulkedit.ignore-on-export = dc.date.accessioned, dc.date.available, \
-#                    dc.date.updated, dc.description.provenance
+#bulkedit.ignore-on-export = dc.date.accessioned
+#bulkedit.ignore-on-export = dc.date.available
+#bulkedit.ignore-on-export = dc.date.updated
+#bulkedit.ignore-on-export = dc.description.provenance
 
 # Should the 'action' column allow the 'expunge' method.  By default this is set to false
 # bulkedit.allowexpunge = false


### PR DESCRIPTION
This PR is to fix an issue during export with CSV or excel where the metadata to ignore are included the same.
This was due to a wrong use of the `bulkedit.ignore-on-export` parameter as an array 