### PR TITLE
DS-4037 - In JSPUI "Browse by" pages, the "starts_with" parameter is lost on the second page

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/AbstractBrowserServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/AbstractBrowserServlet.java
@@ -356,7 +356,9 @@ public abstract class AbstractBrowserServlet extends DSpaceServlet
                 		}
                 		request.setAttribute("tagCloudConfig", tagCloudConfiguration);
                 	}
-                	
+
+                    request.setAttribute("starts_with", scope.getStartsWith());
+
                     showSinglePage(context, request, response);
                 }
                 else

--- a/dspace-jspui/src/main/webapp/browse/single.jsp
+++ b/dspace-jspui/src/main/webapp/browse/single.jsp
@@ -34,6 +34,8 @@
 	BrowseInfo bi = (BrowseInfo) request.getAttribute("browse.info");
 	BrowseIndex bix = bi.getBrowseIndex();
 
+	String starts_with = (String) request.getAttribute("starts_with");
+
 	//values used by the header
 	String scope = "";
 	String type = "";
@@ -88,11 +90,19 @@
 	
 	if (bi.hasNextPage())
     {
+		if (StringUtils.isNotBlank(starts_with)) {
+			next = next + "&amp;starts_with=" + starts_with;
+		}
+
         next = next + "&amp;offset=" + bi.getNextOffset();
     }
 
 	if (bi.hasPrevPage())
     {
+		if (StringUtils.isNotBlank(starts_with)) {
+			prev = prev + "&amp;starts_with=" + starts_with;
+		}
+
         prev = prev + "&amp;offset=" + bi.getPrevOffset();
     }
 
@@ -233,6 +243,13 @@
 	}
 %>
 		</select>
+<%
+	if (StringUtils.isNotBlank(starts_with)) {
+%>
+		<input type="hidden" name="starts_with" value="<%= starts_with %>"/>
+<%
+	}
+%>
 		<input type="submit" class="btn btn-default" name="submit_browse" value="<fmt:message key="jsp.general.update"/>"/>
 	</form>
 	</div>


### PR DESCRIPTION
Fixes #7384

This change adds the starts_with parameter to the next and previous page link and also adds a hidden field to the form for updating the results per page and sorting.

