### PR TITLE
Account profile management 

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
@@ -20,7 +20,6 @@ import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.EPersonRest;
 import org.dspace.app.rest.model.patch.Patch;
-import org.dspace.app.rest.repository.patch.operation.DSpaceObjectMetadataPatchUtils;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.core.Context;
@@ -44,9 +43,6 @@ public class EPersonRestRepository extends DSpaceObjectRestRepository<EPerson, E
 
     @Autowired
     AuthorizeService authorizeService;
-
-    @Autowired
-    DSpaceObjectMetadataPatchUtils metadataPatchUtils;
 
     private final EPersonService es;
 
@@ -111,7 +107,7 @@ public class EPersonRestRepository extends DSpaceObjectRestRepository<EPerson, E
         try {
             long total = es.countTotal(context);
             List<EPerson> epersons = es.findAll(context, EPerson.EMAIL, pageable.getPageSize(),
-                                                Math.toIntExact(pageable.getOffset()));
+                Math.toIntExact(pageable.getOffset()));
             return converter.toRestPage(epersons, pageable, total, utils.obtainProjection());
         } catch (SQLException e) {
             throw new RuntimeException(e.getMessage(), e);
@@ -122,8 +118,7 @@ public class EPersonRestRepository extends DSpaceObjectRestRepository<EPerson, E
      * Find the eperson with the provided email address if any. The search is delegated to the
      * {@link EPersonService#findByEmail(Context, String)} method
      *
-     * @param email
-     *            is the *required* email address
+     * @param email is the *required* email address
      * @return a Page of EPersonRest instances matching the user query
      */
     @SearchRestMethod(name = "byEmail")
@@ -145,10 +140,8 @@ public class EPersonRestRepository extends DSpaceObjectRestRepository<EPerson, E
      * Find the epersons matching the query parameter. The search is delegated to the
      * {@link EPersonService#search(Context, String, int, int)} method
      *
-     * @param query
-     *            is the *required* query string
-     * @param pageable
-     *            contains the pagination information
+     * @param query    is the *required* query string
+     * @param pageable contains the pagination information
      * @return a Page of EPersonRest instances matching the user query
      */
     @PreAuthorize("hasAuthority('ADMIN')")
@@ -160,7 +153,7 @@ public class EPersonRestRepository extends DSpaceObjectRestRepository<EPerson, E
             Context context = obtainContext();
             long total = es.searchResultCount(context, query);
             List<EPerson> epersons = es.search(context, query, Math.toIntExact(pageable.getOffset()),
-                                               Math.toIntExact(pageable.getOffset() + pageable.getPageSize()));
+                Math.toIntExact(pageable.getOffset() + pageable.getPageSize()));
             return converter.toRestPage(epersons, pageable, total, utils.obtainProjection());
         } catch (SQLException e) {
             throw new RuntimeException(e.getMessage(), e);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
@@ -54,7 +54,7 @@ public class EPersonRestRepository extends DSpaceObjectRestRepository<EPerson, E
 
     @Override
     protected EPersonRest createAndReturn(Context context)
-        throws AuthorizeException {
+            throws AuthorizeException {
         // this need to be revisited we should receive an EPersonRest as input
         HttpServletRequest req = getRequestService().getCurrentRequest().getHttpServletRequest();
         ObjectMapper mapper = new ObjectMapper();
@@ -107,7 +107,7 @@ public class EPersonRestRepository extends DSpaceObjectRestRepository<EPerson, E
         try {
             long total = es.countTotal(context);
             List<EPerson> epersons = es.findAll(context, EPerson.EMAIL, pageable.getPageSize(),
-                Math.toIntExact(pageable.getOffset()));
+                    Math.toIntExact(pageable.getOffset()));
             return converter.toRestPage(epersons, pageable, total, utils.obtainProjection());
         } catch (SQLException e) {
             throw new RuntimeException(e.getMessage(), e);
@@ -118,7 +118,8 @@ public class EPersonRestRepository extends DSpaceObjectRestRepository<EPerson, E
      * Find the eperson with the provided email address if any. The search is delegated to the
      * {@link EPersonService#findByEmail(Context, String)} method
      *
-     * @param email is the *required* email address
+     * @param email
+     *            is the *required* email address
      * @return a Page of EPersonRest instances matching the user query
      */
     @SearchRestMethod(name = "byEmail")
@@ -140,20 +141,22 @@ public class EPersonRestRepository extends DSpaceObjectRestRepository<EPerson, E
      * Find the epersons matching the query parameter. The search is delegated to the
      * {@link EPersonService#search(Context, String, int, int)} method
      *
-     * @param query    is the *required* query string
-     * @param pageable contains the pagination information
+     * @param query
+     *            is the *required* query string
+     * @param pageable
+     *            contains the pagination information
      * @return a Page of EPersonRest instances matching the user query
      */
     @PreAuthorize("hasAuthority('ADMIN')")
     @SearchRestMethod(name = "byMetadata")
     public Page<EPersonRest> findByMetadata(@Parameter(value = "query", required = true) String query,
-                                            Pageable pageable) {
+            Pageable pageable) {
 
         try {
             Context context = obtainContext();
             long total = es.searchResultCount(context, query);
             List<EPerson> epersons = es.search(context, query, Math.toIntExact(pageable.getOffset()),
-                Math.toIntExact(pageable.getOffset() + pageable.getPageSize()));
+                                               Math.toIntExact(pageable.getOffset() + pageable.getPageSize()));
             return converter.toRestPage(epersons, pageable, total, utils.obtainProjection());
         } catch (SQLException e) {
             throw new RuntimeException(e.getMessage(), e);
@@ -175,8 +178,8 @@ public class EPersonRestRepository extends DSpaceObjectRestRepository<EPerson, E
             List<String> constraints = es.getDeleteConstraints(context, eperson);
             if (constraints != null && constraints.size() > 0) {
                 throw new UnprocessableEntityException(
-                    "The eperson cannot be deleted due to the following constraints: "
-                    + StringUtils.join(constraints, ", "));
+                        "The eperson cannot be deleted due to the following constraints: "
+                                + StringUtils.join(constraints, ", "));
             }
         } catch (SQLException e) {
             throw new RuntimeException(e.getMessage(), e);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataAddOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataAddOperation.java
@@ -77,8 +77,7 @@ public class DSpaceObjectMetadataAddOperation<R extends DSpaceObject> extends Pa
 
     @Override
     public boolean supports(Object objectToMatch, Operation operation) {
-        return ((operation.getPath().startsWith(metadataPatchUtils.OPERATION_METADATA_PATH)
-                || operation.getPath().equals(metadataPatchUtils.OPERATION_METADATA_PATH))
+        return (operation.getPath().startsWith(metadataPatchUtils.OPERATION_METADATA_PATH)
                 && operation.getOp().trim().equalsIgnoreCase(OPERATION_ADD)
                 && objectToMatch instanceof DSpaceObject);
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataCopyOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataCopyOperation.java
@@ -94,8 +94,7 @@ public class DSpaceObjectMetadataCopyOperation<R extends DSpaceObject> extends P
 
     @Override
     public boolean supports(Object objectToMatch, Operation operation) {
-        return ((operation.getPath().startsWith(metadataPatchUtils.OPERATION_METADATA_PATH)
-                || operation.getPath().equals(metadataPatchUtils.OPERATION_METADATA_PATH))
+        return (operation.getPath().startsWith(metadataPatchUtils.OPERATION_METADATA_PATH)
                 && operation.getOp().trim().equalsIgnoreCase(OPERATION_COPY)
                 && objectToMatch instanceof DSpaceObject);
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataMoveOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataMoveOperation.java
@@ -76,8 +76,7 @@ public class DSpaceObjectMetadataMoveOperation<R extends DSpaceObject> extends P
 
     @Override
     public boolean supports(Object objectToMatch, Operation operation) {
-        return ((operation.getPath().startsWith(metadataPatchUtils.OPERATION_METADATA_PATH)
-                || operation.getPath().equals(metadataPatchUtils.OPERATION_METADATA_PATH))
+        return (operation.getPath().startsWith(metadataPatchUtils.OPERATION_METADATA_PATH)
                 && operation.getOp().trim().equalsIgnoreCase(OPERATION_MOVE)
                 && objectToMatch instanceof DSpaceObject);
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataPatchUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataPatchUtils.java
@@ -39,7 +39,7 @@ public final class DSpaceObjectMetadataPatchUtils {
     /**
      * Path in json body of patch that uses these metadata operations
      */
-    protected static final String OPERATION_METADATA_PATH = "/metadata";
+    public static final String OPERATION_METADATA_PATH = "/metadata";
 
     private DSpaceObjectMetadataPatchUtils() {
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataRemoveOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataRemoveOperation.java
@@ -99,8 +99,7 @@ public class DSpaceObjectMetadataRemoveOperation<R extends DSpaceObject> extends
 
     @Override
     public boolean supports(Object objectToMatch, Operation operation) {
-        return ((operation.getPath().startsWith(metadataPatchUtils.OPERATION_METADATA_PATH)
-                || operation.getPath().equals(metadataPatchUtils.OPERATION_METADATA_PATH))
+        return (operation.getPath().startsWith(metadataPatchUtils.OPERATION_METADATA_PATH)
                 && operation.getOp().trim().equalsIgnoreCase(OPERATION_REMOVE)
                 && objectToMatch instanceof DSpaceObject);
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataReplaceOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataReplaceOperation.java
@@ -214,8 +214,7 @@ public class DSpaceObjectMetadataReplaceOperation<R extends DSpaceObject> extend
 
     @Override
     public boolean supports(Object objectToMatch, Operation operation) {
-        return ((operation.getPath().startsWith(metadataPatchUtils.OPERATION_METADATA_PATH)
-                || operation.getPath().equals(metadataPatchUtils.OPERATION_METADATA_PATH))
+        return (operation.getPath().startsWith(metadataPatchUtils.OPERATION_METADATA_PATH)
                 && operation.getOp().trim().equalsIgnoreCase(OPERATION_REPLACE)
                 && objectToMatch instanceof DSpaceObject);
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/EPersonRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/EPersonRestPermissionEvaluatorPlugin.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 
 import org.dspace.app.rest.model.patch.Operation;
 import org.dspace.app.rest.model.patch.Patch;
+import org.dspace.app.rest.repository.patch.operation.DSpaceObjectMetadataPatchUtils;
 import org.dspace.app.rest.repository.patch.operation.EPersonPasswordReplaceOperation;
 import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.authorize.service.AuthorizeService;
@@ -102,10 +103,12 @@ public class EPersonRestPermissionEvaluatorPlugin extends RestObjectPermissionEv
         /**
          * The entire Patch request should be denied if it contains operations that are
          * restricted to Dspace administrators. The authenticated user is currently allowed to
-         * update their own password.
+         * update their own password and their own metadata.
          */
         for (Operation op: operations) {
-            if (!op.getPath().contentEquals(EPersonPasswordReplaceOperation.OPERATION_PASSWORD_CHANGE)) {
+            if (!(op.getPath().contentEquals(EPersonPasswordReplaceOperation.OPERATION_PASSWORD_CHANGE)
+                || (op.getPath().startsWith(DSpaceObjectMetadataPatchUtils.OPERATION_METADATA_PATH)
+                || op.getPath().equals(DSpaceObjectMetadataPatchUtils.OPERATION_METADATA_PATH)))) {
                 return false;
             }
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/EPersonRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/EPersonRestPermissionEvaluatorPlugin.java
@@ -107,8 +107,7 @@ public class EPersonRestPermissionEvaluatorPlugin extends RestObjectPermissionEv
          */
         for (Operation op: operations) {
             if (!(op.getPath().contentEquals(EPersonPasswordReplaceOperation.OPERATION_PASSWORD_CHANGE)
-                || (op.getPath().startsWith(DSpaceObjectMetadataPatchUtils.OPERATION_METADATA_PATH)
-                || op.getPath().equals(DSpaceObjectMetadataPatchUtils.OPERATION_METADATA_PATH)))) {
+                || (op.getPath().startsWith(DSpaceObjectMetadataPatchUtils.OPERATION_METADATA_PATH)))) {
                 return false;
             }
         }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
@@ -81,32 +81,32 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(post("/api/eperson/epersons")
-            .content(mapper.writeValueAsBytes(data))
-            .contentType(contentType)
-            .param("projection", "full"))
+                                        .content(mapper.writeValueAsBytes(data))
+                                        .contentType(contentType)
+                            .param("projection", "full"))
                             .andExpect(status().isCreated())
                             .andExpect(content().contentType(contentType))
                             .andExpect(jsonPath("$", EPersonMatcher.matchFullEmbeds()))
                             .andExpect(jsonPath("$", Matchers.allOf(
-                                hasJsonPath("$.uuid", not(empty())),
-                                // is it what you expect? EPerson.getName() returns the email...
-                                //hasJsonPath("$.name", is("Doe John")),
-                                hasJsonPath("$.email", is("createtest@example.com")),
-                                hasJsonPath("$.type", is("eperson")),
-                                hasJsonPath("$.canLogIn", is(true)),
-                                hasJsonPath("$.requireCertificate", is(false)),
-                                hasJsonPath("$._links.self.href", not(empty())),
-                                hasJsonPath("$.metadata", Matchers.allOf(
-                                    matchMetadata("eperson.firstname", "John"),
-                                    matchMetadata("eperson.lastname", "Doe")
-                                                                        )))));
+                               hasJsonPath("$.uuid", not(empty())),
+                               // is it what you expect? EPerson.getName() returns the email...
+                               //hasJsonPath("$.name", is("Doe John")),
+                               hasJsonPath("$.email", is("createtest@example.com")),
+                               hasJsonPath("$.type", is("eperson")),
+                               hasJsonPath("$.canLogIn", is(true)),
+                               hasJsonPath("$.requireCertificate", is(false)),
+                               hasJsonPath("$._links.self.href", not(empty())),
+                               hasJsonPath("$.metadata", Matchers.allOf(
+                                       matchMetadata("eperson.firstname", "John"),
+                                       matchMetadata("eperson.lastname", "Doe")
+                               )))));
 
         getClient(authToken).perform(post("/api/eperson/epersons")
-            .content(mapper.writeValueAsBytes(dataFull))
-            .contentType(contentType))
-                            .andExpect(status().isCreated())
-                            .andExpect(content().contentType(contentType))
-                            .andExpect(jsonPath("$", HalMatcher.matchNoEmbeds()));
+                .content(mapper.writeValueAsBytes(dataFull))
+                .contentType(contentType))
+                .andExpect(status().isCreated())
+                .andExpect(content().contentType(contentType))
+                .andExpect(jsonPath("$", HalMatcher.matchNoEmbeds()));
         // TODO cleanup the context!!!
     }
 
@@ -123,15 +123,15 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/eperson"))
-                            .andExpect(status().isOk())
-                            .andExpect(content().contentType(contentType))
-                            .andExpect(jsonPath("$._embedded.epersons", Matchers.containsInAnyOrder(
-                                EPersonMatcher.matchEPersonEntry(newUser),
-                                EPersonMatcher.matchEPersonOnEmail(admin.getEmail()),
-                                EPersonMatcher.matchEPersonOnEmail(eperson.getEmail())
-                                                                                                   )))
-                            .andExpect(jsonPath("$.page.size", is(20)))
-                            .andExpect(jsonPath("$.page.totalElements", is(3)))
+                   .andExpect(status().isOk())
+                   .andExpect(content().contentType(contentType))
+                   .andExpect(jsonPath("$._embedded.epersons", Matchers.containsInAnyOrder(
+                       EPersonMatcher.matchEPersonEntry(newUser),
+                       EPersonMatcher.matchEPersonOnEmail(admin.getEmail()),
+                       EPersonMatcher.matchEPersonOnEmail(eperson.getEmail())
+                   )))
+                   .andExpect(jsonPath("$.page.size", is(20)))
+                   .andExpect(jsonPath("$.page.totalElements", is(3)))
         ;
 
         getClient().perform(get("/api/eperson/epersons"))
@@ -159,9 +159,9 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.turnOffAuthorisationSystem();
 
         EPerson testEPerson = EPersonBuilder.createEPerson(context)
-                                            .withNameInMetadata("John", "Doe")
-                                            .withEmail("Johndoe@example.com")
-                                            .build();
+                                        .withNameInMetadata("John", "Doe")
+                                        .withEmail("Johndoe@example.com")
+                                        .build();
 
         context.restoreAuthSystemState();
 
@@ -169,34 +169,34 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         // NOTE: /eperson/epersons endpoint returns users sorted by email
         // using size = 2 the first page will contain our new test user and default 'admin' ONLY
         getClient(authToken).perform(get("/api/eperson/epersons")
-            .param("size", "2"))
-                            .andExpect(status().isOk())
-                            .andExpect(content().contentType(contentType))
-                            .andExpect(jsonPath("$._embedded.epersons", Matchers.containsInAnyOrder(
-                                EPersonMatcher.matchEPersonEntry(testEPerson),
-                                EPersonMatcher.matchEPersonOnEmail(admin.getEmail())
-                                                                                                   )))
-                            .andExpect(jsonPath("$._embedded.epersons", Matchers.not(
-                                Matchers.contains(
-                                    EPersonMatcher.matchEPersonOnEmail(eperson.getEmail())
-                                                 )
-                                                                                    )))
-                            .andExpect(jsonPath("$.page.size", is(2)))
-                            .andExpect(jsonPath("$.page.totalElements", is(3)))
+                                .param("size", "2"))
+                   .andExpect(status().isOk())
+                   .andExpect(content().contentType(contentType))
+                   .andExpect(jsonPath("$._embedded.epersons", Matchers.containsInAnyOrder(
+                           EPersonMatcher.matchEPersonEntry(testEPerson),
+                           EPersonMatcher.matchEPersonOnEmail(admin.getEmail())
+                   )))
+                   .andExpect(jsonPath("$._embedded.epersons", Matchers.not(
+                       Matchers.contains(
+                           EPersonMatcher.matchEPersonOnEmail(eperson.getEmail())
+                       )
+                   )))
+                   .andExpect(jsonPath("$.page.size", is(2)))
+                   .andExpect(jsonPath("$.page.totalElements", is(3)))
         ;
 
         // using size = 2 the *second* page will contains our default 'eperson' ONLY
         getClient(authToken).perform(get("/api/eperson/epersons")
-            .param("size", "2")
-            .param("page", "1"))
-                            .andExpect(status().isOk())
-                            .andExpect(content().contentType(contentType))
-                            .andExpect(jsonPath("$._embedded.epersons", Matchers.contains(
-                                EPersonMatcher.matchEPersonOnEmail(eperson.getEmail())
-                                                                                         )))
-                            .andExpect(jsonPath("$._embedded.epersons", Matchers.hasSize(1)))
-                            .andExpect(jsonPath("$.page.size", is(2)))
-                            .andExpect(jsonPath("$.page.totalElements", is(3)))
+                                .param("size", "2")
+                                .param("page", "1"))
+                   .andExpect(status().isOk())
+                   .andExpect(content().contentType(contentType))
+                   .andExpect(jsonPath("$._embedded.epersons", Matchers.contains(
+                       EPersonMatcher.matchEPersonOnEmail(eperson.getEmail())
+                   )))
+                   .andExpect(jsonPath("$._embedded.epersons", Matchers.hasSize(1)))
+                   .andExpect(jsonPath("$.page.size", is(2)))
+                   .andExpect(jsonPath("$.page.totalElements", is(3)))
         ;
 
         getClient().perform(get("/api/eperson/epersons"))
@@ -224,23 +224,23 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         // When full projection is requested, response should include expected properties, links, and embeds.
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons/" + ePerson2.getID()).param("projection", "full"))
-                            .andExpect(status().isOk())
-                            .andExpect(jsonPath("$", EPersonMatcher.matchFullEmbeds()))
-                            .andExpect(content().contentType(contentType))
-                            .andExpect(jsonPath("$", is(
-                                EPersonMatcher.matchEPersonEntry(ePerson2)
-                                                       )))
-                            .andExpect(jsonPath("$", Matchers.not(
-                                is(
-                                    EPersonMatcher.matchEPersonEntry(ePerson)
-                                  )
-                                                                 )))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", EPersonMatcher.matchFullEmbeds()))
+                   .andExpect(content().contentType(contentType))
+                   .andExpect(jsonPath("$", is(
+                       EPersonMatcher.matchEPersonEntry(ePerson2)
+                   )))
+                   .andExpect(jsonPath("$", Matchers.not(
+                       is(
+                           EPersonMatcher.matchEPersonEntry(ePerson)
+                       )
+                   )))
         ;
 
         // When no projection is requested, response should include expected properties, links, and no embeds.
         getClient(authToken).perform(get("/api/eperson/epersons/" + ePerson2.getID()))
-                            .andExpect(status().isOk())
-                            .andExpect(jsonPath("$", HalMatcher.matchNoEmbeds()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", HalMatcher.matchNoEmbeds()))
         ;
 
     }
@@ -250,21 +250,21 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.turnOffAuthorisationSystem();
 
         EPerson ePerson1 = EPersonBuilder.createEPerson(context)
-                                         .withNameInMetadata("Mik", "Reck")
-                                         .withEmail("MikReck@email.com")
-                                         .withPassword("qwerty01")
-                                         .build();
+                .withNameInMetadata("Mik", "Reck")
+                .withEmail("MikReck@email.com")
+                .withPassword("qwerty01")
+                .build();
 
         EPerson ePerson2 = EPersonBuilder.createEPerson(context)
-                                         .withNameInMetadata("Bob", "Smith")
-                                         .withEmail("bobsmith@example.com")
-                                         .build();
+                .withNameInMetadata("Bob", "Smith")
+                .withEmail("bobsmith@example.com")
+                .build();
 
         context.restoreAuthSystemState();
 
         String tokenEperson1 = getAuthToken(ePerson1.getEmail(), "qwerty01");
         getClient(tokenEperson1).perform(get("/api/eperson/epersons/" + ePerson2.getID()))
-                                .andExpect(status().isForbidden());
+                .andExpect(status().isForbidden());
     }
 
     @Test
@@ -272,9 +272,9 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.turnOffAuthorisationSystem();
 
         EPerson ePerson1 = EPersonBuilder.createEPerson(context)
-                                         .withNameInMetadata("John", "Doe")
-                                         .withEmail("Johndoe@example.com")
-                                         .build();
+                                        .withNameInMetadata("John", "Doe")
+                                        .withEmail("Johndoe@example.com")
+                                        .build();
 
         EPerson ePerson2 = EPersonBuilder.createEPerson(context)
                                          .withNameInMetadata("Jane", "Smith")
@@ -286,18 +286,18 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         // Verify admin can access information about any user (and only one user is included in response)
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons/" + ePerson2.getID()))
-                            .andExpect(status().isOk())
-                            .andExpect(content().contentType(contentType))
-                            .andExpect(jsonPath("$", is(
-                                EPersonMatcher.matchEPersonEntry(ePerson2)
-                                                       )))
-                            .andExpect(jsonPath("$", Matchers.not(
-                                is(
-                                    EPersonMatcher.matchEPersonEntry(ePerson1)
-                                  )
-                                                                 )))
-                            .andExpect(jsonPath("$._links.self.href",
-                                Matchers.containsString("/api/eperson/epersons/" + ePerson2.getID())));
+                   .andExpect(status().isOk())
+                   .andExpect(content().contentType(contentType))
+                   .andExpect(jsonPath("$", is(
+                       EPersonMatcher.matchEPersonEntry(ePerson2)
+                   )))
+                   .andExpect(jsonPath("$", Matchers.not(
+                       is(
+                           EPersonMatcher.matchEPersonEntry(ePerson1)
+                       )
+                   )))
+                   .andExpect(jsonPath("$._links.self.href",
+                                       Matchers.containsString("/api/eperson/epersons/" + ePerson2.getID())));
 
 
         // Verify an unprivileged user cannot access information about a *different* user
@@ -307,13 +307,13 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // Verify an unprivilegd user can access information about himself/herself
         getClient(epersonToken).perform(get("/api/eperson/epersons/" + eperson.getID()))
-                               .andExpect(status().isOk())
-                               .andExpect(content().contentType(contentType))
-                               .andExpect(jsonPath("$", is(
-                                   EPersonMatcher.matchEPersonOnEmail(eperson.getEmail())
-                                                          )))
-                               .andExpect(jsonPath("$._links.self.href",
-                                   Matchers.containsString("/api/eperson/epersons/" + eperson.getID())));
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(contentType))
+                .andExpect(jsonPath("$", is(
+                        EPersonMatcher.matchEPersonOnEmail(eperson.getEmail())
+                )))
+                .andExpect(jsonPath("$._links.self.href",
+                                    Matchers.containsString("/api/eperson/epersons/" + eperson.getID())));
 
     }
 
@@ -322,20 +322,20 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.turnOffAuthorisationSystem();
 
         EPerson testEPerson1 = EPersonBuilder.createEPerson(context)
-                                             .withNameInMetadata("John", "Doe")
-                                             .withEmail("Johndoe@example.com")
-                                             .build();
+                                        .withNameInMetadata("John", "Doe")
+                                        .withEmail("Johndoe@example.com")
+                                        .build();
 
         EPerson testEPerson2 = EPersonBuilder.createEPerson(context)
-                                             .withNameInMetadata("Jane", "Smith")
-                                             .withEmail("janesmith@example.com")
-                                             .build();
+                                         .withNameInMetadata("Jane", "Smith")
+                                         .withEmail("janesmith@example.com")
+                                         .build();
 
         context.restoreAuthSystemState();
 
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons/" + UUID.randomUUID()))
-                            .andExpect(status().isNotFound());
+                   .andExpect(status().isNotFound());
 
     }
 
@@ -343,13 +343,13 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
     public void searchMethodsExist() throws Exception {
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons"))
-                            .andExpect(jsonPath("$._links.search.href", Matchers.notNullValue()));
+                .andExpect(jsonPath("$._links.search.href", Matchers.notNullValue()));
 
         getClient(authToken).perform(get("/api/eperson/epersons/search"))
-                            .andExpect(status().isOk())
-                            .andExpect(content().contentType(contentType))
-                            .andExpect(jsonPath("$._links.byEmail", Matchers.notNullValue()))
-                            .andExpect(jsonPath("$._links.byMetadata", Matchers.notNullValue()));
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(contentType))
+        .andExpect(jsonPath("$._links.byEmail", Matchers.notNullValue()))
+        .andExpect(jsonPath("$._links.byMetadata", Matchers.notNullValue()));
     }
 
     @Test
@@ -372,28 +372,28 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons/search/byEmail")
-            .param("email", ePerson.getEmail()))
+                                             .param("email", ePerson.getEmail()))
                             .andExpect(status().isOk())
                             .andExpect(content().contentType(contentType))
                             .andExpect(jsonPath("$", is(
-                                EPersonMatcher.matchEPersonEntry(ePerson)
-                                                       )));
+                                    EPersonMatcher.matchEPersonEntry(ePerson)
+                            )));
 
         // it must be case-insensitive
         getClient(authToken).perform(get("/api/eperson/epersons/search/byEmail")
-            .param("email", ePerson.getEmail().toUpperCase()))
+                                             .param("email", ePerson.getEmail().toUpperCase()))
                             .andExpect(status().isOk())
                             .andExpect(content().contentType(contentType))
                             .andExpect(jsonPath("$", is(
-                                EPersonMatcher.matchEPersonEntry(ePerson)
-                                                       )));
+                                    EPersonMatcher.matchEPersonEntry(ePerson)
+                            )));
     }
 
     @Test
     public void findByEmailUndefined() throws Exception {
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons/search/byEmail")
-            .param("email", "undefined@undefined.com"))
+                                             .param("email", "undefined@undefined.com"))
                             .andExpect(status().isNoContent());
     }
 
