### PR TITLE
Curation tasks using the scripts and processes functionality

### DIFF
--- a/dspace-api/src/main/java/org/dspace/curate/CurationCli.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CurationCli.java
@@ -94,7 +94,8 @@ public class CurationCli extends DSpaceRunnable<CurationScriptConfiguration> {
      */
     private boolean handleCurationTaskAndReturnSuccess(Curator curator) throws IOException, SQLException {
         if (!commandLine.hasOption('i')) {
-            super.handler.logWarning("Id must be specified: a handle, 'all', or a task queue (-h for help)");
+            super.handler.logWarning("Id must be specified: a handle, 'all', or no -i and a -T task queue (-h for " +
+                                     "help)");
             return false;
         }
         String idName = this.commandLine.getOptionValue('i');
@@ -130,13 +131,13 @@ public class CurationCli extends DSpaceRunnable<CurationScriptConfiguration> {
         if (verbose) {
             super.handler.logInfo("Starting curation");
             super.handler.logInfo("Curating id: " + idName);
-            if ("all".equals(idName)) {
-                // run on whole Site
-                curator.curate(context,
-                    ContentServiceFactory.getInstance().getSiteService().findSite(context).getHandle());
-            } else {
-                curator.curate(context, idName);
-            }
+        }
+        if ("all".equals(idName)) {
+            // run on whole Site
+            curator.curate(context,
+                ContentServiceFactory.getInstance().getSiteService().findSite(context).getHandle());
+        } else {
+            curator.curate(context, idName);
         }
         return true;
     }
@@ -280,7 +281,7 @@ public class CurationCli extends DSpaceRunnable<CurationScriptConfiguration> {
 
     @Override
     public CurationScriptConfiguration getScriptConfiguration() {
-        return new DSpace().getServiceManager().getServiceByName("curation", CurationScriptConfiguration.class);
+        return new DSpace().getServiceManager().getServiceByName("curate", CurationScriptConfiguration.class);
     }
 
     @Override
@@ -296,7 +297,7 @@ public class CurationCli extends DSpaceRunnable<CurationScriptConfiguration> {
                 }
                 this.context.setCurrentUser(ePerson);
             } else {
-                this.context.turnOffAuthorisationSystem();
+                throw new IllegalArgumentException("Needs an -e to set eperson (admin)");
             }
         } catch (Exception e) {
             throw new ParseException("Unable to create a new DSpace Context: " + e.getMessage());

--- a/dspace-api/src/main/java/org/dspace/curate/CurationCli.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CurationCli.java
@@ -8,21 +8,21 @@
 package org.dspace.curate;
 
 import java.io.BufferedReader;
+import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.Writer;
+import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.PosixParser;
+import org.apache.commons.cli.ParseException;
 import org.apache.commons.io.output.NullOutputStream;
+import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.core.Context;
 import org.dspace.core.factory.CoreServiceFactory;
@@ -30,183 +30,93 @@ import org.dspace.curate.factory.CurateServiceFactory;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
+import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.utils.DSpace;
 
 /**
  * CurationCli provides command-line access to Curation tools and processes.
  *
  * @author richardrodgers
  */
-public class CurationCli {
+public class CurationCli extends DSpaceRunnable<CurationScriptConfiguration> {
+
+    private EPersonService ePersonService = EPersonServiceFactory.getInstance().getEPersonService();
+
+    private Context context;
+    private CurationClientOptions curationClientOptions;
+
+    private String scope;
+    private String reporter;
+    private Map<String, String> parameters;
+    private boolean verbose;
+
+    @Override
+    public void internalRun() throws Exception {
+        if (curationClientOptions == CurationClientOptions.HELP) {
+            printHelp();
+            return;
+        }
+
+        if (!this.initLineOptionsAndCheckIfValid()) {
+            return;
+        }
+
+        Curator curator = initCurator();
+
+        // load curation tasks
+        if (curationClientOptions == CurationClientOptions.TASK) {
+            long start = System.currentTimeMillis();
+            if (!handleCurationTaskAndReturnSuccess(curator)) {
+                return;
+            }
+            this.endScript(start);
+        }
+
+        // process task queue
+        if (curationClientOptions == CurationClientOptions.QUEUE) {
+            // process the task queue
+            TaskQueue queue = (TaskQueue) CoreServiceFactory.getInstance().getPluginService()
+                                                            .getSinglePlugin(TaskQueue.class);
+            if (queue == null) {
+                super.handler.logError("No implementation configured for queue");
+                throw new UnsupportedOperationException("No queue service available");
+            }
+            long timeRun = this.runQueue(queue, curator);
+            this.endScript(timeRun);
+        }
+    }
 
     /**
-     * Default constructor
+     * Does the curation task (-t) or the task in the given file (-T).
+     * Returns false if required option -i is missing.
+     *
+     * @return False if there are missing/invalid command line options (-i); otherwise true
      */
-    private CurationCli() { }
-
-    public static void main(String[] args) throws Exception {
-        // create an options object and populate it
-        CommandLineParser parser = new PosixParser();
-
-        Options options = new Options();
-
-        options.addOption("t", "task", true,
-                          "curation task name");
-        options.addOption("T", "taskfile", true,
-                          "file containing curation task names");
-        options.addOption("i", "id", true,
-                          "Id (handle) of object to perform task on, or 'all' to perform on whole repository");
-        options.addOption("p", "parameter", true,
-                          "a task parameter 'NAME=VALUE'");
-        options.addOption("q", "queue", true,
-                          "name of task queue to process");
-        options.addOption("e", "eperson", true,
-                          "email address of curating eperson");
-        options.addOption("r", "reporter", true,
-                "relative or absolute path to the desired report file.  "
-                        + "Use '-' to report to console.  "
-                        + "If absent, no reporting");
-        options.addOption("s", "scope", true,
-                          "transaction scope to impose: use 'object', 'curation', or 'open'. If absent, 'open' " +
-                              "applies");
-        options.addOption("v", "verbose", false,
-                          "report activity to stdout");
-        options.addOption("h", "help", false, "help");
-
-        CommandLine line = parser.parse(options, args);
-
-        String taskName = null;
-        String taskFileName = null;
-        String idName = null;
-        String taskQueueName = null;
-        String ePersonName = null;
-        String reporterName = null;
-        String scope = null;
-        boolean verbose = false;
-        final Map<String, String> parameters = new HashMap<>();
-
-        if (line.hasOption('h')) {
-            HelpFormatter help = new HelpFormatter();
-            help.printHelp("CurationCli\n", options);
-            System.out
-                .println("\nwhole repo: CurationCli -t estimate -i all");
-            System.out
-                .println("single item: CurationCli -t generate -i itemId");
-            System.out
-                .println("task queue: CurationCli -q monthly");
-            System.exit(0);
+    private boolean handleCurationTaskAndReturnSuccess(Curator curator) throws IOException, SQLException {
+        if (!commandLine.hasOption('i')) {
+            super.handler.logWarning("Id must be specified: a handle, 'all', or a task queue (-h for help)");
+            return false;
         }
-
-        if (line.hasOption('t')) { // task
-            taskName = line.getOptionValue('t');
-        }
-
-        if (line.hasOption('T')) { // task file
-            taskFileName = line.getOptionValue('T');
-        }
-
-        if (line.hasOption('i')) { // id
-            idName = line.getOptionValue('i');
-        }
-
-        if (line.hasOption('q')) { // task queue
-            taskQueueName = line.getOptionValue('q');
-        }
-
-        if (line.hasOption('e')) { // eperson
-            ePersonName = line.getOptionValue('e');
-        }
-
-        if (line.hasOption('p')) { // parameter
-            for (String parameter : line.getOptionValues('p')) {
-                String[] parts = parameter.split("=", 2);
-                String name = parts[0].trim();
-                String value;
-                if (parts.length > 1) {
-                    value = parts[1].trim();
-                } else {
-                    value = "true";
-                }
-                parameters.put(name, value);
-            }
-        }
-        if (line.hasOption('r')) { // report file
-            reporterName = line.getOptionValue('r');
-        }
-
-
-        if (line.hasOption('s')) { // transaction scope
-            scope = line.getOptionValue('s');
-        }
-
-        if (line.hasOption('v')) { // verbose
-            verbose = true;
-        }
-
-        // now validate the args
-        if (idName == null && taskQueueName == null) {
-            System.out.println("Id must be specified: a handle, 'all', or a task queue (-h for help)");
-            System.exit(1);
-        }
-
-        if (taskName == null && taskFileName == null && taskQueueName == null) {
-            System.out.println("A curation task or queue must be specified (-h for help)");
-            System.exit(1);
-        }
-
-        if (scope != null && Curator.TxScope.valueOf(scope.toUpperCase()) == null) {
-            System.out.println("Bad transaction scope '" + scope + "': only 'object', 'curation' or 'open' recognized");
-            System.exit(1);
-        }
-        EPersonService ePersonService = EPersonServiceFactory.getInstance().getEPersonService();
-
-        Context c = new Context(Context.Mode.BATCH_EDIT);
-        if (ePersonName != null) {
-            EPerson ePerson = ePersonService.findByEmail(c, ePersonName);
-            if (ePerson == null) {
-                System.out.println("EPerson not found: " + ePersonName);
-                System.exit(1);
-            }
-            c.setCurrentUser(ePerson);
-        } else {
-            c.turnOffAuthorisationSystem();
-        }
-
-        Curator curator = new Curator();
-        OutputStream reporter;
-        if (null == reporterName) {
-            reporter = new NullOutputStream();
-        } else if ("-".equals(reporterName)) {
-            reporter = System.out;
-        } else {
-            reporter = new PrintStream(reporterName);
-        }
-        Writer reportWriter = new OutputStreamWriter(reporter);
-        curator.setReporter(reportWriter);
-
-        if (scope != null) {
-            Curator.TxScope txScope = Curator.TxScope.valueOf(scope.toUpperCase());
-            curator.setTransactionScope(txScope);
-        }
-        curator.addParameters(parameters);
-        // we are operating in batch mode, if anyone cares.
-        curator.setInvoked(Curator.Invoked.BATCH);
-        // load curation tasks
-        if (taskName != null) {
+        String idName = this.commandLine.getOptionValue('i');
+        String taskName;
+        if (commandLine.hasOption('t')) {
+            taskName = commandLine.getOptionValue('t');
             if (verbose) {
-                System.out.println("Adding task: " + taskName);
+                handler.logInfo("Adding task: " + taskName);
             }
             curator.addTask(taskName);
             if (verbose && !curator.hasTask(taskName)) {
-                System.out.println("Task: " + taskName + " not resolved");
+                handler.logInfo("Task: " + taskName + " not resolved");
             }
-        } else if (taskQueueName == null) {
+        } else if (commandLine.hasOption('T')) {
             // load taskFile
+            String taskFileName = commandLine.getOptionValue('T');
             BufferedReader reader = null;
             try {
                 reader = new BufferedReader(new FileReader(taskFileName));
                 while ((taskName = reader.readLine()) != null) {
                     if (verbose) {
-                        System.out.println("Adding task: " + taskName);
+                        super.handler.logInfo("Adding task: " + taskName);
                     }
                     curator.addTask(taskName);
                 }
@@ -217,59 +127,180 @@ public class CurationCli {
             }
         }
         // run tasks against object
-        long start = System.currentTimeMillis();
         if (verbose) {
-            System.out.println("Starting curation");
-        }
-        if (idName != null) {
-            if (verbose) {
-                System.out.println("Curating id: " + idName);
-            }
+            super.handler.logInfo("Starting curation");
+            super.handler.logInfo("Curating id: " + idName);
             if ("all".equals(idName)) {
                 // run on whole Site
-                curator.curate(c, ContentServiceFactory.getInstance().getSiteService().findSite(c).getHandle());
+                curator.curate(context,
+                    ContentServiceFactory.getInstance().getSiteService().findSite(context).getHandle());
             } else {
-                curator.curate(c, idName);
+                curator.curate(context, idName);
             }
-        } else {
-            // process the task queue
-            TaskQueue queue = (TaskQueue) CoreServiceFactory.getInstance().getPluginService()
-                                                            .getSinglePlugin(TaskQueue.class);
-            if (queue == null) {
-                System.out.println("No implementation configured for queue");
-                throw new UnsupportedOperationException("No queue service available");
-            }
-            // use current time as our reader 'ticket'
-            long ticket = System.currentTimeMillis();
-            Iterator<TaskQueueEntry> entryIter = queue.dequeue(taskQueueName, ticket).iterator();
-            while (entryIter.hasNext()) {
-                TaskQueueEntry entry = entryIter.next();
-                if (verbose) {
-                    System.out.println("Curating id: " + entry.getObjectId());
-                }
-                curator.clear();
-                // does entry relate to a DSO or workflow object?
-                if (entry.getObjectId().indexOf("/") > 0) {
-                    for (String task : entry.getTaskNames()) {
-                        curator.addTask(task);
-                    }
-                    curator.curate(c, entry.getObjectId());
-                } else {
-                    // make eperson who queued task the effective user
-                    EPerson agent = ePersonService.findByEmail(c, entry.getEpersonId());
-                    if (agent != null) {
-                        c.setCurrentUser(agent);
-                    }
-                    CurateServiceFactory.getInstance().getWorkflowCuratorService()
-                                        .curate(curator, c, entry.getObjectId());
-                }
-            }
-            queue.release(taskQueueName, ticket, true);
         }
-        c.complete();
+        return true;
+    }
+
+    /**
+     * Runs task queue (-q set)
+     *
+     * @param queue   The task cueue
+     * @param curator The curator
+     * @return Time when queue started
+     */
+    private long runQueue(TaskQueue queue, Curator curator) throws SQLException, AuthorizeException, IOException {
+        String taskQueueName = this.commandLine.getOptionValue('q');
+        // use current time as our reader 'ticket'
+        long ticket = System.currentTimeMillis();
+        Iterator<TaskQueueEntry> entryIter = queue.dequeue(taskQueueName, ticket).iterator();
+        while (entryIter.hasNext()) {
+            TaskQueueEntry entry = entryIter.next();
+            if (verbose) {
+                super.handler.logInfo("Curating id: " + entry.getObjectId());
+            }
+            curator.clear();
+            // does entry relate to a DSO or workflow object?
+            if (entry.getObjectId().indexOf('/') > 0) {
+                for (String task : entry.getTaskNames()) {
+                    curator.addTask(task);
+                }
+                curator.curate(context, entry.getObjectId());
+            } else {
+                // make eperson who queued task the effective user
+                EPerson agent = ePersonService.findByEmail(context, entry.getEpersonId());
+                if (agent != null) {
+                    context.setCurrentUser(agent);
+                }
+                CurateServiceFactory.getInstance().getWorkflowCuratorService()
+                                    .curate(curator, context, entry.getObjectId());
+            }
+        }
+        queue.release(taskQueueName, ticket, true);
+        return ticket;
+    }
+
+    /**
+     * End of curation script; logs script time if -v verbose is set
+     *
+     * @param timeRun Time script was started
+     * @throws SQLException If DSpace contextx can't complete
+     */
+    private void endScript(long timeRun) throws SQLException {
+        context.complete();
         if (verbose) {
-            long elapsed = System.currentTimeMillis() - start;
-            System.out.println("Ending curation. Elapsed time: " + elapsed);
+            long elapsed = System.currentTimeMillis() - timeRun;
+            this.handler.logInfo("Ending curation. Elapsed time: " + elapsed);
         }
+    }
+
+    /**
+     * Fills in some optional command line options; to be used by curator. And check if no required options are
+     * missing; or if they have an invalid value. If they are missing/invalid it returns false; otherwise true
+     *
+     * @return False if there are missing required options or invalid values for options.
+     */
+    private boolean initLineOptionsAndCheckIfValid() {
+        // report file
+        if (this.commandLine.hasOption('r')) {
+            this.reporter = this.commandLine.getOptionValue('r');
+        }
+
+        // parameters
+        this.parameters = new HashMap<>();
+        if (this.commandLine.hasOption('p')) {
+            for (String parameter : this.commandLine.getOptionValues('p')) {
+                String[] parts = parameter.split("=", 2);
+                String name = parts[0].trim();
+                String value;
+                if (parts.length > 1) {
+                    value = parts[1].trim();
+                } else {
+                    value = "true";
+                }
+                this.parameters.put(name, value);
+            }
+        }
+
+        // verbose
+        verbose = false;
+        if (commandLine.hasOption('v')) {
+            verbose = true;
+        }
+
+        // scope
+        if (this.commandLine.getOptionValue('s') != null) {
+            this.scope = this.commandLine.getOptionValue('s');
+            if (this.scope != null && Curator.TxScope.valueOf(this.scope.toUpperCase()) == null) {
+                this.handler.logError("Bad transaction scope '" + this.scope + "': only 'object', 'curation' or " +
+                                      "'open' recognized");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Initialize the curator with command line variables
+     *
+     * @return Initialised curator
+     * @throws FileNotFoundException If file of command line variable -r reporter is not found
+     */
+    private Curator initCurator() throws FileNotFoundException {
+        Curator curator = new Curator();
+        OutputStream reporterStream;
+        if (null == this.reporter) {
+            reporterStream = new NullOutputStream();
+        } else if ("-".equals(this.reporter)) {
+            reporterStream = System.out;
+        } else {
+            reporterStream = new PrintStream(this.reporter);
+        }
+        Writer reportWriter = new OutputStreamWriter(reporterStream);
+        curator.setReporter(reportWriter);
+
+        if (this.scope != null) {
+            Curator.TxScope txScope = Curator.TxScope.valueOf(this.scope.toUpperCase());
+            curator.setTransactionScope(txScope);
+        }
+
+        curator.addParameters(parameters);
+        // we are operating in batch mode, if anyone cares.
+        curator.setInvoked(Curator.Invoked.BATCH);
+        return curator;
+    }
+
+    @Override
+    public void printHelp() {
+        super.printHelp();
+        super.handler.logInfo("\nwhole repo: CurationCli -t estimate -i all");
+        super.handler.logInfo("single item: CurationCli -t generate -i itemId");
+        super.handler.logInfo("task queue: CurationCli -q monthly");
+    }
+
+    @Override
+    public CurationScriptConfiguration getScriptConfiguration() {
+        return new DSpace().getServiceManager().getServiceByName("curation", CurationScriptConfiguration.class);
+    }
+
+    @Override
+    public void setup() throws ParseException {
+        try {
+            this.context = new Context(Context.Mode.BATCH_EDIT);
+            if (this.commandLine.hasOption('e')) {
+                String ePersonEmail = this.commandLine.getOptionValue('e');
+                EPerson ePerson = ePersonService.findByEmail(this.context, ePersonEmail);
+                if (ePerson == null) {
+                    super.handler.logError("EPerson not found: " + ePersonEmail);
+                    throw new ParseException("EPerson not found: " + ePersonEmail);
+                }
+                this.context.setCurrentUser(ePerson);
+            } else {
+                this.context.turnOffAuthorisationSystem();
+            }
+        } catch (Exception e) {
+            throw new ParseException("Unable to create a new DSpace Context: " + e.getMessage());
+        }
+        this.curationClientOptions = CurationClientOptions.getClientOption(commandLine);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/curate/CurationCli.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CurationCli.java
@@ -145,7 +145,7 @@ public class CurationCli extends DSpaceRunnable<CurationScriptConfiguration> {
     /**
      * Runs task queue (-q set)
      *
-     * @param queue   The task cueue
+     * @param queue   The task queue
      * @param curator The curator
      * @return Time when queue started
      */

--- a/dspace-api/src/main/java/org/dspace/curate/CurationClientOptions.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CurationClientOptions.java
@@ -7,10 +7,12 @@
  */
 package org.dspace.curate;
 
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 
@@ -23,6 +25,8 @@ public enum CurationClientOptions {
     TASK,
     QUEUE,
     HELP;
+
+    private static List<String> taskOptions;
 
     /**
      * This method resolves the CommandLine parameters to figure out which action the curation script should perform
@@ -44,7 +48,7 @@ public enum CurationClientOptions {
     protected static Options constructOptions() {
         Options options = new Options();
 
-        options.addOption("t", "task", true, "curation task name; options: " + Arrays.toString(getTaskOptions()));
+        options.addOption("t", "task", true, "curation task name; options: " + getTaskOptions());
         options.addOption("T", "taskfile", true, "file containing curation task names");
         options.addOption("i", "id", true,
             "Id (handle) of object to perform task on, or 'all' to perform on whole repository");
@@ -62,8 +66,20 @@ public enum CurationClientOptions {
         return options;
     }
 
-    public static String[] getTaskOptions() {
-        ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
-        return configurationService.getArrayProperty("plugin.named.org.dspace.curate.CurationTask");
+    /**
+     * Creates list of the taskOptions' keys from the configs of plugin.named.org.dspace.curate.CurationTask
+     *
+     * @return List of the taskOptions' keys from the configs of plugin.named.org.dspace.curate.CurationTask
+     */
+    public static List<String> getTaskOptions() {
+        if (taskOptions == null) {
+            ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+            String[] taskConfigs = configurationService.getArrayProperty("plugin.named.org.dspace.curate.CurationTask");
+            taskOptions = new ArrayList<>();
+            for (String taskConfig : taskConfigs) {
+                taskOptions.add(StringUtils.substringAfterLast(taskConfig, "=").trim());
+            }
+        }
+        return taskOptions;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/curate/CurationClientOptions.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CurationClientOptions.java
@@ -1,0 +1,69 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.curate;
+
+import java.util.Arrays;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+
+/**
+ * This Enum holds all the possible options and combinations for the Curation script
+ *
+ * @author Maria Verdonck (Atmire) on 23/06/2020
+ */
+public enum CurationClientOptions {
+    TASK,
+    QUEUE,
+    HELP;
+
+    /**
+     * This method resolves the CommandLine parameters to figure out which action the curation script should perform
+     *
+     * @param commandLine The relevant CommandLine for the curation script
+     * @return The curation option to be ran, parsed from the CommandLine
+     */
+    protected static CurationClientOptions getClientOption(CommandLine commandLine) {
+        if (commandLine.hasOption("h")) {
+            return CurationClientOptions.HELP;
+        } else if (commandLine.hasOption("t") || commandLine.hasOption("T")) {
+            return CurationClientOptions.TASK;
+        } else if (commandLine.hasOption("q")) {
+            return CurationClientOptions.QUEUE;
+        }
+        return CurationClientOptions.HELP;
+    }
+
+    protected static Options constructOptions() {
+        Options options = new Options();
+
+        options.addOption("t", "task", true, "curation task name; options: " + Arrays.toString(getTaskOptions()));
+        options.addOption("T", "taskfile", true, "file containing curation task names");
+        options.addOption("i", "id", true,
+            "Id (handle) of object to perform task on, or 'all' to perform on whole repository");
+        options.addOption("p", "parameter", true, "a task parameter 'NAME=VALUE'");
+        options.addOption("q", "queue", true, "name of task queue to process");
+        options.addOption("e", "eperson", true, "email address of curating eperson");
+        options.addOption("r", "reporter", true,
+            "relative or absolute path to the desired report file. Use '-' to report to console. If absent, no " +
+            "reporting");
+        options.addOption("s", "scope", true,
+            "transaction scope to impose: use 'object', 'curation', or 'open'. If absent, 'open' applies");
+        options.addOption("v", "verbose", false, "report activity to stdout");
+        options.addOption("h", "help", false, "help");
+
+        return options;
+    }
+
+    private static String[] getTaskOptions() {
+        ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+        return configurationService.getArrayProperty("plugin.named.org.dspace.curate.CurationTask");
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/curate/CurationClientOptions.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CurationClientOptions.java
@@ -38,7 +38,7 @@ public enum CurationClientOptions {
         } else if (commandLine.hasOption("q")) {
             return CurationClientOptions.QUEUE;
         }
-        return CurationClientOptions.HELP;
+        return null;
     }
 
     protected static Options constructOptions() {
@@ -62,7 +62,7 @@ public enum CurationClientOptions {
         return options;
     }
 
-    private static String[] getTaskOptions() {
+    public static String[] getTaskOptions() {
         ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
         return configurationService.getArrayProperty("plugin.named.org.dspace.curate.CurationTask");
     }

--- a/dspace-api/src/main/java/org/dspace/curate/CurationScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CurationScriptConfiguration.java
@@ -37,6 +37,11 @@ public class CurationScriptConfiguration<T extends CurationCli> extends ScriptCo
         this.dspaceRunnableClass = dspaceRunnableClass;
     }
 
+    /**
+     * Only admin can run Curation script via the scripts and processes endpoints.
+     * @param context   The relevant DSpace context
+     * @return  True if currentUser is admin, otherwise false
+     */
     @Override
     public boolean isAllowedToExecute(Context context) {
         try {

--- a/dspace-api/src/main/java/org/dspace/curate/CurationScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CurationScriptConfiguration.java
@@ -1,0 +1,56 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.curate;
+
+import java.sql.SQLException;
+
+import org.apache.commons.cli.Options;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.core.Context;
+import org.dspace.scripts.configuration.ScriptConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * The {@link ScriptConfiguration} for the {@link CurationCli} script
+ *
+ * @author Maria Verdonck (Atmire) on 23/06/2020
+ */
+public class CurationScriptConfiguration<T extends CurationCli> extends ScriptConfiguration<T> {
+
+    @Autowired
+    private AuthorizeService authorizeService;
+
+    private Class<T> dspaceRunnableClass;
+
+    @Override
+    public Class<T> getDspaceRunnableClass() {
+        return this.dspaceRunnableClass;
+    }
+
+    @Override
+    public void setDspaceRunnableClass(Class<T> dspaceRunnableClass) {
+        this.dspaceRunnableClass = dspaceRunnableClass;
+    }
+
+    @Override
+    public boolean isAllowedToExecute(Context context) {
+        try {
+            return authorizeService.isAdmin(context);
+        } catch (SQLException e) {
+            throw new RuntimeException("SQLException occurred when checking if the current user is an admin", e);
+        }
+    }
+
+    @Override
+    public Options getOptions() {
+        if (options == null) {
+            super.options = CurationClientOptions.constructOptions();
+        }
+        return options;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/curate/Curator.java
+++ b/dspace-api/src/main/java/org/dspace/curate/Curator.java
@@ -98,6 +98,7 @@ public class Curator {
         communityService = ContentServiceFactory.getInstance().getCommunityService();
         itemService = ContentServiceFactory.getInstance().getItemService();
         handleService = HandleServiceFactory.getInstance().getHandleService();
+        resolver = new TaskResolver();
     }
 
     /**
@@ -142,10 +143,10 @@ public class Curator {
                 // performance order currently FIFO - to be revisited
                 perfList.add(taskName);
             } catch (IOException ioE) {
-                log.error("Task: '" + taskName + "' initialization failure: " + ioE.getMessage());
+                System.out.println("Task: '" + taskName + "' initialization failure: " + ioE.getMessage());
             }
         } else {
-            log.error("Task: '" + taskName + "' does not resolve");
+            System.out.println("Task: '" + taskName + "' does not resolve");
         }
         return this;
     }
@@ -259,13 +260,6 @@ public class Curator {
     /**
      * Performs all configured tasks upon DSpace object
      * (Community, Collection or Item).
-     * <P>
-     * Note: Site-wide tasks will default to running as
-     * an Anonymous User unless you call the Site-wide task
-     * via the {@link curate(Context,String)} or
-     * {@link #curate(Context, DSpaceObject)} method with an
-     * authenticated Context object.
-     *
      * @param dso the DSpace object
      * @throws IOException if IO error
      */
@@ -325,7 +319,7 @@ public class Curator {
             taskQ.enqueue(queueId, new TaskQueueEntry(c.getCurrentUser().getName(),
                                                       System.currentTimeMillis(), perfList, id));
         } else {
-            log.error("curate - no TaskQueue implemented");
+            System.out.println("curate - no TaskQueue implemented");
         }
     }
 
@@ -346,7 +340,7 @@ public class Curator {
         try {
             reporter.append(message);
         } catch (IOException ex) {
-            log.error("Task reporting failure", ex);
+            System.out.println("Task reporting failure: " +  ex);
         }
     }
 
@@ -552,7 +546,7 @@ public class Curator {
                 return !suspend(statusCode);
             } catch (IOException ioe) {
                 //log error & pass exception upwards
-                log.error("Error executing curation task '" + task.getName() + "'", ioe);
+                System.out.println("Error executing curation task '" + task.getName() + "'; " + ioe);
                 throw ioe;
             }
         }
@@ -568,7 +562,7 @@ public class Curator {
                 return !suspend(statusCode);
             } catch (IOException ioe) {
                 //log error & pass exception upwards
-                log.error("Error executing curation task '" + task.getName() + "'", ioe);
+                System.out.println("Error executing curation task '" + task.getName() + "'; " + ioe);
                 throw ioe;
             }
         }

--- a/dspace-api/src/test/data/dspaceFolder/assetstore/curate.txt
+++ b/dspace-api/src/test/data/dspaceFolder/assetstore/curate.txt
@@ -1,0 +1,2 @@
+checklinks
+requiredmetadata

--- a/dspace-api/src/test/data/dspaceFolder/config/spring/api/scripts.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/spring/api/scripts.xml
@@ -19,7 +19,7 @@
         <property name="dspaceRunnableClass" value="org.dspace.app.bulkedit.MetadataExport"/>
     </bean>
 
-    <bean id="curation" class="org.dspace.curate.CurationScriptConfiguration">
+    <bean id="curate" class="org.dspace.curate.CurationScriptConfiguration">
         <property name="description" value="Curation tasks"/>
         <property name="dspaceRunnableClass" value="org.dspace.curate.CurationCli"/>
     </bean>

--- a/dspace-api/src/test/data/dspaceFolder/config/spring/api/scripts.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/spring/api/scripts.xml
@@ -24,6 +24,7 @@
         <property name="dspaceRunnableClass" value="org.dspace.curate.CurationCli"/>
     </bean>
 
+    <!-- Keep as last script; for test ScriptRestRepository#findOneScriptByNameTest -->
     <bean id="mock-script" class="org.dspace.scripts.MockDSpaceRunnableScriptConfiguration" scope="prototype">
         <property name="description" value="Mocking a script for testing purposes" />
         <property name="dspaceRunnableClass" value="org.dspace.scripts.impl.MockDSpaceRunnableScript"/>

--- a/dspace-api/src/test/data/dspaceFolder/config/spring/api/scripts.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/spring/api/scripts.xml
@@ -19,6 +19,11 @@
         <property name="dspaceRunnableClass" value="org.dspace.app.bulkedit.MetadataExport"/>
     </bean>
 
+    <bean id="curation" class="org.dspace.curate.CurationScriptConfiguration">
+        <property name="description" value="Curation tasks"/>
+        <property name="dspaceRunnableClass" value="org.dspace.curate.CurationCli"/>
+    </bean>
+
     <bean id="mock-script" class="org.dspace.scripts.MockDSpaceRunnableScriptConfiguration" scope="prototype">
         <property name="description" value="Mocking a script for testing purposes" />
         <property name="dspaceRunnableClass" value="org.dspace.scripts.impl.MockDSpaceRunnableScript"/>

--- a/dspace-api/src/test/java/org/dspace/curate/CuratorTest.java
+++ b/dspace-api/src/test/java/org/dspace/curate/CuratorTest.java
@@ -23,26 +23,11 @@ import org.dspace.core.factory.CoreServiceFactory;
 import org.dspace.ctask.general.NoOpCurationTask;
 import org.dspace.services.ConfigurationService;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * @author mhwood
  */
-@RunWith(MockitoJUnitRunner.class)
 public class CuratorTest extends AbstractUnitTest {
-
-    @InjectMocks
-    private Curator curator;
-
-    @Mock
-    NoOpCurationTask noOpCurationTask;
-
-    @Spy
-    TaskResolver taskResolver;
 
     private static final SiteService SITE_SERVICE = ContentServiceFactory.getInstance().getSiteService();
 
@@ -115,6 +100,9 @@ public class CuratorTest extends AbstractUnitTest {
         ConfigurationService cfg = kernelImpl.getConfigurationService();
         cfg.setProperty("plugin.named.org.dspace.curate.CurationTask",
             NoOpCurationTask.class.getName() + " = " + TASK_NAME);
+
+        // Get and configure a Curator.
+        Curator curator = new Curator();
 
         StringBuilder reporterOutput = new StringBuilder();
         curator.setReporter(reporterOutput); // Send any report to our StringBuilder.

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ScriptRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ScriptRestRepositoryIT.java
@@ -82,7 +82,9 @@ public class ScriptRestRepositoryIT extends AbstractControllerIntegrationTest {
                             ScriptMatcher.matchScript(scriptConfigurations.get(2).getName(),
                                                       scriptConfigurations.get(2).getDescription()),
                             ScriptMatcher.matchScript(scriptConfigurations.get(3).getName(),
-                                                      scriptConfigurations.get(3).getDescription())
+                                                      scriptConfigurations.get(3).getDescription()),
+                            ScriptMatcher.matchScript(scriptConfigurations.get(4).getName(),
+                                scriptConfigurations.get(4).getDescription())
                         )));
 
     }
@@ -139,7 +141,7 @@ public class ScriptRestRepositoryIT extends AbstractControllerIntegrationTest {
         getClient(token).perform(get("/api/system/scripts/mock-script"))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$", ScriptMatcher
-                            .matchMockScript(scriptConfigurations.get(3).getOptions())));
+                            .matchMockScript(scriptConfigurations.get(scriptConfigurations.size() - 1).getOptions())));
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/curate/CurationScriptIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/curate/CurationScriptIT.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.curate;
 
 import static org.hamcrest.Matchers.containsStringIgnoringCase;

--- a/dspace-server-webapp/src/test/java/org/dspace/curate/CurationScriptIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/curate/CurationScriptIT.java
@@ -1,0 +1,407 @@
+package org.dspace.curate;
+
+import static org.hamcrest.Matchers.is;
+import static com.jayway.jsonpath.JsonPath.read;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import com.google.gson.Gson;
+import org.dspace.app.rest.builder.CollectionBuilder;
+import org.dspace.app.rest.builder.CommunityBuilder;
+import org.dspace.app.rest.builder.ItemBuilder;
+import org.dspace.app.rest.builder.ProcessBuilder;
+import org.dspace.app.rest.converter.DSpaceRunnableParameterConverter;
+import org.dspace.app.rest.matcher.ProcessMatcher;
+import org.dspace.app.rest.model.ParameterValueRest;
+import org.dspace.app.rest.model.ProcessRest;
+import org.dspace.app.rest.model.ScriptRest;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.content.ProcessStatus;
+import org.dspace.scripts.DSpaceCommandLineParameter;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author Maria Verdonck (Atmire) on 24/06/2020
+ */
+public class CurationScriptIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private DSpaceRunnableParameterConverter dSpaceRunnableParameterConverter;
+
+    private final static String SCRIPTS_ENDPOINT = "/api/" + ScriptRest.CATEGORY + "/" + ScriptRest.PLURAL_NAME;
+    private final static String CURATE_SCRIPT_ENDPOINT = SCRIPTS_ENDPOINT + "/curate/" + ProcessRest.PLURAL_NAME;
+
+    @Test
+    public void curateScript_invalidTaskOption() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community")
+                                           .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                                      .withTitle("Public item 1")
+                                      .withIssueDate("2017-10-17")
+                                      .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                                      .withSubject("ExtraEntry")
+                                      .build();
+
+        LinkedList<DSpaceCommandLineParameter> parameters = new LinkedList<>();
+
+        parameters.add(new DSpaceCommandLineParameter("-e", admin.getEmail()));
+        parameters.add(new DSpaceCommandLineParameter("-i", publicItem1.getHandle()));
+        parameters.add(new DSpaceCommandLineParameter("-t", "invalidTaskOption"));
+
+        List<ParameterValueRest> list = parameters.stream()
+                                                  .map(dSpaceCommandLineParameter -> dSpaceRunnableParameterConverter
+                                                      .convert(dSpaceCommandLineParameter, Projection.DEFAULT))
+                                                  .collect(Collectors.toList());
+
+        context.restoreAuthSystemState();
+
+        // Request with -t <invalidTaskOption>
+        getClient(token)
+            .perform(post(CURATE_SCRIPT_ENDPOINT).contentType("multipart/form-data")
+                                                 .param("properties",
+                                                     new Gson().toJson(list)))
+            // Illegal Argument Exception
+            .andExpect(status().isBadRequest())
+            // Contains the valid options
+            .andExpect(status().reason(containsString(Arrays.toString(CurationClientOptions.getTaskOptions()))));
+    }
+
+    @Test
+    public void curateScript_MissingEperson() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community")
+                                           .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                                      .withTitle("Public item 1")
+                                      .withIssueDate("2017-10-17")
+                                      .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                                      .withSubject("ExtraEntry")
+                                      .build();
+
+        LinkedList<DSpaceCommandLineParameter> parameters = new LinkedList<>();
+
+        parameters.add(new DSpaceCommandLineParameter("-i", publicItem1.getHandle()));
+        parameters.add(new DSpaceCommandLineParameter("-t", CurationClientOptions.getTaskOptions()[0]));
+
+        List<ParameterValueRest> list = parameters.stream()
+                                                  .map(dSpaceCommandLineParameter -> dSpaceRunnableParameterConverter
+                                                      .convert(dSpaceCommandLineParameter, Projection.DEFAULT))
+                                                  .collect(Collectors.toList());
+
+        context.restoreAuthSystemState();
+
+        // Request with missing required -e <email>
+        getClient(token)
+            .perform(post(CURATE_SCRIPT_ENDPOINT).contentType("multipart/form-data")
+                                                 .param("properties",
+                                                     new Gson().toJson(list)))
+            // Illegal Argument Exception
+            .andExpect(status().isBadRequest())
+            // Contains -e (the missing required cl option
+            .andExpect(status().reason(containsString("-e")));
+    }
+
+    @Test
+    public void curateScript_NonExistentEPerson() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community")
+                                           .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                                      .withTitle("Public item 1")
+                                      .withIssueDate("2017-10-17")
+                                      .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                                      .withSubject("ExtraEntry")
+                                      .build();
+
+        LinkedList<DSpaceCommandLineParameter> parameters = new LinkedList<>();
+
+        parameters.add(new DSpaceCommandLineParameter("-e", "nonExistentEmail@test.com"));
+        parameters.add(new DSpaceCommandLineParameter("-i", publicItem1.getHandle()));
+        parameters.add(new DSpaceCommandLineParameter("-t", CurationClientOptions.getTaskOptions()[0]));
+
+        List<ParameterValueRest> list = parameters.stream()
+                                                  .map(dSpaceCommandLineParameter -> dSpaceRunnableParameterConverter
+                                                      .convert(dSpaceCommandLineParameter, Projection.DEFAULT))
+                                                  .collect(Collectors.toList());
+
+        context.restoreAuthSystemState();
+
+        // Request with -e <nonExistingEPersonEmail>
+        getClient(token)
+            .perform(post(CURATE_SCRIPT_ENDPOINT).contentType("multipart/form-data")
+                                                 .param("properties",
+                                                     new Gson().toJson(list)))
+            // Illegal Argument Exception
+            .andExpect(status().isBadRequest())
+            // Contains email
+            .andExpect(status().reason(containsString("email")));
+    }
+
+    @Test
+    public void curateScript_MissingHandle() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        LinkedList<DSpaceCommandLineParameter> parameters = new LinkedList<>();
+
+        parameters.add(new DSpaceCommandLineParameter("-e", admin.getEmail()));
+        parameters.add(new DSpaceCommandLineParameter("-t", CurationClientOptions.getTaskOptions()[0]));
+
+        List<ParameterValueRest> list = parameters.stream()
+                                                  .map(dSpaceCommandLineParameter -> dSpaceRunnableParameterConverter
+                                                      .convert(dSpaceCommandLineParameter, Projection.DEFAULT))
+                                                  .collect(Collectors.toList());
+
+        // Request with missing required -i <handle>
+        getClient(token)
+            .perform(post(CURATE_SCRIPT_ENDPOINT).contentType("multipart/form-data")
+                                                 .param("properties",
+                                                     new Gson().toJson(list)))
+            // Illegal Argument Exception
+            .andExpect(status().isBadRequest())
+            // Contains handle
+            .andExpect(status().reason(containsString("handle")));
+    }
+
+    @Test
+    public void curateScript_MissingTaskOrTaskFile() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community")
+                                           .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                                      .withTitle("Public item 1")
+                                      .withIssueDate("2017-10-17")
+                                      .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                                      .withSubject("ExtraEntry")
+                                      .build();
+
+        LinkedList<DSpaceCommandLineParameter> parameters = new LinkedList<>();
+
+        parameters.add(new DSpaceCommandLineParameter("-e", admin.getEmail()));
+        parameters.add(new DSpaceCommandLineParameter("-i", publicItem1.getHandle()));
+
+        List<ParameterValueRest> list = parameters.stream()
+                                                  .map(dSpaceCommandLineParameter -> dSpaceRunnableParameterConverter
+                                                      .convert(dSpaceCommandLineParameter, Projection.DEFAULT))
+                                                  .collect(Collectors.toList());
+
+        context.restoreAuthSystemState();
+
+        // Request without -t <task> or -T <taskFile> (and no -q <queue>)
+        getClient(token)
+            .perform(post(CURATE_SCRIPT_ENDPOINT).contentType("multipart/form-data")
+                                                 .param("properties",
+                                                     new Gson().toJson(list)))
+            // Illegal Argument Exception
+            .andExpect(status().isBadRequest())
+            // Contains task
+            .andExpect(status().reason(containsString("task")));
+    }
+
+    @Test
+    public void curateScript_InvalidScope() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        LinkedList<DSpaceCommandLineParameter> parameters = new LinkedList<>();
+
+        parameters.add(new DSpaceCommandLineParameter("-e", admin.getEmail()));
+        parameters.add(new DSpaceCommandLineParameter("-i", "all"));
+        parameters.add(new DSpaceCommandLineParameter("-s", "invalidScope"));
+
+        List<ParameterValueRest> list = parameters.stream()
+                                                  .map(dSpaceCommandLineParameter -> dSpaceRunnableParameterConverter
+                                                      .convert(dSpaceCommandLineParameter, Projection.DEFAULT))
+                                                  .collect(Collectors.toList());
+
+        // Request with invalid -s <scope>; must be object, curation or open
+        getClient(token)
+            .perform(post(CURATE_SCRIPT_ENDPOINT).contentType("multipart/form-data")
+                                                 .param("properties",
+                                                     new Gson().toJson(list)))
+            // Illegal Argument Exception
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void curateScript_InvalidTaskFile() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        LinkedList<DSpaceCommandLineParameter> parameters = new LinkedList<>();
+
+        parameters.add(new DSpaceCommandLineParameter("-e", admin.getEmail()));
+        parameters.add(new DSpaceCommandLineParameter("-i", "all"));
+        parameters.add(new DSpaceCommandLineParameter("-T", "invalidTaskFile"));
+
+        List<ParameterValueRest> list = parameters.stream()
+                                                  .map(dSpaceCommandLineParameter -> dSpaceRunnableParameterConverter
+                                                      .convert(dSpaceCommandLineParameter, Projection.DEFAULT))
+                                                  .collect(Collectors.toList());
+
+        // Request with invalid -s <scope>; must be object, curation or open
+        getClient(token)
+            .perform(post(CURATE_SCRIPT_ENDPOINT).contentType("multipart/form-data")
+                                                 .param("properties",
+                                                     new Gson().toJson(list)))
+            // Illegal Argument Exception
+            .andExpect(status().isBadRequest())
+            // Contains taskFile
+            .andExpect(status().reason(containsString("taskFile")));
+    }
+
+    @Test
+    public void curateScript_validRequest_Task() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        String token = getAuthToken(admin.getEmail(), password);
+        AtomicReference<Integer> idRef = new AtomicReference<>();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community")
+                                           .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                                      .withTitle("Public item 1")
+                                      .withIssueDate("2017-10-17")
+                                      .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                                      .withSubject("ExtraEntry")
+                                      .build();
+
+        LinkedList<DSpaceCommandLineParameter> parameters = new LinkedList<>();
+
+        parameters.add(new DSpaceCommandLineParameter("-e", admin.getEmail()));
+        parameters.add(new DSpaceCommandLineParameter("-i", publicItem1.getHandle()));
+        parameters.add(new DSpaceCommandLineParameter("-t", CurationClientOptions.getTaskOptions()[0]));
+
+        List<ParameterValueRest> list = parameters.stream()
+                                                  .map(dSpaceCommandLineParameter -> dSpaceRunnableParameterConverter
+                                                      .convert(dSpaceCommandLineParameter, Projection.DEFAULT))
+                                                  .collect(Collectors.toList());
+
+        context.restoreAuthSystemState();
+
+        try {
+            getClient(token)
+                .perform(post(CURATE_SCRIPT_ENDPOINT).contentType("multipart/form-data")
+                                                     .param("properties",
+                                                         new Gson().toJson(list)))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$", is(
+                    ProcessMatcher.matchProcess("curate",
+                        String.valueOf(admin.getID()), parameters,
+                        ProcessStatus.SCHEDULED))))
+                .andDo(result -> idRef
+                    .set(read(result.getResponse().getContentAsString(), "$.processId")));
+        } finally {
+            ProcessBuilder.deleteProcess(idRef.get());
+        }
+    }
+
+    @Test
+    public void curateScript_validRequest_TaskFile() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        String token = getAuthToken(admin.getEmail(), password);
+        AtomicReference<Integer> idRef = new AtomicReference<>();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community")
+                                           .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                                      .withTitle("Public item 1")
+                                      .withIssueDate("2017-10-17")
+                                      .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                                      .withSubject("ExtraEntry")
+                                      .build();
+
+        File taskFile = new File(testProps.get("test.curateTaskFile").toString());
+
+        LinkedList<DSpaceCommandLineParameter> parameters = new LinkedList<>();
+        parameters.add(new DSpaceCommandLineParameter("-e", admin.getEmail()));
+        parameters.add(new DSpaceCommandLineParameter("-i", publicItem1.getHandle()));
+        parameters.add(new DSpaceCommandLineParameter("-T", taskFile.getAbsolutePath()));
+
+        List<ParameterValueRest> list = parameters.stream()
+                                                  .map(dSpaceCommandLineParameter -> dSpaceRunnableParameterConverter
+                                                      .convert(dSpaceCommandLineParameter, Projection.DEFAULT))
+                                                  .collect(Collectors.toList());
+
+        context.restoreAuthSystemState();
+
+        try {
+            getClient(token)
+                .perform(post(CURATE_SCRIPT_ENDPOINT).contentType("multipart/form-data")
+                                                     .param("properties",
+                                                         new Gson().toJson(list)))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$", is(
+                    ProcessMatcher.matchProcess("curate",
+                        String.valueOf(admin.getID()), parameters,
+                        ProcessStatus.SCHEDULED))))
+                .andDo(result -> idRef
+                    .set(read(result.getResponse().getContentAsString(), "$.processId")));
+        } finally {
+            ProcessBuilder.deleteProcess(idRef.get());
+        }
+    }
+
+
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/curate/CurationScriptIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/curate/CurationScriptIT.java
@@ -7,10 +7,10 @@
  */
 package org.dspace.curate;
 
