### PR TITLE
DS-4509 Update AWS SDK version

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -700,11 +700,19 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.10.50</version>
+            <version>1.11.785</version>
             <exclusions>
                 <exclusion>
                     <groupId>joda-time</groupId>
                     <artifactId>joda-time</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
See: https://jira.lyrasis.org/browse/DS-4509
Fixes #7843

The current AWS SDK version is 1.10.50, this version currently does not support some of our clients regions E.G `ca-central-1`. Submitting a PR that bumps the version and excludes conflicting dependencies.

 

Credit for this discovery goes to Chris Wilper.