### PR TITLE
This is an alternative PR for DS-4487 that also include test to proof the issue and solution

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DSpaceObjectConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DSpaceObjectConverter.java
@@ -8,6 +8,7 @@
 package org.dspace.app.rest.converter;
 
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
@@ -78,23 +79,24 @@ public abstract class DSpaceObjectConverter<M extends DSpaceObject, R extends or
      */
     public MetadataValueList getPermissionFilteredMetadata(Context context, M obj) {
         List<MetadataValue> metadata = obj.getMetadata();
+        List<MetadataValue> visibleMetadata = new ArrayList<MetadataValue>();
         try {
             if (context != null && authorizeService.isAdmin(context)) {
                 return new MetadataValueList(metadata);
             }
             for (MetadataValue mv : metadata) {
                 MetadataField metadataField = mv.getMetadataField();
-                if (metadataExposureService
+                if (!metadataExposureService
                         .isHidden(context, metadataField.getMetadataSchema().getName(),
                                   metadataField.getElement(),
                                   metadataField.getQualifier())) {
-                    metadata.remove(mv);
+                    visibleMetadata.add(mv);
                 }
             }
         } catch (SQLException e) {
             log.error("Error filtering metadata based on permissions", e);
         }
-        return new MetadataValueList(metadata);
+        return new MetadataValueList(visibleMetadata);
     }
 
     /**

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
@@ -1404,7 +1404,7 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
                          .withNameForLanguage("col2", "it")
                          .build();
 
-        context.turnOffAuthorisationSystem();
+        context.restoreAuthSystemState();
 
         String tokenEPerson = getAuthToken(eperson.getEmail(), password);
 


### PR DESCRIPTION
## References
Fixes bug described here: https://jira.lyrasis.org/browse/DS-4487
Related to #2719 (where the bug was accidentally introduced)

## Description
Fixes ConcurrentModificationException by ensuring that the List of metadata in getPermissionFilteredMetadata() is not modified while looping through its values.

See Ticket for how to reproduce this bug easily on the /api/core/collections endpoint.

