### PR TITLE
DS-4380 : Fix errorprone test warnings after JDK11 upgrade

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authority/PersonAuthorityValue.java
+++ b/dspace-api/src/main/java/org/dspace/authority/PersonAuthorityValue.java
@@ -140,8 +140,8 @@ public class PersonAuthorityValue extends AuthorityValue {
     @Override
     public void setValues(SolrDocument document) {
         super.setValues(document);
-        this.firstName = Objects.toString(document.getFieldValue("first_name"));
-        this.lastName = Objects.toString(document.getFieldValue("last_name"));
+        this.firstName = Objects.toString(document.getFieldValue("first_name"), "");
+        this.lastName = Objects.toString(document.getFieldValue("last_name"), "");
         nameVariants = new ArrayList<String>();
         Collection<Object> document_name_variant = document.getFieldValues("name_variant");
         if (document_name_variant != null) {

--- a/dspace-api/src/main/java/org/dspace/authority/PersonAuthorityValue.java
+++ b/dspace-api/src/main/java/org/dspace/authority/PersonAuthorityValue.java
@@ -11,8 +11,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrInputDocument;
@@ -140,8 +140,8 @@ public class PersonAuthorityValue extends AuthorityValue {
     @Override
     public void setValues(SolrDocument document) {
         super.setValues(document);
-        this.firstName = ObjectUtils.toString(document.getFieldValue("first_name"));
-        this.lastName = ObjectUtils.toString(document.getFieldValue("last_name"));
+        this.firstName = Objects.toString(document.getFieldValue("first_name"));
+        this.lastName = Objects.toString(document.getFieldValue("last_name"));
         nameVariants = new ArrayList<String>();
         Collection<Object> document_name_variant = document.getFieldValues("name_variant");
         if (document_name_variant != null) {

--- a/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicy.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicy.java
@@ -8,6 +8,7 @@
 package org.dspace.authorize;
 
 import java.util.Date;
+import java.util.Objects;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -23,7 +24,6 @@ import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.dspace.content.DSpaceObject;
 import org.dspace.core.Context;
 import org.dspace.core.ReloadableEntity;
@@ -123,16 +123,16 @@ public class ResourcePolicy implements ReloadableEntity<Integer> {
         if (getAction() != other.getAction()) {
             return false;
         }
-        if (!ObjectUtils.equals(getEPerson(), other.getEPerson())) {
+        if (!Objects.equals(getEPerson(), other.getEPerson())) {
             return false;
         }
-        if (!ObjectUtils.equals(getGroup(), other.getGroup())) {
+        if (!Objects.equals(getGroup(), other.getGroup())) {
             return false;
         }
-        if (!ObjectUtils.equals(getStartDate(), other.getStartDate())) {
+        if (!Objects.equals(getStartDate(), other.getStartDate())) {
             return false;
         }
-        if (!ObjectUtils.equals(getEndDate(), other.getEndDate())) {
+        if (!Objects.equals(getEndDate(), other.getEndDate())) {
             return false;
         }
         return true;
@@ -185,7 +185,7 @@ public class ResourcePolicy implements ReloadableEntity<Integer> {
     /**
      * set the action this policy authorizes
      *
-     * @param myid action ID from {@link org.dspace.core.Constants#Constants Constants}
+     * @param myid action ID from {@link org.dspace.core.Constants Constants}
      */
     public void setAction(int myid) {
         this.actionId = myid;

--- a/dspace-api/src/test/java/org/dspace/administer/StructBuilderIT.java
+++ b/dspace-api/src/test/java/org/dspace/administer/StructBuilderIT.java
@@ -314,9 +314,9 @@ public class StructBuilderIT
     }
 
     /**
-     * Reject uninteresting nodes.
+     * Reject uninteresting nodes. (currently commented out of tests above)
      */
-    private static class MyNodeFilter implements Predicate<Node> {
+    /*private static class MyNodeFilter implements Predicate<Node> {
         private static final List<String> dontCare = Arrays.asList(
             "description",
             "intro",
@@ -330,5 +330,5 @@ public class StructBuilderIT
             String type = node.getLocalName();
             return ! dontCare.contains(type);
         }
-    }
+    }*/
 }

--- a/dspace-api/src/test/java/org/dspace/administer/StructBuilderIT.java
+++ b/dspace-api/src/test/java/org/dspace/administer/StructBuilderIT.java
@@ -15,9 +15,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.Iterator;
-import java.util.List;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Source;
 import javax.xml.transform.TransformerException;
@@ -47,7 +45,6 @@ import org.xmlunit.diff.ComparisonFormatter;
 import org.xmlunit.diff.DefaultComparisonFormatter;
 import org.xmlunit.diff.Diff;
 import org.xmlunit.diff.Difference;
-import org.xmlunit.util.Predicate;
 
 /**
  * Tests of {@link StructBuilder}.

--- a/dspace-api/src/test/java/org/dspace/app/util/GoogleBitstreamComparatorTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/GoogleBitstreamComparatorTest.java
@@ -8,7 +8,7 @@
 package org.dspace.app.util;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;

--- a/dspace-api/src/test/java/org/dspace/app/util/GoogleMetadataTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/GoogleMetadataTest.java
@@ -14,7 +14,9 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
+import java.util.List;
 
+import com.google.common.base.Splitter;
 import org.apache.logging.log4j.Logger;
 import org.dspace.AbstractUnitTest;
 import org.dspace.authorize.AuthorizeException;
@@ -85,7 +87,8 @@ public class GoogleMetadataTest extends AbstractUnitTest {
             log.error("SQL Error in init", ex);
             fail("SQL Error in init: " + ex.getMessage());
         } catch (IOException e) {
-            e.printStackTrace();
+            log.error("IO Error in init", e);
+            fail("IO Error in init: " + e.getMessage());
         }
     }
 
@@ -119,8 +122,8 @@ public class GoogleMetadataTest extends AbstractUnitTest {
         context.restoreAuthSystemState();
         context.commit();
         GoogleMetadata gm = new GoogleMetadata(this.context, it);
-        String[] urlSplitted = gm.getPDFURL().get(0).split("/");
-        assertEquals("Pdf", urlSplitted[urlSplitted.length - 1]);
+        List<String> urlSplitted = Splitter.on("/").splitToList(gm.getPDFURL().get(0));
+        assertEquals("Pdf", urlSplitted.get(urlSplitted.size() - 1));
     }
 
     /**
@@ -154,8 +157,8 @@ public class GoogleMetadataTest extends AbstractUnitTest {
         context.restoreAuthSystemState();
         context.commit();
         GoogleMetadata gm = new GoogleMetadata(this.context, it);
-        String[] urlSplitted = gm.getPDFURL().get(0).split("/");
-        assertEquals("size9", urlSplitted[urlSplitted.length - 1]);
+        List<String> urlSplitted = Splitter.on("/").splitToList(gm.getPDFURL().get(0));
+        assertEquals("size9", urlSplitted.get(urlSplitted.size() - 1));
     }
 
     /**
@@ -189,8 +192,8 @@ public class GoogleMetadataTest extends AbstractUnitTest {
         context.restoreAuthSystemState();
         context.commit();
         GoogleMetadata gm = new GoogleMetadata(this.context, it);
-        String[] urlSplitted = gm.getPDFURL().get(0).split("/");
-        assertEquals("first", urlSplitted[urlSplitted.length - 1]);
+        List<String> urlSplitted = Splitter.on("/").splitToList(gm.getPDFURL().get(0));
+        assertEquals("first", urlSplitted.get(urlSplitted.size() - 1));
     }
 
     /**
@@ -225,8 +228,8 @@ public class GoogleMetadataTest extends AbstractUnitTest {
         context.restoreAuthSystemState();
         context.commit();
         GoogleMetadata gm = new GoogleMetadata(this.context, it);
-        String[] urlSplitted = gm.getPDFURL().get(0).split("/");
-        assertEquals("primary", urlSplitted[urlSplitted.length - 1]);
+        List<String> urlSplitted = Splitter.on("/").splitToList(gm.getPDFURL().get(0));
+        assertEquals("primary", urlSplitted.get(urlSplitted.size() - 1));
     }
 
     /**
@@ -261,8 +264,8 @@ public class GoogleMetadataTest extends AbstractUnitTest {
         context.restoreAuthSystemState();
         context.commit();
         GoogleMetadata gm = new GoogleMetadata(this.context, it);
-        String[] urlSplitted = gm.getPDFURL().get(0).split("/");
-        assertEquals("large", urlSplitted[urlSplitted.length - 1]);
+        List<String> urlSplitted = Splitter.on("/").splitToList(gm.getPDFURL().get(0));
+        assertEquals("large", urlSplitted.get(urlSplitted.size() - 1));
     }
 
 
@@ -285,7 +288,7 @@ public class GoogleMetadataTest extends AbstractUnitTest {
     @Test
     public void testGetPDFURLWithNoBitstreams() throws Exception {
         context.turnOffAuthorisationSystem();
-        Bundle bundle = ContentServiceFactory.getInstance().getBundleService().create(context, it, "ORIGINAL");
+        ContentServiceFactory.getInstance().getBundleService().create(context, it, "ORIGINAL");
 
         context.restoreAuthSystemState();
         context.commit();
@@ -319,8 +322,8 @@ public class GoogleMetadataTest extends AbstractUnitTest {
         context.restoreAuthSystemState();
         context.commit();
         GoogleMetadata gm = new GoogleMetadata(this.context, it);
-        String[] urlSplitted = gm.getPDFURL().get(0).split("/");
-        assertEquals("small", urlSplitted[urlSplitted.length - 1]);
+        List<String> urlSplitted = Splitter.on("/").splitToList(gm.getPDFURL().get(0));
+        assertEquals("small", urlSplitted.get(urlSplitted.size() - 1));
     }
 
     @After
@@ -334,12 +337,8 @@ public class GoogleMetadataTest extends AbstractUnitTest {
             community = context.reloadEntity(community);
             ContentServiceFactory.getInstance().getCommunityService().delete(context, community);
             community = null;
-        } catch (SQLException e) {
-            e.printStackTrace();
-        } catch (AuthorizeException e) {
-            e.printStackTrace();
-        } catch (IOException e) {
-            e.printStackTrace();
+        } catch (Exception e) {
+            throw new AssertionError("Error occurred in destroy()", e);
         }
         it = null;
         super.destroy();

--- a/dspace-api/src/test/java/org/dspace/authenticate/IPMatcherTest.java
+++ b/dspace-api/src/test/java/org/dspace/authenticate/IPMatcherTest.java
@@ -264,8 +264,8 @@ public class IPMatcherTest {
         assertFalse(ipMatcher.match("192.1.2.2"));
     }
 
-
-    private ArrayList<String> getAllIp4Except(ArrayList<String> exceptions) {
+    // Commented out as this is currently not used in tests
+    /*private ArrayList<String> getAllIp4Except(ArrayList<String> exceptions) {
         int d1 = 0;
         int d2 = 0;
         int d3 = 0;
@@ -284,7 +284,7 @@ public class IPMatcherTest {
             }
         }
         return ips;
-    }
+    }*/
 
     private void verifyAllIp4Except(ArrayList<String> exceptions, boolean asserted, IPMatcher ipMatcher)
         throws IPMatcherException {

--- a/dspace-api/src/test/java/org/dspace/authorize/AuthorizeServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/authorize/AuthorizeServiceTest.java
@@ -90,8 +90,7 @@ public class AuthorizeServiceTest extends AbstractUnitTest {
     @Test
     public void testauthorizeMethodRespectSpecialGroups() {
 
-        EPerson eperson1;
-        EPerson eperson2;
+        EPerson eperson;
         Group group1;
 
         Community dso;
@@ -99,7 +98,7 @@ public class AuthorizeServiceTest extends AbstractUnitTest {
             context.turnOffAuthorisationSystem();
 
             // create an eperson and a group
-            eperson1 = ePersonService.create(context);
+            eperson = ePersonService.create(context);
             group1 = groupService.create(context);
             // A group has to have a name, otherwise there are queries that break
             groupService.setName(group1, "My test group 2");
@@ -111,19 +110,19 @@ public class AuthorizeServiceTest extends AbstractUnitTest {
             // special group to the user. Then test if the action on the DSO
             // is allowed for the user
             authorizeService.addPolicy(context, dso, Constants.ADD, group1);
-            context.setCurrentUser(eperson1);
+            context.setCurrentUser(eperson);
             context.setSpecialGroup(group1.getID());
             context.commit();
         } catch (SQLException | AuthorizeException ex) {
-            throw new RuntimeException(ex);
+            throw new AssertionError(ex);
         } finally {
             context.restoreAuthSystemState();
         }
 
         try {
-            Assert.assertTrue(authorizeService.authorizeActionBoolean(context, eperson1, dso, Constants.ADD, true));
+            Assert.assertTrue(authorizeService.authorizeActionBoolean(context, eperson, dso, Constants.ADD, true));
         } catch (SQLException ex) {
-            throw new RuntimeException(ex);
+            throw new AssertionError(ex);
         }
     }
 }

--- a/dspace-api/src/test/java/org/dspace/content/BitstreamFormatTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/BitstreamFormatTest.java
@@ -232,7 +232,7 @@ public class BitstreamFormatTest extends AbstractUnitTest {
         // Disalow full Admin perms
         when(authorizeServiceSpy.isAdmin(context)).thenReturn(false);
 
-        BitstreamFormat found = bitstreamFormatService.create(context);
+        bitstreamFormatService.create(context);
         fail("Exception should have been thrown");
     }
 

--- a/dspace-api/src/test/java/org/dspace/content/BundleTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/BundleTest.java
@@ -363,7 +363,7 @@ public class BundleTest extends AbstractDSpaceObjectTest {
         doThrow(new AuthorizeException()).when(authorizeServiceSpy).authorizeAction(context, b, Constants.ADD);
 
         File f = new File(testProps.get("test.bitstream").toString());
-        Bitstream bs = bitstreamService.create(context, b, new FileInputStream(f));
+        bitstreamService.create(context, b, new FileInputStream(f));
         fail("Exception should be thrown");
     }
 
@@ -399,7 +399,7 @@ public class BundleTest extends AbstractDSpaceObjectTest {
 
         int assetstore = 0; //default assetstore
         File f = new File(testProps.get("test.bitstream").toString());
-        Bitstream bs = bitstreamService.register(context, b, assetstore, f.getAbsolutePath());
+        bitstreamService.register(context, b, assetstore, f.getAbsolutePath());
         fail("Exception should be thrown");
     }
 

--- a/dspace-api/src/test/java/org/dspace/content/CollectionTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/CollectionTest.java
@@ -196,7 +196,7 @@ public class CollectionTest extends AbstractDSpaceObjectTest {
 
         // test creating collection with a specified handle which IS already in use
         // This should throw an exception
-        Collection created = collectionService.create(context, owningCommunity, inUseHandle);
+        collectionService.create(context, owningCommunity, inUseHandle);
         fail("Exception expected");
     }
 
@@ -291,7 +291,6 @@ public class CollectionTest extends AbstractDSpaceObjectTest {
         String itext = "introductory text";
         String copy = "copyright declaration";
         String sidebar = "side bar text";
-        String tempItem = "3";
         String provDesc = "provenance description";
         String license = "license text";
 
@@ -370,7 +369,7 @@ public class CollectionTest extends AbstractDSpaceObjectTest {
     @Test(expected = AuthorizeException.class)
     public void testSetLogoNoAuth() throws Exception {
         File f = new File(testProps.get("test.bitstream").toString());
-        Bitstream logo = collectionService.setLogo(context, collection, new FileInputStream(f));
+        collectionService.setLogo(context, collection, new FileInputStream(f));
         fail("Exception expected");
     }
 
@@ -393,7 +392,7 @@ public class CollectionTest extends AbstractDSpaceObjectTest {
     @Test(expected = AuthorizeException.class)
     public void testCreateWorkflowGroupNoAuth() throws Exception {
         int step = 1;
-        Group result = collectionService.createWorkflowGroup(context, collection, step);
+        collectionService.createWorkflowGroup(context, collection, step);
         fail("Exception expected");
     }
 
@@ -461,7 +460,7 @@ public class CollectionTest extends AbstractDSpaceObjectTest {
      */
     @Test(expected = AuthorizeException.class)
     public void testCreateSubmittersNoAuth() throws Exception {
-        Group result = collectionService.createSubmitters(context, collection);
+        collectionService.createSubmitters(context, collection);
         fail("Exception expected");
     }
 
@@ -511,7 +510,7 @@ public class CollectionTest extends AbstractDSpaceObjectTest {
      */
     @Test(expected = AuthorizeException.class)
     public void testCreateAdministratorsNoAuth() throws Exception {
-        Group result = collectionService.createAdministrators(context, collection);
+        collectionService.createAdministrators(context, collection);
         fail("Exception expected");
     }
 

--- a/dspace-api/src/test/java/org/dspace/content/CommunityTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/CommunityTest.java
@@ -195,7 +195,7 @@ public class CommunityTest extends AbstractDSpaceObjectTest {
 
         // test creating community with no parent (as a non-admin)
         // this should throw an exception
-        Community created = communityService.create(null, context);
+        communityService.create(null, context);
         fail("Exception expected");
     }
 
@@ -230,7 +230,7 @@ public class CommunityTest extends AbstractDSpaceObjectTest {
 
         // test creating community with a specified handle which IS already in use
         // This should throw an exception
-        Community created = communityService.create(null, context, inUseHandle);
+        communityService.create(null, context, inUseHandle);
         fail("Exception expected");
     }
 
@@ -378,7 +378,7 @@ public class CommunityTest extends AbstractDSpaceObjectTest {
         doThrow(new AuthorizeException()).when(authorizeServiceSpy).authorizeAction(context, c, Constants.WRITE);
 
         File f = new File(testProps.get("test.bitstream").toString());
-        Bitstream logo = communityService.setLogo(context, c, new FileInputStream(f));
+        communityService.setLogo(context, c, new FileInputStream(f));
         fail("Exception expected");
     }
 
@@ -425,7 +425,7 @@ public class CommunityTest extends AbstractDSpaceObjectTest {
      */
     @Test(expected = AuthorizeException.class)
     public void testCreateAdministratorsNoAuth() throws Exception {
-        Group result = communityService.createAdministrators(context, c);
+        communityService.createAdministrators(context, c);
         fail("Exception should have been thrown");
     }
 
@@ -617,7 +617,7 @@ public class CommunityTest extends AbstractDSpaceObjectTest {
         // Disallow current Community ADD perms
         doThrow(new AuthorizeException()).when(authorizeServiceSpy).authorizeAction(context, c, Constants.ADD);
 
-        Collection result = collectionService.create(context, c);
+        collectionService.create(context, c);
         fail("Exception expected");
     }
 
@@ -672,7 +672,7 @@ public class CommunityTest extends AbstractDSpaceObjectTest {
         // Disallow current Community ADD perms
         doThrow(new AuthorizeException()).when(authorizeServiceSpy).authorizeAction(context, c, Constants.ADD);
 
-        Community result = communityService.createSubcommunity(context, c);
+        communityService.createSubcommunity(context, c);
         fail("Exception expected");
     }
 
@@ -872,8 +872,9 @@ public class CommunityTest extends AbstractDSpaceObjectTest {
         Collection grandchildCol = collectionService.create(context, grandchild);
         // Create two separate items
         WorkspaceItem wsItem = workspaceItemService.create(context, childCol, false);
-        wsItem = workspaceItemService.create(context, childCol, false);
         Item item = installItemService.installItem(context, wsItem);
+        wsItem = workspaceItemService.create(context, grandchildCol, false);
+        Item item2 = installItemService.installItem(context, wsItem);
 
         // Done creating the objects. Turn auth system back on
         context.restoreAuthSystemState();
@@ -885,6 +886,7 @@ public class CommunityTest extends AbstractDSpaceObjectTest {
         UUID childColId = childCol.getID();
         UUID grandchildColId = grandchildCol.getID();
         UUID itemId = item.getID();
+        UUID item2Id = item2.getID();
 
         // Delete the parent of this entire hierarchy
         communityService.delete(context, parent);
@@ -902,6 +904,8 @@ public class CommunityTest extends AbstractDSpaceObjectTest {
                    collectionService.find(context, grandchildColId), nullValue());
         assertThat("Item not deleted",
                    itemService.find(context, itemId), nullValue());
+        assertThat("Item not deleted",
+                   itemService.find(context, item2Id), nullValue());
     }
 
     /**
@@ -1030,7 +1034,7 @@ public class CommunityTest extends AbstractDSpaceObjectTest {
             assertThat("testGetParentObject 1", communityService.getParentObject(context, son), notNullValue());
             assertThat("testGetParentObject 2", (Community) communityService.getParentObject(context, son), equalTo(c));
         } catch (AuthorizeException ex) {
-            fail("Authorize exception catched");
+            throw new AssertionError("AuthorizeException occurred", ex);
         }
     }
 

--- a/dspace-api/src/test/java/org/dspace/content/DCDateTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/DCDateTest.java
@@ -19,7 +19,6 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 import org.apache.commons.lang3.time.DateUtils;
-import org.apache.logging.log4j.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/dspace-api/src/test/java/org/dspace/content/DCDateTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/DCDateTest.java
@@ -29,11 +29,6 @@ import org.junit.Test;
  */
 public class DCDateTest {
     /**
-     * log4j category
-     */
-    private static Logger log = org.apache.logging.log4j.LogManager.getLogger(DCDateTest.class);
-
-    /**
      * Object to use in the tests
      */
     private DCDate dc;

--- a/dspace-api/src/test/java/org/dspace/content/EntityServiceImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/EntityServiceImplTest.java
@@ -8,7 +8,7 @@
 package org.dspace.content;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/dspace-api/src/test/java/org/dspace/content/EntityServiceImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/EntityServiceImplTest.java
@@ -13,11 +13,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
 
-import org.dspace.content.dao.RelationshipTypeDAO;
 import org.dspace.content.service.EntityTypeService;
 import org.dspace.content.service.ItemService;
 import org.dspace.content.service.RelationshipService;
@@ -60,10 +58,8 @@ public class EntityServiceImplTest  {
     public void testfindByItemId() throws Exception {
         // Declare objects utilized in unit test
         Item item = mock(Item.class);
-        List<Relationship> relationshipList = new ArrayList<>();
         Relationship relationship = mock(Relationship.class);
         relationship.setId(9);
-        relationshipList.add(relationship);
 
         // Mock the state of objects utilized in findByItemId() to meet the success criteria of an invocation
         when(itemService.find(any(), any())).thenReturn(item);
@@ -79,10 +75,6 @@ public class EntityServiceImplTest  {
         // Declare objects utilized in unit test
         Entity entity = mock(Entity.class);
         EntityTypeService entityTypeService = mock(EntityTypeService.class);
-        Item item = mock(Item.class);
-        List<MetadataValue> list = new ArrayList<>();
-        MetadataValue metadataValue = mock(MetadataValue.class);
-        list.add(metadataValue);
         EntityType entityType = entityTypeService.findByEntityType(context, "testType");
 
         // The returned EntityType should equal our defined entityType case
@@ -151,11 +143,7 @@ public class EntityServiceImplTest  {
     @Test
     public void testGetAllRelationshipTypes() throws Exception {
         // Declare objects utilized for this test
-        List<MetadataValue> list = new ArrayList<>();
-        MetadataValue metadataValue = mock(MetadataValue.class);
-        list.add(metadataValue);
         Item item = mock(Item.class);
-        RelationshipTypeDAO relationshipTypeDAO = mock(RelationshipTypeDAO.class);
         Entity entity = mock(Entity.class);
         RelationshipType relationshipType = mock(RelationshipType.class);
         relationshipType.setLeftType(leftType);
@@ -185,7 +173,7 @@ public class EntityServiceImplTest  {
         RelationshipType relationshipType = mock(RelationshipType.class);
 
         // Currently this unit test will only test one case with one relationshipType
-        List<RelationshipType> relationshipTypeList = new LinkedList<>();
+        List<RelationshipType> relationshipTypeList = new ArrayList<>();
         relationshipTypeList.add(relationshipType);
         List<MetadataValue> metsList = new ArrayList<>();
         MetadataValue metadataValue = mock(MetadataValue.class);
@@ -213,7 +201,7 @@ public class EntityServiceImplTest  {
         RelationshipType relationshipType = mock(RelationshipType.class);
 
         // Currently this unit test will only test one case with one relationshipType
-        List<RelationshipType> relationshipTypeList = new LinkedList<>();
+        List<RelationshipType> relationshipTypeList = new ArrayList<>();
         relationshipTypeList.add(relationshipType);
         List<MetadataValue> metsList = new ArrayList<>();
         MetadataValue metadataValue = mock(MetadataValue.class);
@@ -236,7 +224,7 @@ public class EntityServiceImplTest  {
     @Test
     public void testGetRelationshipTypesByTypeName() throws Exception {
         // Declare objects utilized in unit test
-        List<RelationshipType> list = new LinkedList<>();
+        List<RelationshipType> list = new ArrayList<>();
         RelationshipType relationshipType = mock(RelationshipType.class);
         list.add(relationshipType);
 

--- a/dspace-api/src/test/java/org/dspace/content/EntityTypeServiceImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/EntityTypeServiceImplTest.java
@@ -8,7 +8,7 @@
 package org.dspace.content;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 

--- a/dspace-api/src/test/java/org/dspace/content/FormatIdentifierTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/FormatIdentifierTest.java
@@ -14,7 +14,6 @@ import static org.junit.Assert.assertThat;
 import java.io.File;
 import java.io.FileInputStream;
 
-import org.apache.logging.log4j.Logger;
 import org.dspace.AbstractUnitTest;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.BitstreamFormatService;
@@ -29,11 +28,6 @@ import org.junit.Test;
  * @author pvillega
  */
 public class FormatIdentifierTest extends AbstractUnitTest {
-
-    /**
-     * log4j category
-     */
-    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(FormatIdentifierTest.class);
 
     protected BitstreamService bitstreamService = ContentServiceFactory.getInstance().getBitstreamService();
     protected BitstreamFormatService bitstreamFormatService = ContentServiceFactory.getInstance()
@@ -71,8 +65,8 @@ public class FormatIdentifierTest extends AbstractUnitTest {
     @Test
     public void testGuessFormat() throws Exception {
         File f = new File(testProps.get("test.bitstream").toString());
-        Bitstream bs = null;
-        BitstreamFormat result = null;
+        Bitstream bs;
+        BitstreamFormat result;
         BitstreamFormat pdf = bitstreamFormatService.findByShortDescription(context, "Adobe PDF");
 
         //test null filename

--- a/dspace-api/src/test/java/org/dspace/content/ITCommunityCollection.java
+++ b/dspace-api/src/test/java/org/dspace/content/ITCommunityCollection.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.UUID;
 
-import org.apache.logging.log4j.Logger;
 import org.dspace.AbstractIntegrationTest;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.factory.ContentServiceFactory;
@@ -48,11 +47,6 @@ import org.junit.Test;
  * @author tdonohue
  */
 public class ITCommunityCollection extends AbstractIntegrationTest {
-    /**
-     * log4j category
-     */
-    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ITCommunityCollection.class);
-
     protected CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
     protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
     protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();
@@ -107,8 +101,8 @@ public class ITCommunityCollection extends AbstractIntegrationTest {
         //verify it works as expected
         assertThat("testCreateTree 0", parent.getParentCommunities().size(), is(0));
         assertThat("testCreateTree 1", child1.getParentCommunities().get(0), equalTo(parent));
-        assertThat("testCreateTree 2", (Community) collectionService.getParentObject(context, col1), equalTo(child1));
-        assertThat("testCreateTree 3", (Community) collectionService.getParentObject(context, col2), equalTo(child1));
+        assertThat("testCreateTree 2", collectionService.getParentObject(context, col1), equalTo(child1));
+        assertThat("testCreateTree 3", collectionService.getParentObject(context, col2), equalTo(child1));
 
         context.turnOffAuthorisationSystem();
         communityService.delete(context, parent);
@@ -133,8 +127,8 @@ public class ITCommunityCollection extends AbstractIntegrationTest {
         context.restoreAuthSystemState();
 
         //verify it works as expected
-        assertThat("testCreateItems 0", (Collection) itemService.getParentObject(context, item1), equalTo(col1));
-        assertThat("testCreateItems 1", (Collection) itemService.getParentObject(context, item2), equalTo(col2));
+        assertThat("testCreateItems 0", itemService.getParentObject(context, item1), equalTo(col1));
+        assertThat("testCreateItems 1", itemService.getParentObject(context, item2), equalTo(col2));
 
         context.turnOffAuthorisationSystem();
         communityService.delete(context, parent);
@@ -158,8 +152,8 @@ public class ITCommunityCollection extends AbstractIntegrationTest {
 
         // Add same number of items to each collection
         for (int count = 0; count < items_per_collection; count++) {
-            Item item1 = installItemService.installItem(context, workspaceItemService.create(context, col1, false));
-            Item item2 = installItemService.installItem(context, workspaceItemService.create(context, col2, false));
+            installItemService.installItem(context, workspaceItemService.create(context, col1, false));
+            installItemService.installItem(context, workspaceItemService.create(context, col2, false));
         }
 
         // Finally, let's throw in a small wrench and add a mapped item
@@ -229,7 +223,6 @@ public class ITCommunityCollection extends AbstractIntegrationTest {
         context.setCurrentUser(commAdmin);
 
         // Test deletion of single Bitstream as a Community Admin (delete just flags as deleted)
-        UUID bitstreamId = bitstream.getID();
         bitstreamService.delete(context, bitstream);
         assertTrue("Community Admin unable to flag Bitstream as deleted",
                    bitstream.isDeleted());
@@ -312,7 +305,6 @@ public class ITCommunityCollection extends AbstractIntegrationTest {
         context.setCurrentUser(collAdmin);
 
         // Test deletion of single Bitstream as a Collection Admin (delete just flags as deleted)
-        UUID bitstreamId = bitstream2.getID();
         bitstreamService.delete(context, bitstream2);
         assertTrue("Collection Admin unable to flag Bitstream as deleted",
                    bitstream2.isDeleted());
@@ -327,7 +319,6 @@ public class ITCommunityCollection extends AbstractIntegrationTest {
         // Test deletion of single Item as a Collection Admin
         UUID itemId = item.getID();
         bundleId = bundle.getID();
-        bitstreamId = bitstream.getID();
         itemService.delete(context, item);
         assertThat("Collection Admin unable to delete sub-Item",
                    itemService.find(context, itemId), nullValue());

--- a/dspace-api/src/test/java/org/dspace/content/ITMetadata.java
+++ b/dspace-api/src/test/java/org/dspace/content/ITMetadata.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
 
-import org.apache.logging.log4j.Logger;
 import org.dspace.AbstractIntegrationTest;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.factory.ContentServiceFactory;
@@ -37,11 +36,6 @@ import org.junit.Test;
  * @author pvillega
  */
 public class ITMetadata extends AbstractIntegrationTest {
-    /**
-     * log4j category
-     */
-    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ITMetadata.class);
-
 
     protected CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
     protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();

--- a/dspace-api/src/test/java/org/dspace/content/InProgressSubmissionTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/InProgressSubmissionTest.java
@@ -7,7 +7,6 @@
  */
 package org.dspace.content;
 
-import org.apache.logging.log4j.Logger;
 import org.dspace.AbstractUnitTest;
 import org.junit.After;
 import org.junit.Before;
@@ -22,11 +21,6 @@ import org.junit.Test;
  * @author pvillega
  */
 public class InProgressSubmissionTest extends AbstractUnitTest {
-
-    /**
-     * log4j category
-     */
-    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(InProgressSubmissionTest.class);
 
     /**
      * This method will be run before every test as per @Before. It will

--- a/dspace-api/src/test/java/org/dspace/content/ItemComparatorTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemComparatorTest.java
@@ -132,8 +132,8 @@ public class ItemComparatorTest extends AbstractUnitTest {
      */
     @Test
     public void testCompare() throws SQLException {
-        int result = 0;
-        ItemComparator ic = null;
+        int result;
+        ItemComparator ic;
 
         //one of the tiems has no value
         ic = new ItemComparator("test", "one", Item.ANY, true);
@@ -246,7 +246,7 @@ public class ItemComparatorTest extends AbstractUnitTest {
     @SuppressWarnings( {"ObjectEqualsNull", "IncompatibleEquals"})
     public void testEquals() {
         ItemComparator ic = new ItemComparator("test", "one", Item.ANY, true);
-        ItemComparator target = null;
+        ItemComparator target;
 
         assertFalse("testEquals 0", ic.equals(null));
         assertFalse("testEquals 1", ic.equals("test one"));

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -41,7 +41,6 @@ import org.dspace.authorize.factory.AuthorizeServiceFactory;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.BitstreamFormatService;
-import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.MetadataFieldService;
 import org.dspace.content.service.MetadataSchemaService;
 import org.dspace.core.Constants;
@@ -75,8 +74,6 @@ public class ItemTest extends AbstractDSpaceObjectTest {
     private BitstreamFormatService bitstreamFormatService = ContentServiceFactory.getInstance()
                                                                                  .getBitstreamFormatService();
     private MetadataFieldService metadataFieldService = ContentServiceFactory.getInstance().getMetadataFieldService();
-
-    private CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
 
     private Collection collection;
     private Community owningCommunity;
@@ -839,7 +836,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
     @Test(expected = AuthorizeException.class)
     public void testCreateBundleNoAuth() throws Exception {
         String name = "bundle";
-        Bundle created = bundleService.create(context, it, name);
+        bundleService.create(context, it, name);
         fail("Exception expected");
     }
 
@@ -941,7 +938,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
     public void testCreateSingleBitstream_InputStream_StringNoAuth() throws Exception {
         String name = "new bundle";
         File f = new File(testProps.get("test.bitstream").toString());
-        Bitstream result = itemService.createSingleBitstream(context, new FileInputStream(f), it, name);
+        itemService.createSingleBitstream(context, new FileInputStream(f), it, name);
         fail("Exception expected");
     }
 
@@ -972,7 +969,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
     @Test(expected = AuthorizeException.class)
     public void testCreateSingleBitstream_InputStreamNoAuth() throws Exception {
         File f = new File(testProps.get("test.bitstream").toString());
-        Bitstream result = itemService.createSingleBitstream(context, new FileInputStream(f), it);
+        itemService.createSingleBitstream(context, new FileInputStream(f), it);
         fail("Expected exception");
     }
 
@@ -1624,7 +1621,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
             assertThat("testGetParentObject 1", itemService.getParentObject(context, it), notNullValue());
             assertThat("testGetParentObject 2", (Collection) itemService.getParentObject(context, it), equalTo(parent));
         } catch (AuthorizeException ex) {
-            fail("Authorize exception catched");
+            throw new AssertionError("Authorize Exception occurred", ex);
         }
     }
 

--- a/dspace-api/src/test/java/org/dspace/content/LicenseUtilsTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/LicenseUtilsTest.java
@@ -104,11 +104,11 @@ public class LicenseUtilsTest extends AbstractUnitTest {
     @Test
     public void testGetLicenseText_5args() throws SQLException, AuthorizeException, IOException {
         //parameters for the test
-        Locale locale = null;
-        Collection collection = null;
-        Item item = null;
-        EPerson person = null;
-        Map<String, Object> additionalInfo = null;
+        Locale locale;
+        Collection collection;
+        Item item;
+        EPerson person;
+        Map<String, Object> additionalInfo;
 
         // We don't test attribute 4 as this is the date, and the date often differs between when the test
         // is executed, and when the LicenceUtils code gets the current date/time which causes the test to fail
@@ -195,10 +195,10 @@ public class LicenseUtilsTest extends AbstractUnitTest {
     @Test
     public void testGetLicenseText_4args() throws SQLException, AuthorizeException, IOException {
         //parameters for the test
-        Locale locale = null;
-        Collection collection = null;
-        Item item = null;
-        EPerson person = null;
+        Locale locale;
+        Collection collection;
+        Item item;
+        EPerson person;
 
         String template = "Template license: %1$s %2$s %3$s %5$s %6$s";
         String templateResult = "Template license: first name last name testgetlicensetext_4args@email.com  ";

--- a/dspace-api/src/test/java/org/dspace/content/NonUniqueMetadataExceptionTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/NonUniqueMetadataExceptionTest.java
@@ -9,8 +9,6 @@ package org.dspace.content;
 
 import static org.junit.Assert.assertTrue;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.junit.Test;
 
 /**
@@ -20,12 +18,6 @@ import org.junit.Test;
  * @author pvillega
  */
 public class NonUniqueMetadataExceptionTest {
-
-    /**
-     * log4j category
-     */
-    private static final Logger log = LogManager
-            .getLogger(NonUniqueMetadataExceptionTest.class);
 
     /**
      * Dummy test to avoid initialization errors

--- a/dspace-api/src/test/java/org/dspace/content/RelationshipMetadataServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/RelationshipMetadataServiceTest.java
@@ -463,8 +463,8 @@ public class RelationshipMetadataServiceTest extends AbstractUnitTest {
         WorkspaceItem is = workspaceItemService.create(context, col, false);
         Item secondItem = installItemService.installItem(context, is);
         itemService.addMetadata(context, secondItem, "relationship", "type", null, null, "Publication");
-        Relationship secondRelationship = relationshipService.create(context, secondItem, rightItem,
-                                                                     isAuthorOfPublicationRelationshipType, 0, 0);
+        relationshipService.create(context, secondItem, rightItem,
+                                   isAuthorOfPublicationRelationshipType, 0, 0);
         context.restoreAuthSystemState();
 
         assertThat(relationshipService.findNextRightPlaceByRightItem(context, rightItem), equalTo(2));
@@ -489,8 +489,8 @@ public class RelationshipMetadataServiceTest extends AbstractUnitTest {
         itemService.addMetadata(context, secondAuthor, "relationship", "type", null, null, "Author");
         itemService.addMetadata(context, secondAuthor, "person", "familyName", null, null, "familyName");
         itemService.addMetadata(context, secondAuthor, "person", "givenName", null, null, "firstName");
-        Relationship secondRelationship = relationshipService.create(context, leftItem, secondAuthor,
-                                                                     isAuthorOfPublicationRelationshipType, 0, 0);
+        relationshipService.create(context, leftItem, secondAuthor,
+                                   isAuthorOfPublicationRelationshipType, 0, 0);
         context.restoreAuthSystemState();
 
         assertThat(relationshipService.findNextLeftPlaceByLeftItem(context, leftItem), equalTo(2));

--- a/dspace-api/src/test/java/org/dspace/content/RelationshipServiceImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/RelationshipServiceImplTest.java
@@ -8,7 +8,7 @@
 package org.dspace.content;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/dspace-api/src/test/java/org/dspace/content/RelationshipServiceImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/RelationshipServiceImplTest.java
@@ -230,7 +230,6 @@ public class RelationshipServiceImplTest {
     public void testDelete() throws Exception {
 
         // Declare objects utilized in unit test
-        MetadataValue metVal = mock(MetadataValue.class);
         List<Relationship> leftTypelist = new ArrayList<>();
         List<Relationship> rightTypelist = new ArrayList<>();
         Item leftItem = mock(Item.class);

--- a/dspace-api/src/test/java/org/dspace/content/RelationshipServiceImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/RelationshipServiceImplTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 
 import org.dspace.authorize.service.AuthorizeService;
@@ -137,7 +136,7 @@ public class RelationshipServiceImplTest {
     @Test
     public void testFindByItemAndRelationshipType() throws Exception {
         // Declare objects utilized in unit test
-        List<Relationship> relList = new LinkedList<>();
+        List<Relationship> relList = new ArrayList<>();
         Item item = mock(Item.class);
         RelationshipType testRel = new RelationshipType();
 
@@ -152,7 +151,7 @@ public class RelationshipServiceImplTest {
     @Test
     public void testFindByRelationshipType() throws Exception {
         // Declare objects utilized in unit test
-        List<Relationship> relList = new LinkedList<>();
+        List<Relationship> relList = new ArrayList<>();
         RelationshipType testRel = new RelationshipType();
 
         // The Relationship(s) reported should match our our relList
@@ -232,7 +231,6 @@ public class RelationshipServiceImplTest {
 
         // Declare objects utilized in unit test
         MetadataValue metVal = mock(MetadataValue.class);
-        List<MetadataValue> metsList = new ArrayList<>();
         List<Relationship> leftTypelist = new ArrayList<>();
         List<Relationship> rightTypelist = new ArrayList<>();
         Item leftItem = mock(Item.class);
@@ -246,7 +244,6 @@ public class RelationshipServiceImplTest {
         testRel.setRightwardType("Entitylabel");
         testRel.setLeftMinCardinality(0);
         testRel.setRightMinCardinality(0);
-        metsList.add(metVal);
         relationship = getRelationship(leftItem, rightItem, testRel, 0,0);
         leftTypelist.add(relationship);
         rightTypelist.add(relationship);

--- a/dspace-api/src/test/java/org/dspace/content/RelationshipTypeTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/RelationshipTypeTest.java
@@ -10,7 +10,7 @@ package org.dspace.content;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/dspace-api/src/test/java/org/dspace/content/RelationshipTypeTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/RelationshipTypeTest.java
@@ -14,11 +14,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import org.apache.logging.log4j.Logger;
 import org.dspace.content.dao.RelationshipTypeDAO;
 import org.dspace.core.Context;
 import org.junit.Before;
@@ -30,9 +29,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RelationshipTypeTest {
-
-    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(RelationshipTypeTest.class);
-
     @InjectMocks
     private RelationshipTypeServiceImpl relationshipTypeService;
 
@@ -102,7 +98,7 @@ public class RelationshipTypeTest {
     @Test
     public void testRelationshipTypeFindAll() throws Exception {
         // Declare objects utilized for this test
-        List<RelationshipType> mockedList = new LinkedList<>();
+        List<RelationshipType> mockedList = new ArrayList<>();
         mockedList.add(firstRelationshipType);
         mockedList.add(secondRelationshipType);
 
@@ -120,7 +116,7 @@ public class RelationshipTypeTest {
     @Test
     public void testRelationshipTypeFindByLeftOrRightwardType() throws Exception {
         // Declare objects utilized for this test
-        List<RelationshipType> mockedList = new LinkedList<>();
+        List<RelationshipType> mockedList = new ArrayList<>();
         mockedList.add(firstRelationshipType);
 
         // Mock DAO to return our mockedList
@@ -138,7 +134,7 @@ public class RelationshipTypeTest {
     @Test
     public void testRelationshipTypefindByEntityType() throws Exception {
         // Declare objects utilized for this test
-        List<RelationshipType> mockedList = new LinkedList<>();
+        List<RelationshipType> mockedList = new ArrayList<>();
         mockedList.add(firstRelationshipType);
 
         // Mock DAO to return our mockedList

--- a/dspace-api/src/test/java/org/dspace/content/SiteTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/SiteTest.java
@@ -58,7 +58,7 @@ public class SiteTest extends AbstractUnitTest {
         try {
             //we have to create a new community in the database
             context.turnOffAuthorisationSystem();
-            this.s = (Site) siteService.findSite(context);
+            this.s = siteService.findSite(context);
             //we need to commit the changes so we don't block the table for testing
             context.restoreAuthSystemState();
         } catch (SQLException ex) {
@@ -120,8 +120,7 @@ public class SiteTest extends AbstractUnitTest {
      */
     @Test
     public void testSiteFind() throws Exception {
-        int id = 0;
-        Site found = (Site) siteService.findSite(context);
+        Site found = siteService.findSite(context);
         assertThat("testSiteFind 0", found, notNullValue());
         assertThat("testSiteFind 1", found, equalTo(s));
     }

--- a/dspace-api/src/test/java/org/dspace/content/ThumbnailTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ThumbnailTest.java
@@ -49,11 +49,6 @@ public class ThumbnailTest extends AbstractUnitTest {
     private Bitstream orig;
 
     /**
-     * Thumbnail instance for the tests, original copy
-     */
-    private Thumbnail t;
-
-    /**
      * This method will be run before every test as per @Before. It will
      * initialize resources required for the tests.
      *
@@ -69,7 +64,7 @@ public class ThumbnailTest extends AbstractUnitTest {
             File f = new File(testProps.get("test.bitstream").toString());
             thumb = bitstreamService.create(context, new FileInputStream(f));
             orig = bitstreamService.create(context, new FileInputStream(f));
-            t = new Thumbnail(thumb, orig);
+            Thumbnail t = new Thumbnail(thumb, orig);
         } catch (IOException ex) {
             log.error("IO Error in init", ex);
             fail("SQL Error in init: " + ex.getMessage());
@@ -91,7 +86,6 @@ public class ThumbnailTest extends AbstractUnitTest {
     public void destroy() {
         thumb = null;
         orig = null;
-        t = null;
         super.destroy();
     }
 

--- a/dspace-api/src/test/java/org/dspace/content/ThumbnailTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ThumbnailTest.java
@@ -88,8 +88,10 @@ public class ThumbnailTest extends AbstractUnitTest {
     @Override
     public void destroy() {
         try {
+            context.turnOffAuthorisationSystem();
             bitstreamService.delete(context, thumb);
             bitstreamService.delete(context, orig);
+            context.restoreAuthSystemState();
             thumb = null;
             orig = null;
         } catch (Exception e) {

--- a/dspace-api/src/test/java/org/dspace/content/ThumbnailTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ThumbnailTest.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.content;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -65,6 +66,8 @@ public class ThumbnailTest extends AbstractUnitTest {
             thumb = bitstreamService.create(context, new FileInputStream(f));
             orig = bitstreamService.create(context, new FileInputStream(f));
             Thumbnail t = new Thumbnail(thumb, orig);
+            assertEquals(orig, t.getOriginal());
+            assertEquals(thumb, t.getThumb());
         } catch (IOException ex) {
             log.error("IO Error in init", ex);
             fail("SQL Error in init: " + ex.getMessage());
@@ -84,8 +87,14 @@ public class ThumbnailTest extends AbstractUnitTest {
     @After
     @Override
     public void destroy() {
-        thumb = null;
-        orig = null;
+        try {
+            bitstreamService.delete(context, thumb);
+            bitstreamService.delete(context, orig);
+            thumb = null;
+            orig = null;
+        } catch (Exception e) {
+            throw new AssertionError("Error in destroy()", e);
+        }
         super.destroy();
     }
 

--- a/dspace-api/src/test/java/org/dspace/content/VersioningTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/VersioningTest.java
@@ -25,7 +25,6 @@ import org.dspace.content.service.CommunityService;
 import org.dspace.content.service.InstallItemService;
 import org.dspace.content.service.ItemService;
 import org.dspace.content.service.WorkspaceItemService;
-import org.dspace.core.ConfigurationManager;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
 import org.dspace.versioning.Version;
@@ -49,7 +48,6 @@ public class VersioningTest extends AbstractUnitTest {
 
     private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(VersioningTest.class);
 
-    private String originalHandle;
     private Item originalItem;
     private Item versionedItem;
     private String summary = "Unit test version";
@@ -65,7 +63,7 @@ public class VersioningTest extends AbstractUnitTest {
 
     //A regex that can be used to see if a handle contains the format of handle created by the org.dspace.identifier
     // .VersionedHandleIdentifierProvider*
-    protected String versionedHandleRegex = ConfigurationManager.getProperty("handle.prefix") + "\\/[0-9]*\\.[0-9]";
+    //protected String versionedHandleRegex = ConfigurationManager.getProperty("handle.prefix") + "\\/[0-9]*\\.[0-9]";
 
     /**
      * This method will be run before every test as per @Before. It will
@@ -86,7 +84,6 @@ public class VersioningTest extends AbstractUnitTest {
             WorkspaceItem is = workspaceItemService.create(context, col, false);
 
             originalItem = installItemService.installItem(context, is);
-            originalHandle = originalItem.getHandle();
 
             Version version = versionService.createNewVersion(context, originalItem, summary);
             WorkspaceItem wsi = workspaceItemService.findByItem(context, version.getItem());

--- a/dspace-api/src/test/java/org/dspace/content/WorkspaceItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/WorkspaceItemTest.java
@@ -160,8 +160,8 @@ public class WorkspaceItemTest extends AbstractUnitTest {
         // Allow Collection ADD perms
         doNothing().when(authorizeServiceSpy).authorizeAction(context, collection, Constants.ADD);
 
-        boolean template = false;
-        WorkspaceItem created = null;
+        boolean template;
+        WorkspaceItem created;
 
         template = false;
         created = workspaceItemService.create(context, collection, template);

--- a/dspace-api/src/test/java/org/dspace/content/packager/ITDSpaceAIP.java
+++ b/dspace-api/src/test/java/org/dspace/content/packager/ITDSpaceAIP.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 
+import com.google.common.base.Splitter;
 import org.apache.logging.log4j.Logger;
 import org.dspace.AbstractIntegrationTest;
 import org.dspace.authorize.AuthorizeException;
@@ -1194,9 +1195,9 @@ public class ITDSpaceAIP extends AbstractIntegrationTest {
 
             // Get the typeText & name of this object from the values
             String info = infoMap.get(key);
-            String[] values = info.split(valueseparator);
-            String typeText = values[0];
-            String name = values[1];
+            List<String> values = Splitter.on(valueseparator).splitToList(info);
+            String typeText = values.get(0);
+            String name = values.get(1);
 
             // Also assert type and name are correct
             assertEquals("assertObjectsExist object " + key + " type",

--- a/dspace-api/src/test/java/org/dspace/content/virtual/CollectedTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/virtual/CollectedTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.common.base.Splitter;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.service.ItemService;
@@ -85,18 +86,15 @@ public class CollectedTest {
         metadataValueList.add(metadataValue);
         String s = "dc.title";
         list.add(s);
-        String[] splittedString = s.split("\\.");
+        List<String> splittedString = Splitter.on('.').splitToList(s);
         collected.setFields(list);
         valueList.add("TestValue");
 
         // Mock the state of objects utilized in getValues() to meet the success criteria of an invocation
-        when(itemService.getMetadata(item, splittedString.length > 0 ? splittedString[0] :
-                        null,
-                splittedString.length > 1 ? splittedString[1] :
-                        null,
-                splittedString.length > 2 ? splittedString[2] :
-                        null,
-                Item.ANY, false)).thenReturn(metadataValueList);
+        when(itemService.getMetadata(item, splittedString.size() > 0 ? splittedString.get(0) : null,
+                                     splittedString.size() > 1 ? splittedString.get(1) : null,
+                                     splittedString.size() > 2 ? splittedString.get(2) : null,
+                                     Item.ANY, false)).thenReturn(metadataValueList);
         when(metadataValue.getValue()).thenReturn("TestValue");
 
         // The reported value(s) should match our valueList

--- a/dspace-api/src/test/java/org/dspace/content/virtual/ConcatenateTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/virtual/ConcatenateTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.common.base.Splitter;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.service.ItemService;
@@ -107,18 +108,15 @@ public class ConcatenateTest {
         metadataValueList.add(metadataValue);
         String s = "dc.title";
         list.add(s);
-        String[] splittedString = s.split("\\.");
+        List<String> splittedString = Splitter.on(".").splitToList(s);
         concatenate.setFields(list);
         valueList.add("TestValue");
 
         // Mock the state of objects utilized in getValues() to meet the success criteria of an invocation
-        when(itemService.getMetadata(item, splittedString.length > 0 ? splittedString[0] :
-                        null,
-                splittedString.length > 1 ? splittedString[1] :
-                        null,
-                splittedString.length > 2 ? splittedString[2] :
-                        null,
-                Item.ANY, false)).thenReturn(metadataValueList);
+        when(itemService.getMetadata(item, splittedString.size() > 0 ? splittedString.get(0) : null,
+                                     splittedString.size() > 1 ? splittedString.get(1) : null,
+                                     splittedString.size() > 2 ? splittedString.get(2) : null,
+                                     Item.ANY, false)).thenReturn(metadataValueList);
         when(metadataValue.getValue()).thenReturn("TestValue");
 
 

--- a/dspace-api/src/test/java/org/dspace/content/virtual/RelatedTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/virtual/RelatedTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
 
@@ -150,8 +149,8 @@ public class RelatedTest {
         assertEquals("TestGetValues 1", virtualMetadataConfiguration.getValues(context, item),
                 related.getValues(context, item));
         related.setPlace(2);
-        // No match should return empty LinkedList
-        assertEquals("TestGetValues 2", new LinkedList<>(), related.getValues(context, item));
+        // No match should return empty List
+        assertEquals("TestGetValues 2", new ArrayList<>(), related.getValues(context, item));
     }
 
 

--- a/dspace-api/src/test/java/org/dspace/content/virtual/UUIDValueTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/virtual/UUIDValueTest.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -28,7 +28,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class UUIDValueTest {
 
     @InjectMocks
-    private UUIDValue UUIDValue;
+    private UUIDValue uuidValue;
 
     @Mock
     private Context context;
@@ -36,32 +36,32 @@ public class UUIDValueTest {
     @Test
     public void testGetValues() throws Exception {
         // Setup objects utilized in unit test
-        List<String> list = new LinkedList<>();
+        List<String> list = new ArrayList<>();
         Item item = mock(Item.class);
         UUID uuid = UUID.randomUUID();
         when(item.getID()).thenReturn(uuid);
         list.add(String.valueOf(uuid));
 
         // The reported value(s) should match our defined list
-        assertEquals("TestGetValues 0", list, UUIDValue.getValues(context, item));
+        assertEquals("TestGetValues 0", list, uuidValue.getValues(context, item));
     }
 
     @Test
     public void testSetUseForPlace() {
         // Setup objects utilized in unit test
-        UUIDValue.setUseForPlace(true);
+        uuidValue.setUseForPlace(true);
 
         // The reported boolean should return true
-        assertEquals("TestSetUseForPlace 0", true, UUIDValue.getUseForPlace());
+        assertEquals("TestSetUseForPlace 0", true, uuidValue.getUseForPlace());
 
     }
 
     @Test
     public void testGetUseForPlace() {
         // Setup objects utilized in unit test
-        UUIDValue.setUseForPlace(true);
+        uuidValue.setUseForPlace(true);
 
         // The reported boolean should return true
-        assertEquals("TestGetUseForPlace 0", true, UUIDValue.getUseForPlace());
+        assertEquals("TestGetUseForPlace 0", true, uuidValue.getUseForPlace());
     }
 }

--- a/dspace-api/src/test/java/org/dspace/core/PathsClassLoaderTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/PathsClassLoaderTest.java
@@ -8,7 +8,7 @@
 package org.dspace.core;
 
 import static org.apache.bcel.Const.ACC_PUBLIC;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -136,12 +136,12 @@ public class PathsClassLoaderTest {
             jarFile.getCanonicalPath()};
         PathsClassLoader instance = new PathsClassLoader(parentCL, classpath);
         Class result = instance.findClass(className);
-        assertTrue("Should return a Class from file", result instanceof Class);
+        assertNotNull("Should return a Class from file", result);
 
         classpath[0] = jarFile.getCanonicalPath();
         instance = new PathsClassLoader(parentCL, classpath);
         result = instance.findClass(jarClassName);
-        assertTrue("Should return a Class from JAR", result instanceof Class);
+        assertNotNull("Should return a Class from JAR", result);
     }
 
 }

--- a/dspace-api/src/test/java/org/dspace/external/provider/impl/MockDataProvider.java
+++ b/dspace-api/src/test/java/org/dspace/external/provider/impl/MockDataProvider.java
@@ -8,8 +8,8 @@
 package org.dspace.external.provider.impl;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -28,10 +28,12 @@ public class MockDataProvider implements ExternalDataProvider {
      * Generic getter for the sourceIdentifier
      * @return the sourceIdentifier value of this MockDataProvider
      */
+    @Override
     public String getSourceIdentifier() {
         return sourceIdentifier;
     }
 
+    @Override
     public Optional<ExternalDataObject> getExternalDataObject(String id) {
         ExternalDataObject externalDataObject = mockLookupMap.get(id);
         if (externalDataObject == null) {
@@ -41,8 +43,9 @@ public class MockDataProvider implements ExternalDataProvider {
         }
     }
 
+    @Override
     public List<ExternalDataObject> searchExternalDataObjects(String query, int start, int limit) {
-        List<ExternalDataObject> listToReturn = new LinkedList<>();
+        List<ExternalDataObject> listToReturn = new ArrayList<>();
         for (Map.Entry<String, ExternalDataObject> entry : mockLookupMap.entrySet()) {
             if (StringUtils.containsIgnoreCase(entry.getKey(), query)) {
                 listToReturn.add(entry.getValue());
@@ -72,7 +75,7 @@ public class MockDataProvider implements ExternalDataProvider {
 
     public void init() throws IOException {
         mockLookupMap = new HashMap<>();
-        List<String> externalDataObjectsToMake = new LinkedList<>();
+        List<String> externalDataObjectsToMake = new ArrayList<>();
         externalDataObjectsToMake.add("one");
         externalDataObjectsToMake.add("two");
         externalDataObjectsToMake.add("three");
@@ -83,7 +86,7 @@ public class MockDataProvider implements ExternalDataProvider {
             externalDataObject.setId(id);
             externalDataObject.setValue(id);
             externalDataObject.setDisplayValue(id);
-            List<MetadataValueDTO> list = new LinkedList<>();
+            List<MetadataValueDTO> list = new ArrayList<>();
             list.add(new MetadataValueDTO("dc", "contributor", "author", null, "Donald, Smith"));
             externalDataObject.setMetadata(list);
 

--- a/dspace-api/src/test/java/org/dspace/handle/dao/impl/HandleDAOImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/handle/dao/impl/HandleDAOImplTest.java
@@ -128,12 +128,8 @@ public class HandleDAOImplTest extends AbstractUnitTest {
             owningCommunity = context.reloadEntity(owningCommunity);
             ContentServiceFactory.getInstance().getCommunityService().delete(context, owningCommunity);
             owningCommunity = null;
-        } catch (SQLException e) {
-            e.printStackTrace();
-        } catch (AuthorizeException e) {
-            e.printStackTrace();
-        } catch (IOException e) {
-            e.printStackTrace();
+        } catch (Exception e) {
+            throw new AssertionError("Error occurred in destroy()", e);
         }
         item1 = null;
         item2 = null;

--- a/dspace-api/src/test/java/org/dspace/scripts/DSpaceCommandLineParameterTest.java
+++ b/dspace-api/src/test/java/org/dspace/scripts/DSpaceCommandLineParameterTest.java
@@ -11,7 +11,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.dspace.AbstractUnitTest;
@@ -121,7 +121,7 @@ public class DSpaceCommandLineParameterTest extends AbstractUnitTest {
         String value3 = null;
         DSpaceCommandLineParameter dSpaceCommandLineParameter3 = new DSpaceCommandLineParameter(key3, value3);
 
-        List<DSpaceCommandLineParameter> dSpaceCommandLineParameterList = new LinkedList<>();
+        List<DSpaceCommandLineParameter> dSpaceCommandLineParameterList = new ArrayList<>();
         dSpaceCommandLineParameterList.add(dSpaceCommandLineParameter);
         dSpaceCommandLineParameterList.add(dSpaceCommandLineParameter1);
         dSpaceCommandLineParameterList.add(dSpaceCommandLineParameter2);

--- a/dspace-api/src/test/java/org/dspace/statistics/util/DummyHttpServletRequest.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/util/DummyHttpServletRequest.java
@@ -11,11 +11,11 @@ package org.dspace.statistics.util;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.security.Principal;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -114,7 +114,7 @@ public class DummyHttpServletRequest implements HttpServletRequest {
      * @param headerValue The value of the header
      */
     public void addHeader(String headerName, String headerValue) {
-        List<String> values = headers.computeIfAbsent(headerName, k -> new LinkedList<>());
+        List<String> values = headers.computeIfAbsent(headerName, k -> new ArrayList<>());
         values.add(headerValue);
     }
     /* (non-Javadoc)

--- a/dspace-api/src/test/java/org/dspace/statistics/util/DummyHttpServletRequest.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/util/DummyHttpServletRequest.java
@@ -292,6 +292,7 @@ public class DummyHttpServletRequest implements HttpServletRequest {
      * @see javax.servlet.http.HttpServletRequest#isRequestedSessionIdFromUrl()
      */
     @Override
+    @Deprecated
     public boolean isRequestedSessionIdFromUrl() {
         // TODO Auto-generated method stub
         return false;
@@ -502,6 +503,7 @@ public class DummyHttpServletRequest implements HttpServletRequest {
      * @see javax.servlet.ServletRequest#getRealPath(java.lang.String)
      */
     @Override
+    @Deprecated
     public String getRealPath(String arg0) {
         // TODO Auto-generated method stub
         return null;

--- a/dspace-api/src/test/java/org/dspace/workflowbasic/BasicWorkflowAuthorizationIT.java
+++ b/dspace-api/src/test/java/org/dspace/workflowbasic/BasicWorkflowAuthorizationIT.java
@@ -271,7 +271,7 @@ public class BasicWorkflowAuthorizationIT
             Item item = wsi.getItem();
             Bundle bundle = bundleService.create(context, item, "ORIGINAL");
             File f = new File(AbstractDSpaceTest.testProps.get("test.bitstream").toString());
-            Bitstream bs = bitstreamService.create(context, bundle, new FileInputStream(f));
+            bitstreamService.create(context, bundle, new FileInputStream(f));
             bundleService.update(context, bundle);
             itemService.update(context, item);
             workspaceItemService.update(context, wsi);
@@ -323,7 +323,7 @@ public class BasicWorkflowAuthorizationIT
             Item item = wsi.getItem();
             Bundle bundle = bundleService.create(context, item, "ORIGINAL");
             File f = new File(AbstractDSpaceTest.testProps.get("test.bitstream").toString());
-            Bitstream bs = bitstreamService.create(context, bundle, new FileInputStream(f));
+            bitstreamService.create(context, bundle, new FileInputStream(f));
             bundleService.update(context, bundle);
             itemService.update(context, item);
             workspaceItemService.update(context, wsi);
@@ -365,7 +365,7 @@ public class BasicWorkflowAuthorizationIT
             item.setSubmitter(submitter);
             Bundle bundle = bundleService.create(context, item, "ORIGINAL");
             File f = new File(AbstractDSpaceTest.testProps.get("test.bitstream").toString());
-            Bitstream bs = bitstreamService.create(context, bundle, new FileInputStream(f));
+            bitstreamService.create(context, bundle, new FileInputStream(f));
             bundleService.update(context, bundle);
             itemService.update(context, item);
             workspaceItemService.update(context, wsi);

--- a/dspace-api/src/test/java/org/dspace/xmlworkflow/RoleTest.java
+++ b/dspace-api/src/test/java/org/dspace/xmlworkflow/RoleTest.java
@@ -31,49 +31,48 @@ public class RoleTest extends AbstractUnitTest {
     @Test
     public void defaultWorkflow_RoleReviewer() {
         Role role = defaultWorkflow.getRoles().get("Reviewer");
-        assertEquals(role.getDescription(),
-                "The people responsible for this step are able to edit the metadata of incoming submissions, " +
-                        "and then accept or reject them.");
-        assertEquals(role.getName(), "Reviewer");
-        assertEquals(role.getScope(), Role.Scope.COLLECTION);
+        assertEquals("The people responsible for this step are able to edit the metadata of incoming submissions, " +
+                        "and then accept or reject them.", role.getDescription());
+        assertEquals("Reviewer", role.getName());
+        assertEquals(Role.Scope.COLLECTION, role.getScope());
     }
 
     @Test
     public void defaultWorkflow_RoleEditor() {
         Role role = defaultWorkflow.getRoles().get("Editor");
-        assertEquals(role.getDescription(), "The people responsible for this step are able to edit the " +
-                "metadata of incoming submissions, and then accept or reject them.");
-        assertEquals(role.getName(), "Editor");
-        assertEquals(role.getScope(), Role.Scope.COLLECTION);
+        assertEquals("The people responsible for this step are able to edit the " +
+                "metadata of incoming submissions, and then accept or reject them.", role.getDescription());
+        assertEquals("Editor", role.getName());
+        assertEquals(Role.Scope.COLLECTION, role.getScope());
     }
 
     @Test
     public void defaultWorkflow_RoleFinalEditor() {
         Role role = defaultWorkflow.getRoles().get("Final Editor");
-        assertEquals(role.getDescription(), "The people responsible for this step are able to edit the " +
-                "metadata of incoming submissions, but will not be able to reject them.");
-        assertEquals(role.getName(), "Final Editor");
-        assertEquals(role.getScope(), Role.Scope.COLLECTION);
+        assertEquals("The people responsible for this step are able to edit the " +
+                "metadata of incoming submissions, but will not be able to reject them.", role.getDescription());
+        assertEquals("Final Editor", role.getName());
+        assertEquals(Role.Scope.COLLECTION, role.getScope());
     }
 
     @Test
     public void selectSingleReviewer_RoleReviewManagers() {
         Role role = selectSingleReviewer.getRoles().get("ReviewManagers");
-        assertEquals(role.getName(), "ReviewManagers");
-        assertEquals(role.getScope(), Role.Scope.REPOSITORY);
+        assertEquals("ReviewManagers", role.getName());
+        assertEquals(Role.Scope.REPOSITORY, role.getScope());
     }
 
     @Test
     public void selectSingleReviewer_RoleReviewer() {
         Role role = selectSingleReviewer.getRoles().get("Reviewer");
-        assertEquals(role.getName(), "Reviewer");
-        assertEquals(role.getScope(), Role.Scope.ITEM);
+        assertEquals("Reviewer", role.getName());
+        assertEquals(Role.Scope.ITEM, role.getScope());
     }
 
     @Test
     public void scoreReview_RoleScoreReviewers() {
         Role role = scoreReview.getRoles().get("ScoreReviewers");
-        assertEquals(role.getName(), "ScoreReviewers");
-        assertEquals(role.getScope(), Role.Scope.COLLECTION);
+        assertEquals("ScoreReviewers", role.getName());
+        assertEquals(Role.Scope.COLLECTION, role.getScope());
     }
 }

--- a/dspace-api/src/test/java/org/dspace/xmlworkflow/XmlWorkflowFactoryTest.java
+++ b/dspace-api/src/test/java/org/dspace/xmlworkflow/XmlWorkflowFactoryTest.java
@@ -78,14 +78,14 @@ public class XmlWorkflowFactoryTest extends AbstractUnitTest {
     public void workflowMapping_NonMappedCollection() throws WorkflowConfigurationException {
         Collection collection = this.findOrCreateCollectionWithHandle("123456789/6");
         Workflow workflow = xmlWorkflowFactory.getWorkflow(collection);
-        assertEquals(workflow.getID(), "defaultWorkflow");
+        assertEquals("defaultWorkflow", workflow.getID());
     }
 
     @Test
     public void workflowMapping_MappedCollection() throws WorkflowConfigurationException {
         Collection collection = this.findOrCreateCollectionWithHandle("123456789/4");
         Workflow workflow = xmlWorkflowFactory.getWorkflow(collection);
-        assertEquals(workflow.getID(), "selectSingleReviewer");
+        assertEquals("selectSingleReviewer", workflow.getID());
     }
 
     private Collection findOrCreateCollectionWithHandle(String handle) {

--- a/dspace-api/src/test/java/org/dspace/xmlworkflow/state/StepTest.java
+++ b/dspace-api/src/test/java/org/dspace/xmlworkflow/state/StepTest.java
@@ -7,8 +7,9 @@
  */
 package org.dspace.xmlworkflow.state;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
@@ -35,70 +36,70 @@ public class StepTest extends AbstractUnitTest {
     @Test
     public void defaultWorkflow_ReviewStep() throws WorkflowConfigurationException {
         Step step = defaultWorkflow.getStep("reviewstep");
-        assertEquals(step.getUserSelectionMethod().getId(), "claimaction");
-        assertEquals(step.getRole().getName(), "Reviewer");
+        assertEquals("claimaction", step.getUserSelectionMethod().getId());
+        assertEquals("Reviewer", step.getRole().getName());
         List<WorkflowActionConfig> actions = step.getActions();
-        assert (this.containsActionNamed(actions, "reviewaction"));
-        assertEquals(step.getNextStep(0).getId(), "editstep");
+        assertTrue(this.containsActionNamed(actions, "reviewaction"));
+        assertEquals("editstep", step.getNextStep(0).getId());
     }
 
     @Test
     public void defaultWorkflow_EditStep() throws WorkflowConfigurationException {
         Step step = defaultWorkflow.getStep("editstep");
-        assertEquals(step.getUserSelectionMethod().getId(), "claimaction");
-        assertEquals(step.getRole().getName(), "Editor");
+        assertEquals("claimaction", step.getUserSelectionMethod().getId());
+        assertEquals("Editor", step.getRole().getName());
         List<WorkflowActionConfig> actions = step.getActions();
-        assert (this.containsActionNamed(actions, "editaction"));
-        assertEquals(step.getNextStep(0).getId(), "finaleditstep");
+        assertTrue(this.containsActionNamed(actions, "editaction"));
+        assertEquals("finaleditstep", step.getNextStep(0).getId());
     }
 
     @Test
     public void defaultWorkflow_FinalEditStep() throws WorkflowConfigurationException {
         Step step = defaultWorkflow.getStep("finaleditstep");
-        assertEquals(step.getUserSelectionMethod().getId(), "claimaction");
-        assertEquals(step.getRole().getName(), "Final Editor");
+        assertEquals("claimaction", step.getUserSelectionMethod().getId());
+        assertEquals("Final Editor", step.getRole().getName());
         List<WorkflowActionConfig> actions = step.getActions();
-        assert (this.containsActionNamed(actions, "finaleditaction"));
+        assertTrue(this.containsActionNamed(actions, "finaleditaction"));
         assertNull(step.getNextStep(0));
     }
 
     @Test
     public void selectSingleReviewer_SelectReviewerStep() throws WorkflowConfigurationException {
         Step step = selectSingleReviewer.getStep("selectReviewerStep");
-        assertEquals(step.getUserSelectionMethod().getId(), "claimaction");
-        assertEquals(step.getRole().getName(), "ReviewManagers");
+        assertEquals("claimaction", step.getUserSelectionMethod().getId());
+        assertEquals("ReviewManagers", step.getRole().getName());
         List<WorkflowActionConfig> actions = step.getActions();
-        assert (this.containsActionNamed(actions, "selectrevieweraction"));
-        assertEquals(step.getNextStep(0).getId(), "singleUserReviewStep");
+        assertTrue(this.containsActionNamed(actions, "selectrevieweraction"));
+        assertEquals("singleUserReviewStep", step.getNextStep(0).getId());
     }
 
     @Test
     public void selectSingleReviewer_SingleUserReviewStep() throws WorkflowConfigurationException {
         Step step = selectSingleReviewer.getStep("singleUserReviewStep");
-        assertEquals(step.getUserSelectionMethod().getId(), "autoassignAction");
-        assert (step.getRole().getName().equals("Reviewer"));
+        assertEquals("autoassignAction", step.getUserSelectionMethod().getId());
+        assertEquals("Reviewer", step.getRole().getName());
         List<WorkflowActionConfig> actions = step.getActions();
-        assert (this.containsActionNamed(actions, "singleuserreviewaction"));
-        assertEquals(step.getNextStep(1).getId(), "selectReviewerStep");
+        assertTrue(this.containsActionNamed(actions, "singleuserreviewaction"));
+        assertEquals("selectReviewerStep", step.getNextStep(1).getId());
     }
 
     @Test
     public void scoreReview_ScoreReviewStep() throws WorkflowConfigurationException {
         Step step = scoreReview.getStep("scoreReviewStep");
-        assertEquals(step.getUserSelectionMethod().getId(), "claimaction");
-        assertEquals(step.getRole().getName(), "ScoreReviewers");
+        assertEquals("claimaction", step.getUserSelectionMethod().getId());
+        assertEquals("ScoreReviewers", step.getRole().getName());
         List<WorkflowActionConfig> actions = step.getActions();
-        assert (this.containsActionNamed(actions, "scorereviewaction"));
-        assertEquals(step.getNextStep(0).getId(), "evaluationStep");
-        assertEquals(step.getRequiredUsers(), 2);
+        assertTrue(this.containsActionNamed(actions, "scorereviewaction"));
+        assertEquals("evaluationStep", step.getNextStep(0).getId());
+        assertEquals(2, step.getRequiredUsers());
     }
 
     @Test
     public void scoreReview_EvaluationStep() throws WorkflowConfigurationException {
         Step step = scoreReview.getStep("evaluationStep");
-        assertEquals(step.getUserSelectionMethod().getId(), "noUserSelectionAction");
+        assertEquals("noUserSelectionAction", step.getUserSelectionMethod().getId());
         List<WorkflowActionConfig> actions = step.getActions();
-        assert (this.containsActionNamed(actions, "evaluationaction"));
+        assertTrue(this.containsActionNamed(actions, "evaluationaction"));
         assertNull(step.getNextStep(0));
     }
 

--- a/dspace-api/src/test/java/org/dspace/xmlworkflow/state/WorkflowTest.java
+++ b/dspace-api/src/test/java/org/dspace/xmlworkflow/state/WorkflowTest.java
@@ -7,7 +7,8 @@
  */
 package org.dspace.xmlworkflow.state;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
@@ -31,30 +32,30 @@ public class WorkflowTest extends AbstractUnitTest {
 
     @Test
     public void defaultWorkflow() {
-        assertEquals(defaultWorkflow.getFirstStep().getId(), "reviewstep");
+        assertEquals("reviewstep", defaultWorkflow.getFirstStep().getId());
         List<Step> steps = defaultWorkflow.getSteps();
-        assertEquals(steps.size(), 3);
-        assert (this.containsStepNamed(steps, "reviewstep"));
-        assert (this.containsStepNamed(steps, "editstep"));
-        assert (this.containsStepNamed(steps, "finaleditstep"));
+        assertEquals(3, steps.size());
+        assertTrue(this.containsStepNamed(steps, "reviewstep"));
+        assertTrue(this.containsStepNamed(steps, "editstep"));
+        assertTrue(this.containsStepNamed(steps, "finaleditstep"));
     }
 
     @Test
     public void selectSingleReviewer() {
-        assertEquals(selectSingleReviewer.getFirstStep().getId(), "selectReviewerStep");
+        assertEquals("selectReviewerStep", selectSingleReviewer.getFirstStep().getId());
         List<Step> steps = selectSingleReviewer.getSteps();
-        assertEquals(steps.size(), 2);
-        assert (this.containsStepNamed(steps, "selectReviewerStep"));
-        assert (this.containsStepNamed(steps, "singleUserReviewStep"));
+        assertEquals(2, steps.size());
+        assertTrue(this.containsStepNamed(steps, "selectReviewerStep"));
+        assertTrue(this.containsStepNamed(steps, "singleUserReviewStep"));
     }
 
     @Test
     public void scoreReview() {
-        assertEquals(scoreReview.getFirstStep().getId(), "scoreReviewStep");
+        assertEquals("scoreReviewStep", scoreReview.getFirstStep().getId());
         List<Step> steps = scoreReview.getSteps();
-        assertEquals(steps.size(), 2);
-        assert (this.containsStepNamed(steps, "scoreReviewStep"));
-        assert (this.containsStepNamed(steps, "evaluationStep"));
+        assertEquals(2, steps.size());
+        assertTrue(this.containsStepNamed(steps, "scoreReviewStep"));
+        assertTrue(this.containsStepNamed(steps, "evaluationStep"));
     }
 
     private boolean containsStepNamed(List<Step> steps, String stepName) {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/oai/OAIpmhIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/oai/OAIpmhIT.java
@@ -9,8 +9,8 @@
 package org.dspace.app.oai;
 
 import static org.hamcrest.Matchers.startsWith;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/csv/CSVMetadataImportReferenceIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/csv/CSVMetadataImportReferenceIT.java
@@ -41,7 +41,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  * Created by: Andrew Wood
  * Date: 26 Jul 2019
  */
-public class CSVMetadataImportReferenceTest extends AbstractEntityIntegrationTest {
+public class CSVMetadataImportReferenceIT extends AbstractEntityIntegrationTest {
 
     //Common collection to utilize for test
     private Collection col1;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/jwt/EPersonClaimProviderTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/jwt/EPersonClaimProviderTest.java
@@ -8,7 +8,7 @@
 package org.dspace.app.rest.security.jwt;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/jwt/JWTTokenHandlerTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/jwt/JWTTokenHandlerTest.java
@@ -8,7 +8,7 @@
 package org.dspace.app.rest.security.jwt;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.text.ParseException;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/jwt/SpecialGroupClaimProviderTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/jwt/SpecialGroupClaimProviderTest.java
@@ -9,7 +9,7 @@ package org.dspace.app.rest.security.jwt;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/utils/MultipartFileSenderTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/utils/MultipartFileSenderTest.java
@@ -9,7 +9,7 @@ package org.dspace.app.rest.utils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
This is a followup to #2654 (which has now been merged).

This PR resolves various warnings returned by errorprone after upgrading to the latest [errorprone](https://errorprone.info/).  Namely, these issues were resolved in code (primarily tests in `dspace-api` module):

* https://errorprone.info/bugpattern/StringSplitter 
* https://errorprone.info/bugpattern/UnusedVariable
* https://errorprone.info/bugpattern/JdkObsolete
* https://errorprone.info/bugpattern/UseCorrectAssertInTests
* https://errorprone.info/bugpattern/AssertEqualsArgumentOrderChecker
* https://errorprone.info/bugpattern/UnusedNestedClass
* https://errorprone.info/bugpattern/UnusedMethod

A few very minor deprecation warnings were cleaned up as well. Namely
* `toString(java.lang.Object) in org.apache.commons.lang3.ObjectUtils has been deprecated`
