### PR TITLE
DS-4457 Avoid smtp authentication by default

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -99,8 +99,8 @@ db.maxidle = 10
 mail.server = smtp.example.com
 
 # SMTP mail server authentication username and password (if required)
-mail.server.username =
-mail.server.password =
+#mail.server.username =
+#mail.server.password =
 
 # SMTP mail server alternate port (defaults to 25)
 mail.server.port = 25


### PR DESCRIPTION
https://jira.lyrasis.org/browse/DS-4457

This comments out the username and password values by default, so that they are not treated as present, and smtp authentication is not attempted. It has been tested successfully with a local sendmail relay. With the change, DSpace correctly does not attempt authentication.