### PR TITLE
DS-4017: using DEFAULT_BITSTREAM_READ as actionId if the DSpaceObject passed to 'generateAutomaticPolicies' is a Bitstream

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
@@ -736,8 +736,8 @@ public class AuthorizeServiceImpl implements AuthorizeService
 
         if (embargoDate != null || (embargoDate == null && dso instanceof Bitstream))
         {
-
-            List<Group> authorizedGroups = getAuthorizedGroups(context, owningCollection, Constants.DEFAULT_ITEM_READ);
+            int actionId = dso instanceof Bitstream ? Constants.DEFAULT_BITSTREAM_READ : Constants.DEFAULT_ITEM_READ;
+            List<Group> authorizedGroups = getAuthorizedGroups(context, owningCollection, actionId);
 
             removeAllPoliciesByDSOAndType(context, dso, ResourcePolicy.TYPE_CUSTOM);
 


### PR DESCRIPTION
Hello,

this PR fixes the issue described in DS-4017.
Fixes #7364

## References
* [JIRA Ticket DS-4017](https://jira.lyrasis.org/browse/DS-4017)

## Description
The fix sets the appropriate actionId by analysing whether the _DSpaceObject_ object is of type _Bitstream_ or not. Without the bugfix, the policies for the bitstream are always set for DEFAULT_ITEM_READ after uploading a file using the embargo feature, which causes the issue described in the ticket.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide) (**not relevant, dspace 6.x**)
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods. (**not relevant, private method modified**)
- [x] My PR passes all tests ~~and includes new/updated Unit or Integration Tests for any bug fixes, improvements or new features~~. A few reminders about what constitutes good tests:
    * Include tests for different user types, including: (1) Anonymous user, (2) Logged in user (non-admin), and (3) Administrator.
    * Include tests for known error scenarios and error codes (e.g. `400 Bad Request`, `401 Unauthorized`, `403 Forbidden`, `404 Not Found`, etc)
    * For bug fixes, include a test that reproduces the bug and proves it is fixed. For clarity, it may be useful to provide the test in a separate commit from the bug fix.
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/master/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
