### PR TITLE
Upgrade to Checkstyle v8.30

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -44,15 +44,16 @@ For more information on CheckStyle configurations below, see: http://checkstyle.
          with @SuppressWarnings. See also SuppressWarningsHolder below -->
     <module name="SuppressWarningsFilter" />
 
+    <!-- Maximum line length is 120 characters -->
+    <module name="LineLength">
+        <property name="fileExtensions" value="java"/>
+        <property name="max" value="120"/>
+        <!-- Only exceptions for packages, imports, URLs, and JavaDoc {@link} tags -->
+        <property name="ignorePattern" value="^package.*|^import.*|http://|https://|@link"/>
+    </module>
+
     <!-- Check individual Java source files for specific rules -->
     <module name="TreeWalker">
-        <!-- Maximum line length is 120 characters -->
-        <module name="LineLength">
-            <property name="max" value="120"/>
-            <!-- Only exceptions for packages, imports, URLs, and JavaDoc {@link} tags -->
-            <property name="ignorePattern" value="^package.*|^import.*|http://|https://|@link"/>
-        </module>
-
         <!-- Highlight any TODO or FIXME comments in info messages -->
         <module name="TodoComment">
             <property name="severity" value="info"/>
@@ -94,11 +95,8 @@ For more information on CheckStyle configurations below, see: http://checkstyle.
             <!-- <property name="scope" value="public"/> -->
             <!-- TODO: Above rule has been disabled because of large amount of missing public method Javadocs -->
             <property name="scope" value="nothing"/>
-            <!-- Allow RuntimeExceptions to be undeclared -->
-            <property name="allowUndeclaredRTE" value="true"/>
             <!-- Allow params, throws and return tags to be optional -->
             <property name="allowMissingParamTags" value="true"/>
-            <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
         </module>
 

--- a/dspace-api/src/main/java/org/dspace/app/util/OpenSearchServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/OpenSearchServiceImpl.java
@@ -20,7 +20,6 @@ import com.sun.syndication.feed.module.opensearch.OpenSearchModule;
 import com.sun.syndication.feed.module.opensearch.entity.OSQuery;
 import com.sun.syndication.feed.module.opensearch.impl.OpenSearchModuleImpl;
 import com.sun.syndication.io.FeedException;
-
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.util.service.OpenSearchService;
 import org.dspace.content.DSpaceObject;

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
@@ -8,10 +8,8 @@
 package org.dspace.authorize.dao.impl;
 
 import java.sql.SQLException;
-
 import java.util.List;
 import java.util.UUID;
-
 import javax.persistence.Query;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;

--- a/dspace-api/src/main/java/org/dspace/content/Bitstream.java
+++ b/dspace-api/src/main/java/org/dspace/content/Bitstream.java
@@ -11,7 +11,6 @@ import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;

--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -13,7 +13,6 @@ import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
-
 import javax.annotation.Nullable;
 
 import org.apache.commons.collections4.CollectionUtils;

--- a/dspace-api/src/main/java/org/dspace/content/Collection.java
+++ b/dspace-api/src/main/java/org/dspace/content/Collection.java
@@ -12,7 +12,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
 import javax.persistence.Cacheable;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;

--- a/dspace-api/src/main/java/org/dspace/content/Community.java
+++ b/dspace-api/src/main/java/org/dspace/content/Community.java
@@ -11,7 +11,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
 import javax.persistence.Cacheable;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;

--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
@@ -11,7 +11,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/dspace-api/src/main/java/org/dspace/content/Item.java
+++ b/dspace-api/src/main/java/org/dspace/content/Item.java
@@ -13,7 +13,6 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/dspace-api/src/main/java/org/dspace/content/WorkspaceItem.java
+++ b/dspace-api/src/main/java/org/dspace/content/WorkspaceItem.java
@@ -10,7 +10,6 @@ package org.dspace.content;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/ProcessDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/ProcessDAOImpl.java
@@ -8,7 +8,6 @@
 package org.dspace.content.dao.impl;
 
 import java.sql.SQLException;
-
 import java.util.List;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
