### PR TITLE
Allow DSpace's ConfigurationService to override Spring Boot properties

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/DSpaceConfigurationInitializer.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/DSpaceConfigurationInitializer.java
@@ -41,8 +41,10 @@ public class DSpaceConfigurationInitializer implements ApplicationContextInitial
         ConfigurationPropertySource apacheCommonsConfigPropertySource =
             new ConfigurationPropertySource(configuration.getClass().getName(), configuration);
 
-        // Append it to the Environment's list of PropertySources
-        applicationContext.getEnvironment().getPropertySources().addLast(apacheCommonsConfigPropertySource);
+        // Prepend it to the Environment's list of PropertySources
+        // NOTE: This is added *first* in the list so that settings in DSpace's ConfigurationService *override*
+        // any default values in Spring Boot's application.properties (or similar)
+        applicationContext.getEnvironment().getPropertySources().addFirst(apacheCommonsConfigPropertySource);
     }
 }
 

--- a/dspace-server-webapp/src/main/resources/application.properties
+++ b/dspace-server-webapp/src/main/resources/application.properties
@@ -17,6 +17,10 @@
 # configurations/settings. Therefore settings in this file CANNOT depend on any DSpace configurations.
 # The *only* DSpace configuration allowed in this file is "dspace.dir", which is documented below.
 #
+# HOW TO OVERRIDE SPRING SETTINGS: Since the DSpace Configuration Service loads early in the Spring Boot
+# startup process (see DSpaceConfigurationInitializer), most Spring Boot properties can be OVERRIDDEN in
+# your local.cfg.
+#
 # Docs (including info on how to override these default settings)
 #    http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html
 # For common settings see:
@@ -28,7 +32,8 @@
 #
 # DSpace home/installation directory
 # REQUIRED to be specified in this application.properties file, as it is used to locate and initialize
-# the DSpace Kernel and all Services (including configuration). See org.dspace.app.rest.Application.getDSpaceHome()
+# the DSpace Kernel and all Services (including configuration).
+#  * See org.dspace.app.rest.utils.DSpaceKernelInitializer.getDSpaceHome()
 # NOTE: this configuration is filled out by Apache Ant during the DSpace install/update process. It does NOT
 # interact with or read its configuration from dspace.cfg.
 dspace.dir=${dspace.dir}
@@ -107,8 +112,8 @@ spring.main.allow-bean-definition-overriding = true
 # Log4J configuration
 logging.config = ${dspace.dir}/config/log4j2.xml
 
-# Maximum size of uploaded files in bytes (512Mb)
-spring.servlet.multipart.max-file-size = 536870912
+# Maximum size of a single uploaded file (default = 1MB)
+spring.servlet.multipart.max-file-size = 512MB
 
-# Maximum size of a multipart request (512Mb)
-spring.servlet.multipart.max-request-size= 536870912
+# Maximum size of a multipart request (i.e. max total size of all files in one request) (default = 10MB)
+spring.servlet.multipart.max-request-size = 512MB

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -4,9 +4,11 @@
 # of the same name in any of the DSpace *.cfg files. This includes overriding
 # settings in any of these files:
 #    * [dspace]/config/dspace.cfg
-#    * Or any configuration file that is included in 'dspace.cfg'
+#    * Any configuration file that is included in 'dspace.cfg'
 #     (See "include = [filepath]" settings near the end of dspace.cfg.
 #      By default, it includes all [dspace]/config/modules/*.cfg files)
+#    * Spring Boot's application.properties
+#      ([dspace-src]/dspace-server-webapp/src/main/resources/application.properties)
 #
 # By default, this EXAMPLE file includes a number of commonly overridden configurations.
 # * ADD configurations by simply copying them into this file from any existing *.cfg file.
@@ -193,3 +195,21 @@ db.schema = public
 # Authentication by Password (encrypted in DSpace's database). See authentication-password.cfg for default configuration.
 # Enabled by default in authentication.cfg
 #plugin.sequence.org.dspace.authenticate.AuthenticationMethod = org.dspace.authenticate.PasswordAuthentication
+
+
+#################################################
+# SPRING BOOT SETTINGS (Used by Server Webapp)  #
+#################################################
+# NOTE: Common Spring Boot application settings may be found at
+# http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
+#
+# EXAMPLE OVERRIDE:
+# By uncommenting the below Spring Boot settings, you can increase or decrease the maximum upload size.
+# These defaults are specified in [dspace-src]/dspace-server-webapp/src/main/resources/application.properties
+# but may be overridden in this local.cfg
+#
+# Maximum size of a single uploaded file
+#spring.servlet.multipart.max-file-size = 512MB
+
+# Maximum size of a multipart request (i.e. max total size of all files in one request)
+#spring.servlet.multipart.max-request-size = 512MB


### PR DESCRIPTION
## References
* Enhancement to #2729 (which ensured our Spring Boot settings had a higher `max-file-size` set for uploads)

## Description
When reviewing #2729, I realized that some Spring Boot properties would be nice to be able to override in `local.cfg`. The `max-file-size` is a good example, as some sites may want to increase or decrease this easily (without rebuilding the entire Server webapp). 

This small PR does that by ensuring the DSpace ConfigurationService is checked *first* for properties.  See the small, one-line change to our `DSpaceConfigurationInitializer`.

## Instructions for Reviewers
An easy way to test this is to simply decrease the Spring Boot max upload size in your `local.cfg` and see if you can reproduce the bug that was fixed by #2729.

In other words, this setting in your `local.cfg` will ensure you cannot upload any file >1MB.
```
spring.servlet.multipart.max-file-size = 1MB
```
Removing that setting from your `local.cfg` will then result in files up to 512MB being allowable (as that's the default now in our Spring Boot `application.properties` file).