### PR TITLE
[DS-4434] Fix Context.commit() and Context.isValid() behavior. Add more tests

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -361,20 +361,19 @@ public class Context implements AutoCloseable {
         // If Context is no longer open/valid, just note that it has already been closed
         if (!isValid()) {
             log.info("complete() was called on a closed Context object. No changes to commit.");
+            return;
         }
 
         try {
             // As long as we have a valid, writeable database connection,
-            // rollback any changes if we are in read-only mode,
+            // commit changes. Otherwise, we'll just close the DB connection (below)
             // otherwise, commit any changes made as part of the transaction
-            if (isReadOnly()) {
-                abort();
-            } else {
+            if (!isReadOnly()) {
                 commit();
             }
         } finally {
             if (dbConnection != null) {
-                // Free the DB connection
+                // Free the DB connection and invalidate the Context
                 dbConnection.closeDBConnection();
                 dbConnection = null;
             }
@@ -395,22 +394,17 @@ public class Context implements AutoCloseable {
         // If Context is no longer open/valid, just note that it has already been closed
         if (!isValid()) {
             log.info("commit() was called on a closed Context object. No changes to commit.");
+            return;
         }
 
         if (isReadOnly()) {
             throw new UnsupportedOperationException("You cannot commit a read-only context");
         }
 
-        // Our DB Connection (Hibernate) will decide if an actual commit is required or not
         try {
-            // As long as we have a valid, writeable database connection,
-            // commit any changes made as part of the transaction
-            if (isValid()) {
-                // Dispatch events before committing changes to the database,
-                // as the consumers may change something too
-                dispatchEvents();
-            }
-
+            // Dispatch events before committing changes to the database,
+            // as the consumers may change something too
+            dispatchEvents();
         } finally {
             if (log.isDebugEnabled()) {
                 log.debug("Cache size on commit is " + getCacheSize());
@@ -425,8 +419,12 @@ public class Context implements AutoCloseable {
     }
 
 
+    /**
+     * Dispatch any events (cached in current Context) to configured EventListeners (consumers)
+     * in the EventService. This should be called prior to any commit as some consumers may add
+     * to the current transaction. Once events are dispatched, the Context's event cache is cleared.
+     */
     public void dispatchEvents() {
-        // Commit any changes made as part of the transaction
         Dispatcher dispatcher = null;
 
         try {
@@ -462,6 +460,7 @@ public class Context implements AutoCloseable {
 
     /**
      * Add an event to be dispatched when this context is committed.
+     * NOTE: Read-only Contexts cannot add events, as they cannot modify objects.
      *
      * @param event event to be dispatched
      */
@@ -490,6 +489,10 @@ public class Context implements AutoCloseable {
         return events;
     }
 
+    /**
+     * Whether or not the context has events cached.
+     * @return true or false
+     */
     public boolean hasEvents() {
         return !CollectionUtils.isEmpty(events);
     }
@@ -521,19 +524,22 @@ public class Context implements AutoCloseable {
         // If Context is no longer open/valid, just note that it has already been closed
         if (!isValid()) {
             log.info("abort() was called on a closed Context object. No changes to abort.");
+            return;
         }
 
         try {
-            // Rollback ONLY if we have a database connection, and it is NOT Read Only
-            if (isValid() && !isReadOnly()) {
+            // Rollback ONLY if we have a database transaction, and it is NOT Read Only
+            if (!isReadOnly() && isTransactionAlive()) {
                 dbConnection.rollback();
             }
         } catch (SQLException se) {
             log.error(se.getMessage(), se);
         } finally {
             try {
-                if (!dbConnection.isSessionAlive()) {
+                if (dbConnection != null) {
+                    // Free the DB connection & invalidate the Context
                     dbConnection.closeDBConnection();
+                    dbConnection = null;
                 }
             } catch (Exception ex) {
                 log.error("Exception aborting context", ex);
@@ -558,7 +564,21 @@ public class Context implements AutoCloseable {
      */
     public boolean isValid() {
         // Only return true if our DB connection is live
-        return dbConnection != null && dbConnection.isTransActionAlive();
+        return dbConnection != null && dbConnection.isSessionAlive();
+    }
+
+    /**
+     * Find out whether our context includes an open database transaction.
+     * Returns <code>true</code> if there is an open transaction. Returns
+     * <code>false</code> if the context is invalid (e.g. abort() or complete())
+     * was called OR no current transaction exists (e.g. commit() was just called
+     * and no new transaction has begun)
+     *
+     * @return
+     */
+    protected boolean isTransactionAlive() {
+        // Only return true if both Context is valid *and* transaction is alive
+        return isValid() && dbConnection.isTransActionAlive();
     }
 
     /**
@@ -571,21 +591,22 @@ public class Context implements AutoCloseable {
         return mode != null && mode == Mode.READ_ONLY;
     }
 
+    /**
+     * Add a group's UUID to the list of special groups cached in Context
+     * @param groupID UUID of group
+     */
     public void setSpecialGroup(UUID groupID) {
         specialGroups.add(groupID);
-
-        // System.out.println("Added " + groupID);
     }
 
     /**
-     * test if member of special group
+     * Test if a group is a special group
      *
      * @param groupID ID of special group to test
      * @return true if member
      */
     public boolean inSpecialGroup(UUID groupID) {
         if (specialGroups.contains(groupID)) {
-            // System.out.println("Contains " + groupID);
             return true;
         }
 
@@ -593,10 +614,9 @@ public class Context implements AutoCloseable {
     }
 
     /**
-     * Get an array of all of the special groups that current user is a member
-     * of.
+     * Get an array of all of the special groups that current user is a member of.
      *
-     * @return list of groups
+     * @return list of special groups
      * @throws SQLException if database error
      */
     public List<Group> getSpecialGroups() throws SQLException {
@@ -608,6 +628,10 @@ public class Context implements AutoCloseable {
         return myGroups;
     }
 
+    /**
+     *  Close the context, aborting any open transactions (if any).
+     * @throws Throwable
+     */
     @Override
     protected void finalize() throws Throwable {
         /*

--- a/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
@@ -49,7 +49,7 @@ import org.springframework.orm.hibernate5.SessionFactoryUtils;
  * <P>
  * If an Error occurs, the Session itself is invalidated. No further Transactions can be run on that Session.
  * <P>
- * DSpace follows the "Session-per-request" transactional pattern described here:
+ * DSpace generally follows the "Session-per-request" transactional pattern described here:
  * https://docs.jboss.org/hibernate/orm/5.0/userguide/en-US/html/ch06.html#session-per-request
  *
  *
@@ -199,12 +199,12 @@ public class HibernateDBConnection implements DBConnection<Session> {
     }
 
     /**
-     * Reload an entity into the Hibernate cache. This can be called after a call to commit() to recache an object
+     * Reload an entity into the Hibernate cache. This can be called after a call to commit() to re-cache an object
      * in the Hibernate Session (see commit()). Failing to reload objects into the cache may result in a Hibernate
      * throwing a "LazyInitializationException" if you attempt to use an object that has been disconnected from the
      * Session cache.
      * @param entity The DSpace object to reload
-     * @param <E> The class of the enity. The entity must implement the {@link ReloadableEntity} interface.
+     * @param <E> The class of the entity. The entity must implement the {@link ReloadableEntity} interface.
      * @return the newly cached object.
      * @throws SQLException
      */
@@ -243,10 +243,13 @@ public class HibernateDBConnection implements DBConnection<Session> {
     }
 
     /**
-     * Evict an entity from the hibernate cache. This is necessary when batch processing a large number of items.
+     * Evict an entity from the hibernate cache.
+     * <P>
+     * When an entity is evicted, it frees up the memory used by that entity in the cache. This is often
+     * necessary when batch processing a large number of objects (to avoid out-of-memory exceptions).
      *
      * @param entity The entity to evict
-     * @param <E>    The class of the enity. The entity must implement the {@link ReloadableEntity} interface.
+     * @param <E>    The class of the entity. The entity must implement the {@link ReloadableEntity} interface.
      * @throws SQLException When reloading the entity from the database fails.
      */
     @Override

--- a/dspace-api/src/test/java/org/dspace/core/ContextTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/ContextTest.java
@@ -278,7 +278,7 @@ public class ContextTest extends AbstractUnitTest {
         when(authorizeServiceSpy.isAdmin(instance)).thenReturn(true);
 
         // Create a new EPerson (to be committed)
-        String createdEmail = "myfakeemail@gmail.com";
+        String createdEmail = "myfakeemail@example.com";
         EPerson newUser = ePersonService.create(instance);
         newUser.setFirstName(instance, "Tim");
         newUser.setLastName(instance, "Smith");
@@ -302,7 +302,7 @@ public class ContextTest extends AbstractUnitTest {
         assertEquals("New user should be created", newUser.getEmail(), createdEmail);
 
         // Change the email and commit again (a Context should support multiple commit() calls)
-        String newEmail = "myrealemail@gmail.com";
+        String newEmail = "myrealemail@example.com";
         newUser.setEmail(newEmail);
         instance.commit();
 

--- a/dspace-api/src/test/java/org/dspace/core/HibernateDBConnectionTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/HibernateDBConnectionTest.java
@@ -123,7 +123,7 @@ public class HibernateDBConnectionTest extends AbstractUnitTest {
 
         // Close the DB connection / Session
         // NOTE: Because of our Hibernate configuration, Hibernate automatically creates a new Session per thread.
-        // So, even though we "close" the connection, Hibernate will reopen a new on immediately. So, all this actually
+        // Even though we "close" the connection, Hibernate will reopen a new one immediately. So, all this actually
         // does is create a *new* Session
         connection.closeDBConnection();
 

--- a/dspace-api/src/test/java/org/dspace/core/HibernateDBConnectionTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/HibernateDBConnectionTest.java
@@ -1,0 +1,229 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.SQLException;
+
+import org.dspace.AbstractUnitTest;
+import org.dspace.eperson.EPerson;
+import org.dspace.utils.DSpace;
+import org.hibernate.Session;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Perform some basic unit tests for HibernateDBConnection
+ *
+ * @author tdonohue
+ */
+public class HibernateDBConnectionTest extends AbstractUnitTest {
+
+    private HibernateDBConnection connection;
+
+    /**
+     * This method will be run before every test as per @Before. It will
+     * initialize resources required for the tests.
+     *
+     * Other methods can be annotated with @Before here or in subclasses
+     * but no execution order is guaranteed
+     */
+    @Before
+    @Override
+    public void init() {
+        super.init();
+        // Get a DB connection to test with
+        connection = new DSpace().getServiceManager()
+                                 .getServiceByName(null, HibernateDBConnection.class);
+    }
+
+    /**
+     * Test of getSession method
+     */
+    @Test
+    public void testGetSession() throws SQLException {
+        assertNotNull("DB connection should not be null", connection);
+        // Connection should begin with an active transaction
+        assertTrue("A transaction should be open by default", connection.getTransaction().isActive());
+
+        // Rollback current transaction
+        connection.getTransaction().rollback();
+
+        // Transaction should be closed
+        assertFalse("Transaction should be closed after rollback", connection.getTransaction().isActive());
+
+        //Now call getSession(), saving a reference to the session
+        Session currentSession = connection.getSession();
+
+        // New transaction should be initialized
+        assertTrue("New transaction should be open after getSession() call",
+                   connection.getTransaction().isActive());
+
+        // Call getSession again. The same Session should still be returned
+        assertEquals("Multiple calls to getSession should return same Session", currentSession,
+                     connection.getSession());
+    }
+
+    /**
+     * Test of isTransactionAlive method
+     */
+    @Test
+    public void testIsTransactionAlive() {
+        assertNotNull("DB connection should not be null", connection);
+        assertNotNull("Transaction should not be null", connection.getTransaction());
+        // Connection should begin with a transaction
+        assertTrue("A transaction should be open by default", connection.isTransActionAlive());
+
+        // Rollback current transaction
+        connection.getTransaction().rollback();
+
+        // Transaction should be closed
+        assertFalse("Transaction should be closed after rollback", connection.isTransActionAlive());
+    }
+
+    /**
+     * Test of isSessionAlive method
+     */
+    @Test
+    public void testIsSessionAlive() throws SQLException {
+        assertNotNull("DB connection should not be null", connection);
+        assertNotNull("Session should not be null", connection.getSession());
+        assertTrue("A Session should be alive by default", connection.isSessionAlive());
+
+        // Rollback current transaction, closing it
+        connection.getTransaction().rollback();
+
+        // Session should still be alive even after transaction closes
+        assertTrue("A Session should still be alive if transaction closes", connection.isSessionAlive());
+
+        // NOTE: Because we configure Hibernate Session objects to be bound to a thread
+        // (see 'hibernate.current_session_context_class' in hibernate.cfg.xml), a Session is ALWAYS ALIVE until
+        // the thread closes (at which point Hibernate will clean it up automatically).
+        // This means that essentially isSessionAlive() will always return true, unless the connection is severed
+        // in some unexpected way.  See also "testCloseDBConnection()"
+    }
+
+    /**
+     * Test of closeDBConnection method
+     */
+    @Test
+    public void testCloseDBConnection() throws SQLException {
+        // Get a reference to the current Session
+        Session initialSession = connection.getSession();
+
+        // Close the DB connection / Session
+        // NOTE: Because of our Hibernate configuration, Hibernate automatically creates a new Session per thread.
+        // So, even though we "close" the connection, Hibernate will reopen a new on immediately. So, all this actually
+        // does is create a *new* Session
+        connection.closeDBConnection();
+
+        Session newSession = connection.getSession();
+        assertNotEquals("New Session expected",initialSession, newSession);
+    }
+
+    /**
+     * Test of commit method
+     */
+    @Test
+    public void testCommit() throws SQLException {
+        // Ensure a transaction exists
+        connection.getSession();
+        assertTrue("Transaction should be active", connection.getTransaction().isActive());
+
+        connection.commit();
+        assertFalse("Commit should close transaction", connection.getTransaction().isActive());
+
+        // A second commit should be a no-op (no error thrown)
+        connection.commit();
+    }
+
+    /**
+     * Test of rollback method
+     */
+    @Test
+    public void testRollback() throws SQLException {
+        // Ensure a transaction exists
+        connection.getSession();
+        assertTrue("Transaction should be active", connection.getTransaction().isActive());
+
+        connection.rollback();
+        assertFalse("Rollback should close transaction", connection.getTransaction().isActive());
+
+        // A second rollback should be a no-op (no error thrown)
+        connection.rollback();
+    }
+
+    /**
+     * Test of reloadEntity method
+     */
+    @Test
+    public void testReloadEntityAfterRollback() throws SQLException {
+        // Get DBConnection  associated with DSpace Context
+        HibernateDBConnection dbConnection = (HibernateDBConnection) context.getDBConnection();
+        EPerson person = context.getCurrentUser();
+
+        assertTrue("Current user should be cached in session", dbConnection.getSession()
+                                                                           .contains(person));
+
+        dbConnection.rollback();
+        assertFalse("Current user should be gone from cache", dbConnection.getSession()
+                                                                           .contains(person));
+
+        person = dbConnection.reloadEntity(person);
+        assertTrue("Current user should be cached back in session", dbConnection.getSession()
+                                                                           .contains(person));
+    }
+
+    /**
+     * Test of reloadEntity method
+     */
+    @Test
+    public void testReloadEntityAfterCommit() throws SQLException {
+        // Get DBConnection associated with DSpace Context
+        HibernateDBConnection dbConnection = (HibernateDBConnection) context.getDBConnection();
+        EPerson person = context.getCurrentUser();
+
+        assertTrue("Current user should be cached in session", dbConnection.getSession()
+                                                                           .contains(person));
+
+        dbConnection.commit();
+        assertFalse("Current user should be gone from cache", dbConnection.getSession()
+                                                                          .contains(person));
+
+        person = dbConnection.reloadEntity(person);
+        assertTrue("Current user should be cached back in session", dbConnection.getSession()
+                                                                                .contains(person));
+    }
+
+    /**
+     * Test of uncacheEntity method
+     */
+    @Test
+    public void testUncacheEntity() throws SQLException {
+        // Get DBConnection associated with DSpace Context
+        HibernateDBConnection dbConnection = (HibernateDBConnection) context.getDBConnection();
+        EPerson person = context.getCurrentUser();
+
+        assertTrue("Current user should be cached in session", dbConnection.getSession()
+                                                                           .contains(person));
+
+        dbConnection.uncacheEntity(person);
+        assertFalse("Current user should be gone from cache", dbConnection.getSession()
+                                                                          .contains(person));
+
+        // Test ability to reload an uncached entity
+        person = dbConnection.reloadEntity(person);
+        assertTrue("Current user should be cached back in session", dbConnection.getSession()
+                                                                                .contains(person));
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/builder/RelationshipTypeBuilder.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/builder/RelationshipTypeBuilder.java
@@ -37,12 +37,15 @@ public class RelationshipTypeBuilder extends AbstractBuilder<RelationshipType, R
 
     @Override
     public void cleanup() throws Exception {
-        context.turnOffAuthorisationSystem();
-        List<Relationship> byRelationshipType = relationshipService.findByRelationshipType(context, relationshipType);
-        for (Relationship relationship : byRelationshipType) {
-            relationshipService.delete(context, relationship);
+        try (Context c = new Context()) {
+            c.turnOffAuthorisationSystem();
+            List<Relationship> byRelationshipType = relationshipService
+                .findByRelationshipType(c, relationshipType);
+            for (Relationship relationship : byRelationshipType) {
+                relationshipService.delete(c, relationship);
+            }
+            c.complete();
         }
-        context.restoreAuthSystemState();
 
         delete(relationshipType);
     }


### PR DESCRIPTION
Fix for https://jira.lyrasis.org/browse/DS-4434

This PR refactors the Context object slightly to ensure proper behavior of the commit(), complete() and abort() methods. It enhances the comments & tests to prove these methods all behave as described.  Namely, the behaviors are as such:
* `complete()` and `abort()` should both invalidate a Context & close the current Hibernate Transaction & Session (database connection). These mostly behaved as expected, though minor refactors were made.
* `commit()` should simply close the current Hibernate Transaction, but keep the same Hibernate Session & also keep the Context valid.  The misbehavior of commit() was noted in the DS-4434 ticket, and proven by a new test in this PR (see my inline comment below).

I've also enhanced the comments in `HibernateDBConnection` and added tests for methods in that class to prove their behavior.

These changes to `Context` & `HibernateDBConnection` work for *all existing tests* except for the `RelationshipTypeBuilder`, which was improperly reusing a globally shared Context to cleanup test context (unlike any other Builder class).  This Builder was fixed to use its own Context.

**More eyes on this PR are obviously welcome as these are core classes in the DSpace backend.**  This is ready for review.

(I have not tested this on DSpace 6.x, but I expect the same flaw exists there as well. This area of the code has not changed significantly between 6.x and 7.x)