### PR TITLE
[DS-4149] porting OpenAIREv4 metadata format support for OAI-PMH (5.x)

### DIFF
--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -16,7 +16,7 @@
         <!-- This is the path to the root [dspace-src] directory. -->
         <root.basedir>${basedir}/..</root.basedir>
         <spring.version>3.2.5.RELEASE</spring.version>
-        <xoai.version>3.2.10</xoai.version>
+        <xoai.version>3.3.0</xoai.version>
         <jtwig.version>2.0.1</jtwig.version>
     </properties>
 

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/CCElementAdditional.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/CCElementAdditional.java
@@ -1,0 +1,57 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xoai.app;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+import org.dspace.license.CCLookup;
+import org.dspace.license.CreativeCommons;
+import org.dspace.xoai.util.ItemUtils;
+
+import com.lyncode.xoai.dataprovider.xml.xoai.Element;
+import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
+
+public class CCElementAdditional implements XOAIItemCompilePlugin {
+
+	private static Logger log = LogManager.getLogger(CCElementAdditional.class);
+
+	@Override
+	public Metadata additionalMetadata(Context context, Metadata metadata, Item item) {
+
+		Element other;
+		List<Element> elements = metadata.getElement();
+		if (ItemUtils.getElement(elements, "others") != null) {
+			other = ItemUtils.getElement(elements, "others");
+		} else {
+			other = ItemUtils.create("others");
+		}
+		String ccLicense = null;
+
+		try {
+			String licenseURL = CreativeCommons.getLicenseURL(item);
+			if (StringUtils.isNotBlank(licenseURL)) {
+				CCLookup ccLookup = new CCLookup();
+				ccLookup.issue(licenseURL);
+				String licenseName = ccLookup.getLicenseName();
+				ccLicense = licenseName + "|||" + licenseURL;
+			}
+		} catch (SQLException | IOException | AuthorizeException e) {
+			log.error(e.getMessage(), e);
+		}
+		other.getField().add(ItemUtils.createValue("cc", ccLicense));
+		return metadata;
+	}
+}

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/CCElementAdditional.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/CCElementAdditional.java
@@ -55,7 +55,9 @@ public class CCElementAdditional implements XOAIItemCompilePlugin {
 		} catch (SQLException | IOException | AuthorizeException e) {
 			log.error(e.getMessage(), e);
 		}
-		other.getField().add(ItemUtils.createValue("cc", ccLicense));
+		if (StringUtils.isNotBlank(ccLicense)) {
+			other.getField().add(ItemUtils.createValue("cc", ccLicense));
+		}
 		return metadata;
 	}
 }

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/CCElementAdditional.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/CCElementAdditional.java
@@ -24,6 +24,10 @@ import org.dspace.xoai.util.ItemUtils;
 import com.lyncode.xoai.dataprovider.xml.xoai.Element;
 import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
 
