### PR TITLE
DS-3725: Adds 'id' property to 'default' and 'site' DiscoveryConfiguration (7.x)

### DIFF
--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -114,6 +114,7 @@
 
     <!--The default configuration settings for discovery-->
     <bean id="defaultConfiguration" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
+        <property name="id" value="default" />
         <!--Which sidebar facets are to be displayed-->
         <property name="sidebarFacets">
             <list>
@@ -540,6 +541,7 @@
 
     <!--The Homepage specific configuration settings for discovery-->
     <bean id="homepageConfiguration" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
+        <property name="id" value="site" />
         <!--Which sidebar facets are to be displayed (same as defaultConfiguration above)-->
         <property name="sidebarFacets">
             <list>


### PR DESCRIPTION
Jira issue: https://jira.lyrasis.org/browse/DS-3725

Port of https://github.com/DSpace/DSpace/pull/2662
Fixes #7072