@@ -418,47 +418,47 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
                                          .build();
 
         EPerson ePerson3 = EPersonBuilder.createEPerson(context)
-                                         .withNameInMetadata("Tom", "Doe")
-                                         .withEmail("tomdoe@example.com")
-                                         .build();
+                .withNameInMetadata("Tom", "Doe")
+                .withEmail("tomdoe@example.com")
+                .build();
 
         EPerson ePerson4 = EPersonBuilder.createEPerson(context)
-                                         .withNameInMetadata("Dirk", "Doe-Postfix")
-                                         .withEmail("dirkdoepostfix@example.com")
-                                         .build();
+                .withNameInMetadata("Dirk", "Doe-Postfix")
+                .withEmail("dirkdoepostfix@example.com")
+                .build();
 
         EPerson ePerson5 = EPersonBuilder.createEPerson(context)
-                                         .withNameInMetadata("Harry", "Prefix-Doe")
-                                         .withEmail("harrydoeprefix@example.com")
-                                         .build();
+                .withNameInMetadata("Harry", "Prefix-Doe")
+                .withEmail("harrydoeprefix@example.com")
+                .build();
 
         context.restoreAuthSystemState();
 
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons/search/byMetadata")
-            .param("query", ePerson.getLastName()))
-                            .andExpect(status().isOk())
-                            .andExpect(content().contentType(contentType))
-                            .andExpect(jsonPath("$._embedded.epersons", Matchers.containsInAnyOrder(
-                                EPersonMatcher.matchEPersonEntry(ePerson),
-                                EPersonMatcher.matchEPersonEntry(ePerson3),
-                                EPersonMatcher.matchEPersonEntry(ePerson4),
-                                EPersonMatcher.matchEPersonEntry(ePerson5)
-                                                                                                   )))
-                            .andExpect(jsonPath("$.page.totalElements", is(4)));
+                    .param("query", ePerson.getLastName()))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(contentType))
+                    .andExpect(jsonPath("$._embedded.epersons", Matchers.containsInAnyOrder(
+                            EPersonMatcher.matchEPersonEntry(ePerson),
+                            EPersonMatcher.matchEPersonEntry(ePerson3),
+                            EPersonMatcher.matchEPersonEntry(ePerson4),
+                            EPersonMatcher.matchEPersonEntry(ePerson5)
+                    )))
+                    .andExpect(jsonPath("$.page.totalElements", is(4)));
 
         // it must be case insensitive
         getClient(authToken).perform(get("/api/eperson/epersons/search/byMetadata")
-            .param("query", ePerson.getLastName().toLowerCase()))
-                            .andExpect(status().isOk())
-                            .andExpect(content().contentType(contentType))
-                            .andExpect(jsonPath("$._embedded.epersons", Matchers.containsInAnyOrder(
-                                EPersonMatcher.matchEPersonEntry(ePerson),
-                                EPersonMatcher.matchEPersonEntry(ePerson3),
-                                EPersonMatcher.matchEPersonEntry(ePerson4),
-                                EPersonMatcher.matchEPersonEntry(ePerson5)
-                                                                                                   )))
-                            .andExpect(jsonPath("$.page.totalElements", is(4)));
+                .param("query", ePerson.getLastName().toLowerCase()))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(contentType))
+                .andExpect(jsonPath("$._embedded.epersons", Matchers.containsInAnyOrder(
+                        EPersonMatcher.matchEPersonEntry(ePerson),
+                        EPersonMatcher.matchEPersonEntry(ePerson3),
+                        EPersonMatcher.matchEPersonEntry(ePerson4),
+                        EPersonMatcher.matchEPersonEntry(ePerson5)
+                )))
+                .andExpect(jsonPath("$.page.totalElements", is(4)));
     }
 
     @Test
