### PR TITLE
DS-4073 fix. FindByValue should pass in value, not qualifier (dspace-6_x port)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authority/AuthorityValueServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authority/AuthorityValueServiceImpl.java
@@ -147,7 +147,7 @@ public class AuthorityValueServiceImpl implements AuthorityValueService{
     @Override
     public List<AuthorityValue> findByValue(Context context, String schema, String element, String qualifier, String value) {
         String field = fieldParameter(schema, element, qualifier);
-        return findByValue(context, field, qualifier);
+        return findByValue(context, field, value);
     }
 
     @Override


### PR DESCRIPTION
Port of https://github.com/DSpace/DSpace/pull/2454 to fix the same bug in DSpace 6.