### PR TITLE
DS-4440 GDPR - Anonymize statistics feature

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/AnonymizeStatistics.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/AnonymizeStatistics.java
@@ -66,7 +66,7 @@ public class AnonymizeStatistics {
     private static int batchSize = 100;
     private static int threads = 2;
 
-    private static final Object ANONYMIZED = configurationService.getProperty("anonymize_statistics.dns_mask", "anonymized");
+    private static final Object DNS_MASK = configurationService.getProperty("anonymize_statistics.dns_mask", "anonymized");
 
     private static final String TIME_LIMIT;
 
@@ -231,7 +231,7 @@ public class AnonymizeStatistics {
 
         return solrLoggerService.query(
                 "ip:*",
-                "time:[* TO " + TIME_LIMIT + "] AND -dns:" + ANONYMIZED,
+                "time:[* TO " + TIME_LIMIT + "] AND -dns:" + DNS_MASK,
                 null, batchSize, -1, null, null, null, null, null, false, false, true
         );
     }
@@ -257,7 +257,7 @@ public class AnonymizeStatistics {
                     ),
                     asList(
                         singletonList(solrLoggerService.anonymizeIp(document.getFieldValue("ip").toString())),
-                        singletonList(ANONYMIZED)
+                        singletonList(DNS_MASK)
                     ),
                     false
                 );