@@ -475,47 +475,47 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
                                          .build();
 
         EPerson ePerson3 = EPersonBuilder.createEPerson(context)
-                                         .withNameInMetadata("John", "Smith")
-                                         .withEmail("tomdoe@example.com")
-                                         .build();
+                .withNameInMetadata("John", "Smith")
+                .withEmail("tomdoe@example.com")
+                .build();
 
         EPerson ePerson4 = EPersonBuilder.createEPerson(context)
-                                         .withNameInMetadata("John-Postfix", "Smath")
-                                         .withEmail("dirkdoepostfix@example.com")
-                                         .build();
+                .withNameInMetadata("John-Postfix", "Smath")
+                .withEmail("dirkdoepostfix@example.com")
+                .build();
 
         EPerson ePerson5 = EPersonBuilder.createEPerson(context)
-                                         .withNameInMetadata("Prefix-John", "Smoth")
-                                         .withEmail("harrydoeprefix@example.com")
-                                         .build();
+                .withNameInMetadata("Prefix-John", "Smoth")
+                .withEmail("harrydoeprefix@example.com")
+                .build();
 
         context.restoreAuthSystemState();
 
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons/search/byMetadata")
-            .param("query", ePerson.getFirstName()))
-                            .andExpect(status().isOk())
-                            .andExpect(content().contentType(contentType))
-                            .andExpect(jsonPath("$._embedded.epersons", Matchers.containsInAnyOrder(
-                                EPersonMatcher.matchEPersonEntry(ePerson),
-                                EPersonMatcher.matchEPersonEntry(ePerson3),
-                                EPersonMatcher.matchEPersonEntry(ePerson4),
-                                EPersonMatcher.matchEPersonEntry(ePerson5)
-                                                                                                   )))
-                            .andExpect(jsonPath("$.page.totalElements", is(4)));
+                    .param("query", ePerson.getFirstName()))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(contentType))
+                    .andExpect(jsonPath("$._embedded.epersons", Matchers.containsInAnyOrder(
+                            EPersonMatcher.matchEPersonEntry(ePerson),
+                            EPersonMatcher.matchEPersonEntry(ePerson3),
+                            EPersonMatcher.matchEPersonEntry(ePerson4),
+                            EPersonMatcher.matchEPersonEntry(ePerson5)
+                    )))
+                    .andExpect(jsonPath("$.page.totalElements", is(4)));
 
         // it must be case insensitive
         getClient(authToken).perform(get("/api/eperson/epersons/search/byMetadata")
-            .param("query", ePerson.getFirstName().toLowerCase()))
-                            .andExpect(status().isOk())
-                            .andExpect(content().contentType(contentType))
-                            .andExpect(jsonPath("$._embedded.epersons", Matchers.containsInAnyOrder(
-                                EPersonMatcher.matchEPersonEntry(ePerson),
-                                EPersonMatcher.matchEPersonEntry(ePerson3),
-                                EPersonMatcher.matchEPersonEntry(ePerson4),
-                                EPersonMatcher.matchEPersonEntry(ePerson5)
-                                                                                                   )))
-                            .andExpect(jsonPath("$.page.totalElements", is(4)));
+                .param("query", ePerson.getFirstName().toLowerCase()))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(contentType))
+                .andExpect(jsonPath("$._embedded.epersons", Matchers.containsInAnyOrder(
+                        EPersonMatcher.matchEPersonEntry(ePerson),
+                        EPersonMatcher.matchEPersonEntry(ePerson3),
+                        EPersonMatcher.matchEPersonEntry(ePerson4),
+                        EPersonMatcher.matchEPersonEntry(ePerson5)
+                )))
+                .andExpect(jsonPath("$.page.totalElements", is(4)));
     }
 
     @Test
@@ -550,22 +550,22 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons/search/byMetadata")
-            .param("query", ePerson.getEmail()))
+                                             .param("query", ePerson.getEmail()))
                             .andExpect(status().isOk())
                             .andExpect(content().contentType(contentType))
                             .andExpect(jsonPath("$._embedded.epersons", Matchers.contains(
-                                EPersonMatcher.matchEPersonEntry(ePerson)
-                                                                                         )))
+                                    EPersonMatcher.matchEPersonEntry(ePerson)
+                            )))
                             .andExpect(jsonPath("$.page.totalElements", is(1)));
 
         // it must be case insensitive
         getClient(authToken).perform(get("/api/eperson/epersons/search/byMetadata")
-            .param("query", ePerson.getEmail().toLowerCase()))
+                                             .param("query", ePerson.getEmail().toLowerCase()))
                             .andExpect(status().isOk())
                             .andExpect(content().contentType(contentType))
                             .andExpect(jsonPath("$._embedded.epersons", Matchers.contains(
-                                EPersonMatcher.matchEPersonEntry(ePerson)
-                                                                                         )))
+                                    EPersonMatcher.matchEPersonEntry(ePerson)
+                            )))
                             .andExpect(jsonPath("$.page.totalElements", is(1)));
     }
 
@@ -601,22 +601,22 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons/search/byMetadata")
-            .param("query", String.valueOf(ePerson.getID())))
+                                             .param("query", String.valueOf(ePerson.getID())))
                             .andExpect(status().isOk())
                             .andExpect(content().contentType(contentType))
                             .andExpect(jsonPath("$._embedded.epersons", Matchers.contains(
-                                EPersonMatcher.matchEPersonEntry(ePerson)
-                                                                                         )))
+                                    EPersonMatcher.matchEPersonEntry(ePerson)
+                            )))
                             .andExpect(jsonPath("$.page.totalElements", is(1)));
 
         // it must be case insensitive
         getClient(authToken).perform(get("/api/eperson/epersons/search/byMetadata")
-            .param("query", String.valueOf(ePerson.getID()).toLowerCase()))
+                                             .param("query", String.valueOf(ePerson.getID()).toLowerCase()))
                             .andExpect(status().isOk())
                             .andExpect(content().contentType(contentType))
                             .andExpect(jsonPath("$._embedded.epersons", Matchers.contains(
-                                EPersonMatcher.matchEPersonEntry(ePerson)
-                                                                                         )))
+                                    EPersonMatcher.matchEPersonEntry(ePerson)
+                            )))
                             .andExpect(jsonPath("$.page.totalElements", is(1)));
     }
 
@@ -624,15 +624,15 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Test
     public void findByMetadataUnauthorized() throws Exception {
         getClient().perform(get("/api/eperson/epersons/search/byMetadata")
-            .param("query", "Doe, John"))
-                   .andExpect(status().isUnauthorized());
+                                             .param("query", "Doe, John"))
+                            .andExpect(status().isUnauthorized());
     }
 
     @Test
     public void findByMetadataForbidden() throws Exception {
         String authToken = getAuthToken(eperson.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons/search/byMetadata")
-            .param("query", "Doe, John"))
+                                             .param("query", "Doe, John"))
                             .andExpect(status().isForbidden());
     }
 
@@ -640,17 +640,17 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
     public void findByMetadataUndefined() throws Exception {
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons/search/byMetadata")
-            .param("query", "Doe, John"))
-                            .andExpect(status().isOk())
-                            .andExpect(content().contentType(contentType))
-                            .andExpect(jsonPath("$.page.totalElements", is(0)));
+                .param("query", "Doe, John"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(contentType))
+        .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 
     @Test
     public void findByMetadataMissingParameter() throws Exception {
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons/search/byMetadata"))
-                            .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -667,11 +667,11 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // Delete
         getClient(token).perform(delete("/api/eperson/epersons/" + ePerson.getID()))
-                        .andExpect(status().is(204));
+                .andExpect(status().is(204));
 
         // Verify 404 after delete
         getClient().perform(get("/api/eperson/epersons/" + ePerson.getID()))
-                   .andExpect(status().isNotFound());
+                .andExpect(status().isNotFound());
     }
 
     @Test
@@ -689,14 +689,14 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // Delete using an unauthorized user
         getClient(token).perform(delete("/api/eperson/epersons/" + ePerson.getID()))
