### PR TITLE
DS-4473: Configurable whitelist for Access-Control-Allow-Origin, add support for Access-Control-Allow-Credentials

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/Application.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/Application.java
@@ -133,12 +133,19 @@ public class Application extends SpringBootServletInitializer {
             @Override
             public void addCorsMappings(@NonNull CorsRegistry registry) {
                 String[] corsAllowedOrigins = configuration.getCorsAllowedOrigins();
+                boolean corsAllowCredentials = configuration.getCorsAllowCredentials();
                 if (corsAllowedOrigins != null) {
                     registry.addMapping("/api/**").allowedMethods(CorsConfiguration.ALL)
-                        .allowedOrigins(corsAllowedOrigins).allowedHeaders("Authorization", "Content-Type",
-                            "X-Requested-With", "accept", "Origin", "Access-Control-Request-Method",
-                            "Access-Control-Request-Headers", "X-On-Behalf-Of")
-                        .exposedHeaders("Access-Control-Allow-Origin", "Authorization");
+                            // Set Access-Control-Allow-Credentials to "true" and specify which origins are valid
+                            // for our Access-Control-Allow-Origin header
+                            .allowCredentials(corsAllowCredentials).allowedOrigins(corsAllowedOrigins)
+                            // Whitelist of request preflight headers allowed to be sent to us from the client
+                            .allowedHeaders("Authorization", "Content-Type", "X-Requested-With", "accept", "Origin",
+                                            "Access-Control-Request-Method", "Access-Control-Request-Headers",
+                                            "X-On-Behalf-Of")
+                            // Whitelist of response headers allowed to be sent by us (the server)
+                            .exposedHeaders("Access-Control-Allow-Origin", "Access-Control-Allow-Credentials",
+                                            "Authorization");
                 }
             }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/Application.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/Application.java
@@ -126,6 +126,10 @@ public class Application extends SpringBootServletInitializer {
     public WebMvcConfigurer webMvcConfigurer() {
 
         return new WebMvcConfigurer() {
+            /**
+             * Create a custom CORS mapping for the DSpace REST API (/api/ paths), based on configured allowed origins.
+             * @param registry CorsRegistry
+             */
             @Override
             public void addCorsMappings(@NonNull CorsRegistry registry) {
                 String[] corsAllowedOrigins = configuration.getCorsAllowedOrigins();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/ApplicationConfig.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/ApplicationConfig.java
@@ -26,14 +26,26 @@ import org.springframework.data.web.config.EnableSpringDataWebSupport;
 @ComponentScan( {"org.dspace.app.rest.converter", "org.dspace.app.rest.repository", "org.dspace.app.rest.utils",
         "org.dspace.app.configuration"})
 public class ApplicationConfig {
-    // Allowed CORS origins. Defaults to * (everywhere)
+    // Allowed CORS origins ("Access-Control-Allow-Origin" header)
     // Can be overridden in DSpace configuration
-    @Value("${rest.cors.allowed-origins:*}")
-    private String corsAllowedOrigins;
+    @Value("${rest.cors.allowed-origins}")
+    private String[] corsAllowedOrigins;
 
+    // Configured User Interface URL (default: http://localhost:3000)
+    @Value("${dspace.ui.url:http://localhost:3000}")
+    private String uiURL;
+
+    /**
+     * Return the array of allowed origins (client URLs) for the CORS "Access-Control-Allow-Origin" header
+     * Used by Application.
+     * @return Array of URLs
+     */
     public String[] getCorsAllowedOrigins() {
+        // Use "rest.cors.allowed-origins" if configured. Otherwise, default to the "dspace.ui.url" setting.
         if (corsAllowedOrigins != null) {
-            return corsAllowedOrigins.split("\\s*,\\s*");
+            return corsAllowedOrigins;
+        } else if (uiURL != null) {
+            return new String[] {uiURL};
         }
         return null;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/ApplicationConfig.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/ApplicationConfig.java
@@ -31,13 +31,18 @@ public class ApplicationConfig {
     @Value("${rest.cors.allowed-origins}")
     private String[] corsAllowedOrigins;
 
+    // Whether to allow credentials (cookies) in CORS requests ("Access-Control-Allow-Credentials" header)
+    // Defaults to true. Can be overridden in DSpace configuration
+    @Value("${rest.cors.allow-credentials:true}")
+    private boolean corsAllowCredentials;
+
     // Configured User Interface URL (default: http://localhost:3000)
     @Value("${dspace.ui.url:http://localhost:3000}")
     private String uiURL;
 
     /**
      * Return the array of allowed origins (client URLs) for the CORS "Access-Control-Allow-Origin" header
-     * Used by Application.
+     * Used by Application class
      * @return Array of URLs
      */
     public String[] getCorsAllowedOrigins() {
@@ -48,5 +53,14 @@ public class ApplicationConfig {
             return new String[] {uiURL};
         }
         return null;
+    }
+
+    /**
+     * Return whether to allow credentials (cookies) on CORS requests. This is used to set the
+     * CORS "Access-Control-Allow-Credentials" header in Application class.
+     * @return true or false
+     */
+    public boolean getCorsAllowCredentials() {
+        return corsAllowCredentials;
     }
 }

--- a/dspace/config/modules/rest.cfg
+++ b/dspace/config/modules/rest.cfg
@@ -3,11 +3,19 @@
 #---------------------------------------------------------------#
 # These configs are used by the RESTv7 module                   #
 #---------------------------------------------------------------#
-# Allowed CORS origins ("Access-Control-Allow-Origin" header).
-# Defaults to ${dspace.ui.url} if unspecified.
-# Multiple allowed origin URLs may be comma separated. Wildcard value (*) is *NOT SUPPORTED*.
+# Allowed CORS origins (in "Access-Control-Allow-Origin" header).
+# Defaults to ${dspace.ui.url} if unspecified (as the UI must have access to the REST API).
+# Multiple allowed origin URLs may be comma separated. Wildcard value (*) is NOT SUPPORTED.
 # (Requires reboot of servlet container, e.g. Tomcat, to reload)
 rest.cors.allowed-origins = ${dspace.ui.url}
+
+# Whether or not to allow credentials (e.g. cookies) sent by the client/browser in CORS
+# requests (in "Access-Control-Allow-Credentials" header).
+# For DSpace, we default this to "true" to support external authentication via Shibboleth (and similar).
+# However, if any of the "allowed-origins" above are *not* trusted, you may choose to set this to "false"
+# for additional security. Defaults to "true" if unspecified.
+# (Requires reboot of servlet container, e.g. Tomcat, to reload)
+rest.cors.allow-credentials = true
 
 # This property determines the max embeddepth for a FullProjection. This is also used by the SpecificLevelProjection
 # as a fallback in case the property is defined on the bean

--- a/dspace/config/modules/rest.cfg
+++ b/dspace/config/modules/rest.cfg
@@ -3,13 +3,14 @@
 #---------------------------------------------------------------#
 # These configs are used by the RESTv7 module                   #
 #---------------------------------------------------------------#
-# Allowed CORS origins. Defaults to * (everywhere)
-# Multiple allowed origin URLs may be comma separated
+# Allowed CORS origins ("Access-Control-Allow-Origin" header).
+# Defaults to ${dspace.ui.url} if unspecified.
+# Multiple allowed origin URLs may be comma separated. Wildcard value (*) is *NOT SUPPORTED*.
 # (Requires reboot of servlet container, e.g. Tomcat, to reload)
-rest.cors.allowed-origins = *
+rest.cors.allowed-origins = ${dspace.ui.url}
 
 # This property determines the max embeddepth for a FullProjection. This is also used by the SpecificLevelProjection
-# as a fallback incase the property is defined on the bean
+# as a fallback in case the property is defined on the bean
 rest.projections.full.max = 2
 
 # This property determines the max embed depth for a SpecificLevelProjection
@@ -24,34 +25,34 @@ rest.stats = true
 #------------------------------------------------------------------#
 # REST API Reporting Tools                                         #
 #------------------------------------------------------------------#
-# This project is intended as an optional add-on to DSpace to provide 
-# Quality Control Reporting for Collection Managers.       
+# This project is intended as an optional add-on to DSpace to provide
+# Quality Control Reporting for Collection Managers.
 #
 # See https://github.com/DSpace-Labs/DSpace-REST-Reports
-#                                                                  
-# These reports utilize the DSpace REST API to provide a Collection 
+#
+# These reports utilize the DSpace REST API to provide a Collection
 # Manager with
 #  - an overview of their collections
 #  - a tool to query metadata for consistency
 #
-# When deploying the DSpace REST API, and institution may choose to 
-# make the API publicly accessible or to restrict access to the API. 
-# If these reports are deployed in a protected manner, the reporting 
-# tools can be configured to bypass DSpace authorization when 
-# reporting on collections and items. 
+# When deploying the DSpace REST API, and institution may choose to
+# make the API publicly accessible or to restrict access to the API.
+# If these reports are deployed in a protected manner, the reporting
+# tools can be configured to bypass DSpace authorization when
+# reporting on collections and items.
 
 ##### Configure the report pages that can be requested by name #####
 # Create a map of named reports that are available to a report tool user
-# Each map entry should be prefixed with rest-report-url 
+# Each map entry should be prefixed with rest-report-url
 #   The map key is a name for a report
 #   The map value is a URL to a report page
 # A list of available reports will be available with the call /rest/reports.
 # If a request is sent to /rest/reports/[report key], the request will be re-directed to the specified URL
-# 
+#
 # This project currently contains 2 sample reports.  Eventually, additional reports could be introduced through this mechanism.
 rest.report-url.collections = static/reports/index.html
 rest.report-url.item-query = static/reports/query.html
-#rest.report-url.custom = 
+#rest.report-url.custom =
 
 ##### database specific way to format a regex SQL clause #####
 # The REST Report Tools may pass a regular expression test to the database.
@@ -64,10 +65,10 @@ rest.regex-clause = text_value ~ ?
 # Private items and withdrawn items are frequently excluded from DSpace reports.
 # Additional filters can be configured to examine other item properties.
 # For instance, items containing an image bitstream often have different requirements from a item containing a PDF.
-# The DSpace REST reports come with a variety of filters that examine item properties, item bitstream properties, 
+# The DSpace REST reports come with a variety of filters that examine item properties, item bitstream properties,
 # and item authorization policies.  The existing filters can be used as an example to construct institution specific filters
 # that will test conformity to a set of institutional policies.
-# plugin.sequence.org.dspace.rest.filter points to a list of classes that contain available filters.  
+# plugin.sequence.org.dspace.rest.filter points to a list of classes that contain available filters.
 # Each class must implement the ItemFilterList interface.
 #   ItemFilterDefs:     Filters that examine simple item and bitstream type properties
 #   ItemFilterDefsMisc: Filters that examine bitstream mime types and dependencies between bitstreams
@@ -99,17 +100,17 @@ rest.report-mime-document-supported = application/pdf
 rest.report-mime-document-image = image/jpeg,image/jp2
 
 # Minimum size for a supported PDF in the repository
-# PDF bitstreams smaller than this size will be highlighted in a report.  
+# PDF bitstreams smaller than this size will be highlighted in a report.
 # PDF files smaller than this size are potentially corrupt.
 rest.report-pdf-min-size = 20000
 
 # Maximum size for a typical PDF in the repository
-# PDF bitstreams larger than this size will be highlighted in a report.  
+# PDF bitstreams larger than this size will be highlighted in a report.
 # PDF files larger than this size may be slow to retrieve.
 rest.report-pdf-max-size = 25000000
 
 # Minimum size for a thumbnail - could indicate a corrupted original
-# Thumbnail bitstreams smaller than this size will be highlighted in a report.  
+# Thumbnail bitstreams smaller than this size will be highlighted in a report.
 # Thumbnail files smaller than this size are potentially corrupt.
 rest.report-thumbnail-min-size = 400
 
@@ -118,7 +119,7 @@ rest.report-thumbnail-min-size = 400
 # This description identifies thumbnails that can safely be re-generated.
 rest.report-gen-thumbnail-desc = Generated Thumbnail
 
-#### Metadata Filtering by Regular Expression ##### 
+#### Metadata Filtering by Regular Expression #####
 # Used by org.dspace.rest.filter.ItemFilterDefsMeta
 # This class filters items based on metadata properties.
 # These filters are useful for filtering a small set of items.  These filters will be inefficient as a query tool.


### PR DESCRIPTION
## References
* https://jira.lyrasis.org/browse/DS-4473
* Loosely related to https://github.com/DSpace/dspace-angular/issues/641 (withCredentials issues in Angular UI)
* May also be related to https://github.com/DSpace/dspace-angular/issues/289 (Needs testing to verify if the problem is fixed by this PR)

## Description
1. This is a small improvement to our `ApplicationConfig` to ensure the existing `rest.cors.allowed-origins` both (1) works properly for Apache Commons Config (which treats comma-separated values as an array, and (2) defaults to the value of `dspace.ui.url` if unspecified.
2. It updates `rest.cfg` to set `rest.cors.allowed-origins=${dspace.ui.url}` by default.
3. Adds a new `rest.cors.allow-credentials` setting to `rest.cfg` and sets to `true` by default. This adds support for the `Access-Control-Allow-Credentials` CORS Header.

## Instructions for Reviewers
* This should be tested with the Edit Item Bitstreams UI to see if it solves the CORS error noted here: https://github.com/DSpace/dspace-angular/pull/577#issuecomment-607685503
* This should ideally be tested with Shibboleth to see if the `rest.cors.allowed-origins` configuration can replace the special Apache configuration instructions listed here: https://wiki.lyrasis.org/display/DSPACE/DSpace+7+Shibboleth+Configuration#DSpace7ShibbolethConfiguration-SeparateRESTandAngularhostname
