### PR TITLE
Create an initial PR template for DSpace 7

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,28 @@
-Fixes [Link to [JIRA](https://jira.lyrasis.org/projects/DS/summary) ticket, if any]
+# References
+Link to [JIRA](https://jira.lyrasis.org/projects/DS/summary) ticket(s), if any
+Link to [REST Contract](https://github.com/DSpace/Rest7Contract) or PR containing the new REST Contract or required changes
+Link to [Angular issue or PR](https://github.com/DSpace/dspace-angular/issues) related to this PR, if any
 
+# Description
 Short summary of changes (1-2 sentences)
 
+# Instruction to Test/Review
 Longer description (as necessary). May include code examples if those are helpful. 
+
 **Be sure to add any guidance for how to test or review this PR.**
 
 List of changes in this PR:
 * First, ...
 * Second, ...
 
+# Checklist
 Checklist of things all PRs should include. _These are just friendly reminders for you to check off before submitting your PR!_
 - [ ] Your PR must follow the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
+- [ ] Your PR must implement an already approved REST Contract or at least be linked to an existing PR 
+- [ ] Your PR must provide javadoc for all the new public methods and classes. You are also requested to update javadoc of touched methods according to your changes and adding javadoc to complex private methods
 - [ ] Your PR must include new Unit/Integration Tests for any new improvements/features.
     * Remember to provide tests based on different user types, including (1) Anonymous user, (2) Logged in user (non-admin), and (3) Administrator.
+    * Remember to provide tests for both normal than error scenarios, all expected return codes should be tested
+    * Avoid as much as possible to alter existing tests except if they were buggy. Be sure to note in the description any test that have been changed due to a change in the behavior so that we can evaluate impact on the Angular side (this typically result also in the need of REST Contract PR)
+- [ ] If your PR is related to a bug fix you should have at least one test able to reproduce the bug and proof that the bug is now solved. Having a first commit with the test that has triggered a failed Travis build and a subsequent commit with the fix approved by the CI will drastically reduce the review time     
 - [ ] If you add new third-party libraries/dependencies to any `pom.xml`, make sure their licenses align with our BSD-license.  See [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,7 +22,7 @@ _This checklist provides a reminder of what we are going to look for when review
 - [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
 - [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide)
 - [ ] My PR includes Javadoc for _all the new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
-- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests for any bug fixes, improvements or new features. A few reminders about what consistutes good tests:
+- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests for any bug fixes, improvements or new features. A few reminders about what constitutes good tests:
     * Include tests for different user types, including: (1) Anonymous user, (2) Logged in user (non-admin), and (3) Administrator.
     * Include tests for known error scenarios and error codes (e.g. `400 Bad Request`, `401 Unauthorized`, `403 Forbidden`, `404 Not Found`, etc)
     * For bug fixes, include a test that reproduces the bug and proves it is fixed. For clarity, it may be useful to provide the test in a separate commit from the bug fix.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,29 +1,30 @@
 # References
-Link to [JIRA](https://jira.lyrasis.org/projects/DS/summary) ticket(s), if any
-Link to [REST Contract](https://github.com/DSpace/Rest7Contract) or PR containing the new REST Contract or required changes
-Link to [Angular issue or PR](https://github.com/DSpace/dspace-angular/issues) related to this PR, if any
+_Add references/links to any related tickets or PRs. These may include:_
+* Link to [JIRA](https://jira.lyrasis.org/projects/DS/summary) ticket(s), if any
+* Link to [REST Contract](https://github.com/DSpace/Rest7Contract) or an open REST Contract PR, if any
+* Link to [Angular issue or PR](https://github.com/DSpace/dspace-angular/issues) related to this PR, if any
 
 # Description
-Short summary of changes (1-2 sentences)
+Short summary of changes (1-2 sentences).
 
-# Instruction to Test/Review
-Longer description (as necessary). May include code examples if those are helpful. 
-
-**Be sure to add any guidance for how to test or review this PR.**
+# Instructions for Reviewers
+Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.
 
 List of changes in this PR:
 * First, ...
 * Second, ...
 
+**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 
+
 # Checklist
-Checklist of things all PRs should include. _These are just friendly reminders for you to check off before submitting your PR!_
-- [ ] Your PR must be small in size (e.g. less than 1,000 lines of code, not including comments & integration tests) to make reviewing easier.  Exceptions may be made for larger efforts
-- [ ] Your PR must follow the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
-- [ ] Your PR must implement an already approved REST Contract or at least be linked to an existing PR 
-- [ ] Your PR must provide javadoc for all the new public methods and classes. You are also requested to update javadoc of touched methods according to your changes and adding javadoc to complex private methods
-- [ ] Your PR must include new Unit/Integration Tests for any new improvements/features.
-    * Remember to provide tests based on different user types, including (1) Anonymous user, (2) Logged in user (non-admin), and (3) Administrator.
-    * Remember to provide tests for both normal than error scenarios, all expected return codes should be tested
-    * Avoid as much as possible to alter existing tests except if they were buggy. Be sure to note in the description any test that have been changed due to a change in the behavior so that we can evaluate impact on the Angular side (this typically result also in the need of REST Contract PR)
-- [ ] If your PR is related to a bug fix you should have at least one test able to reproduce the bug and proof that the bug is now solved. Having a first commit with the test that has triggered a failed Travis build and a subsequent commit with the fix approved by the CI will drastically reduce the review time     
-- [ ] If you add new third-party libraries/dependencies to any `pom.xml`, make sure their licenses align with our BSD-license.  See [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions)
+_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_
+
+- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
+- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide)
+- [ ] My PR includes Javadoc for _all the new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
+- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests for any bug fixes, improvements or new features. A few reminders about what consistutes good tests:
+    * Include tests for different user types, including: (1) Anonymous user, (2) Logged in user (non-admin), and (3) Administrator.
+    * Include tests for known error scenarios and error codes (e.g. `400 Bad Request`, `401 Unauthorized`, `403 Forbidden`, `404 Not Found`, etc)
+    * For bug fixes, include a test that reproduces the bug and proves it is fixed. For clarity, it may be useful to provide the test in a separate commit from the bug fix.
+- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/master/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
+- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,13 @@
-# References
+## References
 _Add references/links to any related tickets or PRs. These may include:_
 * Link to [JIRA](https://jira.lyrasis.org/projects/DS/summary) ticket(s), if any
 * Link to [REST Contract](https://github.com/DSpace/Rest7Contract) or an open REST Contract PR, if any
 * Link to [Angular issue or PR](https://github.com/DSpace/dspace-angular/issues) related to this PR, if any
 
-# Description
+## Description
 Short summary of changes (1-2 sentences).
 
-# Instructions for Reviewers
+## Instructions for Reviewers
 Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.
 
 List of changes in this PR:
@@ -16,12 +16,12 @@ List of changes in this PR:
 
 **Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 
 
-# Checklist
+## Checklist
 _This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_
 
 - [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
 - [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide)
-- [ ] My PR includes Javadoc for _all the new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
+- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
 - [ ] My PR passes all tests and includes new/updated Unit or Integration Tests for any bug fixes, improvements or new features. A few reminders about what constitutes good tests:
     * Include tests for different user types, including: (1) Anonymous user, (2) Logged in user (non-admin), and (3) Administrator.
     * Include tests for known error scenarios and error codes (e.g. `400 Bad Request`, `401 Unauthorized`, `403 Forbidden`, `404 Not Found`, etc)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,7 @@ List of changes in this PR:
 
 # Checklist
 Checklist of things all PRs should include. _These are just friendly reminders for you to check off before submitting your PR!_
+- [ ] Your PR must be small in size (e.g. less than 1,000 lines of code, not including comments & integration tests) to make reviewing easier.  Exceptions may be made for larger efforts
 - [ ] Your PR must follow the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
 - [ ] Your PR must implement an already approved REST Contract or at least be linked to an existing PR 
 - [ ] Your PR must provide javadoc for all the new public methods and classes. You are also requested to update javadoc of touched methods according to your changes and adding javadoc to complex private methods

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+Fixes [Link to [JIRA](https://jira.lyrasis.org/projects/DS/summary) ticket, if any]
+
+Short summary of changes (1-2 sentences)
+
+Longer description (as necessary). May include code examples if those are helpful. 
+**Be sure to add any guidance for how to test or review this PR.**
+
+List of changes in this PR:
+* First, ...
+* Second, ...
+
+Checklist of things all PRs should include. _These are just friendly reminders for you to check off before submitting your PR!_
+- [ ] Your PR must follow the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
+- [ ] Your PR must include new Unit/Integration Tests for any new improvements/features.
+    * Remember to provide tests based on different user types, including (1) Anonymous user, (2) Logged in user (non-admin), and (3) Administrator.
+- [ ] If you add new third-party libraries/dependencies to any `pom.xml`, make sure their licenses align with our BSD-license.  See [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions)


### PR DESCRIPTION
This PR creates a Pull Request template for all new PRs to `master` based on 
https://help.github.com/en/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository

Feedback is welcome!  I created this in a shared branch so that others can help contribute to this PR easily.