### PR TITLE
DS-4506 Add a limit on the maximum value allowed for the parameter rpp (resuts per page) in browse and search pages.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -110,6 +110,8 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
     public static final String VARIANTS_STORE_SEPARATOR = "###";
 
+    public static final int MAX_RESULTS_ALLOWED = 100;
+
     @Autowired(required = true)
     protected ContentServiceFactory contentServiceFactory;
     @Autowired(required = true)
@@ -1684,6 +1686,10 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
         if(discoveryQuery.getMaxResults() != -1)
         {
+            if (discoveryQuery.getMaxResults() > MAX_RESULTS_ALLOWED)
+            {
+                discoveryQuery.setMaxResults(MAX_RESULTS_ALLOWED);
+            }
             solrQuery.setRows(discoveryQuery.getMaxResults());
         }
 

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ConfigurableBrowse.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ConfigurableBrowse.java
@@ -743,7 +743,12 @@ public class ConfigurableBrowse extends AbstractDSpaceTransformer implements
             params.scope.setJumpToItem(RequestUtils.getIntParameter(request, BrowseParams.JUMPTO_ITEM));
             params.scope.setOrder(request.getParameter(BrowseParams.ORDER));
             updateOffset(request, params);
-            params.scope.setResultsPerPage(RequestUtils.getIntParameter(request, BrowseParams.RESULTS_PER_PAGE));
+            int rpp = RequestUtils.getIntParameter(request, BrowseParams.RESULTS_PER_PAGE);
+            int maxRpp = RESULTS_PER_PAGE_PROGRESSION[RESULTS_PER_PAGE_PROGRESSION.length-1];
+            if (rpp > maxRpp) {
+                rpp = maxRpp;
+            }
+            params.scope.setResultsPerPage(rpp);
             params.scope.setStartsWith(decodeFromURL(request.getParameter(BrowseParams.STARTS_WITH)));
             String filterValue = request.getParameter(BrowseParams.FILTER_VALUE[0]);
             if (filterValue == null)


### PR DESCRIPTION
## References
*  [DS-4506](https://jira.lyrasis.org/browse/DS-4506)
* Fixes #7840

## Description
Add a limit on the maximum value allowed for the parameter rpp p (resuts per page) in browse and search pages.

## Instructions for Reviewers
* In solr, a variable MAX_RESULTS_ALLOWED to control the max rpp value was created.
* In xmlui browse page now there is a check for the entered value is not greater than the maximum value shown in the select used to set the parameter.

* Now if a user set the rpp with a value greater than the maximum value allowed, then those changes are not taken into account and the parameter is set with the max value allowed 
