### PR TITLE
Fixes to Docker and default "dspace.ui.url" per Angular CLI update

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -98,20 +98,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Verify OS license headers for all source code files -->
-            <plugin>
-                <groupId>com.mycila</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>**/src/test/resources/**</exclude>
-                        <exclude>**/src/test/data/**</exclude>
-                        <exclude>**/.gitignore</exclude>
-                        <exclude>**/src/main/resources/rebel.xml</exclude>
-                        <exclude>src/test/data/dspaceFolder/config/spiders/**</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
 
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/ApplicationConfig.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/ApplicationConfig.java
@@ -36,8 +36,8 @@ public class ApplicationConfig {
     @Value("${rest.cors.allow-credentials:true}")
     private boolean corsAllowCredentials;
 
-    // Configured User Interface URL (default: http://localhost:3000)
-    @Value("${dspace.ui.url:http://localhost:3000}")
+    // Configured User Interface URL (default: http://localhost:4000)
+    @Value("${dspace.ui.url:http://localhost:4000}")
     private String uiURL;
 
     /**

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RootRestResourceControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RootRestResourceControllerIT.java
@@ -33,7 +33,7 @@ public class RootRestResourceControllerIT extends AbstractControllerIntegrationT
                    .andExpect(status().isOk())
                    //We expect the content type to be "application/hal+json;charset=UTF-8"
                    .andExpect(content().contentType(contentType))
-                   .andExpect(jsonPath("$.dspaceURL", Matchers.is("http://localhost:3000")))
+                   .andExpect(jsonPath("$.dspaceURL", Matchers.is("http://localhost:4000")))
                    .andExpect(jsonPath("$.dspaceName", Matchers.is("DSpace at My University")))
                    .andExpect(jsonPath("$.dspaceRest", Matchers.is(BASE_REST_SERVER_URL)))
                    .andExpect(jsonPath("$.type", Matchers.is("root")));

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ShibbolethRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ShibbolethRestControllerIT.java
@@ -27,7 +27,7 @@ public class ShibbolethRestControllerIT extends AbstractControllerIntegrationTes
 
         getClient(token).perform(get("/api/authn/shibboleth"))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrl("http://localhost:3000"));
+                .andExpect(redirectedUrl("http://localhost:4000"));
     }
 
     @Test

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -28,7 +28,7 @@ dspace.server.url = http://localhost:8080/server
 
 # URL of DSpace frontend (Angular UI). Include port number etc
 # This is used by the backend to provide links in emails, RSS feeds, Sitemaps, etc.
-dspace.ui.url = http://localhost:3000
+dspace.ui.url = http://localhost:4000
 
 # Name of the site
 dspace.name = DSpace at My University

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -38,7 +38,7 @@ dspace.server.url = http://localhost:8080/server
 
 # URL of DSpace frontend (Angular UI). Include port number etc
 # This is used by the backend to provide links in emails, RSS feeds, Sitemaps, etc.
-dspace.ui.url = http://localhost:3000
+dspace.ui.url = http://localhost:4000
 
 # Name of the site
 dspace.name = DSpace at My University

--- a/dspace/src/main/docker-compose/README.md
+++ b/dspace/src/main/docker-compose/README.md
@@ -18,7 +18,7 @@
   - Sets the environment used across containers run with docker-compose
 - docker-compose-angular.yml
   - Docker compose file that will start a published DSpace angular container that interacts with the branch.
-- environment.dev.js
+- environment.dev.ts
   - Default angular environment when testing DSpace-angular from this repo
 
 ## To refresh / pull DSpace images from Dockerhub

--- a/dspace/src/main/docker-compose/docker-compose-angular.yml
+++ b/dspace/src/main/docker-compose/docker-compose-angular.yml
@@ -17,17 +17,17 @@ services:
     environment:
       DSPACE_HOST: dspace-angular
       DSPACE_NAMESPACE: /
-      DSPACE_PORT: '3000'
+      DSPACE_PORT: '4000'
       DSPACE_SSL: "false"
     image: dspace/dspace-angular:latest
     networks:
       dspacenet: {}
     ports:
-    - published: 3000
-      target: 3000
+    - published: 4000
+      target: 4000
     - published: 9876
       target: 9876
     stdin_open: true
     tty: true
     volumes:
-    - ./dspace/src/main/docker-compose/environment.dev.js:/app/config/environment.dev.js
+    - ./dspace/src/main/docker-compose/environment.dev.ts:/app/src/environments/environment.dev.ts

--- a/dspace/src/main/docker-compose/environment.dev.ts
+++ b/dspace/src/main/docker-compose/environment.dev.ts
@@ -5,7 +5,9 @@
  *
  * http://www.dspace.org/license/
  */