-                        .andExpect(status().isForbidden());
+                .andExpect(status().isForbidden());
 
         // login as admin
         String adminToken = getAuthToken(admin.getEmail(), password);
 
         // Verify the eperson is still here
         getClient(adminToken).perform(get("/api/eperson/epersons/" + ePerson.getID()))
-                             .andExpect(status().isOk());
+                .andExpect(status().isOk());
     }
 
     @Test
@@ -711,14 +711,14 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // Delete as anonymous user
         getClient().perform(delete("/api/eperson/epersons/" + ePerson.getID()))
-                   .andExpect(status().isUnauthorized());
+                .andExpect(status().isUnauthorized());
 
         // login as admin
         String adminToken = getAuthToken(admin.getEmail(), password);
 
         // Verify the eperson is still here
         getClient(adminToken).perform(get("/api/eperson/epersons/" + ePerson.getID()))
-                             .andExpect(status().isOk());
+                .andExpect(status().isOk());
     }
 
     @Test
@@ -727,9 +727,9 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.turnOffAuthorisationSystem();
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
-                                        .withNameInMetadata("Sample", "Submitter")
-                                        .withEmail("submitter@example.com")
-                                        .build();
+                .withNameInMetadata("Sample", "Submitter")
+                .withEmail("submitter@example.com")
+                .build();
 
         // force the use of the new user for subsequent operation
         context.setCurrentUser(ePerson);
@@ -753,11 +753,11 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // 422 error when trying to DELETE the eperson=submitter
         getClient(token).perform(delete("/api/eperson/epersons/" + ePerson.getID()))
-                        .andExpect(status().is(422));
+                   .andExpect(status().is(422));
 
         // Verify the eperson is still here
         getClient(token).perform(get("/api/eperson/epersons/" + ePerson.getID()))
-                        .andExpect(status().isOk());
+                .andExpect(status().isOk());
     }
 
     @Test
@@ -781,9 +781,9 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // should be forbidden.
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
-                        .andExpect(status().isForbidden());
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                   .andExpect(status().isForbidden());
 
         token = getAuthToken(admin.getEmail(), password);
 
@@ -811,9 +811,9 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         String patchBody = getPatchContent(ops);
         // should be unauthorized.
         getClient().perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
-                   .andExpect(status().isUnauthorized());
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                        .andExpect(status().isUnauthorized());
 
         String token = getAuthToken(admin.getEmail(), password);
 
@@ -845,8 +845,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // update net id
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.netid", Matchers.is("newNetId")))
                         .andExpect(jsonPath("$.email", Matchers.is("johndoe@example.com")))
@@ -922,8 +922,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // update of netId should fail.
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isBadRequest());
 
         getClient(token).perform(get("/api/eperson/epersons/" + ePerson.getID()))
@@ -957,8 +957,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // initialize to true
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.netid", Matchers.is(newId)));
 
@@ -970,8 +970,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // should return bad request
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isBadRequest());
 
         // value should be unchanged.
@@ -1005,8 +1005,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // updates canLogIn to true
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.canLogIn", Matchers.is(true)))
                         .andExpect(jsonPath("$.email", Matchers.is("johndoe@example.com")))
@@ -1036,11 +1036,10 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // initialize to true
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.canLogIn", Matchers.is(true)));
-        ;
+                        .andExpect(jsonPath("$.canLogIn", Matchers.is(true)));;
 
 
         List<Operation> ops2 = new ArrayList<Operation>();
@@ -1050,8 +1049,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // should return bad request
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isBadRequest());
 
         // value should still be true.
@@ -1085,8 +1084,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // updates requireCertificate to false
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.requireCertificate", Matchers.is(false)))
                         .andExpect(jsonPath("$.email", Matchers.is("johndoe@example.com")))
@@ -1115,21 +1114,20 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // initialize to true
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.requireCertificate", Matchers.is(true)));
-        ;
+                        .andExpect(jsonPath("$.requireCertificate", Matchers.is(true)));;
 
         List<Operation> ops2 = new ArrayList<Operation>();
-        ReplaceOperation replaceOperation2 = new ReplaceOperation("/certificate", null);
+        ReplaceOperation replaceOperation2 = new ReplaceOperation("/certificate",null);
         ops2.add(replaceOperation2);
         patchBody = getPatchContent(ops2);
 
         // should return bad request
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isBadRequest());
 
         // value should still be true.
@@ -1166,8 +1164,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // updates password
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk());
 
         // login with new password
@@ -1183,16 +1181,16 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.turnOffAuthorisationSystem();
 
         EPerson ePerson1 = EPersonBuilder.createEPerson(context)
-                                         .withNameInMetadata("John", "Doe")
-                                         .withEmail("Johndoe@example.com")
-                                         .withPassword(password)
-                                         .build();
+                                        .withNameInMetadata("John", "Doe")
+                                        .withEmail("Johndoe@example.com")
+                                        .withPassword(password)
+                                        .build();
 
         EPerson ePerson2 = EPersonBuilder.createEPerson(context)
-                                         .withNameInMetadata("Jane", "Doe")
-                                         .withEmail("Janedoe@example.com")
-                                         .withPassword(password)
-                                         .build();
+                                          .withNameInMetadata("Jane", "Doe")
+                                          .withEmail("Janedoe@example.com")
+                                          .withPassword(password)
+                                          .build();
 
         context.restoreAuthSystemState();
 
@@ -1208,8 +1206,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // should not be able to update the password of eperson two
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson2.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isForbidden());
 
         // login with old password
@@ -1218,7 +1216,6 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
                         .andExpect(status().isOk());
 
     }
-
     @Test
     public void patchPasswordForNonAdminUser() throws Exception {
 
@@ -1243,8 +1240,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // updates password
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk());
 
         // login with new password
@@ -1260,9 +1257,9 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.turnOffAuthorisationSystem();
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
-                                        .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@example.com")
-                                        .build();
+                .withNameInMetadata("John", "Doe")
+                .withEmail("Johndoe@example.com")
+                .build();
 
         context.restoreAuthSystemState();
 
@@ -1277,9 +1274,9 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // replace of password should fail
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
-                        .andExpect(status().isBadRequest());
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -1303,8 +1300,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // should return
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isForbidden());
 
     }
@@ -1330,8 +1327,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // should return
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isForbidden());
 
     }
@@ -1360,8 +1357,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // initialize passwd
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk());
 
 
@@ -1372,8 +1369,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // should return bad request
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isBadRequest());
 
         // login with original password
@@ -1407,8 +1404,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // updates email
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(jsonPath("$.email", Matchers.is(newEmail)))
                         .andExpect(status().isOk());
 
@@ -1442,8 +1439,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // returns 403
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isForbidden());
 
     }
@@ -1470,8 +1467,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // should return bad request
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isBadRequest());
 
         // login with original password
@@ -1507,8 +1504,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         String patchBody = getPatchContent(ops);
 
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.canLogIn", Matchers.is(true)))
                         .andExpect(jsonPath("$.netid", Matchers.is("multitestId")))
@@ -1537,8 +1534,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // Initialized canLogIn value is true.
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.canLogIn", Matchers.is(true)));
 
@@ -1556,8 +1553,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // The 3rd operation should result in bad request
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .content(patchBody)
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isBadRequest());
 
         // The value of canLogIn should equal the previously initialized value.
@@ -1646,8 +1643,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // replace operation on eperson.firstname by owning user
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                                     .content(patchBody)
+                                     .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.metadata", Matchers.allOf(
                             MetadataMatcher.matchMetadata("eperson.firstname", newName))));
@@ -1671,10 +1668,10 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
                                         .build();
 
         EPerson ePerson2 = EPersonBuilder.createEPerson(context)
-                                         .withNameInMetadata("Jane", "Smith")
-                                         .withEmail("Janesmith@example.com")
-                                         .withPassword(password)
-                                         .build();
+                                        .withNameInMetadata("Jane", "Smith")
+                                        .withEmail("Janesmith@example.com")
+                                        .withPassword(password)
+                                        .build();
 
         String newName = "JohnReplace";
 
@@ -1690,8 +1687,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // attempts to replace eperson.firstname, not allowed, only allowed by admin or owning user
         getClient(token2).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-            .content(patchBody)
-            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                                     .content(patchBody)
+                                     .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isForbidden());
 
         // No replacement of the eperson.firstname
@@ -1706,10 +1703,10 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.turnOffAuthorisationSystem();
 
         EPerson ePerson1 = EPersonBuilder.createEPerson(context)
-                                         .withNameInMetadata("Mik", "Reck")
-                                         .withEmail("MikReck@email.com")
-                                         .withPassword("qwerty01")
-                                         .build();
+                .withNameInMetadata("Mik", "Reck")
+                .withEmail("MikReck@email.com")
+                .withPassword("qwerty01")
+                .build();
 
         context.restoreAuthSystemState();
 
@@ -1717,18 +1714,17 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         // by contract the groups embedded in the eperson only contains direct explicit membership,
         // so the anonymous group is not listed
         getClient(tokenEperson1).perform(get("/api/eperson/epersons/" + ePerson1.getID())
-            .param("projection", "full"))
-                                .andExpect(status().isOk())
-                                .andExpect(content().contentType(contentType))
-                                .andExpect(jsonPath("$", Matchers.allOf(
-                                    hasJsonPath("$._embedded.groups._embedded.groups.length()", is(0)),
-                                    hasJsonPath("$._embedded.groups.page.totalElements", is(0))
-                                                                       )));
+                .param("projection", "full"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(contentType))
+                .andExpect(jsonPath("$", Matchers.allOf(
+                        hasJsonPath("$._embedded.groups._embedded.groups.length()", is(0)),
+                        hasJsonPath("$._embedded.groups.page.totalElements", is(0))
+                )));
     }
 
     /**
      * Test that epersons/<:uuid>/groups endpoint returns the direct groups of the epersons
-     *
      * @throws Exception
      */
     @Test
@@ -1742,14 +1738,14 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
                                         .build();
 
         Group parentGroup1 = GroupBuilder.createGroup(context)
-                                         .withName("Test Parent Group 1")
-                                         .build();
+                                        .withName("Test Parent Group 1")
+                                        .build();
 
         Group childGroup1 = GroupBuilder.createGroup(context)
-                                        .withName("Test Child Group 1")
-                                        .withParent(parentGroup1)
-                                        .addMember(ePerson)
-                                        .build();
+                                       .withName("Test Child Group 1")
+                                       .withParent(parentGroup1)
+                                       .addMember(ePerson)
+                                       .build();
 
         Group parentGroup2 = GroupBuilder.createGroup(context)
                                          .withName("Test Parent Group 2")
@@ -1768,13 +1764,13 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
                             .andExpect(status().isOk())
                             .andExpect(content().contentType(contentType))
                             .andExpect(jsonPath("$._embedded.groups", containsInAnyOrder(
-                                GroupMatcher.matchGroupWithName(childGroup1.getName()),
-                                GroupMatcher.matchGroupWithName(childGroup2.getName()))))
+                                    GroupMatcher.matchGroupWithName(childGroup1.getName()),
+                                    GroupMatcher.matchGroupWithName(childGroup2.getName()))))
                             .andExpect(jsonPath("$._embedded.groups", Matchers.not(
-                                containsInAnyOrder(
-                                    GroupMatcher.matchGroupWithName(parentGroup1.getName()),
-                                    GroupMatcher.matchGroupWithName(parentGroup2.getName()))))
-                                      );
+                                    containsInAnyOrder(
+                                            GroupMatcher.matchGroupWithName(parentGroup1.getName()),
+                                            GroupMatcher.matchGroupWithName(parentGroup2.getName()))))
+                            );
 
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
@@ -9,6 +9,7 @@ package org.dspace.app.rest;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadata;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
@@ -63,7 +64,7 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         EPersonRest data = new EPersonRest();
         EPersonRest dataFull = new EPersonRest();
         MetadataRest metadataRest = new MetadataRest();
-        data.setEmail("createtest@fake-email.com");
+        data.setEmail("createtest@example.com");
         data.setCanLogIn(true);
         MetadataValueRest surname = new MetadataValueRest();
         surname.setValue("Doe");
@@ -72,38 +73,40 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         firstname.setValue("John");
         metadataRest.put("eperson.firstname", firstname);
         data.setMetadata(metadataRest);
-        dataFull.setEmail("createtestFull@fake-email.com");
+        dataFull.setEmail("createtestFull@example.com");
         dataFull.setCanLogIn(true);
         dataFull.setMetadata(metadataRest);
 
