### PR TITLE
DS-4493 prevent empty string assignment for language

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -1120,13 +1120,8 @@ public class ItemImport
         String language = null;
 
         //DS-4493 protection against initialising as an empty string
-        if (!"".equals(getAttributeValue(n, "language"))){
-            language = getAttributeValue(n, "language");
-        }
-
-        if (language != null)
-        {
-            language = language.trim();
+        if (StringUtils.isNotBlank(getAttributeValue(n, "language"))){
+            language = getAttributeValue(n, "language").trim();
         }
 
         if (!isQuiet)

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -1117,7 +1117,13 @@ public class ItemImport
         String qualifier = getAttributeValue(n, "qualifier"); //NodeValue();
         // //getElementData(n,
         // "qualifier");
-        String language = getAttributeValue(n, "language");
+        String language = null;
+
+        //DS-4493 protection against initialising as an empty string
+        if (!"".equals(getAttributeValue(n, "language"))){
+            language = getAttributeValue(n, "language");
+        }
+
         if (language != null)
         {
             language = language.trim();


### PR DESCRIPTION
## References
* https://jira.lyrasis.org/browse/DS-4493

## Description
Preventing empty string "" set as language codes during item import.