### PR TITLE
DS-4537 Update OAI index for deleted items

### DIFF
--- a/dspace-api/src/main/java/org/dspace/handle/HandleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/handle/HandleServiceImpl.java
@@ -417,6 +417,19 @@ public class HandleServiceImpl implements HandleService
         return handlePrefix + (handlePrefix.endsWith("/") ? "" : "/") + handleSuffix.toString();
     }
 
+    /**
+     * Returns a list of handles of items that have been deleted.
+     *
+     * @param context
+     *            DSpace context
+     * @return The handle for object, or null if the object has no handle.
+     * @exception SQLException
+     *                If a database error occurs
+     */
+    public List<Handle> getDeletedItemHandles(Context context) throws SQLException {
+        return handleDAO.getDeletedItemHandles(context);
+    }
+
     @Override
     public int countTotal(Context context) throws SQLException {
         return handleDAO.countRows(context);

--- a/dspace-api/src/main/java/org/dspace/handle/dao/HandleDAO.java
+++ b/dspace-api/src/main/java/org/dspace/handle/dao/HandleDAO.java
@@ -37,4 +37,6 @@ public interface HandleDAO extends GenericDAO<Handle> {
     int updateHandlesWithNewPrefix(Context context, String newPrefix, String oldPrefix) throws SQLException;
 
     int countRows(Context context) throws SQLException;
+
+    List<Handle> getDeletedItemHandles(Context context) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/handle/dao/impl/HandleDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/handle/dao/impl/HandleDAOImpl.java
@@ -146,4 +146,16 @@ public class HandleDAOImpl extends AbstractHibernateDAO<Handle> implements Handl
         // Run our work, returning the next value in the sequence (see 'nextValReturningWork' above)
         return getHibernateSession(context).doReturningWork(nextValReturningWork);
     }
+
+    @Override
+    public List<Handle> getDeletedItemHandles(Context context) throws SQLException {
+        Query query = createQuery(context,
+                "SELECT h " +
+                        "FROM Handle h " +
+                        "LEFT JOIN FETCH h.dso " +
+                        "WHERE h.dso.id is NULL and " +
+                        "h.resourceTypeId = 2");
+        query.setCacheable(true);
+        return list(query);
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/handle/service/HandleService.java
+++ b/dspace-api/src/main/java/org/dspace/handle/service/HandleService.java
@@ -9,6 +9,7 @@ package org.dspace.handle.service;
 
 import org.dspace.content.DSpaceObject;
 import org.dspace.core.Context;
+import org.dspace.handle.Handle;
 
 import java.sql.SQLException;
 import java.util.List;
@@ -188,6 +189,17 @@ public interface HandleService {
      * @return configured prefix or "123456789"
      */
     public String getPrefix();
+
+    /**
+     * Returns a list of handles of items that have been deleted.
+     *
+     * @param context
+     *            DSpace context
+     * @return The handle for object, or null if the object has no handle.
+     * @exception SQLException
+     *                If a database error occurs
+     */
+    public List<Handle> getDeletedItemHandles(Context context) throws SQLException;
 
     public long countHandlesByPrefix(Context context, String prefix) throws SQLException;
 


### PR DESCRIPTION
See: https://jira.lyrasis.org/browse/DS-4537

When items are deleted (not withdrawn, deleted) from DSpace, the OAI index holds onto them until a clean oai index rebuild is done. This is not ideal because it means rebuilding the OAI index has to happen periodically, and during those windows, OAI can report erroneous results (just like a full discovery re-index would). Even with that approach, there is no opportunity for OAI to report that the item is deleted (aka “persistent deletion support” in OAI).

 
I have created a solution that cross references handles that belonged to Items that no longer have a resource id with OAI docs sharing that set of handles and updated item.deleted to true.

`main` version of this PR at https://github.com/DSpace/DSpace/pull/2856