### PR TITLE
DS-4534 fix for Anonymous as a sub-group.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
@@ -175,7 +175,7 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
             return false;
 
             // special, everyone is member of group 0 (anonymous)
-        } else if (StringUtils.equals(group.getName(), Group.ANONYMOUS)) {
+        } else if (StringUtils.equals(group.getName(), Group.ANONYMOUS) || isParentOf(context, group, findByName(context, Group.ANONYMOUS))) {
             return true;
 
         } else {


### PR DESCRIPTION
## References
[JIRA](https://jira.lyrasis.org/browse/DS-4534) ticket

## Description
If a group contains the Anonymous as a sub-group this Anonymous group is skipped. This means that an un-authenticated user is not able view the bitstreams having this group.

## Instructions for Reviewers

List of changes in this PR:
* Additional check has been added when checking for the Anonymous group using the function `isParentOf`.

To test the fix please create a group _A_ which contains the Anonymous group as a sub-group. Then apply the group _A_ for a bitstream of an item and check if this bitstream as avaiable for view by an un-authenticated user.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/master/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
