### PR TITLE
Non-admin User can't create new item via REST

### DIFF
--- a/dspace-rest/src/main/java/org/dspace/rest/CollectionsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/CollectionsResource.java
@@ -347,7 +347,7 @@ public class CollectionsResource extends Resource
         {
             context = createContext();
             org.dspace.content.Collection dspaceCollection = findCollection(context, collectionId,
-                    org.dspace.core.Constants.WRITE);
+                    org.dspace.core.Constants.ADD);
 
             writeStats(dspaceCollection, UsageEvent.Action.UPDATE, user_ip, user_agent, xforwardedfor,
                     headers, request, context);


### PR DESCRIPTION
REST interface should support user to create a new item in a collction. 
But if the user is not an administrator of this collection, it failed, the system checks the authority for adding item in this collection with WRITE action. 
I think it should check that with action ADD, then it allows normaler user to add new item in this collection.
 