### PR TITLE
Upgrade version of m-enforcer-plugin to fix DS-4476

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4.1</version>
+                    <version>3.0.0-M3</version>
                     <executions>
                         <execution>
                             <id>enforce-java</id>


### PR DESCRIPTION
## References
* https://jira.lyrasis.org/browse/DS-4476

## Description
One line change to upgrade the version of maven-enforcer-plugin we are using in order to fix the bug described here: https://issues.apache.org/jira/browse/MENFORCER-274

## Instructions for Reviewers
Just requires testing the build. This change was already tested by Eric Montague using Oracle JDK 11 on Windows 10, see https://groups.google.com/d/msg/dspace-tech/iXwUc33tXQM/zZf3J7rDCAAJ