### PR TITLE
DSpace (Solr) Statistics - Usage Reports

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
@@ -842,18 +842,18 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
     }
 
     @Override
-    public void query(String query, int max)
+    public void query(String query, int max, int facetMinCount)
             throws SolrServerException, IOException {
-        query(query, null, null, 0, max, null, null, null, null, null, false);
+        query(query, null, null, 0, max, null, null, null, null, null, false, facetMinCount);
     }
 
     @Override
     public ObjectCount[] queryFacetField(String query,
                                          String filterQuery, String facetField, int max, boolean showTotal,
-                                         List<String> facetQueries)
+                                         List<String> facetQueries, int facetMinCount)
             throws SolrServerException, IOException {
         QueryResponse queryResponse = query(query, filterQuery, facetField,
-                                            0, max, null, null, null, facetQueries, null, false);
+                                            0, max, null, null, null, facetQueries, null, false, facetMinCount);
         if (queryResponse == null) {
             return new ObjectCount[0];
         }
@@ -887,50 +887,55 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
     @Override
     public ObjectCount[] queryFacetDate(String query,
                                         String filterQuery, int max, String dateType, String dateStart,
-                                        String dateEnd, boolean showTotal, Context context)
+                                        String dateEnd, boolean showTotal, Context context, int facetMinCount)
             throws SolrServerException, IOException {
         QueryResponse queryResponse = query(query, filterQuery, null, 0, max,
-                                            dateType, dateStart, dateEnd, null, null, false);
+                                            dateType, dateStart, dateEnd, null, null, false, facetMinCount);
         if (queryResponse == null) {
             return new ObjectCount[0];
         }
 
-        FacetField dateFacet = queryResponse.getFacetDate("time");
-        // TODO: check if this cannot crash I checked it, it crashed!!!
-        // Create an array for our result
-        ObjectCount[] result = new ObjectCount[dateFacet.getValueCount()
-            + (showTotal ? 1 : 0)];
-        // Run over our datefacet & store all the values
-        for (int i = 0; i < dateFacet.getValues().size(); i++) {
-            FacetField.Count dateCount = dateFacet.getValues().get(i);
-            result[i] = new ObjectCount();
-            result[i].setCount(dateCount.getCount());
-            result[i].setValue(getDateView(dateCount.getName(), dateType, context));
+        List<RangeFacet> rangeFacets = queryResponse.getFacetRanges();
+        for (RangeFacet rangeFacet: rangeFacets) {
+            if (rangeFacet.getName().equalsIgnoreCase("time")) {
+                RangeFacet timeFacet = rangeFacet;
+                // Create an array for our result
+                ObjectCount[] result = new ObjectCount[timeFacet.getCounts().size()
+                                                       + (showTotal ? 1 : 0)];
+                // Run over our datefacet & store all the values
+                for (int i = 0; i < timeFacet.getCounts().size(); i++) {
+                    RangeFacet.Count dateCount = (RangeFacet.Count) timeFacet.getCounts().get(i);
+                    result[i] = new ObjectCount();
+                    result[i].setCount(dateCount.getCount());
+                    result[i].setValue(getDateView(dateCount.getValue(), dateType, context));
+                }
+                if (showTotal) {
+                    result[result.length - 1] = new ObjectCount();
+                    result[result.length - 1].setCount(queryResponse.getResults()
+                                                                    .getNumFound());
+                    // TODO: Make sure that this total is gotten out of the msgs.xml
+                    result[result.length - 1].setValue("total");
+                }
+                return result;
+            }
         }
-        if (showTotal) {
-            result[result.length - 1] = new ObjectCount();
-            result[result.length - 1].setCount(queryResponse.getResults()
-                                                            .getNumFound());
-            // TODO: Make sure that this total is gotten out of the msgs.xml
-            result[result.length - 1].setValue("total");
-        }
-        return result;
+        return new ObjectCount[0];
     }
 
     @Override
-    public Map<String, Integer> queryFacetQuery(String query,
-                                                String filterQuery, List<String> facetQueries)
+    public Map<String, Integer> queryFacetQuery(String query, String filterQuery, List<String> facetQueries,
+                                                int facetMinCount)
         throws SolrServerException, IOException {
         QueryResponse response = query(query, filterQuery, null, 0, 1, null, null,
-                                       null, facetQueries, null, false);
+                                       null, facetQueries, null, false, facetMinCount);
         return response.getFacetQuery();
     }
 
     @Override
-    public ObjectCount queryTotal(String query, String filterQuery)
+    public ObjectCount queryTotal(String query, String filterQuery, int facetMinCount)
         throws SolrServerException, IOException {
         QueryResponse queryResponse = query(query, filterQuery, null, 0, -1, null,
-                                            null, null, null, null, false);
+                                            null, null, null, null, false, facetMinCount);
         ObjectCount objCount = new ObjectCount();
         objCount.setCount(queryResponse.getResults().getNumFound());
 