+        context.restoreAuthSystemState();
+
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(post("/api/eperson/epersons")
-                                        .content(mapper.writeValueAsBytes(data))
-                                        .contentType(contentType)
-                            .param("projection", "full"))
+            .content(mapper.writeValueAsBytes(data))
+            .contentType(contentType)
+            .param("projection", "full"))
                             .andExpect(status().isCreated())
                             .andExpect(content().contentType(contentType))
                             .andExpect(jsonPath("$", EPersonMatcher.matchFullEmbeds()))
                             .andExpect(jsonPath("$", Matchers.allOf(
-                               hasJsonPath("$.uuid", not(empty())),
-                               // is it what you expect? EPerson.getName() returns the email...
-                               //hasJsonPath("$.name", is("Doe John")),
-                               hasJsonPath("$.email", is("createtest@fake-email.com")),
-                               hasJsonPath("$.type", is("eperson")),
-                               hasJsonPath("$.canLogIn", is(true)),
-                               hasJsonPath("$.requireCertificate", is(false)),
-                               hasJsonPath("$._links.self.href", not(empty())),
-                               hasJsonPath("$.metadata", Matchers.allOf(
-                                       matchMetadata("eperson.firstname", "John"),
-                                       matchMetadata("eperson.lastname", "Doe")
-                               )))));
+                                hasJsonPath("$.uuid", not(empty())),
+                                // is it what you expect? EPerson.getName() returns the email...
+                                //hasJsonPath("$.name", is("Doe John")),
+                                hasJsonPath("$.email", is("createtest@example.com")),
+                                hasJsonPath("$.type", is("eperson")),
+                                hasJsonPath("$.canLogIn", is(true)),
+                                hasJsonPath("$.requireCertificate", is(false)),
+                                hasJsonPath("$._links.self.href", not(empty())),
+                                hasJsonPath("$.metadata", Matchers.allOf(
+                                    matchMetadata("eperson.firstname", "John"),
+                                    matchMetadata("eperson.lastname", "Doe")
+                                                                        )))));
 
         getClient(authToken).perform(post("/api/eperson/epersons")
-                .content(mapper.writeValueAsBytes(dataFull))
-                .contentType(contentType))
-                .andExpect(status().isCreated())
-                .andExpect(content().contentType(contentType))
-                .andExpect(jsonPath("$", HalMatcher.matchNoEmbeds()));
+            .content(mapper.writeValueAsBytes(dataFull))
+            .contentType(contentType))
+                            .andExpect(status().isCreated())
+                            .andExpect(content().contentType(contentType))
+                            .andExpect(jsonPath("$", HalMatcher.matchNoEmbeds()));
         // TODO cleanup the context!!!
     }
 
@@ -113,20 +116,22 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson newUser = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .build();
+
+        context.restoreAuthSystemState();
 
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/eperson"))
-                   .andExpect(status().isOk())
-                   .andExpect(content().contentType(contentType))
-                   .andExpect(jsonPath("$._embedded.epersons", Matchers.containsInAnyOrder(
-                       EPersonMatcher.matchEPersonEntry(newUser),
-                       EPersonMatcher.matchEPersonOnEmail(admin.getEmail()),
-                       EPersonMatcher.matchEPersonOnEmail(eperson.getEmail())
-                   )))
-                   .andExpect(jsonPath("$.page.size", is(20)))
-                   .andExpect(jsonPath("$.page.totalElements", is(3)))
+                            .andExpect(status().isOk())
+                            .andExpect(content().contentType(contentType))
+                            .andExpect(jsonPath("$._embedded.epersons", Matchers.containsInAnyOrder(
+                                EPersonMatcher.matchEPersonEntry(newUser),
+                                EPersonMatcher.matchEPersonOnEmail(admin.getEmail()),
+                                EPersonMatcher.matchEPersonOnEmail(eperson.getEmail())
+                                                                                                   )))
+                            .andExpect(jsonPath("$.page.size", is(20)))
+                            .andExpect(jsonPath("$.page.totalElements", is(3)))
         ;
 
         getClient().perform(get("/api/eperson/epersons"))
@@ -154,42 +159,44 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.turnOffAuthorisationSystem();
 
         EPerson testEPerson = EPersonBuilder.createEPerson(context)
-                                        .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
-                                        .build();
+                                            .withNameInMetadata("John", "Doe")
+                                            .withEmail("Johndoe@example.com")
+                                            .build();
+
+        context.restoreAuthSystemState();
 
         String authToken = getAuthToken(admin.getEmail(), password);
         // NOTE: /eperson/epersons endpoint returns users sorted by email
         // using size = 2 the first page will contain our new test user and default 'admin' ONLY
         getClient(authToken).perform(get("/api/eperson/epersons")
-                                .param("size", "2"))
-                   .andExpect(status().isOk())
-                   .andExpect(content().contentType(contentType))
-                   .andExpect(jsonPath("$._embedded.epersons", Matchers.containsInAnyOrder(
-                           EPersonMatcher.matchEPersonEntry(testEPerson),
-                           EPersonMatcher.matchEPersonOnEmail(admin.getEmail())
-                   )))
-                   .andExpect(jsonPath("$._embedded.epersons", Matchers.not(
-                       Matchers.contains(
-                           EPersonMatcher.matchEPersonOnEmail(eperson.getEmail())
-                       )
-                   )))
-                   .andExpect(jsonPath("$.page.size", is(2)))
-                   .andExpect(jsonPath("$.page.totalElements", is(3)))
+            .param("size", "2"))
+                            .andExpect(status().isOk())
+                            .andExpect(content().contentType(contentType))
+                            .andExpect(jsonPath("$._embedded.epersons", Matchers.containsInAnyOrder(
+                                EPersonMatcher.matchEPersonEntry(testEPerson),
+                                EPersonMatcher.matchEPersonOnEmail(admin.getEmail())
+                                                                                                   )))
+                            .andExpect(jsonPath("$._embedded.epersons", Matchers.not(
+                                Matchers.contains(
+                                    EPersonMatcher.matchEPersonOnEmail(eperson.getEmail())
+                                                 )
+                                                                                    )))
+                            .andExpect(jsonPath("$.page.size", is(2)))
+                            .andExpect(jsonPath("$.page.totalElements", is(3)))
         ;
 
         // using size = 2 the *second* page will contains our default 'eperson' ONLY
         getClient(authToken).perform(get("/api/eperson/epersons")
-                                .param("size", "2")
-                                .param("page", "1"))
-                   .andExpect(status().isOk())
-                   .andExpect(content().contentType(contentType))
-                   .andExpect(jsonPath("$._embedded.epersons", Matchers.contains(
-                       EPersonMatcher.matchEPersonOnEmail(eperson.getEmail())
-                   )))
-                   .andExpect(jsonPath("$._embedded.epersons", Matchers.hasSize(1)))
-                   .andExpect(jsonPath("$.page.size", is(2)))
-                   .andExpect(jsonPath("$.page.totalElements", is(3)))
+            .param("size", "2")
+            .param("page", "1"))
+                            .andExpect(status().isOk())
+                            .andExpect(content().contentType(contentType))
+                            .andExpect(jsonPath("$._embedded.epersons", Matchers.contains(
+                                EPersonMatcher.matchEPersonOnEmail(eperson.getEmail())
+                                                                                         )))
+                            .andExpect(jsonPath("$._embedded.epersons", Matchers.hasSize(1)))
+                            .andExpect(jsonPath("$.page.size", is(2)))
+                            .andExpect(jsonPath("$.page.totalElements", is(3)))
         ;
 
         getClient().perform(get("/api/eperson/epersons"))
@@ -204,34 +211,36 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .build();
 
         EPerson ePerson2 = EPersonBuilder.createEPerson(context)
                                          .withNameInMetadata("Jane", "Smith")
-                                         .withEmail("janesmith@fake-email.com")
+                                         .withEmail("janesmith@example.com")
                                          .build();
+
+        context.restoreAuthSystemState();
 
         // When full projection is requested, response should include expected properties, links, and embeds.
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons/" + ePerson2.getID()).param("projection", "full"))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$", EPersonMatcher.matchFullEmbeds()))
-                   .andExpect(content().contentType(contentType))
-                   .andExpect(jsonPath("$", is(
-                       EPersonMatcher.matchEPersonEntry(ePerson2)
-                   )))
-                   .andExpect(jsonPath("$", Matchers.not(
-                       is(
-                           EPersonMatcher.matchEPersonEntry(ePerson)
-                       )
-                   )))
+                            .andExpect(status().isOk())
+                            .andExpect(jsonPath("$", EPersonMatcher.matchFullEmbeds()))
+                            .andExpect(content().contentType(contentType))
+                            .andExpect(jsonPath("$", is(
+                                EPersonMatcher.matchEPersonEntry(ePerson2)
+                                                       )))
+                            .andExpect(jsonPath("$", Matchers.not(
+                                is(
+                                    EPersonMatcher.matchEPersonEntry(ePerson)
+                                  )
+                                                                 )))
         ;
 
         // When no projection is requested, response should include expected properties, links, and no embeds.
         getClient(authToken).perform(get("/api/eperson/epersons/" + ePerson2.getID()))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$", HalMatcher.matchNoEmbeds()))
+                            .andExpect(status().isOk())
+                            .andExpect(jsonPath("$", HalMatcher.matchNoEmbeds()))
         ;
 
     }
@@ -241,21 +250,21 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.turnOffAuthorisationSystem();
 
         EPerson ePerson1 = EPersonBuilder.createEPerson(context)
-                .withNameInMetadata("Mik", "Reck")
-                .withEmail("MikReck@email.com")
-                .withPassword("qwerty01")
-                .build();
+                                         .withNameInMetadata("Mik", "Reck")
+                                         .withEmail("MikReck@email.com")
+                                         .withPassword("qwerty01")
+                                         .build();
 
         EPerson ePerson2 = EPersonBuilder.createEPerson(context)
-                .withNameInMetadata("Bob", "Smith")
-                .withEmail("bobsmith@fake-email.com")
-                .build();
+                                         .withNameInMetadata("Bob", "Smith")
+                                         .withEmail("bobsmith@example.com")
+                                         .build();
 
         context.restoreAuthSystemState();
 
         String tokenEperson1 = getAuthToken(ePerson1.getEmail(), "qwerty01");
         getClient(tokenEperson1).perform(get("/api/eperson/epersons/" + ePerson2.getID()))
-                .andExpect(status().isForbidden());
+                                .andExpect(status().isForbidden());
     }
 
     @Test
@@ -263,31 +272,32 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.turnOffAuthorisationSystem();
 
         EPerson ePerson1 = EPersonBuilder.createEPerson(context)
-                                        .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
-                                        .build();
+                                         .withNameInMetadata("John", "Doe")
+                                         .withEmail("Johndoe@example.com")
+                                         .build();
 
         EPerson ePerson2 = EPersonBuilder.createEPerson(context)
                                          .withNameInMetadata("Jane", "Smith")
-                                         .withEmail("janesmith@fake-email.com")
+                                         .withEmail("janesmith@example.com")
                                          .build();
 
+        context.restoreAuthSystemState();
 
         // Verify admin can access information about any user (and only one user is included in response)
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons/" + ePerson2.getID()))
-                   .andExpect(status().isOk())
-                   .andExpect(content().contentType(contentType))
-                   .andExpect(jsonPath("$", is(
-                       EPersonMatcher.matchEPersonEntry(ePerson2)
-                   )))
-                   .andExpect(jsonPath("$", Matchers.not(
-                       is(
-                           EPersonMatcher.matchEPersonEntry(ePerson1)
-                       )
-                   )))
-                   .andExpect(jsonPath("$._links.self.href",
-                                       Matchers.containsString("/api/eperson/epersons/" + ePerson2.getID())));
+                            .andExpect(status().isOk())
+                            .andExpect(content().contentType(contentType))
+                            .andExpect(jsonPath("$", is(
+                                EPersonMatcher.matchEPersonEntry(ePerson2)
+                                                       )))
+                            .andExpect(jsonPath("$", Matchers.not(
+                                is(
+                                    EPersonMatcher.matchEPersonEntry(ePerson1)
+                                  )
+                                                                 )))
+                            .andExpect(jsonPath("$._links.self.href",
+                                Matchers.containsString("/api/eperson/epersons/" + ePerson2.getID())));
 
 
         // Verify an unprivileged user cannot access information about a *different* user
@@ -297,13 +307,13 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // Verify an unprivilegd user can access information about himself/herself
         getClient(epersonToken).perform(get("/api/eperson/epersons/" + eperson.getID()))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(contentType))
-                .andExpect(jsonPath("$", is(
-                        EPersonMatcher.matchEPersonOnEmail(eperson.getEmail())
-                )))
-                .andExpect(jsonPath("$._links.self.href",
-                                    Matchers.containsString("/api/eperson/epersons/" + eperson.getID())));
+                               .andExpect(status().isOk())
+                               .andExpect(content().contentType(contentType))
+                               .andExpect(jsonPath("$", is(
+                                   EPersonMatcher.matchEPersonOnEmail(eperson.getEmail())
+                                                          )))
+                               .andExpect(jsonPath("$._links.self.href",
+                                   Matchers.containsString("/api/eperson/epersons/" + eperson.getID())));
 
     }
 
@@ -312,18 +322,20 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.turnOffAuthorisationSystem();
 
         EPerson testEPerson1 = EPersonBuilder.createEPerson(context)
-                                        .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
-                                        .build();
+                                             .withNameInMetadata("John", "Doe")
+                                             .withEmail("Johndoe@example.com")
+                                             .build();
 
         EPerson testEPerson2 = EPersonBuilder.createEPerson(context)
-                                         .withNameInMetadata("Jane", "Smith")
-                                         .withEmail("janesmith@fake-email.com")
-                                         .build();
+                                             .withNameInMetadata("Jane", "Smith")
+                                             .withEmail("janesmith@example.com")
+                                             .build();
+
+        context.restoreAuthSystemState();
 
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons/" + UUID.randomUUID()))
-                   .andExpect(status().isNotFound());
+                            .andExpect(status().isNotFound());
 
     }
 
