### PR TITLE
Expose the action and step as an embed on workflow related objects

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ClaimedTaskConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ClaimedTaskConverter.java
@@ -10,6 +10,7 @@ package org.dspace.app.rest.converter;
 import org.dspace.app.rest.model.ClaimedTaskRest;
 import org.dspace.app.rest.projection.Projection;
 import org.dspace.discovery.IndexableObject;
+import org.dspace.xmlworkflow.factory.XmlWorkflowFactory;
 import org.dspace.xmlworkflow.storedcomponents.ClaimedTask;
 import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +29,9 @@ public class ClaimedTaskConverter
     @Autowired
     private ConverterService converter;
 
+    @Autowired
+    protected XmlWorkflowFactory xmlWorkflowFactory;
+
     @Override
     public ClaimedTaskRest convert(ClaimedTask obj, Projection projection) {
         ClaimedTaskRest taskRest = new ClaimedTaskRest();
@@ -35,7 +39,7 @@ public class ClaimedTaskConverter
         XmlWorkflowItem witem = obj.getWorkflowItem();
         taskRest.setId(obj.getID());
         taskRest.setWorkflowitem(converter.toRest(witem, projection));
-        taskRest.setAction(obj.getActionID());
+        taskRest.setAction(converter.toRest(xmlWorkflowFactory.getActionByName(obj.getActionID()), projection));
         taskRest.setStep(obj.getStepID());
         taskRest.setOwner(converter.toRest(obj.getOwner(), projection));
         return taskRest;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ClaimedTaskConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ClaimedTaskConverter.java
@@ -40,7 +40,6 @@ public class ClaimedTaskConverter
         taskRest.setId(obj.getID());
         taskRest.setWorkflowitem(converter.toRest(witem, projection));
         taskRest.setAction(converter.toRest(xmlWorkflowFactory.getActionByName(obj.getActionID()), projection));
-        taskRest.setStep(obj.getStepID());
         taskRest.setOwner(converter.toRest(obj.getOwner(), projection));
         return taskRest;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/PoolTaskConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/PoolTaskConverter.java
@@ -43,7 +43,6 @@ public class PoolTaskConverter
             taskRest.setGroup(converter.toRest(obj.getGroup(), projection));
         }
         taskRest.setAction(obj.getActionID());
-        taskRest.setStep(obj.getStepID());
         return taskRest;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ClaimedTaskRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ClaimedTaskRest.java