-import static org.hamcrest.Matchers.containsStringIgnoringCase;
-import static org.hamcrest.Matchers.is;
 import static com.jayway.jsonpath.JsonPath.read;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.containsStringIgnoringCase;
+import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -42,6 +42,8 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
+ * IT for {@link CurationCli}
+ *
  * @author Maria Verdonck (Atmire) on 24/06/2020
  */
 public class CurationScriptIT extends AbstractControllerIntegrationTest {
@@ -435,6 +437,5 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
             ProcessBuilder.deleteProcess(idRef.get());
         }
     }
-
 
 }

--- a/dspace-server-webapp/src/test/resources/test-config.properties
+++ b/dspace-server-webapp/src/test/resources/test-config.properties
@@ -11,3 +11,6 @@ test.folder.assetstore = ./target/testing/dspace/assetstore
 
 #Path for a test file to create bitstreams
 test.bitstream = ./target/testing/dspace/assetstore/ConstitutionofIreland.pdf
+
+#Path for a test Taskfile for the curate script
+test.curateTaskFile = ./target/testing/dspace/assetstore/curate.txt

--- a/dspace/config/launcher.xml
+++ b/dspace/config/launcher.xml
@@ -55,13 +55,6 @@
         </step>
     </command>
     <command>
-        <name>curate</name>
-        <description>Perform curation tasks on DSpace objects</description>
-        <step>
-            <class>org.dspace.curate.CurationCli</class>
-        </step>
-    </command>
-    <command>
         <name>database</name>
         <description>Perform database tasks like test database connection, migrate/repair database, remove database</description>
         <step>