@@ -331,13 +343,13 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
     public void searchMethodsExist() throws Exception {
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons"))
-                .andExpect(jsonPath("$._links.search.href", Matchers.notNullValue()));
+                            .andExpect(jsonPath("$._links.search.href", Matchers.notNullValue()));
 
         getClient(authToken).perform(get("/api/eperson/epersons/search"))
-        .andExpect(status().isOk())
-        .andExpect(content().contentType(contentType))
-        .andExpect(jsonPath("$._links.byEmail", Matchers.notNullValue()))
-        .andExpect(jsonPath("$._links.byMetadata", Matchers.notNullValue()));
+                            .andExpect(status().isOk())
+                            .andExpect(content().contentType(contentType))
+                            .andExpect(jsonPath("$._links.byEmail", Matchers.notNullValue()))
+                            .andExpect(jsonPath("$._links.byMetadata", Matchers.notNullValue()));
     }
 
     @Test
@@ -346,40 +358,42 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .build();
 
         // create a second eperson to put the previous one in a no special position (is not the first as we have default
         // epersons is not the latest created)
         EPerson ePerson2 = EPersonBuilder.createEPerson(context)
                                          .withNameInMetadata("Jane", "Smith")
-                                         .withEmail("janesmith@fake-email.com")
+                                         .withEmail("janesmith@example.com")
                                          .build();
+
+        context.restoreAuthSystemState();
 
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons/search/byEmail")
-                                             .param("email", ePerson.getEmail()))
+            .param("email", ePerson.getEmail()))
                             .andExpect(status().isOk())
                             .andExpect(content().contentType(contentType))
                             .andExpect(jsonPath("$", is(
-                                    EPersonMatcher.matchEPersonEntry(ePerson)
-                            )));
+                                EPersonMatcher.matchEPersonEntry(ePerson)
+                                                       )));
 
         // it must be case-insensitive
         getClient(authToken).perform(get("/api/eperson/epersons/search/byEmail")
-                                             .param("email", ePerson.getEmail().toUpperCase()))
+            .param("email", ePerson.getEmail().toUpperCase()))
                             .andExpect(status().isOk())
                             .andExpect(content().contentType(contentType))
                             .andExpect(jsonPath("$", is(
-                                    EPersonMatcher.matchEPersonEntry(ePerson)
-                            )));
+                                EPersonMatcher.matchEPersonEntry(ePerson)
+                                                       )));
     }
 
     @Test
     public void findByEmailUndefined() throws Exception {
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons/search/byEmail")
-                                             .param("email", "undefined@undefined.com"))
+            .param("email", "undefined@undefined.com"))
                             .andExpect(status().isNoContent());
     }
 
@@ -395,54 +409,56 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.turnOffAuthorisationSystem();
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .build();
 
         EPerson ePerson2 = EPersonBuilder.createEPerson(context)
                                          .withNameInMetadata("Jane", "Smith")
-                                         .withEmail("janesmith@fake-email.com")
+                                         .withEmail("janesmith@example.com")
                                          .build();
 
         EPerson ePerson3 = EPersonBuilder.createEPerson(context)
-                .withNameInMetadata("Tom", "Doe")
-                .withEmail("tomdoe@fake-email.com")
-                .build();
+                                         .withNameInMetadata("Tom", "Doe")
+                                         .withEmail("tomdoe@example.com")
+                                         .build();
 
         EPerson ePerson4 = EPersonBuilder.createEPerson(context)
-                .withNameInMetadata("Dirk", "Doe-Postfix")
-                .withEmail("dirkdoepostfix@fake-email.com")
-                .build();
+                                         .withNameInMetadata("Dirk", "Doe-Postfix")
+                                         .withEmail("dirkdoepostfix@example.com")
+                                         .build();
 
         EPerson ePerson5 = EPersonBuilder.createEPerson(context)
-                .withNameInMetadata("Harry", "Prefix-Doe")
-                .withEmail("harrydoeprefix@fake-email.com")
-                .build();
+                                         .withNameInMetadata("Harry", "Prefix-Doe")
+                                         .withEmail("harrydoeprefix@example.com")
+                                         .build();
+
+        context.restoreAuthSystemState();
 
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons/search/byMetadata")
-                    .param("query", ePerson.getLastName()))
-                    .andExpect(status().isOk())
-                    .andExpect(content().contentType(contentType))
-                    .andExpect(jsonPath("$._embedded.epersons", Matchers.containsInAnyOrder(
-                            EPersonMatcher.matchEPersonEntry(ePerson),
-                            EPersonMatcher.matchEPersonEntry(ePerson3),
-                            EPersonMatcher.matchEPersonEntry(ePerson4),
-                            EPersonMatcher.matchEPersonEntry(ePerson5)
-                    )))
-                    .andExpect(jsonPath("$.page.totalElements", is(4)));
+            .param("query", ePerson.getLastName()))
+                            .andExpect(status().isOk())
+                            .andExpect(content().contentType(contentType))
+                            .andExpect(jsonPath("$._embedded.epersons", Matchers.containsInAnyOrder(
+                                EPersonMatcher.matchEPersonEntry(ePerson),
+                                EPersonMatcher.matchEPersonEntry(ePerson3),
+                                EPersonMatcher.matchEPersonEntry(ePerson4),
+                                EPersonMatcher.matchEPersonEntry(ePerson5)
+                                                                                                   )))
+                            .andExpect(jsonPath("$.page.totalElements", is(4)));
 
         // it must be case insensitive
         getClient(authToken).perform(get("/api/eperson/epersons/search/byMetadata")
-                .param("query", ePerson.getLastName().toLowerCase()))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(contentType))
-                .andExpect(jsonPath("$._embedded.epersons", Matchers.containsInAnyOrder(
-                        EPersonMatcher.matchEPersonEntry(ePerson),
-                        EPersonMatcher.matchEPersonEntry(ePerson3),
-                        EPersonMatcher.matchEPersonEntry(ePerson4),
-                        EPersonMatcher.matchEPersonEntry(ePerson5)
-                )))
-                .andExpect(jsonPath("$.page.totalElements", is(4)));
+            .param("query", ePerson.getLastName().toLowerCase()))
+                            .andExpect(status().isOk())
+                            .andExpect(content().contentType(contentType))
+                            .andExpect(jsonPath("$._embedded.epersons", Matchers.containsInAnyOrder(
+                                EPersonMatcher.matchEPersonEntry(ePerson),
+                                EPersonMatcher.matchEPersonEntry(ePerson3),
+                                EPersonMatcher.matchEPersonEntry(ePerson4),
+                                EPersonMatcher.matchEPersonEntry(ePerson5)
+                                                                                                   )))
+                            .andExpect(jsonPath("$.page.totalElements", is(4)));
     }
 
     @Test
@@ -450,54 +466,56 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.turnOffAuthorisationSystem();
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .build();
 
         EPerson ePerson2 = EPersonBuilder.createEPerson(context)
                                          .withNameInMetadata("Jane", "Smith")
-                                         .withEmail("janesmith@fake-email.com")
+                                         .withEmail("janesmith@example.com")
                                          .build();
 
         EPerson ePerson3 = EPersonBuilder.createEPerson(context)
-                .withNameInMetadata("John", "Smith")
-                .withEmail("tomdoe@fake-email.com")
-                .build();
+                                         .withNameInMetadata("John", "Smith")
+                                         .withEmail("tomdoe@example.com")
+                                         .build();
 
         EPerson ePerson4 = EPersonBuilder.createEPerson(context)
-                .withNameInMetadata("John-Postfix", "Smath")
-                .withEmail("dirkdoepostfix@fake-email.com")
-                .build();
+                                         .withNameInMetadata("John-Postfix", "Smath")
+                                         .withEmail("dirkdoepostfix@example.com")
+                                         .build();
 
         EPerson ePerson5 = EPersonBuilder.createEPerson(context)
-                .withNameInMetadata("Prefix-John", "Smoth")
-                .withEmail("harrydoeprefix@fake-email.com")
-                .build();
+                                         .withNameInMetadata("Prefix-John", "Smoth")
+                                         .withEmail("harrydoeprefix@example.com")
+                                         .build();
+
+        context.restoreAuthSystemState();
 
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons/search/byMetadata")
-                    .param("query", ePerson.getFirstName()))
-                    .andExpect(status().isOk())
-                    .andExpect(content().contentType(contentType))
-                    .andExpect(jsonPath("$._embedded.epersons", Matchers.containsInAnyOrder(
-                            EPersonMatcher.matchEPersonEntry(ePerson),
-                            EPersonMatcher.matchEPersonEntry(ePerson3),
-                            EPersonMatcher.matchEPersonEntry(ePerson4),
-                            EPersonMatcher.matchEPersonEntry(ePerson5)
-                    )))
-                    .andExpect(jsonPath("$.page.totalElements", is(4)));
+            .param("query", ePerson.getFirstName()))
+                            .andExpect(status().isOk())
+                            .andExpect(content().contentType(contentType))
+                            .andExpect(jsonPath("$._embedded.epersons", Matchers.containsInAnyOrder(
+                                EPersonMatcher.matchEPersonEntry(ePerson),
+                                EPersonMatcher.matchEPersonEntry(ePerson3),
+                                EPersonMatcher.matchEPersonEntry(ePerson4),
+                                EPersonMatcher.matchEPersonEntry(ePerson5)
+                                                                                                   )))
+                            .andExpect(jsonPath("$.page.totalElements", is(4)));
 
         // it must be case insensitive
         getClient(authToken).perform(get("/api/eperson/epersons/search/byMetadata")
-                .param("query", ePerson.getFirstName().toLowerCase()))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(contentType))
-                .andExpect(jsonPath("$._embedded.epersons", Matchers.containsInAnyOrder(
-                        EPersonMatcher.matchEPersonEntry(ePerson),
-                        EPersonMatcher.matchEPersonEntry(ePerson3),
-                        EPersonMatcher.matchEPersonEntry(ePerson4),
-                        EPersonMatcher.matchEPersonEntry(ePerson5)
-                )))
-                .andExpect(jsonPath("$.page.totalElements", is(4)));
+            .param("query", ePerson.getFirstName().toLowerCase()))
+                            .andExpect(status().isOk())
+                            .andExpect(content().contentType(contentType))
+                            .andExpect(jsonPath("$._embedded.epersons", Matchers.containsInAnyOrder(
+                                EPersonMatcher.matchEPersonEntry(ePerson),
+                                EPersonMatcher.matchEPersonEntry(ePerson3),
+                                EPersonMatcher.matchEPersonEntry(ePerson4),
+                                EPersonMatcher.matchEPersonEntry(ePerson5)
+                                                                                                   )))
+                            .andExpect(jsonPath("$.page.totalElements", is(4)));
     }
 
     @Test
@@ -505,47 +523,49 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.turnOffAuthorisationSystem();
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .build();
 
         EPerson ePerson2 = EPersonBuilder.createEPerson(context)
                                          .withNameInMetadata("Jane", "Smith")
-                                         .withEmail("janesmith@fake-email.com")
+                                         .withEmail("janesmith@example.com")
                                          .build();
 
         EPerson ePerson3 = EPersonBuilder.createEPerson(context)
                                          .withNameInMetadata("Tom", "Doe")
-                                         .withEmail("tomdoe@fake-email.com")
+                                         .withEmail("tomdoe@example.com")
                                          .build();
 
         EPerson ePerson4 = EPersonBuilder.createEPerson(context)
                                          .withNameInMetadata("Dirk", "Doe-Postfix")
-                                         .withEmail("dirkdoepostfix@fake-email.com")
+                                         .withEmail("dirkdoepostfix@example.com")
                                          .build();
 
         EPerson ePerson5 = EPersonBuilder.createEPerson(context)
                                          .withNameInMetadata("Harry", "Prefix-Doe")
-                                         .withEmail("harrydoeprefix@fake-email.com")
+                                         .withEmail("harrydoeprefix@example.com")
                                          .build();
+
+        context.restoreAuthSystemState();
 
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons/search/byMetadata")
-                                             .param("query", ePerson.getEmail()))
+            .param("query", ePerson.getEmail()))
                             .andExpect(status().isOk())
                             .andExpect(content().contentType(contentType))
                             .andExpect(jsonPath("$._embedded.epersons", Matchers.contains(
-                                    EPersonMatcher.matchEPersonEntry(ePerson)
-                            )))
+                                EPersonMatcher.matchEPersonEntry(ePerson)
+                                                                                         )))
                             .andExpect(jsonPath("$.page.totalElements", is(1)));
 
         // it must be case insensitive
         getClient(authToken).perform(get("/api/eperson/epersons/search/byMetadata")
-                                             .param("query", ePerson.getEmail().toLowerCase()))
+            .param("query", ePerson.getEmail().toLowerCase()))
                             .andExpect(status().isOk())
                             .andExpect(content().contentType(contentType))
                             .andExpect(jsonPath("$._embedded.epersons", Matchers.contains(
-                                    EPersonMatcher.matchEPersonEntry(ePerson)
-                            )))
+                                EPersonMatcher.matchEPersonEntry(ePerson)
+                                                                                         )))
                             .andExpect(jsonPath("$.page.totalElements", is(1)));
     }
 