+/**
+ * Utility class to build xml element to support Creative Commons information
+ *
+ */
 public class CCElementAdditional implements XOAIItemCompilePlugin {
 
 	private static Logger log = LogManager.getLogger(CCElementAdditional.class);

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/OAISpringLoader.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/OAISpringLoader.java
@@ -1,0 +1,42 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xoai.app;
+
+import java.io.File;
+import java.net.MalformedURLException;
+
+import org.dspace.kernel.config.SpringLoader;
+import org.dspace.services.ConfigurationService;
+
+/**
+ * Spring Loader to load specific bean implementation only for OAI Spring context
+ *
+ */
+public class OAISpringLoader implements SpringLoader{
+
+    @Override
+    public String[] getResourcePaths(ConfigurationService configurationService) {
+        StringBuffer filePath = new StringBuffer();
+        filePath.append(configurationService.getProperty("dspace.dir"));
+        filePath.append(File.separator);
+        filePath.append("config");
+        filePath.append(File.separator);
+        filePath.append("spring");
+        filePath.append(File.separator);
+        filePath.append("oai");
+        filePath.append(File.separator);
+
+        try {
+            return new String[]{new File(filePath.toString()).toURI().toURL().toString() + XML_SUFFIX};
+        } catch (MalformedURLException e) {
+            return new String[0];
+        }
+    }
+
+}
+

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/OrcidVirtualElementAdditional.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/OrcidVirtualElementAdditional.java
@@ -25,6 +25,11 @@ import org.dspace.xoai.util.ItemUtils;
 import com.lyncode.xoai.dataprovider.xml.xoai.Element;
 import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
 
+/**
+ * Utility class to build xml element to support additional element on author
+ *
+ */
+@Deprecated
 public class OrcidVirtualElementAdditional implements XOAIItemCompilePlugin {
 
 	private static final Logger log = Logger.getLogger(OrcidVirtualElementAdditional.class);

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/OrcidVirtualElementAdditional.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/OrcidVirtualElementAdditional.java
@@ -1,0 +1,116 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xoai.app;
+
+import java.net.MalformedURLException;
+import java.util.StringTokenizer;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocumentList;
+import org.dspace.authority.AuthoritySearchService;
+import org.dspace.content.Item;
+import org.dspace.content.Metadatum;
+import org.dspace.core.Context;
+import org.dspace.xoai.util.ItemUtils;
+
+import com.lyncode.xoai.dataprovider.xml.xoai.Element;
+import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
+
+public class OrcidVirtualElementAdditional implements XOAIItemCompilePlugin {
+
+	private static final Logger log = Logger.getLogger(OrcidVirtualElementAdditional.class);
+	
+	private String metadata = "dc.contributor.author";
+
+	private AuthoritySearchService authorityService;
+
+	@Override
+	public Metadata additionalMetadata(Context context, Metadata metadata, Item item) {
+		Element personElement = ItemUtils.create("person");
+		Element identifierElement = ItemUtils.create("identifier");
+		Element orcidElement = ItemUtils.create("orcid");
+		Element noneElement = ItemUtils.create("none");
+
+		StringTokenizer dcf = new StringTokenizer(getMetadata(), ".");
+
+		String[] tokens = { "", "", "" };
+		int i = 0;
+		while (dcf.hasMoreTokens()) {
+			tokens[i] = dcf.nextToken().trim();
+			i++;
+		}
+		String schema = tokens[0];
+		String element = tokens[1];
+		String qualifier = tokens[2];
+
+		Metadatum[] values;
+		if ("*".equals(qualifier)) {
+			values = item.getMetadata(schema, element, Item.ANY, Item.ANY);
+		} else if ("".equals(qualifier)) {
+			values = item.getMetadata(schema, element, null, Item.ANY);
+		} else {
+			values = item.getMetadata(schema, element, qualifier, Item.ANY);
+		}
+		for (Metadatum val : values) {
+			if (StringUtils.isNotBlank(val.authority)) {
+				SolrQuery queryArgs = new SolrQuery();
+				queryArgs.setQuery("id:" + val.authority);
+				queryArgs.addFilterQuery("authority_type:orcid");
+				queryArgs.addField("orcid_id");
+				queryArgs.setRows(1);
+				QueryResponse searchResponse;
+				try {
+					searchResponse = getAuthorityService().search(queryArgs);
+					SolrDocumentList docs = searchResponse.getResults();
+
+					if (docs.getNumFound() == 1) {
+						String orcid = null;
+						try {
+							orcid = (String) docs.get(0).getFieldValue("orcid_id");
+						} catch (Exception e) {
+							log.error("couldn't get field value for key orcid_id", e);
+						}
+						if(StringUtils.isNotBlank(orcid)) {
+							noneElement.getField().add(ItemUtils.createValue("value", orcid));
+							noneElement.getField().add(ItemUtils.createValue("authority", val.authority));
+							noneElement.getField().add(ItemUtils.createValue("confidence", "" + val.confidence));
+						}
+					}
+				} catch (MalformedURLException | SolrServerException e1) {
+					log.error(e1.getMessage(), e1);
+				}
+
+			}
+		}
+		orcidElement.getElement().add(noneElement);
+		identifierElement.getElement().add(orcidElement);
+		personElement.getElement().add(identifierElement);
+		metadata.getElement().add(personElement);
+		return metadata;
+	}
+
+	public String getMetadata() {
+		return metadata;
+	}
+
+	public void setMetadata(String metadata) {
+		this.metadata = metadata;
+	}
+
+	public AuthoritySearchService getAuthorityService() {
+		return authorityService;
+	}
+
+	public void setAuthorityService(AuthoritySearchService authorityService) {
+		this.authorityService = authorityService;
+	}
+}

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/PermissionElementAdditional.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/PermissionElementAdditional.java
@@ -23,6 +23,10 @@ import org.dspace.xoai.util.ItemUtils;
 import com.lyncode.xoai.dataprovider.xml.xoai.Element;
 import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
 
+/**
+ * Utility class to build xml element to support Item access rights information at Bitstream level
+ *
+ */
 public class PermissionElementAdditional implements XOAIItemCompilePlugin {
 
 	private static Logger log = LogManager.getLogger(PermissionElementAdditional.class);
@@ -51,9 +55,18 @@ public class PermissionElementAdditional implements XOAIItemCompilePlugin {
 		return metadata;
 	}
 
+	/**
+	 *
+	 * Build access rights of the Item on Bitstream level
+	 *
+	 * @param context
+	 * @param item
+	 * @return
+	 * @throws SQLException
+	 */
 	private String buildPermission(Context context, Item item) throws SQLException {
 
-		String values = "metadata only access";
+		String value = ItemUtils.METADATA_ONLY_ACCESS;
 		Bundle[] bnds;
 		try {
 			bnds = item.getBundles(Constants.DEFAULT_BUNDLE_NAME);
@@ -72,11 +85,11 @@ public class PermissionElementAdditional implements XOAIItemCompilePlugin {
 			}
 
 			if (bitstream == null) {
-				return "metadata only access";
+				return value;
 			}
-			values = ItemUtils.getDRM(AuthorizeManager.getPoliciesActionFilter(context, bitstream, Constants.READ));
+			value = ItemUtils.getAccessRightsValue(AuthorizeManager.getPoliciesActionFilter(context, bitstream, Constants.READ));
 		}
-		return values;
+		return value;
 	}
 
 }

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/PermissionElementAdditional.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/PermissionElementAdditional.java
@@ -87,7 +87,7 @@ public class PermissionElementAdditional implements XOAIItemCompilePlugin {
 			if (bitstream == null) {
 				return value;
 			}
-			value = ItemUtils.getAccessRightsValue(AuthorizeManager.getPoliciesActionFilter(context, bitstream, Constants.READ));
+			value = ItemUtils.getAccessRightsValue(context, AuthorizeManager.getPoliciesActionFilter(context, bitstream, Constants.READ));
 		}
 		return value;
 	}

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/PermissionElementAdditional.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/PermissionElementAdditional.java
@@ -1,0 +1,82 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xoai.app;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.dspace.authorize.AuthorizeManager;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Item;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.xoai.util.ItemUtils;
+
+import com.lyncode.xoai.dataprovider.xml.xoai.Element;
+import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
+
+public class PermissionElementAdditional implements XOAIItemCompilePlugin {
+
+	private static Logger log = LogManager.getLogger(PermissionElementAdditional.class);
+
+	@Override
+	public Metadata additionalMetadata(Context context, Metadata metadata, Item item) {
+		
+		Element other;
+		List<Element> elements = metadata.getElement();
+		if (ItemUtils.getElement(elements, "others") != null) {
+			other = ItemUtils.getElement(elements, "others");
+		} else {
+			other = ItemUtils.create("others");
+		}
+
+		String drm = null;
+
+		try {
+			drm = buildPermission(context, item);
+		} catch (SQLException e) {
+			log.error(e.getMessage(), e);
+		}
+
+		other.getField().add(ItemUtils.createValue("drm", drm));
+
+		return metadata;
+	}
+
+	private String buildPermission(Context context, Item item) throws SQLException {
+
+		String values = "metadata only access";
+		Bundle[] bnds;
+		try {
+			bnds = item.getBundles(Constants.DEFAULT_BUNDLE_NAME);
+		} catch (SQLException e) {
+			throw new RuntimeException(e.getMessage(), e);
+		}
+
+		for (Bundle bnd : bnds) {
+
+			Bitstream bitstream = Bitstream.find(context, bnd.getPrimaryBitstreamID());
+			if (bitstream == null) {
+				for (Bitstream b : bnd.getBitstreams()) {
+					bitstream = b;
+					break;
+				}
+			}
+
+			if (bitstream == null) {
+				return "metadata only access";
+			}
+			values = ItemUtils.getDRM(AuthorizeManager.getPoliciesActionFilter(context, bitstream, Constants.READ));
+		}
+		return values;
+	}
+
+}

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -288,7 +288,7 @@ public class XOAI {
         XmlOutputContext xmlContext = XmlOutputContext.emptyContext(out, Second);
         Metadata metadata = retrieveMetadata(context, item);
         
-        //Do any additional metadata element, depends on the plugins
+        //Do any additional content on "item.compile" field, depends on the plugins
         List<XOAIItemCompilePlugin> xOAIItemCompilePlugins = new DSpace().getServiceManager().getServicesByType(XOAIItemCompilePlugin.class);
         for (XOAIItemCompilePlugin xOAIItemCompilePlugin : xOAIItemCompilePlugins)
         {

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAIItemCompilePlugin.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAIItemCompilePlugin.java
@@ -1,0 +1,25 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xoai.app;
+
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+
+import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
+
+/**
+ * Used to enrich item.compile field description
+ *
+ */
+public interface XOAIItemCompilePlugin
+{
+
+    public Metadata additionalMetadata(Context context, Metadata metadata,
+            Item item);
+
+}

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/resources/DSpaceResourceResolver.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/resources/DSpaceResourceResolver.java
@@ -25,7 +25,7 @@ import com.lyncode.xoai.dataprovider.services.api.ResourceResolver;
 public class DSpaceResourceResolver implements ResourceResolver
 {
     private static final TransformerFactory transformerFactory = TransformerFactory
-            .newInstance();
+            .newInstance("net.sf.saxon.TransformerFactoryImpl", null);
 
     private final String basePath = ConfigurationManager.getProperty("oai",
             "config.dir");

--- a/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
@@ -232,7 +232,7 @@ public class ItemUtils
                     String oname = bit.getSource();
                     String name = bit.getName();
                     String description = bit.getDescription();
-                    String drm = ItemUtils.getAccessRightsValue(AuthorizeManager.getPoliciesActionFilter(context, bit,  Constants.READ));
+                    String drm = ItemUtils.getAccessRightsValue(context, AuthorizeManager.getPoliciesActionFilter(context, bit,  Constants.READ));
                         
                     if (name != null)
                         bitstream.getField().add(
@@ -346,7 +346,8 @@ public class ItemUtils
 	 * @param rps
 	 * @return
 	 */
-	public static String getAccessRightsValue(List<ResourcePolicy> rps) {
+	public static String getAccessRightsValue(Context context, List<ResourcePolicy> rps)
+			throws SQLException {
 		Date now = new Date();
 		Date embargoEndDate = null;
 		boolean openAccess = false;
@@ -370,6 +371,7 @@ public class ItemUtils
 						embargoEndDate = rp.getStartDate();
 					}
 				}
+				context.removeCached(rp, rp.getID());
 			}
 		}
 		String value = METADATA_ONLY_ACCESS;

--- a/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
@@ -44,7 +44,14 @@ import com.lyncode.xoai.util.Base64Utils;
 @SuppressWarnings("deprecation")
 public class ItemUtils
 {
-    
+    public static final String RESTRICTED_ACCESS = "restricted access";
+
+    public static final String EMBARGOED_ACCESS = "embargoed access";
+
+    public static final String OPEN_ACCESS = "open access";
+
+    public static final String METADATA_ONLY_ACCESS = "metadata only access";
+
     private static Logger log = LogManager
             .getLogger(ItemUtils.class);
 
@@ -225,7 +232,7 @@ public class ItemUtils
                     String oname = bit.getSource();
                     String name = bit.getName();
                     String description = bit.getDescription();
-                    String drm = ItemUtils.getDRM(AuthorizeManager.getPoliciesActionFilter(context, bit,  Constants.READ));
+                    String drm = ItemUtils.getAccessRightsValue(AuthorizeManager.getPoliciesActionFilter(context, bit,  Constants.READ));
                         
                     if (name != null)
                         bitstream.getField().add(
@@ -330,7 +337,16 @@ public class ItemUtils
         return metadata;
     }
     
-	public static String getDRM(List<ResourcePolicy> rps) {
+	/**
+	 * Method to return a default value text to identify access rights:
+	 * 'open access','embargoed access','restricted access','metadata only access'
+	 *
+	 * NOTE: embargoed access contains also embargo end date in the form "embargoed access|||yyyy-MM-dd"
+	 *
+	 * @param rps
+	 * @return
+	 */
+	public static String getAccessRightsValue(List<ResourcePolicy> rps) {
 		Date now = new Date();
 		Date embargoEndDate = null;
 		boolean openAccess = false;
@@ -356,19 +372,19 @@ public class ItemUtils
 				}
 			}
 		}
-		String values = "metadata only access";
+		String value = METADATA_ONLY_ACCESS;
 		// if there are fulltext build the values
 		if (openAccess) {
 			// open access
-			values = "open access";
+			value = OPEN_ACCESS;
 		} else if (withEmbargo) {
 			// all embargoed
-			values = "embargoed access" + "|||" + sdf.format(embargoEndDate);
+			value = EMBARGOED_ACCESS + "|||" + sdf.format(embargoEndDate);
 		} else if (groupRestricted) {
 			// all restricted
-			values = "restricted access";
+			value = RESTRICTED_ACCESS;
 		}
-		return values;
+		return value;
 	}
 
  }

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/stylesheets/AbstractXSLTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/stylesheets/AbstractXSLTest.java
@@ -19,7 +19,8 @@ import java.io.File;
 import java.io.InputStream;
 
 public abstract class AbstractXSLTest {
-    private static final TransformerFactory factory = TransformerFactory.newInstance();
+    private static final TransformerFactory factory = TransformerFactory
+            .newInstance("net.sf.saxon.TransformerFactoryImpl", null);
 
     protected TransformBuilder apply (String xslLocation) throws Exception {
         return new TransformBuilder(xslLocation);

--- a/dspace/config/crosswalks/oai/metadataFormats/mets.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/mets.xsl
@@ -12,10 +12,7 @@
 	
 	>  http://www.loc.gov/standards/mets/mets.xsd
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-	xmlns:doc="http://www.lyncode.com/xoai" 
-    xmlns:date="http://exslt.org/dates-and-times" 
-    extension-element-prefixes="date" version="1.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:doc="http://www.lyncode.com/xoai" version="2.0">
     
 	<xsl:output omit-xml-declaration="yes" method="xml" indent="yes" />
 
@@ -32,7 +29,7 @@
 			</xsl:attribute>
 			<metsHdr>
 				<xsl:attribute name="CREATEDATE">
-					<xsl:value-of select="concat(date:format-date(date:date(), 'yyyy-MM-dd'), 'T' , date:format-date(date:time(), 'HH:mm:ss'), 'Z')"/>
+					<xsl:value-of select="concat(format-date(current-date(), 'yyyy-MM-dd'), 'T' , format-time(current-time(), 'HH:mm:ss'), 'Z')"/>
 				</xsl:attribute>
 				<agent ROLE="CUSTODIAN" TYPE="ORGANIZATION">
 					<name><xsl:value-of select="doc:metadata/doc:element[@name='repository']/doc:field[@name='name']/text()" /></name>

--- a/dspace/config/crosswalks/oai/metadataFormats/mets.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/mets.xsl
@@ -29,7 +29,7 @@
 			</xsl:attribute>
 			<metsHdr>
 				<xsl:attribute name="CREATEDATE">
-					<xsl:value-of select="concat(format-date(current-date(), 'yyyy-MM-dd'), 'T' , format-time(current-time(), 'HH:mm:ss'), 'Z')"/>
+					<xsl:value-of select="concat(format-date(current-date(), '[Y0001]-[M02]-[D02]'), 'T' , format-time(current-time(), '[H01]:[m01]:[s01]'), 'Z')"/>
 				</xsl:attribute>
 				<agent ROLE="CUSTODIAN" TYPE="ORGANIZATION">
 					<name><xsl:value-of select="doc:metadata/doc:element[@name='repository']/doc:field[@name='name']/text()" /></name>

--- a/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
@@ -26,6 +26,14 @@
 					<xsl:value-of select="." />
 				</datacite:title>
 			</xsl:for-each>
+
+			<!-- dc.title.alternative -->
+			<xsl:for-each
+				select="doc:metadata/doc:element[@name='dc']/doc:element[@name='title']/doc:element[@name='alternative']/doc:element/doc:field[@name='value']">
+				<datacite:title titleType="AlternativeTitle">
+					<xsl:value-of select="." />
+				</datacite:title>
+			</xsl:for-each>
 			
             <!-- datacite:creator -->
             <xsl:apply-templates
@@ -39,19 +47,16 @@
 			</datacite:date>
 			
 			<!-- EMBARGO PERIOD DATES -->
-
 			<xsl:if test="contains(doc:metadata/doc:element[@name='others']/doc:field[@name='drm']/text(),'embargoed')">
-                <datacite:dates>
-                    <datacite:date>
-                    	<xsl:attribute name="Accepted"/>
-                        <xsl:value-of select="substring-after(doc:metadata/doc:element[@name='others']/doc:field[@name='drm']/text(),'|||')"/>
-                    </datacite:date>    
-                    <datacite:date>
-                    	<xsl:attribute name="Available"/>
-                        <xsl:value-of select="doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='accessioned']/doc:element/doc:field[@name='value']/text()"/>
-                    </datacite:date>    
-                </datacite:dates>
-            </xsl:if>
+				<datacite:dates>
+					<datacite:date dateType="Accepted">
+						<xsl:value-of select="substring-before(doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='accessioned']/doc:element/doc:field[@name='value']/text(), 'T')"/>
+					</datacite:date>
+					<datacite:date dateType="Available">
+						<xsl:value-of select="substring-after(doc:metadata/doc:element[@name='others']/doc:field[@name='drm']/text(),'|||')"/>
+					</datacite:date>
+				</datacite:dates>
+			</xsl:if>
 
 			<!-- RESOURCE IDENTIFIER - HANDLE -->
 			<datacite:identifier>
@@ -207,14 +212,23 @@
 				<xsl:if test="doc:field[@name='name']/text() = 'ORIGINAL'">
 					<xsl:for-each
 						select="doc:element[@name='bitstreams']/doc:element">
+						<xsl:variable name="accessRightsURI">
+							<xsl:call-template name="resolveRightsURI">
+								<xsl:with-param name="field"
+										select="doc:field[@name='drm']" />
+							</xsl:call-template>
+						</xsl:variable>
 						<oaire:file>
-							<xsl:attribute name="accessRightsURI">
-								<xsl:value-of select="doc:field[@name='drm']/text()"/>
-							</xsl:attribute>
+							<xsl:if test="$accessRightsURI">
+								<xsl:attribute name="accessRightsURI">
+									<xsl:value-of select="$accessRightsURI" />
+								</xsl:attribute>
+							</xsl:if>
 							<xsl:attribute name="mimeType">
 								<xsl:value-of
 									select="doc:field[@name='format']/text()"/>
 							</xsl:attribute>
+							<xsl:value-of select="doc:field[@name='url']"/>
 						</oaire:file>
 					</xsl:for-each>
 				</xsl:if>
@@ -281,7 +295,9 @@
 			<datacite:sizes>
 				<xsl:for-each
 					select="doc:element[@name='bitstreams']/doc:element[@name='bitstream']">
-		            <xsl:value-of select="concat(doc:field[@name='size'],' bytes')"/>
+					<datacite:size>
+						<xsl:value-of select="concat(doc:field[@name='size'],' bytes')"/>
+					</datacite:size>
 				</xsl:for-each>
 			</datacite:sizes>
 		</xsl:if>
@@ -349,7 +365,7 @@
 		</xsl:variable>
 		<datacite:rights>
 			<xsl:if test="$rightsURI">
-				<xsl:attribute name="uri">
+				<xsl:attribute name="rightsURI">
                 <xsl:value-of select="$rightsURI" />
             </xsl:attribute>
 			</xsl:if>

--- a/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
@@ -129,7 +129,7 @@
 			
 			<!-- DC PUBLISHER -->
 			<xsl:for-each
-				select="doc:metadata/doc:element[@name='dc']/doc:element[@name='publisher']/doc:element/doc:element/doc:field[@name='value']">
+				select="doc:metadata/doc:element[@name='dc']/doc:element[@name='publisher']/doc:element/doc:field[@name='value']">
 				<dc:publisher>
 					<xsl:value-of select="." />
 				</dc:publisher>
@@ -223,9 +223,9 @@
 			<!-- select all funding references -->
 					<xsl:variable name="funder" select="doc:metadata/doc:element[@name='project']/doc:element[@name='funder']/doc:element[@name='name']/doc:element/doc:field[@name='value']"/>
 					<xsl:variable name="funderid" select="doc:metadata/doc:element[@name='project']/doc:element[@name='funder']/doc:element[@name='identifier']/doc:element/doc:field[@name='value']"/>
-					<xsl:variable name="awardnumber" select="doc:metadata/doc:element[@name='oaire']/doc:element[@name='awardNumber']/doc:element/doc:element/doc:field[@name='value']"/>
-					<xsl:variable name="awarduri" select="doc:metadata/doc:element[@name='oaire']/doc:element[@name='awardURI']/doc:element/doc:element/doc:field[@name='value']"/>
-					<xsl:variable name="awardtitle" select="doc:metadata/doc:element[@name='dc']/doc:element[@name='relation']/doc:element/doc:element/doc:field[@name='value']"/>
+					<xsl:variable name="awardnumber" select="doc:metadata/doc:element[@name='oaire']/doc:element[@name='awardNumber']/doc:element/doc:field[@name='value']"/>
+					<xsl:variable name="awarduri" select="doc:metadata/doc:element[@name='oaire']/doc:element[@name='awardURI']/doc:element/doc:field[@name='value']"/>
+					<xsl:variable name="awardtitle" select="doc:metadata/doc:element[@name='dc']/doc:element[@name='relation']/doc:element/doc:field[@name='value']"/>
 					
 					<xsl:variable name="check_fundingreference"> 
 						<xsl:for-each select="$awardtitle">
@@ -293,23 +293,14 @@
 		match="doc:element[@name='dc']/doc:element[@name='subject']"
 		mode="datacite">
 		<datacite:subjects>
-			<xsl:for-each select="./doc:element">
-				<xsl:apply-templates select="." mode="datacite" />
+			<xsl:for-each select="./doc:element/doc:field[@name='value']">
+				<datacite:subject>
+					<xsl:value-of select="./text()" />
+				</datacite:subject>
 			</xsl:for-each>
 		</datacite:subjects>
 	</xsl:template>
 
-	<!-- datacite:subject -->
-	<xsl:template
-		match="doc:element[@name='dc']/doc:element[@name='subject']/doc:element"
-		mode="datacite">
-		<xsl:for-each select="./doc:element/doc:field[@name='value']">
-			<datacite:subject>
-				<xsl:value-of select="./text()" />
-			</datacite:subject>
-		</xsl:for-each>
-	</xsl:template>
-		
 	<xsl:template
 		match="doc:element[@name='dc']/doc:element[@name='identifier']/doc:element[@name='issn']"
 		mode="datacite_ids">

--- a/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
@@ -1,0 +1,964 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- 
+	The contents of this file are subject to the license and copyright detailed 
+	in the LICENSE and NOTICE files at the root of the source tree and available 
+	online at http://www.dspace.org/license/ 
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:oaire="http://namespace.openaire.eu/schema/oaire/" xmlns:datacite="http://datacite.org/schema/kernel-4"
+    xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:doc="http://www.lyncode.com/xoai"
+    xmlns:rdf="http://www.w3.org/TR/rdf-concepts/" version="1.0">
+    <xsl:output omit-xml-declaration="yes" method="xml" indent="yes"/>
+    
+    <!--  Please note that this crosswalk is mostly a backport from the DSpace 7 version 
+    	  available here https://github.com/DSpace/DSpace/blob/master/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
+          adapted to work with the limitation of the flat data model of DSpace pre version 7 -->	
+	<xsl:template match="/">
+		<oaire:resource
+			xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning"
+			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			xsi:schemaLocation="http://namespace.openaire.eu/schema/oaire/ https://www.openaire.eu/schema/repo-lit/4.0/openaire.xsd">
+
+			<!-- DC TITLE -->
+			<xsl:for-each
+				select="doc:metadata/doc:element[@name='dc']/doc:element[@name='title']/doc:element/doc:field[@name='value']">
+				<datacite:title>
+					<xsl:value-of select="." />
+				</datacite:title>
+			</xsl:for-each>
+			
+            <!-- datacite:creator -->
+            <xsl:apply-templates
+                select="doc:metadata/doc:element[@name='dc']/doc:element[@name='contributor']/doc:element[@name='author']"
+                mode="datacite"/>			
+
+			<!-- ISSUE DATE -->
+			<datacite:date>
+				<xsl:attribute name="dateType">Issued</xsl:attribute>
+				<xsl:value-of select="doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='issued']/doc:element/doc:field[@name='value']/text()" />
+			</datacite:date>
+			
+			<!-- EMBARGO PERIOD DATES -->
+
+			<xsl:if test="contains(doc:metadata/doc:element[@name='others']/doc:field[@name='drm']/text(),'embargoed')">
+                <datacite:dates>
+                    <datacite:date>
+                    	<xsl:attribute name="Accepted"/>
+                        <xsl:value-of select="substring-after(doc:metadata/doc:element[@name='others']/doc:field[@name='drm']/text(),'|||')"/>
+                    </datacite:date>    
+                    <datacite:date>
+                    	<xsl:attribute name="Available"/>
+                        <xsl:value-of select="doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='accessioned']/doc:element/doc:field[@name='value']/text()"/>
+                    </datacite:date>    
+                </datacite:dates>
+            </xsl:if>
+
+			<!-- RESOURCE IDENTIFIER - HANDLE -->
+			<datacite:identifier>
+				<xsl:attribute name="identifierType">
+					<xsl:text>handle</xsl:text>
+				</xsl:attribute>
+					<xsl:value-of select= "concat('http://hdl.handle.net/',doc:metadata/doc:element[@name='others']/doc:field[@name='handle'])"/>
+			</datacite:identifier>
+
+			<!-- DRM -->
+			<xsl:apply-templates
+				select="doc:metadata/doc:element[@name='others']/doc:field[@name='drm']"
+				mode="datacite" />
+
+			<!-- DC CONTRIBUTOR -->
+				
+			<datacite:contributors>
+			
+				<xsl:for-each
+					select="doc:metadata/doc:element[@name='dc']/doc:element[@name='contributor']/doc:element[@name!='author' and @name!='editor']/doc:element">
+					<datacite:contributor>
+						<xsl:attribute name="contributorType">
+							<xsl:text>Other</xsl:text>
+						</xsl:attribute>
+						<datacite:contributorName>
+							<xsl:value-of select="./doc:field[@name='value']/text()"/>
+						</datacite:contributorName>
+					</datacite:contributor>
+				</xsl:for-each>
+				
+				<xsl:for-each
+					select="doc:metadata/doc:element[@name='dc']/doc:element[@name='contributor']/doc:element[@name='editor']/doc:element/doc:field[@name='value']">
+					<datacite:contributor>
+						<xsl:attribute name="contributorType">
+							<xsl:text>Editor</xsl:text>
+						</xsl:attribute>
+						<datacite:contributorName>
+							<xsl:value-of select="./text()" />
+						</datacite:contributorName>
+					</datacite:contributor>
+				</xsl:for-each>				
+				
+			</datacite:contributors>
+
+			<!-- RESOURCE TYPE -->
+				<xsl:apply-templates
+					select="doc:metadata/doc:element[@name='dc']/doc:element[@name='type']" 
+					mode="oaire"/>
+
+			
+			<!-- CREATIVE COMMON LICENSE -->
+			<xsl:apply-templates
+				select="doc:metadata/doc:element[@name='others']/doc:field[@name='cc']"
+				mode="oaire" />
+
+			<!-- ALTERNATE IDENTIFIER -->
+			<datacite:alternateIdentifiers>
+				<xsl:apply-templates
+			 	select="doc:metadata/doc:element[@name='dc']/doc:element[@name='identifier']/doc:element[@name!='issn']"
+			 	mode="datacite_ids"/>
+			</datacite:alternateIdentifiers>
+			
+			<!-- ISSN -->
+			<xsl:apply-templates
+			 select="doc:metadata/doc:element[@name='dc']/doc:element[@name='identifier']/doc:element[@name='issn']"
+			 mode="datacite_ids"/>
+			 
+			<!-- DC LANGUAGE ISO -->
+			<xsl:for-each
+				select="doc:metadata/doc:element[@name='dc']/doc:element[@name='language']/doc:element/doc:element/doc:field[@name='value']">
+				<dc:language>
+					<xsl:value-of select="." />
+				</dc:language>
+			</xsl:for-each>
+			
+			<!-- DC PUBLISHER -->
+			<xsl:for-each
+				select="doc:metadata/doc:element[@name='dc']/doc:element[@name='publisher']/doc:element/doc:element/doc:field[@name='value']">
+				<dc:publisher>
+					<xsl:value-of select="." />
+				</dc:publisher>
+			</xsl:for-each>
+
+			<!-- DC DESCRIPTION ABSTRACT -->
+			<xsl:for-each
+				select="doc:metadata/doc:element[@name='dc']/doc:element[@name='description']/doc:element[@name='abstract']/doc:element/doc:field[@name='value']">
+				<dc:description>
+					<xsl:value-of select="." />
+				</dc:description>
+			</xsl:for-each>
+			
+			<!-- DC SUBJECT -->
+			<xsl:apply-templates
+				select="doc:metadata/doc:element[@name='dc']/doc:element[@name='subject']"
+				mode="datacite">
+			</xsl:apply-templates>
+			
+			<!-- DC DESCRIPTION -->
+			<xsl:for-each
+				select="doc:metadata/doc:element[@name='dc']/doc:element[@name='description']/doc:element[@name='abstract']/doc:field[@name='value']">
+				<dc:description>
+					<xsl:value-of select="." />
+				</dc:description>
+			</xsl:for-each>
+			
+			<!-- DATACITE SIZE -->
+			<xsl:apply-templates
+				select="doc:metadata/doc:element[@name='bundles']/doc:element[@name='bundle']"
+				mode="datacite">
+			</xsl:apply-templates>
+			
+			<xsl:for-each
+				select="doc:metadata/doc:element[@name='dc']/doc:element[@name='relation']/doc:element[@name='ispartofseries']/doc:element/doc:field[@name='value']">
+				<xsl:choose>
+					<xsl:when test="contains(.,';')">
+						<!-- CITATION TITLE -->
+						<oaire:citationTitle>
+							<xsl:value-of select="substring-before(.,';')"/>
+						</oaire:citationTitle>
+						<!-- CITATION VOLUME -->
+						<oaire:citationVolume>
+							<xsl:value-of select="substring-after(.,';')" />
+						</oaire:citationVolume>
+					</xsl:when>
+					<xsl:when test=".!=''">
+						<!-- CITATION TITLE -->
+						<oaire:citationTitle>
+							<xsl:value-of select="."/>
+						</oaire:citationTitle>
+					</xsl:when>
+					<xsl:otherwise>
+					</xsl:otherwise>
+				</xsl:choose>
+			</xsl:for-each>
+			
+			<!-- CITATION ISSUE -->
+			<xsl:for-each
+				select="doc:metadata/doc:element[@name='dc']/doc:element[@name='publisher']/doc:element/doc:element/doc:field[@name='value']">
+				<oaire:citationIssue>
+					<xsl:value-of select="." />
+				</oaire:citationIssue>
+			</xsl:for-each>
+					
+			<xsl:variable name="rightsURI">
+				<xsl:call-template name="resolveRightsURI">
+					<xsl:with-param name="field"
+							select="doc:metadata/doc:element[@name='others']/doc:field[@name='drm']" />
+				</xsl:call-template>
+			</xsl:variable>
+
+			<xsl:for-each
+				select="doc:metadata/doc:element[@name='bundles']/doc:element[@name='bundle']">
+				<xsl:if test="doc:field[@name='name']/text() = 'ORIGINAL'">
+					<xsl:for-each
+						select="doc:element[@name='bitstreams']/doc:element">
+						<oaire:file>
+							<xsl:attribute name="accessRightsURI">
+								<xsl:value-of select="doc:field[@name='drm']/text()"/>
+							</xsl:attribute>
+							<xsl:attribute name="mimeType">
+								<xsl:value-of
+									select="doc:field[@name='format']/text()"/>
+							</xsl:attribute>
+						</oaire:file>
+					</xsl:for-each>
+				</xsl:if>
+			</xsl:for-each>
+		
+			<!-- select all funding references -->
+					<xsl:variable name="funder" select="doc:metadata/doc:element[@name='project']/doc:element[@name='funder']/doc:element[@name='name']/doc:element/doc:field[@name='value']"/>
+					<xsl:variable name="funderid" select="doc:metadata/doc:element[@name='project']/doc:element[@name='funder']/doc:element[@name='identifier']/doc:element/doc:field[@name='value']"/>
+					<xsl:variable name="awardnumber" select="doc:metadata/doc:element[@name='oaire']/doc:element[@name='awardNumber']/doc:element/doc:element/doc:field[@name='value']"/>
+					<xsl:variable name="awarduri" select="doc:metadata/doc:element[@name='oaire']/doc:element[@name='awardURI']/doc:element/doc:element/doc:field[@name='value']"/>
+					<xsl:variable name="awardtitle" select="doc:metadata/doc:element[@name='dc']/doc:element[@name='relation']/doc:element/doc:element/doc:field[@name='value']"/>
+					
+					<xsl:variable name="check_fundingreference"> 
+						<xsl:for-each select="$awardtitle">
+							<xsl:if test="$awardtitle!=''">
+								<xsl:value-of select="."/>
+							</xsl:if>
+						</xsl:for-each>
+					</xsl:variable>
+					
+					<xsl:if test="$check_fundingreference!=''">
+						<oaire:fundingReferences>
+							<xsl:for-each select="$awardtitle">
+								<xsl:if test=".!='' ">
+									<oaire:fundingReference>
+										<xsl:variable name="counter" select="position()"/>
+										<oaire:funderName>
+											<xsl:value-of select="$funder[$counter]"/>
+										</oaire:funderName>
+										<xsl:if test="$funderid[$counter]!='' ">
+											<oaire:funderIdentifier funderIdentifierType="Crossref Funder ID">
+												<xsl:value-of select="$funderid[$counter]"/>	
+											</oaire:funderIdentifier>
+										</xsl:if>
+										<xsl:if test="$awardnumber[$counter]!='' ">
+											<oaire:awardNumber>
+												<xsl:if test="$awarduri[$counter]!='' ">
+													<xsl:attribute name="awardURI">
+														<xsl:value-of select="$awarduri"/>
+													</xsl:attribute>
+												</xsl:if>
+												<xsl:value-of select="$awardnumber[$counter]"/>
+											</oaire:awardNumber>
+										</xsl:if>
+										<xsl:if test=".!='' ">
+											<oaire:awardTitle>
+												<xsl:value-of select="."/>
+											</oaire:awardTitle>
+										</xsl:if>
+									</oaire:fundingReference>
+								</xsl:if>
+							</xsl:for-each>
+						</oaire:fundingReferences>
+					</xsl:if>
+		</oaire:resource>
+	</xsl:template>
+
+	<!-- datacite:sizes -->
+	<!-- https://openaire-guidelines-for-literature-repository-managers.readthedocs.io/en/v4.0.0/field_size.html -->
+	<xsl:template
+		match="doc:element[@name='bundles']/doc:element[@name='bundle']"
+		mode="datacite">
+		<xsl:if test="doc:field[@name='name' and text()='ORIGINAL']">
+			<datacite:sizes>
+				<xsl:for-each
+					select="doc:element[@name='bitstreams']/doc:element[@name='bitstream']">
+		            <xsl:value-of select="concat(doc:field[@name='size'],' bytes')"/>
+				</xsl:for-each>
+			</datacite:sizes>
+		</xsl:if>
+	</xsl:template>
+
+		<!-- datacite:subjects -->
+	<!-- https://openaire-guidelines-for-literature-repository-managers.readthedocs.io/en/v4.0.0/field_subject.html -->
+			<xsl:template
+		match="doc:element[@name='dc']/doc:element[@name='subject']"
+		mode="datacite">
+		<datacite:subjects>
+			<xsl:for-each select="./doc:element">
+				<xsl:apply-templates select="." mode="datacite" />
+			</xsl:for-each>
+		</datacite:subjects>
+	</xsl:template>
+
+	<!-- datacite:subject -->
+	<xsl:template
+		match="doc:element[@name='dc']/doc:element[@name='subject']/doc:element"
+		mode="datacite">
+		<xsl:for-each select="./doc:element/doc:field[@name='value']">
+			<datacite:subject>
+				<xsl:value-of select="./text()" />
+			</datacite:subject>
+		</xsl:for-each>
+	</xsl:template>
+		
+	<xsl:template
+		match="doc:element[@name='dc']/doc:element[@name='identifier']/doc:element[@name='issn']"
+		mode="datacite_ids">
+			<datacite:relatedIdentifiers>
+				<datacite:relatedIdentifier>
+					<xsl:attribute name="relatedIdentifierType">ISSN</xsl:attribute>
+					<xsl:attribute name="relationType">IsPartOf</xsl:attribute>
+					<xsl:value-of
+						select="./doc:element/doc:field[@name='value']" />
+				</datacite:relatedIdentifier>
+			</datacite:relatedIdentifiers>
+	</xsl:template>
+
+	<xsl:template
+		match="doc:element[@name='dc']/doc:element[@name='identifier']/doc:element[@name!='issn']"
+		mode="datacite_ids">
+        <xsl:variable name="isHandle">
+            <xsl:call-template name="isHandle">
+                <xsl:with-param name="field" select="./doc:element/doc:field"/>
+            </xsl:call-template>
+        </xsl:variable>
+        <xsl:if test="$isHandle = 'false'">
+		<xsl:variable name="alternateIdentifierType">
+			<xsl:call-template name="getRelatedIdentifierType">
+				<xsl:with-param name="element" select="./doc:element" />
+			</xsl:call-template>
+		</xsl:variable>
+			<datacite:alternateIdentifier>
+				<xsl:attribute name="alternateIdentifierType">
+					<xsl:value-of	select="$alternateIdentifierType" />
+				</xsl:attribute>
+				<xsl:value-of
+					select="./doc:element/doc:field[@name='value']/text()" />
+			</datacite:alternateIdentifier>
+		</xsl:if>
+	</xsl:template>
+
+	<xsl:template
+		match="doc:element[@name='others']/doc:field[@name='drm']"
+		mode="datacite">
+		<xsl:variable name="rightsURI">
+			<xsl:call-template name="resolveRightsURI">
+				<xsl:with-param name="field"
+					select="." />
+			</xsl:call-template>
+		</xsl:variable>
+		<datacite:rights>
+			<xsl:if test="$rightsURI">
+				<xsl:attribute name="uri">
+                <xsl:value-of select="$rightsURI" />
+            </xsl:attribute>
+			</xsl:if>
+			<xsl:choose>
+				<xsl:when test="contains(.,'|||')"> 
+					<xsl:value-of
+						select="substring-before(.,'|||')" />
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:value-of select="."/>
+				</xsl:otherwise>
+			</xsl:choose>
+		</datacite:rights>
+	</xsl:template>
+
+	<!-- License CC splitter -->
+	<xsl:variable name="ccstart">
+		<xsl:value-of select="doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='issued']/doc:element/doc:field[@name='value']/text()"/>
+	</xsl:variable>
+	
+	<xsl:template
+		match="doc:element[@name='others']/doc:field[@name='cc']"
+		mode="oaire">
+		<oaire:licenseCondition>
+			<xsl:attribute name="startDate">
+				<xsl:value-of
+					select="$ccstart"/>
+			</xsl:attribute>
+			<xsl:attribute name="uri">
+				<xsl:value-of
+					select="substring-after(./text(),'|||')" />
+		</xsl:attribute>
+			<xsl:value-of select="substring-before(./text(),'|||')"/>
+		</oaire:licenseCondition>
+	</xsl:template>
+
+	<xsl:param name="uppercase"
+		select="'ABCDEFGHIJKLMNOPQRSTUVWXYZÀÈÌÒÙÁÉÍÓÚÝÂÊÎÔÛÃÑÕÄËÏÖÜŸÅÆŒÇÐØ'" />
+	
+	<xsl:param name="smallcase"
+		select="'abcdefghijklmnopqrstuvwxyzàèìòùáéíóúýâêîôûãñõäëïöüÿåæœçðø'" />
+
+	<!-- it will verify if a given field is an handle -->
+	<xsl:template name="isHandle">
+		<xsl:param name="field" />
+		<xsl:choose>
+			<xsl:when test="$field[contains(text(),'hdl.handle.net')]">
+				<xsl:value-of select="true()" />
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:value-of select="false()" />
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
+	<!-- it will verify if a given field is a DOI -->
+	<xsl:template name="isDOI">
+		<xsl:param name="field" />
+		<xsl:choose>
+			<xsl:when
+				test="$field[contains(text(),'doi.org') or starts-with(text(),'10.')]">
+				<xsl:value-of select="true()" />
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:value-of select="false()" />
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
+	<!-- it will verify if a given field is an ORCID -->
+	<xsl:template name="isORCID">
+		<xsl:param name="field" />
+		<xsl:choose>
+			<xsl:when test="$field[contains(text(),'orcid.org')]">
+				<xsl:value-of select="true()" />
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:value-of select="false()" />
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
+	<!-- it will verify if a given field is an URL -->
+	<xsl:template name="isURL">
+		<xsl:param name="field" />
+		<xsl:variable name="lc_field">
+			<xsl:call-template name="lowercase">
+				<xsl:with-param name="value" select="$field" />
+			</xsl:call-template>
+		</xsl:variable>
+		<xsl:choose>
+			<xsl:when
+				test="$lc_field[starts-with(text(),'http://') or starts-with(text(),'https://')]">
+				<xsl:value-of select="true()" />
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:value-of select="false()" />
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
+	<!-- to retrieve a string in lowercase -->
+	<xsl:template name="lowercase">
+		<xsl:param name="value" />
+		<xsl:value-of
+			select="translate($value, $uppercase, $smallcase)" />
+	</xsl:template>
+
+	<!-- This template will retrieve the identifier type based on the element 
+		name -->
+	<!-- there are some special cases like DOI or HANDLE which the type is also 
+		inferred from the value itself -->
+	<xsl:template name="getRelatedIdentifierType">
+		<xsl:param name="element" />
+		<xsl:variable name="lc_identifier_type">
+			<xsl:call-template name="lowercase">
+				<xsl:with-param name="value" select="$element/@name" />
+			</xsl:call-template>
+		</xsl:variable>
+		<xsl:variable name="isDOI">
+			<xsl:call-template name="isDOI">
+				<xsl:with-param name="field"
+					select="$element/doc:field" />
+			</xsl:call-template>
+		</xsl:variable>
+		<xsl:variable name="isURL">
+			<xsl:call-template name="isURL">
+				<xsl:with-param name="field"
+					select="$element/doc:field" />
+			</xsl:call-template>
+		</xsl:variable>
+		<xsl:choose>
+			<xsl:when test="$lc_identifier_type = 'ark'">
+				<xsl:text>ARK</xsl:text>
+			</xsl:when>
+			<xsl:when test="$lc_identifier_type = 'arxiv'">
+				<xsl:text>arXiv</xsl:text>
+			</xsl:when>
+			<xsl:when test="$lc_identifier_type = 'bibcode'">
+				<xsl:text>bibcode</xsl:text>
+			</xsl:when>
+			<xsl:when
+				test="$isDOI = 'true' or $lc_identifier_type = 'doi'">
+				<xsl:text>DOI</xsl:text>
+			</xsl:when>
+			<xsl:when test="$lc_identifier_type = 'ean13'">
+				<xsl:text>EAN13</xsl:text>
+			</xsl:when>
+			<xsl:when test="$lc_identifier_type = 'eissn'">
+				<xsl:text>EISSN</xsl:text>
+			</xsl:when>
+			<xsl:when test="$lc_identifier_type = 'igsn'">
+				<xsl:text>IGSN</xsl:text>
+			</xsl:when>
+			<xsl:when test="$lc_identifier_type = 'isbn'">
+				<xsl:text>ISBN</xsl:text>
+			</xsl:when>
+			<xsl:when test="$lc_identifier_type = 'istc'">
+				<xsl:text>ISTC</xsl:text>
+			</xsl:when>
+			<xsl:when test="$lc_identifier_type = 'lissn'">
+				<xsl:text>LISSN</xsl:text>
+			</xsl:when>
+			<xsl:when test="$lc_identifier_type = 'lsid'">
+				<xsl:text>LSID</xsl:text>
+			</xsl:when>
+			<xsl:when test="$lc_identifier_type = 'pmid'">
+				<xsl:text>PMID</xsl:text>
+			</xsl:when>
+			<xsl:when test="$lc_identifier_type = 'purl'">
+				<xsl:text>PURL</xsl:text>
+			</xsl:when>
+			<xsl:when test="$lc_identifier_type = 'upc'">
+				<xsl:text>UPC</xsl:text>
+			</xsl:when>
+			<xsl:when
+				test="$isURL = 'true' or $lc_identifier_type = 'url'">
+				<xsl:text>URL</xsl:text>
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:text>URN</xsl:text>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+	
+	<xsl:template name="resolveRightsURI">
+		<xsl:param name="field" />
+		<xsl:variable name="lc_value">
+			<xsl:call-template name="lowercase">
+				<xsl:with-param name="value" select="$field" />
+			</xsl:call-template>
+		</xsl:variable>
+		<xsl:choose>
+			<xsl:when test="$lc_value = 'open access'">
+				<xsl:text>http://purl.org/coar/access_right/c_abf2</xsl:text>
+			</xsl:when>
+			<xsl:when
+				test="substring-before($lc_value,'|||')= 'embargoed access'">
+				<xsl:text>http://purl.org/coar/access_right/c_f1cf</xsl:text>
+			</xsl:when>
+			<xsl:when test="$lc_value = 'restricted access'">
+				<xsl:text>http://purl.org/coar/access_right/c_16ec</xsl:text>
+			</xsl:when>
+			<xsl:when test="$lc_value = 'metadata only access'">
+				<xsl:text>http://purl.org/coar/access_right/c_14cb</xsl:text>
+			</xsl:when>
+			<xsl:otherwise />
+		</xsl:choose>
+	</xsl:template>
+	
+	 <xsl:template match="doc:element[@name='dc']/doc:element[@name='type']/doc:element" 
+	 		mode="oaire">
+        <xsl:variable name="resourceTypeGeneral">
+            <xsl:call-template name="resolveResourceTypeGeneral">
+                <xsl:with-param name="field" select="./doc:field[@name='value']/text()"/>
+            </xsl:call-template>
+        </xsl:variable>
+        <xsl:variable name="resourceTypeURI">
+            <xsl:call-template name="resolveResourceTypeURI">
+                <xsl:with-param name="field" select="./doc:field[@name='value']/text()"/>
+            </xsl:call-template>
+        </xsl:variable>
+        <oaire:resourceType>
+            <xsl:attribute name="resourceTypeGeneral">
+                <xsl:value-of select="$resourceTypeGeneral"/>
+            </xsl:attribute>
+            <xsl:attribute name="uri">
+                <xsl:value-of select="$resourceTypeURI"/>
+            </xsl:attribute>
+            <xsl:value-of select="./doc:field[@name='value']/text()"/>
+        </oaire:resourceType>
+    </xsl:template>
+	
+	    <!--
+        This template will return the general type of the resource
+        based on a valued text like 'article'
+        https://openaire-guidelines-for-literature-repository-managers.readthedocs.io/en/v4.0.0/field_publicationtype.html#attribute-resourcetypegeneral-m 
+     -->
+    <xsl:template name="resolveResourceTypeGeneral">
+        <xsl:param name="field"/>
+        <xsl:variable name="lc_dc_type">
+            <xsl:call-template name="lowercase">
+                <xsl:with-param name="value" select="$field"/>
+            </xsl:call-template>
+        </xsl:variable>
+        <xsl:choose>
+            <xsl:when test="$lc_dc_type = 'article'">
+                <xsl:text>literature</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'journal article'">
+                <xsl:text>literature</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'book'">
+                <xsl:text>literature</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'book part'">
+                <xsl:text>literature</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'book review'">
+                <xsl:text>literature</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'dataset'">
+                <xsl:text>dataset</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'software'">
+                <xsl:text>software</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:text>other research product</xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!--
+        This template will return the COAR Resource Type Vocabulary URI
+        like http://purl.org/coar/resource_type/c_6501
+        based on a valued text like 'article'
+        https://openaire-guidelines-for-literature-repository-managers.readthedocs.io/en/v4.0.0/field_publicationtype.html#attribute-uri-m
+     -->
+    <xsl:template name="resolveResourceTypeURI">
+        <xsl:param name="field"/>
+        <xsl:variable name="lc_dc_type">
+            <xsl:call-template name="lowercase">
+                <xsl:with-param name="value" select="$field"/>
+            </xsl:call-template>
+        </xsl:variable>
+        <xsl:choose>
+            <xsl:when test="$lc_dc_type = 'annotation'">
+                <xsl:text>http://purl.org/coar/resource_type/c_1162</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'journal'">
+                <xsl:text>http://purl.org/coar/resource_type/c_0640</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'article'">
+                <xsl:text>http://purl.org/coar/resource_type/c_6501</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'journal article'">
+                <xsl:text>http://purl.org/coar/resource_type/c_6501</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'editorial'">
+                <xsl:text>http://purl.org/coar/resource_type/c_b239</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'bachelor thesis'">
+                <xsl:text>http://purl.org/coar/resource_type/c_7a1f</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'bibliography'">
+                <xsl:text>http://purl.org/coar/resource_type/c_86bc</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'book'">
+                <xsl:text>http://purl.org/coar/resource_type/c_2f33</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'book part'">
+                <xsl:text>http://purl.org/coar/resource_type/c_3248</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'book review'">
+                <xsl:text>http://purl.org/coar/resource_type/c_ba08</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'website'">
+                <xsl:text>http://purl.org/coar/resource_type/c_7ad9</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'interactive resource'">
+                <xsl:text>http://purl.org/coar/resource_type/c_e9a0</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'conference proceedings'">
+                <xsl:text>http://purl.org/coar/resource_type/c_f744</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'conference object'">
+                <xsl:text>http://purl.org/coar/resource_type/c_c94f</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'conference paper'">
+                <xsl:text>http://purl.org/coar/resource_type/c_5794</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'conference poster'">
+                <xsl:text>http://purl.org/coar/resource_type/c_6670</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'contribution to journal'">
+                <xsl:text>http://purl.org/coar/resource_type/c_3e5a</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'data paper'">
+                <xsl:text>http://purl.org/coar/resource_type/c_beb9</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'dataset'">
+                <xsl:text>http://purl.org/coar/resource_type/c_ddb1</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'doctoral thesis'">
+                <xsl:text>http://purl.org/coar/resource_type/c_db06</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'image'">
+                <xsl:text>http://purl.org/coar/resource_type/c_c513</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'lecture'">
+                <xsl:text>http://purl.org/coar/resource_type/c_8544</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'letter'">
+                <xsl:text>http://purl.org/coar/resource_type/c_0857</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'master thesis'">
+                <xsl:text>http://purl.org/coar/resource_type/c_bdcc</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'moving image'">
+                <xsl:text>http://purl.org/coar/resource_type/c_8a7e</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'periodical'">
+                <xsl:text>http://purl.org/coar/resource_type/c_2659</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'letter to the editor'">
+                <xsl:text>http://purl.org/coar/resource_type/c_545b</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'patent'">
+                <xsl:text>http://purl.org/coar/resource_type/c_15cd</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'preprint'">
+                <xsl:text>http://purl.org/coar/resource_type/c_816b</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'report'">
+                <xsl:text>http://purl.org/coar/resource_type/c_93fc</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'report part'">
+                <xsl:text>http://purl.org/coar/resource_type/c_ba1f</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'research proposal'">
+                <xsl:text>http://purl.org/coar/resource_type/c_baaf</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'review'">
+                <xsl:text>http://purl.org/coar/resource_type/c_efa0</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'software'">
+                <xsl:text>http://purl.org/coar/resource_type/c_5ce6</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'still image'">
+                <xsl:text>http://purl.org/coar/resource_type/c_ecc8</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'technical documentation'">
+                <xsl:text>http://purl.org/coar/resource_type/c_71bd</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'workflow'">
+                <xsl:text>http://purl.org/coar/resource_type/c_393c</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'working paper'">
+                <xsl:text>http://purl.org/coar/resource_type/c_8042</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'thesis'">
+                <xsl:text>http://purl.org/coar/resource_type/c_46ec</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'cartographic material'">
+                <xsl:text>http://purl.org/coar/resource_type/c_12cc</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'map'">
+                <xsl:text>http://purl.org/coar/resource_type/c_12cd</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'video'">
+                <xsl:text>http://purl.org/coar/resource_type/c_12ce</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'sound'">
+                <xsl:text>http://purl.org/coar/resource_type/c_18cc</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'musical composition'">
+                <xsl:text>http://purl.org/coar/resource_type/c_18cd</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'text'">
+                <xsl:text>http://purl.org/coar/resource_type/c_18cf</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'conference paper not in proceedings'">
+                <xsl:text>http://purl.org/coar/resource_type/c_18cp</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'conference poster not in proceedings'">
+                <xsl:text>http://purl.org/coar/resource_type/c_18co</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'musical notation'">
+                <xsl:text>http://purl.org/coar/resource_type/c_18cw</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'internal report'">
+                <xsl:text>http://purl.org/coar/resource_type/c_18ww</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'memorandum'">
+                <xsl:text>http://purl.org/coar/resource_type/c_18wz</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'other type of report'">
+                <xsl:text>http://purl.org/coar/resource_type/c_18wq</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'policy report'">
+                <xsl:text>http://purl.org/coar/resource_type/c_186u</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'project deliverable'">
+                <xsl:text>http://purl.org/coar/resource_type/c_18op</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'report to funding agency'">
+                <xsl:text>http://purl.org/coar/resource_type/c_18hj</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'research report'">
+                <xsl:text>http://purl.org/coar/resource_type/c_18ws</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'technical report'">
+                <xsl:text>http://purl.org/coar/resource_type/c_18gh</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'review article'">
+                <xsl:text>http://purl.org/coar/resource_type/c_dcae04bc</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'research article'">
+                <xsl:text>http://purl.org/coar/resource_type/c_2df8fbb1</xsl:text>
+            </xsl:when>
+            <!-- other -->
+            <xsl:otherwise>
+                <xsl:text>http://purl.org/coar/resource_type/c_1843</xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
+    <!-- datacite.creators -->
+    <!-- https://openaire-guidelines-for-literature-repository-managers.readthedocs.io/en/v4.0.0/field_creator.html -->
+    <xsl:template
+        match="doc:element[@name='dc']/doc:element[@name='contributor']/doc:element[@name='author']" mode="datacite">
+        <datacite:creators>
+            <!-- datacite.creator -->
+            <xsl:for-each select="./doc:element/doc:field[@name='value']">
+                <xsl:variable name="isAuthorityValue">
+                    <xsl:call-template name="isAuthorityValue">
+                        <xsl:with-param name="element" select="."/>
+                    </xsl:call-template>
+                </xsl:variable>
+                <xsl:choose>
+                    <!-- if next sibling is authority and starts with virtual:: -->
+                    <xsl:when test="$isAuthorityValue = 'true'">
+                        <xsl:variable name="entity">
+                            <xsl:call-template name="buildAuthorityNode">
+                                <xsl:with-param name="element" select="."/>
+                            </xsl:call-template>
+                        </xsl:variable>
+                        <xsl:apply-templates select="$entity" mode="authority_creator"/>
+                    </xsl:when>
+                    <!-- simple text metadata -->
+                    <xsl:otherwise>
+                        <datacite:creator>
+                            <datacite:creatorName>
+                                <xsl:value-of select="./text()"/>
+                            </datacite:creatorName>
+                        </datacite:creator>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:for-each>
+        </datacite:creators>
+    </xsl:template>
+    
+   <!--  -->
+   <!-- Auxiliary templates -->
+   <!--  -->
+
+    <!-- 
+        this template will verify if a field name with "authority"
+        is present and if it is not empty
+        if it occurs, than we are in a presence of a related entity 
+     -->
+    <xsl:template name="isAuthorityValue">
+        <xsl:param name="element"/>
+        <xsl:variable name="sibling1" select="$element/following-sibling::*[1]"/>
+        <!-- if next sibling is authority and is not empty -->
+        <xsl:choose>
+            <xsl:when test="$sibling1[@name='authority' and (text()!='')]">
+                <xsl:value-of select="true()"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="false()"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
+    <!-- 
+        this template will try to look for all "additional metadata" 
+        This will retrieve something like:
+        <element name="10f8e9ba-6d4f-4550-beae-53e5d07c66fc">
+           <field name="dc.contributor.author.none">Doe, John</field>
+           <field name="person.identifier.orcid">3f685bbd-07d9-403e-9de2-b8f0fabe27a7</field>
+        </element>
+     -->
+    <xsl:template name="buildAuthorityNode">
+        <xsl:param name="element"/>
+        <!-- authority? -->
+        <xsl:variable name="sibling1" select="$element/following-sibling::*[1]"/>
+        <!-- confidence? -->
+        <xsl:variable name="sibling2" select="$element/following-sibling::*[2]"/>
+        <!-- if next sibling is authority and is not empty -->
+        <xsl:if test="$sibling1[@name='authority' and (text()!='')]">
+            <xsl:variable name="relation_id" select="$sibling1[1]/text()"/>
+            <xsl:element name="element" namespace="http://www.lyncode.com/xoai">
+                <xsl:attribute name="name">
+                    <xsl:value-of select="$relation_id"/>
+                </xsl:attribute>
+                <!-- search for all virtual relations elements in XML -->
+                <xsl:for-each select="//doc:field[text()=$relation_id]/preceding-sibling::*[1]">
+                    <xsl:element name="field" namespace="http://www.lyncode.com/xoai">
+                        <xsl:attribute name="name">
+                        <xsl:call-template name="buildAuthorityFieldName">
+                        <xsl:with-param name="element" select="."/>
+                          </xsl:call-template>
+                        </xsl:attribute>
+                        <!-- field value -->
+                        <xsl:value-of select="./text()"/>
+                    </xsl:element>
+                </xsl:for-each>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+    
+   <!-- 
+        This template will recursively create the field name based on parent node names
+        to be something like this:
+        person.familyName.*
+    -->
+    <xsl:template name="buildAuthorityFieldName">
+        <xsl:param name="element"/>
+        <xsl:choose>
+            <xsl:when test="$element/..">
+                <xsl:call-template name="buildAuthorityFieldName">
+                    <xsl:with-param name="element" select="$element/.."/>
+                </xsl:call-template>
+                <!-- if parent isn't an element then don't include '.' -->
+                <xsl:if test="local-name($element/../..) = 'element'">
+                    <xsl:text>.</xsl:text>
+                </xsl:if>
+                <xsl:value-of select="$element/../@name"/>
+            </xsl:when>
+            <xsl:otherwise/>
+        </xsl:choose>
+    </xsl:template>
+    
+    <!-- datacite:creator -->
+    <xsl:template match="doc:element" mode="authority_creator">
+        <datacite:creator>
+            <datacite:creatorName>
+                <xsl:value-of select="doc:field[starts-with(@name,'dc.contributor.author')]"/>
+            </datacite:creatorName>
+            <xsl:choose>
+            <xsl:when test="doc:field[starts-with(@name,'person.identifier.orcid')]">
+		        <datacite:nameIdentifier nameIdentifierScheme="ORCID" schemeURI="http://orcid.org">
+		        	<xsl:value-of select="doc:field[starts-with(@name,'person.identifier.orcid')]"/>
+		        </datacite:nameIdentifier>            
+            </xsl:when>
+            <xsl:otherwise/>
+        	</xsl:choose>
+        </datacite:creator>
+    </xsl:template>
+    
+</xsl:stylesheet>

--- a/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
@@ -242,8 +242,8 @@
 					<xsl:variable name="awardtitle" select="doc:metadata/doc:element[@name='dc']/doc:element[@name='relation']/doc:element/doc:field[@name='value']"/>
 					
 					<xsl:variable name="check_fundingreference"> 
-						<xsl:for-each select="$awardtitle">
-							<xsl:if test="$awardtitle!=''">
+						<xsl:for-each select="$funder">
+							<xsl:if test="$funder!=''">
 								<xsl:value-of select="."/>
 							</xsl:if>
 						</xsl:for-each>
@@ -251,12 +251,12 @@
 					
 					<xsl:if test="$check_fundingreference!=''">
 						<oaire:fundingReferences>
-							<xsl:for-each select="$awardtitle">
+							<xsl:for-each select="$funder">
 								<xsl:if test=".!='' ">
 									<oaire:fundingReference>
 										<xsl:variable name="counter" select="position()"/>
 										<oaire:funderName>
-											<xsl:value-of select="$funder[$counter]"/>
+											<xsl:value-of select="."/>
 										</oaire:funderName>
 										<xsl:if test="$funderid[$counter]!='' ">
 											<oaire:funderIdentifier funderIdentifierType="Crossref Funder ID">
@@ -267,15 +267,15 @@
 											<oaire:awardNumber>
 												<xsl:if test="$awarduri[$counter]!='' ">
 													<xsl:attribute name="awardURI">
-														<xsl:value-of select="$awarduri"/>
+														<xsl:value-of select="$awarduri[$counter]"/>
 													</xsl:attribute>
 												</xsl:if>
 												<xsl:value-of select="$awardnumber[$counter]"/>
 											</oaire:awardNumber>
 										</xsl:if>
-										<xsl:if test=".!='' ">
+										<xsl:if test="$awardtitle[$counter]!='' ">
 											<oaire:awardTitle>
-												<xsl:value-of select="."/>
+												<xsl:value-of select="$awardtitle[$counter]"/>
 											</oaire:awardTitle>
 										</xsl:if>
 									</oaire:fundingReference>

--- a/dspace/config/crosswalks/oai/transformers/openaire4.xsl
+++ b/dspace/config/crosswalks/oai/transformers/openaire4.xsl
@@ -54,7 +54,7 @@
                 <xsl:text>ita</xsl:text>
             </xsl:when>
             <xsl:when test="$lc_value = 'ja'">
-                <xsl:text>jap</xsl:text>
+                <xsl:text>jpn</xsl:text>
             </xsl:when>
             <xsl:when test="$lc_value = 'zh'">
                 <xsl:text>zho</xsl:text>

--- a/dspace/config/crosswalks/oai/transformers/openaire4.xsl
+++ b/dspace/config/crosswalks/oai/transformers/openaire4.xsl
@@ -1,0 +1,357 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Following OpenAIRE Guidelines 4 -->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:doc="http://www.lyncode.com/xoai">
+    <xsl:output indent="yes" method="xml" omit-xml-declaration="yes"/>
+
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- 
+        Formatting dc.date.issued
+        based on what OpenAIRE4 specifies for issued dates 
+        https://openaire-guidelines-for-literature-repository-managers.readthedocs.io/en/v4.0.0/field_publicationdate.html
+    -->
+    <xsl:template
+        match="/doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='issued']/doc:element/doc:field/text()">
+        <xsl:call-template name="formatdate">
+            <xsl:with-param name="datestr" select="."/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!-- 
+        Modifying and normalizing dc.language
+        to ISO 639-3 (from ISO 639-1) for each language available at the submission form
+     -->
+    <xsl:template
+        match="/doc:metadata/doc:element[@name='dc']/doc:element[@name='language']/doc:element[@name='iso']/doc:element/doc:field/text()">
+
+        <xsl:variable name="lc_value">
+            <xsl:call-template name="lowercase">
+                <xsl:with-param name="value" select="."/>
+            </xsl:call-template>
+        </xsl:variable>
+        <xsl:choose>
+            <xsl:when test="$lc_value = 'en_US'">
+                <xsl:text>eng</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_value = 'en'">
+                <xsl:text>eng</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_value = 'es'">
+                <xsl:text>spa</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_value = 'de'">
+                <xsl:text>deu</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_value = 'fr'">
+                <xsl:text>fra</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_value = 'it'">
+                <xsl:text>ita</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_value = 'ja'">
+                <xsl:text>jap</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_value = 'zh'">
+                <xsl:text>zho</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_value = 'pt'">
+                <xsl:text>por</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_value = 'tr'">
+                <xsl:text>tur</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="."/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- Modifying dc.rights -->
+    <!-- Removing unwanted -->
+    <xsl:template
+        match="/doc:metadata/doc:element[@name='dc']/doc:element[@name='rights']/doc:element/doc:element"/>
+
+    <!-- Modifying and normalizing dc.type according to COAR Controlled Vocabulary for Resource Type 
+        Genres (Version 2.0) (http://vocabularies.coar-repositories.org/documentation/resource_types/)
+        available at 
+        https://openaire-guidelines-for-literature-repository-managers.readthedocs.io/en/v4.0.0/field_publicationtype.html#attribute-uri-m
+    -->
+    <xsl:template
+        match="/doc:metadata/doc:element[@name='dc']/doc:element[@name='type']/doc:element/doc:field/text()">
+        <xsl:variable name="dc_type" select="."/>
+        <xsl:variable name="lc_dc_type">
+            <xsl:call-template name="lowercase">
+                <xsl:with-param name="value" select="."/>
+            </xsl:call-template>
+        </xsl:variable>
+        <xsl:choose>
+            <xsl:when
+                test="$lc_dc_type = 'annotation' or $dc_type = 'http://purl.org/coar/resource_type/c_1162'">
+                <xsl:text>annotation</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'journal'">
+                <xsl:text>journal</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'journal article' or $lc_dc_type = 'article' or $lc_dc_type = 'journalarticle' or $dc_type = 'http://purl.org/coar/resource_type/c_6501'">
+                <xsl:text>journal article</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'editorial' or $dc_type = 'http://purl.org/coar/resource_type/c_b239'">
+                <xsl:text>editorial</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'bachelor thesis' or $lc_dc_type = 'bachelorthesis' or $dc_type = 'http://purl.org/coar/resource_type/c_7a1f'">
+                <xsl:text>bachelor thesis</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'bibliography' or $dc_type = 'http://purl.org/coar/resource_type/c_86bc'">
+                <xsl:text>bibliography</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'book' or $dc_type = 'http://purl.org/coar/resource_type/c_2f33'">
+                <xsl:text>book</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'book part' or $lc_dc_type = 'bookpart' or $dc_type = 'http://purl.org/coar/resource_type/c_3248'">
+                <xsl:text>book part</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'book review' or $lc_dc_type = 'bookreview' or $dc_type = 'http://purl.org/coar/resource_type/c_ba08'">
+                <xsl:text>book review</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'website' or $dc_type = 'http://purl.org/coar/resource_type/c_7ad9'">
+                <xsl:text>website</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'interactive resource' or $lc_dc_type = 'interactiveresource' or $dc_type = 'http://purl.org/coar/resource_type/c_e9a0'">
+                <xsl:text>interactive resource</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'conference proceedings' or $lc_dc_type = 'conferenceproceedings' or $dc_type = 'http://purl.org/coar/resource_type/c_f744'">
+                <xsl:text>conference proceedings</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'conference object' or $lc_dc_type = 'conferenceobject' or $dc_type = 'http://purl.org/coar/resource_type/c_c94f'">
+                <xsl:text>conference object</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'conference paper' or $lc_dc_type = 'conferencepaper' or $dc_type = 'http://purl.org/coar/resource_type/c_5794'">
+                <xsl:text>conference paper</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'conference poster' or $lc_dc_type = 'conferenceposter' or $dc_type = 'http://purl.org/coar/resource_type/c_6670'">
+                <xsl:text>conference poster</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'contribution to journal' or $lc_dc_type = 'contributiontojournal' or $dc_type = 'http://purl.org/coar/resource_type/c_3e5a'">
+                <xsl:text>contribution to journal</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'datapaper' or $dc_type = 'http://purl.org/coar/resource_type/c_beb9'">
+                <xsl:text>data paper</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'dataset' or $dc_type = 'http://purl.org/coar/resource_type/c_ddb1'">
+                <xsl:text>dataset</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'doctoral thesis' or $lc_dc_type = 'doctoralthesis' or $dc_type = 'http://purl.org/coar/resource_type/c_db06'">
+                <xsl:text>doctoral thesis</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'image' or $dc_type = 'http://purl.org/coar/resource_type/c_c513'">
+                <xsl:text>image</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'lecture' or $dc_type = 'http://purl.org/coar/resource_type/c_8544'">
+                <xsl:text>lecture</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'letter' or $dc_type = 'http://purl.org/coar/resource_type/c_0857'">
+                <xsl:text>letter</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'master thesis' or $lc_dc_type = 'masterthesis' or $dc_type = 'http://purl.org/coar/resource_type/c_bdcc'">
+                <xsl:text>master thesis</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'moving image' or $lc_dc_type = 'movingimage' or $dc_type = 'http://purl.org/coar/resource_type/c_8a7e'">
+                <xsl:text>moving image</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'periodical' or $dc_type = 'http://purl.org/coar/resource_type/c_2659'">
+                <xsl:text>periodical</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'letter to the editor' or $lc_dc_type = 'lettertotheeditor' or $dc_type = 'http://purl.org/coar/resource_type/c_545b'">
+                <xsl:text>letter to the editor</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'patent' or $dc_type = 'http://purl.org/coar/resource_type/c_15cd'">
+                <xsl:text>patent</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'preprint' or $dc_type = 'http://purl.org/coar/resource_type/c_816b'">
+                <xsl:text>preprint</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'report' or $dc_type = 'http://purl.org/coar/resource_type/c_93fc'">
+                <xsl:text>report</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'report part' or $lc_dc_type = 'reportpart' or $dc_type = 'http://purl.org/coar/resource_type/c_ba1f'">
+                <xsl:text>report part</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'research proposal' or $lc_dc_type = 'researchproposal' or $dc_type = 'http://purl.org/coar/resource_type/c_baaf'">
+                <xsl:text>research proposal</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'review' or $dc_type = 'http://purl.org/coar/resource_type/c_efa0'">
+                <xsl:text>review</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'software' or $dc_type = 'http://purl.org/coar/resource_type/c_5ce6'">
+                <xsl:text>software</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'still image' or $lc_dc_type = 'stillimage' or $dc_type = 'http://purl.org/coar/resource_type/c_ecc8'">
+                <xsl:text>still image</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'technical documentation' or $lc_dc_type = 'technicaldocumentation' or $dc_type = 'http://purl.org/coar/resource_type/c_71bd'">
+                <xsl:text>technical documentation</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'workflow' or $dc_type = 'http://purl.org/coar/resource_type/c_393c'">
+                <xsl:text>workflow</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'working paper' or $lc_dc_type = 'workingpaper' or $dc_type = 'http://purl.org/coar/resource_type/c_8042'">
+                <xsl:text>working paper</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'thesis' or $dc_type = 'http://purl.org/coar/resource_type/c_46ec'">
+                <xsl:text>thesis</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'cartographic material' or $lc_dc_type = 'cartographicmaterial' or $dc_type = 'http://purl.org/coar/resource_type/c_12cc'">
+                <xsl:text>cartographic material</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'map' or $dc_type = 'http://purl.org/coar/resource_type/c_12cd'">
+                <xsl:text>map</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'video' or $dc_type = 'http://purl.org/coar/resource_type/c_12ce'">
+                <xsl:text>video</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'sound' or $dc_type = 'http://purl.org/coar/resource_type/c_18cc'">
+                <xsl:text>sound</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'musical composition' or $lc_dc_type = 'musicalcomposition' or $dc_type = 'http://purl.org/coar/resource_type/c_18cd'">
+                <xsl:text>musical composition</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'text' or $dc_type = 'http://purl.org/coar/resource_type/c_18cf'">
+                <xsl:text>text</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'conference paper not in proceedings' or $lc_dc_type = 'conferencepapernotinproceedings' or $dc_type = 'http://purl.org/coar/resource_type/c_18cp'">
+                <xsl:text>conference paper not in proceedings</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'conference poster not in proceedings' or $lc_dc_type = 'conferenceposternotinproceedings' or $dc_type = 'http://purl.org/coar/resource_type/c_18co'">
+                <xsl:text>conference poster not in proceedings</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'musical notation' or $dc_type = 'http://purl.org/coar/resource_type/c_18cw'">
+                <xsl:text>musical notation</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'internal report' or $lc_dc_type = 'internalreport' or $dc_type = 'http://purl.org/coar/resource_type/c_18ww'">
+                <xsl:text>internal report</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'memorandum' or $dc_type = 'http://purl.org/coar/resource_type/c_18wz'">
+                <xsl:text>memorandum</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'other type of report'  or $lc_dc_type = 'othertypeofreport' or $dc_type = 'http://purl.org/coar/resource_type/c_18wq'">
+                <xsl:text>other type of report</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'policy report' or $lc_dc_type = 'policyreport'  or $dc_type = 'http://purl.org/coar/resource_type/c_186u'">
+                <xsl:text>policy report</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'project deliverable' or $lc_dc_type = 'projectdeliverable' or $dc_type = 'http://purl.org/coar/resource_type/c_18op'">
+                <xsl:text>project deliverable</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'report to funding agency' or $lc_dc_type = 'reporttofundingagency' or $dc_type = 'http://purl.org/coar/resource_type/c_18hj'">
+                <xsl:text>report to funding agency</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'research report' or $lc_dc_type = 'researchreport' or $dc_type = 'http://purl.org/coar/resource_type/c_18ws'">
+                <xsl:text>research report</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'technical report' or $lc_dc_type = 'technicalreport' or $dc_type = 'http://purl.org/coar/resource_type/c_18gh'">
+                <xsl:text>technical report</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'review article' or $lc_dc_type = 'reviewarticle' or $dc_type = 'http://purl.org/coar/resource_type/c_dcae04bc'">
+                <xsl:text>review article</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'research article' or $lc_dc_type = 'researcharticle' or $dc_type = 'http://purl.org/coar/resource_type/c_2df8fbb1'">
+                <xsl:text>research article</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:text>other</xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
+
+    </xsl:template>
+
+
+
+    <!-- AUXILIARY TEMPLATES -->
+
+
+    <!--  
+        Date format
+        This template is discarding the " 16:53:24.556" part from a date and time 
+        like "2019-04-30 16:53:24.556" to support the YYYY-MM-DD format of 
+        ISO 8601 [W3CDTF]
+    -->
+    <xsl:template name="formatdate">
+        <xsl:param name="datestr"/>
+        <xsl:variable name="sub">
+            <xsl:value-of select="substring($datestr,1,10)"/>
+        </xsl:variable>
+        <xsl:value-of select="$sub"/>
+    </xsl:template>
+
+   <!--  -->
+   <!-- Other Auxiliary templates -->
+   <!--  -->
+    <xsl:param name="smallcase" select="'abcdefghijklmnopqrstuvwxyzàèìòùáéíóúýâêîôûãñõäëïöüÿåæœçðø'"/>
+    <xsl:param name="uppercase" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZÀÈÌÒÙÁÉÍÓÚÝÂÊÎÔÛÃÑÕÄËÏÖÜŸÅÆŒÇÐØ'"/>    
+
+   <!-- to retrieve a string in uppercase -->
+    <xsl:template name="uppercase">
+        <xsl:param name="value"/>
+        <xsl:value-of select="translate($value, $smallcase, $uppercase)"/>
+    </xsl:template>
+
+   <!-- to retrieve a string in lowercase -->
+    <xsl:template name="lowercase">
+        <xsl:param name="value"/>
+        <xsl:value-of select="translate($value, $uppercase, $smallcase)"/>
+    </xsl:template>
+
+    <!-- to retrieve a string which the first letter is in uppercase -->
+    <xsl:template name="ucfirst">
+        <xsl:param name="value"/>
+        <xsl:call-template name="uppercase">
+            <xsl:with-param name="value" select="substring($value, 1, 1)"/>
+        </xsl:call-template>
+        <xsl:call-template name="lowercase">
+            <xsl:with-param name="value" select="substring($value, 2)"/>
+        </xsl:call-template>
+    </xsl:template>
+</xsl:stylesheet>

--- a/dspace/config/crosswalks/oai/xoai.xml
+++ b/dspace/config/crosswalks/oai/xoai.xml
@@ -80,8 +80,26 @@
                 This contexts complies with OpenAIRE rules.
             </Description>
         </Context>
-    </Contexts>
 
+        <!--
+            OpenAIRE Guidelines 4.0:
+
+            - https://openaire-guidelines-for-literature-repository-managers.readthedocs.io/en/v4.0.0/
+
+		-->
+        <Context baseurl="openaire4" name="OpenAIRE v4 Context">
+            <!-- Date format, field prefixes, etc are ensured by the transformer -->
+            <Transformer ref="openaire4Transformer"/>
+            <!-- OpenAIRE filter -->
+			<!-- This Context includes bibliographic metadata describing open access and non open access items -->            
+            <Set ref="openaire4Set"/>
+            <!-- Metadata Formats -->
+            <Format ref="oaiopenaire"/>
+            <Description>
+				This contexts complies with OpenAIRE Guidelines for Literature Repositories v4.0.
+            </Description>
+        </Context>
+    </Contexts>
 
     <Formats>
         <Format id="oaidc">
@@ -165,6 +183,15 @@
             <Namespace>http://irdb.nii.ac.jp/oai</Namespace>
             <SchemaLocation>http://irdb.nii.ac.jp/oai/junii2-3-1.xsd</SchemaLocation>
         </Format>
+        <!-- Metadata format based on the OpenAIRE 4.0 guidelines
+             https://openaire-guidelines-for-literature-repository-managers.readthedocs.io/en/v4.0.0/use_of_oai_pmh.html 
+        -->        
+        <Format id="oaiopenaire">
+            <Prefix>oai_openaire</Prefix>
+            <XSLT>metadataFormats/oai_openaire.xsl</XSLT>
+            <Namespace>http://namespace.openaire.eu/schema/oaire/</Namespace>
+            <SchemaLocation>https://www.openaire.eu/schema/repo-lit/4.0/openaire.xsd</SchemaLocation>
+        </Format>
     </Formats>
 
     <Transformers>
@@ -173,6 +200,9 @@
         </Transformer>
         <Transformer id="openaireTransformer">
             <XSLT>transformers/openaire.xsl</XSLT>
+        </Transformer>
+        <Transformer id="openaire4Transformer">
+            <XSLT>transformers/openaire4.xsl</XSLT>
         </Transformer>
     </Transformers>
 
@@ -414,5 +444,10 @@
             <Name>EC_fundedresources set</Name>
             <!-- Just an alias -->
         </Set>
+        <Set id="openaire4Set">
+            <Spec>openaire</Spec>
+            <Name>OpenAIRE set</Name>
+            <!-- Just an alias -->
+        </Set>        
     </Sets>
 </Configuration>

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -200,6 +200,62 @@ it, please enter the types and the actual numbers or codes.</hint>
          <required></required>
        </field>
      </page>
+     
+     <page number="3">
+     	  <field>
+         <dc-schema>project</dc-schema>
+         <dc-element>funder</dc-element>
+         <dc-qualifier>name</dc-qualifier>
+         <repeatable>false</repeatable>
+         <label>Funder Name</label>
+         <input-type>onebox</input-type>
+         <hint>Name of the funding provider.</hint>
+         <required></required>
+       </field>
+
+     	  <field>
+         <dc-schema>oaire</dc-schema>
+         <dc-element>awardNumber</dc-element>
+         <repeatable>false</repeatable>
+         <label>Funder Grant</label>
+         <input-type>onebox</input-type>
+         <hint>Project grantId or awardNumber.</hint>
+         <required></required>
+       </field>
+
+       <field>
+         <dc-schema>project</dc-schema>
+         <dc-element>funder</dc-element>
+         <dc-qualifier>identifier</dc-qualifier>
+         <repeatable>false</repeatable>
+         <label>Funder Identifier</label>
+         <input-type>onebox</input-type>
+         <hint>Unique identifier of the funding entity.</hint>
+         <required></required>
+       </field>
+
+       <field>
+         <dc-schema>dc</dc-schema>
+         <dc-element>relation</dc-element>
+         <dc-qualifier></dc-qualifier>
+         <repeatable>false</repeatable>
+         <label>Award Title</label>
+         <input-type>onebox</input-type>
+         <hint>Title of the project, award or grant.</hint>
+         <required></required>
+       </field>
+
+       <field>
+         <dc-schema>oaire</dc-schema>
+         <dc-element>awardURI</dc-element>
+         <repeatable>false</repeatable>
+         <label>Award URI.</label>
+         <input-type>onebox</input-type>
+         <hint>URI of the project landing page provided by the funder for more information about the award.</hint>
+         <required></required>
+       </field>
+	</page>
+	
    </form>
 
    <form name="one">

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -201,7 +201,9 @@ it, please enter the types and the actual numbers or codes.</hint>
        </field>
      </page>
      
-     <page number="3">
+<!-- Please enable follow page element to support OpenAIRE v.4 Literature context
+
+      <page number="3">
      	  <field>
          <dc-schema>project</dc-schema>
          <dc-element>funder</dc-element>
@@ -254,7 +256,7 @@ it, please enter the types and the actual numbers or codes.</hint>
          <hint>URI of the project landing page provided by the funder for more information about the award.</hint>
          <required></required>
        </field>
-	</page>
+	</page> -->
 	
    </form>
 

--- a/dspace/config/modules/spring.cfg
+++ b/dspace/config/modules/spring.cfg
@@ -8,4 +8,5 @@
 # These classes contain the paths to where to spring files are loaded
 springloader.modules=org.dspace.app.configuration.APISpringLoader,\
   org.dspace.app.xmlui.configuration.XMLUISpringLoader,\
-  org.dspace.app.webui.configuration.JSPUISpringLoader
+  org.dspace.app.webui.configuration.JSPUISpringLoader,\
+  org.dspace.xoai.app.OAISpringLoader

--- a/dspace/config/registries/openaire4-types.xml
+++ b/dspace/config/registries/openaire4-types.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  This document was based on the OpenAIRE4 Guidelines for Literature Repositories
+  https://openaire-guidelines-for-literature-repository-managers.readthedocs.io/en/v4.0.0/index.html
+  -->
+  
+<dspace-dc-types>
+    <dspace-header>
+        <title>OpenAIRE4 fields definition</title>
+    </dspace-header>
+
+    <dc-schema>
+        <name>oaire</name>
+        <namespace>http://namespace.openaire.eu/schema/oaire/</namespace>
+    </dc-schema>
+	
+    <dc-type>
+        <schema>oaire</schema>
+        <element>awardNumber</element>
+        <scope_note>Project grantId or awardNumber</scope_note>
+    </dc-type>
+	
+    <dc-type>
+        <schema>oaire</schema>
+        <element>awardURI</element>
+        <scope_note>URI of the project landing page provided by the funder for more information about the award (grant).</scope_note>
+    </dc-type>
+
+</dspace-dc-types>

--- a/dspace/config/registries/project-types.xml
+++ b/dspace/config/registries/project-types.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  This document was based on the OpenAIRE4 Guidelines for Literature Repositories
+  https://openaire-guidelines-for-literature-repository-managers.readthedocs.io/en/v4.0.0/index.html
+  -->
+  
+<dspace-dc-types>
+    <dspace-header>
+        <title>Project fields definition for OpenAIRE 4</title>
+    </dspace-header>
+
+    <dc-schema>
+        <name>project</name>
+        <namespace>http://dspace.org/project</namespace>
+    </dc-schema>
+    	
+    <dc-type>
+        <schema>project</schema>
+        <element>funder</element>
+        <qualifier>identifier</qualifier>
+        <scope_note></scope_note>
+    </dc-type>
+	
+    <dc-type>
+        <schema>project</schema>
+        <element>funder</element>
+        <qualifier>name</qualifier>
+        <scope_note></scope_note>
+    </dc-type>
+        
+</dspace-dc-types>

--- a/dspace/config/spring/oai/oai.xml
+++ b/dspace/config/spring/oai/oai.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                  http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+                  http://www.springframework.org/schema/context
+                  http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+
+    <context:annotation-config /> <!-- allows us to use spring annotations in beans -->
+
+	<!-- Additional item.compile plugin to enrich field with information about orcid metadata: to use it activate ORCID based authority control on dspace.cfg-->
+<!--  	<bean id="orcidVirtualElementAdditional"
+		class="org.dspace.xoai.app.OrcidVirtualElementAdditional">
+		<property name="metadata" value="dc.contributor.author"/>
+		<property name="authorityService" ref="org.dspace.authority.AuthoritySearchService"/>
+	</bean> -->
+	
+	<!-- Additional item.compile plugin to enrich field with information about DRM metadata -->
+	<bean id="PermissionElementAdditional"
+	class="org.dspace.xoai.app.PermissionElementAdditional"/>
+
+	<!-- Additional item.compile plugin to enrich field with information about Creative Commons License metadata -->
+	<bean id="CCElementAdditional"
+	class="org.dspace.xoai.app.CCElementAdditional"/>
+</beans>

--- a/dspace/config/spring/oai/oai.xml
+++ b/dspace/config/spring/oai/oai.xml
@@ -30,6 +30,8 @@
 	class="org.dspace.xoai.app.PermissionElementAdditional"/>
 
 	<!-- Additional item.compile plugin to enrich field with information about Creative Commons License metadata -->
-	<bean id="CCElementAdditional"
-	class="org.dspace.xoai.app.CCElementAdditional"/>
+	<!-- For large repository the strategy used to retrieve Creative Commons information could be degraded the indexing performance.
+		Tested it on a repository of 163K items and the full reindex process takes 2 hours more - the full reindex process without this takes 1 hour. -->
+	<!-- <bean id="CCElementAdditional"
+	class="org.dspace.xoai.app.CCElementAdditional"/> -->
 </beans>


### PR DESCRIPTION
This PR is more or less the backport of the work done in DSpace 7 for OpenAIRE 4 support.

The major changes are:
- upgrade to XOAI 3.3.0 (the same version used for DSpace 7)
- support for build "metadata" on "item.compile" solr document field from external plugin
 