### PR TITLE
Private Bitstreams should still return name, content link

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamRestRepository.java
@@ -71,7 +71,7 @@ public class BitstreamRestRepository extends DSpaceObjectRestRepository<Bitstrea
     }
 
     @Override
-    @PreAuthorize("hasPermission(#uuid, 'BITSTREAM', 'METADATA_READ')")
+    @PreAuthorize("hasPermission(#id, 'BITSTREAM', 'METADATA_READ')")
     public BitstreamRest findOne(Context context, UUID id) {
         Bitstream bit = null;
         try {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamRestRepository.java
@@ -71,7 +71,7 @@ public class BitstreamRestRepository extends DSpaceObjectRestRepository<Bitstrea
     }
 
     @Override
-    @PreAuthorize("hasPermission(#id, 'BITSTREAM', 'READ')")
+    @PreAuthorize("hasPermission(#uuid, 'BITSTREAM', 'METADATA_READ')")
     public BitstreamRest findOne(Context context, UUID id) {
         Bitstream bit = null;
         try {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/BitstreamMetadataReadPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/BitstreamMetadataReadPermissionEvaluatorPlugin.java
@@ -8,10 +8,25 @@
 package org.dspace.app.rest.security;
 
 import java.io.Serializable;
+import java.sql.SQLException;
 import java.util.UUID;
 
 import org.dspace.app.rest.repository.BitstreamRestRepository;
+import org.dspace.app.rest.utils.ContextUtil;
+import org.dspace.app.rest.utils.DSpaceObjectUtils;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.content.service.BitstreamService;
+import org.dspace.core.Constants;
 import org.dspace.core.Context;
+import org.dspace.services.RequestService;
+import org.dspace.services.model.Request;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
@@ -24,13 +39,52 @@ import org.springframework.stereotype.Component;
 @Component
 public class BitstreamMetadataReadPermissionEvaluatorPlugin extends RestObjectPermissionEvaluatorPlugin {
 
+    private static final Logger log = LoggerFactory.getLogger(BitstreamMetadataReadPermissionEvaluatorPlugin.class);
+
+    @Autowired
+    private RequestService requestService;
+    @Autowired
+    private DSpaceObjectUtils dspaceObjectUtil;
+    @Autowired
+    AuthorizeService authorizeService;
+    @Autowired
+    protected BitstreamService bitstreamService;
+
     private final static String METADATA_READ_PERMISSION = "METADATA_READ";
 
     @Override
     public boolean hasPermission(Authentication authentication, Serializable targetId, String targetType,
                                  Object permission) {
-        if (permission.toString().equalsIgnoreCase(METADATA_READ_PERMISSION)) {
-            return true;
+        if (permission.toString().equalsIgnoreCase(METADATA_READ_PERMISSION) && targetId != null) {
+            Request request = requestService.getCurrentRequest();
+            Context context = ContextUtil.obtainContext(request.getServletRequest());
+
+            try {
+                UUID dsoUuid = UUID.fromString(targetId.toString());
+                DSpaceObject dso = dspaceObjectUtil.findDSpaceObject(context, dsoUuid);
+                if (dso instanceof Bitstream) {
+                    if (authorizeService.isAdmin(context, dso)) {
+                        // Is Admin on bitstream
+                        return true;
+                    }
+                    if (authorizeService.authorizeActionBoolean(context, dso, Constants.READ)) {
+                        // Has READ rights on bitstream
+                        return true;
+                    }
+                    DSpaceObject bitstreamParentObject = bitstreamService.getParentObject(context, (Bitstream) dso);
+                    if (bitstreamParentObject instanceof Item && !((Bitstream) dso).getBundles().isEmpty()) {
+                        // If parent is item and it is in a bundle
+                        Bundle firstBundle = ((Bitstream) dso).getBundles().get(0);
+                        if (authorizeService.authorizeActionBoolean(context, bitstreamParentObject, Constants.READ)
+                            && authorizeService.authorizeActionBoolean(context, firstBundle, Constants.READ)) {
+                            // Has READ rights on bitstream's parent item AND first bundle bitstream is in
+                            return true;
+                        }
+                    }
+                }
+            } catch (SQLException e) {
+                log.error(e.getMessage(), e);
+            }
         }
         return false;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/BitstreamMetadataReadPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/BitstreamMetadataReadPermissionEvaluatorPlugin.java
@@ -1,0 +1,38 @@
+package org.dspace.app.rest.security;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+import org.dspace.app.rest.repository.BitstreamRestRepository;
+import org.dspace.core.Context;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+/**
+ * Used by {@link BitstreamRestRepository#findOne(Context, UUID)} to get metadata of private bitstreams even though user
+ * can't access actual file
+ *
+ * @author Maria Verdonck (Atmire) on 15/06/2020
+ */
+@Component
+public class BitstreamMetadataReadPermissionEvaluatorPlugin extends RestObjectPermissionEvaluatorPlugin {
+
+    private final static String METADATA_READ_PERMISSION = "METADATA_READ";
+
+    @Override
+    public boolean hasPermission(Authentication authentication, Serializable targetId, String targetType,
+                                 Object permission) {
+        if (permission.toString().equalsIgnoreCase(METADATA_READ_PERMISSION)) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean hasDSpacePermission(Authentication authentication, Serializable targetId, String targetType,
+                                       DSpaceRestPermission restPermission) {
+        // No need to override, since only user by super.hasPermission(Authentication authentication, Serializable
+        // targetId, String targetType, Object permission) which is overrode above
+        return false;
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/BitstreamMetadataReadPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/BitstreamMetadataReadPermissionEvaluatorPlugin.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.app.rest.security;
 
 import java.io.Serializable;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/BitstreamMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/BitstreamMatcher.java
@@ -116,7 +116,7 @@ public class BitstreamMatcher {
         );
     }
 
-    private static Matcher<? super Object> matchProperties(Bitstream bitstream) {
+    public static Matcher<? super Object> matchProperties(Bitstream bitstream) {
         try {
             return allOf(
                     hasJsonPath("$.uuid", is(bitstream.getID().toString())),


### PR DESCRIPTION
## References
* Link to [JIRA](https://jira.lyrasis.org/browse/DS-4454) ticket
* Link to [previous REST implementation](https://github.com/DSpace/DSpace/pull/2778)

## Description
This functionality allows for bitstream metadata to be retrieved if:
* the current user has READ rights on the bitstream
* OR the current user has READ rights on the bitstream's bundle AND item

## Instructions for Reviewers
This is built on https://github.com/DSpace/DSpace/pull/2778, so only the last few commits are relevant here.

You can test this by creating private bitstreams and testing with anonymous or non-admin users to verify the bitstreams are only accessible on the given conditions.  
You can test this with direct bitstream retrievals or embeds

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/master/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