@@ -985,7 +990,8 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
     @Override
     public QueryResponse query(String query, String filterQuery,
                                String facetField, int rows, int max, String dateType, String dateStart,
-                               String dateEnd, List<String> facetQueries, String sort, boolean ascending)
+                               String dateEnd, List<String> facetQueries, String sort, boolean ascending,
+                               int facetMinCount)
         throws SolrServerException, IOException {
         if (solr == null) {
             return null;
@@ -993,20 +999,20 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
 
         // System.out.println("QUERY");
         SolrQuery solrQuery = new SolrQuery().setRows(rows).setQuery(query)
-                                             .setFacetMinCount(1);
+                                             .setFacetMinCount(facetMinCount);
         addAdditionalSolrYearCores(solrQuery);
 
         // Set the date facet if present
         if (dateType != null) {
-            solrQuery.setParam("facet.date", "time")
+            solrQuery.setParam("facet.range", "time")
                 .
                 // EXAMPLE: NOW/MONTH+1MONTH
-                    setParam("facet.date.end",
+                    setParam("f.time.facet.range.end",
                              "NOW/" + dateType + dateEnd + dateType).setParam(
-                "facet.date.gap", "+1" + dateType)
+                "f.time.facet.range.gap", "+1" + dateType)
                 .
                 // EXAMPLE: NOW/MONTH-" + nbMonths + "MONTHS
-                    setParam("facet.date.start",
+                    setParam("f.time.facet.range.start",
                              "NOW/" + dateType + dateStart + dateType + "S")
                 .setFacet(true);
         }

--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
@@ -253,7 +253,7 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
 
             solr.add(doc1);
             //commits are executed automatically using the solr autocommit
-//            solr.commit(false, false);
+            solr.commit(false, false);
 
         } catch (RuntimeException re) {
             throw re;
@@ -289,7 +289,7 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
 
             solr.add(doc1);
             // commits are executed automatically using the solr autocommit
-            // solr.commit(false, false);
+             solr.commit(false, false);
 
         } catch (RuntimeException re) {
             throw re;

--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
@@ -252,8 +252,11 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
 
 
             solr.add(doc1);
-            //commits are executed automatically using the solr autocommit
-            solr.commit(false, false);
+            // commits are executed automatically using the solr autocommit
+            boolean useAutoCommit = configurationService.getBooleanProperty("solr-statistics.autoCommit", true);
+            if (!useAutoCommit) {
+                solr.commit(false, false);
+            }
 
         } catch (RuntimeException re) {
             throw re;
@@ -289,7 +292,10 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
 
             solr.add(doc1);
             // commits are executed automatically using the solr autocommit
-            solr.commit(false, false);
+            boolean useAutoCommit = configurationService.getBooleanProperty("solr-statistics.autoCommit", true);
+            if (!useAutoCommit) {
+                solr.commit(false, false);
+            }
 
         } catch (RuntimeException re) {
             throw re;

--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
@@ -1561,7 +1561,8 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
      * initialization at the same time.
      */
     protected synchronized void initSolrYearCores() {
-        if (statisticYearCoresInit || !(solr instanceof HttpSolrClient)) {
+        if (statisticYearCoresInit || !(solr instanceof HttpSolrClient) || !configurationService.getBooleanProperty(
+            "usage-statistics.shardedByYear", false)) {
             return;
         }
 

--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
@@ -289,7 +289,7 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
 
             solr.add(doc1);
             // commits are executed automatically using the solr autocommit
-             solr.commit(false, false);
+            solr.commit(false, false);
 
         } catch (RuntimeException re) {
             throw re;

--- a/dspace-api/src/main/java/org/dspace/statistics/content/DatasetTimeGenerator.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/DatasetTimeGenerator.java
@@ -31,7 +31,7 @@ public class DatasetTimeGenerator extends DatasetGenerator {
     /**
      * Default constructor
      */
-    private DatasetTimeGenerator() { }
+    public DatasetTimeGenerator() { }
 
     /**
      * Sets the date interval.

--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsBSAdapter.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsBSAdapter.java
@@ -68,11 +68,11 @@ public class StatisticsBSAdapter {
         switch (visitType) {
             case ITEM_VISITS:
                 return solrLoggerService
-                    .queryTotal("type: " + Constants.ITEM + " AND id: " + item.getID(), resolveFilterQueries())
+                    .queryTotal("type: " + Constants.ITEM + " AND id: " + item.getID(), resolveFilterQueries(), 0)
                     .getCount();
             case BITSTREAM_VISITS:
                 return solrLoggerService.queryTotal("type: " + Constants.BITSTREAM + " AND owningItem: " + item.getID(),
-                                                    resolveFilterQueries()).getCount();
+                                                    resolveFilterQueries(), 0).getCount();
             case TOTAL_VISITS:
                 return getNumberOfVisits(ITEM_VISITS, item) + getNumberOfVisits(BITSTREAM_VISITS, item);
             default:

--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsData.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsData.java
@@ -115,13 +115,14 @@ public abstract class StatisticsData {
      * Run the accumulated query and return its results.
      *
      * @param context The relevant DSpace Context.
+     * @param facetMinCount Minimum count of results facet must have to return a result
      * @return accumulated query results
      * @throws SQLException        An exception that provides information on a database access error or other errors.
      * @throws SolrServerException Exception from the Solr server to the solrj Java client.
      * @throws IOException         A general class of exceptions produced by failed or interrupted I/O operations.
      * @throws ParseException      if the dataset cannot be parsed
      */
-    public abstract Dataset createDataset(Context context) throws SQLException,
+    public abstract Dataset createDataset(Context context, int facetMinCount) throws SQLException,
         SolrServerException, IOException, ParseException;
 
 }

--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
@@ -284,7 +284,8 @@ public class StatisticsDataVisits extends StatisticsData {
 
             ObjectCount[] topCounts1 = null;
 //            if (firsDataset.getQueries().size() == 1) {
-            topCounts1 = queryFacetField(firsDataset, firsDataset.getQueries().get(0).getQuery(), filterQuery, facetMinCount);
+            topCounts1 =
+                queryFacetField(firsDataset, firsDataset.getQueries().get(0).getQuery(), filterQuery, facetMinCount);
 //            } else {
 //                TODO: do this
 //            }

--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
@@ -673,7 +673,7 @@ public class StatisticsDataVisits extends StatisticsData {
 
                 case Constants.ITEM:
                     Item item = itemService.findByIdOrLegacyId(context, dsoId);
-                    if (item == null) {
+                    if (item == null || item.getHandle() == null) {
                         break;
                     }
 
@@ -682,7 +682,7 @@ public class StatisticsDataVisits extends StatisticsData {
 
                 case Constants.COLLECTION:
                     Collection coll = collectionService.findByIdOrLegacyId(context, dsoId);
-                    if (coll == null) {
+                    if (coll == null || coll.getHandle() == null) {
                         break;
                     }
 
@@ -691,7 +691,7 @@ public class StatisticsDataVisits extends StatisticsData {
 
                 case Constants.COMMUNITY:
                     Community comm = communityService.findByIdOrLegacyId(context, dsoId);
-                    if (comm == null) {
+                    if (comm == null || comm.getHandle() == null) {
                         break;
                     }
 

--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
@@ -58,7 +58,7 @@ import org.dspace.statistics.util.LocationUtils;
  * <li>Add a {@link DatasetDSpaceObjectGenerator} for the appropriate object type.</li>
  * <li>Add other generators as required to get the statistic you want.</li>
  * <li>Add {@link org.dspace.statistics.content.filter filters} as required.</li>
- * <li>{@link #createDataset(Context)} will run the query and return a result matrix.
+ * <li>{@link #createDataset(Context, int)} will run the query and return a result matrix.
  * Subsequent calls skip the query and return the same matrix.</li>
  * </ol>
  *
@@ -117,7 +117,7 @@ public class StatisticsDataVisits extends StatisticsData {
     }
 
     @Override
-    public Dataset createDataset(Context context) throws SQLException,
+    public Dataset createDataset(Context context, int facetMinCount) throws SQLException,
         SolrServerException, ParseException, IOException {
         // Check if we already have one.
         // If we do then give it back.
@@ -214,7 +214,8 @@ public class StatisticsDataVisits extends StatisticsData {
                         // We are asking from our current query all the visits faceted by date
                         ObjectCount[] results = solrLoggerService
                             .queryFacetDate(query, filterQuery, dataSetQuery.getMax(), dateFacet.getDateType(),
-                                            dateFacet.getStartDate(), dateFacet.getEndDate(), showTotal, context);
+                                            dateFacet.getStartDate(), dateFacet.getEndDate(), showTotal, context,
+                                            facetMinCount);
                         dataset = new Dataset(1, results.length);
                         // Now that we have our results put em in a matrix
                         for (int j = 0; j < results.length; j++) {
@@ -230,15 +231,15 @@ public class StatisticsDataVisits extends StatisticsData {
                         // the datasettimequery
                         ObjectCount[] maxObjectCounts = solrLoggerService
                             .queryFacetField(query, filterQuery, dataSetQuery.getFacetField(), dataSetQuery.getMax(),
-                                             false, null);
+                                             false, null, facetMinCount);
                         for (int j = 0; j < maxObjectCounts.length; j++) {
                             ObjectCount firstCount = maxObjectCounts[j];
                             String newQuery = dataSetQuery.getFacetField() + ": " + ClientUtils
                                 .escapeQueryChars(firstCount.getValue()) + " AND " + query;
                             ObjectCount[] maxDateFacetCounts = solrLoggerService
                                 .queryFacetDate(newQuery, filterQuery, dataSetQuery.getMax(), dateFacet.getDateType(),
-                                                dateFacet.getStartDate(), dateFacet.getEndDate(), showTotal, context);
-
+                                                dateFacet.getStartDate(), dateFacet.getEndDate(), showTotal, context,
+                                                facetMinCount);
 
                             // Make sure we have a dataSet
                             if (dataset == null) {
@@ -283,7 +284,7 @@ public class StatisticsDataVisits extends StatisticsData {
 
             ObjectCount[] topCounts1 = null;
 //            if (firsDataset.getQueries().size() == 1) {
-            topCounts1 = queryFacetField(firsDataset, firsDataset.getQueries().get(0).getQuery(), filterQuery);
+            topCounts1 = queryFacetField(firsDataset, firsDataset.getQueries().get(0).getQuery(), filterQuery, facetMinCount);
 //            } else {
 //                TODO: do this
 //            }
@@ -292,7 +293,7 @@ public class StatisticsDataVisits extends StatisticsData {
                 DatasetQuery secondDataSet = datasetQueries.get(1);
                 // Now do the second one
                 ObjectCount[] topCounts2 = queryFacetField(secondDataSet, secondDataSet.getQueries().get(0).getQuery(),
-                                                           filterQuery);
+                                                           filterQuery, facetMinCount);
                 // Now that have results for both of them lets do x.y queries
                 List<String> facetQueries = new ArrayList<String>();
                 for (ObjectCount count2 : topCounts2) {
@@ -325,7 +326,7 @@ public class StatisticsDataVisits extends StatisticsData {
                     }
 
                     Map<String, Integer> facetResult = solrLoggerService
-                        .queryFacetQuery(query, filterQuery, facetQueries);
+                        .queryFacetQuery(query, filterQuery, facetQueries, facetMinCount);
 
 
                     // TODO: the show total
@@ -704,12 +705,12 @@ public class StatisticsDataVisits extends StatisticsData {
 
 
     protected ObjectCount[] queryFacetField(DatasetQuery dataset, String query,
-                                            String filterQuery)
+                                            String filterQuery, int facetMinCount)
             throws SolrServerException, IOException {
         String facetType = dataset.getFacetField() == null ? "id" : dataset
             .getFacetField();
         return solrLoggerService.queryFacetField(query, filterQuery, facetType,
-                                                 dataset.getMax(), false, null);
+                                                 dataset.getMax(), false, null, facetMinCount);
     }
 
     public static class DatasetQuery {

--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDisplay.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDisplay.java
@@ -83,8 +83,9 @@ public abstract class StatisticsDisplay {
         return statisticsData.getDataset();
     }
 
-    public Dataset getDataset(Context context) throws SQLException, SolrServerException, IOException, ParseException {
-        return statisticsData.createDataset(context);
+    public Dataset getDataset(Context context, int facetMinCount) throws SQLException, SolrServerException, IOException,
+        ParseException {
+        return statisticsData.createDataset(context, facetMinCount);
     }
 
     public void addCss(String style) {

--- a/dspace-api/src/main/java/org/dspace/statistics/service/SolrLoggerService.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/service/SolrLoggerService.java
@@ -116,7 +116,7 @@ public interface SolrLoggerService {
                        List<String> fieldNames, List<List<Object>> fieldValuesList)
         throws SolrServerException, IOException;
 
-    public void query(String query, int max)
+    public void query(String query, int max, int facetMinCount)
         throws SolrServerException, IOException;
 
     /**
@@ -130,13 +130,14 @@ public interface SolrLoggerService {
      * @param showTotal    a boolean determining whether the total amount should be given
      *                     back as the last element of the array
      * @param facetQueries list of facet queries
+     * @param facetMinCount Minimum count of results facet must have to return a result
      * @return an array containing our results
      * @throws SolrServerException Exception from the Solr server to the solrj Java client.
      * @throws java.io.IOException passed through.
      */
     public ObjectCount[] queryFacetField(String query,
                                          String filterQuery, String facetField, int max, boolean showTotal,
-                                         List<String> facetQueries)
+                                         List<String> facetQueries, int facetMinCount)
         throws SolrServerException, IOException;
 
     /**
@@ -154,25 +155,27 @@ public interface SolrLoggerService {
      * @param showTotal   a boolean determining whether the total amount should be given
      *                    back as the last element of the array
      * @param context     The relevant DSpace Context.
+     * @param facetMinCount Minimum count of results facet must have to return a result
      * @return and array containing our results
      * @throws SolrServerException Exception from the Solr server to the solrj Java client.
      * @throws java.io.IOException passed through.
      */
     public ObjectCount[] queryFacetDate(String query,
                                         String filterQuery, int max, String dateType, String dateStart,
-                                        String dateEnd, boolean showTotal, Context context)
+                                        String dateEnd, boolean showTotal, Context context, int facetMinCount)
         throws SolrServerException, IOException;
 
-    public Map<String, Integer> queryFacetQuery(String query,
-                                                String filterQuery, List<String> facetQueries)
+    public Map<String, Integer> queryFacetQuery(String query, String filterQuery, List<String> facetQueries,
+                                                int facetMinCount)
         throws SolrServerException, IOException;
 
-    public ObjectCount queryTotal(String query, String filterQuery)
+    public ObjectCount queryTotal(String query, String filterQuery, int facetMinCount)
         throws SolrServerException, IOException;
 
     public QueryResponse query(String query, String filterQuery,
                                String facetField, int rows, int max, String dateType, String dateStart,
-                               String dateEnd, List<String> facetQueries, String sort, boolean ascending)
+                               String dateEnd, List<String> facetQueries, String sort, boolean ascending,
+                               int facetMinCount)
         throws SolrServerException, IOException;
 
     /**

--- a/dspace-api/src/main/java/org/dspace/statistics/util/LocationUtils.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/LocationUtils.java
@@ -8,7 +8,9 @@
 package org.dspace.statistics.util;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 import java.util.MissingResourceException;
 import java.util.Properties;
 import java.util.ResourceBundle;
@@ -34,7 +36,8 @@ public class LocationUtils {
     /**
      * Default constructor
      */
-    private LocationUtils() { }
+    private LocationUtils() {
+    }
 
     /**
      * Map DSpace continent codes onto ISO country codes.
@@ -53,7 +56,7 @@ public class LocationUtils {
         if (countryToContinent.isEmpty()) {
             try {
                 countryToContinent.load(LocationUtils.class
-                                            .getResourceAsStream("country-continent-codes.properties"));
+                    .getResourceAsStream("country-continent-codes.properties"));
             } catch (IOException e) {
                 logger.error("Could not load country/continent map file", e);
             }
@@ -105,7 +108,7 @@ public class LocationUtils {
             names = ResourceBundle.getBundle(CONTINENT_NAMES_BUNDLE, locale);
         } catch (MissingResourceException e) {
             logger.error("Could not load continent code/name resource bundle",
-                         e);
+                e);
             return I18nUtil
                 .getMessage("org.dspace.statistics.util.LocationUtils.unknown-continent");
         }
@@ -115,7 +118,7 @@ public class LocationUtils {
             name = names.getString(continentCode);
         } catch (MissingResourceException e) {
             logger.info("No continent code " + continentCode + " in bundle "
-                            + names.getLocale().getDisplayName());
+                        + names.getLocale().getDisplayName());
             return I18nUtil
                 .getMessage("org.dspace.statistics.util.LocationUtils.unknown-continent");
         }
@@ -132,6 +135,36 @@ public class LocationUtils {
     @Deprecated
     static public String getCountryName(String countryCode) {
         return getCountryName(countryCode, Locale.getDefault());
+    }
+
+    /**
+     * Revert a country name back into a country code (iso2)
+     * Source: https://stackoverflow.com/a/38588988
+     *
+     * @param countryName Name of country (according to Locale)
+     * @return Corresponding iso2 country code
+     */
+    static public String getCountryCode(String countryName) {
+        // Get all country codes in a string array.
+        String[] isoCountryCodes = Locale.getISOCountries();
+        Map<String, String> countryMap = new HashMap<>();
+        Locale locale;
+        String name;
+
+        // Iterate through all country codes:
+        for (String code : isoCountryCodes) {
+            // Create a locale using each country code
+            locale = new Locale("", code);
+            // Get country name for each code.
+            name = locale.getDisplayCountry();
+            // Map all country names and codes in key - value pairs.
+            countryMap.put(name, code);
+        }
+
+        // Return the country code for the given country name using the map.
+        // Here you will need some validation or better yet
+        // a list of countries to give to user to choose from.
+        return countryMap.get(countryName); // "NL" for Netherlands.
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/statistics/MockSolrLoggerServiceImpl.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/MockSolrLoggerServiceImpl.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.maxmind.geoip2.DatabaseReader;
 import com.maxmind.geoip2.model.CityResponse;
@@ -66,8 +67,10 @@ public class MockSolrLoggerServiceImpl
      * @return faked CityResponse
      */
     private CityResponse mockCityResponse() {
-        List<String> cityNames = new ArrayList<>(Collections.singleton("New York"));
-        City city = new City(cityNames, 1, 1, new HashMap());
+        List<String> cityLocales = new ArrayList<String>(Collections.singleton("en"));
+        Map<String, String> cityNames = new HashMap<>();
+        cityNames.put("en", "New York");
+        City city = new City(cityLocales, 1, 1, cityNames);
 
         List<String> countryNames = new ArrayList<>(Collections.singleton("United States"));
         Country country = new Country(countryNames, 1, 1, "US", new HashMap());

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/StatisticsRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/StatisticsRestController.java
@@ -40,6 +40,7 @@ import org.springframework.hateoas.RepresentationModel;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -125,6 +126,7 @@ public class StatisticsRestController implements InitializingBean {
     }
 
     @RequestMapping(method = RequestMethod.GET, value = "/usagereports/{uuid_id}")
+    @PreAuthorize("hasPermission(#uuidObjectReportId, 'usagereport', 'READ')")
     public UsageReportRest getUsageReport(@PathVariable(name = "uuid_id") String uuidObjectReportId,
                                           HttpServletRequest request)
         throws ParseException, SolrServerException, IOException {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/StatisticsRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/StatisticsRestController.java
@@ -120,12 +120,13 @@ public class StatisticsRestController implements InitializingBean {
 
     @RequestMapping(method = RequestMethod.GET, value = "/usagereports")
     public PagedModel<SearchEventResource> getUsageReports() {
-        throw new RepositoryMethodNotImplementedException("No implementation found; Method not allowed!", "getUsageReports");
+        throw new RepositoryMethodNotImplementedException("No implementation found; Method not allowed!",
+            "getUsageReports");
     }
 
     @RequestMapping(method = RequestMethod.GET, value = "/usagereports/{uuid_id}")
     public UsageReportRest getUsageReport(@PathVariable(name = "uuid_id") String uuidObjectReportId,
-                                              HttpServletRequest request)
+                                          HttpServletRequest request)
         throws ParseException, SolrServerException, IOException {
         if (StringUtils.countMatches(uuidObjectReportId, "_") != 1) {
             throw new IllegalArgumentException("Must end in objectUUID_reportId, example: " +

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/StatisticsRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/StatisticsRestController.java
@@ -132,9 +132,7 @@ public class StatisticsRestController implements InitializingBean {
                                                "1911e8a4-6939-490c-b58b-a5d70f8d91fb_TopCountries");
         }
         UUID uuidObject = UUID.fromString(StringUtils.substringBefore(uuidObjectReportId, "_"));
-        // TODO check if valid object uuid
         String reportId = StringUtils.substringAfter(uuidObjectReportId, "_");
-        // TODO check if valid report id
         Context context = ContextUtil.obtainContext(request);
 
         UsageReportRest usageReportRest = usageReportRestRepository.createUsageReport(context, uuidObject, reportId);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/StatisticsRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/StatisticsRestController.java
@@ -7,50 +7,32 @@
  */
 package org.dspace.app.rest;
 
-import java.io.IOException;
-import java.sql.SQLException;
-import java.text.ParseException;
 import java.util.Arrays;
-import java.util.List;
 import java.util.UUID;
-import javax.servlet.http.HttpServletRequest;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.solr.client.solrj.SolrServerException;
 import org.dspace.app.rest.converter.ConverterService;
 import org.dspace.app.rest.exception.RepositoryMethodNotImplementedException;
-import org.dspace.app.rest.link.HalLinkService;
 import org.dspace.app.rest.model.RestAddressableModel;
 import org.dspace.app.rest.model.StatisticsSupportRest;
-import org.dspace.app.rest.model.UsageReportRest;
 import org.dspace.app.rest.model.hateoas.SearchEventResource;
 import org.dspace.app.rest.model.hateoas.StatisticsSupportResource;
-import org.dspace.app.rest.model.hateoas.UsageReportResource;
 import org.dspace.app.rest.model.hateoas.ViewEventResource;
 import org.dspace.app.rest.repository.SearchEventRestRepository;
 import org.dspace.app.rest.repository.StatisticsRestRepository;
-import org.dspace.app.rest.repository.UsageReportRestRepository;
 import org.dspace.app.rest.repository.ViewEventRestRepository;
-import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.app.rest.utils.Utils;
-import org.dspace.core.Context;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.ControllerUtils;
-import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.hateoas.RepresentationModel;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -64,9 +46,6 @@ public class StatisticsRestController implements InitializingBean {
     private DiscoverableEndpointsService discoverableEndpointsService;
 
     @Autowired
-    private HalLinkService halLinkService;
-
-    @Autowired
     private ConverterService converter;
 
     @Autowired
@@ -77,9 +56,6 @@ public class StatisticsRestController implements InitializingBean {
 
     @Autowired
     private SearchEventRestRepository searchEventRestRepository;
-
-    @Autowired
-    private UsageReportRestRepository usageReportRestRepository;
 
     @Override
     public void afterPropertiesSet() throws Exception {
@@ -124,50 +100,6 @@ public class StatisticsRestController implements InitializingBean {
     public ResponseEntity<RepresentationModel<?>> postSearchEvent() throws Exception {
         SearchEventResource result = converter.toResource(searchEventRestRepository.createSearchEvent());
         return ControllerUtils.toResponseEntity(HttpStatus.CREATED, new HttpHeaders(), result);
-    }
-
-    @RequestMapping(method = RequestMethod.GET, value = "/usagereports")
-    public PagedModel<SearchEventResource> getUsageReports() {
-        throw new RepositoryMethodNotImplementedException("No implementation found; Method not allowed!",
-            "getUsageReports");
-    }
-
-    @RequestMapping(method = RequestMethod.GET, value = "/usagereports/{uuid_id}")
-    @PreAuthorize("hasPermission(#uuidObjectReportId, 'usagereport', 'READ')")
-    public UsageReportRest getUsageReport(@PathVariable(name = "uuid_id") String uuidObjectReportId,
-                                          HttpServletRequest request)
-        throws ParseException, SolrServerException, IOException {
-        if (StringUtils.countMatches(uuidObjectReportId, "_") != 1) {
-            throw new IllegalArgumentException("Must end in objectUUID_reportId, example: " +
-                                               "1911e8a4-6939-490c-b58b-a5d70f8d91fb_TopCountries");
-        }
-        UUID uuidObject = UUID.fromString(StringUtils.substringBefore(uuidObjectReportId, "_"));
-        String reportId = StringUtils.substringAfter(uuidObjectReportId, "_");
-        Context context = ContextUtil.obtainContext(request);
-
-        UsageReportRest usageReportRest = usageReportRestRepository.createUsageReport(context, uuidObject, reportId);
-
-        return usageReportRest;
-    }
-
-    @RequestMapping(method = RequestMethod.GET, value = "/usagereports/search/object")
-    @PreAuthorize("hasPermission(#uri, 'usagereportsearch', 'READ')")
-    public PagedModel<UsageReportResource> searchUsageReports(HttpServletRequest request,
-                                                    @RequestParam(name = "uri", required = true) String uri,
-                                                    Pageable pageable,
-                                                    PagedResourcesAssembler assembler)
-        throws SQLException, IOException, ParseException, SolrServerException {
-        UUID uuid = UUID.fromString(StringUtils.substringAfterLast(uri, "/"));
-        Context context = ContextUtil.obtainContext(request);
-        List<UsageReportRest> usageReportsOfItem = usageReportRestRepository.getUsageReportsOfDSO(context, uuid);
-        Page<UsageReportRest> usageReportsRestPage = converter.toRestPage(usageReportsOfItem, pageable,
-            utils.obtainProjection());
-
-        Page<UsageReportResource> usageReportsRestPageResources = usageReportsRestPage
-            .map(usageReportRest -> new UsageReportResource(usageReportRest, utils));
-        usageReportsRestPageResources.forEach(halLinkService::addLinks);
-        PagedModel<UsageReportResource> result = assembler.toModel(usageReportsRestPageResources);
-        return result;
     }
 
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/UsageReportConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/UsageReportConverter.java
@@ -1,0 +1,31 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.converter;
+
+import org.dspace.app.rest.model.UsageReportRest;
+import org.dspace.app.rest.projection.Projection;
+import org.springframework.stereotype.Component;
+
+/**
+ * Converter so list of UsageReportRest can be converted in to a rest page
+ *
+ * @author Maria Verdonck (Atmire) on 11/06/2020
+ */
+@Component
+public class UsageReportConverter implements DSpaceConverter<UsageReportRest, UsageReportRest> {
+    @Override
+    public UsageReportRest convert(UsageReportRest modelObject, Projection projection) {
+        modelObject.setProjection(projection);
+        return modelObject;
+    }
+
+    @Override
+    public Class<UsageReportRest> getModelClass() {
+        return UsageReportRest.class;
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointCityRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointCityRest.java
@@ -20,4 +20,10 @@ public class UsageReportPointCityRest extends UsageReportPointRest {
     public String getType() {
         return NAME;
     }
+
+    @Override
+    public void setId(String id) {
+        super.id = id;
+        super.label = id;
+    }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointCityRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointCityRest.java
@@ -1,0 +1,52 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class serves as a REST representation of a City data Point of a {@link UsageReportRest} from the DSpace
+ * statistics
+ *
+ * @author Maria Verdonck (Atmire) on 08/06/2020
+ */
+public class UsageReportPointCityRest extends UsageReportPointRest {
+    public static final String NAME = "city";
+
+    private String id;
+    private Map<String, Integer> values;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Map<String, Integer> getValues() {
+        return values;
+    }
+
+    public void addValue(String key, Integer value) {
+        if (values == null) {
+            values = new HashMap<>();
+        }
+        values.put(key, value);
+    }
+
+    public void setValues(Map<String, Integer> values) {
+        this.values = values;
+    }
+
+    @Override
+    public String getType() {
+        return NAME;
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointCityRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointCityRest.java
@@ -7,9 +7,6 @@
  */
 package org.dspace.app.rest.model;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * This class serves as a REST representation of a City data Point of a {@link UsageReportRest} from the DSpace
  * statistics
@@ -18,32 +15,6 @@ import java.util.Map;
  */
 public class UsageReportPointCityRest extends UsageReportPointRest {
     public static final String NAME = "city";
-
-    private String id;
-    private Map<String, Integer> values;
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public Map<String, Integer> getValues() {
-        return values;
-    }
-
-    public void addValue(String key, Integer value) {
-        if (values == null) {
-            values = new HashMap<>();
-        }
-        values.put(key, value);
-    }
-
-    public void setValues(Map<String, Integer> values) {
-        this.values = values;
-    }
 
     @Override
     public String getType() {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointCountryRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointCountryRest.java
@@ -18,20 +18,16 @@ import org.dspace.statistics.util.LocationUtils;
 public class UsageReportPointCountryRest extends UsageReportPointRest {
     public static final String NAME = "country";
 
-    private String label;
-    public String getLabel() {
-        return label;
-    }
-
+    @Override
     public void setLabel(String label) {
-        this.label = label;
+        super.label = label;
         super.id = LocationUtils.getCountryCode(label);
     }
 
     @Override
     public void setId(String id) {
         super.id = id;
-        this.label = LocationUtils.getCountryName(id);
+        super.label = LocationUtils.getCountryName(id);
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointCountryRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointCountryRest.java
@@ -1,0 +1,65 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.dspace.statistics.util.LocationUtils;
+
+/**
+ * This class serves as a REST representation of a Country data Point of a {@link UsageReportRest} from the DSpace
+ * statistics
+ *
+ * @author Maria Verdonck (Atmire) on 08/06/2020
+ */
+public class UsageReportPointCountryRest extends UsageReportPointRest {
+    public static final String NAME = "country";
+
+    private String label;
+    private String id;
+    private Map<String, Integer> values;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+        this.label = LocationUtils.getCountryName(id);
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+        this.id = LocationUtils.getCountryCode(label);
+    }
+
+    public Map<String, Integer> getValues() {
+        return values;
+    }
+
+    public void addValue(String key, Integer value) {
+        if (values == null) {
+            values = new HashMap<>();
+        }
+        values.put(key, value);
+    }
+
+    public void setValues(Map<String, Integer> values) {
+        this.values = values;
+    }
+
+    @Override
+    public String getType() {
+        return NAME;
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointCountryRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointCountryRest.java
@@ -7,9 +7,6 @@
  */
 package org.dspace.app.rest.model;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.dspace.statistics.util.LocationUtils;
 
 /**
@@ -22,40 +19,19 @@ public class UsageReportPointCountryRest extends UsageReportPointRest {
     public static final String NAME = "country";
 
     private String label;
-    private String id;
-    private Map<String, Integer> values;
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-        this.label = LocationUtils.getCountryName(id);
-    }
-
     public String getLabel() {
         return label;
     }
 
     public void setLabel(String label) {
         this.label = label;
-        this.id = LocationUtils.getCountryCode(label);
+        super.id = LocationUtils.getCountryCode(label);
     }
 
-    public Map<String, Integer> getValues() {
-        return values;
-    }
-
-    public void addValue(String key, Integer value) {
-        if (values == null) {
-            values = new HashMap<>();
-        }
-        values.put(key, value);
-    }
-
-    public void setValues(Map<String, Integer> values) {
-        this.values = values;
+    @Override
+    public void setId(String id) {
+        super.id = id;
+        this.label = LocationUtils.getCountryName(id);
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointDateRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointDateRest.java
@@ -1,0 +1,52 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class serves as a REST representation of a Date (month) data Point of a {@link UsageReportRest} from the DSpace
+ * statistics
+ *
+ * @author Maria Verdonck (Atmire) on 08/06/2020
+ */
+public class UsageReportPointDateRest extends UsageReportPointRest {
+    public static final String NAME = "date";
+
+    private String id;
+    private Map<String, Integer> values;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Map<String, Integer> getValues() {
+        return values;
+    }
+
+    public void addValue(String key, Integer value) {
+        if (values == null) {
+            values = new HashMap<>();
+        }
+        values.put(key, value);
+    }
+
+    public void setValues(Map<String, Integer> values) {
+        this.values = values;
+    }
+
+    @Override
+    public String getType() {
+        return NAME;
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointDateRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointDateRest.java
@@ -7,9 +7,6 @@
  */
 package org.dspace.app.rest.model;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * This class serves as a REST representation of a Date (month) data Point of a {@link UsageReportRest} from the DSpace
  * statistics
@@ -18,32 +15,6 @@ import java.util.Map;
  */
 public class UsageReportPointDateRest extends UsageReportPointRest {
     public static final String NAME = "date";
-
-    private String id;
-    private Map<String, Integer> values;
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public Map<String, Integer> getValues() {
-        return values;
-    }
-
-    public void addValue(String key, Integer value) {
-        if (values == null) {
-            values = new HashMap<>();
-        }
-        values.put(key, value);
-    }
-
-    public void setValues(Map<String, Integer> values) {
-        this.values = values;
-    }
 
     @Override
     public String getType() {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointDateRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointDateRest.java
@@ -20,4 +20,10 @@ public class UsageReportPointDateRest extends UsageReportPointRest {
     public String getType() {
         return NAME;
     }
+
+    @Override
+    public void setId(String id) {
+        super.id = id;
+        super.label = id;
+    }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointDsoTotalVisitsRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointDsoTotalVisitsRest.java
@@ -15,6 +15,9 @@ package org.dspace.app.rest.model;
  */
 public class UsageReportPointDsoTotalVisitsRest extends UsageReportPointRest {
 
+    /**
+     * Type of dso a UsageReport is being requested of (e.g. item, bitstream, ...)
+     */
     private String type;
 
     @Override
@@ -22,6 +25,11 @@ public class UsageReportPointDsoTotalVisitsRest extends UsageReportPointRest {
         return this.type;
     }
 
+    /**
+     * Sets the type of this {@link UsageReportPointRest} object, should be type of dso concerned (e.g. item, bitstream, ...)
+     *
+     * @param type Type of dso a {@link UsageReportRest} object is being requested of (e.g. item, bitstream, ...)
+     */
     public void setType(String type) {
         this.type = type;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointDsoTotalVisitsRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointDsoTotalVisitsRest.java
@@ -16,6 +16,7 @@ package org.dspace.app.rest.model;
 public class UsageReportPointDsoTotalVisitsRest extends UsageReportPointRest {
 
     private String type;
+    private String label;
 
     @Override
     public String getType() {
@@ -24,5 +25,13 @@ public class UsageReportPointDsoTotalVisitsRest extends UsageReportPointRest {
 
     public void setType(String type) {
         this.type = type;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointDsoTotalVisitsRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointDsoTotalVisitsRest.java
@@ -1,0 +1,56 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class serves as a REST representation of a TotalVisit data Point of a DSO's {@link UsageReportRest} from the
+ * DSpace statistics
+ *
+ * @author Maria Verdonck (Atmire) on 08/06/2020
+ */
+public class UsageReportPointDsoTotalVisitsRest extends UsageReportPointRest {
+
+    private String type;
+    private String id;
+    private Map<String, Integer> values;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Map<String, Integer> getValues() {
+        return values;
+    }
+
+    public void addValue(String key, Integer value) {
+        if (values == null) {
+            values = new HashMap<>();
+        }
+        values.put(key, value);
+    }
+
+    public void setValues(Map<String, Integer> values) {
+        this.values = values;
+    }
+
+    @Override
+    public String getType() {
+        return this.type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointDsoTotalVisitsRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointDsoTotalVisitsRest.java
@@ -7,9 +7,6 @@
  */
 package org.dspace.app.rest.model;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * This class serves as a REST representation of a TotalVisit data Point of a DSO's {@link UsageReportRest} from the
  * DSpace statistics
@@ -19,31 +16,6 @@ import java.util.Map;
 public class UsageReportPointDsoTotalVisitsRest extends UsageReportPointRest {
 
     private String type;
-    private String id;
-    private Map<String, Integer> values;
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public Map<String, Integer> getValues() {
-        return values;
-    }
-
-    public void addValue(String key, Integer value) {
-        if (values == null) {
-            values = new HashMap<>();
-        }
-        values.put(key, value);
-    }
-
-    public void setValues(Map<String, Integer> values) {
-        this.values = values;
-    }
 
     @Override
     public String getType() {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointDsoTotalVisitsRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointDsoTotalVisitsRest.java
@@ -16,7 +16,6 @@ package org.dspace.app.rest.model;
 public class UsageReportPointDsoTotalVisitsRest extends UsageReportPointRest {
 
     private String type;
-    private String label;
 
     @Override
     public String getType() {
@@ -25,13 +24,5 @@ public class UsageReportPointDsoTotalVisitsRest extends UsageReportPointRest {
 
     public void setType(String type) {
         this.type = type;
-    }
-
-    public String getLabel() {
-        return label;
-    }
-
-    public void setLabel(String label) {
-        this.label = label;
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointRest.java
@@ -7,6 +7,9 @@
  */
 package org.dspace.app.rest.model;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.dspace.app.rest.StatisticsRestController;
 
 /**
@@ -17,6 +20,8 @@ import org.dspace.app.rest.StatisticsRestController;
 public class UsageReportPointRest extends BaseObjectRest<String> {
     public static final String NAME = "point";
     public static final String CATEGORY = RestModel.STATISTICS;
+    protected String id;
+    private Map<String, Integer> values;
 
     public String getCategory() {
         return CATEGORY;
@@ -28,5 +33,28 @@ public class UsageReportPointRest extends BaseObjectRest<String> {
 
     public String getType() {
         return NAME;
+    }
+
+    public Map<String, Integer> getValues() {
+        return values;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public void addValue(String key, Integer value) {
+        if (values == null) {
+            values = new HashMap<>();
+        }
+        values.put(key, value);
+    }
+
+    public void setValues(Map<String, Integer> values) {
+        this.values = values;
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointRest.java
@@ -1,0 +1,32 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import org.dspace.app.rest.StatisticsRestController;
+
+/**
+ * This class serves as a REST representation of a Point of a {@link UsageReportRest} from the DSpace statistics
+ *
+ * @author Maria Verdonck (Atmire) on 08/06/2020
+ */
+public class UsageReportPointRest extends BaseObjectRest<String> {
+    public static final String NAME = "point";
+    public static final String CATEGORY = RestModel.STATISTICS;
+
+    public String getCategory() {
+        return CATEGORY;
+    }
+
+    public Class getController() {
+        return StatisticsRestController.class;
+    }
+
+    public String getType() {
+        return NAME;
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointRest.java
@@ -10,7 +10,7 @@ package org.dspace.app.rest.model;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.dspace.app.rest.StatisticsRestController;
+import org.dspace.app.rest.RestResourceController;
 
 /**
  * This class serves as a REST representation of a Point of a {@link UsageReportRest} from the DSpace statistics
@@ -41,7 +41,7 @@ public class UsageReportPointRest extends BaseObjectRest<String> {
      */
     @Override
     public Class getController() {
-        return StatisticsRestController.class;
+        return RestResourceController.class;
     }
 
     /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointRest.java
@@ -21,6 +21,7 @@ public class UsageReportPointRest extends BaseObjectRest<String> {
     public static final String NAME = "point";
     public static final String CATEGORY = RestModel.STATISTICS;
     protected String id;
+    protected String label;
     private Map<String, Integer> values;
 
     public String getCategory() {
@@ -56,5 +57,13 @@ public class UsageReportPointRest extends BaseObjectRest<String> {
 
     public void setValues(Map<String, Integer> values) {
         this.values = values;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointRest.java
@@ -24,30 +24,69 @@ public class UsageReportPointRest extends BaseObjectRest<String> {
     protected String label;
     private Map<String, Integer> values;
 
+    /**
+     * Returns the category of this Rest object, {@link #CATEGORY}
+     *
+     * @return The category of this Rest object, {@link #CATEGORY}
+     */
+    @Override
     public String getCategory() {
         return CATEGORY;
     }
 
+    /**
+     * Return controller class responsible for this Rest object
+     *
+     * @return Controller class responsible for this Rest object
+     */
+    @Override
     public Class getController() {
         return StatisticsRestController.class;
     }
 
+    /**
+     * Returns the type of this {@link UsageReportPointRest} object
+     *
+     * @return Type of this {@link UsageReportPointRest} object
+     */
+    @Override
     public String getType() {
         return NAME;
     }
 
+    /**
+     * Returns the values of this {@link UsageReportPointRest} object, containing the amount of views
+     *
+     * @return The values of this {@link UsageReportPointRest} object, containing the amount of views
+     */
     public Map<String, Integer> getValues() {
         return values;
     }
 
+    /**
+     * Returns the id of this {@link UsageReportPointRest} object, of the form: type of UsageReport_dso uuid
+     *
+     * @return The id of this {@link UsageReportPointRest} object, of the form: type of UsageReport_dso uuid
+     */
     public String getId() {
         return id;
     }
 
+    /**
+     * Set the id of this {@link UsageReportPointRest} object, of the form: type of UsageReport_dso uuid
+     *
+     * @param id The id of this {@link UsageReportPointRest} object, of the form: type of UsageReport_dso uuid
+     */
     public void setId(String id) {
         this.id = id;
     }
 
+    /**
+     * Add a value pair to this {@link UsageReportPointRest} object's values
+     *
+     * @param key   Key of new value pair
+     * @param value Value of new value pair
+     */
     public void addValue(String key, Integer value) {
         if (values == null) {
             values = new HashMap<>();
@@ -55,14 +94,29 @@ public class UsageReportPointRest extends BaseObjectRest<String> {
         values.put(key, value);
     }
 
+    /**
+     * Sets all values of this {@link UsageReportPointRest} object
+     *
+     * @param values All values of this {@link UsageReportPointRest} object
+     */
     public void setValues(Map<String, Integer> values) {
         this.values = values;
     }
 
+    /**
+     * Returns label of this {@link UsageReportPointRest} object, e.g. the dso's name
+     *
+     * @return Label of this {@link UsageReportPointRest} object, e.g. the dso's name
+     */
     public String getLabel() {
         return label;
     }
 
+    /**
+     * Sets the label of this {@link UsageReportPointRest} object, e.g. the dso's name
+     *
+     * @param label Label of this {@link UsageReportPointRest} object, e.g. the dso's name
+     */
     public void setLabel(String label) {
         this.label = label;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportRest.java
@@ -47,6 +47,9 @@ public class UsageReportRest extends BaseObjectRest<String> {
     }
 
     public List<UsageReportPointRest> getPoints() {
+        if (points == null) {
+            points = new ArrayList<>();
+        }
         return points;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportRest.java
@@ -1,0 +1,63 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.dspace.app.rest.StatisticsRestController;
+
+/**
+ * This class serves as a REST representation of a Usage Report from the DSpace statistics
+ *
+ * @author Maria Verdonck (Atmire) on 08/06/2020
+ */
+public class UsageReportRest extends BaseObjectRest<String> {
+    public static final String NAME = "usagereport";
+    public static final String CATEGORY = RestModel.STATISTICS;
+
+    @JsonProperty(value = "report-type")
+    private String reportType;
+    private List<UsageReportPointRest> points;
+
+    public String getCategory() {
+        return CATEGORY;
+    }
+
+    public Class getController() {
+        return StatisticsRestController.class;
+    }
+
+    public String getType() {
+        return NAME;
+    }
+
+    public String getReportType() {
+        return reportType;
+    }
+
+    public void setReportType(String reportType) {
+        this.reportType = reportType;
+    }
+
+    public List<UsageReportPointRest> getPoints() {
+        return points;
+    }
+
+    public void addPoint(UsageReportPointRest point) {
+        if (points == null) {
+            points = new ArrayList<>();
+        }
+        points.add(point);
+    }
+
+    public void setPoints(List<UsageReportPointRest> points) {
+        this.points = points;
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportRest.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.dspace.app.rest.StatisticsRestController;
+import org.dspace.app.rest.RestResourceController;
 
 /**
  * This class serves as a REST representation of a Usage Report from the DSpace statistics
@@ -43,7 +43,7 @@ public class UsageReportRest extends BaseObjectRest<String> {
      */
     @Override
     public Class getController() {
-        return StatisticsRestController.class;
+        return RestResourceController.class;
     }
 
     /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportRest.java
@@ -26,26 +26,69 @@ public class UsageReportRest extends BaseObjectRest<String> {
     private String reportType;
     private List<UsageReportPointRest> points;
 
+    /**
+     * Returns the category of this Rest object, {@link #CATEGORY}
+     *
+     * @return The category of this Rest object, {@link #CATEGORY}
+     */
+    @Override
     public String getCategory() {
         return CATEGORY;
     }
 
+    /**
+     * Return controller class responsible for this Rest object
+     *
+     * @return Controller class responsible for this Rest object
+     */
+    @Override
     public Class getController() {
         return StatisticsRestController.class;
     }
 
+    /**
+     * Returns the type of this {@link UsageReportRest} object
+     *
+     * @return Type of this {@link UsageReportRest} object
+     */
+    @Override
     public String getType() {
         return NAME;
     }
 
+    /**
+     * Returns the report type of this UsageReport, options listed in
+     * {@link org.dspace.app.rest.utils.UsageReportUtils}, e.g.
+     * {@link org.dspace.app.rest.utils.UsageReportUtils#TOTAL_VISITS_REPORT_ID}
+     *
+     * @return The report type of this UsageReport, options listed in
+     * {@link org.dspace.app.rest.utils.UsageReportUtils}, e.g.
+     * {@link org.dspace.app.rest.utils.UsageReportUtils#TOTAL_VISITS_REPORT_ID}
+     */
     public String getReportType() {
         return reportType;
     }
 
+    /**
+     * Sets the report type of this UsageReport, options listed in
+     * {@link org.dspace.app.rest.utils.UsageReportUtils}, e.g.
+     * {@link org.dspace.app.rest.utils.UsageReportUtils#TOTAL_VISITS_REPORT_ID}
+     *
+     * @param reportType The report type of this UsageReport, options listed in
+     *                   {@link org.dspace.app.rest.utils.UsageReportUtils}, e.g.
+     *                   {@link org.dspace.app.rest.utils.UsageReportUtils#TOTAL_VISITS_REPORT_ID}
+     */
     public void setReportType(String reportType) {
         this.reportType = reportType;
     }
 
+    /**
+     * Returns the list of {@link UsageReportPointRest} objects attached to this {@link UsageReportRest} object, or
+     * empty list if none
+     *
+     * @return The list of {@link UsageReportPointRest} objects attached to this {@link UsageReportRest} object, or
+     * empty list if none
+     */
     public List<UsageReportPointRest> getPoints() {
         if (points == null) {
             points = new ArrayList<>();
@@ -53,6 +96,11 @@ public class UsageReportRest extends BaseObjectRest<String> {
         return points;
     }
 
+    /**
+     * Adds a {@link UsageReportPointRest} object to this {@link UsageReportRest} object
+     *
+     * @param point {@link UsageReportPointRest} to add to this {@link UsageReportRest} object
+     */
     public void addPoint(UsageReportPointRest point) {
         if (points == null) {
             points = new ArrayList<>();
@@ -60,6 +108,11 @@ public class UsageReportRest extends BaseObjectRest<String> {
         points.add(point);
     }
 
+    /**
+     * Set all {@link UsageReportPointRest} objects on this {@link UsageReportRest} object
+     *
+     * @param points All {@link UsageReportPointRest} objects on this {@link UsageReportRest} object
+     */
     public void setPoints(List<UsageReportPointRest> points) {
         this.points = points;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/UsageReportResource.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/UsageReportResource.java
@@ -1,0 +1,23 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model.hateoas;
+
+import org.dspace.app.rest.model.UsageReportRest;
+import org.dspace.app.rest.model.hateoas.annotations.RelNameDSpaceResource;
+
+/**
+ * The Resource representation of a {@link UsageReportRest} object
+ *
+ * @author Maria Verdonck (Atmire) on 08/06/2020
+ */
+@RelNameDSpaceResource(UsageReportRest.NAME)
+public class UsageReportResource extends HALResource<UsageReportRest> {
+    public UsageReportResource(UsageReportRest content) {
+        super(content);
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/UsageReportResource.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/UsageReportResource.java
@@ -9,6 +9,7 @@ package org.dspace.app.rest.model.hateoas;
 
 import org.dspace.app.rest.model.UsageReportRest;
 import org.dspace.app.rest.model.hateoas.annotations.RelNameDSpaceResource;
+import org.dspace.app.rest.utils.Utils;
 
 /**
  * The Resource representation of a {@link UsageReportRest} object
@@ -16,8 +17,8 @@ import org.dspace.app.rest.model.hateoas.annotations.RelNameDSpaceResource;
  * @author Maria Verdonck (Atmire) on 08/06/2020
  */
 @RelNameDSpaceResource(UsageReportRest.NAME)
-public class UsageReportResource extends HALResource<UsageReportRest> {
-    public UsageReportResource(UsageReportRest content) {
-        super(content);
+public class UsageReportResource extends DSpaceResource<UsageReportRest>{
+    public UsageReportResource(UsageReportRest content, Utils utils) {
+        super(content, utils);
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/UsageReportResource.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/UsageReportResource.java
@@ -17,7 +17,7 @@ import org.dspace.app.rest.utils.Utils;
  * @author Maria Verdonck (Atmire) on 08/06/2020
  */
 @RelNameDSpaceResource(UsageReportRest.NAME)
-public class UsageReportResource extends DSpaceResource<UsageReportRest>{
+public class UsageReportResource extends DSpaceResource<UsageReportRest> {
     public UsageReportResource(UsageReportRest content, Utils utils) {
         super(content, utils);
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/StatisticsRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/StatisticsRestRepository.java
@@ -70,8 +70,7 @@ public class StatisticsRestRepository extends DSpaceRestRepository<UsageReportRe
 
     @Override
     public Page<UsageReportRest> findAll(Context context, Pageable pageable) {
-        throw new RepositoryMethodNotImplementedException("No implementation found; Method not allowed!",
-            "getUsageReports");
+        throw new RepositoryMethodNotImplementedException("No implementation found; Method not allowed!", "findAll");
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/StatisticsRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/StatisticsRestRepository.java
@@ -49,8 +49,7 @@ public class StatisticsRestRepository extends DSpaceRestRepository<UsageReportRe
         } catch (ParseException | SolrServerException | IOException e) {
             throw new RuntimeException(e.getMessage(), e);
         }
-
-        return usageReportRest;
+        return converter.toRest(usageReportRest, utils.obtainProjection());
     }
 
     @PreAuthorize("hasPermission(#uri, 'usagereportsearch', 'READ')")

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/StatisticsRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/StatisticsRestRepository.java
@@ -20,6 +20,7 @@ import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.exception.RepositoryMethodNotImplementedException;
 import org.dspace.app.rest.model.StatisticsSupportRest;
 import org.dspace.app.rest.model.UsageReportRest;
+import org.dspace.app.rest.utils.UsageReportUtils;
 import org.dspace.core.Context;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -31,7 +32,7 @@ import org.springframework.stereotype.Component;
 public class StatisticsRestRepository extends DSpaceRestRepository<UsageReportRest, String> {
 
     @Autowired
-    private UsageReportService usageReportService;
+    private UsageReportUtils usageReportUtils;
 
     public StatisticsSupportRest getStatisticsSupport() {
         return new StatisticsSupportRest();
@@ -45,7 +46,7 @@ public class StatisticsRestRepository extends DSpaceRestRepository<UsageReportRe
 
         UsageReportRest usageReportRest = null;
         try {
-            usageReportRest = usageReportService.createUsageReport(context, uuidObject, reportId);
+            usageReportRest = usageReportUtils.createUsageReport(context, uuidObject, reportId);
         } catch (ParseException | SolrServerException | IOException e) {
             throw new RuntimeException(e.getMessage(), e);
         }
@@ -59,7 +60,7 @@ public class StatisticsRestRepository extends DSpaceRestRepository<UsageReportRe
         UUID uuid = UUID.fromString(StringUtils.substringAfterLast(uri, "/"));
         List<UsageReportRest> usageReportsOfItem = null;
         try {
-            usageReportsOfItem = usageReportService.getUsageReportsOfDSO(obtainContext(), uuid);
+            usageReportsOfItem = usageReportUtils.getUsageReportsOfDSO(obtainContext(), uuid);
         } catch (SQLException | ParseException | SolrServerException | IOException e) {
             throw new RuntimeException(e.getMessage(), e);
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/StatisticsRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/StatisticsRestRepository.java
@@ -7,13 +7,75 @@
  */
 package org.dspace.app.rest.repository;
 
+import java.io.IOException;
+import java.sql.SQLException;
+import java.text.ParseException;
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.dspace.app.rest.Parameter;
+import org.dspace.app.rest.SearchRestMethod;
+import org.dspace.app.rest.exception.RepositoryMethodNotImplementedException;
 import org.dspace.app.rest.model.StatisticsSupportRest;
+import org.dspace.app.rest.model.UsageReportRest;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Component;
 
-@Component(StatisticsSupportRest.CATEGORY + "." + StatisticsSupportRest.NAME)
-public class StatisticsRestRepository extends AbstractDSpaceRestRepository {
+@Component(StatisticsSupportRest.CATEGORY + "." + UsageReportRest.NAME)
+public class StatisticsRestRepository extends DSpaceRestRepository<UsageReportRest, String> {
+
+    @Autowired
+    private UsageReportService usageReportService;
 
     public StatisticsSupportRest getStatisticsSupport() {
         return new StatisticsSupportRest();
+    }
+
+    @Override
+    @PreAuthorize("hasPermission(#uuidObjectReportId, 'usagereport', 'READ')")
+    public UsageReportRest findOne(Context context, String uuidObjectReportId) {
+        UUID uuidObject = UUID.fromString(StringUtils.substringBefore(uuidObjectReportId, "_"));
+        String reportId = StringUtils.substringAfter(uuidObjectReportId, "_");
+
+        UsageReportRest usageReportRest = null;
+        try {
+            usageReportRest = usageReportService.createUsageReport(context, uuidObject, reportId);
+        } catch (ParseException | SolrServerException | IOException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+
+        return usageReportRest;
+    }
+
+    @PreAuthorize("hasPermission(#uri, 'usagereportsearch', 'READ')")
+    @SearchRestMethod(name = "object")
+    public Page<UsageReportRest> findByObject(@Parameter(value = "uri", required = true) String uri,
+                                              Pageable pageable) {
+        UUID uuid = UUID.fromString(StringUtils.substringAfterLast(uri, "/"));
+        List<UsageReportRest> usageReportsOfItem = null;
+        try {
+            usageReportsOfItem = usageReportService.getUsageReportsOfDSO(obtainContext(), uuid);
+        } catch (SQLException | ParseException | SolrServerException | IOException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+
+        return converter.toRestPage(usageReportsOfItem, pageable, usageReportsOfItem.size(), utils.obtainProjection());
+    }
+
+    @Override
+    public Page<UsageReportRest> findAll(Context context, Pageable pageable) {
+        throw new RepositoryMethodNotImplementedException("No implementation found; Method not allowed!",
+            "getUsageReports");
+    }
+
+    @Override
+    public Class<UsageReportRest> getDomainClass() {
+        return UsageReportRest.class;
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/UsageReportRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/UsageReportRestRepository.java
@@ -1,0 +1,173 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.repository;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.text.ParseException;
+import java.util.UUID;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.dspace.app.rest.exception.DSpaceBadRequestException;
+import org.dspace.app.rest.exception.RepositoryMethodNotImplementedException;
+import org.dspace.app.rest.model.UsageReportPointCityRest;
+import org.dspace.app.rest.model.UsageReportPointCountryRest;
+import org.dspace.app.rest.model.UsageReportPointDateRest;
+import org.dspace.app.rest.model.UsageReportPointDsoTotalVisitsRest;
+import org.dspace.app.rest.model.UsageReportRest;
+import org.dspace.app.rest.utils.DSpaceObjectUtils;
+import org.dspace.content.DSpaceObject;
+import org.dspace.core.Context;
+import org.dspace.statistics.Dataset;
+import org.dspace.statistics.content.DatasetDSpaceObjectGenerator;
+import org.dspace.statistics.content.DatasetTimeGenerator;
+import org.dspace.statistics.content.DatasetTypeGenerator;
+import org.dspace.statistics.content.StatisticsDataVisits;
+import org.dspace.statistics.content.StatisticsListing;
+import org.dspace.statistics.content.StatisticsTable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * This is the REST repository dealing with the {@link UsageReportRest} logic
+ *
+ * @author Maria Verdonck (Atmire) on 08/06/2020
+ */
+@Component(UsageReportRest.CATEGORY + "." + UsageReportRest.NAME)
+public class UsageReportRestRepository extends AbstractDSpaceRestRepository {
+
+    @Autowired
+    private DSpaceObjectUtils dspaceObjectUtil;
+
+    /**
+     * TODO
+     *
+     * @param context
+     * @param uuid
+     * @param reportId
+     * @return
+     * @throws ParseException
+     * @throws SolrServerException
+     * @throws IOException
+     */
+    public UsageReportRest createUsageReport(Context context, UUID uuid, String reportId)
+        throws ParseException, SolrServerException, IOException {
+        try {
+            DSpaceObject dso = dspaceObjectUtil.findDSpaceObject(context, uuid);
+            UsageReportRest usageReportRest;
+            switch (reportId) {
+                case "TotalVisits":
+                    usageReportRest = resolveTotalVisits(context, dso);
+                    usageReportRest.setReportType("TotalVisits");
+                    break;
+                case "TotalVisitsPerMonth":
+                    usageReportRest = resolveTotalVisitsPerMonth(context, dso);
+                    usageReportRest.setReportType("TotalVisitsPerMonth");
+                    break;
+                case "TotalDownloads":
+                    throw new RepositoryMethodNotImplementedException("TODO", "TotalDownloads");
+                case "TopCountries":
+                    usageReportRest = resolveTopCountries(context, dso);
+                    usageReportRest.setReportType("TopCountries");
+                    break;
+                case "TopCities":
+                    usageReportRest = resolveTopCities(context, dso);
+                    usageReportRest.setReportType("TopCities");
+                    break;
+                default:
+                    throw new DSpaceBadRequestException("The given report id can't be resolved: " + reportId + "; " +
+                                                        "available reports: TotalVisits, TotalVisitsPerMonth, " +
+                                                        "TotalDownloads, TopCountries, TopCities");
+            }
+            return usageReportRest;
+        } catch (SQLException e) {
+            throw new DSpaceBadRequestException("The given object uuid can't be resolved to an object: " + uuid);
+        }
+    }
+
+    private UsageReportRest resolveTotalVisits(Context context, DSpaceObject dso)
+        throws SQLException, IOException, ParseException, SolrServerException {
+        StatisticsListing statListing = new StatisticsListing(new StatisticsDataVisits(dso));
+        DatasetDSpaceObjectGenerator dsoAxis = new DatasetDSpaceObjectGenerator();
+        dsoAxis.addDsoChild(dso.getType(), 10, false, -1);
+        statListing.addDatasetGenerator(dsoAxis);
+        Dataset dataset = statListing.getDataset(context);
+
+        UsageReportRest usageReportRest = new UsageReportRest();
+        for (int i = 0; i < dataset.getColLabels().size(); i++) {
+            UsageReportPointDsoTotalVisitsRest totalVisitPoint = new UsageReportPointDsoTotalVisitsRest();
+            totalVisitPoint.setType(StringUtils.substringAfterLast(dso.getClass().getName().toLowerCase(), "."));
+            totalVisitPoint.setId(dso.getID().toString());
+            totalVisitPoint.addValue("views", Integer.valueOf(dataset.getMatrix()[0][i]));
+            usageReportRest.addPoint(totalVisitPoint);
+        }
+        return usageReportRest;
+    }
+
+    private UsageReportRest resolveTotalVisitsPerMonth(Context context, DSpaceObject dso)
+        throws SQLException, IOException, ParseException, SolrServerException {
+        StatisticsTable statisticsTable = new StatisticsTable(new StatisticsDataVisits(dso));
+        DatasetTimeGenerator timeAxis = new DatasetTimeGenerator();
+        // TODO month start and end as request para?
+        timeAxis.setDateInterval("month", "-6", "+1");
+        statisticsTable.addDatasetGenerator(timeAxis);
+        DatasetDSpaceObjectGenerator dsoAxis = new DatasetDSpaceObjectGenerator();
+        dsoAxis.addDsoChild(dso.getType(), 10, false, -1);
+        statisticsTable.addDatasetGenerator(dsoAxis);
+        Dataset dataset = statisticsTable.getDataset(context);
+
+        UsageReportRest usageReportRest = new UsageReportRest();
+        for (int i = 0; i < dataset.getColLabels().size(); i++) {
+            UsageReportPointDateRest monthPoint = new UsageReportPointDateRest();
+            monthPoint.setId(dataset.getColLabels().get(i));
+            monthPoint.addValue("views", Integer.valueOf(dataset.getMatrix()[0][i]));
+            usageReportRest.addPoint(monthPoint);
+        }
+        return usageReportRest;
+    }
+
+    private UsageReportRest resolveTopCountries(Context context, DSpaceObject dso)
+        throws SQLException, IOException, ParseException, SolrServerException {
+        Dataset dataset = this.getTypeStatsDataset(context, dso, "countryCode");
+
+        UsageReportRest usageReportRest = new UsageReportRest();
+        for (int i = 0; i < dataset.getColLabels().size(); i++) {
+            UsageReportPointCountryRest countryPoint = new UsageReportPointCountryRest();
+            countryPoint.setLabel(dataset.getColLabels().get(i));
+            countryPoint.addValue("views", Integer.valueOf(dataset.getMatrix()[0][i]));
+            usageReportRest.addPoint(countryPoint);
+        }
+        return usageReportRest;
+    }
+
+    private UsageReportRest resolveTopCities(Context context, DSpaceObject dso)
+        throws SQLException, IOException, ParseException, SolrServerException {
+        Dataset dataset = this.getTypeStatsDataset(context, dso, "city");
+
+        UsageReportRest usageReportRest = new UsageReportRest();
+        for (int i = 0; i < dataset.getColLabels().size(); i++) {
+            UsageReportPointCityRest cityPoint = new UsageReportPointCityRest();
+            cityPoint.setId(dataset.getColLabels().get(i));
+            cityPoint.addValue("views", Integer.valueOf(dataset.getMatrix()[0][i]));
+            usageReportRest.addPoint(cityPoint);
+        }
+        return usageReportRest;
+    }
+
+    private Dataset getTypeStatsDataset(Context context, DSpaceObject dso, String typeAxisString)
+        throws SQLException, IOException, ParseException, SolrServerException {
+        StatisticsListing statListing = new StatisticsListing(new StatisticsDataVisits(dso));
+        DatasetTypeGenerator typeAxis = new DatasetTypeGenerator();
+        typeAxis.setType(typeAxisString);
+        // TODO make max nr of top countries/cities a request para? Must be set
+        typeAxis.setMax(100);
+        statListing.addDatasetGenerator(typeAxis);
+        return statListing.getDataset(context);
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/UsageReportRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/UsageReportRestRepository.java
@@ -146,11 +146,6 @@ public class UsageReportRestRepository extends AbstractDSpaceRestRepository {
         }
 
         if (dso instanceof org.dspace.content.Item) {
-            // Make sure our item has at least one bitstream
-            org.dspace.content.Item item = (org.dspace.content.Item) dso;
-//            if (itemService.hasUploadedFiles(item)) {
-//            }
-
             Dataset dataset = this.getDSOStatsDataset(context, dso, 1, Constants.BITSTREAM);
 
             UsageReportRest usageReportRest = new UsageReportRest();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/UsageReportRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/UsageReportRestRepository.java
@@ -58,9 +58,6 @@ public class UsageReportRestRepository extends AbstractDSpaceRestRepository {
         throws ParseException, SolrServerException, IOException {
         try {
             DSpaceObject dso = dspaceObjectUtil.findDSpaceObject(context, uuid);
-            if (dso == null) {
-                throw new IllegalArgumentException("No DSO found with this UUID: " + uuid);
-            }
             UsageReportRest usageReportRest;
             switch (reportId) {
                 case "TotalVisits":

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/UsageReportService.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/UsageReportService.java
@@ -22,9 +22,7 @@ import org.dspace.app.rest.model.UsageReportPointCountryRest;
 import org.dspace.app.rest.model.UsageReportPointDateRest;
 import org.dspace.app.rest.model.UsageReportPointDsoTotalVisitsRest;
 import org.dspace.app.rest.model.UsageReportRest;
-import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.app.rest.utils.DSpaceObjectUtils;
-import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Bitstream;
 import org.dspace.content.DSpaceObject;
@@ -33,7 +31,6 @@ import org.dspace.content.Site;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.handle.service.HandleService;
-import org.dspace.services.model.Request;
 import org.dspace.statistics.Dataset;
 import org.dspace.statistics.content.DatasetDSpaceObjectGenerator;
 import org.dspace.statistics.content.DatasetTimeGenerator;
@@ -69,40 +66,6 @@ public class UsageReportService extends AbstractDSpaceRestRepository {
     public static final String TOTAL_DOWNLOADS_REPORT_ID = "TotalDownloads";
     public static final String TOP_COUNTRIES_REPORT_ID = "TopCountries";
     public static final String TOP_CITIES_REPORT_ID = "TopCities";
-
-    /**
-     * Responsible for checking whether or not the user has used a valid request (valid UUID in /usagereports/{
-     * UUID_ReportID} or in /usagereports/search/object?uri={uri-ending-in/UUID} and whether or not the used has the
-     * given (READ) rights on the corresponding DSO.
-     *
-     * @param targetType usagereport or usagereportsearch, so we know how to extract the UUID
-     * @param targetId   string to extract uuid from
-     * @param action     type of access rights (READ)
-     * @throws AuthorizeException if user does not have given rights on dso whose uuid is extracted from the targetID
-     */
-    public void checkForPermissionAndValidRequest(String targetType, String targetId, int action)
-        throws AuthorizeException {
-        Request request = requestService.getCurrentRequest();
-        Context context = ContextUtil.obtainContext(request.getServletRequest());
-        UUID uuidObject = null;
-        if (StringUtils.equalsIgnoreCase(UsageReportRest.NAME, targetType)) {
-            // Get uuid from uuidDSO_reportId pathParam
-            uuidObject = UUID.fromString(StringUtils.substringBefore(targetId, "_"));
-        } else if (StringUtils.equalsIgnoreCase(UsageReportRest.NAME + "search", targetType)) {
-            // Get uuid from url (selfLink of dso) queryParam
-            uuidObject = UUID.fromString(StringUtils.substringAfterLast(targetId, "/"));
-        }
-        try {
-            DSpaceObject dso = dspaceObjectUtil.findDSpaceObject(context, uuidObject);
-            if (dso == null) {
-                throw new ResourceNotFoundException("No DSO found with this UUID: " + uuidObject);
-            }
-            authorizeService.authorizeAction(context, dso, action);
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-        }
-
-    }
 
     /**
      * Get list of usage reports that are applicable to the DSO (of given UUID)

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/UsageReportService.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/UsageReportService.java
@@ -23,7 +23,6 @@ import org.dspace.app.rest.model.UsageReportPointDateRest;
 import org.dspace.app.rest.model.UsageReportPointDsoTotalVisitsRest;
 import org.dspace.app.rest.model.UsageReportRest;
 import org.dspace.app.rest.utils.DSpaceObjectUtils;
-import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Bitstream;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
@@ -38,8 +37,6 @@ import org.dspace.statistics.content.DatasetTypeGenerator;
 import org.dspace.statistics.content.StatisticsDataVisits;
 import org.dspace.statistics.content.StatisticsListing;
 import org.dspace.statistics.content.StatisticsTable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.stereotype.Component;
@@ -52,10 +49,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class UsageReportService extends AbstractDSpaceRestRepository {
 
-    private static final Logger log = LoggerFactory.getLogger(UsageReportService.class);
-
-    @Autowired
-    private AuthorizeService authorizeService;
     @Autowired
     private DSpaceObjectUtils dspaceObjectUtil;
     @Autowired
@@ -66,8 +59,6 @@ public class UsageReportService extends AbstractDSpaceRestRepository {
     public static final String TOTAL_DOWNLOADS_REPORT_ID = "TotalDownloads";
     public static final String TOP_COUNTRIES_REPORT_ID = "TopCountries";
     public static final String TOP_CITIES_REPORT_ID = "TopCities";
-
-    public static final String SITE_WIDE_USAGE_REPORT_LABEL = "All of DSpace";
 
     /**
      * Get list of usage reports that are applicable to the DSO (of given UUID)
@@ -166,13 +157,13 @@ public class UsageReportService extends AbstractDSpaceRestRepository {
         for (int i = 0; i < dataset.getColLabels().size(); i++) {
             UsageReportPointDsoTotalVisitsRest totalVisitPoint = new UsageReportPointDsoTotalVisitsRest();
             totalVisitPoint.setType("item");
-            totalVisitPoint.setLabel(SITE_WIDE_USAGE_REPORT_LABEL);
             String urlOfItem = dataset.getColLabelsAttrs().get(i).get("url");
             if (urlOfItem != null) {
                 String handle = StringUtils.substringAfterLast(urlOfItem, "handle/");
                 if (handle != null) {
                     DSpaceObject dso = handleService.resolveToObject(context, handle);
                     totalVisitPoint.setId(dso != null ? dso.getID().toString() : urlOfItem);
+                    totalVisitPoint.setLabel(dso != null ? dso.getName() : urlOfItem);
                     totalVisitPoint.addValue("views", Integer.valueOf(dataset.getMatrix()[0][i]));
                     usageReportRest.addPoint(totalVisitPoint);
                 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/UsageReportService.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/UsageReportService.java
@@ -22,7 +22,10 @@ import org.dspace.app.rest.model.UsageReportPointCountryRest;
 import org.dspace.app.rest.model.UsageReportPointDateRest;
 import org.dspace.app.rest.model.UsageReportPointDsoTotalVisitsRest;
 import org.dspace.app.rest.model.UsageReportRest;
+import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.app.rest.utils.DSpaceObjectUtils;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Bitstream;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
@@ -30,6 +33,7 @@ import org.dspace.content.Site;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.handle.service.HandleService;
+import org.dspace.services.model.Request;
 import org.dspace.statistics.Dataset;
 import org.dspace.statistics.content.DatasetDSpaceObjectGenerator;
 import org.dspace.statistics.content.DatasetTimeGenerator;
@@ -37,28 +41,68 @@ import org.dspace.statistics.content.DatasetTypeGenerator;
 import org.dspace.statistics.content.StatisticsDataVisits;
 import org.dspace.statistics.content.StatisticsListing;
 import org.dspace.statistics.content.StatisticsTable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.stereotype.Component;
 
 /**
- * This is the REST repository dealing with the {@link UsageReportRest} logic
+ * This is the Service dealing with the {@link UsageReportRest} logic
  *
  * @author Maria Verdonck (Atmire) on 08/06/2020
  */
-@Component(UsageReportRest.CATEGORY + "." + UsageReportRest.NAME)
-public class UsageReportRestRepository extends AbstractDSpaceRestRepository {
+@Component
+public class UsageReportService extends AbstractDSpaceRestRepository {
 
+    private static final Logger log = LoggerFactory.getLogger(UsageReportService.class);
+
+    @Autowired
+    private AuthorizeService authorizeService;
     @Autowired
     private DSpaceObjectUtils dspaceObjectUtil;
     @Autowired
-    protected HandleService handleService;
+    private HandleService handleService;
 
     public static final String TOTAL_VISITS_REPORT_ID = "TotalVisits";
     public static final String TOTAL_VISITS_PER_MONTH_REPORT_ID = "TotalVisitsPerMonth";
     public static final String TOTAL_DOWNLOADS_REPORT_ID = "TotalDownloads";
     public static final String TOP_COUNTRIES_REPORT_ID = "TopCountries";
     public static final String TOP_CITIES_REPORT_ID = "TopCities";
+
+    /**
+     * Responsible for checking whether or not the user has used a valid request (valid UUID in /usagereports/{
+     * UUID_ReportID} or in /usagereports/search/object?uri={uri-ending-in/UUID} and whether or not the used has the
+     * given (READ) rights on the corresponding DSO.
+     *
+     * @param targetType usagereport or usagereportsearch, so we know how to extract the UUID
+     * @param targetId   string to extract uuid from
+     * @param action     type of access rights (READ)
+     * @throws AuthorizeException if user does not have given rights on dso whose uuid is extracted from the targetID
+     */
+    public void checkForPermissionAndValidRequest(String targetType, String targetId, int action)
+        throws AuthorizeException {
+        Request request = requestService.getCurrentRequest();
+        Context context = ContextUtil.obtainContext(request.getServletRequest());
+        UUID uuidObject = null;
+        if (StringUtils.equalsIgnoreCase(UsageReportRest.NAME, targetType)) {
+            // Get uuid from uuidDSO_reportId pathParam
+            uuidObject = UUID.fromString(StringUtils.substringBefore(targetId, "_"));
+        } else if (StringUtils.equalsIgnoreCase(UsageReportRest.NAME + "search", targetType)) {
+            // Get uuid from url (selfLink of dso) queryParam
+            uuidObject = UUID.fromString(StringUtils.substringAfterLast(targetId, "/"));
+        }
+        try {
+            DSpaceObject dso = dspaceObjectUtil.findDSpaceObject(context, uuidObject);
+            if (dso == null) {
+                throw new ResourceNotFoundException("No DSO found with this UUID: " + uuidObject);
+            }
+            authorizeService.authorizeAction(context, dso, action);
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
+        }
+
+    }
 
     /**
      * Get list of usage reports that are applicable to the DSO (of given UUID)

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/UsageReportService.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/UsageReportService.java
@@ -67,6 +67,8 @@ public class UsageReportService extends AbstractDSpaceRestRepository {
     public static final String TOP_COUNTRIES_REPORT_ID = "TopCountries";
     public static final String TOP_CITIES_REPORT_ID = "TopCities";
 
+    public static final String SITE_WIDE_USAGE_REPORT_LABEL = "All of DSpace";
+
     /**
      * Get list of usage reports that are applicable to the DSO (of given UUID)
      *
@@ -164,7 +166,7 @@ public class UsageReportService extends AbstractDSpaceRestRepository {
         for (int i = 0; i < dataset.getColLabels().size(); i++) {
             UsageReportPointDsoTotalVisitsRest totalVisitPoint = new UsageReportPointDsoTotalVisitsRest();
             totalVisitPoint.setType("item");
-            totalVisitPoint.setLabel(dataset.getColLabels().get(i));
+            totalVisitPoint.setLabel(SITE_WIDE_USAGE_REPORT_LABEL);
             String urlOfItem = dataset.getColLabelsAttrs().get(i).get("url");
             DSpaceObject dso = handleService.resolveToObject(context, StringUtils.substringAfterLast(urlOfItem,
                 "handle/"));
@@ -193,7 +195,7 @@ public class UsageReportService extends AbstractDSpaceRestRepository {
         totalVisitPoint.setType(StringUtils.substringAfterLast(dso.getClass().getName().toLowerCase(), "."));
         totalVisitPoint.setId(dso.getID().toString());
         if (dataset.getColLabels().size() > 0) {
-            totalVisitPoint.setLabel(dataset.getColLabels().get(0));
+            totalVisitPoint.setLabel(dso.getName());
             totalVisitPoint.addValue("views", Integer.valueOf(dataset.getMatrix()[0][0]));
         } else {
             totalVisitPoint.setLabel(dso.getName());

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/UsageReportService.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/UsageReportService.java
@@ -168,11 +168,15 @@ public class UsageReportService extends AbstractDSpaceRestRepository {
             totalVisitPoint.setType("item");
             totalVisitPoint.setLabel(SITE_WIDE_USAGE_REPORT_LABEL);
             String urlOfItem = dataset.getColLabelsAttrs().get(i).get("url");
-            DSpaceObject dso = handleService.resolveToObject(context, StringUtils.substringAfterLast(urlOfItem,
-                "handle/"));
-            totalVisitPoint.setId(dso != null ? dso.getID().toString() : urlOfItem);
-            totalVisitPoint.addValue("views", Integer.valueOf(dataset.getMatrix()[0][i]));
-            usageReportRest.addPoint(totalVisitPoint);
+            if (urlOfItem != null) {
+                String handle = StringUtils.substringAfterLast(urlOfItem, "handle/");
+                if (handle != null) {
+                    DSpaceObject dso = handleService.resolveToObject(context, handle);
+                    totalVisitPoint.setId(dso != null ? dso.getID().toString() : urlOfItem);
+                    totalVisitPoint.addValue("views", Integer.valueOf(dataset.getMatrix()[0][i]));
+                    usageReportRest.addPoint(totalVisitPoint);
+                }
+            }
         }
         usageReportRest.setReportType(TOTAL_VISITS_REPORT_ID);
         return usageReportRest;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/AuthorizeServicePermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/AuthorizeServicePermissionEvaluatorPlugin.java
@@ -65,37 +65,39 @@ public class AuthorizeServicePermissionEvaluatorPlugin extends RestObjectPermiss
         Context context = ContextUtil.obtainContext(request.getServletRequest());
         EPerson ePerson = null;
         try {
-            UUID dsoId = UUIDUtils.fromString(targetId.toString());
-            DSpaceObjectService<DSpaceObject> dSpaceObjectService;
-            try {
-                dSpaceObjectService =
+            if (targetId != null) {
+                UUID dsoId = UUIDUtils.fromString(targetId.toString());
+                DSpaceObjectService<DSpaceObject> dSpaceObjectService;
+                try {
+                    dSpaceObjectService =
                         contentServiceFactory.getDSpaceObjectService(Constants.getTypeID(targetType));
-            } catch (UnsupportedOperationException e) {
-                // ok not a dspace object
-                return false;
-            }
-
-            ePerson = ePersonService.findByEmail(context, (String) authentication.getPrincipal());
-
-            if (dSpaceObjectService != null && dsoId != null) {
-                DSpaceObject dSpaceObject = dSpaceObjectService.find(context, dsoId);
-
-                //If the dso is null then we give permission so we can throw another status code instead
-                if (dSpaceObject == null) {
-                    return true;
+                } catch (UnsupportedOperationException e) {
+                    // ok not a dspace object
+                    return false;
                 }
 
-                // If the item is still inprogress we can process here only the READ permission.
-                // Other actions need to be evaluated against the wrapper object (workspace or workflow item)
-                if (dSpaceObject instanceof Item) {
-                    if (!DSpaceRestPermission.READ.equals(restPermission)
-                        && !((Item) dSpaceObject).isArchived() && !((Item) dSpaceObject).isWithdrawn()) {
-                        return false;
+                ePerson = ePersonService.findByEmail(context, (String) authentication.getPrincipal());
+
+                if (dSpaceObjectService != null && dsoId != null) {
+                    DSpaceObject dSpaceObject = dSpaceObjectService.find(context, dsoId);
+
+                    //If the dso is null then we give permission so we can throw another status code instead
+                    if (dSpaceObject == null) {
+                        return true;
                     }
-                }
 
-                return authorizeService.authorizeActionBoolean(context, ePerson, dSpaceObject,
+                    // If the item is still inprogress we can process here only the READ permission.
+                    // Other actions need to be evaluated against the wrapper object (workspace or workflow item)
+                    if (dSpaceObject instanceof Item) {
+                        if (!DSpaceRestPermission.READ.equals(restPermission)
+                            && !((Item) dSpaceObject).isArchived() && !((Item) dSpaceObject).isWithdrawn()) {
+                            return false;
+                        }
+                    }
+
+                    return authorizeService.authorizeActionBoolean(context, ePerson, dSpaceObject,
                         restPermission.getDspaceApiActionId(), true);
+                }
             }
 
         } catch (SQLException e) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/UsageReportRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/UsageReportRestPermissionEvaluatorPlugin.java
@@ -53,6 +53,10 @@ public class UsageReportRestPermissionEvaluatorPlugin extends RestObjectPermissi
         Context context = ContextUtil.obtainContext(request.getServletRequest());
         UUID uuidObject = null;
         if (StringUtils.equalsIgnoreCase(UsageReportRest.NAME, targetType)) {
+            if (StringUtils.countMatches(targetId.toString(), "_") != 1) {
+                throw new IllegalArgumentException("Must end in objectUUID_reportId, example: " +
+                                                   "1911e8a4-6939-490c-b58b-a5d70f8d91fb_TopCountries");
+            }
             // Get uuid from uuidDSO_reportId pathParam
             uuidObject = UUID.fromString(StringUtils.substringBefore(targetId.toString(), "_"));
         } else if (StringUtils.equalsIgnoreCase(UsageReportRest.NAME + "search", targetType)) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/UsageReportRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/UsageReportRestPermissionEvaluatorPlugin.java
@@ -62,27 +62,29 @@ public class UsageReportRestPermissionEvaluatorPlugin extends RestObjectPermissi
         Request request = requestService.getCurrentRequest();
         Context context = ContextUtil.obtainContext(request.getServletRequest());
         UUID uuidObject = null;
-        if (StringUtils.equalsIgnoreCase(UsageReportRest.NAME, targetType)) {
-            if (StringUtils.countMatches(targetId.toString(), "_") != 1) {
-                throw new IllegalArgumentException("Must end in objectUUID_reportId, example: " +
-                                                   "1911e8a4-6939-490c-b58b-a5d70f8d91fb_TopCountries");
+        if (targetId != null) {
+            if (StringUtils.equalsIgnoreCase(UsageReportRest.NAME, targetType)) {
+                if (StringUtils.countMatches(targetId.toString(), "_") != 1) {
+                    throw new IllegalArgumentException("Must end in objectUUID_reportId, example: " +
+                                                       "1911e8a4-6939-490c-b58b-a5d70f8d91fb_TopCountries");
+                }
+                // Get uuid from uuidDSO_reportId pathParam
+                uuidObject = UUID.fromString(StringUtils.substringBefore(targetId.toString(), "_"));
+            } else if (StringUtils.equalsIgnoreCase(UsageReportRest.NAME + "search", targetType)) {
+                // Get uuid from url (selfLink of dso) queryParam
+                uuidObject = UUID.fromString(StringUtils.substringAfterLast(targetId.toString(), "/"));
+            } else {
+                return false;
             }
-            // Get uuid from uuidDSO_reportId pathParam
-            uuidObject = UUID.fromString(StringUtils.substringBefore(targetId.toString(), "_"));
-        } else if (StringUtils.equalsIgnoreCase(UsageReportRest.NAME + "search", targetType)) {
-            // Get uuid from url (selfLink of dso) queryParam
-            uuidObject = UUID.fromString(StringUtils.substringAfterLast(targetId.toString(), "/"));
-        } else {
-            return false;
-        }
-        try {
-            DSpaceObject dso = dspaceObjectUtil.findDSpaceObject(context, uuidObject);
-            if (dso == null) {
-                throw new ResourceNotFoundException("No DSO found with this UUID: " + uuidObject);
+            try {
+                DSpaceObject dso = dspaceObjectUtil.findDSpaceObject(context, uuidObject);
+                if (dso == null) {
+                    throw new ResourceNotFoundException("No DSO found with this UUID: " + uuidObject);
+                }
+                return authorizeService.authorizeActionBoolean(context, dso, restPermission.getDspaceApiActionId());
+            } catch (SQLException e) {
+                log.error(e.getMessage(), e);
             }
-            return authorizeService.authorizeActionBoolean(context, dso, restPermission.getDspaceApiActionId());
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
         }
         return true;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/UsageReportRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/UsageReportRestPermissionEvaluatorPlugin.java
@@ -1,0 +1,69 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.security;
+
+import java.io.Serializable;
+import java.sql.SQLException;
+import java.util.UUID;
+
+import org.apache.commons.lang3.StringUtils;
+import org.dspace.app.rest.model.UsageReportRest;
+import org.dspace.app.rest.utils.ContextUtil;
+import org.dspace.app.rest.utils.DSpaceObjectUtils;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.DSpaceObject;
+import org.dspace.core.Context;
+import org.dspace.services.RequestService;
+import org.dspace.services.model.Request;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+/**
+ * This class will handle Permissions for the {@link UsageReportRest} object and its calls
+ *
+ * @author Maria Verdonck (Atmire) on 11/06/2020
+ */
+@Component
+public class UsageReportRestPermissionEvaluatorPlugin extends RestObjectPermissionEvaluatorPlugin {
+
+    private static final Logger log = LoggerFactory.getLogger(UsageReportRestPermissionEvaluatorPlugin.class);
+
+    @Autowired
+    private RequestService requestService;
+
+    @Autowired
+    private DSpaceObjectUtils dspaceObjectUtil;
+
+    @Autowired
+    AuthorizeService authorizeService;
+
+    @Override
+    public boolean hasDSpacePermission(Authentication authentication, Serializable targetId, String targetType,
+                                       DSpaceRestPermission restPermission) {
+        if (StringUtils.equalsIgnoreCase(UsageReportRest.NAME, targetType)) {
+            UUID uuidObject = UUID.fromString(StringUtils.substringBefore(targetId.toString(), "_"));
+            Request request = requestService.getCurrentRequest();
+            Context context = ContextUtil.obtainContext(request.getServletRequest());
+            try {
+                DSpaceObject dso = dspaceObjectUtil.findDSpaceObject(context, uuidObject);
+                if (dso == null) {
+                    throw new IllegalArgumentException("No DSO found with this UUID: " + uuidObject);
+                }
+                return authorizeService.authorizeActionBoolean(context, dso, restPermission.getDspaceApiActionId());
+            } catch (SQLException e) {
+                log.error(e.getMessage(), e);
+            }
+        } else {
+            return false;
+        }
+        return true;
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/UsageReportRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/UsageReportRestPermissionEvaluatorPlugin.java
@@ -46,6 +46,16 @@ public class UsageReportRestPermissionEvaluatorPlugin extends RestObjectPermissi
     @Autowired
     AuthorizeService authorizeService;
 
+
+
+    /**
+     * Responsible for checking whether or not the user has used a valid request (valid UUID in /usagereports/{
+     * UUID_ReportID} or in /usagereports/search/object?uri={uri-ending-in/UUID} and whether or not the used has the
+     * given (READ) rights on the corresponding DSO.
+     *
+     * @param targetType usagereport or usagereportsearch, so we know how to extract the UUID
+     * @param targetId   string to extract uuid from
+     */
     @Override
     public boolean hasDSpacePermission(Authentication authentication, Serializable targetId, String targetType,
                                        DSpaceRestPermission restPermission) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/UsageReportUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/UsageReportUtils.java
@@ -5,7 +5,7 @@
  *
  * http://www.dspace.org/license/
  */
-package org.dspace.app.rest.repository;
+package org.dspace.app.rest.utils;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -22,7 +22,7 @@ import org.dspace.app.rest.model.UsageReportPointCountryRest;
 import org.dspace.app.rest.model.UsageReportPointDateRest;
 import org.dspace.app.rest.model.UsageReportPointDsoTotalVisitsRest;
 import org.dspace.app.rest.model.UsageReportRest;
-import org.dspace.app.rest.utils.DSpaceObjectUtils;
+import org.dspace.app.rest.repository.AbstractDSpaceRestRepository;
 import org.dspace.content.Bitstream;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
@@ -47,7 +47,7 @@ import org.springframework.stereotype.Component;
  * @author Maria Verdonck (Atmire) on 08/06/2020
  */
 @Component
-public class UsageReportService extends AbstractDSpaceRestRepository {
+public class UsageReportUtils extends AbstractDSpaceRestRepository {
 
     @Autowired
     private DSpaceObjectUtils dspaceObjectUtil;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/UsageReportUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/UsageReportUtils.java
@@ -22,7 +22,6 @@ import org.dspace.app.rest.model.UsageReportPointCountryRest;
 import org.dspace.app.rest.model.UsageReportPointDateRest;
 import org.dspace.app.rest.model.UsageReportPointDsoTotalVisitsRest;
 import org.dspace.app.rest.model.UsageReportRest;
-import org.dspace.app.rest.repository.AbstractDSpaceRestRepository;
 import org.dspace.content.Bitstream;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
@@ -47,7 +46,7 @@ import org.springframework.stereotype.Component;
  * @author Maria Verdonck (Atmire) on 08/06/2020
  */
 @Component
-public class UsageReportUtils extends AbstractDSpaceRestRepository {
+public class UsageReportUtils {
 
     @Autowired
     private DSpaceObjectUtils dspaceObjectUtil;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -729,7 +729,7 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
 
         // Find all hits/views of bitstream
         ObjectCount objectCount = solrLoggerService.queryTotal("type:" + Constants.BITSTREAM +
-                                                               " AND id:" + bitstream.getID(), null);
+                                                               " AND id:" + bitstream.getID(), null, 1);
         assertEquals(expectedNumberOfStatsRecords, objectCount.getCount());
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -12,11 +12,7 @@ import static org.apache.commons.codec.CharEncoding.UTF_8;
 import static org.apache.commons.collections.CollectionUtils.isEmpty;
 import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.dspace.app.rest.matcher.BitstreamFormatMatcher.matchBitstreamFormat;
-import static org.dspace.builder.BitstreamBuilder.createBitstream;
 import static org.dspace.builder.BitstreamFormatBuilder.createBitstreamFormat;
-import static org.dspace.builder.CollectionBuilder.createCollection;
-import static org.dspace.builder.CommunityBuilder.createCommunity;
-import static org.dspace.builder.ItemBuilder.createItem;
 import static org.dspace.builder.ResourcePolicyBuilder.createResourcePolicy;
 import static org.dspace.content.BitstreamFormat.KNOWN;
 import static org.dspace.content.BitstreamFormat.SUPPORTED;
@@ -129,22 +125,22 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
 
         context.turnOffAuthorisationSystem();
 
-        Community community = createCommunity(context).build();
-        Collection collection = createCollection(context, community).build();
-        Item item = createItem(context, collection).build();
+        Community community = CommunityBuilder.createCommunity(context).build();
+        Collection collection = CollectionBuilder.createCollection(context, community).build();
+        Item item = ItemBuilder.createItem(context, collection).build();
 
-        bitstream = createBitstream(context, item, toInputStream("test", UTF_8))
+        bitstream = BitstreamBuilder.createBitstream(context, item, toInputStream("test", UTF_8))
                 .withFormat("test format")
                 .build();
 
         unknownFormat = bitstreamFormatService.findUnknown(context);
 
         knownFormat = createBitstreamFormat(context)
-                .withMimeType("known test mime type")
-                .withDescription("known test description")
-                .withShortDescription("known test short description")
-                .withSupportLevel(KNOWN)
-                .build();
+                                            .withMimeType("known test mime type")
+                                            .withDescription("known test description")
+                                            .withShortDescription("known test short description")
+                                            .withSupportLevel(KNOWN)
+                                            .build();
 
         supportedFormat = createBitstreamFormat(context)
                 .withMimeType("supported mime type")

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
@@ -9,11 +9,11 @@ package org.dspace.app.rest;
 
 import static org.apache.commons.codec.CharEncoding.UTF_8;
 import static org.apache.commons.io.IOUtils.toInputStream;
-import static org.dspace.app.rest.repository.UsageReportService.TOP_CITIES_REPORT_ID;
-import static org.dspace.app.rest.repository.UsageReportService.TOP_COUNTRIES_REPORT_ID;
-import static org.dspace.app.rest.repository.UsageReportService.TOTAL_DOWNLOADS_REPORT_ID;
-import static org.dspace.app.rest.repository.UsageReportService.TOTAL_VISITS_PER_MONTH_REPORT_ID;
-import static org.dspace.app.rest.repository.UsageReportService.TOTAL_VISITS_REPORT_ID;
+import static org.dspace.app.rest.utils.UsageReportUtils.TOP_CITIES_REPORT_ID;
+import static org.dspace.app.rest.utils.UsageReportUtils.TOP_COUNTRIES_REPORT_ID;
+import static org.dspace.app.rest.utils.UsageReportUtils.TOTAL_DOWNLOADS_REPORT_ID;
+import static org.dspace.app.rest.utils.UsageReportUtils.TOTAL_VISITS_PER_MONTH_REPORT_ID;
+import static org.dspace.app.rest.utils.UsageReportUtils.TOTAL_VISITS_REPORT_ID;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.not;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -37,8 +37,8 @@ import org.dspace.app.rest.model.UsageReportPointDsoTotalVisitsRest;
 import org.dspace.app.rest.model.UsageReportPointRest;
 import org.dspace.app.rest.model.ViewEventRest;
 import org.dspace.app.rest.repository.StatisticsRestRepository;
-import org.dspace.app.rest.repository.UsageReportService;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.app.rest.utils.UsageReportUtils;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.builder.BitstreamBuilder;
 import org.dspace.builder.CollectionBuilder;
@@ -64,7 +64,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
 /**
- * Integration test to test the /api/statistics/usagereports/ endpoints, see {@link UsageReportService} and
+ * Integration test to test the /api/statistics/usagereports/ endpoints, see {@link UsageReportUtils} and
  * {@link StatisticsRestRepository}
  *
  * @author Maria Verdonck (Atmire) on 10/06/2020

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
@@ -9,11 +9,6 @@ package org.dspace.app.rest;
 
 import static org.apache.commons.codec.CharEncoding.UTF_8;
 import static org.apache.commons.io.IOUtils.toInputStream;
-import static org.dspace.app.rest.builder.BitstreamBuilder.createBitstream;
-import static org.dspace.app.rest.builder.CollectionBuilder.createCollection;
-import static org.dspace.app.rest.builder.CommunityBuilder.createCommunity;
-import static org.dspace.app.rest.builder.CommunityBuilder.createSubCommunity;
-import static org.dspace.app.rest.builder.ItemBuilder.createItem;
 import static org.dspace.app.rest.repository.UsageReportService.TOP_CITIES_REPORT_ID;
 import static org.dspace.app.rest.repository.UsageReportService.TOP_COUNTRIES_REPORT_ID;
 import static org.dspace.app.rest.repository.UsageReportService.TOTAL_DOWNLOADS_REPORT_ID;
@@ -34,9 +29,6 @@ import java.util.Locale;
 import java.util.UUID;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.dspace.app.rest.builder.EPersonBuilder;
-import org.dspace.app.rest.builder.ResourcePolicyBuilder;
-import org.dspace.app.rest.builder.SiteBuilder;
 import org.dspace.app.rest.matcher.UsageReportMatcher;
 import org.dspace.app.rest.model.UsageReportPointCityRest;
 import org.dspace.app.rest.model.UsageReportPointCountryRest;
@@ -48,6 +40,13 @@ import org.dspace.app.rest.repository.StatisticsRestRepository;
 import org.dspace.app.rest.repository.UsageReportService;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.builder.BitstreamBuilder;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.EPersonBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.builder.ResourcePolicyBuilder;
+import org.dspace.builder.SiteBuilder;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
@@ -99,16 +98,17 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
 
         context.turnOffAuthorisationSystem();
 
-        Community community = createCommunity(context).build();
-        communityNotVisited = createSubCommunity(context, community).build();
-        communityVisited = createSubCommunity(context, community).build();
-        collectionNotVisited = createCollection(context, community).build();
-        collectionVisited = createCollection(context, community).build();
-        itemVisited = createItem(context, collectionNotVisited).build();
-        itemNotVisitedWithBitstreams = createItem(context, collectionNotVisited).build();
-        bitstreamNotVisited = createBitstream(context,
+        Community community = CommunityBuilder.createCommunity(context).build();
+        communityNotVisited = CommunityBuilder.createSubCommunity(context, community).build();
+        communityVisited = CommunityBuilder.createSubCommunity(context, community).build();
+        collectionNotVisited = CollectionBuilder.createCollection(context, community).build();
+        collectionVisited = CollectionBuilder.createCollection(context, community).build();
+        itemVisited = ItemBuilder.createItem(context, collectionNotVisited).build();
+        itemNotVisitedWithBitstreams = ItemBuilder.createItem(context, collectionNotVisited).build();
+        bitstreamNotVisited = BitstreamBuilder.createBitstream(context,
             itemNotVisitedWithBitstreams, toInputStream("test", UTF_8)).withName("BitstreamNotVisitedName").build();
-        bitstreamVisited = createBitstream(context, itemNotVisitedWithBitstreams, toInputStream("test", UTF_8))
+        bitstreamVisited = BitstreamBuilder
+            .createBitstream(context, itemNotVisitedWithBitstreams, toInputStream("test", UTF_8))
             .withName("BitstreamVisitedName").build();
 
         loggedInToken = getAuthToken(eperson.getEmail(), password);
@@ -866,7 +866,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
     public void usageReportsSearch_Site() throws Exception {
         context.turnOffAuthorisationSystem();
         Site site = SiteBuilder.createSite(context).build();
-        Item itemVisited2 = createItem(context, collectionNotVisited).build();
+        Item itemVisited2 = ItemBuilder.createItem(context, collectionNotVisited).build();
         context.restoreAuthSystemState();
 
         // ** WHEN **
@@ -1058,9 +1058,11 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
     public void usageReportsSearch_ItemVisited_FilesVisited() throws Exception {
         context.turnOffAuthorisationSystem();
         Bitstream bitstream1 =
-            createBitstream(context, itemVisited, toInputStream("test", UTF_8)).withName("bitstream1").build();
+            BitstreamBuilder.createBitstream(context, itemVisited, toInputStream("test", UTF_8)).withName("bitstream1")
+                            .build();
         Bitstream bitstream2 =
-            createBitstream(context, itemVisited, toInputStream("test", UTF_8)).withName("bitstream2").build();
+            BitstreamBuilder.createBitstream(context, itemVisited, toInputStream("test", UTF_8)).withName("bitstream2")
+                            .build();
         context.restoreAuthSystemState();
 
         // ** WHEN **

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
@@ -54,6 +54,7 @@ import org.dspace.content.Item;
 import org.dspace.content.Site;
 import org.dspace.core.Constants;
 import org.dspace.eperson.EPerson;
+import org.dspace.services.ConfigurationService;
 import org.dspace.statistics.factory.StatisticsServiceFactory;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -69,6 +70,9 @@ import org.springframework.http.HttpStatus;
  * @author Maria Verdonck (Atmire) on 10/06/2020
  */
 public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    ConfigurationService configurationService;
     @Autowired
     protected AuthorizeService authorizeService;
 
@@ -95,6 +99,9 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
     @Override
     public void setUp() throws Exception {
         super.setUp();
+
+        // Explicitly use solr commit in SolrLoggerServiceImpl#postView
+        configurationService.setProperty("solr-statistics.autoCommit", false);
 
         context.turnOffAuthorisationSystem();
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
@@ -14,11 +14,11 @@ import static org.dspace.app.rest.builder.CollectionBuilder.createCollection;
 import static org.dspace.app.rest.builder.CommunityBuilder.createCommunity;
 import static org.dspace.app.rest.builder.CommunityBuilder.createSubCommunity;
 import static org.dspace.app.rest.builder.ItemBuilder.createItem;
-import static org.dspace.app.rest.repository.UsageReportRestRepository.TOP_CITIES_REPORT_ID;
-import static org.dspace.app.rest.repository.UsageReportRestRepository.TOP_COUNTRIES_REPORT_ID;
-import static org.dspace.app.rest.repository.UsageReportRestRepository.TOTAL_DOWNLOADS_REPORT_ID;
-import static org.dspace.app.rest.repository.UsageReportRestRepository.TOTAL_VISITS_PER_MONTH_REPORT_ID;
-import static org.dspace.app.rest.repository.UsageReportRestRepository.TOTAL_VISITS_REPORT_ID;
+import static org.dspace.app.rest.repository.UsageReportService.TOP_CITIES_REPORT_ID;
+import static org.dspace.app.rest.repository.UsageReportService.TOP_COUNTRIES_REPORT_ID;
+import static org.dspace.app.rest.repository.UsageReportService.TOTAL_DOWNLOADS_REPORT_ID;
+import static org.dspace.app.rest.repository.UsageReportService.TOTAL_VISITS_PER_MONTH_REPORT_ID;
+import static org.dspace.app.rest.repository.UsageReportService.TOTAL_VISITS_REPORT_ID;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.not;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -44,7 +44,8 @@ import org.dspace.app.rest.model.UsageReportPointDateRest;
 import org.dspace.app.rest.model.UsageReportPointDsoTotalVisitsRest;
 import org.dspace.app.rest.model.UsageReportPointRest;
 import org.dspace.app.rest.model.ViewEventRest;
-import org.dspace.app.rest.repository.UsageReportRestRepository;
+import org.dspace.app.rest.repository.StatisticsRestRepository;
+import org.dspace.app.rest.repository.UsageReportService;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Bitstream;
@@ -63,11 +64,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
 /**
- * Integration test to test the /api/statistics/usagereports/ endpoints, see {@link UsageReportRestRepository}
+ * Integration test to test the /api/statistics/usagereports/ endpoints, see {@link UsageReportService} and
+ * {@link StatisticsRestRepository}
  *
  * @author Maria Verdonck (Atmire) on 10/06/2020
  */
-public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTest {
+public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Autowired
     protected AuthorizeService authorizeService;
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/UsageReportRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/UsageReportRestRepositoryIT.java
@@ -519,7 +519,7 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
             .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
     }
 
-    // Create expected points from -6 months to now, with a view in current month
+    // Create expected points from -6 months to now, with given number of views in current month
     private List<UsageReportPointRest> getListOfVisitsPerMonthsPoints(int viewsLastMonth) {
         List<UsageReportPointRest> expectedPoints = new ArrayList<>();
         int nrOfMonthsBack = 6;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/UsageReportRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/UsageReportRestRepositoryIT.java
@@ -14,6 +14,11 @@ import static org.dspace.app.rest.builder.CollectionBuilder.createCollection;
 import static org.dspace.app.rest.builder.CommunityBuilder.createCommunity;
 import static org.dspace.app.rest.builder.CommunityBuilder.createSubCommunity;
 import static org.dspace.app.rest.builder.ItemBuilder.createItem;
+import static org.dspace.app.rest.repository.UsageReportRestRepository.TOP_CITIES_REPORT_ID;
+import static org.dspace.app.rest.repository.UsageReportRestRepository.TOP_COUNTRIES_REPORT_ID;
+import static org.dspace.app.rest.repository.UsageReportRestRepository.TOTAL_DOWNLOADS_REPORT_ID;
+import static org.dspace.app.rest.repository.UsageReportRestRepository.TOTAL_VISITS_PER_MONTH_REPORT_ID;
+import static org.dspace.app.rest.repository.UsageReportRestRepository.TOTAL_VISITS_REPORT_ID;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -74,12 +79,6 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
     private String loggedInToken;
     private String adminToken;
 
-    private static final String TOTAL_VISITS_REPORT_ID = "TotalVisits";
-    private static final String TOTAL_VISITS_PER_MONTH_REPORT_ID = "TotalVisitsPerMonth";
-    private static final String TOTAL_DOWNLOADS_REPORT_ID = "TotalDownloads";
-    private static final String TOP_COUNTRIES_REPORT_ID = "TopCountries";
-    private static final String TOP_CITIES_REPORT_ID = "TopCities";
-
     @BeforeClass
     public static void clearStatistics() throws Exception {
         // To ensure these tests start "fresh", clear out any existing statistics data.
@@ -126,20 +125,21 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
 
     @Test
     public void usagereports_nonValidUUIDpart_Exception() throws Exception {
-        getClient().perform(get("/api/statistics/usagereports/notAnUUID_TotalVisits"))
+        getClient().perform(get("/api/statistics/usagereports/notAnUUID" + "_" + TOTAL_VISITS_REPORT_ID))
                    .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
     }
 
     @Test
     public void usagereports_nonValidReportIDpart_Exception() throws Exception {
-        getClient().perform(get("/api/statistics/usagereports/" + UUID.randomUUID() + "_NotValidReport"))
-                   .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
+        getClient().perform(get("/api/statistics/usagereports/" + itemNotVisitedWithBitstreams.getID() +
+                                "_NotValidReport"))
+                   .andExpect(status().is(HttpStatus.NOT_FOUND.value()));
     }
 
     @Test
     public void usagereports_NonExistentUUID_Exception() throws Exception {
         getClient().perform(get("/api/statistics/usagereports/" + UUID.randomUUID() + "_" + TOTAL_VISITS_REPORT_ID))
-                   .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
+                   .andExpect(status().is(HttpStatus.NOT_FOUND.value()));
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/UsageReportRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/UsageReportRestRepositoryIT.java
@@ -1,0 +1,439 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import static org.apache.commons.codec.CharEncoding.UTF_8;
+import static org.apache.commons.io.IOUtils.toInputStream;
+import static org.dspace.app.rest.builder.BitstreamBuilder.createBitstream;
+import static org.dspace.app.rest.builder.CollectionBuilder.createCollection;
+import static org.dspace.app.rest.builder.CommunityBuilder.createCommunity;
+import static org.dspace.app.rest.builder.CommunityBuilder.createSubCommunity;
+import static org.dspace.app.rest.builder.ItemBuilder.createItem;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.dspace.app.rest.matcher.UsageReportMatcher;
+import org.dspace.app.rest.model.UsageReportPointDateRest;
+import org.dspace.app.rest.model.UsageReportPointDsoTotalVisitsRest;
+import org.dspace.app.rest.model.UsageReportPointRest;
+import org.dspace.app.rest.model.ViewEventRest;
+import org.dspace.app.rest.repository.UsageReportRestRepository;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.statistics.factory.StatisticsServiceFactory;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Integration test to test the /api/statistics/usagereports/ endpoints of {@link UsageReportRestRepository}
+ *
+ * @author Maria Verdonck (Atmire) on 10/06/2020
+ */
+public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTest {
+
+    private Community communityNotVisited;
+    private Community communityVisited;
+    private Collection collectionNotVisited;
+    private Collection collectionVisited;
+    private Item itemNotVisited;
+    private Item itemVisited;
+    private Bitstream bitstreamNotVisited;
+    private Bitstream bitstreamVisited;
+    private String loggedInToken;
+
+    private static final String TOTAL_VISITS_REPORT_ID = "TotalVisits";
+    private static final String TOTAL_VISITS_PER_MONTH_REPORT_ID = "TotalVisitsPerMonth";
+
+    @BeforeClass
+    public static void clearStatistics() throws Exception {
+        // To ensure these tests start "fresh", clear out any existing statistics data.
+        // NOTE: this is committed immediately in removeIndex()
+        StatisticsServiceFactory.getInstance().getSolrLoggerService().removeIndex("*:*");
+    }
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        context.turnOffAuthorisationSystem();
+
+        Community community = createCommunity(context).build();
+        communityNotVisited = createSubCommunity(context, community).build();
+        communityVisited = createSubCommunity(context, community).build();
+        collectionNotVisited = createCollection(context, community).build();
+        collectionVisited = createCollection(context, community).build();
+        itemVisited = createItem(context, collectionNotVisited).build();
+        itemNotVisited = createItem(context, collectionNotVisited).build();
+        bitstreamNotVisited = createBitstream(context, itemNotVisited, toInputStream("test", UTF_8)).build();
+        bitstreamVisited = createBitstream(context, itemNotVisited, toInputStream("test", UTF_8)).build();
+
+        loggedInToken = getAuthToken(eperson.getEmail(), password);
+
+        context.restoreAuthSystemState();
+    }
+
+    @Test
+    public void usagereports_withoutId_NotImplementedException() throws Exception {
+        getClient().perform(get("/api/statistics/usagereports"))
+                   .andExpect(status().is(HttpStatus.METHOD_NOT_ALLOWED.value()));
+    }
+
+    @Test
+    public void usagereports_notProperUUIDAndReportId_Exception() throws Exception {
+        getClient().perform(get("/api/statistics/usagereports/notProperUUIDAndReportId"))
+                   .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @Test
+    public void usagereports_nonValidUUIDpart_Exception() throws Exception {
+        getClient().perform(get("/api/statistics/usagereports/notAnUUID_TotalVisits"))
+                   .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @Test
+    public void usagereports_nonValidReportIDpart_Exception() throws Exception {
+        getClient().perform(get("/api/statistics/usagereports/" + UUID.randomUUID() + "_NotValidReport"))
+                   .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @Test
+    public void usagereports_NonExistentUUID_Exception() throws Exception {
+        getClient().perform(get("/api/statistics/usagereports/" + UUID.randomUUID() + "_TotalVisits"))
+                   .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @Test
+    public void totalVisitsReport_Community_Visited() throws Exception {
+        //** WHEN **
+        //We visit the community
+        ViewEventRest viewEventRest = new ViewEventRest();
+        viewEventRest.setTargetType("community");
+        viewEventRest.setTargetId(communityVisited.getID());
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        UsageReportPointDsoTotalVisitsRest expectedPoint = new UsageReportPointDsoTotalVisitsRest();
+        expectedPoint.addValue("views", 1);
+        expectedPoint.setType("community");
+        expectedPoint.setId(communityVisited.getID().toString());
+
+        // And request that community's TotalVisits stat report
+        getClient().perform(
+            get("/api/statistics/usagereports/" + communityVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
+                   //** THEN **
+                   .andExpect(status().isOk())
+
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher
+                           .matchUsageReport(communityVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID,
+                               TOTAL_VISITS_REPORT_ID, Arrays.asList(expectedPoint))))
+                             );
+    }
+
+    @Test
+    public void totalVisitsReport_Community_NotVisited() throws Exception {
+        //** WHEN **
+        //Community is never visited
+        UsageReportPointDsoTotalVisitsRest expectedPoint = new UsageReportPointDsoTotalVisitsRest();
+        expectedPoint.addValue("views", 0);
+        expectedPoint.setType("community");
+        expectedPoint.setId(communityNotVisited.getID().toString());
+
+        // And request that community's TotalVisits stat report
+        getClient().perform(
+            get("/api/statistics/usagereports/" + communityNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
+                   //** THEN **
+                   .andExpect(status().isOk())
+
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher
+                           .matchUsageReport(communityNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID,
+                               TOTAL_VISITS_REPORT_ID, Arrays.asList(expectedPoint))))
+                             );
+    }
+
+    @Test
+    public void totalVisitsReport_Collection_Visited() throws Exception {
+        //** WHEN **
+        //We visit the collection twice
+        ViewEventRest viewEventRest = new ViewEventRest();
+        viewEventRest.setTargetType("collection");
+        viewEventRest.setTargetId(collectionVisited.getID());
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        UsageReportPointDsoTotalVisitsRest expectedPoint = new UsageReportPointDsoTotalVisitsRest();
+        expectedPoint.addValue("views", 2);
+        expectedPoint.setType("collection");
+        expectedPoint.setId(collectionVisited.getID().toString());
+
+        // And request that collection's TotalVisits stat report
+        getClient().perform(
+            get("/api/statistics/usagereports/" + collectionVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
+                   //** THEN **
+                   .andExpect(status().isOk())
+
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher
+                           .matchUsageReport(collectionVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID,
+                               TOTAL_VISITS_REPORT_ID, Arrays.asList(expectedPoint))))
+                             );
+    }
+
+    @Test
+    public void totalVisitsReport_Collection_NotVisited() throws Exception {
+        //** WHEN **
+        //Collection is never visited
+        UsageReportPointDsoTotalVisitsRest expectedPoint = new UsageReportPointDsoTotalVisitsRest();
+        expectedPoint.addValue("views", 0);
+        expectedPoint.setType("collection");
+        expectedPoint.setId(collectionNotVisited.getID().toString());
+
+        // And request that collection's TotalVisits stat report
+        getClient().perform(
+            get("/api/statistics/usagereports/" + collectionNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
+                   //** THEN **
+                   .andExpect(status().isOk())
+
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher
+                           .matchUsageReport(collectionNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID,
+                               TOTAL_VISITS_REPORT_ID, Arrays.asList(expectedPoint))))
+                             );
+    }
+
+    @Test
+    public void totalVisitsReport_Item_Visited() throws Exception {
+        //** WHEN **
+        //We visit an Item
+        ViewEventRest viewEventRest = new ViewEventRest();
+        viewEventRest.setTargetType("item");
+        viewEventRest.setTargetId(itemVisited.getID());
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        UsageReportPointDsoTotalVisitsRest expectedPoint = new UsageReportPointDsoTotalVisitsRest();
+        expectedPoint.addValue("views", 1);
+        expectedPoint.setType("item");
+        expectedPoint.setId(itemVisited.getID().toString());
+
+        // And request that collection's TotalVisits stat report
+        getClient().perform(
+            get("/api/statistics/usagereports/" + itemVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
+                   //** THEN **
+                   .andExpect(status().isOk())
+
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher
+                           .matchUsageReport(itemVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID,
+                               TOTAL_VISITS_REPORT_ID, Arrays.asList(expectedPoint))))
+                             );
+    }
+
+    @Test
+    public void totalVisitsReport_Item_NotVisited() throws Exception {
+        //** WHEN **
+        //Item is never visited
+        UsageReportPointDsoTotalVisitsRest expectedPoint = new UsageReportPointDsoTotalVisitsRest();
+        expectedPoint.addValue("views", 0);
+        expectedPoint.setType("item");
+        expectedPoint.setId(itemNotVisited.getID().toString());
+
+        // And request that item's TotalVisits stat report
+        getClient().perform(
+            get("/api/statistics/usagereports/" + itemNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
+                   //** THEN **
+                   .andExpect(status().isOk())
+
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher
+                           .matchUsageReport(itemNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID,
+                               TOTAL_VISITS_REPORT_ID, Arrays.asList(expectedPoint))))
+                             );
+    }
+
+    @Test
+    public void totalVisitsReport_Bitstream_Visited() throws Exception {
+        //** WHEN **
+        //We visit a Bitstream
+        ViewEventRest viewEventRest = new ViewEventRest();
+        viewEventRest.setTargetType("bitstream");
+        viewEventRest.setTargetId(bitstreamVisited.getID());
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        UsageReportPointDsoTotalVisitsRest expectedPoint = new UsageReportPointDsoTotalVisitsRest();
+        expectedPoint.addValue("views", 1);
+        expectedPoint.setType("bitstream");
+        expectedPoint.setId(bitstreamVisited.getID().toString());
+
+        // And request that bitstream's TotalVisits stat report
+        getClient().perform(
+            get("/api/statistics/usagereports/" + bitstreamVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
+                   //** THEN **
+                   .andExpect(status().isOk())
+
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher
+                           .matchUsageReport(bitstreamVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID,
+                               TOTAL_VISITS_REPORT_ID, Arrays.asList(expectedPoint))))
+                             );
+    }
+
+    @Test
+    public void totalVisitsReport_Bitstream_NotVisited() throws Exception {
+        //** WHEN **
+        //Bitstream is never visited
+        UsageReportPointDsoTotalVisitsRest expectedPoint = new UsageReportPointDsoTotalVisitsRest();
+        expectedPoint.addValue("views", 0);
+        expectedPoint.setType("bitstream");
+        expectedPoint.setId(bitstreamNotVisited.getID().toString());
+
+        // And request that bitstream's TotalVisits stat report
+        getClient().perform(
+            get("/api/statistics/usagereports/" + bitstreamNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
+                   //** THEN **
+                   .andExpect(status().isOk())
+
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher
+                           .matchUsageReport(bitstreamNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID,
+                               TOTAL_VISITS_REPORT_ID, Arrays.asList(expectedPoint))))
+                             );
+    }
+
+    @Test
+    public void totalVisitsPerMonthReport_Item_Visited() throws Exception {
+        //** WHEN **
+        //We visit an Item
+        ViewEventRest viewEventRest = new ViewEventRest();
+        viewEventRest.setTargetType("item");
+        viewEventRest.setTargetId(itemVisited.getID());
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        // Create expected points from -6 months to now, with a view in current month
+        List<UsageReportPointRest> expectedPoints = new ArrayList<>();
+        int nrOfMonthsBack = 6;
+        Calendar cal = Calendar.getInstance();
+        for (int i = 0; i <= nrOfMonthsBack; i++) {
+            UsageReportPointDateRest expectedPoint = new UsageReportPointDateRest();
+            if (i > 0) {
+                expectedPoint.addValue("views", 0);
+            } else {
+                expectedPoint.addValue("views", 1);
+            }
+            String month = cal.getDisplayName(Calendar.MONTH, Calendar.LONG, Locale.getDefault());
+            expectedPoint.setId(month + " " + cal.get(Calendar.YEAR));
+
+            expectedPoints.add(expectedPoint);
+            cal.add(Calendar.MONTH, -1);
+        }
+
+        // And request that collection's TotalVisits stat report
+        getClient().perform(
+            get("/api/statistics/usagereports/" + itemVisited.getID() + "_" + TOTAL_VISITS_PER_MONTH_REPORT_ID))
+                   //** THEN **
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher
+                           .matchUsageReport(itemVisited.getID() + "_" + TOTAL_VISITS_PER_MONTH_REPORT_ID,
+                               TOTAL_VISITS_PER_MONTH_REPORT_ID, expectedPoints))));
+    }
+
+    @Test
+    public void totalVisitsPerMonthReport_Collection_Visited() throws Exception {
+        //** WHEN **
+        //We visit an Item
+        ViewEventRest viewEventRest = new ViewEventRest();
+        viewEventRest.setTargetType("collection");
+        viewEventRest.setTargetId(collectionVisited.getID());
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        // Create expected points from -6 months to now, with a view in current month
+        List<UsageReportPointRest> expectedPoints = new ArrayList<>();
+        int nrOfMonthsBack = 6;
+        Calendar cal = Calendar.getInstance();
+        for (int i = 0; i <= nrOfMonthsBack; i++) {
+            UsageReportPointDateRest expectedPoint = new UsageReportPointDateRest();
+            if (i > 0) {
+                expectedPoint.addValue("views", 0);
+            } else {
+                expectedPoint.addValue("views", 1);
+            }
+            String month = cal.getDisplayName(Calendar.MONTH, Calendar.LONG, Locale.getDefault());
+            expectedPoint.setId(month + " " + cal.get(Calendar.YEAR));
+
+            expectedPoints.add(expectedPoint);
+            cal.add(Calendar.MONTH, -1);
+        }
+
+        // And request that collection's TotalVisits stat report
+        getClient().perform(
+            get("/api/statistics/usagereports/" + collectionVisited.getID() + "_" + TOTAL_VISITS_PER_MONTH_REPORT_ID))
+                   //** THEN **
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher
+                           .matchUsageReport(collectionVisited.getID() + "_" + TOTAL_VISITS_PER_MONTH_REPORT_ID,
+                               TOTAL_VISITS_PER_MONTH_REPORT_ID, expectedPoints))));
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/UsageReportRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/UsageReportRestRepositoryIT.java
@@ -28,6 +28,8 @@ import java.util.UUID;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dspace.app.rest.matcher.UsageReportMatcher;
+import org.dspace.app.rest.model.UsageReportPointCityRest;
+import org.dspace.app.rest.model.UsageReportPointCountryRest;
 import org.dspace.app.rest.model.UsageReportPointDateRest;
 import org.dspace.app.rest.model.UsageReportPointDsoTotalVisitsRest;
 import org.dspace.app.rest.model.UsageReportPointRest;
@@ -46,7 +48,7 @@ import org.junit.Test;
 import org.springframework.http.HttpStatus;
 
 /**
- * Integration test to test the /api/statistics/usagereports/ endpoints of {@link UsageReportRestRepository}
+ * Integration test to test the /api/statistics/usagereports/ endpoints, see {@link UsageReportRestRepository}
  *
  * @author Maria Verdonck (Atmire) on 10/06/2020
  */
@@ -65,6 +67,8 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
     private static final String TOTAL_VISITS_REPORT_ID = "TotalVisits";
     private static final String TOTAL_VISITS_PER_MONTH_REPORT_ID = "TotalVisitsPerMonth";
     private static final String TOTAL_DOWNLOADS_REPORT_ID = "TotalDownloads";
+    private static final String TOP_COUNTRIES_REPORT_ID = "TopCountries";
+    private static final String TOP_CITIES_REPORT_ID = "TopCities";
 
     @BeforeClass
     public static void clearStatistics() throws Exception {
@@ -129,8 +133,8 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
 
     @Test
     public void totalVisitsReport_Community_Visited() throws Exception {
-        //** WHEN **
-        //We visit the community
+        // ** WHEN **
+        // We visit the community
         ViewEventRest viewEventRest = new ViewEventRest();
         viewEventRest.setTargetType("community");
         viewEventRest.setTargetId(communityVisited.getID());
@@ -150,9 +154,8 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
         // And request that community's TotalVisits stat report
         getClient().perform(
             get("/api/statistics/usagereports/" + communityVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
-                   //** THEN **
+                   // ** THEN **
                    .andExpect(status().isOk())
-
                    .andExpect(jsonPath("$", Matchers.is(
                        UsageReportMatcher
                            .matchUsageReport(communityVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID,
@@ -162,8 +165,8 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
 
     @Test
     public void totalVisitsReport_Community_NotVisited() throws Exception {
-        //** WHEN **
-        //Community is never visited
+        // ** WHEN **
+        // Community is never visited
         UsageReportPointDsoTotalVisitsRest expectedPoint = new UsageReportPointDsoTotalVisitsRest();
         expectedPoint.addValue("views", 0);
         expectedPoint.setType("community");
@@ -172,9 +175,8 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
         // And request that community's TotalVisits stat report
         getClient().perform(
             get("/api/statistics/usagereports/" + communityNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
-                   //** THEN **
+                   // ** THEN **
                    .andExpect(status().isOk())
-
                    .andExpect(jsonPath("$", Matchers.is(
                        UsageReportMatcher
                            .matchUsageReport(communityNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID,
@@ -184,8 +186,8 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
 
     @Test
     public void totalVisitsReport_Collection_Visited() throws Exception {
-        //** WHEN **
-        //We visit the collection twice
+        // ** WHEN **
+        // We visit the collection twice
         ViewEventRest viewEventRest = new ViewEventRest();
         viewEventRest.setTargetType("collection");
         viewEventRest.setTargetId(collectionVisited.getID());
@@ -210,9 +212,8 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
         // And request that collection's TotalVisits stat report
         getClient().perform(
             get("/api/statistics/usagereports/" + collectionVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
-                   //** THEN **
+                   // ** THEN **
                    .andExpect(status().isOk())
-
                    .andExpect(jsonPath("$", Matchers.is(
                        UsageReportMatcher
                            .matchUsageReport(collectionVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID,
@@ -222,8 +223,8 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
 
     @Test
     public void totalVisitsReport_Collection_NotVisited() throws Exception {
-        //** WHEN **
-        //Collection is never visited
+        // ** WHEN **
+        // Collection is never visited
         UsageReportPointDsoTotalVisitsRest expectedPoint = new UsageReportPointDsoTotalVisitsRest();
         expectedPoint.addValue("views", 0);
         expectedPoint.setType("collection");
@@ -232,9 +233,8 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
         // And request that collection's TotalVisits stat report
         getClient().perform(
             get("/api/statistics/usagereports/" + collectionNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
-                   //** THEN **
+                   // ** THEN **
                    .andExpect(status().isOk())
-
                    .andExpect(jsonPath("$", Matchers.is(
                        UsageReportMatcher
                            .matchUsageReport(collectionNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID,
@@ -244,8 +244,8 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
 
     @Test
     public void totalVisitsReport_Item_Visited() throws Exception {
-        //** WHEN **
-        //We visit an Item
+        // ** WHEN **
+        // We visit an Item
         ViewEventRest viewEventRest = new ViewEventRest();
         viewEventRest.setTargetType("item");
         viewEventRest.setTargetId(itemVisited.getID());
@@ -265,9 +265,8 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
         // And request that collection's TotalVisits stat report
         getClient().perform(
             get("/api/statistics/usagereports/" + itemVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
-                   //** THEN **
+                   // ** THEN **
                    .andExpect(status().isOk())
-
                    .andExpect(jsonPath("$", Matchers.is(
                        UsageReportMatcher
                            .matchUsageReport(itemVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID,
@@ -277,7 +276,7 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
 
     @Test
     public void totalVisitsReport_Item_NotVisited() throws Exception {
-        //** WHEN **
+        // ** WHEN **
         //Item is never visited
         UsageReportPointDsoTotalVisitsRest expectedPoint = new UsageReportPointDsoTotalVisitsRest();
         expectedPoint.addValue("views", 0);
@@ -287,9 +286,8 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
         // And request that item's TotalVisits stat report
         getClient().perform(
             get("/api/statistics/usagereports/" + itemNotVisitedWithBitstreams.getID() + "_" + TOTAL_VISITS_REPORT_ID))
-                   //** THEN **
+                   // ** THEN **
                    .andExpect(status().isOk())
-
                    .andExpect(jsonPath("$", Matchers.is(
                        UsageReportMatcher
                            .matchUsageReport(itemNotVisitedWithBitstreams.getID() + "_" + TOTAL_VISITS_REPORT_ID,
@@ -299,8 +297,8 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
 
     @Test
     public void totalVisitsReport_Bitstream_Visited() throws Exception {
-        //** WHEN **
-        //We visit a Bitstream
+        // ** WHEN **
+        // We visit a Bitstream
         ViewEventRest viewEventRest = new ViewEventRest();
         viewEventRest.setTargetType("bitstream");
         viewEventRest.setTargetId(bitstreamVisited.getID());
@@ -320,9 +318,8 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
         // And request that bitstream's TotalVisits stat report
         getClient().perform(
             get("/api/statistics/usagereports/" + bitstreamVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
-                   //** THEN **
+                   // ** THEN **
                    .andExpect(status().isOk())
-
                    .andExpect(jsonPath("$", Matchers.is(
                        UsageReportMatcher
                            .matchUsageReport(bitstreamVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID,
@@ -332,8 +329,8 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
 
     @Test
     public void totalVisitsReport_Bitstream_NotVisited() throws Exception {
-        //** WHEN **
-        //Bitstream is never visited
+        // ** WHEN **
+        // Bitstream is never visited
         UsageReportPointDsoTotalVisitsRest expectedPoint = new UsageReportPointDsoTotalVisitsRest();
         expectedPoint.addValue("views", 0);
         expectedPoint.setType("bitstream");
@@ -342,9 +339,8 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
         // And request that bitstream's TotalVisits stat report
         getClient().perform(
             get("/api/statistics/usagereports/" + bitstreamNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
-                   //** THEN **
+                   // ** THEN **
                    .andExpect(status().isOk())
-
                    .andExpect(jsonPath("$", Matchers.is(
                        UsageReportMatcher
                            .matchUsageReport(bitstreamNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID,
@@ -354,8 +350,8 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
 
     @Test
     public void totalVisitsPerMonthReport_Item_Visited() throws Exception {
-        //** WHEN **
-        //We visit an Item
+        // ** WHEN **
+        // We visit an Item
         ViewEventRest viewEventRest = new ViewEventRest();
         viewEventRest.setTargetType("item");
         viewEventRest.setTargetId(itemVisited.getID());
@@ -372,7 +368,7 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
         // And request that item's TotalVisitsPerMonth stat report
         getClient().perform(
             get("/api/statistics/usagereports/" + itemVisited.getID() + "_" + TOTAL_VISITS_PER_MONTH_REPORT_ID))
-                   //** THEN **
+                   // ** THEN **
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$", Matchers.is(
                        UsageReportMatcher
@@ -382,15 +378,15 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
 
     @Test
     public void totalVisitsPerMonthReport_Item_NotVisited() throws Exception {
-        //** WHEN **
-        //Item is not visited
+        // ** WHEN **
+        // Item is not visited
         List<UsageReportPointRest> expectedPoints = this.getListOfVisitsPerMonthsPoints(0);
 
         // And request that item's TotalVisitsPerMonth stat report
         getClient().perform(
             get("/api/statistics/usagereports/" + itemNotVisitedWithBitstreams.getID() + "_" +
                 TOTAL_VISITS_PER_MONTH_REPORT_ID))
-                   //** THEN **
+                   // ** THEN **
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$", Matchers.is(
                        UsageReportMatcher
@@ -401,8 +397,8 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
 
     @Test
     public void totalVisitsPerMonthReport_Collection_Visited() throws Exception {
-        //** WHEN **
-        //We visit a Collection twice
+        // ** WHEN **
+        // We visit a Collection twice
         ViewEventRest viewEventRest = new ViewEventRest();
         viewEventRest.setTargetType("collection");
         viewEventRest.setTargetId(collectionVisited.getID());
@@ -424,7 +420,7 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
         // And request that collection's TotalVisitsPerMonth stat report
         getClient().perform(
             get("/api/statistics/usagereports/" + collectionVisited.getID() + "_" + TOTAL_VISITS_PER_MONTH_REPORT_ID))
-                   //** THEN **
+                   // ** THEN **
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$", Matchers.is(
                        UsageReportMatcher
@@ -434,8 +430,8 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
 
     @Test
     public void TotalDownloadsReport_Bitstream() throws Exception {
-        //** WHEN **
-        //We visit a Bitstream
+        // ** WHEN **
+        // We visit a Bitstream
         ViewEventRest viewEventRest = new ViewEventRest();
         viewEventRest.setTargetType("bitstream");
         viewEventRest.setTargetId(bitstreamVisited.getID());
@@ -455,7 +451,7 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
         // And request that bitstreams's TotalDownloads stat report
         getClient().perform(
             get("/api/statistics/usagereports/" + bitstreamVisited.getID() + "_" + TOTAL_DOWNLOADS_REPORT_ID))
-                   //** THEN **
+                   // ** THEN **
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$", Matchers.is(
                        UsageReportMatcher
@@ -465,8 +461,8 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
 
     @Test
     public void TotalDownloadsReport_Item() throws Exception {
-        //** WHEN **
-        //We visit an Item's bitstream
+        // ** WHEN **
+        // We visit an Item's bitstream
         ViewEventRest viewEventRest = new ViewEventRest();
         viewEventRest.setTargetType("bitstream");
         viewEventRest.setTargetId(bitstreamVisited.getID());
@@ -483,12 +479,11 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
         expectedPoint.setType("bitstream");
         expectedPoint.setId("Bitstream");
 
-
         // And request that item's TotalDownloads stat report
         getClient().perform(
             get("/api/statistics/usagereports/" + itemNotVisitedWithBitstreams.getID() + "_" +
                 TOTAL_DOWNLOADS_REPORT_ID))
-                   //** THEN **
+                   // ** THEN **
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$", Matchers.is(
                        UsageReportMatcher
@@ -498,13 +493,13 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
 
     @Test
     public void TotalDownloadsReport_Item_NotVisited() throws Exception {
-        //** WHEN **
+        // ** WHEN **
         // You don't visit an item's bitstreams
         // And request that item's TotalDownloads stat report
         getClient().perform(
             get("/api/statistics/usagereports/" + itemNotVisitedWithBitstreams.getID() + "_" +
                 TOTAL_DOWNLOADS_REPORT_ID))
-                   //** THEN **
+                   // ** THEN **
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$", Matchers.is(
                        UsageReportMatcher
@@ -517,6 +512,191 @@ public class UsageReportRestRepositoryIT extends AbstractControllerIntegrationTe
         getClient()
             .perform(get("/api/statistics/usagereports/" + collectionVisited.getID() + "_" + TOTAL_DOWNLOADS_REPORT_ID))
             .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    /**
+     * Note: Geolite response mocked in {@link org.dspace.statistics.MockSolrLoggerServiceImpl}
+     */
+    @Test
+    public void topCountriesReport_Collection_Visited() throws Exception {
+        // ** WHEN **
+        // We visit a Collection
+        ViewEventRest viewEventRest = new ViewEventRest();
+        viewEventRest.setTargetType("collection");
+        viewEventRest.setTargetId(collectionVisited.getID());
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        UsageReportPointCountryRest expectedPoint = new UsageReportPointCountryRest();
+        expectedPoint.addValue("views", 1);
+        expectedPoint.setId("US");
+        expectedPoint.setLabel("United States");
+
+        // And request that collection's TopCountries report
+        getClient().perform(
+            get("/api/statistics/usagereports/" + collectionVisited.getID() + "_" + TOP_COUNTRIES_REPORT_ID))
+                   // ** THEN **
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher
+                           .matchUsageReport(collectionVisited.getID() + "_" + TOP_COUNTRIES_REPORT_ID,
+                               TOP_COUNTRIES_REPORT_ID, Arrays.asList(expectedPoint)))));
+    }
+
+    /**
+     * Note: Geolite response mocked in {@link org.dspace.statistics.MockSolrLoggerServiceImpl}
+     */
+    @Test
+    public void topCountriesReport_Community_Visited() throws Exception {
+        // ** WHEN **
+        // We visit a Community twice
+        ViewEventRest viewEventRest = new ViewEventRest();
+        viewEventRest.setTargetType("community");
+        viewEventRest.setTargetId(communityVisited.getID());
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        UsageReportPointCountryRest expectedPoint = new UsageReportPointCountryRest();
+        expectedPoint.addValue("views", 2);
+        expectedPoint.setId("US");
+        expectedPoint.setLabel("United States");
+
+        // And request that collection's TopCountries report
+        getClient().perform(
+            get("/api/statistics/usagereports/" + communityVisited.getID() + "_" + TOP_COUNTRIES_REPORT_ID))
+                   // ** THEN **
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher
+                           .matchUsageReport(communityVisited.getID() + "_" + TOP_COUNTRIES_REPORT_ID,
+                               TOP_COUNTRIES_REPORT_ID, Arrays.asList(expectedPoint)))));
+    }
+
+    /**
+     * Note: Geolite response mocked in {@link org.dspace.statistics.MockSolrLoggerServiceImpl}
+     */
+    @Test
+    public void topCountriesReport_Item_NotVisited() throws Exception {
+        // ** WHEN **
+        // Item is not visited
+        // And request that item's TopCountries report
+        getClient().perform(
+            get("/api/statistics/usagereports/" + itemNotVisitedWithBitstreams.getID() + "_" + TOP_COUNTRIES_REPORT_ID))
+                   // ** THEN **
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher
+                           .matchUsageReport(itemNotVisitedWithBitstreams.getID() + "_" + TOP_COUNTRIES_REPORT_ID,
+                               TOP_COUNTRIES_REPORT_ID, new ArrayList<>()))));
+    }
+
+    /**
+     * Note: Geolite response mocked in {@link org.dspace.statistics.MockSolrLoggerServiceImpl}
+     */
+    @Test
+    public void topCitiesReport_Item_Visited() throws Exception {
+        // ** WHEN **
+        // We visit an Item
+        ViewEventRest viewEventRest = new ViewEventRest();
+        viewEventRest.setTargetType("item");
+        viewEventRest.setTargetId(itemVisited.getID());
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        UsageReportPointCityRest expectedPoint = new UsageReportPointCityRest();
+        expectedPoint.addValue("views", 1);
+        expectedPoint.setId("New York");
+
+        // And request that item's TopCities report
+        getClient().perform(
+            get("/api/statistics/usagereports/" + itemVisited.getID() + "_" + TOP_CITIES_REPORT_ID))
+                   // ** THEN **
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher
+                           .matchUsageReport(itemVisited.getID() + "_" + TOP_CITIES_REPORT_ID,
+                               TOP_CITIES_REPORT_ID, Arrays.asList(expectedPoint)))));
+    }
+
+    /**
+     * Note: Geolite response mocked in {@link org.dspace.statistics.MockSolrLoggerServiceImpl}
+     */
+    @Test
+    public void topCitiesReport_Community_Visited() throws Exception {
+        // ** WHEN **
+        // We visit a Community thrice
+        ViewEventRest viewEventRest = new ViewEventRest();
+        viewEventRest.setTargetType("community");
+        viewEventRest.setTargetId(communityVisited.getID());
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        UsageReportPointCityRest expectedPoint = new UsageReportPointCityRest();
+        expectedPoint.addValue("views", 3);
+        expectedPoint.setId("New York");
+
+        // And request that community's TopCities report
+        getClient().perform(
+            get("/api/statistics/usagereports/" + communityVisited.getID() + "_" + TOP_CITIES_REPORT_ID))
+                   // ** THEN **
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher
+                           .matchUsageReport(communityVisited.getID() + "_" + TOP_CITIES_REPORT_ID,
+                               TOP_CITIES_REPORT_ID, Arrays.asList(expectedPoint)))));
+    }
+
+    /**
+     * Note: Geolite response mocked in {@link org.dspace.statistics.MockSolrLoggerServiceImpl}
+     */
+    @Test
+    public void topCitiesReport_Collection_NotVisited() throws Exception {
+        // ** WHEN **
+        // Collection is not visited
+        // And request that collection's TopCountries report
+        getClient().perform(
+            get("/api/statistics/usagereports/" + collectionNotVisited.getID() + "_" + TOP_CITIES_REPORT_ID))
+                   // ** THEN **
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher
+                           .matchUsageReport(collectionNotVisited.getID() + "_" + TOP_CITIES_REPORT_ID,
+                               TOP_CITIES_REPORT_ID, new ArrayList<>()))));
     }
 
     // Create expected points from -6 months to now, with given number of views in current month

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/UsageReportMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/UsageReportMatcher.java
@@ -1,0 +1,40 @@
+package org.dspace.app.rest.matcher;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.dspace.app.rest.model.UsageReportPointRest;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+
+/**
+ * Matcher to match {@Link UsageReportRest}
+ *
+ * @author Maria Verdonck (Atmire) on 10/06/2020
+ */
+public class UsageReportMatcher {
+
+    private UsageReportMatcher() {
+    }
+
+    private static Matcher<? super Object> matchUsageReport(String id, String reportType) {
+        return allOf(
+            hasJsonPath("$.id", is(id)),
+            hasJsonPath("$.report-type", is(reportType))
+                    );
+    }
+
+    public static Matcher<? super Object> matchUsageReport(String id, String reportType,
+                                                           List<UsageReportPointRest> points) {
+        return allOf(
+            matchUsageReport(id, reportType),
+            hasJsonPath("$.points", Matchers.containsInAnyOrder(
+                points.stream().map(point -> UsageReportPointMatcher
+                    .matchUsageReportPoint(point.getId(), point.getType(), point.getValues().get("views")))
+                      .collect(Collectors.toList()))));
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/UsageReportMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/UsageReportMatcher.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.app.rest.matcher;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/UsageReportMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/UsageReportMatcher.java
@@ -28,13 +28,27 @@ public class UsageReportMatcher {
     private UsageReportMatcher() {
     }
 
+    /**
+     * Matcher for the usage report on just id and report-type
+     *
+     * @param id         Id to match if of json of UsageReport
+     * @param reportType ReportType to match if of json of UsageReport
+     * @return The matcher
+     */
     private static Matcher<? super Object> matchUsageReport(String id, String reportType) {
         return allOf(
             hasJsonPath("$.id", is(id)),
-            hasJsonPath("$.report-type", is(reportType))
-                    );
+            hasJsonPath("$.report-type", is(reportType)));
     }
 
+    /**
+     * Matcher for the usage report including the {@link UsageReportPointRest} points
+     *
+     * @param id         Id to match if of json of UsageReport
+     * @param reportType ReportType to match if of json of UsageReport
+     * @param points     List of points to match to the json of UsageReport's list of points
+     * @return The matcher
+     */
     public static Matcher<? super Object> matchUsageReport(String id, String reportType,
                                                            List<UsageReportPointRest> points) {
         return allOf(

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/UsageReportPointMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/UsageReportPointMatcher.java
@@ -11,6 +11,7 @@ import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.is;
 
+import org.dspace.app.rest.model.UsageReportPointRest;
 import org.hamcrest.Matcher;
 
 /**
@@ -23,6 +24,14 @@ public class UsageReportPointMatcher {
     private UsageReportPointMatcher() {
     }
 
+    /**
+     * Matcher for the usage report points (see {@link UsageReportPointRest})
+     *
+     * @param id    Id to match if of json of UsageReportPoint
+     * @param type  Type to match if of json of UsageReportPoint
+     * @param views Nr of views, is in the values key-value pair of values of UsageReportPoint with key "views"
+     * @return The matcher
+     */
     public static Matcher<? super Object> matchUsageReportPoint(String id, String type, int views) {
         return allOf(
             hasJsonPath("$.id", is(id)),

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/UsageReportPointMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/UsageReportPointMatcher.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.app.rest.matcher;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/UsageReportPointMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/UsageReportPointMatcher.java
@@ -1,0 +1,25 @@
+package org.dspace.app.rest.matcher;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.is;
+
+import org.hamcrest.Matcher;
+
+/**
+ * Matcher to match {@Link UsageReportPointRest}
+ *
+ * @author Maria Verdonck (Atmire) on 10/06/2020
+ */
+public class UsageReportPointMatcher {
+
+    private UsageReportPointMatcher() {
+    }
+
+    public static Matcher<? super Object> matchUsageReportPoint(String id, String type, int views) {
+        return allOf(
+            hasJsonPath("$.id", is(id)),
+            hasJsonPath("$.values.views", is(views))
+                    );
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/UsageReportPointMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/UsageReportPointMatcher.java
@@ -35,6 +35,7 @@ public class UsageReportPointMatcher {
     public static Matcher<? super Object> matchUsageReportPoint(String id, String type, int views) {
         return allOf(
             hasJsonPath("$.id", is(id)),
+            hasJsonPath("$.type", is(type)),
             hasJsonPath("$.values.views", is(views))
                     );
     }

--- a/dspace/config/modules/solr-statistics.cfg
+++ b/dspace/config/modules/solr-statistics.cfg
@@ -27,6 +27,10 @@ solr-statistics.configset = statistics
 # if record is a bot. true by default.
 #solr-statistics.query.filter.isBot = true
 
+# Whether or not explicit solr.commit can be done in SolrLoggerServiceImpl#postView, or to be left to the autocommit.
+# Defaults to true (i.e. via autoCommit, no explicit commits); set to false in statistics tests (e.g. StatisticsRestRepositoryIT)
+solr-statistics.autoCommit = true
+
 # URLs to download IP addresses of search engine spiders from
 solr-statistics.spiderips.urls = http://iplists.com/google.txt, \
                  http://iplists.com/inktomi.txt, \

--- a/dspace/config/modules/usage-statistics.cfg
+++ b/dspace/config/modules/usage-statistics.cfg
@@ -40,3 +40,6 @@ usage-statistics.authorization.admin.workflow=true
 # Enable/disable if a matching for a bot should be case sensitive
 # Setting this value to true will increase cpu usage, but bots will be found more accurately
 #usage-statistics.bots.case-insensitive = false
+
+# Set to true if the statistics core is sharded into a core per year, defaults to false
+usage-statistics.shardedByYear = false

--- a/dspace/config/modules/usage-statistics.cfg
+++ b/dspace/config/modules/usage-statistics.cfg
@@ -42,4 +42,5 @@ usage-statistics.authorization.admin.workflow=true
 #usage-statistics.bots.case-insensitive = false
 
 # Set to true if the statistics core is sharded into a core per year, defaults to false
+# If you are sharding your statistics index each year by running "dspace stats-util -s", you should set this to "true"
 usage-statistics.shardedByYear = false


### PR DESCRIPTION
## References
* [REST Contract](https://github.com/DSpace/Rest7Contract/blob/master/statistics-reports.md)

## Description
This PR adds in the functionality to retrieve the statistics created through the [viewevents](https://github.com/DSpace/Rest7Contract/blob/master/statistics-viewevents.md)

## Instructions for Reviewers
List of changes in this PR:
* Rest representations of Usage Reports in the DSpace statistics, and it's related converter
* Endpoints have been added to the StatisticsRestRepository, keeping the open [PreAuthorize related PR](https://github.com/DSpace/DSpace/pull/2778) in mind (using the findOne method for permission checks)

Please refer to the [viewevents](https://github.com/DSpace/Rest7Contract/blob/master/statistics-viewevents.md) information on stats creation
**Make sure to also have a valid GeoLite configured in [usage-statistics.cfg](https://github.com/DSpace/DSpace/blob/master/dspace/config/modules/usage-statistics.cfg#L9)** 
### Sharded Cores
Note that we added in a flag to check if the solr statistics core is sharded or not. We noticed that, if the code assumes that the core is sharded, while it isn't that statistics are counted twice.
This is because the 'default' statistics core is loaded in, and then from the related solr, [it tries to find any additional core/shard](https://github.com/DSpace/DSpace/blob/bf7a8136189a3d93b9f9624b291daca69b12dae2/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java#L1540), resulting in a query being done similar to the following
>shards=localhost:8983/solr/statistics,localhost:8983/solr/statistics 

### Solr autocommit
Please keep in mind that solr's autocommit might not be 100% functional in all cases 
The time between autocommits is defined as:
><maxTime>${solr.autoCommit.maxTime:900000}</maxTime> 

If a solr.autoCommit.maxtime is found, that is used, otherwise it defaults to 15 minutes.
In some instances, this (A workaround is 'hardcoding' it to 15 minutes manually in [solrconfig.xml](https://github.com/DSpace/DSpace/blob/master/dspace/solr/statistics/conf/solrconfig.xml#L54)) 
This will need to be followed up separately as well for investigation (Not a technically breaking problem at this point)
## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/master/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
