### PR TITLE
DS-3895b: restores getSize() in Bitstream

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/Bitstream.java
+++ b/dspace-api/src/main/java/org/dspace/content/Bitstream.java
@@ -213,6 +213,17 @@ public class Bitstream extends DSpaceObject implements DSpaceObjectLegacySupport
 
     /**
      * Get the size of the bitstream
+     *
+     * @return the size in bytes
+     */
+    @Deprecated
+    public long getSize()
+    {
+        return getSizeBytes();
+    }
+
+    /**
+     * Get the size of the bitstream
      * 
      * @return the size in bytes
      */


### PR DESCRIPTION
Original Jira issue: https://jira.lyrasis.org/browse/DS-3895

Original PR: https://github.com/DSpace/DSpace/pull/2042/

This PR restores the old getSize() method in the Bitstream class and points it at the new getSizeBytes() method. The old method is needed to ensure compatibility with the 6.x releases of the Replication Task Suite (https://github.com/DSpace/dspace-replicate). It is marked as deprecated and is not needed for the 7.x codebase.
