### PR TITLE
[DS-4149] support for additional "metadata" insertion on "item.compile" solr document field from external plugin (6.x)

### DIFF
--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -16,7 +16,7 @@
         <!-- This is the path to the root [dspace-src] directory. -->
         <root.basedir>${basedir}/..</root.basedir>
         <spring.version>3.2.5.RELEASE</spring.version>
-        <xoai.version>3.2.10</xoai.version>
+        <xoai.version>3.3.0</xoai.version>
         <jtwig.version>2.0.1</jtwig.version>
     </properties>
 

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/CCElementAdditional.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/CCElementAdditional.java
@@ -1,0 +1,71 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xoai.app;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+import org.dspace.license.CCLookup;
+import org.dspace.license.factory.LicenseServiceFactory;
+import org.dspace.license.service.CreativeCommonsService;
+import org.dspace.xoai.util.ItemUtils;
+
+import com.lyncode.xoai.dataprovider.xml.xoai.Element;
+import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
+
+public class CCElementAdditional implements XOAIItemCompilePlugin {
+
+	private static Logger log = LogManager.getLogger(CCElementAdditional.class);
+
+	private CreativeCommonsService creativeCommonsService;
+	
+	@Override
+	public Metadata additionalMetadata(Context context, Metadata metadata, Item item) {
+
+		Element other;
+		List<Element> elements = metadata.getElement();
+		if (ItemUtils.getElement(elements, "others") != null) {
+			other = ItemUtils.getElement(elements, "others");
+		} else {
+			other = ItemUtils.create("others");
+		}
+		String ccLicense = null;
+
+		try {
+			String licenseURL = getCreativeCommonsService().getLicenseURL(context, item);
+			if (StringUtils.isNotBlank(licenseURL)) {
+				CCLookup ccLookup = new CCLookup();
+				ccLookup.issue(licenseURL);
+				String licenseName = ccLookup.getLicenseName();
+				ccLicense = licenseName + "|||" + licenseURL;
+			}
+		} catch (SQLException | IOException | AuthorizeException e) {
+			log.error(e.getMessage(), e);
+		}
+		other.getField().add(ItemUtils.createValue("cc", ccLicense));
+		return metadata;
+	}
+
+	public CreativeCommonsService getCreativeCommonsService() {
+		if(creativeCommonsService==null) {
+			creativeCommonsService = LicenseServiceFactory.getInstance().getCreativeCommonsService();
+		}
+		return creativeCommonsService;
+	}
+
+	public void setCreativeCommonsService(CreativeCommonsService creativeCommonsService) {
+		this.creativeCommonsService = creativeCommonsService;
+	}
+}

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/CCElementAdditional.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/CCElementAdditional.java
@@ -58,7 +58,9 @@ public class CCElementAdditional implements XOAIItemCompilePlugin {
 		} catch (SQLException | IOException | AuthorizeException e) {
 			log.error(e.getMessage(), e);
 		}
-		other.getField().add(ItemUtils.createValue("cc", ccLicense));
+		if (StringUtils.isNotBlank(ccLicense)) {
+			other.getField().add(ItemUtils.createValue("cc", ccLicense));
+		}
 		return metadata;
 	}
 

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/CCElementAdditional.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/CCElementAdditional.java
@@ -25,6 +25,10 @@ import org.dspace.xoai.util.ItemUtils;
 import com.lyncode.xoai.dataprovider.xml.xoai.Element;
 import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
 
