### PR TITLE
[DS-4205] Bump Handle to version 9.3.0-SNAPSHOT

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -291,8 +291,19 @@
         </dependency>
 
         <dependency>
-            <groupId>org.dspace</groupId>
+            <groupId>net.handle</groupId>
             <artifactId>handle</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.cnri</groupId>
+            <artifactId>cnri-servlet-container</artifactId>
+            <exclusions>
+                <!-- Newer versions provided in our parent POM -->
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-commons</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Jetty is needed to run Handle Server -->
         <dependency>
@@ -471,10 +482,58 @@
             <artifactId>solr-cell</artifactId>
             <version>${solr.client.version}</version>
             <exclusions>
-                <!-- Newer version provided in our parent POM -->
+                <!-- Newer versions provided in our parent POM -->
                 <exclusion>
                     <groupId>org.ow2.asm</groupId>
                     <artifactId>asm-commons</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-xml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-http</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-servlet</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-webapp</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-util</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-deploy</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-continuation</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-servlets</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-io</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-security</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -461,6 +461,14 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-continuation</artifactId>
                 </exclusion>

--- a/dspace/config/log4j-handle-plugin.properties
+++ b/dspace/config/log4j-handle-plugin.properties
@@ -20,12 +20,12 @@ log.dir=${dspace.dir}/log
 log4j.rootCategory=INFO, A1
 
 # A1 is set to be a DailyRollingFileAppender.
-log4j.appender.A1=org.apache.logging.log4j.DailyRollingFileAppender
+log4j.appender.A1=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.A1.File=${log.dir}/handle-plugin.log
 log4j.appender.A1.DatePattern='.'yyyy-MM-dd
 
 # A1 uses PatternLayout.
-log4j.appender.A1.layout=org.apache.logging.log4j.PatternLayout
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
 log4j.appender.A1.layout.ConversionPattern=%d %-5p %c @ %m%n
 
 

--- a/dspace/modules/server/pom.xml
+++ b/dspace/modules/server/pom.xml
@@ -267,6 +267,14 @@ just adding new jar in the classloader</description>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-continuation</artifactId>
                 </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <jaxb-runtime.version>2.3.1</jaxb-runtime.version>
         <!-- NOTE: Jetty needed for Handle Server & tests. Should be synced with version provided by solr-cell -->
-        <jetty.version>9.4.8.v20171121</jetty.version>
+        <jetty.version>9.4.15.v20190215</jetty.version>
         <log4j.version>2.11.2</log4j.version>
         <pdfbox-version>2.0.15</pdfbox-version>
         <poi-version>3.17</poi-version>
@@ -1236,9 +1236,14 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.dspace</groupId>
+                <groupId>net.handle</groupId>
                 <artifactId>handle</artifactId>
-                <version>9.1.0.v20190416</version>
+                <version>9.3.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>net.cnri</groupId>
+                <artifactId>cnri-servlet-container</artifactId>
+                <version>3.0.0-SNAPSHOT</version>
             </dependency>
             <!-- Jetty is needed to run Handle Server (and tests in some modules) -->
             <dependency>
@@ -1590,7 +1595,7 @@
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
-                <version>2.6.1</version>
+                <version>2.8.6</version>
                 <scope>compile</scope>
             </dependency>
             <!-- Google Analytics -->
@@ -1841,6 +1846,10 @@
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
+        </repository>
+        <repository>
+            <id>handle.net</id>
+            <url>https://handle.net/maven</url>
         </repository>
         <!-- For Solr 7.x, as the solr-parent POM has an old URL for this maven-restlet repository.
              The URL is corrected (to the below value) as of Solr 8.3.x, but has not yet been backported to 7.x.

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <javax-annotation.version>1.3.2</javax-annotation.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <jaxb-runtime.version>2.3.1</jaxb-runtime.version>
-        <!-- NOTE: Jetty needed for Handle Server & tests. Should be synced with version provided by solr-cell -->
+        <!-- NOTE: Jetty needed for Handle Server & tests -->
         <jetty.version>9.4.15.v20190215</jetty.version>
         <log4j.version>2.11.2</log4j.version>
         <pdfbox-version>2.0.15</pdfbox-version>
@@ -1240,6 +1240,7 @@
                 <artifactId>handle</artifactId>
                 <version>9.3.0-SNAPSHOT</version>
             </dependency>
+            <!-- Required to run Handle Server -->
             <dependency>
                 <groupId>net.cnri</groupId>
                 <artifactId>cnri-servlet-container</artifactId>
@@ -1847,6 +1848,7 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+        <!-- For Handle Server -->
         <repository>
             <id>handle.net</id>
             <url>https://handle.net/maven</url>


### PR DESCRIPTION
## References
* [JIRA ticket](https://jira.lyrasis.org/browse/DS-4205)

## Description
Handle jar files are now coming from CNRI maven repository. This required bumping Jetty version also, which meant some fiddling with solr-cell jetty exclusions.

CNRI intends to release the final version of 9.3.0 before DSpace 7 final is out, so there will probably be another PR in the future for that bump. It should be minor though, assuming this one works as expected.

## Instructions for Reviewers
It would be good to check that the jetty upgrade did not break anything. All tests passed when I ran them, but I don't know or other things to check in particular there.

Also, it would be good to check that you can still setup and run the built-in Handle server.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] ~~My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).~~ N/A
- [ ] ~~My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.~~ N/A
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/master/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] ~~If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.~~ N/A
