### PR TITLE
Ensure *.sh and *.bat files keep line endings by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,12 @@
 # Auto detect text files and perform LF normalization
 * text=auto
 
+# Ensure Unix files always keep Unix line endings
+*.sh text eol=lf
+
+# Ensure Windows files always keep Windows line endings
+*.bat text eol=crlf
+
 # Standard to msysgit
 *.doc  diff=astextplain
 *.DOC  diff=astextplain


### PR DESCRIPTION
Tiny PR to `.gitattributes` to ensure that *.sh (Bash scripts) and *.bat (Windows scripts) files keep their respective line endings.

I ran into an annoying issue in Docker where it was copying *.sh scripts from Windows to a Linux-based container, and those scripts didn't work anymore.  This fixes the issue, and ensures that all scripts of these types simply keep the appropriate line endings.