@@ -554,47 +574,49 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.turnOffAuthorisationSystem();
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .build();
 
         EPerson ePerson2 = EPersonBuilder.createEPerson(context)
                                          .withNameInMetadata("Jane", "Smith")
-                                         .withEmail("janesmith@fake-email.com")
+                                         .withEmail("janesmith@example.com")
                                          .build();
 
         EPerson ePerson3 = EPersonBuilder.createEPerson(context)
                                          .withNameInMetadata("Tom", "Doe")
-                                         .withEmail("tomdoe@fake-email.com")
+                                         .withEmail("tomdoe@example.com")
                                          .build();
 
         EPerson ePerson4 = EPersonBuilder.createEPerson(context)
                                          .withNameInMetadata("Dirk", "Doe-Postfix")
-                                         .withEmail("dirkdoepostfix@fake-email.com")
+                                         .withEmail("dirkdoepostfix@example.com")
                                          .build();
 
         EPerson ePerson5 = EPersonBuilder.createEPerson(context)
                                          .withNameInMetadata("Harry", "Prefix-Doe")
-                                         .withEmail("harrydoeprefix@fake-email.com")
+                                         .withEmail("harrydoeprefix@example.com")
                                          .build();
+
+        context.restoreAuthSystemState();
 
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons/search/byMetadata")
-                                             .param("query", String.valueOf(ePerson.getID())))
+            .param("query", String.valueOf(ePerson.getID())))
                             .andExpect(status().isOk())
                             .andExpect(content().contentType(contentType))
                             .andExpect(jsonPath("$._embedded.epersons", Matchers.contains(
-                                    EPersonMatcher.matchEPersonEntry(ePerson)
-                            )))
+                                EPersonMatcher.matchEPersonEntry(ePerson)
+                                                                                         )))
                             .andExpect(jsonPath("$.page.totalElements", is(1)));
 
         // it must be case insensitive
         getClient(authToken).perform(get("/api/eperson/epersons/search/byMetadata")
-                                             .param("query", String.valueOf(ePerson.getID()).toLowerCase()))
+            .param("query", String.valueOf(ePerson.getID()).toLowerCase()))
                             .andExpect(status().isOk())
                             .andExpect(content().contentType(contentType))
                             .andExpect(jsonPath("$._embedded.epersons", Matchers.contains(
-                                    EPersonMatcher.matchEPersonEntry(ePerson)
-                            )))
+                                EPersonMatcher.matchEPersonEntry(ePerson)
+                                                                                         )))
                             .andExpect(jsonPath("$.page.totalElements", is(1)));
     }
 
@@ -602,15 +624,15 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Test
     public void findByMetadataUnauthorized() throws Exception {
         getClient().perform(get("/api/eperson/epersons/search/byMetadata")
-                                             .param("query", "Doe, John"))
-                            .andExpect(status().isUnauthorized());
+            .param("query", "Doe, John"))
+                   .andExpect(status().isUnauthorized());
     }
 
     @Test
     public void findByMetadataForbidden() throws Exception {
         String authToken = getAuthToken(eperson.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons/search/byMetadata")
-                                             .param("query", "Doe, John"))
+            .param("query", "Doe, John"))
                             .andExpect(status().isForbidden());
     }
 
@@ -618,17 +640,17 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
     public void findByMetadataUndefined() throws Exception {
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons/search/byMetadata")
-                .param("query", "Doe, John"))
-        .andExpect(status().isOk())
-        .andExpect(content().contentType(contentType))
-        .andExpect(jsonPath("$.page.totalElements", is(0)));
+            .param("query", "Doe, John"))
+                            .andExpect(status().isOk())
+                            .andExpect(content().contentType(contentType))
+                            .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 
     @Test
     public void findByMetadataMissingParameter() throws Exception {
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons/search/byMetadata"))
-                .andExpect(status().isBadRequest());
+                            .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -636,18 +658,20 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.turnOffAuthorisationSystem();
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .build();
+
+        context.restoreAuthSystemState();
 
         String token = getAuthToken(admin.getEmail(), password);
 
         // Delete
         getClient(token).perform(delete("/api/eperson/epersons/" + ePerson.getID()))
-                .andExpect(status().is(204));
+                        .andExpect(status().is(204));
 
         // Verify 404 after delete
         getClient().perform(get("/api/eperson/epersons/" + ePerson.getID()))
-                .andExpect(status().isNotFound());
+                   .andExpect(status().isNotFound());
     }
 
     @Test
@@ -655,22 +679,24 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.turnOffAuthorisationSystem();
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .build();
+
+        context.restoreAuthSystemState();
 
         // login as a basic user
         String token = getAuthToken(eperson.getEmail(), password);
 
         // Delete using an unauthorized user
         getClient(token).perform(delete("/api/eperson/epersons/" + ePerson.getID()))
-                .andExpect(status().isForbidden());
+                        .andExpect(status().isForbidden());
 
         // login as admin
         String adminToken = getAuthToken(admin.getEmail(), password);
 
         // Verify the eperson is still here
         getClient(adminToken).perform(get("/api/eperson/epersons/" + ePerson.getID()))
-                .andExpect(status().isOk());
+                             .andExpect(status().isOk());
     }
 
     @Test
@@ -678,19 +704,21 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.turnOffAuthorisationSystem();
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .build();
+
+        context.restoreAuthSystemState();
 
         // Delete as anonymous user
         getClient().perform(delete("/api/eperson/epersons/" + ePerson.getID()))
-                .andExpect(status().isUnauthorized());
+                   .andExpect(status().isUnauthorized());
 
         // login as admin
         String adminToken = getAuthToken(admin.getEmail(), password);
 
         // Verify the eperson is still here
         getClient(adminToken).perform(get("/api/eperson/epersons/" + ePerson.getID()))
-                .andExpect(status().isOk());
+                             .andExpect(status().isOk());
     }
 
     @Test
@@ -699,9 +727,9 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.turnOffAuthorisationSystem();
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
-                .withNameInMetadata("Sample", "Submitter")
-                .withEmail("submitter@fake-email.com")
-                .build();
+                                        .withNameInMetadata("Sample", "Submitter")
+                                        .withEmail("submitter@example.com")
+                                        .build();
 
         // force the use of the new user for subsequent operation
         context.setCurrentUser(ePerson);
@@ -716,18 +744,20 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
                                           .withLogo("logo_collection").build();
 
 
-        // 3. Create an item that will prevent the deletation of the eperson account (it is the submitter)
+        // 3. Create an item that will prevent the deletion of the eperson account (it is the submitter)
         Item item = ItemBuilder.createItem(context, col).build();
+
+        context.restoreAuthSystemState();
 
         String token = getAuthToken(admin.getEmail(), password);
 
         // 422 error when trying to DELETE the eperson=submitter
         getClient(token).perform(delete("/api/eperson/epersons/" + ePerson.getID()))
-                   .andExpect(status().is(422));
+                        .andExpect(status().is(422));
 
         // Verify the eperson is still here
         getClient(token).perform(get("/api/eperson/epersons/" + ePerson.getID()))
-                .andExpect(status().isOk());
+                        .andExpect(status().isOk());
     }
 
     @Test
@@ -737,8 +767,10 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .build();
+
+        context.restoreAuthSystemState();
 
         List<Operation> ops = new ArrayList<Operation>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/netid", "newNetId");
@@ -749,9 +781,9 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // should be forbidden.
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
-                   .andExpect(status().isForbidden());
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                        .andExpect(status().isForbidden());
 
         token = getAuthToken(admin.getEmail(), password);
 
@@ -768,8 +800,10 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .build();
+
+        context.restoreAuthSystemState();
 
         List<Operation> ops = new ArrayList<Operation>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/netid", "newNetId");
@@ -777,9 +811,9 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         String patchBody = getPatchContent(ops);
         // should be unauthorized.
         getClient().perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
-                        .andExpect(status().isUnauthorized());
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                   .andExpect(status().isUnauthorized());
 
         String token = getAuthToken(admin.getEmail(), password);
 
@@ -796,9 +830,11 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .withNetId("testId")
                                         .build();
+
+        context.restoreAuthSystemState();
 
         List<Operation> ops = new ArrayList<Operation>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/netid", "newNetId");
@@ -809,11 +845,11 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // update net id
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.netid", Matchers.is("newNetId")))
-                        .andExpect(jsonPath("$.email", Matchers.is("johndoe@fake-email.com")))
+                        .andExpect(jsonPath("$.email", Matchers.is("johndoe@example.com")))
                         .andExpect(jsonPath("$.canLogIn", Matchers.is(false)));
 
     }
@@ -825,9 +861,11 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .withNetId("testId")
                                         .build();
+
+        context.restoreAuthSystemState();
 
         String token = getAuthToken(admin.getEmail(), password);
 
@@ -844,7 +882,7 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
             .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.netid", Matchers.is("testId")))
-                        .andExpect(jsonPath("$.email", Matchers.is("johndoe@fake-email.com")))
+                        .andExpect(jsonPath("$.email", Matchers.is("johndoe@example.com")))
                         .andExpect(jsonPath("$.canLogIn", Matchers.is(true)));
 
         // String should be converted to boolean.
@@ -858,7 +896,7 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
             .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.netid", Matchers.is("testId")))
-                        .andExpect(jsonPath("$.email", Matchers.is("johndoe@fake-email.com")))
+                        .andExpect(jsonPath("$.email", Matchers.is("johndoe@example.com")))
                         .andExpect(jsonPath("$.canLogIn", Matchers.is(false)));
 
     }
@@ -870,8 +908,10 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .build();
+
+        context.restoreAuthSystemState();
 
         List<Operation> ops = new ArrayList<Operation>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/netid", "newNetId");
@@ -882,13 +922,13 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // update of netId should fail.
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isBadRequest());
 
         getClient(token).perform(get("/api/eperson/epersons/" + ePerson.getID()))
                         .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.email", Matchers.is("johndoe@fake-email.com")))
+                        .andExpect(jsonPath("$.email", Matchers.is("johndoe@example.com")))
                         .andExpect(jsonPath("$.netid", Matchers.nullValue()));
 
     }
@@ -900,9 +940,11 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .withNetId("testId")
                                         .build();
+
+        context.restoreAuthSystemState();
 
         String newId = "newId";
 
@@ -915,8 +957,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // initialize to true
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.netid", Matchers.is(newId)));
 
@@ -928,15 +970,15 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // should return bad request
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isBadRequest());
 
         // value should be unchanged.
         getClient(token).perform(get("/api/eperson/epersons/" + ePerson.getID()))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.netid", Matchers.is(newId)))
-                        .andExpect(jsonPath("$.email", Matchers.is("johndoe@fake-email.com")))
+                        .andExpect(jsonPath("$.email", Matchers.is("johndoe@example.com")))
                         .andExpect(jsonPath("$.canLogIn", Matchers.is(false)));
 
 
@@ -949,8 +991,10 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .build();
+
+        context.restoreAuthSystemState();
 
         List<Operation> ops = new ArrayList<Operation>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/canLogin", true);
@@ -961,11 +1005,11 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // updates canLogIn to true
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.canLogIn", Matchers.is(true)))
-                        .andExpect(jsonPath("$.email", Matchers.is("johndoe@fake-email.com")))
+                        .andExpect(jsonPath("$.email", Matchers.is("johndoe@example.com")))
                         .andExpect(jsonPath("$.netid", Matchers.nullValue()));
 
 
@@ -978,8 +1022,10 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .build();
+
+        context.restoreAuthSystemState();
 
         String token = getAuthToken(admin.getEmail(), password);
 
@@ -990,10 +1036,11 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // initialize to true
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.canLogIn", Matchers.is(true)));;
+                        .andExpect(jsonPath("$.canLogIn", Matchers.is(true)));
+        ;
 
 
         List<Operation> ops2 = new ArrayList<Operation>();
@@ -1003,15 +1050,15 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // should return bad request
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isBadRequest());
 
         // value should still be true.
         getClient(token).perform(get("/api/eperson/epersons/" + ePerson.getID()))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.canLogIn", Matchers.is(true)))
-                        .andExpect(jsonPath("$.email", Matchers.is("johndoe@fake-email.com")))
+                        .andExpect(jsonPath("$.email", Matchers.is("johndoe@example.com")))
                         .andExpect(jsonPath("$.requireCertificate", Matchers.is(false)));
 
     }
@@ -1023,8 +1070,10 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .build();
+
+        context.restoreAuthSystemState();
 
         List<Operation> ops = new ArrayList<Operation>();
         // Boolean operations should accept either string or boolean as value. Try boolean.
@@ -1036,11 +1085,11 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // updates requireCertificate to false
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.requireCertificate", Matchers.is(false)))
-                        .andExpect(jsonPath("$.email", Matchers.is("johndoe@fake-email.com")))
+                        .andExpect(jsonPath("$.email", Matchers.is("johndoe@example.com")))
                         .andExpect(jsonPath("$.netid", Matchers.nullValue()));
 
     }
@@ -1052,8 +1101,10 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .build();
+
+        context.restoreAuthSystemState();
 
         String token = getAuthToken(admin.getEmail(), password);
 
