### PR TITLE
Fix bug running individual tests on `master`

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,36 +88,33 @@ run automatically by [Travis CI](https://travis-ci.org/DSpace/DSpace/) for all P
 
 * How to run both Unit Tests (via `maven-surefire-plugin`) and Integration Tests (via `maven-failsafe-plugin`):
   ```
-  # NOTE: while "mvn test" runs Unit Tests,
-  # Integration Tests only run for "verify" or "install" phases
-  mvn clean install -Dmaven.test.skip=false -DskipITs=false
+  mvn clean test -Dmaven.test.skip=false -DskipITs=false
   ```
 * How to run just Unit Tests:
   ```
-  mvn clean test -Dmaven.test.skip=false
+  mvn test -Dmaven.test.skip=false
   ```
 * How to run a *single* Unit Test
   ```
   # Run all tests in a specific test class
-  # NOTE: testClassName is just the class name, do not include package
-  mvn clean test -Dmaven.test.skip=false -Dtest=[testClassName]
+  # NOTE: failIfNoTests=false is required to skip tests in other modules
+  mvn test -Dmaven.test.skip=false -Dtest=[full.package.testClassName] -DfailIfNoTests=false
 
   # Run one test method in a specific test class
-  mvn clean test -Dmaven.test.skip=false -Dtest=[testClassName]#[testMethodName]
+  mvn test -Dmaven.test.skip=false -Dtest=[full.package.testClassName]#[testMethodName] -DfailIfNoTests=false
   ```
-* How to run Integration Tests (requires running Unit tests too)
+* How to run Integration Tests (requires enabling Unit tests too)
   ```
-  mvn clean verify -Dmaven.test.skip=false -DskipITs=false
+  mvn verify -Dmaven.test.skip=false -DskipITs=false
   ```
-* How to run a *single* Integration Test (requires running Unit tests too)
+* How to run a *single* Integration Test (requires enabling Unit tests too)
   ```
   # Run all integration tests in a specific test class
-  # NOTE: Integration Tests only run for "verify" or "install" phases
-  # NOTE: testClassName is just the class name, do not include package
-  mvn clean verify -Dmaven.test.skip=false -DskipITs=false -Dit.test=[testClassName]
+  # NOTE: failIfNoTests=false is required to skip tests in other modules
+  mvn test -Dmaven.test.skip=false -DskipITs=false -Dtest=[full.package.testClassName] -DfailIfNoTests=false
 
   # Run one test method in a specific test class
-  mvn clean verify -Dmaven.test.skip=false -DskipITs=false -Dit.test=[testClassName]#[testMethodName]
+  mvn test -Dmaven.test.skip=false -DskipITs=false -Dtest=[full.package.testClassName]#[testMethodName] -DfailIfNoTests=false
   ```
 * How to run only tests of a specific DSpace module
   ```

--- a/dspace/pom.xml
+++ b/dspace/pom.xml
@@ -190,6 +190,7 @@
             </build>
             <dependencies>
                 <!-- Add all modules that should be taken into account for the coverage reports -->
+                <!-- (Excludes dspace-rest which is deprecated and doesn't build by default) -->
                 <dependency>
                     <groupId>org.dspace</groupId>
                     <artifactId>dspace-api</artifactId>
@@ -203,12 +204,6 @@
                 <dependency>
                     <groupId>org.dspace</groupId>
                     <artifactId>dspace-rdf</artifactId>
-                    <scope>compile</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.dspace</groupId>
-                    <artifactId>dspace-rest</artifactId>
-                    <classifier>classes</classifier>
                     <scope>compile</scope>
                 </dependency>
                 <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -829,6 +829,23 @@
            <modules>
                <module>dspace-rest</module>
            </modules>
+           <dependencyManagement>
+               <dependencies>
+                   <dependency>
+                       <groupId>org.dspace</groupId>
+                       <artifactId>dspace-rest</artifactId>
+                       <version>7.0-beta3-SNAPSHOT</version>
+                       <type>jar</type>
+                       <classifier>classes</classifier>
+                   </dependency>
+                   <dependency>
+                       <groupId>org.dspace</groupId>
+                       <artifactId>dspace-rest</artifactId>
+                       <version>7.0-beta3-SNAPSHOT</version>
+                       <type>war</type>
+                   </dependency>
+               </dependencies>
+           </dependencyManagement>
        </profile>
 
 
@@ -1009,19 +1026,6 @@
                 <groupId>org.dspace</groupId>
                 <artifactId>dspace-rdf</artifactId>
                 <version>7.0-beta3-SNAPSHOT</version>
-            </dependency>
-            <dependency>
-                <groupId>org.dspace</groupId>
-                <artifactId>dspace-rest</artifactId>
-                <version>7.0-beta3-SNAPSHOT</version>
-                <type>jar</type>
-                <classifier>classes</classifier>
-            </dependency>
-            <dependency>
-                <groupId>org.dspace</groupId>
-                <artifactId>dspace-rest</artifactId>
-                <version>7.0-beta3-SNAPSHOT</version>
-                <type>war</type>
             </dependency>
             <dependency>
                 <groupId>org.dspace</groupId>


### PR DESCRIPTION
## References
Bug was discovered by @abollini in #2720 in this comment: https://github.com/DSpace/DSpace/pull/2720#pullrequestreview-399901564

## Description
Currently, individual test classes (unit or integration tests) cannot be run as documented in our README.  They all throw the error:
```
[ERROR] Failed to execute goal on project dspace: Could not resolve dependencies for project org.dspace:dspace:pom:7.0-beta3-SNAPSHOT: Failure to find org.dspace:dspace-rest:jar:classes:7.0-beta3-SNAPSHOT
```

I've fixed the bug (which was related to the disabled, optional `dspace-rest` module) and updated our README instructions (which were also outdated)

## Instructions for Reviewers
See updates to the README in this PR for how to run various individual tests.

One quick example is to try: 
```
mvn test -Dtest=org.dspace.app.rest.AuthorityRestRepositoryIT -Dmaven.test.skip=false -DskipITs=false -DfailIfNoTests=false
```