### PR TITLE
Duplicate: Non-admin User can't create new item via REST

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authority/orcid/Orcidv2AuthorityValue.java
+++ b/dspace-api/src/main/java/org/dspace/authority/orcid/Orcidv2AuthorityValue.java
@@ -83,9 +83,13 @@ public class Orcidv2AuthorityValue extends PersonAuthorityValue {
             return null;
         }
         Orcidv2AuthorityValue authority = Orcidv2AuthorityValue.create();
-
-        authority.setValues(person);
-
+        try {
+            authority.setValues(person);
+            return authority;
+        } catch (Exception e) {
+            return null;
+        }
+        
         return authority;
     }
 

--- a/dspace-api/src/main/java/org/dspace/authority/orcid/Orcidv2AuthorityValue.java
+++ b/dspace-api/src/main/java/org/dspace/authority/orcid/Orcidv2AuthorityValue.java
@@ -83,13 +83,9 @@ public class Orcidv2AuthorityValue extends PersonAuthorityValue {
             return null;
         }
         Orcidv2AuthorityValue authority = Orcidv2AuthorityValue.create();
-        try {
-            authority.setValues(person);
-            return authority;
-        } catch (Exception e) {
-            return null;
-        }
-        
+
+        authority.setValues(person);
+
         return authority;
     }
 

--- a/dspace-rest/src/main/java/org/dspace/rest/CollectionsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/CollectionsResource.java
@@ -349,7 +349,7 @@ public class CollectionsResource extends Resource
         {
             context = createContext();
             org.dspace.content.Collection dspaceCollection = findCollection(context, collectionId,
-                    org.dspace.core.Constants.WRITE);
+                    org.dspace.core.Constants.ADD);
 
             writeStats(dspaceCollection, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor,
                     headers, request, context);


### PR DESCRIPTION
REST interface should support user to create a new item in a collction. 
But if the user is not an administrator of this collection, it failed, the system checks the authority for adding item in this collection with WRITE action. 
I think it should check that with action ADD, then it allows normaler user to add new item in this collection.
 