### PR TITLE
[Travis CI] Switch to OpenJDK as OracleJDK is having download/install issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-sudo: false
+os: linux
 dist: trusty
 
 env:
@@ -7,17 +7,8 @@ env:
   - MAVEN_OPTS=-Xmx1024M
 
 jdk:
-  # DS-3384 Oracle JDK has DocLint enabled by default.
-  # Let's use this to catch any newly introduced DocLint issues.
-  - oraclejdk11
-
-## Should we run into any problems with oraclejdk8 on Travis, we may try the following workaround.
-## https://docs.travis-ci.com/user/languages/java#Testing-Against-Multiple-JDKs
-## https://github.com/travis-ci/travis-ci/issues/3259#issuecomment-130860338
-#addons:
-#  apt:
-#    packages:
-#      - oracle-java8-installer
+  # Java 11 (NOTE: OracleJDK no longer well supported as Oracle requires account signup to download)
+  - openjdk11
 
 before_install:
   # Remove outdated settings.xml from Travis builds. Workaround for https://github.com/travis-ci/travis-ci/issues/4629

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 os: linux
-dist: trusty
+dist: xenial
 
 env:
   # Give Maven 1GB of memory to work with

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationFeatureServiceIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationFeatureServiceIT.java
@@ -27,18 +27,10 @@ import org.dspace.app.rest.model.CollectionRest;
 import org.dspace.app.rest.model.SiteRest;
 import org.dspace.app.rest.projection.DefaultProjection;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
-import org.dspace.app.rest.test.AbstractIntegrationTestWithDatabase;
-import org.dspace.app.rest.utils.DSpaceConfigurationInitializer;
-import org.dspace.app.rest.utils.DSpaceKernelInitializer;
 import org.dspace.content.Site;
 import org.dspace.content.service.SiteService;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.context.web.WebAppConfiguration;
 
 /**
  * Test for the Authorization Feature Service

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationFeatureServiceIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationFeatureServiceIT.java
@@ -26,6 +26,7 @@ import org.dspace.app.rest.converter.SiteConverter;
 import org.dspace.app.rest.model.CollectionRest;
 import org.dspace.app.rest.model.SiteRest;
 import org.dspace.app.rest.projection.DefaultProjection;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.app.rest.test.AbstractIntegrationTestWithDatabase;
 import org.dspace.app.rest.utils.DSpaceConfigurationInitializer;
 import org.dspace.app.rest.utils.DSpaceKernelInitializer;
@@ -41,21 +42,11 @@ import org.springframework.test.context.web.WebAppConfiguration;
 
 /**
  * Test for the Authorization Feature Service
- * 
+ *
  * @author Andrea Bollini (andrea.bollini at 4science.it)
  *
  */
