### PR TITLE
refactoring max file size

### DIFF
--- a/dspace-server-webapp/src/main/resources/application.properties
+++ b/dspace-server-webapp/src/main/resources/application.properties
@@ -108,7 +108,7 @@ spring.main.allow-bean-definition-overriding = true
 logging.config = ${dspace.dir}/config/log4j2.xml
 
 # Maximum size of uploaded files in bytes (512Mb)
-spring.http.multipart.max-file-size = 536870912
+spring.servlet.multipart.max-file-size = 536870912
 
 # Maximum size of a multipart request (512Mb)
-spring.http.multipart.max-request-size= 536870912
+spring.servlet.multipart.max-request-size= 536870912


### PR DESCRIPTION


## References
* https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/web/servlet/MultipartProperties.html
* https://github.com/DSpace/dspace-angular/pull/577#pullrequestreview-384052998

## Description
File uploads were limited to 1MB. This is because the incorrect configuration fields were used to determine the max size

## Instructions for Reviewers
I've tested this by uploading a 6MB file based on master code and based on this PR

## Checklist
- [X] My PR is small in size
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide)
- [X] My PR passes all tests