### PR TITLE
Discovery index for private and withdrawn items

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -3790,7 +3790,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.type", is("discover")))
                 .andExpect(jsonPath("$._embedded.searchResult.page", is(
-                        PageMatcher.pageEntry(0, 20)
+                        PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 1)
                 )))
                 .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.contains(
                         SearchResultMatcher.matchOnItemName("item", "items", "Public Test Item")
@@ -3871,7 +3871,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.type", is("discover")))
                 .andExpect(jsonPath("$._embedded.searchResult.page", is(
-                        PageMatcher.pageEntry(0, 20)
+                        PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 3)
                 )))
                 .andExpect(jsonPath("$._embedded.searchResult._embedded.objects",
                         Matchers.containsInAnyOrder(

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -7,11 +7,14 @@
  */
 package org.dspace.app.rest;
 
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -3717,4 +3720,178 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
 
     }
 
+    @Test
+    public void discoverSearchObjectsTestForDiscoverableAndUniscoverableItemsItemsNonAdmin() throws Exception {
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community")
+                                           .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
+        //2. One public item, one private, one withdrawn.
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                                      .withTitle("Test")
+                                      .withIssueDate("2010-10-17")
+                                      .withAuthor("Smith, Donald")
+                                      .withSubject("ExtraEntry")
+                                      .build();
+
+        Item publicItem2 = ItemBuilder.createItem(context, col2)
+                                      .withTitle("WithdrawnTest 2")
+                                      .withIssueDate("1990-02-13")
+                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                                      .withSubject("ExtraEntry")
+                                      .withdrawn()
+                                      .build();
+
+        Item publicItem3 = ItemBuilder.createItem(context, col2)
+                                      .withTitle("Private Test item 2")
+                                      .withIssueDate("2010-02-13")
+                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                                      .withSubject("AnotherTest").withSubject("ExtraEntry")
+                                      .makeUnDiscoverable()
+                                      .build();
+
+
+        String query = "Test";
+        //** WHEN **
+        //A non-admin user browses this endpoint to find the withdrawn or private objects in the system
+        //With a query stating 'Test'
+        getClient().perform(get("/api/discover/search/objects")
+            .param("configuration", "discoverableAndUndiscoverableItems")
+            .param("query", query))
+                   //** THEN **
+                   //The status has to be 200 OK
+                   .andExpect(status().isOk())
+                   //The type has to be 'discover'
+                   .andExpect(jsonPath("$.type", is("discover")))
+                   //The page object needs to look like this
+                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                       PageMatcher.pageEntry(0, 20)
+                   )))
+                   //The search results should be an empty list.
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.empty()))
+                   //There always needs to be a self link available
+                   .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+
+        ;
+
+    }
+
+    @Test
+    public void discoverSearchObjectsTestForDiscoverableAndUniscoverableItemsItemsByAdminUser() throws Exception {
+
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+
+        parentCommunity = CommunityBuilder
+                .createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder
+                .createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder
+                .createCollection(context, child1)
+                .withName("Collection 1")
+                .build();
+        Collection col2 = CollectionBuilder
+                .createCollection(context, child1)
+                .withName("Collection 2")
+                .build();
+
+        //2. One public item, one private, one withdrawn.
+
+        ItemBuilder.createItem(context, col1)
+                .withTitle("Public Test Item")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald")
+                .withSubject("ExtraEntry")
+                .build();
+
+        ItemBuilder.createItem(context, col2)
+                .withTitle("Withdrawn Test Item")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria")
+                .withAuthor("Doe, Jane")
+                .withSubject("ExtraEntry")
+                .withdrawn()
+                .build();
+
+        ItemBuilder.createItem(context, col2)
+                .withTitle("Private Test Item")
+                .withIssueDate("2010-02-13")
+                .withAuthor("Smith, Maria")
+                .withAuthor("Doe, Jane")
+                .withSubject("AnotherTest")
+                .withSubject("ExtraEntry")
+                .makeUnDiscoverable()
+                .build();
+
+        context.restoreAuthSystemState();
+
+        //** WHEN **
+
+        // A system admin user browses this endpoint to find the withdrawn or private objects in the system
+        // With a query stating 'Test'
+
+        String adminToken = getAuthToken(admin.getEmail(), password);
+
+        getClient(adminToken).perform(get("/api/discover/search/objects")
+                .param("configuration", "discoverableAndUndiscoverableItems")
+                .param("query", "Test"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.type", is("discover")))
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntry(0, 20)
+                )))
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects",
+                        Matchers.containsInAnyOrder(
+                                SearchResultMatcher.matchOnItemName("item", "items", "Public Test Item"),
+                                SearchResultMatcher.matchOnItemName("item", "items", "Withdrawn Test Item"),
+                                SearchResultMatcher.matchOnItemName("item", "items", "Private Test Item")
+                        )
+                ))
+                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                        allOf(
+                                hasJsonPath("name", is("discoverable"))
+                                hasJsonPath("$._embedded.values", Matchers.containsInAnyOrder(
+                                        allOf(
+                                                hasJsonPath("$.label", is("true")),
+                                                hasJsonPath("$.count", is(2))
+                                        ),
+                                        allOf(
+                                                hasJsonPath("$.label", is("false")),
+                                                hasJsonPath("$.count", is(1))
+                                        )
+                                ))
+                            ),
+                        allOf(
+                                hasJsonPath("$.name", is("withdrawn")),
+                                hasJsonPath("$._embedded.values", Matchers.containsInAnyOrder(
+                                        allOf(
+                                                hasJsonPath("$.label", is("true")),
+                                                hasJsonPath("$.count", is(1))
+                                        ),
+                                        allOf(
+                                                hasJsonPath("$.label", is("false")),
+                                                hasJsonPath("$.count", is(2))
+                                        )
+                                ))
+                        )
+                )))
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")));
+    }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -14,7 +14,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -3720,7 +3720,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
     }
 
     @Test
