### PR TITLE
Removed the RelationshipTypeId from Relationship endpoints

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/RelationshipRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/RelationshipRest.java
@@ -27,7 +27,6 @@ public class RelationshipRest extends BaseObjectRest<Integer> {
     @JsonIgnore
     private UUID rightId;
 
-    private int relationshipTypeId;
     private RelationshipTypeRest relationshipType;
     private int leftPlace;
     private int rightPlace;
@@ -88,14 +87,6 @@ public class RelationshipRest extends BaseObjectRest<Integer> {
 
     public void setRightPlace(int rightPlace) {
         this.rightPlace = rightPlace;
-    }
-
-    public int getRelationshipTypeId() {
-        return relationshipTypeId;
-    }
-
-    public void setRelationshipTypeId(int relationshipTypeId) {
-        this.relationshipTypeId = relationshipTypeId;
     }
 
     public String getRightwardValue() {


### PR DESCRIPTION
## References
* https://github.com/DSpace/Rest7Contract/blob/master/relationships.md#single-relationship

## Description
The relationship still contained a relationshipTypeId while it was replaced with a relationshipType HAL link a long time ago. This old and incorrect property has been removed

## Instructions for Reviewers
This is an unused legacy property, it's not used

## Checklist
- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide)
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests for any bug fixes, improvements or new features. A few reminders about what constitutes good tests:
    * Include tests for different user types, including: (1) Anonymous user, (2) Logged in user (non-admin), and (3) Administrator.
    * Include tests for known error scenarios and error codes (e.g. `400 Bad Request`, `401 Unauthorized`, `403 Forbidden`, `404 Not Found`, etc)
    * For bug fixes, include a test that reproduces the bug and proves it is fixed. For clarity, it may be useful to provide the test in a separate commit from the bug fix.
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/master/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