@@ -21,7 +20,7 @@ import org.dspace.scripts.Process;
 import org.dspace.scripts.Process_;
 
 /**
- * 
+ *
  * Implementation class for {@link ProcessDAO}
  */
 public class ProcessDAOImpl extends AbstractHibernateDAO<Process> implements ProcessDAO {

--- a/dspace-api/src/main/java/org/dspace/content/service/BitstreamService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/BitstreamService.java
@@ -13,7 +13,6 @@ import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
-
 import javax.annotation.Nullable;
 
 import org.dspace.authorize.AuthorizeException;
@@ -46,7 +45,7 @@ public interface BitstreamService extends DSpaceObjectService<Bitstream>, DSpace
      * checksum algorithm as same as the given bitstream.
      * This allows multiple bitstreams to share the same internal identifier of assets .
      * An example of such a use case scenario is versioning.
-     * 
+     *
      * @param context
      *            DSpace context object
      * @param bitstream

--- a/dspace-api/src/main/java/org/dspace/handle/HandlePlugin.java
+++ b/dspace-api/src/main/java/org/dspace/handle/HandlePlugin.java
@@ -21,7 +21,6 @@ import net.handle.hdllib.HandleStorage;
 import net.handle.hdllib.HandleValue;
 import net.handle.hdllib.ScanCallback;
 import net.handle.hdllib.Util;
-
 import org.apache.logging.log4j.Logger;
 import org.dspace.core.Context;
 import org.dspace.handle.factory.HandleServiceFactory;

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
@@ -15,7 +15,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
 import javax.annotation.Nullable;
 
 import org.apache.commons.collections4.MapUtils;

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
@@ -18,7 +18,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
 import java.util.UUID;
-
 import javax.mail.MessagingException;
 import javax.servlet.http.HttpServletRequest;
 

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/ReviewAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/ReviewAction.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.servlet.http.HttpServletRequest;
 
 import org.dspace.authorize.AuthorizeException;

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/dao/impl/XmlWorkflowItemDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/dao/impl/XmlWorkflowItemDAOImpl.java
@@ -9,7 +9,6 @@ package org.dspace.xmlworkflow.storedcomponents.dao.impl;
 
 import java.sql.SQLException;
 import java.util.List;
-
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Join;

--- a/dspace-api/src/test/java/org/dspace/xmlworkflow/XmlWorkflowFactoryTest.java
+++ b/dspace-api/src/test/java/org/dspace/xmlworkflow/XmlWorkflowFactoryTest.java
@@ -13,7 +13,6 @@ import static org.junit.Assert.fail;
 import java.sql.SQLException;
 
 import org.apache.logging.log4j.Logger;
-
 import org.dspace.AbstractUnitTest;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Collection;
@@ -24,7 +23,6 @@ import org.dspace.content.service.CommunityService;
 import org.dspace.utils.DSpace;
 import org.dspace.xmlworkflow.factory.XmlWorkflowFactory;
 import org.dspace.xmlworkflow.state.Workflow;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -22,7 +22,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
-
 import javax.xml.stream.XMLStreamException;
 
 import com.lyncode.xoai.dataprovider.exceptions.ConfigurationException;

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/DSpaceEarliestDateResolver.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/DSpaceEarliestDateResolver.java
@@ -9,7 +9,6 @@ package org.dspace.xoai.services.impl;
 
 import java.sql.SQLException;
 import java.util.Date;
-
 import javax.persistence.NoResultException;
 
 import org.apache.logging.log4j.LogManager;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/CommunityLogoController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/CommunityLogoController.java
@@ -10,7 +10,6 @@ package org.dspace.app.rest;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.UUID;
-
 import javax.servlet.http.HttpServletRequest;
 
 import org.dspace.app.rest.exception.UnprocessableEntityException;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/OpenSearchController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/OpenSearchController.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/step/UploadBitstreamRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/step/UploadBitstreamRest.java
@@ -8,7 +8,6 @@
 package org.dspace.app.rest.model.step;
 
 import java.util.ArrayList;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/DSpaceRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/DSpaceRestRepository.java
@@ -14,7 +14,6 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-
 import javax.servlet.http.HttpServletRequest;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
@@ -11,11 +11,9 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.UUID;
-
 import javax.servlet.http.HttpServletRequest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.dspace.app.rest.Parameter;
 import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.exception.MissingParameterException;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/resourcePolicy/ResourcePolicyEndDateReplaceOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/resourcePolicy/ResourcePolicyEndDateReplaceOperation.java
@@ -15,7 +15,6 @@ import org.dspace.app.rest.model.patch.Operation;
 import org.dspace.app.rest.repository.patch.operation.PatchOperation;
 import org.dspace.authorize.ResourcePolicy;
 import org.dspace.core.Context;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ResourcePolicyAdminPermissionEvalutatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ResourcePolicyAdminPermissionEvalutatorPlugin.java
@@ -8,7 +8,6 @@
 package org.dspace.app.rest.security;
 
 import java.io.Serializable;
-
 import java.sql.SQLException;
 
 import org.apache.commons.lang3.StringUtils;
@@ -29,9 +28,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 /**
- * 
+ *
  * {@link RestPermissionEvaluatorPlugin} class that evaluate ADMIN permissions over a Resource Policy
- * 
+ *
  * @author Mykhaylo Boychuk - (4Science.it)
  */
 @Component

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/SubmissionService.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/SubmissionService.java
@@ -8,7 +8,6 @@
 package org.dspace.app.rest.submit;
 
 import java.io.IOException;
-
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -141,7 +140,7 @@ public class SubmissionService {
  * Build the rest representation of a bitstream as used in the upload section
  * ({@link DataUpload}. It contains all its metadata and the list of applied
  * access conditions (@link {@link UploadBitstreamAccessConditionDTO}
- * 
+ *
  * @param configurationService the DSpace ConfigurationService
  * @param source               the bitstream to translate in its rest submission
  *                             representation

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamResourcePolicyAddPatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamResourcePolicyAddPatchOperation.java
@@ -8,7 +8,6 @@
 package org.dspace.app.rest.submit.factory.impl;
 
 import java.util.ArrayList;
-
 import java.util.Date;
 import java.util.List;
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/oai/OAIpmhIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/oai/OAIpmhIT.java
@@ -28,7 +28,6 @@ import com.lyncode.xoai.dataprovider.services.api.ResourceResolver;
 import com.lyncode.xoai.dataprovider.services.impl.BaseDateProvider;
 import com.lyncode.xoai.dataprovider.xml.xoaiconfig.Configuration;
 import com.lyncode.xoai.dataprovider.xml.xoaiconfig.ContextConfiguration;
-
 import org.apache.commons.lang3.time.DateUtils;
 import org.dspace.app.rest.builder.CollectionBuilder;
 import org.dspace.app.rest.builder.CommunityBuilder;
@@ -39,7 +38,6 @@ import org.dspace.xoai.services.api.EarliestDateResolver;
 import org.dspace.xoai.services.api.cache.XOAICacheService;
 import org.dspace.xoai.services.api.config.XOAIManagerResolver;
 import org.dspace.xoai.services.api.xoai.DSpaceFilterResolver;
-
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/opensearch/OpenSearchControllerDisabledIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/opensearch/OpenSearchControllerDisabledIT.java
@@ -12,10 +12,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
-
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
-
 import org.junit.Before;
 import org.junit.Test;
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/opensearch/OpenSearchControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/opensearch/OpenSearchControllerIT.java
@@ -15,13 +15,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.dspace.app.rest.builder.CollectionBuilder;
 import org.dspace.app.rest.builder.CommunityBuilder;
 import org.dspace.app.rest.builder.ItemBuilder;
-
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
-
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.Item;
-
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.junit.Before;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -8,7 +8,6 @@
 package org.dspace.app.rest;
 
 import static java.util.UUID.randomUUID;
-
 import static org.apache.commons.codec.CharEncoding.UTF_8;
 import static org.apache.commons.collections.CollectionUtils.isEmpty;
 import static org.apache.commons.io.IOUtils.toInputStream;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -8,7 +8,6 @@
 package org.dspace.app.rest;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
-
 import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
@@ -8,7 +8,6 @@
 package org.dspace.app.rest;
 
 import static com.jayway.jsonpath.JsonPath.read;
-
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -27,11 +26,9 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
-
 import javax.ws.rs.core.MediaType;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.dspace.app.rest.builder.CollectionBuilder;
 import org.dspace.app.rest.builder.CommunityBuilder;
 import org.dspace.app.rest.builder.EPersonBuilder;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowItemRestRepositoryIT.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
-
 import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.io.IOUtils;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
 import javax.ws.rs.core.MediaType;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/builder/ResourcePolicyBuilder.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/builder/ResourcePolicyBuilder.java
@@ -8,7 +8,6 @@
 package org.dspace.app.rest.builder;
 
 import java.io.IOException;
-
 import java.sql.SQLException;
 import java.util.Date;
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/ResourcePolicyMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/ResourcePolicyMatcher.java
@@ -9,7 +9,6 @@ package org.dspace.app.rest.matcher;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
-
 import static org.dspace.app.rest.matcher.HalMatcher.matchEmbeds;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.is;
@@ -21,7 +20,7 @@ import org.hamcrest.Matcher;
 
 /**
  * Provide convenient org.hamcrest.Matcher to verify a ResourcePolicyRest json response
- * 
+ *
  * @author Mykhaylo Boychuk (4science.it)
  *
  */

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/WorkflowDefinitionMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/WorkflowDefinitionMatcher.java
@@ -18,7 +18,6 @@ import org.dspace.app.rest.model.WorkflowDefinitionRest;
 import org.dspace.xmlworkflow.factory.XmlWorkflowFactory;
 import org.dspace.xmlworkflow.factory.XmlWorkflowServiceFactory;
 import org.dspace.xmlworkflow.state.Workflow;
-
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 

--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>8.18</version>
+                            <version>8.30</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
Fixes recent security vulnerability with Checkstyle v8.28 and below: https://github.com/DSpace/DSpace/network/alert/pom.xml/com.puppycrawl.tools:checkstyle/open

This PR slightly updates our checkstyle.xml to be compatible with v8.30, including:
* Removal of "allowUndeclaredRTE" and "allowMissingThrowsTags" from "JavadocMethod" as both have been removed, see https://github.com/checkstyle/checkstyle/issues/7329
* Move "LineLength" module outside of "TreeWalker"

This PR also fixes new Checkstyle failures in several classes, all of which are simply additional empty lines in sets of imports.  The failures were all `CustomImportOrder: Extra separation in import group before...`.  These should be easy to review though as they literally are removing an empty line in several classes.