### PR TITLE
DS-4442 Ensure underlying s3object is closed when S3InputStream is closed

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
@@ -139,7 +139,7 @@ public class S3BitStoreService implements BitStoreService
 		try
 		{
             S3Object object = s3Service.getObject(new GetObjectRequest(bucketName, key));
-			return (object != null) ? object.getObjectContent() : null;
+			return (object != null) ? new S3FilterInputStream(object) : null;
 		}
         catch (Exception e)
 		{

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/S3FilterInputStream.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/S3FilterInputStream.java
@@ -1,0 +1,36 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+package org.dspace.storage.bitstore;
+
+import com.amazonaws.services.s3.model.S3Object;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+
+/**
+ * Simple wrapper for S3 InputStreams which properly closes the underlying S3Object when the stream is closed.
+ */
+public class S3FilterInputStream extends FilterInputStream {
+
+    private S3Object s3Object;
+
+    protected S3FilterInputStream(S3Object object) {
+        super(object.getObjectContent());
+        s3Object = object;
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+        if (s3Object != null) {
+            s3Object.close();
+        }
+    }
+
+}


### PR DESCRIPTION
#1999 partially fixed this issue, but because the underlying `S3Object` is never closed after an S3 bitstream is retrieved, an AWS connection pool overflow eventually occurs. This PR wraps any incoming S3InputStreams with a class which automatically closes the underlying S3Object connection when the InputStream is closed.

This is the 6.x version of #2695 