-module.exports = {
+import { GlobalConfig } from '../src/config/global-config.interface';
+
+export const environment: Partial<GlobalConfig> = {
   rest: {
     ssl: false,
     host: 'localhost',

--- a/dspace/src/main/docker-compose/environment.dev.ts
+++ b/dspace/src/main/docker-compose/environment.dev.ts
@@ -5,7 +5,7 @@
  *
  * http://www.dspace.org/license/
  */
-// This file is based on environment.common.ts provided by Angular UI
+// This file is based on environment.template.ts provided by Angular UI
 export const environment = {
   // Default to using the local REST API (running in Docker)
   rest: {

--- a/dspace/src/main/docker-compose/environment.dev.ts
+++ b/dspace/src/main/docker-compose/environment.dev.ts
@@ -5,9 +5,9 @@
  *
  * http://www.dspace.org/license/
  */
-import { GlobalConfig } from '../src/config/global-config.interface';
-
-export const environment: Partial<GlobalConfig> = {
+// This file is based on environment.common.ts provided by Angular UI
+export const environment = {
+  // Default to using the local REST API (running in Docker)
   rest: {
     ssl: false,
     host: 'localhost',

--- a/dspace/src/main/docker-compose/environment.dev.ts
+++ b/dspace/src/main/docker-compose/environment.dev.ts
@@ -1,4 +1,4 @@
-/*
+/**
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at

--- a/dspace/src/main/docker-compose/local.cfg
+++ b/dspace/src/main/docker-compose/local.cfg
@@ -1,5 +1,6 @@
 dspace.dir=/dspace
 db.url=jdbc:postgresql://dspacedb:5432/dspace
 dspace.server.url=http://localhost:8080/server
+dspace.ui.url=http://localhost:4000
 dspace.name=DSpace Started with Docker Compose
 solr.server=http://dspacesolr:8983/solr

--- a/dspace/src/main/docker/local.cfg
+++ b/dspace/src/main/docker/local.cfg
@@ -5,4 +5,5 @@
 dspace.dir = /dspace
 db.url = jdbc:postgresql://dspacedb:5432/dspace
 dspace.server.url=http://localhost:8080/server
+dspace.ui.url=http://localhost:4000
 solr.server=http://dspacesolr:8983/solr

--- a/pom.xml
+++ b/pom.xml
@@ -391,7 +391,7 @@
                         <include>src/**</include>
                     </includes>
                     <!--Use all default exclusions for IDE files & Maven files, see:
-                        http://code.google.com/p/maven-license-plugin/wiki/Configuration#Default_excludes -->
+                        http://mycila.mathieu.photography/license-maven-plugin/ -->
                     <useDefaultExcludes>true</useDefaultExcludes>
                     <!-- Add some default DSpace exclusions not covered by <useDefaultExcludes>
                          Individual Maven projects may choose to override these defaults. -->
@@ -399,21 +399,19 @@
                         <exclude>**/src/test/resources/**</exclude>
                         <exclude>**/src/test/data/**</exclude>
                         <exclude>**/src/main/license/**</exclude>
-                        <exclude>**/test.cfg</exclude>
                         <exclude>**/META-INF/**</exclude>
                         <exclude>**/robots.txt</exclude>
-                        <exclude>**/*.LICENSE</exclude>
                         <exclude>**/LICENSE*</exclude>
                         <exclude>**/README*</exclude>
                         <exclude>**/readme*</exclude>
                         <exclude>**/.gitignore</exclude>
-                        <exclude>**/src/main/resources/rebel.xml</exclude>
+                        <exclude>**/*.cfg</exclude>
                     </excludes>
                     <mapping>
-                        <!-- Custom DSpace file extensions which are not recognized by maven-release-plugin:
-                             *.ttl, *.LICENSE -->
+                        <!-- Custom DSpace file extensions which are not recognized by license-maven-plugin:
+                             *.ttl (used by RDF), *.ts (used in Docker Compose for UI) -->
                         <ttl>SCRIPT_STYLE</ttl>
-                        <LICENSE>TEXT</LICENSE>
+                        <ts>JAVADOC_STYLE</ts>
                     </mapping>
                     <encoding>UTF-8</encoding>
                     <!-- maven-license-plugin recommends a strict check (e.g. check spaces/tabs too) -->


### PR DESCRIPTION
References:
* Required by https://github.com/DSpace/dspace-angular/pull/625
* Related also to https://github.com/DSpace/dspace-angular/pull/690 (as the wrong default port in dspace.cfg was causing test issues in the Angular UI)

This PR is a companion to the recently merged [Angular CLI update](https://github.com/DSpace/dspace-angular/pull/625), fixing the default Docker and DSpace configurations of the backend to align with frontend changes.

Simply put, this corrects our backend configurations as follows:
* Defaults the `dspace.ui.url` to use port 4000 everywhere (i.e. `dspace.ui.url=http://localhost:4000` is the new default)
* Fixes our Angular Docker Compose (docker-compose-angular.yml) configurations to also use port 4000 and to use the new `enviroment.dev.ts` configuration required by Angular CLI.
* Updates all Docker local.cfg files to explicitly set `dspace.ui.url=http://localhost:4000`.  This is simply a safety measure (as that is also the new default setting).  It ensures that if someone were to modify the default `dspace.ui.url` in their local codebase, this explicit value would ensure Docker would still function (as our Docker setup currently requires running the UI on port 4000).

This requires additional Docker testing before merging (which I plan to do tomorrow).  Additional eyes are still welcome in the meantime.