### PR TITLE
DS-4438 Respect client-provided projections for non-GETs

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -27,7 +27,6 @@ import org.dspace.app.rest.converter.ConverterService;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
 import org.dspace.app.rest.model.BitstreamRest;
 import org.dspace.app.rest.model.hateoas.BitstreamResource;
-import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.app.rest.utils.MultipartFileSender;
 import org.dspace.app.rest.utils.Utils;
@@ -243,7 +242,7 @@ public class BitstreamRestController {
 
         context.commit();
 
-        BitstreamRest bitstreamRest = converter.toRest(context.reloadEntity(bitstream), Projection.DEFAULT);
+        BitstreamRest bitstreamRest = converter.toRest(context.reloadEntity(bitstream), utils.obtainProjection());
         return converter.toResource(bitstreamRest);
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ItemAddBundleController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ItemAddBundleController.java
@@ -22,7 +22,6 @@ import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.BundleRest;
 import org.dspace.app.rest.model.ItemRest;
 import org.dspace.app.rest.model.hateoas.BundleResource;
-import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.repository.ItemRestRepository;
 import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.app.rest.utils.Utils;
@@ -108,7 +107,7 @@ public class ItemAddBundleController {
         }
 
         Bundle bundle = itemRestRepository.addBundleToItem(context, item, bundleRest);
-        BundleResource bundleResource = converter.toResource(converter.toRest(bundle, Projection.DEFAULT));
+        BundleResource bundleResource = converter.toResource(converter.toRest(bundle, utils.obtainProjection()));
         return ControllerUtils.toResponseEntity(HttpStatus.CREATED, new HttpHeaders(), bundleResource);
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ItemOwningCollectionUpdateRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ItemOwningCollectionUpdateRestController.java
@@ -21,7 +21,6 @@ import org.dspace.app.rest.converter.ConverterService;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.CollectionRest;
-import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.app.rest.utils.Utils;
 import org.dspace.authorize.AuthorizeException;
@@ -97,7 +96,7 @@ public class ItemOwningCollectionUpdateRestController {
         if (targetCollection == null) {
             return null;
         }
-        return converter.toRest(targetCollection, Projection.DEFAULT);
+        return converter.toRest(targetCollection, utils.obtainProjection());
 
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamFormatRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamFormatRestRepository.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.BitstreamFormatRest;
-import org.dspace.app.rest.projection.Projection;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.BitstreamFormat;
 import org.dspace.content.service.BitstreamFormatService;
@@ -116,7 +115,7 @@ public class BitstreamFormatRestRepository extends DSpaceRestRepository<Bitstrea
         if (id.equals(bitstreamFormatRest.getId())) {
             this.setAllValuesOfRest(context, bitstreamFormat, bitstreamFormatRest);
             bitstreamFormatService.update(context, bitstreamFormat);
-            return converter.toRest(bitstreamFormat, Projection.DEFAULT);
+            return converter.toRest(bitstreamFormat, utils.obtainProjection());
         } else {
             throw new IllegalArgumentException("The id in the Json and the id in the url do not match: "
                     + id + ", "

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamFormatRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamFormatRestRepository.java
@@ -89,7 +89,7 @@ public class BitstreamFormatRestRepository extends DSpaceRestRepository<Bitstrea
                     + bitstreamFormatRest.getShortDescription(), e);
         }
 
-        return converter.toRest(bitstreamFormat, Projection.DEFAULT);
+        return converter.toRest(bitstreamFormat, utils.obtainProjection());
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BundleRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BundleRestRepository.java
@@ -23,7 +23,6 @@ import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.BitstreamRest;
 import org.dspace.app.rest.model.BundleRest;
 import org.dspace.app.rest.model.patch.Patch;
-import org.dspace.app.rest.projection.Projection;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Bitstream;
@@ -150,7 +149,7 @@ public class BundleRestRepository extends DSpaceObjectRestRepository<Bundle, Bun
             throw new RuntimeException(message, e);
         }
 
-        return converter.toRest(bitstream, Projection.DEFAULT);
+        return converter.toRest(bitstream, utils.obtainProjection());
     }
 
     /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
@@ -27,7 +27,6 @@ import org.dspace.app.rest.model.CommunityRest;
 import org.dspace.app.rest.model.TemplateItemRest;
 import org.dspace.app.rest.model.patch.Patch;
 import org.dspace.app.rest.model.wrapper.TemplateItem;
-import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.utils.CollectionRestEqualityUtils;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bitstream;
@@ -200,7 +199,7 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
         if (collection == null) {
             throw new ResourceNotFoundException(apiCategory + "." + model + " with id: " + id + " not found");
         }
-        CollectionRest originalCollectionRest = converter.toRest(collection, Projection.DEFAULT);
+        CollectionRest originalCollectionRest = converter.toRest(collection, utils.obtainProjection());
         if (collectionRestEqualityUtils.isCollectionRestEqualWithoutMetadata(originalCollectionRest, collectionRest)) {
             metadataConverter.setMetadata(context, collection, collectionRest.getMetadata());
         } else {
@@ -208,7 +207,7 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
                 + id + ", "
                 + collectionRest.getId());
         }
-        return converter.toRest(collection, Projection.DEFAULT);
+        return converter.toRest(collection, utils.obtainProjection());
     }
 
     @Override
@@ -250,7 +249,7 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
         Bitstream bitstream = cs.setLogo(context, collection, uploadfile.getInputStream());
         cs.update(context, collection);
         bitstreamService.update(context, bitstream);
