### PR TITLE
DS-3679 E-Mail Configuration not valid if mail.server.username is not specified

### DIFF
--- a/dspace-services/src/main/java/org/dspace/services/email/EmailServiceImpl.java
+++ b/dspace-services/src/main/java/org/dspace/services/email/EmailServiceImpl.java
@@ -16,6 +16,7 @@ import javax.naming.NameNotFoundException;
 import javax.naming.NamingException;
 import javax.naming.NoInitialContextException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.kernel.mixins.InitializedService;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.EmailService;
@@ -106,7 +107,7 @@ public class EmailServiceImpl
                     props.put(key, value);
                 }
             }
-            if (null == cfg.getProperty("mail.server.username")) {
+            if (StringUtils.isBlank(cfg.getProperty("mail.server.username"))) {
                 session = Session.getInstance(props);
             } else {
                 props.put("mail.smtp.auth", "true");
@@ -124,5 +125,13 @@ public class EmailServiceImpl
         return new PasswordAuthentication(
             cfg.getProperty("mail.server.username"),
             cfg.getProperty("mail.server.password"));
+    }
+
+    /**
+     * Force a new initialization of the session, useful for testing purpose
+     */
+    public void reset() {
+        session = null;
+        init();
     }
 }

--- a/dspace-services/src/test/java/org/dspace/services/email/EmailServiceImplTest.java
+++ b/dspace-services/src/test/java/org/dspace/services/email/EmailServiceImplTest.java
@@ -10,6 +10,7 @@ package org.dspace.services.email;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import javax.mail.MessagingException;
 import javax.mail.PasswordAuthentication;
@@ -65,10 +66,41 @@ public class EmailServiceImplTest
         // Try to get a Session
         session = instance.getSession();
         assertNotNull(" getSession returned null", session);
+        assertNull(" getSession returned authenticated session",
+                session.getProperties().getProperty("mail.smtp.auth"));
     }
 
     private static final String CFG_USERNAME = "mail.server.username";
     private static final String CFG_PASSWORD = "mail.server.password";
+
+    /**
+     * Test of testGetSession method, of class EmailServiceImpl when an smtp
+     * username is provided.
+     */
+    @Test
+    public void testGetAuthenticatedInstance() {
+        System.out.println("getSession");
+        ConfigurationService cfg = getKernel().getConfigurationService();
+
+        // Save existing values.
+        String oldUsername = cfg.getProperty(CFG_USERNAME);
+        String oldPassword = cfg.getProperty(CFG_PASSWORD);
+
+        // Set known values.
+        cfg.setProperty(CFG_USERNAME, USERNAME);
+        cfg.setProperty(CFG_PASSWORD, PASSWORD);
+
+        EmailServiceImpl instance = (EmailServiceImpl) getService(EmailServiceImpl.class);
+        instance.reset();
+        assertNotNull(" getSession returned null", instance);
+        assertEquals(" authenticated session ", "true",
+                instance.getSession().getProperties().getProperty("mail.smtp.auth"));
+
+        // Restore old values, if any.
+        cfg.setProperty(CFG_USERNAME, oldUsername);
+        cfg.setProperty(CFG_PASSWORD, oldPassword);
+        instance.reset();
+    }
 
     /**
      * Test of getPasswordAuthentication method, of class EmailServiceImpl.


### PR DESCRIPTION
## References
_Add references/links to any related tickets or PRs. These may include:_
* https://jira.lyrasis.org/browse/DS-3679
* https://github.com/DSpace/DSpace/issues/2811

## Description
Fix the check on the mail.server.username property to avoid the creation of an authenticated session with empty credentials

## Instructions for Reviewers
A default installation of DSpace should be unable to send email via localhost or any smtp server that doesn't required authentication if only the mail.server property is specified in the local.cfg

Unit Test are included to proof the fix

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [N/A] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/master/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [N/A] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