--- a/dspace/config/modules/curate.cfg
+++ b/dspace/config/modules/curate.cfg
@@ -11,8 +11,8 @@
 plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.NoOpCurationTask = noop
 plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.ProfileFormats = profileformats
 plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.RequiredMetadata = requiredmetadata
-plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.ClamScan = vscan
-plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.MicrosoftTranslator = translate
+#plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.ClamScan = vscan
+#plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.MicrosoftTranslator = translate
 plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.MetadataValueLinkChecker = checklinks
 # add new tasks here (or in additional config files)
 
@@ -25,33 +25,6 @@ curate.taskqueue.dir = ${dspace.dir}/ctqueues
 # (optional) directory location of scripted (non-java) tasks
 # curate.script.dir = ${dspace.dir}/ctscripts
 
-# Friendly names for curation tasks to appear in admin UI
-# Also acts as a filter - i.e. tasks not enumerated here can still
-# be invoked on cmd line, etc - just not in UI
-curate.ui.tasknames = profileformats = Profile Bitstream Formats
-curate.ui.tasknames = requiredmetadata = Check for Required Metadata
-curate.ui.tasknames = checklinks = Check Links in Metadata
-
-# Tasks may be organized into named groups which display together in UI drop-downs
-# curate.ui.taskgroups = \
-#   general = General Purpose Tasks,
-
-# Group membership is defined using comma-separated lists of task names, one property per group
-# curate.ui.taskgroup.general = profileformats, requiredmetadata, checklinks
-
-# Name of queue used when tasks queued in Admin UI
-curate.ui.queuename = admin_ui
-
-# Localized names for curation status codes in Admin UI
-curate.ui.statusmessages = \
-    -3 = Unknown Task, \
-    -2 = No Status Set, \
-    -1 = Error, \
-     0 = Success, \
-     1 = Fail, \
-     2 = Skip, \
-     other = Invalid Status
-
-
+# Ensure list of Curation Tasks (defined above) is available via the REST API /api/config/properties endpoint
 rest.properties.exposed = plugin.named.org.dspace.curate.CurationTask
 

