### PR TITLE
Entities Configure search configurations matching name

### DIFF
--- a/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
@@ -237,7 +237,7 @@ it, please enter the types and the actual numbers or codes.</hint>
    <form name="journalVolumeStep">
      <row>
        <relation-field>
-         <relationship-type>isVolumeOfJournal</relationship-type>
+         <relationship-type>isJournalOfVolume</relationship-type>
          <search-configuration>periodical</search-configuration>
          <filter>creativework.publisher:somepublishername</filter>
          <label>Journal</label>

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionFormsControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionFormsControllerIT.java
@@ -138,7 +138,7 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
                         // check the first two rows
                         .andExpect(jsonPath("$.rows[0].fields", contains(
                             SubmissionFormFieldMatcher.matchFormClosedRelationshipFieldDefinition("Journal", null,
-                    false,"Select the journal related to this volume.", "isVolumeOfJournal",
+                    false,"Select the journal related to this volume.", "isJournalOfVolume",
                         "creativework.publisher:somepublishername", "periodical", false))))
         ;
     }

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -63,7 +63,7 @@
                 <entry key="journal" value-ref="journal"/>
                 <entry key="project" value-ref="project"/>
                 <!-- search for an entity that can be a Person or an OrgUnit -->
-                <entry key="personOrOrganization" value-ref="personOrOrganization"/>
+                <entry key="personOrOrgunit" value-ref="personOrOrgunit"/>
                 <!-- OpenAIRE4 guidelines - search for an OrgUnit that have a specific dc.type=FundingOrganization -->
                 <entry key="openAIREFundingAgency" value-ref="openAIREFundingAgency"/>
             </map>
@@ -1096,9 +1096,9 @@
         <property name="spellCheckEnabled" value="true"/>
     </bean>
 
-    <bean id="personOrOrganization" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
+    <bean id="personOrOrgunit" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
           scope="prototype">
-        <property name="id" value="personOrOrganization"/>
+        <property name="id" value="personOrOrgunit"/>
         <property name="indexAlways" value="true"/>
         <!--Which sidebar facets are to be displayed-->
         <property name="sidebarFacets">

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -57,10 +57,10 @@
                 <entry key="undiscoverable" value-ref="unDiscoverableItems" />
                 <entry key="publication" value-ref="publication"/>
                 <entry key="person" value-ref="person"/>
-                <entry key="organization" value-ref="organization"/>
-                <entry key="publicationIssue" value-ref="publicationIssue"/>
-                <entry key="publicationVolume" value-ref="publicationVolume"/>
-                <entry key="periodical" value-ref="periodical"/>
+                <entry key="orgunit" value-ref="orgUnit"/>
+                <entry key="journalissue" value-ref="journalIssue"/>
+                <entry key="journalvolume" value-ref="journalVolume"/>
+                <entry key="journal" value-ref="journal"/>
                 <entry key="project" value-ref="project"/>
                 <!-- search for an entity that can be a Person or an OrgUnit -->
                 <entry key="personOrOrganization" value-ref="personOrOrganization"/>
@@ -850,9 +850,9 @@
         <property name="spellCheckEnabled" value="true"/>
     </bean>
 
-    <bean id="organization" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
+    <bean id="orgUnit" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
           scope="prototype">
-        <property name="id" value="organization"/>
+        <property name="id" value="orgUnit"/>
         <property name="indexAlways" value="true"/>
         <!--Which sidebar facets are to be displayed-->
         <property name="sidebarFacets">
@@ -915,9 +915,9 @@
         <property name="spellCheckEnabled" value="true"/>
     </bean>
 
-    <bean id="publicationIssue" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
+    <bean id="journalIssue" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
           scope="prototype">
-        <property name="id" value="publicationIssue"/>
+        <property name="id" value="journalIssue"/>
         <property name="indexAlways" value="true"/>
         <!--Which sidebar facets are to be displayed-->
         <property name="sidebarFacets">
@@ -976,9 +976,9 @@
         <property name="spellCheckEnabled" value="true"/>
     </bean>
 
-    <bean id="publicationVolume" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
+    <bean id="journalVolume" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
           scope="prototype">
-        <property name="id" value="publicationVolume"/>
+        <property name="id" value="journalVolume"/>
         <property name="indexAlways" value="true"/>
         <!--Which sidebar facets are to be displayed-->
         <property name="sidebarFacets">
@@ -1036,9 +1036,9 @@
         <property name="spellCheckEnabled" value="true"/>
     </bean>
 
-    <bean id="periodical" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
+    <bean id="journal" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
           scope="prototype">
-        <property name="id" value="periodical"/>
+        <property name="id" value="journal"/>
         <property name="indexAlways" value="true"/>
         <!--Which sidebar facets are to be displayed-->
         <property name="sidebarFacets">

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -614,7 +614,7 @@
             <row>
                 <relation-field>
                     <relationship-type>isAuthorOfPublication</relationship-type>
-                    <search-configuration>personOrOrganization</search-configuration>
+                    <search-configuration>personOrOrgunit</search-configuration>
                     <repeatable>true</repeatable>
                     <name-variants>true</name-variants>
                     <label>Author</label>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -490,7 +490,7 @@
             <row>
                 <relation-field>
                     <relationship-type>isVolumeOfJournal</relationship-type>
-                    <search-configuration>periodical</search-configuration>
+                    <search-configuration>journal</search-configuration>
                     <filter>creativework.publisher:somepublishername</filter>
                     <label>Journal</label>
                     <hint>Select the journal related to this volume.</hint>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -489,7 +489,7 @@
         <form name="journalVolumeStep">
             <row>
                 <relation-field>
-                    <relationship-type>isVolumeOfJournal</relationship-type>
+                    <relationship-type>isJournalOfVolume</relationship-type>
                     <search-configuration>journal</search-configuration>
                     <filter>creativework.publisher:somepublishername</filter>
                     <label>Journal</label>


### PR DESCRIPTION
This is a rename of the search configurations to match the entity type. This is relevant for https://github.com/DSpace/dspace-angular/pull/545 because the UI will be easier to work with if there's a search configuration matching the entity type