--- a/dspace-api/src/main/java/org/dspace/statistics/AnonymizeStatistics.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/AnonymizeStatistics.java
@@ -1,0 +1,272 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.statistics;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocument;
+import org.dspace.core.Context;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.statistics.factory.StatisticsServiceFactory;
+import org.dspace.statistics.service.SolrLoggerService;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static java.lang.Integer.parseInt;
+import static java.lang.Thread.currentThread;
+import static java.lang.Thread.sleep;
+import static java.util.Arrays.asList;
+import static java.util.Calendar.DAY_OF_YEAR;
+import static java.util.Collections.singletonList;
+import static org.apache.commons.cli.Option.builder;
+import static org.apache.commons.lang.time.DateFormatUtils.format;
+import static org.apache.log4j.Logger.getLogger;
+import static org.dspace.core.LogManager.getHeader;
+import static org.dspace.statistics.SolrLoggerServiceImpl.DATE_FORMAT_8601;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
+public class AnonymizeStatistics {
+
+    private static Logger log = getLogger(AnonymizeStatistics.class);
+    private static Context context = new Context();
+    private static String action = "anonymise_statistics";
+
+    private static final String HELP_OPTION = "h";
+    private static final String SLEEP_OPTION = "s";
+    private static final String BATCH_SIZE_OPTION = "b";
+    private static final String THREADS_OPTION = "t";
+
+    private static int sleep;
+
+    private static SolrLoggerService solrLoggerService = StatisticsServiceFactory.getInstance().getSolrLoggerService();
+    private static ConfigurationService configurationService =
+            DSpaceServicesFactory.getInstance().getConfigurationService();
+
+    private static int batchSize = 100;
+    private static int threads = 2;
+
+    private static final Object ANONYMISED = configurationService.getProperty("anonymise_statistics.dns_mask", "anonymised");
+
+    private static final String TIME_LIMIT;
+
+    static {
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(DAY_OF_YEAR, -configurationService.getIntProperty("anonymise_statistics.time_limit", 90));
+        TIME_LIMIT = format(calendar, DATE_FORMAT_8601);
+    }
+
+    private AnonymizeStatistics() {
+
+    }
+
+
+    public static void main(String... args) throws ParseException {
+
+        parseCommandLineOptions(createCommandLineOptions(), args);
+        anonymiseStatistics();
+    }
+
+    private static Options createCommandLineOptions() {
+
+        Options options = new Options();
+        options.addOption(
+                builder(HELP_OPTION)
+                        .longOpt("help")
+                        .desc("Print the usage of the script")
+                        .hasArg(false)
+                        .build()
+        );
+
+        options.addOption(
+                builder(SLEEP_OPTION)
+                        .longOpt("sleep")
+                        .desc("Sleep a certain time between each solr request")
+                        .hasArg(true)
+                        .build()
+        );
+
+        options.addOption(
+            builder(BATCH_SIZE_OPTION)
+                .longOpt("batch")
+                .desc("The amount of Solr records to be processed per batch (defaults to 100)")
+                .hasArg(true)
+                .build()
+        );
+
+        options.addOption(
+            builder(THREADS_OPTION)
+                .longOpt("threads")
+                .desc("The amount of threads used by the script (defaults to 2")
+                .hasArg(true)
+                .build()
+        );
+
+        return options;
+    }
+
+    private static void parseCommandLineOptions(Options options, String... args) throws ParseException {
+
+        CommandLine commandLine = new DefaultParser().parse(options, args);
+
+        if (commandLine.hasOption(HELP_OPTION)) {
+            printHelp(options);
+            System.exit(0);
+        }
+
+        if (commandLine.hasOption(SLEEP_OPTION)) {
+            sleep = parseInt(commandLine.getOptionValue(SLEEP_OPTION));
+        }
+
+        if (commandLine.hasOption(BATCH_SIZE_OPTION)) {
+            batchSize = parseInt(commandLine.getOptionValue(BATCH_SIZE_OPTION));
+        }
+
+        if (commandLine.hasOption(THREADS_OPTION)) {
+            threads = parseInt(commandLine.getOptionValue(THREADS_OPTION));
+        }
+    }
+
+    private static void printHelp(Options options) {
+        new HelpFormatter().printHelp("dsrun " + AnonymizeStatistics.class.getCanonicalName(), options);
+    }
+
+    private static void printInfo(String info) {
+        System.out.println(info);
+        log.info(getHeader(context, action, info));
+    }
+
+    private static void printWarning(String warning) {
+        System.out.println(warning);
+        log.warn(getHeader(context, action, warning));
+    }
+
+    private static void printError(Exception error) {
+        error.printStackTrace();
+        log.error(getHeader(context, action, error.getMessage()), error);
+    }
+
+
+    private static void anonymiseStatistics() {
+        try {
+            long updated = 0;
+            long total = getDocuments().getResults().getNumFound();
+            printInfo(total + " documents to update");
+
+            ExecutorService executorService = Executors.newFixedThreadPool(threads);
+
+            QueryResponse documents;
+            do {
+                documents = getDocuments();
+
+                Collection<Callable<Boolean>> callables = new ArrayList<>();
+                Set<String> shards = new HashSet<>();
+
+                for (SolrDocument document : documents.getResults()) {
+                    updated++;
+
+
+                    callables.add(new DoProcessing(document, updated));
+                    String shard = (String) document.getFieldValue("[shard]");
+
+                    if(StringUtils.isNotBlank(shard)){
+                        shards.add(shard);
+                    }
+                }
+
+                executorService.invokeAll(callables);
+
+                solrLoggerService.commit();
+
+                for (String shard : shards) {
+                    solrLoggerService.commitShard(shard);
+                }
+
+                System.out.println("processed " + updated + " records");
+            } while (documents.getResults().getNumFound() > 0);
+
+            printInfo(updated + " documents updated");
+            if (updated == total) {
+                printInfo("all relevant documents were updated");
+            } else {
+                printWarning("not all relevant documents were updated, check the DSpace logs for more details");
+            }
+
+        } catch (Exception e) {
+            printError(e);
+        }
+    }
+
+    private static QueryResponse getDocuments() throws SolrServerException {
+
+        if (sleep > 0) {
+            try {
+                printInfo("sleep " + sleep + "ms");
+                sleep(sleep);
+            } catch (InterruptedException e) {
+                printError(e);
+                currentThread().interrupt();
+            }
+        }
+
+        return solrLoggerService.query(
+                "ip:*",
+                "time:[* TO " + TIME_LIMIT + "] AND -dns:" + ANONYMISED,
+                null, batchSize, -1, null, null, null, null, null, false, false, true
+        );
+    }
+
+    public static class DoProcessing implements Callable<Boolean> {
+        private final SolrDocument document;
+        private final long updated;
+
+        public DoProcessing(SolrDocument document, long updated) {
+            this.document = document;
+            this.updated = updated;
+        }
+
+        @Override
+        public Boolean call() {
+            try {
+                solrLoggerService.update(
+                    "uid:" + document.getFieldValue("uid"),
+                    "replace",
+                    asList(
+                        "ip",
+                        "dns"
+                    ),
+                    asList(
+                        singletonList(solrLoggerService.anonymiseIp(document.getFieldValue("ip").toString())),
+                        singletonList(ANONYMISED)
+                    ),
+                    false
+                );
+                printInfo(updated + ": updated document with uid " + document.getFieldValue("uid") + " " + new Date());
+                return true;
+            } catch (Exception e) {
+                printError(e);
+                return false;
+            }
+        }
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/statistics/AnonymizeStatistics.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/AnonymizeStatistics.java
@@ -101,7 +101,7 @@ public class AnonymizeStatistics {
         options.addOption(
                 builder(SLEEP_OPTION)
                         .longOpt("sleep")
-                        .desc("Sleep a certain time between each solr request")
+                        .desc("Sleep a certain time given in milliseconds between each solr request")
                         .hasArg(true)
                         .build()
         );
@@ -131,7 +131,7 @@ public class AnonymizeStatistics {
 
         if (commandLine.hasOption(HELP_OPTION)) {
             printHelp(options);
-            System.exit(0);
+            System.exit(-1);
         }
 
         if (commandLine.hasOption(SLEEP_OPTION)) {

--- a/dspace-api/src/main/java/org/dspace/statistics/AnonymizeStatistics.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/AnonymizeStatistics.java
@@ -66,7 +66,7 @@ public class AnonymizeStatistics {
     private static int batchSize = 100;
     private static int threads = 2;
 
-    private static final Object ANONYMIZE = configurationService.getProperty("anonymize_statistics.dns_mask", "anonymized");
+    private static final Object ANONYMIZED = configurationService.getProperty("anonymize_statistics.dns_mask", "anonymized");
 
     private static final String TIME_LIMIT;
 
@@ -231,7 +231,7 @@ public class AnonymizeStatistics {
 
         return solrLoggerService.query(
                 "ip:*",
-                "time:[* TO " + TIME_LIMIT + "] AND -dns:" + ANONYMIZE,
+                "time:[* TO " + TIME_LIMIT + "] AND -dns:" + ANONYMIZED,
                 null, batchSize, -1, null, null, null, null, null, false, false, true
         );
     }
@@ -257,7 +257,7 @@ public class AnonymizeStatistics {
                     ),
                     asList(
                         singletonList(solrLoggerService.anonymizeIp(document.getFieldValue("ip").toString())),
-                        singletonList(ANONYMIZE)
+                        singletonList(ANONYMIZED)
                     ),
                     false
                 );

--- a/dspace-api/src/main/java/org/dspace/statistics/AnonymizeStatistics.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/AnonymizeStatistics.java
@@ -50,7 +50,7 @@ public class AnonymizeStatistics {
 
     private static Logger log = getLogger(AnonymizeStatistics.class);
     private static Context context = new Context();
-    private static String action = "anonymise_statistics";
+    private static String action = "anonymize_statistics";
 
     private static final String HELP_OPTION = "h";
     private static final String SLEEP_OPTION = "s";
@@ -66,13 +66,13 @@ public class AnonymizeStatistics {
     private static int batchSize = 100;
     private static int threads = 2;
 
-    private static final Object ANONYMISED = configurationService.getProperty("anonymise_statistics.dns_mask", "anonymised");
+    private static final Object ANONYMIZE = configurationService.getProperty("anonymize_statistics.dns_mask", "anonymized");
 
     private static final String TIME_LIMIT;
 
     static {
         Calendar calendar = Calendar.getInstance();
-        calendar.add(DAY_OF_YEAR, -configurationService.getIntProperty("anonymise_statistics.time_limit", 90));
+        calendar.add(DAY_OF_YEAR, -configurationService.getIntProperty("anonymize_statistics.time_threshold", 90));
         TIME_LIMIT = format(calendar, DATE_FORMAT_8601);
     }
 
@@ -84,7 +84,7 @@ public class AnonymizeStatistics {
     public static void main(String... args) throws ParseException {
 
         parseCommandLineOptions(createCommandLineOptions(), args);
-        anonymiseStatistics();
+        anonymizeStatistics();
     }
 
     private static Options createCommandLineOptions() {
@@ -167,7 +167,7 @@ public class AnonymizeStatistics {
     }
 
 
-    private static void anonymiseStatistics() {
+    private static void anonymizeStatistics() {
         try {
             long updated = 0;
             long total = getDocuments().getResults().getNumFound();
@@ -231,7 +231,7 @@ public class AnonymizeStatistics {
 
         return solrLoggerService.query(
                 "ip:*",
-                "time:[* TO " + TIME_LIMIT + "] AND -dns:" + ANONYMISED,
+                "time:[* TO " + TIME_LIMIT + "] AND -dns:" + ANONYMIZE,
                 null, batchSize, -1, null, null, null, null, null, false, false, true
         );
     }
@@ -256,8 +256,8 @@ public class AnonymizeStatistics {
                         "dns"
                     ),
                     asList(
-                        singletonList(solrLoggerService.anonymiseIp(document.getFieldValue("ip").toString())),
-                        singletonList(ANONYMISED)
+                        singletonList(solrLoggerService.anonymizeIp(document.getFieldValue("ip").toString())),
+                        singletonList(ANONYMIZE)
                     ),
                     false
                 );

--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
@@ -16,8 +16,11 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.URLEncoder;
+import java.net.UnknownHostException;
 import java.sql.SQLException;
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -110,7 +113,10 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
 
     private static List<String> statisticYearCores = new ArrayList<String>();
     private static boolean statisticYearCoresInit = false;
-    
+
+    private static final String IP_V4_REGEX = "^((?:\\d{1,3}\\.){3})\\d{1,3}$";
+    private static final String IP_V6_REGEX = "^(.*):.*:.*$";
+
     @Autowired(required = true)
     protected BitstreamService bitstreamService;
     @Autowired(required = true)
@@ -314,7 +320,15 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
                 }
             }
 
-            doc1.addField("ip", ip);
+            if (configurationService.getBooleanProperty("anonymise_statistics.anonymise_on_log", false)) {
+                try {
+                    doc1.addField("ip", anonymiseIp(ip));
+                } catch (UnknownHostException e) {
+                    log.warn(e.getMessage(), e);
+                }
+            } else {
+                doc1.addField("ip", ip);
+            }
 
             //Also store the referrer
             if(request.getHeader("referer") != null){
@@ -323,7 +337,11 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
 
             try
             {
-                String dns = DnsLookup.reverseDns(ip);
+                String dns = configurationService.getProperty("anonymise_statistics.dns_mask", "anonymised");
+                if (!configurationService.getBooleanProperty("anonymise_statistics.anonymise_on_log", false)) {
+                    dns = DnsLookup.reverseDns(ip);
+                }
+
                 doc1.addField("dns", dns.toLowerCase());
             }
             catch (Exception e)
@@ -407,11 +425,23 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
                     }
                 }
 
-            doc1.addField("ip", ip);
+                if (configurationService.getBooleanProperty("anonymise_statistics.anonymise_on_log", false)) {
+                    try {
+                        doc1.addField("ip", anonymiseIp(ip));
+                    } catch (UnknownHostException e) {
+                        log.warn(e.getMessage(), e);
+                    }
+                } else {
+                    doc1.addField("ip", ip);
+                }
 
             try
             {
-                String dns = DnsLookup.reverseDns(ip);
+                String dns = configurationService.getProperty("anonymise_statistics.dns_mask", "anonymised");
+                if (!configurationService.getBooleanProperty("anonymise_statistics.anonymise_on_log", false)) {
+                    dns = DnsLookup.reverseDns(ip);
+                }
+
                 doc1.addField("dns", dns.toLowerCase());
             }
             catch (Exception e)
@@ -668,6 +698,7 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
             Map<String, String> params = new HashMap<String, String>();
             params.put("q", query);
             params.put("rows", "10");
+            params.put("fl","[shard],*");
             if(0 < statisticYearCores.size()){
                 params.put(ShardParams.SHARDS, StringUtils.join(statisticYearCores.iterator(), ','));
             }
@@ -805,6 +836,14 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
             List<String> fieldNames, List<List<Object>> fieldValuesList)
             throws SolrServerException, IOException
     {
+        update(query, action, fieldNames, fieldValuesList, true);
+    }
+
+    @Override
+    public void update(String query, String action,
+            List<String> fieldNames, List<List<Object>> fieldValuesList, boolean commit)
+            throws SolrServerException, IOException
+    {
         // Since there is NO update
         // We need to get our documents
         // QueryResponse queryResponse = solr.query()//query(query, null, -1,
@@ -821,13 +860,14 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
 
         processor.execute(query);
 
-        // We have all the docs delete the ones we don't need
-        solr.deleteByQuery(query);
-
         // Add the new (updated onces
         for (int i = 0; i < docsToUpdate.size(); i++)
         {
             SolrDocument solrDocument = docsToUpdate.get(i);
+
+            HttpSolrServer shard = new HttpSolrServer("http://" + solrDocument.getFieldValue("[shard]"));
+            shard.deleteByQuery("uid:" + solrDocument.getFieldValue("uid"));
+
             // Now loop over our fieldname actions
             for (int j = 0; j < fieldNames.size(); j++)
             {
@@ -862,11 +902,19 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
                     }
                 }
             }
+
+            solrDocument.removeFields("_version_");
+            solrDocument.removeFields("[shard]");
+
             SolrInputDocument newInput = ClientUtils
                     .toSolrInputDocument(solrDocument);
-            solr.add(newInput);
+
+            shard.add(newInput);
+
+            if (commit) {
+                shard.commit();
+            }
         }
-        solr.commit();
         // System.out.println("SolrLogger.update(\""+query+"\"):"+(new
         // Date().getTime() - start)+"ms,"+numbFound+"records");
     }
@@ -1038,11 +1086,19 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
     }
 
     @Override
-    public QueryResponse query(String query, String filterQuery,
-            String facetField, int rows, int max, String dateType, String dateStart,
-            String dateEnd, List<String> facetQueries, String sort, boolean ascending)
-            throws SolrServerException
-    {
+    public QueryResponse query(String query, String filterQuery, String facetField, int rows, int max, String dateType, String dateStart, String dateEnd, List<String> facetQueries, String sort, boolean ascending) throws SolrServerException {
+
+        return query(query, filterQuery, facetField, rows, max, dateType, dateStart, dateEnd, facetQueries, sort, ascending, true);
+    }
+
+    @Override
+    public QueryResponse query(String query, String filterQuery, String facetField, int rows, int max, String dateType, String dateStart, String dateEnd, List<String> facetQueries, String sort, boolean ascending, boolean defaultFilterQueries) throws SolrServerException {
+        return query(query, filterQuery, facetField, rows, max, dateType, dateStart, dateEnd, facetQueries, sort, ascending, defaultFilterQueries, false);
+    }
+
+    @Override
+    public QueryResponse query(String query, String filterQuery, String facetField, int rows, int max, String dateType, String dateStart, String dateEnd, List<String> facetQueries, String sort, boolean ascending, boolean defaultFilterQueries, boolean includeShardField) throws SolrServerException {
+
         if (solr == null)
         {
             return null;
@@ -1052,6 +1108,10 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
         SolrQuery solrQuery = new SolrQuery().setRows(rows).setQuery(query)
                 .setFacetMinCount(1);
         addAdditionalSolrYearCores(solrQuery);
+
+        if (includeShardField) {
+            solrQuery.setParam("fl", "[shard],*");
+        }
 
         // Set the date facet if present
         if (dateType != null)
@@ -1097,14 +1157,14 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
         // not be influenced
 
         // Choose to filter by the Legacy spider IP list (may get too long to properly filter all IP's
-        if(configurationService.getBooleanProperty("solr-statistics.query.filter.spiderIp",false))
+        if (defaultFilterQueries && configurationService.getBooleanProperty("solr-statistics.query.filter.spiderIp",false))
         {
             solrQuery.addFilterQuery(getIgnoreSpiderIPs());
         }
 
         // Choose to filter by isBot field, may be overriden in future
         // to allow views on stats based on bots.
-        if(configurationService.getBooleanProperty("solr-statistics.query.filter.isBot",true))
+        if (defaultFilterQueries && configurationService.getBooleanProperty("solr-statistics.query.filter.isBot",true))
         {
             solrQuery.addFilterQuery("-isBot:true");
         }
@@ -1114,7 +1174,7 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
         }
 
         String[] bundles = configurationService.getArrayProperty("solr-statistics.query.filter.bundles");
-        if(bundles != null && bundles.length > 0){
+        if (defaultFilterQueries && bundles != null && bundles.length > 0) {
 
             /**
              * The code below creates a query that will allow only records which do not have a bundlename
@@ -1538,6 +1598,17 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
         }
     }
 
+    @Override
+    public void commit() throws Exception {
+        solr.commit();
+    }
+
+    @Override
+    public void commitShard(String shard) throws Exception {
+        HttpSolrServer shardSolr = new HttpSolrServer("http://" + shard);
+        shardSolr.commit();
+    }
+
     protected void addDocumentsToFile(Context context, SolrDocumentList docs, File exportOutput) throws SQLException, ParseException, IOException {
         for(SolrDocument doc : docs) {
             String ip = doc.get("ip").toString();
@@ -1637,5 +1708,16 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
             log.error(e.getMessage(), e);
         }
         statisticYearCoresInit = true;
+    }
+
+    public Object anonymiseIp(String ip) throws UnknownHostException {
+        InetAddress address = InetAddress.getByName(ip);
+        if (address instanceof Inet4Address) {
+            return ip.replaceFirst(IP_V4_REGEX, "$1" + configurationService.getProperty("anonymise_statistics.ip_v4_mask", "255"));
+        } else if (address instanceof Inet6Address) {
+            return ip.replaceFirst(IP_V6_REGEX, "$1:" + configurationService.getProperty("anonymise_statistics.ip_v6_mask", "FFFF:FFFF"));
+        }
+
+        throw new UnknownHostException("unknown ip format");
     }
 }

--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
@@ -320,9 +320,9 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
                 }
             }
 
-            if (configurationService.getBooleanProperty("anonymise_statistics.anonymise_on_log", false)) {
+            if (configurationService.getBooleanProperty("anonymize_statistics.anonymize_on_log", false)) {
                 try {
-                    doc1.addField("ip", anonymiseIp(ip));
+                    doc1.addField("ip", anonymizeIp(ip));
                 } catch (UnknownHostException e) {
                     log.warn(e.getMessage(), e);
                 }
@@ -337,8 +337,8 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
 
             try
             {
-                String dns = configurationService.getProperty("anonymise_statistics.dns_mask", "anonymised");
-                if (!configurationService.getBooleanProperty("anonymise_statistics.anonymise_on_log", false)) {
+                String dns = configurationService.getProperty("anonymize_statistics.dns_mask", "anonymized");
+                if (!configurationService.getBooleanProperty("anonymize_statistics.anonymize_on_log", false)) {
                     dns = DnsLookup.reverseDns(ip);
                 }
 
@@ -425,9 +425,9 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
                     }
                 }
 
-                if (configurationService.getBooleanProperty("anonymise_statistics.anonymise_on_log", false)) {
+                if (configurationService.getBooleanProperty("anonymize_statistics.anonymize_on_log", false)) {
                     try {
-                        doc1.addField("ip", anonymiseIp(ip));
+                        doc1.addField("ip", anonymizeIp(ip));
                     } catch (UnknownHostException e) {
                         log.warn(e.getMessage(), e);
                     }
@@ -437,8 +437,8 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
 
             try
             {
-                String dns = configurationService.getProperty("anonymise_statistics.dns_mask", "anonymised");
-                if (!configurationService.getBooleanProperty("anonymise_statistics.anonymise_on_log", false)) {
+                String dns = configurationService.getProperty("anonymize_statistics.dns_mask", "anonymized");
+                if (!configurationService.getBooleanProperty("anonymize_statistics.anonymize_on_log", false)) {
                     dns = DnsLookup.reverseDns(ip);
                 }
 
@@ -1710,12 +1710,12 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
         statisticYearCoresInit = true;
     }
 
-    public Object anonymiseIp(String ip) throws UnknownHostException {
+    public Object anonymizeIp(String ip) throws UnknownHostException {
         InetAddress address = InetAddress.getByName(ip);
         if (address instanceof Inet4Address) {
-            return ip.replaceFirst(IP_V4_REGEX, "$1" + configurationService.getProperty("anonymise_statistics.ip_v4_mask", "255"));
+            return ip.replaceFirst(IP_V4_REGEX, "$1" + configurationService.getProperty("anonymize_statistics.ip_v4_mask", "255"));
         } else if (address instanceof Inet6Address) {
-            return ip.replaceFirst(IP_V6_REGEX, "$1:" + configurationService.getProperty("anonymise_statistics.ip_v6_mask", "FFFF:FFFF"));
+            return ip.replaceFirst(IP_V6_REGEX, "$1:" + configurationService.getProperty("anonymize_statistics.ip_v6_mask", "FFFF:FFFF"));
         }
 
         throw new UnknownHostException("unknown ip format");

--- a/dspace-api/src/main/java/org/dspace/statistics/service/SolrLoggerService.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/service/SolrLoggerService.java
@@ -18,6 +18,7 @@ import org.dspace.usage.UsageWorkflowEvent;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
+import java.net.UnknownHostException;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
@@ -117,6 +118,10 @@ public interface SolrLoggerService {
             List<String> fieldNames, List<List<Object>> fieldValuesList)
             throws SolrServerException, IOException;
 
+    public void update(String query, String action,
+                       List<String> fieldNames, List<List<Object>> fieldValuesList, boolean commit)
+        throws SolrServerException, IOException;
+
     public void query(String query, int max) throws SolrServerException;
 
     /**
@@ -179,6 +184,18 @@ public interface SolrLoggerService {
             String dateEnd, List<String> facetQueries, String sort, boolean ascending)
             throws SolrServerException;
 
+    public QueryResponse query(String query, String filterQuery,
+                               String facetField, int rows, int max, String dateType, String dateStart,
+                               String dateEnd, List<String> facetQueries, String sort, boolean ascending,
+                               boolean defaultFilterQueries)
+            throws SolrServerException;
+
+    public QueryResponse query(String query, String filterQuery,
+                               String facetField, int rows, int max, String dateType, String dateStart,
+                               String dateEnd, List<String> facetQueries, String sort, boolean ascending,
+                               boolean defaultFilterQueries, boolean includeShardField)
+        throws SolrServerException;
+
     /**
      * Returns in a filterQuery string all the ip addresses that should be ignored
      *
@@ -203,5 +220,11 @@ public interface SolrLoggerService {
      * @throws Exception if error
      */
     public void exportHits() throws Exception;
+
+    public void commit() throws Exception;
+
+    public void commitShard(String shard) throws Exception;
+
+    public Object anonymiseIp(String ip) throws UnknownHostException;
 
 }

--- a/dspace-api/src/main/java/org/dspace/statistics/service/SolrLoggerService.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/service/SolrLoggerService.java
@@ -225,6 +225,6 @@ public interface SolrLoggerService {
 
     public void commitShard(String shard) throws Exception;
 
-    public Object anonymiseIp(String ip) throws UnknownHostException;
+    public Object anonymizeIp(String ip) throws UnknownHostException;
 
 }

--- a/dspace/config/launcher.xml
+++ b/dspace/config/launcher.xml
@@ -384,7 +384,7 @@
         <name>anonymize-statistics</name>
         <description>Anonymize the ip values of the solr statistics</description>
         <step>
-            <class>com.atmire.dspace.statistics.AnonymizeStatistics</class>
+            <class>org.dspace.statistics.AnonymizeStatistics</class>
         </step>
     </command>
 </commands>

--- a/dspace/config/launcher.xml
+++ b/dspace/config/launcher.xml
@@ -380,4 +380,11 @@
             <class>org.dspace.app.util.Version</class>
         </step>
     </command>
+    <command>
+        <name>anonymize-statistics</name>
+        <description>Anonymize the ip values of the solr statistics</description>
+        <step>
+            <class>com.atmire.dspace.statistics.AnonymizeStatistics</class>
+        </step>
+    </command>
 </commands>

--- a/dspace/config/modules/usage-statistics.cfg
+++ b/dspace/config/modules/usage-statistics.cfg
@@ -45,16 +45,16 @@ usage-statistics.authorization.admin.workflow=true
 # Configuration parameters for anonymizing statistics
 
 # Anonymize statistics the moment they are created
-# anonymize_statistics.anonymize_on_log = false
+#anonymize_statistics.anonymize_on_log = false
 
 # Mask to replace the last group of an IPv4 address
-# anonymize_statistics.ip_v4_mask = 255"
+#anonymize_statistics.ip_v4_mask = 255
 
 # Mask to replace the last two groups of an IPv6 address
-# anonymize_statistics.ip_v6_mask = FFFF:FFFF"
+#anonymize_statistics.ip_v6_mask = FFFF:FFFF
 
 # Mask to replace the DNS
-# anonymize_statistics.dns_mask = anonymized
+#anonymize_statistics.dns_mask = anonymized
 
 # Only anonymize statistics records older than this threshold (expressed in days)
-# anonymize_statistics.time_threshold = 90
+#anonymize_statistics.time_threshold = 90

--- a/dspace/config/modules/usage-statistics.cfg
+++ b/dspace/config/modules/usage-statistics.cfg
@@ -41,3 +41,20 @@ usage-statistics.authorization.admin.workflow=true
 # Enable/disable if a matching for a bot should be case sensitive
 # Setting this value to true will increase cpu usage, but bots will be found more accurately
 #usage-statistics.bots.case-insensitive = false
+
+# Configuration parameters for anonymizing statistics
+
+# Anonymize statistics the moment they are created
+# anonymize_statistics.anonymize_on_log = false
+
+# Mask to replace the last group of an IPv4 address
+# anonymize_statistics.ip_v4_mask = 255"
+
+# Mask to replace the last two groups of an IPv6 address
+# anonymize_statistics.ip_v6_mask = FFFF:FFFF"
+
+# Mask to replace the DNS
+# anonymize_statistics.dns_mask = anonymized
+
+# Only anonymize statistics records older than this threshold (expressed in days)
+# anonymize_statistics.time_threshold = 90


### PR DESCRIPTION
Fixes #7777

This PR adds a script to anonymise records in the Solr statistics core. The script will anonymise the IP values by rewriting (‘masking’) the last part. This mask is configurable, both for ipv4 and ipv6 addresses.

For IPv4 addresses, the last number will be replaced by the mask, defined by the configuration key ‘anonymise_statistics.ip_v4_mask’ which defaults to ‘254’.
For example, 109.74.16.171 is rewritten as 109.74.16.254

For IPv6 address, the last two numbers will be replaced by the mask, defined by the configuration key ‘anonymise_statistics.ip_v6_mask’ which defaults to ‘FFFF:FFFF’
For example, 2001:0db8:85a3:0000:0000:8a2e:0370:7334 is rewritten as 2001:0db8:85a3:0000:0000:8a2e:FFFF:FFFF

For each anonymised record, the DNS field is also replaced by “anonymised”.

The program only processes records older than 90 days. This period can be altered with the config ‘anonymise_statistics.time_limit’ (expressed in days).

The command ‘anonymise-statistics’ has been added to launcher.xml to launch the script.

The script takes an optional parameter ‘-s [sleep]’ (expressed in ms), which will make the Java thread sleep between the calls to Solr to reduce the load impact.

The Solr service commit mechanism is also optimised by adding multi-threading support. The script takes an optional parameter ‘-t [threads]’ to indicate how many threads the Solr service can use for this, if not given the thread count defaults to 2.

Besides the 'anonymise-statistics' script, which anonymises existing statistics record, the PR also allows for statistics records to be anonymised the moment they are created.
Enabling this feature can be done by setting the configuration parameter "anonymise_statistics.anonymise_on_log" to true.
When this configuration property is not set, the feature is disabled by default.

Finally, the PR also adds pagination support to SolrLoggerService

The work done on this PR is sponsored and led by the Humboldt-Universität zu Berlin.


This PR is related to https://jira.lyrasis.org/browse/DS-4440