--- a/dspace/config/modules/curate.cfg
+++ b/dspace/config/modules/curate.cfg
@@ -52,3 +52,6 @@ curate.ui.statusmessages = \
      2 = Skip, \
      other = Invalid Status
 
+
+rest.properties.exposed = plugin.named.org.dspace.curate.CurationTask
+

--- a/dspace/config/spring/api/scripts.xml
+++ b/dspace/config/spring/api/scripts.xml
@@ -18,4 +18,9 @@
         <property name="description" value="Export metadata for batch editing"/>
         <property name="dspaceRunnableClass" value="org.dspace.app.bulkedit.MetadataExport"/>
     </bean>
+
+    <bean id="curation" class="org.dspace.curate.CurationScriptConfiguration">
+        <property name="description" value="Curation tasks"/>
+        <property name="dspaceRunnableClass" value="org.dspace.curate.CurationCli"/>
+    </bean>
 </beans>

--- a/dspace/config/spring/api/scripts.xml
+++ b/dspace/config/spring/api/scripts.xml
@@ -19,7 +19,7 @@
         <property name="dspaceRunnableClass" value="org.dspace.app.bulkedit.MetadataExport"/>
     </bean>
 
-    <bean id="curation" class="org.dspace.curate.CurationScriptConfiguration">
+    <bean id="curate" class="org.dspace.curate.CurationScriptConfiguration">
         <property name="description" value="Curation tasks"/>
         <property name="dspaceRunnableClass" value="org.dspace.curate.CurationCli"/>
     </bean>


