### PR TITLE
Default to full projection for workspace item POSTs

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemRestRepository.java
@@ -167,7 +167,7 @@ public class WorkspaceItemRestRepository extends DSpaceRestRepository<WorkspaceI
     @Override
     protected WorkspaceItemRest createAndReturn(Context context) throws SQLException, AuthorizeException {
         WorkspaceItem source = submissionService.createWorkspaceItem(context, getRequestService().getCurrentRequest());
-        return converter.toRest(source, Projection.DEFAULT);
+        return converter.toRest(source, converter.getProjection("full"));
     }
 
     @Override


### PR DESCRIPTION
This is a workaround for the issue discussed on dev-sprint 2010/02/18-19. Angular currently expects embeds here, and this gets it quickly working again.