-        return converter.toRest(context.reloadEntity(bitstream), Projection.DEFAULT);
+        return converter.toRest(context.reloadEntity(bitstream), utils.obtainProjection());
     }
 
     /**
@@ -296,7 +295,7 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
         }
 
         try {
-            return converter.toRest(new TemplateItem(item), Projection.DEFAULT);
+            return converter.toRest(new TemplateItem(item), utils.obtainProjection());
         } catch (IllegalArgumentException e) {
             throw new UnprocessableEntityException("The item with id " + item.getID() + " is not a template item");
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
@@ -181,7 +181,7 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
         } catch (SQLException e) {
             throw new RuntimeException("Unable to create new Collection under parent Community " + id, e);
         }
-        return converter.toRest(collection, Projection.DEFAULT);
+        return converter.toRest(collection, utils.obtainProjection());
     }
 
 
@@ -277,7 +277,7 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
         cs.update(context, collection);
         itemService.update(context, item);
 
-        return converter.toRest(new TemplateItem(item), Projection.DEFAULT);
+        return converter.toRest(new TemplateItem(item), utils.obtainProjection());
     }
 
     /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
@@ -90,7 +90,7 @@ public class CommunityRestRepository extends DSpaceObjectRestRepository<Communit
             throw new RuntimeException(e.getMessage(), e);
         }
 
-        return converter.toRest(community, Projection.DEFAULT);
+        return converter.toRest(community, utils.obtainProjection());
     }
 
     @Override
@@ -127,7 +127,7 @@ public class CommunityRestRepository extends DSpaceObjectRestRepository<Communit
             throw new RuntimeException(e.getMessage(), e);
         }
 
-        return converter.toRest(community, Projection.DEFAULT);
+        return converter.toRest(community, utils.obtainProjection());
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
@@ -25,7 +25,6 @@ import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.BitstreamRest;
 import org.dspace.app.rest.model.CommunityRest;
 import org.dspace.app.rest.model.patch.Patch;
-import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.utils.CommunityRestEqualityUtils;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bitstream;
@@ -215,14 +214,14 @@ public class CommunityRestRepository extends DSpaceObjectRestRepository<Communit
         if (community == null) {
             throw new ResourceNotFoundException(apiCategory + "." + model + " with id: " + id + " not found");
         }
-        CommunityRest originalCommunityRest = converter.toRest(community, Projection.DEFAULT);
+        CommunityRest originalCommunityRest = converter.toRest(community, utils.obtainProjection());
         if (communityRestEqualityUtils.isCommunityRestEqualWithoutMetadata(originalCommunityRest, communityRest)) {
             metadataConverter.setMetadata(context, community, communityRest.getMetadata());
         } else {
             throw new UnprocessableEntityException("The given JSON and the original Community differ more " +
                                                        "than just the metadata");
         }
-        return converter.toRest(community, Projection.DEFAULT);
+        return converter.toRest(community, utils.obtainProjection());
     }
     @Override
     @PreAuthorize("hasPermission(#id, 'COMMUNITY', 'DELETE')")
@@ -267,6 +266,6 @@ public class CommunityRestRepository extends DSpaceObjectRestRepository<Communit
         Bitstream bitstream = cs.setLogo(context, community, uploadfile.getInputStream());
         cs.update(context, community);
         bitstreamService.update(context, bitstream);
-        return converter.toRest(context.reloadEntity(bitstream), Projection.DEFAULT);
+        return converter.toRest(context.reloadEntity(bitstream), utils.obtainProjection());
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
@@ -20,7 +20,6 @@ import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.EPersonRest;
 import org.dspace.app.rest.model.patch.Patch;
-import org.dspace.app.rest.projection.Projection;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.core.Context;
@@ -84,7 +83,7 @@ public class EPersonRestRepository extends DSpaceObjectRestRepository<EPerson, E
             throw new RuntimeException(e.getMessage(), e);
         }
 
-        return converter.toRest(eperson, Projection.DEFAULT);
+        return converter.toRest(eperson, utils.obtainProjection());
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ExternalSourceRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ExternalSourceRestRepository.java
@@ -13,7 +13,6 @@ import java.util.Optional;
 import org.dspace.app.rest.converter.ConverterService;
 import org.dspace.app.rest.model.ExternalSourceEntryRest;
 import org.dspace.app.rest.model.ExternalSourceRest;
-import org.dspace.app.rest.projection.Projection;
 import org.dspace.core.Context;
 import org.dspace.external.model.ExternalDataObject;
 import org.dspace.external.provider.ExternalDataProvider;
@@ -52,7 +51,7 @@ public class ExternalSourceRestRepository extends DSpaceRestRepository<ExternalS
                                                                                                     entryId);
         ExternalDataObject dataObject = externalDataObject.orElseThrow(() -> new ResourceNotFoundException(
             "Couldn't find an ExternalSource for source: " + externalSourceName + " and ID: " + entryId));
-        return converter.toRest(dataObject, Projection.DEFAULT);
+        return converter.toRest(dataObject, utils.obtainProjection());
     }
 
     /**
@@ -84,7 +83,7 @@ public class ExternalSourceRestRepository extends DSpaceRestRepository<ExternalS
             throw new ResourceNotFoundException("ExternalDataProvider for: " +
                                                     externalSourceName + " couldn't be found");
         }
-        return converter.toRest(externalDataProvider, Projection.DEFAULT);
+        return converter.toRest(externalDataProvider, utils.obtainProjection());
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/GroupRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/GroupRestRepository.java
@@ -19,7 +19,6 @@ import org.dspace.app.rest.exception.RepositoryMethodNotImplementedException;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.GroupRest;
 import org.dspace.app.rest.model.patch.Patch;
-import org.dspace.app.rest.projection.Projection;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.core.Context;
 import org.dspace.eperson.Group;
@@ -74,7 +73,7 @@ public class GroupRestRepository extends DSpaceObjectRestRepository<Group, Group
             throw new RuntimeException(excSQL.getMessage(), excSQL);
         }
 
-        return converter.toRest(group, Projection.DEFAULT);
+        return converter.toRest(group, utils.obtainProjection());
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/HarvestedCollectionRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/HarvestedCollectionRestRepository.java
@@ -21,7 +21,6 @@ import org.dspace.app.rest.converter.HarvestedCollectionConverter;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.HarvestTypeEnum;
 import org.dspace.app.rest.model.HarvestedCollectionRest;
-import org.dspace.app.rest.projection.Projection;
 import org.dspace.content.Collection;
 import org.dspace.core.Context;
 import org.dspace.harvest.HarvestedCollection;
@@ -91,7 +90,7 @@ public class HarvestedCollectionRestRepository extends AbstractDSpaceRestReposit
                 List<Map<String,String>> configs = OAIHarvester.getAvailableMetadataFormats();
 
                 return harvestedCollectionConverter.fromModel(harvestedCollection, collection, configs,
-                        Projection.DEFAULT);
+                        utils.obtainProjection());
             } else {
                 throw new UnprocessableEntityException(
                     "Incorrect harvest settings in request. The following errors were found: " + errors.toString()

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemRestRepository.java
@@ -28,7 +28,6 @@ import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.BundleRest;
 import org.dspace.app.rest.model.ItemRest;
 import org.dspace.app.rest.model.patch.Patch;
-import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.repository.handler.service.UriListHandlerService;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bundle;
@@ -355,6 +354,6 @@ public class ItemRestRepository extends DSpaceObjectRestRepository<Item, ItemRes
 
         HttpServletRequest req = getRequestService().getCurrentRequest().getHttpServletRequest();
         Item item = uriListHandlerService.handle(context, req, stringList, Item.class);
-        return converter.toRest(item, Projection.DEFAULT);
+        return converter.toRest(item, utils.obtainProjection());
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemRestRepository.java
@@ -293,7 +293,7 @@ public class ItemRestRepository extends DSpaceObjectRestRepository<Item, ItemRes
 
         Item itemToReturn = installItemService.installItem(context, workspaceItem);
 
-        return converter.toRest(itemToReturn, Projection.DEFAULT);
+        return converter.toRest(itemToReturn, utils.obtainProjection());
     }
 
     @Override
@@ -322,7 +322,7 @@ public class ItemRestRepository extends DSpaceObjectRestRepository<Item, ItemRes
                 + uuid + ", "
                 + itemRest.getId());
         }
-        return converter.toRest(item, Projection.DEFAULT);
+        return converter.toRest(item, utils.obtainProjection());
     }
 
     /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
@@ -24,7 +24,6 @@ import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.MetadataFieldRest;
-import org.dspace.app.rest.projection.Projection;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.MetadataField;
 import org.dspace.content.MetadataSchema;
@@ -147,7 +146,7 @@ public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFi
         }
 
         // return
-        return converter.toRest(metadataField, Projection.DEFAULT);
+        return converter.toRest(metadataField, utils.obtainProjection());
     }
 
     @Override
@@ -203,6 +202,6 @@ public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFi
             throw new RuntimeException(e);
         }
 
-        return converter.toRest(metadataField, Projection.DEFAULT);
+        return converter.toRest(metadataField, utils.obtainProjection());
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataSchemaRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataSchemaRestRepository.java
@@ -21,7 +21,6 @@ import com.google.gson.Gson;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.MetadataSchemaRest;
-import org.dspace.app.rest.projection.Projection;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.MetadataSchema;
 import org.dspace.content.NonUniqueMetadataException;
@@ -167,6 +166,6 @@ public class MetadataSchemaRestRepository extends DSpaceRestRepository<MetadataS
                     + metadataSchemaRest.getPrefix() + "." + metadataSchemaRest.getNamespace() + " already exists");
         }
 
-        return converter.toRest(metadataSchema, Projection.DEFAULT);
+        return converter.toRest(metadataSchema, utils.obtainProjection());
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataSchemaRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataSchemaRestRepository.java
@@ -111,7 +111,7 @@ public class MetadataSchemaRestRepository extends DSpaceRestRepository<MetadataS
         }
 
         // return
-        return converter.toRest(metadataSchema, Projection.DEFAULT);
+        return converter.toRest(metadataSchema, utils.obtainProjection());
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RelationshipRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RelationshipRestRepository.java
@@ -127,7 +127,7 @@ public class RelationshipRestRepository extends DSpaceRestRepository<Relationshi
                 relationshipService.updateItem(context, relationship.getLeftItem());
                 relationshipService.updateItem(context, relationship.getRightItem());
                 context.restoreAuthSystemState();
-                return converter.toRest(relationship, Projection.DEFAULT);
+                return converter.toRest(relationship, utils.obtainProjection());
             } else {
                 throw new AccessDeniedException("You do not have write rights on this relationship's items");
             }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RelationshipRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RelationshipRestRepository.java
@@ -22,7 +22,6 @@ import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.exception.RepositoryMethodNotImplementedException;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.RelationshipRest;
-import org.dspace.app.rest.projection.Projection;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.DSpaceObject;
@@ -192,7 +191,7 @@ public class RelationshipRestRepository extends DSpaceRestRepository<Relationshi
                     throw new AccessDeniedException("You do not have write rights on this relationship's items");
                 }
 
-                return converter.toRest(relationship, Projection.DEFAULT);
+                return converter.toRest(relationship, utils.obtainProjection());
             } else {
                 throw new AccessDeniedException("You do not have write rights on this relationship's items");
             }
@@ -256,7 +255,7 @@ public class RelationshipRestRepository extends DSpaceRestRepository<Relationshi
             context.commit();
             context.reloadEntity(relationship);
 
-            return converter.toRest(relationship, Projection.DEFAULT);
+            return converter.toRest(relationship, utils.obtainProjection());
         } catch (AuthorizeException e) {
             throw new AccessDeniedException("You do not have write rights on this relationship's metadata");
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
@@ -24,7 +24,6 @@ import org.dspace.app.rest.exception.RepositoryMethodNotImplementedException;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.ResourcePolicyRest;
 import org.dspace.app.rest.model.patch.Patch;
-import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.repository.patch.ResourcePatch;
 import org.dspace.app.rest.utils.DSpaceObjectUtils;
 import org.dspace.app.rest.utils.Utils;
@@ -270,7 +269,7 @@ public class ResourcePolicyRestRepository extends DSpaceRestRepository<ResourceP
             } catch (SQLException excSQL) {
                 throw new RuntimeException(excSQL.getMessage(), excSQL);
             }
-            return converter.toRest(resourcePolicy, Projection.DEFAULT);
+            return converter.toRest(resourcePolicy, utils.obtainProjection());
         } else {
             try {
                 UUID groupUuid = UUID.fromString(groupUuidStr);
@@ -283,7 +282,7 @@ public class ResourcePolicyRestRepository extends DSpaceRestRepository<ResourceP
             } catch (SQLException excSQL) {
                 throw new RuntimeException(excSQL.getMessage(), excSQL);
             }
-            return converter.toRest(resourcePolicy, Projection.DEFAULT);
+            return converter.toRest(resourcePolicy, utils.obtainProjection());
         }
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ScriptRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ScriptRestRepository.java
@@ -25,7 +25,6 @@ import org.dspace.app.rest.exception.DSpaceBadRequestException;
 import org.dspace.app.rest.model.ParameterValueRest;
 import org.dspace.app.rest.model.ProcessRest;
 import org.dspace.app.rest.model.ScriptRest;
-import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.scripts.handler.impl.RestDSpaceRunnableHandler;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.core.Context;
@@ -103,7 +102,7 @@ public class ScriptRestRepository extends DSpaceRestRepository<ScriptRest, Strin
         try {
             runDSpaceScript(scriptToExecute, restDSpaceRunnableHandler, args);
             context.complete();
-            return converter.toRest(restDSpaceRunnableHandler.getProcess(), Projection.DEFAULT);
+            return converter.toRest(restDSpaceRunnableHandler.getProcess(), utils.obtainProjection());
         } catch (SQLException e) {
             log.error("Failed to create a process with user: " + context.getCurrentUser() +
                           " scriptname: " + scriptName + " and parameters " + DSpaceCommandLineParameter

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/TemplateItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/TemplateItemRestRepository.java
@@ -17,7 +17,6 @@ import org.dspace.app.rest.converter.JsonPatchConverter;
 import org.dspace.app.rest.model.TemplateItemRest;
 import org.dspace.app.rest.model.patch.Patch;
 import org.dspace.app.rest.model.wrapper.TemplateItem;
-import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.repository.patch.ResourcePatch;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Collection;
@@ -62,7 +61,7 @@ public class TemplateItemRestRepository extends DSpaceRestRepository<TemplateIte
         }
 
         try {
-            return converter.toRest(new TemplateItem(item), Projection.DEFAULT);
+            return converter.toRest(new TemplateItem(item), utils.obtainProjection());
         } catch (IllegalArgumentException e) {
             throw new ResourceNotFoundException("The item with id " + item.getID() + " is not a template item");
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkflowItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkflowItemRestRepository.java
@@ -24,7 +24,6 @@ import org.dspace.app.rest.model.ErrorRest;
 import org.dspace.app.rest.model.WorkflowItemRest;
 import org.dspace.app.rest.model.patch.Operation;
 import org.dspace.app.rest.model.patch.Patch;
-import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.submit.AbstractRestProcessingStep;
 import org.dspace.app.rest.submit.SubmissionService;
 import org.dspace.app.rest.submit.UploadableStep;
@@ -204,7 +203,7 @@ public class WorkflowItemRestRepository extends DSpaceRestRepository<WorkflowIte
             }
 
         }
-        wsi = converter.toRest(source, Projection.DEFAULT);
+        wsi = converter.toRest(source, utils.obtainProjection());
 
         if (!errors.isEmpty()) {
             wsi.getErrors().addAll(errors);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkflowItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkflowItemRestRepository.java
@@ -157,7 +157,7 @@ public class WorkflowItemRestRepository extends DSpaceRestRepository<WorkflowIte
         if (source.getItem().isArchived()) {
             return null;
         }
-        return converter.toRest(source, Projection.DEFAULT);
+        return converter.toRest(source, utils.obtainProjection());
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemRestRepository.java
@@ -31,7 +31,6 @@ import org.dspace.app.rest.model.ErrorRest;
 import org.dspace.app.rest.model.WorkspaceItemRest;
 import org.dspace.app.rest.model.patch.Operation;
 import org.dspace.app.rest.model.patch.Patch;
-import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.repository.handler.service.UriListHandlerService;
 import org.dspace.app.rest.submit.AbstractRestProcessingStep;
 import org.dspace.app.rest.submit.SubmissionService;
@@ -254,7 +253,7 @@ public class WorkspaceItemRestRepository extends DSpaceRestRepository<WorkspaceI
             }
 
         }
-        wsi = converter.toRest(source, Projection.DEFAULT);
+        wsi = converter.toRest(source, utils.obtainProjection());
 
         if (!errors.isEmpty()) {
             wsi.getErrors().addAll(errors);
@@ -473,7 +472,7 @@ public class WorkspaceItemRestRepository extends DSpaceRestRepository<WorkspaceI
                             }
                         }
                     }
-                    WorkspaceItemRest wsi = converter.toRest(wi, Projection.DEFAULT);
+                    WorkspaceItemRest wsi = converter.toRest(wi, utils.obtainProjection());
                     if (result.size() == 1) {
                         if (!errors.isEmpty()) {
                             wsi.getErrors().addAll(errors);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemRestRepository.java
@@ -494,7 +494,7 @@ public class WorkspaceItemRestRepository extends DSpaceRestRepository<WorkspaceI
 
         HttpServletRequest req = getRequestService().getCurrentRequest().getHttpServletRequest();
         WorkspaceItem workspaceItem = uriListHandlerService.handle(context, req, stringList, WorkspaceItem.class);
-        return converter.toRest(workspaceItem, Projection.DEFAULT);
+        return converter.toRest(workspaceItem, utils.obtainProjection());
     }
 
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemRestRepository.java
@@ -167,7 +167,7 @@ public class WorkspaceItemRestRepository extends DSpaceRestRepository<WorkspaceI
     @Override
     protected WorkspaceItemRest createAndReturn(Context context) throws SQLException, AuthorizeException {
         WorkspaceItem source = submissionService.createWorkspaceItem(context, getRequestService().getCurrentRequest());
-        return converter.toRest(source, converter.getProjection("full"));
+        return converter.toRest(source, utils.obtainProjection());
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/SubmissionService.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/SubmissionService.java
@@ -77,6 +77,8 @@ public class SubmissionService {
     private RequestService requestService;
     @Autowired
     private ConverterService converter;
+    @Autowired
+    private org.dspace.app.rest.utils.Utils utils;
 
     /**
      * Create a workspaceitem using the information in the reqest
@@ -162,13 +164,13 @@ public class SubmissionService {
             }
 
         }
-
+        Projection projection = utils.obtainProjection();
         HttpServletRequest request = requestService.getCurrentRequest().getHttpServletRequest();
-        data.setFormat(converter.toRest(source.getFormat(ContextUtil.obtainContext(request)), Projection.DEFAULT));
+        data.setFormat(converter.toRest(source.getFormat(ContextUtil.obtainContext(request)), projection));
 
         for (ResourcePolicy rp : source.getResourcePolicies()) {
             if (ResourcePolicy.TYPE_CUSTOM.equals(rp.getRpType())) {
-                ResourcePolicyRest resourcePolicyRest = converter.toRest(rp, Projection.DEFAULT);
+                ResourcePolicyRest resourcePolicyRest = converter.toRest(rp, projection);
                 data.getAccessConditions().add(resourcePolicyRest);
             }
         }
@@ -219,7 +221,7 @@ public class SubmissionService {
         if (wsi == null) {
             throw new UnprocessableEntityException("Workspace item is not found");
         }
-        WorkspaceItemRest wsiRest = converter.toRest(wsi, Projection.DEFAULT);
+        WorkspaceItemRest wsiRest = converter.toRest(wsi, utils.obtainProjection());
         if (!wsiRest.getErrors().isEmpty()) {
             throw new UnprocessableEntityException(
                     "Start workflow failed due to validation error on workspaceitem");

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamFormatRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamFormatRestRepositoryIT.java
@@ -29,6 +29,7 @@ import org.dspace.app.rest.builder.BitstreamFormatBuilder;
 import org.dspace.app.rest.builder.EPersonBuilder;
 import org.dspace.app.rest.converter.ConverterService;
 import org.dspace.app.rest.matcher.BitstreamFormatMatcher;
+import org.dspace.app.rest.matcher.HalMatcher;
 import org.dspace.app.rest.model.BitstreamFormatRest;
 import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
@@ -134,6 +135,7 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
     public void createAdminAccess() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         BitstreamFormatRest bitstreamFormatRest = this.createRandomMockBitstreamRest(false);
+
         //Create bitstream format
         String token = getAuthToken(admin.getEmail(), password);
 
@@ -142,10 +144,10 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
         try {
 
             MvcResult mvcResult = getClient(token).perform(post("/api/core/bitstreamformats/")
-                                                                   .content(mapper.writeValueAsBytes(
-                                                                           bitstreamFormatRest))
+                                                  .content(mapper.writeValueAsBytes(bitstreamFormatRest))
                                                                    .contentType(contentType))
                                                   .andExpect(status().isCreated())
+                                                  .andExpect(jsonPath("$", HalMatcher.matchNoEmbeds()))
                                                   .andReturn();
 
             String content = mvcResult.getResponse().getContentAsString();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
@@ -513,10 +513,25 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
 
         ObjectMapper mapper = new ObjectMapper();
         CollectionRest collectionRest = new CollectionRest();
+        CollectionRest collectionRestNoEmbeds = new CollectionRest();
         // We send a name but the created collection should set this to the title
         collectionRest.setName("Collection");
+        collectionRestNoEmbeds.setName("Collection No Embeds");
+
 
         collectionRest.setMetadata(new MetadataRest()
+                .put("dc.description",
+                        new MetadataValueRest("<p>Some cool HTML code here</p>"))
+                .put("dc.description.abstract",
+                        new MetadataValueRest("Sample top-level community created via the REST API"))
+                .put("dc.description.tableofcontents",
+                        new MetadataValueRest("<p>HTML News</p>"))
+                .put("dc.rights",
+                        new MetadataValueRest("Custom Copyright Text"))
+                .put("dc.title",
+                        new MetadataValueRest("Title Text")));
+
+        collectionRestNoEmbeds.setMetadata(new MetadataRest()
                 .put("dc.description",
                         new MetadataValueRest("<p>Some cool HTML code here</p>"))
                 .put("dc.description.abstract",
@@ -532,9 +547,11 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
         getClient(authToken).perform(post("/api/core/collections")
                                          .content(mapper.writeValueAsBytes(collectionRest))
                                          .param("parent", parentCommunity.getID().toString())
-                                         .contentType(contentType))
+                                         .contentType(contentType)
+                                         .param("projection", "full"))
                             .andExpect(status().isCreated())
                             .andExpect(content().contentType(contentType))
+                            .andExpect(jsonPath("$", CollectionMatcher.matchFullEmbeds()))
                             .andExpect(jsonPath("$", Matchers.allOf(
                                 hasJsonPath("$.id", not(empty())),
                                 hasJsonPath("$.uuid", not(empty())),
@@ -554,6 +571,13 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
                                             "Title Text")
                                 )))));
 
+        getClient(authToken).perform(post("/api/core/collections")
+                .content(mapper.writeValueAsBytes(collectionRestNoEmbeds))
+                .param("parent", parentCommunity.getID().toString())
+                .contentType(contentType))
+                .andExpect(status().isCreated())
+                .andExpect(content().contentType(contentType))
+                .andExpect(jsonPath("$", HalMatcher.matchNoEmbeds()));
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
@@ -513,25 +513,10 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
 
         ObjectMapper mapper = new ObjectMapper();
         CollectionRest collectionRest = new CollectionRest();
-        CollectionRest collectionRestNoEmbeds = new CollectionRest();
         // We send a name but the created collection should set this to the title
         collectionRest.setName("Collection");
-        collectionRestNoEmbeds.setName("Collection No Embeds");
-
 
         collectionRest.setMetadata(new MetadataRest()
-                .put("dc.description",
-                        new MetadataValueRest("<p>Some cool HTML code here</p>"))
-                .put("dc.description.abstract",
-                        new MetadataValueRest("Sample top-level community created via the REST API"))
-                .put("dc.description.tableofcontents",
-                        new MetadataValueRest("<p>HTML News</p>"))
-                .put("dc.rights",
-                        new MetadataValueRest("Custom Copyright Text"))
-                .put("dc.title",
-                        new MetadataValueRest("Title Text")));
-
-        collectionRestNoEmbeds.setMetadata(new MetadataRest()
                 .put("dc.description",
                         new MetadataValueRest("<p>Some cool HTML code here</p>"))
                 .put("dc.description.abstract",
@@ -572,7 +557,7 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
                                 )))));
 
         getClient(authToken).perform(post("/api/core/collections")
-                .content(mapper.writeValueAsBytes(collectionRestNoEmbeds))
+                .content(mapper.writeValueAsBytes(collectionRest))
                 .param("parent", parentCommunity.getID().toString())
                 .contentType(contentType))
                 .andExpect(status().isCreated())

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -1441,6 +1441,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         ObjectMapper mapper = new ObjectMapper();
         ItemRest itemRest = new ItemRest();
+        ItemRest itemRestFull = new ItemRest();
         itemRest.setName("Practices of research data curation in institutional repositories:" +
                              " A qualitative view from repository staff");
         itemRest.setInArchive(true);
@@ -1454,11 +1455,25 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                 .put("dc.rights", new MetadataValueRest("Custom Copyright Text"))
                 .put("dc.title", new MetadataValueRest("Title Text")));
 
+        itemRestFull.setName("Practices of research data curation in institutional repositories:" +
+                " A qualitative view from repository staff");
+        itemRestFull.setInArchive(true);
+        itemRestFull.setDiscoverable(true);
+        itemRestFull.setWithdrawn(false);
+
+        itemRestFull.setMetadata(new MetadataRest()
+                .put("dc.description", new MetadataValueRest("<p>Some cool HTML code here</p>"))
+                .put("dc.description.abstract", new MetadataValueRest("Sample item created via the REST API"))
+                .put("dc.description.tableofcontents", new MetadataValueRest("<p>HTML News</p>"))
+                .put("dc.rights", new MetadataValueRest("Custom Copyright Text"))
+                .put("dc.title", new MetadataValueRest("Title Text")));
+
         String token = getAuthToken(admin.getEmail(), password);
         MvcResult mvcResult = getClient(token).perform(post("/api/core/items?owningCollection=" +
                                                                 col1.getID().toString())
                                    .content(mapper.writeValueAsBytes(itemRest)).contentType(contentType))
                                               .andExpect(status().isCreated())
+                                              .andExpect(jsonPath("$", HalMatcher.matchNoEmbeds()))
                                               .andReturn();
 
         String content = mvcResult.getResponse().getContentAsString();
@@ -1487,6 +1502,13 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                                 MetadataMatcher.matchMetadata("dc.title",
                                     "Title Text")
                             )))));
+
+        MvcResult mvcResultFull = getClient(token).perform(post("/api/core/items?owningCollection=" +
+                col1.getID().toString()).param("projection", "full")
+                .content(mapper.writeValueAsBytes(itemRestFull)).contentType(contentType))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$", ItemMatcher.matchFullEmbeds()))
+                .andReturn();
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataSchemaRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataSchemaRestRepositoryIT.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dspace.app.rest.builder.MetadataSchemaBuilder;
 import org.dspace.app.rest.converter.ConverterService;
+import org.dspace.app.rest.matcher.HalMatcher;
 import org.dspace.app.rest.matcher.MetadataschemaMatcher;
 import org.dspace.app.rest.model.MetadataSchemaRest;
 import org.dspace.app.rest.projection.Projection;
@@ -102,6 +103,7 @@ public class MetadataSchemaRestRepositoryIT extends AbstractControllerIntegratio
                         .content(new ObjectMapper().writeValueAsBytes(metadataSchemaRest))
                         .contentType(contentType))
                 .andExpect(status().isCreated())
+                .andExpect(jsonPath("$", HalMatcher.matchNoEmbeds()))
                 .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(), "$.id")));
 
         getClient().perform(get("/api/core/metadataschemas/" + idRef.get()))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadatafieldRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadatafieldRestRepositoryIT.java
@@ -184,6 +184,7 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
         getClient(authToken)
             .perform(post("/api/core/metadatafields")
                          .param("schemaId", metadataSchema.getID() + "")
+                         .param("projection", "full")
                          .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
                          .contentType(contentType))
             .andExpect(status().isCreated())

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipRestRepositoryIT.java
@@ -514,6 +514,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                                                            .param("relationshipType",
                                                                   isAuthorOfPublicationRelationshipType.getID()
                                                                                                        .toString())
+                                                           .param("projection", "full")
                                                            .contentType(MediaType.parseMediaType
                                                                (org.springframework.data.rest.webmvc.RestMediaTypes
                                                                     .TEXT_URI_LIST_VALUE))
@@ -523,6 +524,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                                                                    "https://localhost:8080/server/api/core/items/" + author1
                                                                    .getID()))
                                               .andExpect(status().isCreated())
+                                              .andExpect(jsonPath("$", RelationshipMatcher.matchFullEmbeds()))
                                               .andReturn();
 
         ObjectMapper mapper = new ObjectMapper();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
@@ -38,7 +38,7 @@ import org.dspace.app.rest.builder.EPersonBuilder;
 import org.dspace.app.rest.builder.GroupBuilder;
 import org.dspace.app.rest.builder.ItemBuilder;
 import org.dspace.app.rest.builder.ResourcePolicyBuilder;
-import org.dspace.app.rest.matcher.ResoucePolicyMatcher;
+import org.dspace.app.rest.matcher.ResourcePolicyMatcher;
 import org.dspace.app.rest.model.ResourcePolicyRest;
 import org.dspace.app.rest.model.patch.AddOperation;
 import org.dspace.app.rest.model.patch.Operation;
@@ -123,7 +123,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
         getClient(authToken).perform(get("/api/authz/resourcepolicies/" + resourcePolicy.getID()))
             .andExpect(status().isOk()).andExpect(content().contentType(contentType))
             .andExpect(jsonPath("$", is(
-                ResoucePolicyMatcher.matchResourcePolicy(resourcePolicy)
+                    ResourcePolicyMatcher.matchResourcePolicy(resourcePolicy)
             )))
             .andExpect(jsonPath("$._links.self.href", Matchers
                 .containsString("/api/authz/resourcepolicies/" + resourcePolicy.getID())));
@@ -237,8 +237,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/authz/resourcepolicies/" + resourcePolicy.getID()))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$", is(
-                ResoucePolicyMatcher.matchResourcePolicy(resourcePolicy))));
+            .andExpect(jsonPath("$", is(ResourcePolicyMatcher.matchResourcePolicy(resourcePolicy))));
     }
 
     @Test
@@ -273,7 +272,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
         String authToken = getAuthToken(eperson1.getEmail(), "qwerty01");
         getClient(authToken).perform(get("/api/authz/resourcepolicies/" + resourcePolicy.getID()))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$", is(ResoucePolicyMatcher.matchResourcePolicy(resourcePolicy))));
+            .andExpect(jsonPath("$", is(ResourcePolicyMatcher.matchResourcePolicy(resourcePolicy))));
 
         String authTokenEperson2 = getAuthToken(eperson2.getEmail(), "qwerty02");
         getClient(authTokenEperson2).perform(get("/api/authz/resourcepolicies/" + resourcePolicy.getID()))
@@ -316,9 +315,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .andExpect(status().isOk())
             .andExpect(content().contentType(contentType))
             .andExpect(jsonPath("$._embedded.resourcepolicies", Matchers.contains(
-                ResoucePolicyMatcher.matchResourcePolicy(resourcePolicyOfEPerson1))))
+                    ResourcePolicyMatcher.matchResourcePolicy(resourcePolicyOfEPerson1))))
             .andExpect(jsonPath("$._embedded.resourcepolicies",
-                Matchers.not(is(ResoucePolicyMatcher.matchResourcePolicy(resourcePolicyOfEPerson2)))))
+                Matchers.not(is(ResourcePolicyMatcher.matchResourcePolicy(resourcePolicyOfEPerson2)))))
             .andExpect(jsonPath("$._links.self.href", Matchers.containsString(
                 "api/authz/resourcepolicies/search/eperson")))
             .andExpect(jsonPath("$.page.totalElements", is(1)));
@@ -361,11 +360,11 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
                 .param("resource", community.getID().toString()))
             .andExpect(status().isOk()).andExpect(content().contentType(contentType))
             .andExpect(jsonPath("$._embedded.resourcepolicies", Matchers.containsInAnyOrder(
-                ResoucePolicyMatcher.matchResourcePolicy(resourcePolicyOfCommunity),
-                ResoucePolicyMatcher.matchResourcePolicy(secondResourcePolicyOfCommunity)
+                    ResourcePolicyMatcher.matchResourcePolicy(resourcePolicyOfCommunity),
+                    ResourcePolicyMatcher.matchResourcePolicy(secondResourcePolicyOfCommunity)
             )))
             .andExpect(jsonPath("$._embedded.resourcepolicies",
-                Matchers.not(is(ResoucePolicyMatcher.matchResourcePolicy(resourcePolicyOfCollection)))))
+                Matchers.not(is(ResourcePolicyMatcher.matchResourcePolicy(resourcePolicyOfCollection)))))
             .andExpect(jsonPath("$._links.self.href",
                 Matchers.containsString("api/authz/resourcepolicies/search/eperson")))
             .andExpect(jsonPath("$.page.totalElements", is(2)));
@@ -499,11 +498,11 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .andExpect(status().isOk())
             .andExpect(content().contentType(contentType))
             .andExpect(jsonPath("$._embedded.resourcepolicies", Matchers.containsInAnyOrder(
-                ResoucePolicyMatcher.matchResourcePolicy(firstResourcePolicyOfEPerson1),
-                ResoucePolicyMatcher.matchResourcePolicy(resourcePolicyAnonymous)
+                    ResourcePolicyMatcher.matchResourcePolicy(firstResourcePolicyOfEPerson1),
+                    ResourcePolicyMatcher.matchResourcePolicy(resourcePolicyAnonymous)
             )))
             .andExpect(jsonPath("$._embedded.resourcepolicies",
-                Matchers.not(is(ResoucePolicyMatcher.matchResourcePolicy(firstResourcePolicyOfEPerson2)))))
+                Matchers.not(is(ResourcePolicyMatcher.matchResourcePolicy(firstResourcePolicyOfEPerson2)))))
             .andExpect(jsonPath("$._links.self.href",
                 Matchers.containsString("api/authz/resourcepolicies/search/resource")))
             .andExpect(jsonPath("$.page.totalElements", is(2)));
@@ -551,10 +550,10 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .andExpect(status().isOk())
             .andExpect(content().contentType(contentType))
             .andExpect(jsonPath("$._embedded.resourcepolicies", Matchers.contains(
-                ResoucePolicyMatcher.matchResourcePolicy(firstResourcePolicyOfEPerson2)
+                 ResourcePolicyMatcher.matchResourcePolicy(firstResourcePolicyOfEPerson2)
             )))
             .andExpect(jsonPath("$._embedded.resourcepolicies",
-                Matchers.not(is(ResoucePolicyMatcher.matchResourcePolicy(secondResourcePolicyOfEPerson2)))))
+                Matchers.not(is(ResourcePolicyMatcher.matchResourcePolicy(secondResourcePolicyOfEPerson2)))))
             .andExpect(jsonPath("$._links.self.href",
                 Matchers.containsString("api/authz/resourcepolicies/search/resource")))
             .andExpect(jsonPath("$.page.totalElements", is(1)));
@@ -767,11 +766,11 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .andExpect(status().isOk()).andExpect(content().contentType(contentType))
             .andExpect(jsonPath("$._embedded.resourcepolicies",
                 Matchers.containsInAnyOrder(
-                    ResoucePolicyMatcher.matchResourcePolicy(firstResourcePolicyOfGroup1),
-                    ResoucePolicyMatcher.matchResourcePolicy(secondResourcePolicyOfGroup1),
-                    ResoucePolicyMatcher.matchResourcePolicy(collectionResourcePolicyOfGroup1))))
+                     ResourcePolicyMatcher.matchResourcePolicy(firstResourcePolicyOfGroup1),
+                     ResourcePolicyMatcher.matchResourcePolicy(secondResourcePolicyOfGroup1),
+                     ResourcePolicyMatcher.matchResourcePolicy(collectionResourcePolicyOfGroup1))))
             .andExpect(jsonPath("$._embedded.resourcepolicies",
-                Matchers.not(is(ResoucePolicyMatcher.matchResourcePolicy(firstResourcePolicyOfGroup2)))))
+                Matchers.not(is(ResourcePolicyMatcher.matchResourcePolicy(firstResourcePolicyOfGroup2)))))
             .andExpect(jsonPath("$._links.self.href",
                 Matchers.containsString("api/authz/resourcepolicies/search/group")))
             .andExpect(jsonPath("$.page.totalElements", is(3)));
@@ -783,7 +782,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .andExpect(status().isOk()).andExpect(content().contentType(contentType))
             .andExpect(jsonPath("$._embedded.resourcepolicies",
                 Matchers.contains(
-                    ResoucePolicyMatcher.matchResourcePolicy(firstResourcePolicyOfGroup2))))
+                        ResourcePolicyMatcher.matchResourcePolicy(firstResourcePolicyOfGroup2))))
             .andExpect(jsonPath("$._links.self.href",
                 Matchers.containsString("api/authz/resourcepolicies/search/group")))
             .andExpect(jsonPath("$.page.totalElements", is(1)));
@@ -822,9 +821,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .param("resource", community.getID().toString()))
             .andExpect(status().isOk()).andExpect(content().contentType(contentType))
             .andExpect(jsonPath("$._embedded.resourcepolicies",
-                Matchers.contains(ResoucePolicyMatcher.matchResourcePolicy(firstResourcePolicyOfGroup1))))
+                Matchers.contains(ResourcePolicyMatcher.matchResourcePolicy(firstResourcePolicyOfGroup1))))
             .andExpect(jsonPath("$._embedded.resourcepolicies",
-                Matchers.not(is(ResoucePolicyMatcher.matchResourcePolicy(secondResourcePolicyOfGroup1)))))
+                Matchers.not(is(ResourcePolicyMatcher.matchResourcePolicy(secondResourcePolicyOfGroup1)))))
             .andExpect(jsonPath("$._links.self.href",
                 Matchers.containsString("api/authz/resourcepolicies/search/group")))
             .andExpect(jsonPath("$.page.totalElements", is(1)));
@@ -975,9 +974,11 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
                     .content(mapper.writeValueAsBytes(resourcePolicyRest))
                     .param("resource", community.getID().toString())
                     .param("eperson", eperson1.getID().toString())
+                    .param("projections", "full")
                     .contentType(contentType))
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(contentType))
+                .andExpect(jsonPath("$", ResourcePolicyMatcher.matchFullEmbeds()))
                 .andExpect(jsonPath("$", Matchers.allOf(
                     hasJsonPath("$.name", is(resourcePolicyRest.getName())),
                     hasJsonPath("$.description", is(resourcePolicyRest.getDescription())),
@@ -1160,7 +1161,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
         String token = getAuthToken(admin.getEmail(), password);
         getClient(token).perform(get("/api/authz/resourcepolicies/" + resourcePolicy.getID()))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$", is(ResoucePolicyMatcher.matchResourcePolicy(resourcePolicy))))
+            .andExpect(jsonPath("$", is(ResourcePolicyMatcher.matchResourcePolicy(resourcePolicy))))
             .andExpect(jsonPath("$._links.self.href", Matchers
                 .containsString("/api/authz/resourcepolicies/" + resourcePolicy.getID())));
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowItemRestRepositoryIT.java
@@ -767,6 +767,7 @@ public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationT
             // submit the workspaceitem to start the workflow
             getClient(authToken)
                     .perform(post(BASE_REST_SERVER_URL + "/api/workflow/workflowitems")
+                            .param("projection", "full")
                             .content("/api/submission/workspaceitems/" + wsitem.getID())
                             .contentType(textUriContentType))
                     .andExpect(status().isCreated())

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
@@ -484,10 +484,11 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
 
         // create a workspaceitem without an explicit collection, this will go in the first valid collection for the
         // user: the col1
-        getClient(authToken).perform(post("/api/submission/workspaceitems")
-        .contentType(org.springframework.http.MediaType.APPLICATION_JSON))
+        getClient(authToken).perform(post("/api/submission/workspaceitems").param("projection", "full")
+                .contentType(org.springframework.http.MediaType.APPLICATION_JSON))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$._embedded.collection.id", is(col1.getID().toString())));
+                .andExpect(jsonPath("$._embedded.collection.id", is(col1.getID().toString())))
+                .andExpect(jsonPath("$", WorkspaceItemMatcher.matchFullEmbeds()));
 
         // TODO cleanup the context!!!
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/BitstreamFormatMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/BitstreamFormatMatcher.java
@@ -75,5 +75,4 @@ public class BitstreamFormatMatcher {
             hasJsonPath("$.type", is("bitstreamformat"))
         );
     }
-
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/RelationshipMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/RelationshipMatcher.java
@@ -8,6 +8,7 @@
 package org.dspace.app.rest.matcher;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.dspace.app.rest.matcher.HalMatcher.matchEmbeds;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -46,6 +47,15 @@ public class RelationshipMatcher {
             hasJsonPath("$.rightPlace", is(rightPlace)),
             hasJsonPath("$._embedded.relationshipType",
                         RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipType))
+        );
+    }
+
+    /**
+     * Gets a matcher for all expected embeds when the full projection is requested.
+     */
+    public static Matcher<? super Object> matchFullEmbeds() {
+        return matchEmbeds(
+                "relationshipType"
         );
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/ResourcePolicyMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/ResourcePolicyMatcher.java
@@ -10,6 +10,7 @@ package org.dspace.app.rest.matcher;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
 
+import static org.dspace.app.rest.matcher.HalMatcher.matchEmbeds;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -24,9 +25,9 @@ import org.hamcrest.Matcher;
  * @author Mykhaylo Boychuk (4science.it)
  *
  */
-public class ResoucePolicyMatcher {
+public class ResourcePolicyMatcher {
 
-    private ResoucePolicyMatcher() {
+    private ResourcePolicyMatcher() {
     }
 
     public static Matcher<? super Object> matchResourcePolicy(ResourcePolicy resourcePolicy) {
@@ -50,6 +51,17 @@ public class ResoucePolicyMatcher {
                                         is(resourcePolicy.getGroup().getID().toString())) :
                                hasJsonPath("$._embedded.group", nullValue())
                         );
+    }
+
+    /**
+     * Gets a matcher for all expected embeds when the full projection is requested.
+     */
+    public static Matcher<? super Object> matchFullEmbeds() {
+        return matchEmbeds(
+                "eperson",
+                "group",
+                "resource"
+        );
     }
 
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/WorkspaceItemMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/WorkspaceItemMatcher.java
@@ -9,6 +9,7 @@ package org.dspace.app.rest.matcher;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
+import static org.dspace.app.rest.matcher.HalMatcher.matchEmbeds;
 import static org.dspace.app.rest.test.AbstractControllerIntegrationTest.REST_SERVER_URL;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.is;
@@ -126,5 +127,17 @@ public class WorkspaceItemMatcher {
                     hasJsonPath("$._links.submitter.href", startsWith(REST_SERVER_URL)),
                     hasJsonPath("$._links.submissionDefinition.href", startsWith(REST_SERVER_URL)));
         }
+    }
+
+    /**
+     * Gets a matcher for all expected embeds when the full projection is requested.
+     */
+    public static Matcher<? super Object> matchFullEmbeds() {
+        return matchEmbeds(
+                "collection",
+                "item",
+                "submitter",
+                "submissionDefinition"
+        );
     }
 }


### PR DESCRIPTION
https://jira.lyrasis.org/browse/DS-4438

This PR reverts "quick fix" PR: https://github.com/DSpace/DSpace/pull/2682 in favor of updating all relevant REST requests to support a client-provided projection parameter.

Prior to this, projections were only respected for GETs. Now, it's supported for POSTs and other verbs.

This should be merged AFTER the following, related PR is merged for Angular: https://github.com/DSpace/dspace-angular/pull/584