+/**
+ * Utility class to build xml element to support Creative Commons information
+ *
+ */
 public class CCElementAdditional implements XOAIItemCompilePlugin {
 
 	private static Logger log = LogManager.getLogger(CCElementAdditional.class);

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/OAISpringLoader.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/OAISpringLoader.java
@@ -1,0 +1,42 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xoai.app;
+
+import java.io.File;
+import java.net.MalformedURLException;
+
+import org.dspace.kernel.config.SpringLoader;
+import org.dspace.services.ConfigurationService;
+
+/**
+ * Spring Loader to load specific bean implementation only for OAI Spring context
+ *
+ */
+public class OAISpringLoader implements SpringLoader{
+
+    @Override
+    public String[] getResourcePaths(ConfigurationService configurationService) {
+        StringBuffer filePath = new StringBuffer();
+        filePath.append(configurationService.getProperty("dspace.dir"));
+        filePath.append(File.separator);
+        filePath.append("config");
+        filePath.append(File.separator);
+        filePath.append("spring");
+        filePath.append(File.separator);
+        filePath.append("oai");
+        filePath.append(File.separator);
+
+        try {
+            return new String[]{new File(filePath.toString()).toURI().toURL().toString() + XML_SUFFIX};
+        } catch (MalformedURLException e) {
+            return new String[0];
+        }
+    }
+
+}
+

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/OrcidVirtualElementAdditional.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/OrcidVirtualElementAdditional.java
@@ -1,0 +1,134 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xoai.app;
+
+import java.net.MalformedURLException;
+import java.util.List;
+import java.util.StringTokenizer;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocumentList;
+import org.dspace.authority.AuthoritySearchService;
+import org.dspace.authority.factory.AuthorityServiceFactory;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+import org.dspace.xoai.util.ItemUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.lyncode.xoai.dataprovider.xml.xoai.Element;
+import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
+
+public class OrcidVirtualElementAdditional implements XOAIItemCompilePlugin {
+
+	private static final Logger log = Logger.getLogger(OrcidVirtualElementAdditional.class);
+	
+	private String metadata = "dc.contributor.author";
+
+	private AuthoritySearchService authorityService;
+	
+	@Autowired(required=true)
+	private ItemService itemService;
+
+	@Override
+	public Metadata additionalMetadata(Context context, Metadata metadata, Item item) {
+		Element personElement = ItemUtils.create("person");
+		Element identifierElement = ItemUtils.create("identifier");
+		Element orcidElement = ItemUtils.create("orcid");
+		Element noneElement = ItemUtils.create("none");
+
+		StringTokenizer dcf = new StringTokenizer(getMetadata(), ".");
+
+		String[] tokens = { "", "", "" };
+		int i = 0;
+		while (dcf.hasMoreTokens()) {
+			tokens[i] = dcf.nextToken().trim();
+			i++;
+		}
+		String schema = tokens[0];
+		String element = tokens[1];
+		String qualifier = tokens[2];
+
+		List<MetadataValue> values = null;
+		if ("*".equals(qualifier)) {
+			values = itemService.getMetadata(item, schema, element, Item.ANY, Item.ANY);
+		} else if ("".equals(qualifier)) {
+			values = itemService.getMetadata(item, schema, element, null, Item.ANY);
+		} else {
+			values = itemService.getMetadata(item, schema, element, qualifier, Item.ANY);
+		}
+		for (MetadataValue val : values) {
+			if (StringUtils.isNotBlank(val.getAuthority())) {
+				SolrQuery queryArgs = new SolrQuery();
+				queryArgs.setQuery("id:" + val.getAuthority());
+				queryArgs.addFilterQuery("authority_type:orcid");
+				queryArgs.addField("orcid_id");
+				queryArgs.setRows(1);
+				QueryResponse searchResponse;
+				try {
+					searchResponse = getAuthorityService().search(queryArgs);
+					SolrDocumentList docs = searchResponse.getResults();
+
+					if (docs.getNumFound() == 1) {
+						String orcid = null;
+						try {
+							orcid = (String) docs.get(0).getFieldValue("orcid_id");
+						} catch (Exception e) {
+							log.error("couldn't get field value for key orcid_id", e);
+						}
+						if(StringUtils.isNotBlank(orcid)) {
+							noneElement.getField().add(ItemUtils.createValue("value", orcid));
+							noneElement.getField().add(ItemUtils.createValue("authority", val.getAuthority()));
+							noneElement.getField().add(ItemUtils.createValue("confidence", "" + val.getConfidence()));
+						}
+					}
+				} catch (MalformedURLException | SolrServerException e1) {
+					log.error(e1.getMessage(), e1);
+				}
+
+			}
+		}
+		orcidElement.getElement().add(noneElement);
+		identifierElement.getElement().add(orcidElement);
+		personElement.getElement().add(identifierElement);
+		metadata.getElement().add(personElement);
+		return metadata;
+	}
+
+	public String getMetadata() {
+		return metadata;
+	}
+
+	public void setMetadata(String metadata) {
+		this.metadata = metadata;
+	}
+
+	public AuthoritySearchService getAuthorityService() {
+		if(authorityService==null) {
+			 authorityService = AuthorityServiceFactory.getInstance().getAuthoritySearchService();
+		}
+		return authorityService;
+	}
+
+	public void setAuthorityService(AuthoritySearchService authorityService) {
+		this.authorityService = authorityService;
+	}
+
+	public ItemService getItemService() {
+		return itemService;
+	}
+
+	public void setItemService(ItemService itemService) {
+		this.itemService = itemService;
+	}
+}

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/OrcidVirtualElementAdditional.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/OrcidVirtualElementAdditional.java
@@ -29,6 +29,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import com.lyncode.xoai.dataprovider.xml.xoai.Element;
 import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
 
+/**
+ * Utility class to build xml element to support additional element on author
+ *
+ */
+@Deprecated
 public class OrcidVirtualElementAdditional implements XOAIItemCompilePlugin {
 
 	private static final Logger log = Logger.getLogger(OrcidVirtualElementAdditional.class);

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/PermissionElementAdditional.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/PermissionElementAdditional.java
@@ -94,7 +94,7 @@ public class PermissionElementAdditional implements XOAIItemCompilePlugin {
 			if (bitstream == null) {
 				return value;
 			}
-			value = ItemUtils.getAccessRightsValue(authorizeService.getPoliciesActionFilter(context, bitstream, Constants.READ));
+			value = ItemUtils.getAccessRightsValue(context, authorizeService.getPoliciesActionFilter(context, bitstream, Constants.READ));
 		}
 		return value;
 	}

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/PermissionElementAdditional.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/PermissionElementAdditional.java
@@ -25,6 +25,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import com.lyncode.xoai.dataprovider.xml.xoai.Element;
 import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
 
+/**
+ * Utility class to build xml element to support Item access rights information at Bitstream level
+ *
+ */
 public class PermissionElementAdditional implements XOAIItemCompilePlugin {
 
 	private static Logger log = LogManager.getLogger(PermissionElementAdditional.class);
@@ -58,9 +62,18 @@ public class PermissionElementAdditional implements XOAIItemCompilePlugin {
 		return metadata;
 	}
 
+	/**
+	 *
+	 * Build access rights of the Item on Bitstream level
+	 *
+	 * @param context
+	 * @param item
+	 * @return
+	 * @throws SQLException
+	 */
 	private String buildPermission(Context context, Item item) throws SQLException {
 
-		String values = "metadata only access";
+		String value = ItemUtils.METADATA_ONLY_ACCESS;
 		List<Bundle> bnds = null;
 		try {
 			bnds = itemService.getBundles(item, Constants.DEFAULT_BUNDLE_NAME);
@@ -79,11 +92,11 @@ public class PermissionElementAdditional implements XOAIItemCompilePlugin {
 			}
 
 			if (bitstream == null) {
-				return "metadata only access";
+				return value;
 			}
-			values = ItemUtils.getDRM(authorizeService.getPoliciesActionFilter(context, bitstream, Constants.READ));
+			value = ItemUtils.getAccessRightsValue(authorizeService.getPoliciesActionFilter(context, bitstream, Constants.READ));
 		}
-		return values;
+		return value;
 	}
 
 	public ItemService getItemService() {

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/PermissionElementAdditional.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/PermissionElementAdditional.java
@@ -1,0 +1,97 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xoai.app;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Item;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.xoai.util.ItemUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.lyncode.xoai.dataprovider.xml.xoai.Element;
+import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
+
+public class PermissionElementAdditional implements XOAIItemCompilePlugin {
+
+	private static Logger log = LogManager.getLogger(PermissionElementAdditional.class);
+
+	@Autowired(required=true)
+	private ItemService itemService;
+	@Autowired(required=true)	
+	private AuthorizeService authorizeService;
+	
+	@Override
+	public Metadata additionalMetadata(Context context, Metadata metadata, Item item) {
+		
+		Element other;
+		List<Element> elements = metadata.getElement();
+		if (ItemUtils.getElement(elements, "others") != null) {
+			other = ItemUtils.getElement(elements, "others");
+		} else {
+			other = ItemUtils.create("others");
+		}
+
+		String drm = null;
+
+		try {
+			drm = buildPermission(context, item);
+		} catch (SQLException e) {
+			log.error(e.getMessage(), e);
+		}
+
+		other.getField().add(ItemUtils.createValue("drm", drm));
+
+		return metadata;
+	}
+
+	private String buildPermission(Context context, Item item) throws SQLException {
+
+		String values = "metadata only access";
+		List<Bundle> bnds = null;
+		try {
+			bnds = itemService.getBundles(item, Constants.DEFAULT_BUNDLE_NAME);
+		} catch (SQLException e) {
+			throw new RuntimeException(e.getMessage(), e);
+		}
+
+		for (Bundle bnd : bnds) {
+
+			Bitstream bitstream = bnd.getPrimaryBitstream();
+			if (bitstream == null) {
+				for (Bitstream b : bnd.getBitstreams()) {
+					bitstream = b;
+					break;
+				}
+			}
+
+			if (bitstream == null) {
+				return "metadata only access";
+			}
+			values = ItemUtils.getDRM(authorizeService.getPoliciesActionFilter(context, bitstream, Constants.READ));
+		}
+		return values;
+	}
+
+	public ItemService getItemService() {
+		return itemService;
+	}
+
+	public void setItemService(ItemService itemService) {
+		this.itemService = itemService;
+	}
+
+}

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -11,6 +11,7 @@ import com.lyncode.xoai.dataprovider.exceptions.ConfigurationException;
 import com.lyncode.xoai.dataprovider.exceptions.MetadataBindException;
 import com.lyncode.xoai.dataprovider.exceptions.WritingXmlException;
 import com.lyncode.xoai.dataprovider.xml.XmlOutputContext;
+import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.Options;
@@ -82,7 +83,9 @@ public class XOAI {
     private final AuthorizeService authorizeService;
     private final ItemService itemService;
     private static final ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
-
+    
+    private List<XOAIItemCompilePlugin> xOAIItemCompilePlugins;
+    
     private List<String> getFileFormats(Item item) {
         List<String> formats = new ArrayList<>();
         try {
@@ -434,7 +437,15 @@ public class XOAI {
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         XmlOutputContext xmlContext = XmlOutputContext.emptyContext(out, Second);
-        retrieveMetadata(context, item).write(xmlContext);
+        Metadata metadata = retrieveMetadata(context, item);
+        
+        //Do any additional metadata element, depends on the plugins
+        for (XOAIItemCompilePlugin xOAIItemCompilePlugin : getxOAIItemCompilePlugins())
+        {
+            metadata = xOAIItemCompilePlugin.additionalMetadata(context, metadata, item);
+        }
+        
+        metadata.write(xmlContext);
         xmlContext.getWriter().flush();
         xmlContext.getWriter().close();
         doc.addField("item.compile", out.toString());
@@ -671,4 +682,15 @@ public class XOAI {
             System.out.println("     -h Shows this text");
         }
     }
+
+	public List<XOAIItemCompilePlugin> getxOAIItemCompilePlugins() {
+		if(xOAIItemCompilePlugins==null) {
+			xOAIItemCompilePlugins = DSpaceServicesFactory.getInstance().getServiceManager().getServicesByType(XOAIItemCompilePlugin.class);
+		}
+		return xOAIItemCompilePlugins;
+	}
+
+	public void setxOAIItemCompilePlugins(List<XOAIItemCompilePlugin> xOAIItemCompilePlugins) {
+		this.xOAIItemCompilePlugins = xOAIItemCompilePlugins;
+	}
 }

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -683,6 +683,11 @@ public class XOAI {
         }
     }
 
+	/**
+	 * Do any additional content on "item.compile" field, depends on the plugins
+	 * 
+	 * @return
+	 */
 	public List<XOAIItemCompilePlugin> getxOAIItemCompilePlugins() {
 		if(xOAIItemCompilePlugins==null) {
 			xOAIItemCompilePlugins = DSpaceServicesFactory.getInstance().getServiceManager().getServicesByType(XOAIItemCompilePlugin.class);

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAIItemCompilePlugin.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAIItemCompilePlugin.java
@@ -1,0 +1,25 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xoai.app;
+
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+
+import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
+
+/**
+ * Used to enrich item.compile field description
+ *
+ */
+public interface XOAIItemCompilePlugin
+{
+
+    public Metadata additionalMetadata(Context context, Metadata metadata,
+            Item item);
+
+}

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/resources/DSpaceResourceResolver.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/resources/DSpaceResourceResolver.java
@@ -25,7 +25,7 @@ import com.lyncode.xoai.dataprovider.services.api.ResourceResolver;
 public class DSpaceResourceResolver implements ResourceResolver
 {
     private static final TransformerFactory transformerFactory = TransformerFactory
-            .newInstance();
+            .newInstance("net.sf.saxon.TransformerFactoryImpl", null);
 
     private final String basePath = ConfigurationManager.getProperty("oai",
             "config.dir");

--- a/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
@@ -51,7 +51,15 @@ import com.lyncode.xoai.util.Base64Utils;
 @SuppressWarnings("deprecation")
 public class ItemUtils
 {
-    private static final Logger log = LogManager.getLogger(ItemUtils.class);
+    public static final String RESTRICTED_ACCESS = "restricted access";
+
+    public static final String EMBARGOED_ACCESS = "embargoed access";
+
+    public static final String OPEN_ACCESS = "open access";
+
+    public static final String METADATA_ONLY_ACCESS = "metadata only access";
+
+	private static final Logger log = LogManager.getLogger(ItemUtils.class);
     
     private static final MetadataExposureService metadataExposureService
             = UtilServiceFactory.getInstance().getMetadataExposureService();
@@ -243,7 +251,7 @@ public class ItemUtils
                     String oname = bit.getSource();
                     String name = bit.getName();
                     String description = bit.getDescription();
-                    String drm = ItemUtils.getDRM(authorizeService.getPoliciesActionFilter(context, bit,  Constants.READ));
+                    String drm = ItemUtils.getAccessRightsValue(authorizeService.getPoliciesActionFilter(context, bit,  Constants.READ));
                         
                     if (name != null)
                         bitstream.getField().add(
@@ -340,7 +348,16 @@ public class ItemUtils
         return metadata;
     }
     
-	public static String getDRM(List<ResourcePolicy> rps) {
+	/**
+	 * Method to return a default value text to identify access rights:
+	 * 'open access','embargoed access','restricted access','metadata only access'
+	 *
+	 * NOTE: embargoed access contains also embargo end date in the form "embargoed access|||yyyy-MM-dd"
+	 *
+	 * @param rps
+	 * @return
+	 */
+	public static String getAccessRightsValue(List<ResourcePolicy> rps) {
 		Date now = new Date();
 		Date embargoEndDate = null;
 		boolean openAccess = false;
@@ -366,19 +383,19 @@ public class ItemUtils
 				}
 			}
 		}
-		String values = "metadata only access";
+		String value = METADATA_ONLY_ACCESS;
 		// if there are fulltext build the values
 		if (openAccess) {
 			// open access
-			values = "open access";
+			value = OPEN_ACCESS;
 		} else if (withEmbargo) {
 			// all embargoed
-			values = "embargoed access" + "|||" + sdf.format(embargoEndDate);
+			value = EMBARGOED_ACCESS + "|||" + sdf.format(embargoEndDate);
 		} else if (groupRestricted) {
 			// all restricted
-			values = "restricted access";
+			value = RESTRICTED_ACCESS;
 		}
-		return values;
+		return value;
 	}
 
  }

--- a/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
@@ -7,30 +7,42 @@
  */
 package org.dspace.xoai.util;
 
-import com.lyncode.xoai.dataprovider.xml.xoai.Element;
-import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
-import com.lyncode.xoai.util.Base64Utils;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
-import org.dspace.authorize.AuthorizeException;
-import org.dspace.content.*;
-import org.dspace.content.authority.Choices;
-import org.dspace.core.ConfigurationManager;
-import org.dspace.core.Constants;
-import org.dspace.core.Utils;
-import org.dspace.xoai.data.DSpaceItem;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
+
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
 import org.dspace.app.util.factory.UtilServiceFactory;
 import org.dspace.app.util.service.MetadataExposureService;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.authorize.factory.AuthorizeServiceFactory;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.authorize.service.ResourcePolicyService;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataField;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.authority.Choices;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.ItemService;
+import org.dspace.core.ConfigurationManager;
+import org.dspace.core.Constants;
 import org.dspace.core.Context;
+import org.dspace.core.Utils;
+import org.dspace.eperson.Group;
+import org.dspace.xoai.data.DSpaceItem;
+
+import com.lyncode.xoai.dataprovider.xml.xoai.Element;
+import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
+import com.lyncode.xoai.util.Base64Utils;
 
 /**
  * 
@@ -49,8 +61,14 @@ public class ItemUtils
 
     private static final BitstreamService bitstreamService
             = ContentServiceFactory.getInstance().getBitstreamService();
+    
+    private static final AuthorizeService authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();
 
-    private static Element getElement(List<Element> list, String name)
+    private static final ResourcePolicyService resourcePolicyService = AuthorizeServiceFactory.getInstance().getResourcePolicyService();
+    
+    private static SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+    
+    public static Element getElement(List<Element> list, String name)
     {
         for (Element e : list)
             if (name.equals(e.getName()))
@@ -58,14 +76,14 @@ public class ItemUtils
 
         return null;
     }
-    private static Element create(String name)
+    public static Element create(String name)
     {
         Element e = new Element();
         e.setName(name);
         return e;
     }
 
-    private static Element.Field createValue(
+    public static Element.Field createValue(
             String name, String value)
     {
         Element.Field e = new Element.Field();
@@ -225,7 +243,8 @@ public class ItemUtils
                     String oname = bit.getSource();
                     String name = bit.getName();
                     String description = bit.getDescription();
-
+                    String drm = ItemUtils.getDRM(authorizeService.getPoliciesActionFilter(context, bit,  Constants.READ));
+                        
                     if (name != null)
                         bitstream.getField().add(
                                 createValue("name", name));
@@ -248,6 +267,8 @@ public class ItemUtils
                     bitstream.getField().add(
                             createValue("sid", bit.getSequenceID()
                                     + ""));
+                    bitstream.getField()
+                            .add(createValue("drm", drm));
                 }
             }
         }
@@ -318,4 +339,46 @@ public class ItemUtils
         
         return metadata;
     }
-}
+    
+	public static String getDRM(List<ResourcePolicy> rps) {
+		Date now = new Date();
+		Date embargoEndDate = null;
+		boolean openAccess = false;
+		boolean groupRestricted = false;
+		boolean withEmbargo = false;
+
+		if (rps != null) {
+			for (ResourcePolicy rp : rps) {
+				if (Group.ANONYMOUS.equals(rp.getGroup().getName())) {
+					if (resourcePolicyService.isDateValid(rp)) {
+						openAccess = true;
+					} else if (rp.getStartDate() != null && rp.getStartDate().after(now)) {
+						withEmbargo = true;
+						embargoEndDate = rp.getStartDate();
+					}
+				} else if (!Group.ADMIN.equals(rp.getGroup().getName())) {
+					if (resourcePolicyService.isDateValid(rp)) {
+						groupRestricted = true;
+					} else if (rp.getStartDate() == null || rp.getStartDate().after(now)) {
+						withEmbargo = true;
+						embargoEndDate = rp.getStartDate();
+					}
+				}
+			}
+		}
+		String values = "metadata only access";
+		// if there are fulltext build the values
+		if (openAccess) {
+			// open access
+			values = "open access";
+		} else if (withEmbargo) {
+			// all embargoed
+			values = "embargoed access" + "|||" + sdf.format(embargoEndDate);
+		} else if (groupRestricted) {
+			// all restricted
+			values = "restricted access";
+		}
+		return values;
+	}
+
+ }

--- a/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
@@ -251,7 +251,7 @@ public class ItemUtils
                     String oname = bit.getSource();
                     String name = bit.getName();
                     String description = bit.getDescription();
-                    String drm = ItemUtils.getAccessRightsValue(authorizeService.getPoliciesActionFilter(context, bit,  Constants.READ));
+                    String drm = ItemUtils.getAccessRightsValue(context, authorizeService.getPoliciesActionFilter(context, bit,  Constants.READ));
                         
                     if (name != null)
                         bitstream.getField().add(
@@ -357,7 +357,8 @@ public class ItemUtils
 	 * @param rps
 	 * @return
 	 */
-	public static String getAccessRightsValue(List<ResourcePolicy> rps) {
+	public static String getAccessRightsValue(Context context, List<ResourcePolicy> rps)
+		throws SQLException {
 		Date now = new Date();
 		Date embargoEndDate = null;
 		boolean openAccess = false;
@@ -366,14 +367,14 @@ public class ItemUtils
 
 		if (rps != null) {
 			for (ResourcePolicy rp : rps) {
-				if (Group.ANONYMOUS.equals(rp.getGroup().getName())) {
+				if (rp.getGroup() != null && Group.ANONYMOUS.equals(rp.getGroup().getName())) {
 					if (resourcePolicyService.isDateValid(rp)) {
 						openAccess = true;
 					} else if (rp.getStartDate() != null && rp.getStartDate().after(now)) {
 						withEmbargo = true;
 						embargoEndDate = rp.getStartDate();
 					}
-				} else if (!Group.ADMIN.equals(rp.getGroup().getName())) {
+				} else if (rp.getGroup() != null && !Group.ADMIN.equals(rp.getGroup().getName())) {
 					if (resourcePolicyService.isDateValid(rp)) {
 						groupRestricted = true;
 					} else if (rp.getStartDate() == null || rp.getStartDate().after(now)) {
@@ -381,6 +382,7 @@ public class ItemUtils
 						embargoEndDate = rp.getStartDate();
 					}
 				}
+				context.uncacheEntity(rp);
 			}
 		}
 		String value = METADATA_ONLY_ACCESS;

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/stylesheets/AbstractXSLTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/stylesheets/AbstractXSLTest.java
@@ -19,7 +19,8 @@ import java.io.File;
 import java.io.InputStream;
 
 public abstract class AbstractXSLTest {
-    private static final TransformerFactory factory = TransformerFactory.newInstance();
+    private static final TransformerFactory factory = TransformerFactory
+            .newInstance("net.sf.saxon.TransformerFactoryImpl", null);
 
     protected TransformBuilder apply (String xslLocation) throws Exception {
         return new TransformBuilder(xslLocation);

--- a/dspace/config/crosswalks/oai/metadataFormats/mets.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/mets.xsl
@@ -12,10 +12,7 @@
 	
 	>  http://www.loc.gov/standards/mets/mets.xsd
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-	xmlns:doc="http://www.lyncode.com/xoai" 
-    xmlns:date="http://exslt.org/dates-and-times" 
-    extension-element-prefixes="date" version="1.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:doc="http://www.lyncode.com/xoai" version="2.0">
     
 	<xsl:output omit-xml-declaration="yes" method="xml" indent="yes" />
 
@@ -32,7 +29,7 @@
 			</xsl:attribute>
 			<metsHdr>
 				<xsl:attribute name="CREATEDATE">
-					<xsl:value-of select="concat(date:format-date(date:date(), 'yyyy-MM-dd'), 'T' , date:format-date(date:time(), 'HH:mm:ss'), 'Z')"/>
+					<xsl:value-of select="concat(format-date(current-date(), 'yyyy-MM-dd'), 'T' , format-time(current-time(), 'HH:mm:ss'), 'Z')"/>
 				</xsl:attribute>
 				<agent ROLE="CUSTODIAN" TYPE="ORGANIZATION">
 					<name><xsl:value-of select="doc:metadata/doc:element[@name='repository']/doc:field[@name='name']/text()" /></name>

--- a/dspace/config/crosswalks/oai/metadataFormats/mets.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/mets.xsl
@@ -29,7 +29,7 @@
 			</xsl:attribute>
 			<metsHdr>
 				<xsl:attribute name="CREATEDATE">
-					<xsl:value-of select="concat(format-date(current-date(), 'yyyy-MM-dd'), 'T' , format-time(current-time(), 'HH:mm:ss'), 'Z')"/>
+					<xsl:value-of select="concat(format-date(current-date(), '[Y0001]-[M02]-[D02]'), 'T' , format-time(current-time(), '[H01]:[m01]:[s01]'), 'Z')"/>
 				</xsl:attribute>
 				<agent ROLE="CUSTODIAN" TYPE="ORGANIZATION">
 					<name><xsl:value-of select="doc:metadata/doc:element[@name='repository']/doc:field[@name='name']/text()" /></name>

--- a/dspace/config/modules/spring.cfg
+++ b/dspace/config/modules/spring.cfg
@@ -8,4 +8,5 @@
 # These classes contain the paths to where to spring files are loaded
 spring.springloader.modules=org.dspace.app.configuration.APISpringLoader,\
   org.dspace.app.xmlui.configuration.XMLUISpringLoader,\
-  org.dspace.app.webui.configuration.JSPUISpringLoader
+  org.dspace.app.webui.configuration.JSPUISpringLoader,\
+  org.dspace.xoai.app.OAISpringLoader

--- a/dspace/config/spring/oai/oai.xml
+++ b/dspace/config/spring/oai/oai.xml
@@ -29,6 +29,8 @@
 	class="org.dspace.xoai.app.PermissionElementAdditional"/>
 
 	<!-- Additional item.compile plugin to enrich field with information about Creative Commons License metadata -->
-	<bean id="CCElementAdditional"
-	class="org.dspace.xoai.app.CCElementAdditional"/>
+	<!-- For large repository the strategy used to retrieve Creative Commons information could be degraded the indexing performance.
+		Tested it on a repository of 163K items and the full reindex process takes 2 hours more - the full reindex process without this takes 1 hour. -->
+	<!-- <bean id="CCElementAdditional"
+	class="org.dspace.xoai.app.CCElementAdditional"/> -->
 </beans>

--- a/dspace/config/spring/oai/oai.xml
+++ b/dspace/config/spring/oai/oai.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                  http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+                  http://www.springframework.org/schema/context
+                  http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+
+    <context:annotation-config /> <!-- allows us to use spring annotations in beans -->
+
+	<!-- Additional item.compile plugin to enrich field with information about orcid metadata: to use it activate ORCID based authority control on dspace.cfg-->
+<!--  	<bean id="orcidVirtualElementAdditional"
+		class="org.dspace.xoai.app.OrcidVirtualElementAdditional">
+		<property name="metadata" value="dc.contributor.author"/>
+	</bean> -->
+	
+	<!-- Additional item.compile plugin to enrich field with information about DRM metadata -->
+	<bean id="PermissionElementAdditional"
+	class="org.dspace.xoai.app.PermissionElementAdditional"/>
+
+	<!-- Additional item.compile plugin to enrich field with information about Creative Commons License metadata -->
+	<bean id="CCElementAdditional"
+	class="org.dspace.xoai.app.CCElementAdditional"/>
+</beans>


### PR DESCRIPTION
As agreed on https://github.com/DSpace/DSpace/pull/2709#issuecomment-653817186 this PR is a simplify version of https://github.com/DSpace/DSpace/pull/2709 that contains only the  core infrastructure to address the insert of additional metadata into item.compile via spring beans