@@ -22,7 +22,8 @@ public class ClaimedTaskRest extends BaseObjectRest<Integer> {
 
     private String step;
 
-    private String action;
+    @JsonIgnore
+    private WorkflowActionRest action;
 
     @JsonIgnore
     private EPersonRest owner;
@@ -61,11 +62,11 @@ public class ClaimedTaskRest extends BaseObjectRest<Integer> {
      * @see ClaimedTaskRest#getAction()
      * @return the action
      */
-    public String getAction() {
+    public WorkflowActionRest getAction() {
         return action;
     }
 
-    public void setAction(String action) {
+    public void setAction(WorkflowActionRest action) {
         this.action = action;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ClaimedTaskRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ClaimedTaskRest.java
@@ -9,18 +9,23 @@ package org.dspace.app.rest.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.dspace.app.rest.RestResourceController;
-import org.dspace.xmlworkflow.storedcomponents.ClaimedTask;
 
 /**
  * The ClaimedTask REST Resource
  *
  * @author Andrea Bollini (andrea.bollini at 4science.it)
  */
+@LinksRest(links = {
+    @LinkRest(
+        name = ClaimedTaskRest.STEP,
+        method = "getStep"
+    )
+})
 public class ClaimedTaskRest extends BaseObjectRest<Integer> {
     public static final String NAME = "claimedtask";
     public static final String CATEGORY = RestAddressableModel.WORKFLOW;
 
-    private String step;
+    public static final String STEP = "step";
 
     @JsonIgnore
     private WorkflowActionRest action;
@@ -44,18 +49,6 @@ public class ClaimedTaskRest extends BaseObjectRest<Integer> {
     @Override
     public Class getController() {
         return RestResourceController.class;
-    }
-
-    /**
-     * @see ClaimedTask#getStepID()
-     * @return the step
-     */
-    public String getStep() {
-        return step;
-    }
-
-    public void setStep(String step) {
-        this.step = step;
     }
 
     /**
@@ -83,7 +76,7 @@ public class ClaimedTaskRest extends BaseObjectRest<Integer> {
     }
 
     /**
-     * 
+     *
      * @return the WorkflowItemRest that belong to this claimed task
      */
     public WorkflowItemRest getWorkflowitem() {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/PoolTaskRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/PoolTaskRest.java
@@ -16,11 +16,17 @@ import org.dspace.xmlworkflow.storedcomponents.PoolTask;
  *
  * @author Andrea Bollini (andrea.bollini at 4science.it)
  */
+@LinksRest(links = {
+    @LinkRest(
+        name = PoolTaskRest.STEP,
+        method = "getStep"
+    )
+})
 public class PoolTaskRest extends BaseObjectRest<Integer> {
     public static final String NAME = "pooltask";
     public static final String CATEGORY = RestAddressableModel.WORKFLOW;
 
-    private String step;
+    public static final String STEP = "step";
 
     private String action;
 
@@ -46,18 +52,6 @@ public class PoolTaskRest extends BaseObjectRest<Integer> {
     @Override
     public Class getController() {
         return RestResourceController.class;
-    }
-
-    /**
-     * @see PoolTask#getStepID()
-     * @return
-     */
-    public String getStep() {
-        return step;
-    }
-
-    public void setStep(String step) {
-        this.step = step;
     }
 
     /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/WorkflowItemRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/WorkflowItemRest.java
@@ -14,9 +14,17 @@ import org.dspace.app.rest.RestResourceController;
  *
  * @author Andrea Bollini (andrea.bollini at 4science.it)
  */
+@LinksRest(links = {
+    @LinkRest(
+        name = WorkflowItemRest.STEP,
+        method = "getStep"
+    )
+})
 public class WorkflowItemRest extends AInprogressSubmissionRest {
     public static final String NAME = "workflowitem";
     public static final String CATEGORY = RestAddressableModel.WORKFLOW;
+
+    public static final String STEP = "step";
 
     @Override
     public String getCategory() {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClaimedTaskStepLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClaimedTaskStepLinkRepository.java
@@ -23,6 +23,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.stereotype.Component;
 
+/**
+ * Link repository for the Steps subresources for an individual ClaimedTask
+ */
 @Component(ClaimedTaskRest.CATEGORY + "." + ClaimedTaskRest.NAME + "." + ClaimedTaskRest.STEP)
 public class ClaimedTaskStepLinkRepository extends AbstractDSpaceRestRepository implements LinkRestRepository {
 
@@ -32,6 +35,15 @@ public class ClaimedTaskStepLinkRepository extends AbstractDSpaceRestRepository 
     @Autowired
     private XmlWorkflowFactory xmlWorkflowFactory;
 
+    /**
+     * This method will retrieve the {@link WorkflowStepRest} object for the {@link ClaimedTask} with the given id
+     * @param request           The current request
+     * @param claimedTaskId     The id for the ClaimedTask to be used
+     * @param optionalPageable  The pageable if relevant
+     * @param projection        The Projection
+     * @return                  The {@link WorkflowStepRest} object related to the {@link ClaimedTask} specified by
+     *                          the given ID
+     */
     public WorkflowStepRest getStep(@Nullable HttpServletRequest request,
                                     Integer claimedTaskId,
                                     @Nullable Pageable optionalPageable,

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClaimedTaskStepLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ClaimedTaskStepLinkRepository.java
@@ -1,0 +1,51 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.repository;
+
+import java.sql.SQLException;
+import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
+
+import org.dspace.app.rest.model.ClaimedTaskRest;
+import org.dspace.app.rest.model.WorkflowStepRest;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.core.Context;
+import org.dspace.xmlworkflow.factory.XmlWorkflowFactory;
+import org.dspace.xmlworkflow.storedcomponents.ClaimedTask;
+import org.dspace.xmlworkflow.storedcomponents.service.ClaimedTaskService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.stereotype.Component;
+
+@Component(ClaimedTaskRest.CATEGORY + "." + ClaimedTaskRest.NAME + "." + ClaimedTaskRest.STEP)
+public class ClaimedTaskStepLinkRepository extends AbstractDSpaceRestRepository implements LinkRestRepository {
+
+    @Autowired
+    private ClaimedTaskService claimedTaskService;
+
+    @Autowired
+    private XmlWorkflowFactory xmlWorkflowFactory;
+
+    public WorkflowStepRest getStep(@Nullable HttpServletRequest request,
+                                    Integer claimedTaskId,
+                                    @Nullable Pageable optionalPageable,
+                                    Projection projection) {
+
+        Context context = obtainContext();
+        try {
+            ClaimedTask claimedTask = claimedTaskService.find(context, claimedTaskId);
+            if (claimedTask == null) {
+                throw new ResourceNotFoundException("ClaimedTask with id: " + claimedTaskId + " wasn't found");
+            }
+            return converter.toRest(xmlWorkflowFactory.getStepByName(claimedTask.getStepID()), projection);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/PoolTaskStepLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/PoolTaskStepLinkRepository.java
@@ -23,6 +23,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.stereotype.Component;
 
+/**
+ * Link repositoy for the Steps subresources of an individual PoolTask
+ */
 @Component(PoolTaskRest.CATEGORY + "." + PoolTaskRest.NAME + "." + PoolTaskRest.STEP)
 public class PoolTaskStepLinkRepository extends AbstractDSpaceRestRepository implements LinkRestRepository {
 
@@ -32,6 +35,15 @@ public class PoolTaskStepLinkRepository extends AbstractDSpaceRestRepository imp
     @Autowired
     private XmlWorkflowFactory xmlWorkflowFactory;
 
+    /**
+     * This method will retrieve the {@link WorkflowStepRest} object for the {@link PoolTask} with the given id
+     * @param request           The current request
+     * @param poolTaskId        The id for the PoolTask to be used
+     * @param optionalPageable  The pageable if relevant
+     * @param projection        The Projection
+     * @return                  The {@link WorkflowStepRest} object related to the {@link PoolTask} specified by
+     *                          the given ID
+     */
     public WorkflowStepRest getStep(@Nullable HttpServletRequest request,
                                     Integer poolTaskId,
                                     @Nullable Pageable optionalPageable,

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/PoolTaskStepLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/PoolTaskStepLinkRepository.java
@@ -1,0 +1,51 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.repository;
+
+import java.sql.SQLException;
+import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
+
+import org.dspace.app.rest.model.PoolTaskRest;
+import org.dspace.app.rest.model.WorkflowStepRest;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.core.Context;
+import org.dspace.xmlworkflow.factory.XmlWorkflowFactory;
+import org.dspace.xmlworkflow.storedcomponents.PoolTask;
+import org.dspace.xmlworkflow.storedcomponents.service.PoolTaskService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.stereotype.Component;
+
+@Component(PoolTaskRest.CATEGORY + "." + PoolTaskRest.NAME + "." + PoolTaskRest.STEP)
+public class PoolTaskStepLinkRepository extends AbstractDSpaceRestRepository implements LinkRestRepository {
+
+    @Autowired
+    private PoolTaskService poolTaskService;
+
+    @Autowired
+    private XmlWorkflowFactory xmlWorkflowFactory;
+
+    public WorkflowStepRest getStep(@Nullable HttpServletRequest request,
+                                    Integer poolTaskId,
+                                    @Nullable Pageable optionalPageable,
+                                    Projection projection) {
+
+        Context context = obtainContext();
+        try {
+            PoolTask poolTask = poolTaskService.find(context, poolTaskId);
+            if (poolTask == null) {
+                throw new ResourceNotFoundException("ClaimedTask with id: " + poolTaskId + " wasn't found");
+            }
+            return converter.toRest(xmlWorkflowFactory.getStepByName(poolTask.getStepID()), projection);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkflowItemStepLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkflowItemStepLinkRepository.java
@@ -28,6 +28,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.stereotype.Component;
 
+/**
+ * Link Repository for the Steps subresources of an individual WorkflowItem
+ */
 @Component(WorkflowItemRest.CATEGORY + "." + WorkflowItemRest.NAME + "." + WorkflowItemRest.STEP)
 public class WorkflowItemStepLinkRepository extends AbstractDSpaceRestRepository implements LinkRestRepository {
 
@@ -43,6 +46,16 @@ public class WorkflowItemStepLinkRepository extends AbstractDSpaceRestRepository
     @Autowired
     private XmlWorkflowFactory xmlWorkflowFactory;
 
+    /**
+     * This method will retrieve the {@link WorkflowStepRest} object for the {@link org.dspace.workflow.WorkflowItem}
+     * with the given id
+     * @param request           The current request
+     * @param workflowItemId    The id for the WorkflowItem to be used
+     * @param optionalPageable  The pageable if relevant
+     * @param projection        The Projection
+     * @return                  The {@link WorkflowStepRest} object related to the
+     *                          {@link org.dspace.workflow.WorkflowItem} specified by the given ID
+     */
     public WorkflowStepRest getStep(@Nullable HttpServletRequest request,
                                     Integer workflowItemId,
                                     @Nullable Pageable optionalPageable,

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkflowItemStepLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkflowItemStepLinkRepository.java
@@ -1,0 +1,73 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.repository;
+
+import java.sql.SQLException;
+import java.util.List;
+import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
+
+import org.dspace.app.rest.model.WorkflowItemRest;
+import org.dspace.app.rest.model.WorkflowStepRest;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.core.Context;
+import org.dspace.xmlworkflow.factory.XmlWorkflowFactory;
+import org.dspace.xmlworkflow.storedcomponents.ClaimedTask;
+import org.dspace.xmlworkflow.storedcomponents.PoolTask;
+import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
+import org.dspace.xmlworkflow.storedcomponents.service.ClaimedTaskService;
+import org.dspace.xmlworkflow.storedcomponents.service.PoolTaskService;
+import org.dspace.xmlworkflow.storedcomponents.service.XmlWorkflowItemService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.stereotype.Component;
+
+@Component(WorkflowItemRest.CATEGORY + "." + WorkflowItemRest.NAME + "." + WorkflowItemRest.STEP)
+public class WorkflowItemStepLinkRepository extends AbstractDSpaceRestRepository implements LinkRestRepository {
+
+    @Autowired
+    private XmlWorkflowItemService xmlWorkflowItemService;
+
+    @Autowired
+    private PoolTaskService poolTaskService;
+
+    @Autowired
+    private ClaimedTaskService claimedTaskService;
+
+    @Autowired
+    private XmlWorkflowFactory xmlWorkflowFactory;
+
+    public WorkflowStepRest getStep(@Nullable HttpServletRequest request,
+                                    Integer workflowItemId,
+                                    @Nullable Pageable optionalPageable,
+                                    Projection projection) {
+
+        Context context = obtainContext();
+        try {
+            XmlWorkflowItem xmlWorkflowItem = xmlWorkflowItemService.find(context, workflowItemId);
+            if (xmlWorkflowItem == null) {
+                throw new ResourceNotFoundException("XmlWorkflowItem with id: " + workflowItemId + " wasn't found");
+            }
+            List<PoolTask> poolTasks = poolTaskService.find(context, xmlWorkflowItem);
+            List<ClaimedTask> claimedTasks = claimedTaskService.find(context, xmlWorkflowItem);
+            for (PoolTask poolTask : poolTasks) {
+                return converter.toRest(xmlWorkflowFactory.getStepByName(poolTask.getStepID()), projection);
+            }
+            for (ClaimedTask claimedTask : claimedTasks) {
+                return converter.toRest(xmlWorkflowFactory.getStepByName(claimedTask.getStepID()), projection);
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        throw new ResourceNotFoundException("No workflowStep for this workflowItem with id: " + workflowItemId +
+                                                " was found");
+
+
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/TaskRestRepositoriesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/TaskRestRepositoriesIT.java
@@ -27,6 +27,7 @@ import org.dspace.app.rest.builder.WorkflowItemBuilder;
 import org.dspace.app.rest.matcher.ClaimedTaskMatcher;
 import org.dspace.app.rest.matcher.EPersonMatcher;
 import org.dspace.app.rest.matcher.PoolTaskMatcher;
+import org.dspace.app.rest.matcher.WorkflowActionMatcher;
 import org.dspace.app.rest.matcher.WorkflowItemMatcher;
 import org.dspace.app.rest.matcher.WorkspaceItemMatcher;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
@@ -34,11 +35,14 @@ import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.Item;
 import org.dspace.eperson.EPerson;
+import org.dspace.xmlworkflow.factory.XmlWorkflowFactory;
+import org.dspace.xmlworkflow.state.actions.WorkflowActionConfig;
 import org.dspace.xmlworkflow.storedcomponents.ClaimedTask;
 import org.dspace.xmlworkflow.storedcomponents.PoolTask;
 import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 
 /**
@@ -48,6 +52,10 @@ import org.springframework.http.MediaType;
  *
  */
 public class TaskRestRepositoriesIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private XmlWorkflowFactory xmlWorkflowFactory;
+
 
     @Test
     /**
@@ -1821,6 +1829,8 @@ public class TaskRestRepositoriesIT extends AbstractControllerIntegrationTest {
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED))
             .andExpect(status().isNoContent());
 
+        WorkflowActionConfig workflowAction = xmlWorkflowFactory.getActionByName("reviewaction");
+
         // get the id of the claimed task
         getClient(reviewer1Token).perform(get("/api/workflow/claimedtasks/search/findByUser")
                 .param("uuid", reviewer1.getID().toString()))
@@ -1831,7 +1841,9 @@ public class TaskRestRepositoriesIT extends AbstractControllerIntegrationTest {
                             hasJsonPath("$.type", Matchers.is("claimedtask")),
                             hasJsonPath("$._embedded.workflowitem",
                                      Matchers.is(WorkflowItemMatcher.matchItemWithTitleAndDateIssuedAndSubject(
-                                             witem, "Test item full workflow", "2019-03-06", "ExtraEntry")))
+                                             witem, "Test item full workflow", "2019-03-06", "ExtraEntry"))),
+                            hasJsonPath("$._embedded.action",
+                                        WorkflowActionMatcher.matchWorkflowActionEntry(workflowAction))
                     ))))
             .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/workflow/claimedtasks")))
             .andExpect(jsonPath("$.page.size", is(20)))
@@ -1872,6 +1884,8 @@ public class TaskRestRepositoriesIT extends AbstractControllerIntegrationTest {
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED))
             .andExpect(status().isNoContent());
 
+        workflowAction = xmlWorkflowFactory.getActionByName("editaction");
+
         // get the id of the claimed task
         getClient(reviewer2Token).perform(get("/api/workflow/claimedtasks/search/findByUser")
                 .param("uuid", reviewer2.getID().toString()))
@@ -1882,7 +1896,9 @@ public class TaskRestRepositoriesIT extends AbstractControllerIntegrationTest {
                             hasJsonPath("$.type", Matchers.is("claimedtask")),
                             hasJsonPath("$._embedded.workflowitem",
                                      Matchers.is(WorkflowItemMatcher.matchItemWithTitleAndDateIssuedAndSubject(
-                                             witem, "Test item full workflow", "2019-03-06", "ExtraEntry")))
+                                             witem, "Test item full workflow", "2019-03-06", "ExtraEntry"))),
+                            hasJsonPath("$._embedded.action",
+                                        WorkflowActionMatcher.matchWorkflowActionEntry(workflowAction))
                     ))))
             .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/workflow/claimedtasks")))
             .andExpect(jsonPath("$.page.size", is(20)))
@@ -1911,7 +1927,7 @@ public class TaskRestRepositoriesIT extends AbstractControllerIntegrationTest {
                             hasJsonPath("$._embedded.workflowitem",
                                     Matchers.is(WorkflowItemMatcher.matchItemWithTitleAndDateIssuedAndSubject(
                                             witem, "Test item full workflow", "2019-03-06", "ExtraEntry")))
-                            ))))
+                    ))))
             .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/workflow/pooltasks")))
             .andExpect(jsonPath("$.page.size", is(20)))
             .andExpect(jsonPath("$.page.totalElements", is(1)))
@@ -1923,6 +1939,7 @@ public class TaskRestRepositoriesIT extends AbstractControllerIntegrationTest {
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED))
             .andExpect(status().isNoContent());
 
+        workflowAction = xmlWorkflowFactory.getActionByName("finaleditaction");
         // get the id of the claimed task
         getClient(reviewer3Token).perform(get("/api/workflow/claimedtasks/search/findByUser")
                 .param("uuid", reviewer3.getID().toString()))
@@ -1933,7 +1950,9 @@ public class TaskRestRepositoriesIT extends AbstractControllerIntegrationTest {
                             hasJsonPath("$.type", Matchers.is("claimedtask")),
                             hasJsonPath("$._embedded.workflowitem",
                                      Matchers.is(WorkflowItemMatcher.matchItemWithTitleAndDateIssuedAndSubject(
-                                             witem, "Test item full workflow", "2019-03-06", "ExtraEntry")))
+                                             witem, "Test item full workflow", "2019-03-06", "ExtraEntry"))),
+                            hasJsonPath("$._embedded.action",
+                                        WorkflowActionMatcher.matchWorkflowActionEntry(workflowAction))
                     ))))
             .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/workflow/claimedtasks")))
             .andExpect(jsonPath("$.page.size", is(20)))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/TaskRestRepositoriesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/TaskRestRepositoriesIT.java
@@ -29,6 +29,7 @@ import org.dspace.app.rest.matcher.EPersonMatcher;
 import org.dspace.app.rest.matcher.PoolTaskMatcher;
 import org.dspace.app.rest.matcher.WorkflowActionMatcher;
 import org.dspace.app.rest.matcher.WorkflowItemMatcher;
+import org.dspace.app.rest.matcher.WorkflowStepMatcher;
 import org.dspace.app.rest.matcher.WorkspaceItemMatcher;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.content.Collection;
@@ -36,6 +37,7 @@ import org.dspace.content.Community;
 import org.dspace.content.Item;
 import org.dspace.eperson.EPerson;
 import org.dspace.xmlworkflow.factory.XmlWorkflowFactory;
+import org.dspace.xmlworkflow.state.Step;
 import org.dspace.xmlworkflow.state.actions.WorkflowActionConfig;
 import org.dspace.xmlworkflow.storedcomponents.ClaimedTask;
 import org.dspace.xmlworkflow.storedcomponents.PoolTask;
@@ -1807,13 +1809,15 @@ public class TaskRestRepositoriesIT extends AbstractControllerIntegrationTest {
 
         AtomicReference<Integer> idRef = new AtomicReference<Integer>();
 
+        Step step = xmlWorkflowFactory.getStepByName("reviewstep");
         // step 1
         getClient(reviewer1Token).perform(get("/api/workflow/pooltasks/search/findByUser")
-                .param("uuid", reviewer1.getID().toString()))
+                .param("uuid", reviewer1.getID().toString()).param("projection", "full"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$._embedded.pooltasks", Matchers.contains(
                     Matchers.allOf(
                             Matchers.is(PoolTaskMatcher.matchPoolTask(null, "reviewstep")),
+                            hasJsonPath("$._embedded.step", WorkflowStepMatcher.matchWorkflowStepEntry(step)),
                             hasJsonPath("$._embedded.workflowitem",
                                     Matchers.is(WorkflowItemMatcher.matchItemWithTitleAndDateIssuedAndSubject(
                                             witem, "Test item full workflow", "2019-03-06", "ExtraEntry")))
@@ -1833,12 +1837,13 @@ public class TaskRestRepositoriesIT extends AbstractControllerIntegrationTest {
 
         // get the id of the claimed task
         getClient(reviewer1Token).perform(get("/api/workflow/claimedtasks/search/findByUser")
-                .param("uuid", reviewer1.getID().toString()))
+                .param("uuid", reviewer1.getID().toString()).param("projection", "full"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$._embedded.claimedtasks", Matchers.contains(
                     Matchers.allOf(
                             hasJsonPath("$._links.self.href", Matchers.containsString("/api/workflow/claimedtasks/")),
                             hasJsonPath("$.type", Matchers.is("claimedtask")),
+                            hasJsonPath("$._embedded.step", WorkflowStepMatcher.matchWorkflowStepEntry(step)),
                             hasJsonPath("$._embedded.workflowitem",
                                      Matchers.is(WorkflowItemMatcher.matchItemWithTitleAndDateIssuedAndSubject(
                                              witem, "Test item full workflow", "2019-03-06", "ExtraEntry"))),
@@ -1862,13 +1867,16 @@ public class TaskRestRepositoriesIT extends AbstractControllerIntegrationTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.inArchive", is(false)));
 
+        step = xmlWorkflowFactory.getStepByName("editstep");
+
         // step 2
         getClient(reviewer2Token).perform(get("/api/workflow/pooltasks/search/findByUser")
-                .param("uuid", reviewer2.getID().toString()))
+                .param("uuid", reviewer2.getID().toString()).param("projection", "full"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$._embedded.pooltasks", Matchers.contains(
                     Matchers.allOf(
                             Matchers.is(PoolTaskMatcher.matchPoolTask(null, "editstep")),
+                            hasJsonPath("$._embedded.step", WorkflowStepMatcher.matchWorkflowStepEntry(step)),
                             hasJsonPath("$._embedded.workflowitem",
                                     Matchers.is(WorkflowItemMatcher.matchItemWithTitleAndDateIssuedAndSubject(
                                             witem, "Test item full workflow", "2019-03-06", "ExtraEntry")))
@@ -1888,12 +1896,13 @@ public class TaskRestRepositoriesIT extends AbstractControllerIntegrationTest {
 
         // get the id of the claimed task
         getClient(reviewer2Token).perform(get("/api/workflow/claimedtasks/search/findByUser")
-                .param("uuid", reviewer2.getID().toString()))
+                .param("uuid", reviewer2.getID().toString()).param("projection", "full"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$._embedded.claimedtasks", Matchers.contains(
                     Matchers.allOf(
                             hasJsonPath("$._links.self.href", Matchers.containsString("/api/workflow/claimedtasks/")),
                             hasJsonPath("$.type", Matchers.is("claimedtask")),
+                            hasJsonPath("$._embedded.step", WorkflowStepMatcher.matchWorkflowStepEntry(step)),
                             hasJsonPath("$._embedded.workflowitem",
                                      Matchers.is(WorkflowItemMatcher.matchItemWithTitleAndDateIssuedAndSubject(
                                              witem, "Test item full workflow", "2019-03-06", "ExtraEntry"))),
@@ -1917,13 +1926,16 @@ public class TaskRestRepositoriesIT extends AbstractControllerIntegrationTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.inArchive", is(false)));
 
+        step = xmlWorkflowFactory.getStepByName("finaleditstep");
+
         // step 3
         getClient(reviewer3Token).perform(get("/api/workflow/pooltasks/search/findByUser")
-                .param("uuid", reviewer3.getID().toString()))
+                .param("uuid", reviewer3.getID().toString()).param("projection", "full"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$._embedded.pooltasks", Matchers.contains(
                     Matchers.allOf(
                             Matchers.is(PoolTaskMatcher.matchPoolTask(null, "finaleditstep")),
+                            hasJsonPath("$._embedded.step", WorkflowStepMatcher.matchWorkflowStepEntry(step)),
                             hasJsonPath("$._embedded.workflowitem",
                                     Matchers.is(WorkflowItemMatcher.matchItemWithTitleAndDateIssuedAndSubject(
                                             witem, "Test item full workflow", "2019-03-06", "ExtraEntry")))
@@ -1942,12 +1954,13 @@ public class TaskRestRepositoriesIT extends AbstractControllerIntegrationTest {
         workflowAction = xmlWorkflowFactory.getActionByName("finaleditaction");
         // get the id of the claimed task
         getClient(reviewer3Token).perform(get("/api/workflow/claimedtasks/search/findByUser")
-                .param("uuid", reviewer3.getID().toString()))
+                .param("uuid", reviewer3.getID().toString()).param("projection", "full"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$._embedded.claimedtasks", Matchers.contains(
                     Matchers.allOf(
                             hasJsonPath("$._links.self.href", Matchers.containsString("/api/workflow/claimedtasks/")),
                             hasJsonPath("$.type", Matchers.is("claimedtask")),
+                            hasJsonPath("$._embedded.step", WorkflowStepMatcher.matchWorkflowStepEntry(step)),
                             hasJsonPath("$._embedded.workflowitem",
                                      Matchers.is(WorkflowItemMatcher.matchItemWithTitleAndDateIssuedAndSubject(
                                              witem, "Test item full workflow", "2019-03-06", "ExtraEntry"))),

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowItemRestRepositoryIT.java
@@ -39,6 +39,7 @@ import org.dspace.app.rest.builder.WorkspaceItemBuilder;
 import org.dspace.app.rest.matcher.CollectionMatcher;
 import org.dspace.app.rest.matcher.ItemMatcher;
 import org.dspace.app.rest.matcher.WorkflowItemMatcher;
+import org.dspace.app.rest.matcher.WorkflowStepMatcher;
 import org.dspace.app.rest.matcher.WorkspaceItemMatcher;
 import org.dspace.app.rest.model.patch.AddOperation;
 import org.dspace.app.rest.model.patch.Operation;
@@ -52,6 +53,8 @@ import org.dspace.content.Item;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.eperson.EPerson;
 import org.dspace.services.ConfigurationService;
+import org.dspace.xmlworkflow.factory.XmlWorkflowFactory;
+import org.dspace.xmlworkflow.state.Step;
 import org.dspace.xmlworkflow.storedcomponents.ClaimedTask;
 import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 import org.hamcrest.Matchers;
@@ -70,6 +73,8 @@ public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationT
     @Autowired
     private ConfigurationService configurationService;
 
+    @Autowired
+    private XmlWorkflowFactory xmlWorkflowFactory;
 
     @Before
     @Override
@@ -84,7 +89,7 @@ public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationT
     @Test
     /**
      * All the workflowitems should be returned regardless of the collection where they were created
-     * 
+     *
      * @throws Exception
      */
     public void findAllTest() throws Exception {
@@ -139,7 +144,7 @@ public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationT
     @Test
     /**
      * The workflowitem endpoint must provide proper pagination
-     * 
+     *
      * @throws Exception
      */
     public void findAllWithPaginationTest() throws Exception {
@@ -207,7 +212,7 @@ public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationT
     @Test
     /**
      * The findAll should be available only to admins regardless to having or less a role in the workflow
-     * 
+     *
      * @throws Exception
      */
     public void findAllForbiddenTest() throws Exception {
@@ -258,7 +263,7 @@ public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationT
     @Test
     /**
      * The workflowitem resource endpoint must expose the proper structure
-     * 
+     *
      * @throws Exception
      */
     public void findOneTest() throws Exception {
@@ -296,7 +301,7 @@ public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationT
     @Test
     /**
      * The workflowitem resource endpoint should be visible only to member of the corresponding workflow step
-     * 
+     *
      * @throws Exception
      */
     public void findOneForbiddenTest() throws Exception {
@@ -429,7 +434,7 @@ public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationT
     @Test
     /**
      * The workflowitem resource endpoint must expose the proper structure
-     * 
+     *
      * @throws Exception
      */
     public void findOneRelsTest() throws Exception {
@@ -477,7 +482,7 @@ public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationT
     @Test
     /**
      * Check the response code for unexistent workflowitem
-     * 
+     *
      * @throws Exception
      */
     public void findOneWrongIDTest() throws Exception {
@@ -494,7 +499,7 @@ public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationT
     /**
      * Create three workflowitem with two different submitter and verify that the findBySubmitter return the proper
      * list of workflowitem for each submitter also paginating
-     * 
+     *
      * @throws Exception
      */
     public void findBySubmitterTest() throws Exception {
@@ -601,7 +606,7 @@ public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationT
     /**
      * A delete request over a workflowitem should result in abort the workflow sending the item back to the submitter
      * workspace
-     * 
+     *
      * @throws Exception
      */
     public void deleteOneTest() throws Exception {
@@ -1533,5 +1538,85 @@ public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationT
             .andExpect(jsonPath("$.sections.traditionalpagetwo['dc.subject'][4].value", is("Last Subject")))
             .andExpect(jsonPath("$.sections.traditionalpagetwo['dc.subject'][5].value", is("Final Subject")))
         ;
+    }
+
+    @Test
+    public void stepEmbedTest() throws Exception {
+
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        // 1. A community-collection structure with one parent community with sub-community and three collections
+        // (different workflow steps and reviewers).
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community")
+                                           .build();
+        EPerson reviewer1 = EPersonBuilder.createEPerson(context).withEmail("reviewer1@example.com")
+                                          .withPassword(password).build();
+
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1")
+                                           .withWorkflowGroup(1, reviewer1).build();
+
+        EPerson reviewer2 = EPersonBuilder.createEPerson(context).withEmail("reviewer2@example.com")
+                                          .withPassword(password).build();
+
+        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2")
+                                           .withWorkflowGroup(2, reviewer2).build();
+
+        EPerson reviewer3 = EPersonBuilder.createEPerson(context).withEmail("reviewer3@example.com")
+                                          .withPassword(password).build();
+
+        Collection col3 = CollectionBuilder.createCollection(context, child1).withName("Collection 3")
+                                           .withWorkflowGroup(3, reviewer3).build();
+
+        //2. three workflow items in the three collections (this will lead to pool task)
+        XmlWorkflowItem witem1 = WorkflowItemBuilder.createWorkflowItem(context, col1)
+                                                    .withTitle("Workflow Item 1")
+                                                    .withIssueDate("2016-02-13")
+                                                    .build();
+
+        XmlWorkflowItem witem2 = WorkflowItemBuilder.createWorkflowItem(context, col2)
+                                                    .withTitle("Workflow Item 2")
+                                                    .withIssueDate("2016-02-13")
+                                                    .build();
+
+        XmlWorkflowItem witem3 = WorkflowItemBuilder.createWorkflowItem(context, col3)
+                                                    .withTitle("Workflow Item 3")
+                                                    .withIssueDate("2016-02-13")
+                                                    .build();
+
+        Step step = xmlWorkflowFactory.getStepByName("reviewstep");
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/workflow/workflowitems/" + witem1.getID())
+                                .param("projection", "full"))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$",
+                                       WorkflowItemMatcher.matchItemWithTitleAndDateIssued(witem1,
+                                                                   "Workflow Item 1", "2016-02-13")))
+                   .andExpect(jsonPath("$._embedded.step", WorkflowStepMatcher.matchWorkflowStepEntry(step)));
+
+        step = xmlWorkflowFactory.getStepByName("editstep");
+
+        getClient(token).perform(get("/api/workflow/workflowitems/" + witem2.getID())
+                                     .param("projection", "full"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$",
+                                            WorkflowItemMatcher.matchItemWithTitleAndDateIssued(witem2,
+                                                                 "Workflow Item 2", "2016-02-13")))
+                        .andExpect(jsonPath("$._embedded.step", WorkflowStepMatcher.matchWorkflowStepEntry(step)));
+
+        step = xmlWorkflowFactory.getStepByName("finaleditstep");
+
+        getClient(token).perform(get("/api/workflow/workflowitems/" + witem3.getID())
+                                     .param("projection", "full"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$",
+                                            WorkflowItemMatcher.matchItemWithTitleAndDateIssued(witem3,
+                                                                 "Workflow Item 3", "2016-02-13")))
+                        .andExpect(jsonPath("$._embedded.step", WorkflowStepMatcher.matchWorkflowStepEntry(step)));
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/ClaimedTaskMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/ClaimedTaskMatcher.java
@@ -36,7 +36,6 @@ public class ClaimedTaskMatcher {
      */
     public static Matcher matchClaimedTask(ClaimedTask cTask, String step) {
         return allOf(
-                hasJsonPath("$.step", is(step)),
                 // Check workflowitem properties
                 matchProperties(cTask),
                 // Check links

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/PoolTaskMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/PoolTaskMatcher.java
@@ -36,7 +36,6 @@ public class PoolTaskMatcher {
      */
     public static Matcher matchPoolTask(PoolTask pTask, String step) {
         return allOf(
-                hasJsonPath("$.step", is(step)),
                 // Check workflowitem properties
                 matchProperties(pTask),
                 // Check links


### PR DESCRIPTION
This is a customization which is part of https://github.com/DSpace/Rest7Contract/pull/96 to expose the HAL link to the claimed task, and allow embedding of the claimed task where applicable

It also includes https://github.com/DSpace/Rest7Contract/pull/104 to expose the step