-    public void discoverSearchObjectsTestForDiscoverableAndUniscoverableItemsAnonymous() throws Exception {
+    public void discoverSearchObjectsTestForAdministrativeViewAnonymous() throws Exception {
 
         //We turn off the authorization system in order to create the structure as defined below
         context.turnOffAuthorisationSystem();
@@ -3782,7 +3782,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         // With a query stating 'Test'
 
         getClient().perform(get("/api/discover/search/objects")
-                .param("configuration", "discoverableAndUndiscoverableItems")
+                .param("configuration", "administrativeView")
                 .param("query", "Test"))
 
                 //** THEN **
@@ -3799,7 +3799,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
     }
 
     @Test
-    public void discoverSearchObjectsTestForDiscoverableAndUniscoverableItemsEPerson() throws Exception {
+    public void discoverSearchObjectsTestForAdministrativeViewEPerson() throws Exception {
 
         //We turn off the authorization system in order to create the structure as defined below
         context.turnOffAuthorisationSystem();
@@ -3863,7 +3863,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         String authToken = getAuthToken(eperson.getEmail(), password);
 
         getClient(authToken).perform(get("/api/discover/search/objects")
-                .param("configuration", "discoverableAndUndiscoverableItems")
+                .param("configuration", "administrativeView")
                 .param("query", "Test"))
 
                 //** THEN **
@@ -3880,7 +3880,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
     }
 
     @Test
-    public void discoverSearchObjectsTestForDiscoverableAndUniscoverableItemsAdmin() throws Exception {
+    public void discoverSearchObjectsTestForAdministrativeViewAdmin() throws Exception {
 
         //We turn off the authorization system in order to create the structure as defined below
         context.turnOffAuthorisationSystem();
@@ -3944,7 +3944,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         String adminToken = getAuthToken(admin.getEmail(), password);
 
         getClient(adminToken).perform(get("/api/discover/search/objects")
-                .param("configuration", "discoverableAndUndiscoverableItems")
+                .param("configuration", "administrativeView")
                 .param("query", "Test"))
 
                 //** THEN **
@@ -3993,7 +3993,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
     }
 
     @Test
-    public void discoverSearchObjectsTestForDiscoverableAndUniscoverableItemsWithFilters() throws Exception {
+    public void discoverSearchObjectsTestForAdministrativeViewWithFilters() throws Exception {
 
         context.turnOffAuthorisationSystem();
 
@@ -4046,7 +4046,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
 
         getClient(adminToken)
                 .perform(get("/api/discover/search/objects")
-                        .param("configuration", "discoverableAndUndiscoverableItems")
+                        .param("configuration", "administrativeView")
                         .param("query", "Test")
                         .param("f.withdrawn", "true")
                 )
@@ -4065,7 +4065,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
 
         getClient(adminToken)
                 .perform(get("/api/discover/search/objects")
-                        .param("configuration", "discoverableAndUndiscoverableItems")
+                        .param("configuration", "administrativeView")
                         .param("query", "Test")
                         .param("f.withdrawn", "false")
                 )
@@ -4085,7 +4085,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
 
         getClient(adminToken)
                 .perform(get("/api/discover/search/objects")
-                        .param("configuration", "discoverableAndUndiscoverableItems")
+                        .param("configuration", "administrativeView")
                         .param("query", "Test")
                         .param("f.discoverable", "true")
                 )
@@ -4105,7 +4105,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
 
         getClient(adminToken)
                 .perform(get("/api/discover/search/objects")
-                        .param("configuration", "discoverableAndUndiscoverableItems")
+                        .param("configuration", "administrativeView")
                         .param("query", "Test")
                         .param("f.discoverable", "false")
                 )

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -3722,67 +3722,81 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
 
     @Test
     public void discoverSearchObjectsTestForDiscoverableAndUniscoverableItemsItemsNonAdmin() throws Exception {
+
         //We turn off the authorization system in order to create the structure as defined below
         context.turnOffAuthorisationSystem();
 
         //** GIVEN **
+
         //1. A community-collection structure with one parent community with sub-community and two collections.
-        parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
-        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
-        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
-        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
+
+        parentCommunity = CommunityBuilder
+                .createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder
+                .createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder
+                .createCollection(context, child1)
+                .withName("Collection 1")
+                .build();
+        Collection col2 = CollectionBuilder
+                .createCollection(context, child1)
+                .withName("Collection 2")
+                .build();
+
         //2. One public item, one private, one withdrawn.
-        Item publicItem1 = ItemBuilder.createItem(context, col1)
-                                      .withTitle("Test")
-                                      .withIssueDate("2010-10-17")
-                                      .withAuthor("Smith, Donald")
-                                      .withSubject("ExtraEntry")
-                                      .build();
 
-        Item publicItem2 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("WithdrawnTest 2")
-                                      .withIssueDate("1990-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-                                      .withSubject("ExtraEntry")
-                                      .withdrawn()
-                                      .build();
+        ItemBuilder.createItem(context, col1)
+                .withTitle("Public Test Item")
+                .withIssueDate("2010-10-17")
+                .withAuthor("Smith, Donald")
+                .withSubject("ExtraEntry")
+                .build();
 
-        Item publicItem3 = ItemBuilder.createItem(context, col2)
-                                      .withTitle("Private Test item 2")
-                                      .withIssueDate("2010-02-13")
-                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-                                      .withSubject("AnotherTest").withSubject("ExtraEntry")
-                                      .makeUnDiscoverable()
-                                      .build();
+        ItemBuilder.createItem(context, col2)
+                .withTitle("Withdrawn Test Item")
+                .withIssueDate("1990-02-13")
+                .withAuthor("Smith, Maria")
+                .withAuthor("Doe, Jane")
+                .withSubject("ExtraEntry")
+                .withdrawn()
+                .build();
 
+        ItemBuilder.createItem(context, col2)
+                .withTitle("Private Test Item")
+                .withIssueDate("2010-02-13")
+                .withAuthor("Smith, Maria")
+                .withAuthor("Doe, Jane")
+                .withSubject("AnotherTest")
+                .withSubject("ExtraEntry")
+                .makeUnDiscoverable()
+                .build();
 
-        String query = "Test";
+        context.restoreAuthSystemState();
+
         //** WHEN **
+
         //A non-admin user browses this endpoint to find the withdrawn or private objects in the system
         //With a query stating 'Test'
+
         getClient().perform(get("/api/discover/search/objects")
-            .param("configuration", "discoverableAndUndiscoverableItems")
-            .param("query", query))
-                   //** THEN **
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //The type has to be 'discover'
-                   .andExpect(jsonPath("$.type", is("discover")))
-                   //The page object needs to look like this
-                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
-                       PageMatcher.pageEntry(0, 20)
-                   )))
-                   //The search results should be an empty list.
-                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.empty()))
-                   //There always needs to be a self link available
-                   .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+                .param("configuration", "discoverableAndUndiscoverableItems")
+                .param("query", "Test"))
 
-        ;
+                //** THEN **
 
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.type", is("discover")))
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntry(0, 20)
+                )))
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.contains(
+                        SearchResultMatcher.matchOnItemName("item", "items", "Public Test Item")
+                )))
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")));
     }
 
     @Test
