### PR TITLE
Rename root properties in REST API v7 to match dspace.cfg configuration

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/RootConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/RootConverter.java
@@ -24,8 +24,8 @@ public class RootConverter {
     public RootRest convert() {
         RootRest rootRest = new RootRest();
         rootRest.setDspaceName(configurationService.getProperty("dspace.name"));
-        rootRest.setDspaceURL(configurationService.getProperty("dspace.ui.url"));
-        rootRest.setDspaceRest(configurationService.getProperty("dspace.server.url"));
+        rootRest.setDspaceUI(configurationService.getProperty("dspace.ui.url"));
+        rootRest.setDspaceServer(configurationService.getProperty("dspace.server.url"));
         return rootRest;
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/link/RootHalLinkFactory.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/link/RootHalLinkFactory.java
@@ -30,7 +30,7 @@ public class RootHalLinkFactory extends HalLinkFactory<RootResource, RootRestRes
         for (Link endpointLink : discoverableEndpointsService.getDiscoverableEndpoints()) {
             list.add(
                 buildLink(endpointLink.getRel().value(),
-                          halResource.getContent().getDspaceRest() + endpointLink.getHref()));
+                          halResource.getContent().getDspaceServer() + endpointLink.getHref()));
         }
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/link/process/ProcessResourceHalLinkFactory.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/link/process/ProcessResourceHalLinkFactory.java
@@ -28,9 +28,9 @@ public class ProcessResourceHalLinkFactory extends HalLinkFactory<ProcessResourc
     private ConfigurationService configurationService;
 
     protected void addLinks(ProcessResource halResource, Pageable pageable, LinkedList<Link> list) throws Exception {
-        String dspaceRestUrl = configurationService.getProperty("dspace.server.url");
+        String dspaceServerUrl = configurationService.getProperty("dspace.server.url");
         list.add(
-            buildLink("script", dspaceRestUrl + "/api/system/scripts/" + halResource.getContent().getScriptName()));
+            buildLink("script", dspaceServerUrl + "/api/system/scripts/" + halResource.getContent().getScriptName()));
 
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/RootRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/RootRest.java
@@ -17,9 +17,9 @@ import org.dspace.app.rest.RootRestResourceController;
 public class RootRest extends RestAddressableModel {
     public static final String NAME = "root";
     public static final String CATEGORY = RestModel.ROOT;
-    private String dspaceURL;
+    private String dspaceUI;
     private String dspaceName;
-    private String dspaceRest;
+    private String dspaceServer;
 
     public String getCategory() {
         return CATEGORY;
@@ -33,13 +33,13 @@ public class RootRest extends RestAddressableModel {
         return RootRestResourceController.class;
     }
 
-    public String getDspaceURL() {
+    public String getDspaceUI() {
 
-        return dspaceURL;
+        return dspaceUI;
     }
 
-    public void setDspaceURL(String dspaceURL) {
-        this.dspaceURL = dspaceURL;
+    public void setDspaceUI(String dspaceUI) {
+        this.dspaceUI = dspaceUI;
     }
 
     public String getDspaceName() {
@@ -50,12 +50,12 @@ public class RootRest extends RestAddressableModel {
         this.dspaceName = dspaceName;
     }
 
-    public String getDspaceRest() {
-        return dspaceRest;
+    public String getDspaceServer() {
+        return dspaceServer;
     }
 
-    public void setDspaceRest(String dspaceRest) {
-        this.dspaceRest = dspaceRest;
+    public void setDspaceServer(String dspaceServerURL) {
+        this.dspaceServer = dspaceServerURL;
     }
 
     @Override
@@ -64,9 +64,9 @@ public class RootRest extends RestAddressableModel {
             new EqualsBuilder().append(this.getCategory(), ((RootRest) object).getCategory())
                                .append(this.getType(), ((RootRest) object).getType())
                                .append(this.getController(), ((RootRest) object).getController())
-                               .append(this.getDspaceURL(), ((RootRest) object).getDspaceURL())
+                               .append(this.getDspaceUI(), ((RootRest) object).getDspaceUI())
                                .append(this.getDspaceName(), ((RootRest) object).getDspaceName())
-                               .append(this.getDspaceRest(), ((RootRest) object).getDspaceRest())
+                               .append(this.getDspaceServer(), ((RootRest) object).getDspaceServer())
                                .isEquals());
     }
 
@@ -77,8 +77,8 @@ public class RootRest extends RestAddressableModel {
             .append(this.getType())
             .append(this.getController())
             .append(this.getDspaceName())
-            .append(this.getDspaceURL())
-            .append(this.getDspaceRest())
+            .append(this.getDspaceUI())
+            .append(this.getDspaceServer())
             .toHashCode();
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RootRestResourceControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RootRestResourceControllerIT.java
@@ -33,9 +33,9 @@ public class RootRestResourceControllerIT extends AbstractControllerIntegrationT
                    .andExpect(status().isOk())
                    //We expect the content type to be "application/hal+json;charset=UTF-8"
                    .andExpect(content().contentType(contentType))
-                   .andExpect(jsonPath("$.dspaceURL", Matchers.is("http://localhost:4000")))
+                   .andExpect(jsonPath("$.dspaceUI", Matchers.is("http://localhost:4000")))
                    .andExpect(jsonPath("$.dspaceName", Matchers.is("DSpace at My University")))
-                   .andExpect(jsonPath("$.dspaceRest", Matchers.is(BASE_REST_SERVER_URL)))
+                   .andExpect(jsonPath("$.dspaceServer", Matchers.is(BASE_REST_SERVER_URL)))
                    .andExpect(jsonPath("$.type", Matchers.is("root")));
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/converter/RootConverterTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/converter/RootConverterTest.java
@@ -48,9 +48,9 @@ public class RootConverterTest {
     public void testCorrectPropertiesSetFromConfigurationService() throws Exception {
         String restUrl = "rest";
         RootRest rootRest = rootConverter.convert();
-        assertEquals("dspaceurl", rootRest.getDspaceURL());
+        assertEquals("dspaceurl", rootRest.getDspaceUI());
         assertEquals("dspacename", rootRest.getDspaceName());
-        assertEquals(restUrl, rootRest.getDspaceRest());
+        assertEquals(restUrl, rootRest.getDspaceServer());
     }
 
     @Test


### PR DESCRIPTION
This is a small PR that aligns the root "Properties" returned by the REST API with their names in `dspace.cfg`.  I discovered this would be useful when helping someone debug issues in the REST API v7 configuration, as it clarifies how these properties are set in configuration.

Specifically, these property names are changed:
* "dspaceUrl" is renamed to "dspaceUI" (as it is the `dspace.ui.url` configuration)
* "dspaceRest" is renamed to "dspaceServer" (as it is the `dspace.server.url` configuration)

How to test:
* Deploy the PR and look at the Properties made available at the root path (/server/).  They should match the new names listed above (and not the old names visible at https://dspace7.4science.cloud/server/)

_Sidenote:_ This change in property names appears like it would have not impact on the Angular UI, as it uses its own configuration for these URLs.