### PR TITLE
DS-4380:  Update XOAI (OAI-PMH) for full JDK11 compatibility

### DIFF
--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <!-- This is the path to the root [dspace-src] directory. -->
         <root.basedir>${basedir}/..</root.basedir>
-        <xoai.version>3.2.11</xoai.version>
+        <xoai.version>3.3.0</xoai.version>
         <jtwig.version>5.87.0.RELEASE</jtwig.version>
     </properties>
 
@@ -89,7 +89,7 @@
                 <exclusion>
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-lang3</artifactId>
-	        </exclusion>
+                </exclusion>
                 <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
@@ -102,6 +102,11 @@
                 <exclusion>
                     <groupId>org.codehaus.woodstox</groupId>
                     <artifactId>wstx-asl</artifactId>
+                </exclusion>
+                <!-- Later version provided by Hibernate -->
+                <exclusion>
+                    <groupId>org.dom4j</groupId>
+                    <artifactId>dom4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/solr/DSpaceSolrServerResolver.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/solr/DSpaceSolrServerResolver.java
@@ -26,11 +26,12 @@ public class DSpaceSolrServerResolver implements SolrServerResolver {
     @Override
     public SolrClient getServer() throws SolrServerException {
         if (server == null) {
+            String serverUrl = configurationService.getProperty("oai.solr.url");
             try {
-                server = new HttpSolrClient.Builder(configurationService.getProperty("oai", "solr.url")).build();
-                log.debug("Solr Server Initialized");
+                server = new HttpSolrClient.Builder(serverUrl).build();
+                log.debug("OAI Solr Server Initialized");
             } catch (Exception e) {
-                log.error(e.getMessage(), e);
+                log.error("Could not initialize OAI Solr Server at " + serverUrl , e);
             }
         }
         return server;

--- a/dspace-oai/src/main/java/org/dspace/xoai/solr/DSpaceSolrServer.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/solr/DSpaceSolrServer.java
@@ -30,12 +30,12 @@ public class DSpaceSolrServer {
 
     public static SolrClient getServer() throws SolrServerException {
         if (_server == null) {
+            String serverUrl = ConfigurationManager.getProperty("oai.solr.url");
             try {
-                _server = new HttpSolrClient.Builder(
-                    ConfigurationManager.getProperty("oai", "solr.url")).build();
-                log.debug("Solr Server Initialized");
+                _server = new HttpSolrClient.Builder(serverUrl).build();
+                log.debug("OAI Solr Server Initialized");
             } catch (Exception e) {
-                log.error(e.getMessage(), e);
+                log.error("Could not initialize OAI Solr Server at " + serverUrl , e);
             }
         }
         return _server;


### PR DESCRIPTION
Minor PR to update to XOAI v3.3.0, which is more compatible with JDK11.  In XOAI v3.3.0, I've updated dependencies to avoid any "An illegal reflective access operation has occurred" warnings when running JDK 9 or above.  See https://github.com/DSpace/xoai/releases/tag/xoai-3.3.0

This PR also makes a minor refactor to the classes which obtain the Solr configuration for `dspace-oai` to ensure they provide better logging & use the more correct version of the configuration `oai.solr.url`. 

I've tested both of these minor changes locally and they work well on latest `master` and with JDK11.