-//Run tests with JUnit 4 and Spring TestContext Framework
-@RunWith(SpringRunner.class)
-//Specify main class to use to load Spring ApplicationContext
-//NOTE: By default, Spring caches and reuses ApplicationContext for each integration test (to speed up tests)
-//See: https://docs.spring.io/spring/docs/current/spring-framework-reference/testing.html#integration-testing
-@SpringBootTest(classes = Application.class)
-//Load DSpace initializers in Spring ApplicationContext (to initialize DSpace Kernel & Configuration)
-@ContextConfiguration(initializers = { DSpaceKernelInitializer.class, DSpaceConfigurationInitializer.class })
-//Tell Spring to make ApplicationContext an instance of WebApplicationContext (for web-based tests)
-@WebAppConfiguration
-public class AuthorizationFeatureServiceIT extends AbstractIntegrationTestWithDatabase {
+public class AuthorizationFeatureServiceIT extends AbstractControllerIntegrationTest {
     @Autowired
     private SiteService siteService;
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/InitializeEntitiesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/InitializeEntitiesIT.java
@@ -58,7 +58,6 @@ public class InitializeEntitiesIT extends AbstractControllerIntegrationTest {
      */
     @Before
     public void setup() throws Exception {
-
         //Set up the database for the next test
         String pathToFile = configurationService.getProperty("dspace.dir") +
             File.separator + "config" + File.separator + "entities" + File.separator + "relationship-types.xml";
@@ -67,6 +66,7 @@ public class InitializeEntitiesIT extends AbstractControllerIntegrationTest {
     }
 
     @After
+    @Override
     public void destroy() throws Exception {
         //Clean up the database for the next test
         context.turnOffAuthorisationSystem();
@@ -74,26 +74,18 @@ public class InitializeEntitiesIT extends AbstractControllerIntegrationTest {
         List<EntityType> entityTypeList = entityTypeService.findAll(context);
         List<Relationship> relationships = relationshipService.findAll(context);
 
-        Iterator<Relationship> relationshipIterator = relationships.iterator();
-        while (relationshipIterator.hasNext()) {
-            Relationship relationship = relationshipIterator.next();
-            relationshipIterator.remove();
+        for (Relationship relationship : relationships) {
             relationshipService.delete(context, relationship);
         }
 
-        Iterator<RelationshipType> relationshipTypeIterator = relationshipTypeList.iterator();
-        while (relationshipTypeIterator.hasNext()) {
-            RelationshipType relationshipType = relationshipTypeIterator.next();
-            relationshipTypeIterator.remove();
+        for (RelationshipType relationshipType : relationshipTypeList) {
             relationshipTypeService.delete(context, relationshipType);
         }
 
-        Iterator<EntityType> entityTypeIterator = entityTypeList.iterator();
-        while (entityTypeIterator.hasNext()) {
-            EntityType entityType = entityTypeIterator.next();
-            entityTypeIterator.remove();
+        for (EntityType entityType: entityTypeList) {
             entityTypeService.delete(context, entityType);
         }
+        context.restoreAuthSystemState();
 
         super.destroy();
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/InitializeEntitiesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/InitializeEntitiesIT.java
@@ -15,7 +15,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.io.File;
-import java.util.Iterator;
 import java.util.List;
 
 import org.dspace.app.rest.matcher.RelationshipTypeMatcher;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProcessRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProcessRestRepositoryIT.java
@@ -33,7 +33,6 @@ import org.dspace.scripts.DSpaceCommandLineParameter;
 import org.dspace.scripts.Process;
 import org.dspace.scripts.service.ProcessService;
 import org.hamcrest.Matchers;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProcessRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProcessRestRepositoryIT.java
@@ -321,9 +321,4 @@ public class ProcessRestRepositoryIT extends AbstractControllerIntegrationTest {
 
 
     }
-
-    @After
-    public void destroy() throws Exception {
-        super.destroy();
-    }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/builder/RelationshipTypeBuilder.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/builder/RelationshipTypeBuilder.java
@@ -8,12 +8,10 @@
 package org.dspace.app.rest.builder;
 
 import java.sql.SQLException;
-import java.util.List;
 
 import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.EntityType;
-import org.dspace.content.Relationship;
 import org.dspace.content.RelationshipType;
 import org.dspace.content.service.RelationshipTypeService;
 import org.dspace.core.Context;
@@ -41,11 +39,6 @@ public class RelationshipTypeBuilder extends AbstractBuilder<RelationshipType, R
             c.turnOffAuthorisationSystem();
             // Ensure object and any related objects are reloaded before checking to see what needs cleanup
             relationshipType = c.reloadEntity(relationshipType);
-            List<Relationship> byRelationshipType = relationshipService
-                .findByRelationshipType(c, relationshipType);
-            for (Relationship relationship : byRelationshipType) {
-                relationshipService.delete(c, relationship);
-            }
             if (relationshipType != null) {
                 delete(c, relationshipType);
             }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/builder/util/AbstractBuilderCleanupUtil.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/builder/util/AbstractBuilderCleanupUtil.java
@@ -42,12 +42,11 @@ public class AbstractBuilderCleanupUtil {
     private LinkedHashMap<String, List<AbstractBuilder>> map = new LinkedHashMap<>();
 
     /**
-     * Constructor that will initialize the Map with a predefined order for deletion
+     * Constructor that will initialize the Map with a predefined order for deletion.
+     * NOTE: Deletion occurs from top to bottom in the below list.
      */
     public AbstractBuilderCleanupUtil() {
         map.put(RelationshipBuilder.class.getName(), new LinkedList<>());
-        map.put(RelationshipTypeBuilder.class.getName(), new LinkedList<>());
-        map.put(EntityTypeBuilder.class.getName(), new LinkedList<>());
         map.put(PoolTaskBuilder.class.getName(), new LinkedList<>());
         map.put(WorkflowItemBuilder.class.getName(), new LinkedList<>());
         map.put(WorkspaceItemBuilder.class.getName(), new LinkedList<>());
@@ -59,11 +58,12 @@ public class AbstractBuilderCleanupUtil {
         map.put(EPersonBuilder.class.getName(), new LinkedList<>());
         map.put(GroupBuilder.class.getName(), new LinkedList<>());
         map.put(ItemBuilder.class.getName(), new LinkedList<>());
+        map.put(RelationshipTypeBuilder.class.getName(), new LinkedList<>());
+        map.put(EntityTypeBuilder.class.getName(), new LinkedList<>());
         map.put(MetadataFieldBuilder.class.getName(), new LinkedList<>());
         map.put(MetadataSchemaBuilder.class.getName(), new LinkedList<>());
         map.put(SiteBuilder.class.getName(), new LinkedList<>());
         map.put(ProcessBuilder.class.getName(), new LinkedList<>());
-
     }
 
     /**

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/csv/CSVMetadataImportReferenceIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/csv/CSVMetadataImportReferenceIT.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
+ * ITs to test creation of Entity Relationships via CSV Metadata import
  * Created by: Andrew Wood
  * Date: 26 Jul 2019
  */

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/csv/CSVMetadataImportReferenceIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/csv/CSVMetadataImportReferenceIT.java
@@ -12,6 +12,7 @@ import static junit.framework.TestCase.assertEquals;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -106,6 +107,9 @@ public class CSVMetadataImportReferenceIT extends AbstractEntityIntegrationTest 
             "+,Publication,dc.identifier.other:0," +  col1.getHandle() + ",1"};
         Item[] items = runImport(csv);
         assertRelationship(items[1], items[0], 1, "left", 0);
+
+        // remove created items
+        cleanupImportItems(items);
     }
 
     /**
@@ -125,6 +129,20 @@ public class CSVMetadataImportReferenceIT extends AbstractEntityIntegrationTest 
     }
 
     /**
+     * Delete the Items in the given array. This method is used for cleanup after using "runImport"
+     * @param items items array
+     * @throws SQLException
+     * @throws IOException
+     */
+    private void cleanupImportItems(Item[] items) throws SQLException, IOException {
+        context.turnOffAuthorisationSystem();
+        for (Item item: items) {
+            ItemBuilder.deleteItem(item.getID());
+        }
+        context.restoreAuthSystemState();
+    }
+
+    /**
      * Test existence of newly created item with proper relationships defined in the item's metadata via
      * a rowName reference
      */
@@ -136,6 +154,8 @@ public class CSVMetadataImportReferenceIT extends AbstractEntityIntegrationTest 
             "+,Test Item 2,Publication,rowName:idVal," +  col1.getHandle() + ",anything,1"};
         Item[] items = runImport(csv);
         assertRelationship(items[1], items[0], 1, "left", 0);
+        // remove created items
+        cleanupImportItems(items);
     }
 
     /**
@@ -151,6 +171,8 @@ public class CSVMetadataImportReferenceIT extends AbstractEntityIntegrationTest 
         Item[] items = runImport(csv);
         assertRelationship(items[2], items[0], 1, "left", 0);
         assertRelationship(items[2], items[1], 1, "left", 1);
+        // remove created items
+        cleanupImportItems(items);
     }
 
     /**
@@ -166,6 +188,8 @@ public class CSVMetadataImportReferenceIT extends AbstractEntityIntegrationTest 
         Item[] items = runImport(csv);
         assertRelationship(items[2], items[0], 1, "left", 0);
         assertRelationship(items[2], items[1], 1, "left", 1);
+        // remove created items
+        cleanupImportItems(items);
     }
 
     /**
@@ -183,6 +207,8 @@ public class CSVMetadataImportReferenceIT extends AbstractEntityIntegrationTest 
             "+,Publication," + person.getID().toString() + "," +  col1.getHandle() + ",anything,0"};
         Item[] items = runImport(csv);
         assertRelationship(items[0], person, 1, "left", 0);
+        // remove created items
+        cleanupImportItems(items);
     }
 
     /**
@@ -205,6 +231,8 @@ public class CSVMetadataImportReferenceIT extends AbstractEntityIntegrationTest 
         Item[] items = runImport(csv);
         assertRelationship(items[0], person, 1, "left", 0);
         assertRelationship(items[0], person2, 1, "left", 1);
+        // remove created items
+        cleanupImportItems(items);
     }
 
     /**
@@ -226,6 +254,8 @@ public class CSVMetadataImportReferenceIT extends AbstractEntityIntegrationTest 
         Item[] items = runImport(csv);
         assertRelationship(items[1], person, 1, "left", 0);
         assertRelationship(items[1], items[0], 1, "left", 1);
+        // remove created items
+        cleanupImportItems(items);
     }
 
     /**
@@ -254,6 +284,8 @@ public class CSVMetadataImportReferenceIT extends AbstractEntityIntegrationTest 
         assertRelationship(items[1], person, 1, "left", 0);
         assertRelationship(items[1], person2, 1, "left", 1);
         assertRelationship(items[1], items[0], 1, "left", 2);
+        // remove created items
+        cleanupImportItems(items);
     }
 
     /**
@@ -268,6 +300,8 @@ public class CSVMetadataImportReferenceIT extends AbstractEntityIntegrationTest 
             "+,Pub1,Publication,dc.title:Person:," +  col1.getHandle() + ",anything,1"};
         Item[] items = runImport(csv);
         assertRelationship(items[1], items[0], 1, "left", 0);
+        // remove created items
+        cleanupImportItems(items);
     }
 
     /**
@@ -447,6 +481,8 @@ public class CSVMetadataImportReferenceIT extends AbstractEntityIntegrationTest 
         Item[] items = runImport(csv);
         assertRelationship(items[1], items[0], 1, "left", 0);
         assertRelationship(items[2], items[0], 1, "left", 0);
+        // remove created items
+        cleanupImportItems(items);
     }
 
     /**
@@ -510,6 +546,5 @@ public class CSVMetadataImportReferenceIT extends AbstractEntityIntegrationTest 
         }
         return uuidList.get(0);
     }
-
 
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/test/AbstractEntityIntegrationTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/test/AbstractEntityIntegrationTest.java
@@ -10,14 +10,12 @@ package org.dspace.app.rest.test;
 import org.dspace.app.rest.builder.EntityTypeBuilder;
 import org.dspace.app.rest.builder.RelationshipTypeBuilder;
 import org.dspace.content.EntityType;
-import org.dspace.content.service.EntityTypeService;
 import org.junit.Before;
-import org.springframework.beans.factory.annotation.Autowired;
 
+/**
+ * An AbstractControllerIntegrationTest which pre-creates Entities & Relationships for ITs that need them.
+ */
 public class AbstractEntityIntegrationTest extends AbstractControllerIntegrationTest {
-
-    @Autowired
-    private EntityTypeService entityTypeService;
 
     /**
      * This method will call the setUp method from AbstractControllerIntegrationTest.
@@ -40,13 +38,10 @@ public class AbstractEntityIntegrationTest extends AbstractControllerIntegration
     public void setUp() throws Exception {
         super.setUp();
 
-        if (entityTypeService.findAll(context).size() > 0) {
-            //Don't initialize the setup more than once
-            return;
-        }
-
         context.turnOffAuthorisationSystem();
 
+        // Create all Entities/Relationships using Builders.
+        // That way they are cleaned up automatically after tests finish.
         EntityType publication = EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
         EntityType person = EntityTypeBuilder.createEntityTypeBuilder(context, "Person").build();
         EntityType project = EntityTypeBuilder.createEntityTypeBuilder(context, "Project").build();


### PR DESCRIPTION
This PR is just minor updates to our `.travis.yml` to do the following:

1. Switch from OracleJDK to OpenJDK.  Recent PRs are failing on the OracleJDK step, e.g. https://travis-ci.com/github/DSpace/DSpace/jobs/356343027  It's likely this is caused by Oracle changing the download process yet again (as Oracle now requires signup to download Java)
2. Switched to Ubuntu 16.04 LTS (Xenial) as [Trusty is no longer fully supported on Travis](https://docs.travis-ci.com/user/reference/trusty/)
3. Removed obsolete/unused `sudo` setting (that setting is no longer supported by Travis)
4. Added new `os` setting (which defaults to `linux` anyways, but wanted to make it explicit in our config)