@@ -3852,6 +3866,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         getClient(adminToken).perform(get("/api/discover/search/objects")
                 .param("configuration", "discoverableAndUndiscoverableItems")
                 .param("query", "Test"))
+
+                //** THEN **
+
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.type", is("discover")))
                 .andExpect(jsonPath("$._embedded.searchResult.page", is(
@@ -3864,10 +3881,10 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                                 SearchResultMatcher.matchOnItemName("item", "items", "Private Test Item")
                         )
                 ))
-                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                .andExpect(jsonPath("$._embedded.facets", Matchers.hasItems(
                         allOf(
-                                hasJsonPath("name", is("discoverable"))
-                                hasJsonPath("$._embedded.values", Matchers.containsInAnyOrder(
+                                hasJsonPath("$.name", is("discoverable")),
+                                hasJsonPath("$._embedded.values", Matchers.hasItems(
                                         allOf(
                                                 hasJsonPath("$.label", is("true")),
                                                 hasJsonPath("$.count", is(2))
@@ -3877,10 +3894,10 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                                                 hasJsonPath("$.count", is(1))
                                         )
                                 ))
-                            ),
+                        ),
                         allOf(
                                 hasJsonPath("$.name", is("withdrawn")),
-                                hasJsonPath("$._embedded.values", Matchers.containsInAnyOrder(
+                                hasJsonPath("$._embedded.values", Matchers.hasItems(
                                         allOf(
                                                 hasJsonPath("$.label", is("true")),
                                                 hasJsonPath("$.count", is(1))

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -55,6 +55,7 @@
                 <entry key="workspace" value-ref="workspaceConfiguration" />
                 <entry key="workflow" value-ref="workflowConfiguration" />
                 <entry key="undiscoverable" value-ref="unDiscoverableItems" />
+                <entry key="discoverableAndUndiscoveableItems" value-ref="discoverableAndUniscoverableItems" />
                 <entry key="publication" value-ref="publication"/>
                 <entry key="person" value-ref="person"/>
                 <entry key="organization" value-ref="organization"/>
@@ -305,6 +306,150 @@
                 <value>search.resourcetype:Item</value>
                 <!-- Only find withdrawn or undiscoverable-->
                 <value>withdrawn:true OR discoverable:false</value>
+            </list>
+        </property>
+        <!--The configuration for the recent submissions-->
+        <property name="recentSubmissionConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoveryRecentSubmissionsConfiguration">
+                <property name="metadataSortField" value="dc.date.accessioned" />
+                <property name="type" value="date"/>
+                <property name="max" value="20"/>
+                <!-- If enabled the collection home page will not display metadata but show a pageable list of recent submissions -->
+                <property name="useAsHomePage" value="false"/>
+            </bean>
+        </property>
+        <!--Default result per page  -->
+        <property name="defaultRpp" value="10" />
+        <property name="hitHighlightingConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
+                <property name="metadataFields">
+                    <list>
+                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                            <property name="field" value="dc.contributor.author"/>
+                            <property name="snippets" value="5"/>
+                        </bean>
+                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                            <property name="field" value="relationship.type"/>
+                            <property name="snippets" value="5"/>
+                        </bean>
+                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                            <property name="field" value="person.identifier.jobtitle"/>
+                            <property name="snippets" value="5"/>
+                        </bean>
+                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                            <property name="field" value="project.identifier.name"/>
+                            <property name="snippets" value="5"/>
+                        </bean>
+                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                            <property name="field" value="dc.description.abstract"/>
+                            <property name="maxSize" value="250"/>
+                            <property name="snippets" value="2"/>
+                        </bean>
+                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                            <property name="field" value="dc.title"/>
+                            <property name="snippets" value="5"/>
+                        </bean>
+                        <!-- By default, full text snippets are disabled, as snippets of embargoed/restricted bitstreams
+                             may appear in search results when the Item is public. See DS-3498
+                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                            <property name="field" value="project.identifier.status"/>
+                            <property name="snippets" value="5"/>
+                        </bean>
+                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                            <property name="field" value="orgunit.identifier.name"/>
+                            <property name="snippets" value="5"/>
+                        </bean>
+                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                            <property name="field" value="orgunit.identifier.description"/>
+                            <property name="maxSize" value="250"/>
+                            <property name="snippets" value="5"/>
+                        </bean>
+                        -->
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <property name="moreLikeThisConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoveryMoreLikeThisConfiguration">
+                <!--When altering this list also alter the "xmlui.Discovery.RelatedItems.help" key as it describes
+                the metadata fields below-->
+                <property name="similarityMetadataFields">
+                    <list>
+                        <value>dc.title</value>
+                        <value>dc.contributor.author</value>
+                        <value>dc.creator</value>
+                        <value>dc.subject</value>
+                    </list>
+                </property>
+                <!--The minimum number of matching terms across the metadata fields above before an item is found as related -->
+                <property name="minTermFrequency" value="5"/>
+                <!--The maximum number of related items displayed-->
+                <property name="max" value="3"/>
+                <!--The minimum word length below which words will be ignored-->
+                <property name="minWordLength" value="5"/>
+            </bean>
+        </property>
+        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
+        <property name="spellCheckEnabled" value="true"/>
+    </bean>
+
+    <!--The configuration settings for discovery of withdrawn and indiscoverable items (admin only)-->
+    <bean id="discoverableAndUniscoverableItems" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
+        <!--Which sidebar facets are to be displayed-->
+        <property name="sidebarFacets">
+            <list>
+                <ref bean="searchFilterDiscoverable" />
+                <ref bean="searchFilterWithdrawn" />
+                <ref bean="searchFilterAuthor" />
+                <ref bean="searchFilterSubject" />
+                <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterContentInOriginalBundle"/>
+                <ref bean="searchFilterEntityType"/>
+            </list>
+        </property>
+        <!-- Set TagCloud configuration per discovery configuration -->
+        <property name="tagCloudFacetConfiguration" ref="defaultTagCloudFacetConfiguration"/>
+        <!--The search filters which can be used on the discovery search page-->
+        <property name="searchFilters">
+            <list>
+                <ref bean="searchFilterDiscoverable" />
+                <ref bean="searchFilterWithdrawn" />
+                <ref bean="searchFilterTitle" />
+                <ref bean="searchFilterAuthor" />
+                <ref bean="searchFilterSubject" />
+                <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterContentInOriginalBundle"/>
+                <ref bean="searchFilterFileNameInOriginalBundle" />
+                <ref bean="searchFilterFileDescriptionInOriginalBundle" />
+                <ref bean="searchFilterEntityType"/>
+                <ref bean="searchFilterIsAuthorOfPublicationRelation"/>
+                <ref bean="searchFilterIsProjectOfPublicationRelation"/>
+                <ref bean="searchFilterIsOrgUnitOfPublicationRelation"/>
+                <ref bean="searchFilterIsPublicationOfJournalIssueRelation"/>
+                <ref bean="searchFilterIsJournalOfPublicationRelation"/>
+            </list>
+        </property>
+        <!--The sort filters for the discovery search-->
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <!--<property name="defaultSort" ref="sortDateIssued"/>-->
+                <!--DefaultSortOrder can either be desc or asc (desc is default)-->
+                <property name="defaultSortOrder" value="desc"/>
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortTitle" />
+                        <ref bean="sortDateIssued" />
+                        <ref bean="sortDateAccessioned"/>
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <!--Any default filter queries, these filter queries will be used for all
+            queries done by discovery for this configuration -->
+        <property name="defaultFilterQueries">
+            <list>
+                <!--Only find items-->
+                <value>search.resourcetype:Item</value>
             </list>
         </property>
         <!--The configuration for the recent submissions-->
@@ -1313,6 +1458,29 @@
     </bean>
 
     <!--Search filter configuration beans-->
+
+    <bean id="searchFilterDiscoverable" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="discoverable"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.title</value>
+            </list>
+        </property>
+        <property name="isOpenByDefault" value="true"/>
+        <property name="pageSize" value="10"/>
+    </bean>
+
+    <bean id="searchFilterWithdrawn" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="withdrawn"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.title</value>
+            </list>
+        </property>
+        <property name="isOpenByDefault" value="true"/>
+        <property name="pageSize" value="10"/>
+    </bean>
+
     <bean id="searchFilterTitle" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
         <property name="indexFieldName" value="title"/>
         <property name="metadataFields">

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -55,7 +55,7 @@
                 <entry key="workspace" value-ref="workspaceConfiguration" />
                 <entry key="workflow" value-ref="workflowConfiguration" />
                 <entry key="undiscoverable" value-ref="unDiscoverableItems" />
-                <entry key="discoverableAndUndiscoveableItems" value-ref="discoverableAndUniscoverableItems" />
+                <entry key="discoverableAndUndiscoverableItems" value-ref="discoverableAndUndiscoverableItems" />
                 <entry key="publication" value-ref="publication"/>
                 <entry key="person" value-ref="person"/>
                 <entry key="organization" value-ref="organization"/>
@@ -394,7 +394,7 @@
     </bean>
 
     <!--The configuration settings for discovery of withdrawn and indiscoverable items (admin only)-->
-    <bean id="discoverableAndUniscoverableItems" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
+    <bean id="discoverableAndUndiscoverableItems" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
         <!--Which sidebar facets are to be displayed-->
         <property name="sidebarFacets">
             <list>
@@ -1461,9 +1461,9 @@
 
     <bean id="searchFilterDiscoverable" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
         <property name="indexFieldName" value="discoverable"/>
+        <property name="type" value="standard"/>
         <property name="metadataFields">
             <list>
-                <value>dc.title</value>
             </list>
         </property>
         <property name="isOpenByDefault" value="true"/>
@@ -1472,9 +1472,9 @@
 
     <bean id="searchFilterWithdrawn" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
         <property name="indexFieldName" value="withdrawn"/>
+        <property name="type" value="standard"/>
         <property name="metadataFields">
             <list>
-                <value>dc.title</value>
             </list>
         </property>
         <property name="isOpenByDefault" value="true"/>

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -393,7 +393,7 @@
         <property name="spellCheckEnabled" value="true"/>
     </bean>
 
-    <!--The configuration settings for discovery of withdrawn and indiscoverable items (admin only)-->
+    <!--The configuration settings for discovery of withdrawn and undiscoverable items (admin only) and regular items-->
     <bean id="discoverableAndUndiscoverableItems" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
         <!--Which sidebar facets are to be displayed-->
         <property name="sidebarFacets">

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -55,7 +55,7 @@
                 <entry key="workspace" value-ref="workspaceConfiguration" />
                 <entry key="workflow" value-ref="workflowConfiguration" />
                 <entry key="undiscoverable" value-ref="unDiscoverableItems" />
-                <entry key="discoverableAndUndiscoverableItems" value-ref="discoverableAndUndiscoverableItems" />
+                <entry key="administrativeView" value-ref="administrativeView" />
                 <entry key="publication" value-ref="publication"/>
                 <entry key="person" value-ref="person"/>
                 <entry key="organization" value-ref="organization"/>
@@ -394,7 +394,7 @@
     </bean>
 
     <!--The configuration settings for discovery of withdrawn and undiscoverable items (admin only) and regular items-->
-    <bean id="discoverableAndUndiscoverableItems" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
+    <bean id="administrativeView" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
         <!--Which sidebar facets are to be displayed-->
         <property name="sidebarFacets">
             <list>


### PR DESCRIPTION
This PR is limited to discovery configuration and tests.
It creates a new discovery configuration `discoverableAndUndiscoverableItems` which can be used for admins to find withdrawn and private items. It includes facets to verify the withdrawn and private state.

The discovery configuration can be used by anyone, but the SolrServiceResourceRestrictionPlugin will ensure only admins can find withdrawn and private items. This is also displayed in the tests