### PR DESCRIPTION
## References
_Add references/links to any related tickets or PRs._
* Link to [Scripts and processes REST Contract](https://github.com/DSpace/Rest7Contract/blob/master/scripts-endpoint.md) -> There is no explicit rest contract for the curation tasks implementation
* Link to [Curation Tasks documentation](https://wiki.lyrasis.org/display/DSDOC7x/Curation+System)
## Description
This PR adds in the functionality of the curation tasks to the recently merged scripts and processes functionality.
Documentation on the curation task can be found above.

## Instructions for Reviewers

List of changes in this PR:
* The curation tasks process has been moved to the scripts.xml config
* CurationCli has been made a DSpaceRunnable
* Configuration of the script can be found in CurationClientOptions
* At present, all curation tasks are admin only (Which is checked in the CurationScriptConfiguration)

Starting a curation task can be done by performing a POST request on the endpoint
>/api/system/scripts/curate/processes

All parameter values should be provided in the body that has to use the multipart/form-data content type.
The simples of this is with a properties parameter, than contains JSON with the required options, ie the following properties will start the 'noop' curation task(-t) for the provided eperson(-e) and handle (-i)

```[
  {
    "name": "-e",
    "value": "atmirenv@gmail.com"
  },
  {
    "name": "-t",
    "value":"noop"
  },
  {
    "name": "-i",
    "value":"123456789/8"
  }
]
```

When using the '-T' option, this allows the code to handle a text file containing a list of tasknames to be performed. (An example which is also used in the IT can be [found here](https://github.com/atmire/DSpace/blob/e7b33c5fb5bca314384c97088ea43a4dbd93cf6c/dspace-api/src/test/data/dspaceFolder/assetstore/curate.txt)
**Note:**
CurationScriptIT at present does not yet contain the check to see if calling the 'noop' task actually ends up on (This IS logged in the dspace logs, but not explicitly returned as a particular status, apart from the scripts and processes returning the properties that have been sent to the endpoint, but that is not a marker to see if it has been executed or not)
We need to investigate to properly and cleanly mock the 'NoOpCurationTask' (In combination with the autowiring that is being done in the class), after which we can verify if the 'perform' method has been called correctly.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/master/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