@@ -1064,27 +1115,28 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // initialize to true
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.requireCertificate", Matchers.is(true)));;
+                        .andExpect(jsonPath("$.requireCertificate", Matchers.is(true)));
+        ;
 
         List<Operation> ops2 = new ArrayList<Operation>();
-        ReplaceOperation replaceOperation2 = new ReplaceOperation("/certificate",null);
+        ReplaceOperation replaceOperation2 = new ReplaceOperation("/certificate", null);
         ops2.add(replaceOperation2);
         patchBody = getPatchContent(ops2);
 
         // should return bad request
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isBadRequest());
 
         // value should still be true.
         getClient(token).perform(get("/api/eperson/epersons/" + ePerson.getID()))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.requireCertificate", Matchers.is(true)))
-                        .andExpect(jsonPath("$.email", Matchers.is("johndoe@fake-email.com")))
+                        .andExpect(jsonPath("$.email", Matchers.is("johndoe@example.com")))
                         .andExpect(jsonPath("$.canLogIn", Matchers.is(false)));
 
 
@@ -1097,9 +1149,11 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .withPassword(password)
                                         .build();
+
+        context.restoreAuthSystemState();
 
         String newPassword = "newpassword";
 
@@ -1112,8 +1166,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // updates password
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk());
 
         // login with new password
@@ -1129,16 +1183,18 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.turnOffAuthorisationSystem();
 
         EPerson ePerson1 = EPersonBuilder.createEPerson(context)
-                                        .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
-                                        .withPassword(password)
-                                        .build();
+                                         .withNameInMetadata("John", "Doe")
+                                         .withEmail("Johndoe@example.com")
+                                         .withPassword(password)
+                                         .build();
 
         EPerson ePerson2 = EPersonBuilder.createEPerson(context)
-                                          .withNameInMetadata("Jane", "Doe")
-                                          .withEmail("Janedoe@fake-email.com")
-                                          .withPassword(password)
-                                          .build();
+                                         .withNameInMetadata("Jane", "Doe")
+                                         .withEmail("Janedoe@example.com")
+                                         .withPassword(password)
+                                         .build();
+
+        context.restoreAuthSystemState();
 
         String newPassword = "newpassword";
 
@@ -1152,8 +1208,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // should not be able to update the password of eperson two
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson2.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isForbidden());
 
         // login with old password
@@ -1162,6 +1218,7 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
                         .andExpect(status().isOk());
 
     }
+
     @Test
     public void patchPasswordForNonAdminUser() throws Exception {
 
@@ -1169,13 +1226,13 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .withPassword(password)
                                         .build();
 
-        String newPassword = "newpassword";
-
         context.restoreAuthSystemState();
+
+        String newPassword = "newpassword";
 
         List<Operation> ops = new ArrayList<Operation>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/password", newPassword);
@@ -1186,8 +1243,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // updates password
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk());
 
         // login with new password
@@ -1203,9 +1260,11 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.turnOffAuthorisationSystem();
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
-                .withNameInMetadata("John", "Doe")
-                .withEmail("Johndoe@fake-email.com")
-                .build();
+                                        .withNameInMetadata("John", "Doe")
+                                        .withEmail("Johndoe@example.com")
+                                        .build();
+
+        context.restoreAuthSystemState();
 
         String newPassword = "newpassword";
 
@@ -1218,9 +1277,9 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // replace of password should fail
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
-                .andExpect(status().isBadRequest());
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                        .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -1229,7 +1288,7 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("CanLogin@fake-email.com")
+                                        .withEmail("CanLogin@example.com")
                                         .withPassword(password)
                                         .build();
 
@@ -1244,8 +1303,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // should return
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isForbidden());
 
     }
@@ -1256,7 +1315,7 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("CanLogin@fake-email.com")
+                                        .withEmail("CanLogin@example.com")
                                         .withPassword(password)
                                         .build();
 
@@ -1271,8 +1330,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // should return
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isForbidden());
 
     }
@@ -1284,9 +1343,11 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .withPassword("testpass79bC")
                                         .build();
+
+        context.restoreAuthSystemState();
 
         String token = getAuthToken(admin.getEmail(), password);
 
@@ -1299,8 +1360,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // initialize passwd
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk());
 
 
@@ -1311,8 +1372,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // should return bad request
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isBadRequest());
 
         // login with original password
@@ -1329,9 +1390,11 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .withPassword(password)
                                         .build();
+
+        context.restoreAuthSystemState();
 
         String newEmail = "janedoe@real-email.com";
 
@@ -1344,8 +1407,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // updates email
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(jsonPath("$.email", Matchers.is(newEmail)))
                         .andExpect(status().isOk());
 
@@ -1362,7 +1425,7 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .withPassword(password)
                                         .build();
 
@@ -1379,8 +1442,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // returns 403
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isForbidden());
 
     }
@@ -1392,9 +1455,11 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .withPassword(password)
                                         .build();
+
+        context.restoreAuthSystemState();
 
         String token = getAuthToken(admin.getEmail(), password);
 
@@ -1405,8 +1470,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // should return bad request
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isBadRequest());
 
         // login with original password
@@ -1423,9 +1488,11 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .withNetId("testId")
                                         .build();
+
+        context.restoreAuthSystemState();
 
         String token = getAuthToken(admin.getEmail(), password);
 
@@ -1440,8 +1507,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         String patchBody = getPatchContent(ops);
 
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.canLogIn", Matchers.is(true)))
                         .andExpect(jsonPath("$.netid", Matchers.is("multitestId")))
@@ -1456,10 +1523,12 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .build();
 
         String token = getAuthToken(admin.getEmail(), password);
+
+        context.restoreAuthSystemState();
 
         List<Operation> ops = new ArrayList<Operation>();
         ReplaceOperation replaceOperation0 = new ReplaceOperation("/canLogin", true);
@@ -1468,8 +1537,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // Initialized canLogIn value is true.
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.canLogIn", Matchers.is(true)));
 
@@ -1487,8 +1556,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // The 3rd operation should result in bad request
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isBadRequest());
 
         // The value of canLogIn should equal the previously initialized value.
@@ -1510,7 +1579,7 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
     private void runPatchMetadataTests(EPerson asUser, int expectedStatus) throws Exception {
         context.turnOffAuthorisationSystem();
-        EPerson ePerson = EPersonBuilder.createEPerson(context).withEmail("user@test.com").build();
+        EPerson ePerson = EPersonBuilder.createEPerson(context).withEmail("user@example.com").build();
         context.restoreAuthSystemState();
         String token = getAuthToken(asUser.getEmail(), password);
 
@@ -1524,10 +1593,12 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .build();
 
         String newName = "JohnReplace";
+
+        context.restoreAuthSystemState();
 
         List<Operation> ops = new ArrayList<Operation>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/metadata/eperson.firstname", newName);
@@ -1543,6 +1614,12 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.metadata", Matchers.allOf(
                             MetadataMatcher.matchMetadata("eperson.firstname", newName))));
+
+        // The replacement of the eperson.firstname value is persisted
+        getClient(token).perform(get("/api/eperson/epersons/" + ePerson.getID()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$", hasJsonPath("$.metadata", allOf(
+                            matchMetadata("eperson.firstname", newName)))));
     }
 
     @Test
@@ -1552,7 +1629,7 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .withPassword(password)
                                         .build();
 
@@ -1567,14 +1644,19 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         String token = getAuthToken(ePerson.getEmail(), password);
 
-        // updates password
+        // replace operation on eperson.firstname by owning user
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                                     .content(patchBody)
-                                     .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.metadata", Matchers.allOf(
                             MetadataMatcher.matchMetadata("eperson.firstname", newName))));
 
+        // The replacement of the eperson.firstname value is persisted
+        getClient(token).perform(get("/api/eperson/epersons/" + ePerson.getID()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$", hasJsonPath("$.metadata", allOf(
+                            matchMetadata("eperson.firstname", newName)))));
     }
 
     @Test
@@ -1584,15 +1666,15 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .withPassword(password)
                                         .build();
 
         EPerson ePerson2 = EPersonBuilder.createEPerson(context)
-                                        .withNameInMetadata("Jane", "Smith")
-                                        .withEmail("Janesmith@fake-email.com")
-                                        .withPassword(password)
-                                        .build();
+                                         .withNameInMetadata("Jane", "Smith")
+                                         .withEmail("Janesmith@example.com")
+                                         .withPassword(password)
+                                         .build();
 
         String newName = "JohnReplace";
 
@@ -1603,14 +1685,20 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         ops.add(replaceOperation);
         String patchBody = getPatchContent(ops);
 
-        String token = getAuthToken(ePerson2.getEmail(), password);
+        String token2 = getAuthToken(ePerson2.getEmail(), password);
+        String token = getAuthToken(ePerson.getEmail(), password);
 
-        // updates password
-        getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                                     .content(patchBody)
-                                     .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+        // attempts to replace eperson.firstname, not allowed, only allowed by admin or owning user
+        getClient(token2).perform(patch("/api/eperson/epersons/" + ePerson.getID())
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isForbidden());
 
+        // No replacement of the eperson.firstname
+        getClient(token).perform(get("/api/eperson/epersons/" + ePerson.getID()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$", hasJsonPath("$.metadata", allOf(
+                            matchMetadata("eperson.firstname", "John")))));
     }
 
     @Test
@@ -1618,10 +1706,10 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.turnOffAuthorisationSystem();
 
         EPerson ePerson1 = EPersonBuilder.createEPerson(context)
-                .withNameInMetadata("Mik", "Reck")
-                .withEmail("MikReck@email.com")
-                .withPassword("qwerty01")
-                .build();
+                                         .withNameInMetadata("Mik", "Reck")
+                                         .withEmail("MikReck@email.com")
+                                         .withPassword("qwerty01")
+                                         .build();
 
         context.restoreAuthSystemState();
 
@@ -1629,17 +1717,18 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         // by contract the groups embedded in the eperson only contains direct explicit membership,
         // so the anonymous group is not listed
         getClient(tokenEperson1).perform(get("/api/eperson/epersons/" + ePerson1.getID())
-                .param("projection", "full"))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(contentType))
-                .andExpect(jsonPath("$", Matchers.allOf(
-                        hasJsonPath("$._embedded.groups._embedded.groups.length()", is(0)),
-                        hasJsonPath("$._embedded.groups.page.totalElements", is(0))
-                )));
+            .param("projection", "full"))
+                                .andExpect(status().isOk())
+                                .andExpect(content().contentType(contentType))
+                                .andExpect(jsonPath("$", Matchers.allOf(
+                                    hasJsonPath("$._embedded.groups._embedded.groups.length()", is(0)),
+                                    hasJsonPath("$._embedded.groups.page.totalElements", is(0))
+                                                                       )));
     }
 
     /**
      * Test that epersons/<:uuid>/groups endpoint returns the direct groups of the epersons
+     *
      * @throws Exception
      */
     @Test
@@ -1648,19 +1737,19 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@fake-email.com")
+                                        .withEmail("Johndoe@example.com")
                                         .withPassword(password)
                                         .build();
 
         Group parentGroup1 = GroupBuilder.createGroup(context)
-                                        .withName("Test Parent Group 1")
-                                        .build();
+                                         .withName("Test Parent Group 1")
+                                         .build();
 
         Group childGroup1 = GroupBuilder.createGroup(context)
-                                       .withName("Test Child Group 1")
-                                       .withParent(parentGroup1)
-                                       .addMember(ePerson)
-                                       .build();
+                                        .withName("Test Child Group 1")
+                                        .withParent(parentGroup1)
+                                        .addMember(ePerson)
+                                        .build();
 
         Group parentGroup2 = GroupBuilder.createGroup(context)
                                          .withName("Test Parent Group 2")
@@ -1672,19 +1761,20 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
                                         .addMember(ePerson)
                                         .build();
 
+        context.restoreAuthSystemState();
 
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken).perform(get("/api/eperson/epersons/" + ePerson.getID() + "/groups"))
                             .andExpect(status().isOk())
                             .andExpect(content().contentType(contentType))
                             .andExpect(jsonPath("$._embedded.groups", containsInAnyOrder(
-                                    GroupMatcher.matchGroupWithName(childGroup1.getName()),
-                                    GroupMatcher.matchGroupWithName(childGroup2.getName()))))
+                                GroupMatcher.matchGroupWithName(childGroup1.getName()),
+                                GroupMatcher.matchGroupWithName(childGroup2.getName()))))
                             .andExpect(jsonPath("$._embedded.groups", Matchers.not(
-                                    containsInAnyOrder(
-                                            GroupMatcher.matchGroupWithName(parentGroup1.getName()),
-                                            GroupMatcher.matchGroupWithName(parentGroup2.getName()))))
-                            );
+                                containsInAnyOrder(
+                                    GroupMatcher.matchGroupWithName(parentGroup1.getName()),
+                                    GroupMatcher.matchGroupWithName(parentGroup2.getName()))))
+                                      );
 
     }
 }


### PR DESCRIPTION
This PR is related to the rest contract update mentioned in: https://github.com/DSpace/Rest7Contract/pull/113

* Admin users can edit both the non-metadata information (email, netid etc) as well as the metadata information of all users
* Non admin user can edit their own metadata information
* Non admin user can not edit their non-metadata information (email, netid etc)
* Non admin users can not edit another person's information