### PR TITLE
[DS-4149] support for additional "metadata" insertion on "item.compile" solr document field from external plugin (5.x)

### DIFF
--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -16,7 +16,7 @@
         <!-- This is the path to the root [dspace-src] directory. -->
         <root.basedir>${basedir}/..</root.basedir>
         <spring.version>3.2.5.RELEASE</spring.version>
-        <xoai.version>3.2.10</xoai.version>
+        <xoai.version>3.3.0</xoai.version>
         <jtwig.version>2.0.1</jtwig.version>
     </properties>
 

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/CCElementAdditional.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/CCElementAdditional.java
@@ -1,0 +1,57 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xoai.app;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+import org.dspace.license.CCLookup;
+import org.dspace.license.CreativeCommons;
+import org.dspace.xoai.util.ItemUtils;
+
+import com.lyncode.xoai.dataprovider.xml.xoai.Element;
+import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
+
+public class CCElementAdditional implements XOAIItemCompilePlugin {
+
+	private static Logger log = LogManager.getLogger(CCElementAdditional.class);
+
+	@Override
+	public Metadata additionalMetadata(Context context, Metadata metadata, Item item) {
+
+		Element other;
+		List<Element> elements = metadata.getElement();
+		if (ItemUtils.getElement(elements, "others") != null) {
+			other = ItemUtils.getElement(elements, "others");
+		} else {
+			other = ItemUtils.create("others");
+		}
+		String ccLicense = null;
+
+		try {
+			String licenseURL = CreativeCommons.getLicenseURL(item);
+			if (StringUtils.isNotBlank(licenseURL)) {
+				CCLookup ccLookup = new CCLookup();
+				ccLookup.issue(licenseURL);
+				String licenseName = ccLookup.getLicenseName();
+				ccLicense = licenseName + "|||" + licenseURL;
+			}
+		} catch (SQLException | IOException | AuthorizeException e) {
+			log.error(e.getMessage(), e);
+		}
+		other.getField().add(ItemUtils.createValue("cc", ccLicense));
+		return metadata;
+	}
+}

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/CCElementAdditional.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/CCElementAdditional.java
@@ -55,7 +55,9 @@ public class CCElementAdditional implements XOAIItemCompilePlugin {
 		} catch (SQLException | IOException | AuthorizeException e) {
 			log.error(e.getMessage(), e);
 		}
-		other.getField().add(ItemUtils.createValue("cc", ccLicense));
+		if (StringUtils.isNotBlank(ccLicense)) {
+			other.getField().add(ItemUtils.createValue("cc", ccLicense));
+		}
 		return metadata;
 	}
 }

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/CCElementAdditional.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/CCElementAdditional.java
@@ -24,6 +24,10 @@ import org.dspace.xoai.util.ItemUtils;
 import com.lyncode.xoai.dataprovider.xml.xoai.Element;
 import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
 
+/**
+ * Utility class to build xml element to support Creative Commons information
+ *
+ */
 public class CCElementAdditional implements XOAIItemCompilePlugin {
 
 	private static Logger log = LogManager.getLogger(CCElementAdditional.class);

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/OAISpringLoader.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/OAISpringLoader.java
@@ -1,0 +1,42 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xoai.app;
+
+import java.io.File;
+import java.net.MalformedURLException;
+
+import org.dspace.kernel.config.SpringLoader;
+import org.dspace.services.ConfigurationService;
+
+/**
+ * Spring Loader to load specific bean implementation only for OAI Spring context
+ *
+ */
+public class OAISpringLoader implements SpringLoader{
+
+    @Override
+    public String[] getResourcePaths(ConfigurationService configurationService) {
+        StringBuffer filePath = new StringBuffer();
+        filePath.append(configurationService.getProperty("dspace.dir"));
+        filePath.append(File.separator);
+        filePath.append("config");
+        filePath.append(File.separator);
+        filePath.append("spring");
+        filePath.append(File.separator);
+        filePath.append("oai");
+        filePath.append(File.separator);
+
+        try {
+            return new String[]{new File(filePath.toString()).toURI().toURL().toString() + XML_SUFFIX};
+        } catch (MalformedURLException e) {
+            return new String[0];
+        }
+    }
+
+}
+

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/OrcidVirtualElementAdditional.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/OrcidVirtualElementAdditional.java
@@ -25,6 +25,11 @@ import org.dspace.xoai.util.ItemUtils;
 import com.lyncode.xoai.dataprovider.xml.xoai.Element;
 import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
 
+/**
+ * Utility class to build xml element to support additional element on author
+ *
+ */
+@Deprecated
 public class OrcidVirtualElementAdditional implements XOAIItemCompilePlugin {
 
 	private static final Logger log = Logger.getLogger(OrcidVirtualElementAdditional.class);

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/OrcidVirtualElementAdditional.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/OrcidVirtualElementAdditional.java
@@ -1,0 +1,116 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xoai.app;
+
+import java.net.MalformedURLException;
+import java.util.StringTokenizer;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocumentList;
+import org.dspace.authority.AuthoritySearchService;
+import org.dspace.content.Item;
+import org.dspace.content.Metadatum;
+import org.dspace.core.Context;
+import org.dspace.xoai.util.ItemUtils;
+
+import com.lyncode.xoai.dataprovider.xml.xoai.Element;
+import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
+
+public class OrcidVirtualElementAdditional implements XOAIItemCompilePlugin {
+
+	private static final Logger log = Logger.getLogger(OrcidVirtualElementAdditional.class);
+	
+	private String metadata = "dc.contributor.author";
+
+	private AuthoritySearchService authorityService;
+
+	@Override
+	public Metadata additionalMetadata(Context context, Metadata metadata, Item item) {
+		Element personElement = ItemUtils.create("person");
+		Element identifierElement = ItemUtils.create("identifier");
+		Element orcidElement = ItemUtils.create("orcid");
+		Element noneElement = ItemUtils.create("none");
+
+		StringTokenizer dcf = new StringTokenizer(getMetadata(), ".");
+
+		String[] tokens = { "", "", "" };
+		int i = 0;
+		while (dcf.hasMoreTokens()) {
+			tokens[i] = dcf.nextToken().trim();
+			i++;
+		}
+		String schema = tokens[0];
+		String element = tokens[1];
+		String qualifier = tokens[2];
+
+		Metadatum[] values;
+		if ("*".equals(qualifier)) {
+			values = item.getMetadata(schema, element, Item.ANY, Item.ANY);
+		} else if ("".equals(qualifier)) {
+			values = item.getMetadata(schema, element, null, Item.ANY);
+		} else {
+			values = item.getMetadata(schema, element, qualifier, Item.ANY);
+		}
+		for (Metadatum val : values) {
+			if (StringUtils.isNotBlank(val.authority)) {
+				SolrQuery queryArgs = new SolrQuery();
+				queryArgs.setQuery("id:" + val.authority);
+				queryArgs.addFilterQuery("authority_type:orcid");
+				queryArgs.addField("orcid_id");
+				queryArgs.setRows(1);
+				QueryResponse searchResponse;
+				try {
+					searchResponse = getAuthorityService().search(queryArgs);
+					SolrDocumentList docs = searchResponse.getResults();
+
+					if (docs.getNumFound() == 1) {
+						String orcid = null;
+						try {
+							orcid = (String) docs.get(0).getFieldValue("orcid_id");
+						} catch (Exception e) {
+							log.error("couldn't get field value for key orcid_id", e);
+						}
+						if(StringUtils.isNotBlank(orcid)) {
+							noneElement.getField().add(ItemUtils.createValue("value", orcid));
+							noneElement.getField().add(ItemUtils.createValue("authority", val.authority));
+							noneElement.getField().add(ItemUtils.createValue("confidence", "" + val.confidence));
+						}
+					}
+				} catch (MalformedURLException | SolrServerException e1) {
+					log.error(e1.getMessage(), e1);
+				}
+
+			}
+		}
+		orcidElement.getElement().add(noneElement);
+		identifierElement.getElement().add(orcidElement);
+		personElement.getElement().add(identifierElement);
+		metadata.getElement().add(personElement);
+		return metadata;
+	}
+
+	public String getMetadata() {
+		return metadata;
+	}
+
+	public void setMetadata(String metadata) {
+		this.metadata = metadata;
+	}
+
+	public AuthoritySearchService getAuthorityService() {
+		return authorityService;
+	}
+
+	public void setAuthorityService(AuthoritySearchService authorityService) {
+		this.authorityService = authorityService;
+	}
+}

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/PermissionElementAdditional.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/PermissionElementAdditional.java
@@ -23,6 +23,10 @@ import org.dspace.xoai.util.ItemUtils;
 import com.lyncode.xoai.dataprovider.xml.xoai.Element;
 import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
 
+/**
+ * Utility class to build xml element to support Item access rights information at Bitstream level
+ *
+ */
 public class PermissionElementAdditional implements XOAIItemCompilePlugin {
 
 	private static Logger log = LogManager.getLogger(PermissionElementAdditional.class);
@@ -51,9 +55,18 @@ public class PermissionElementAdditional implements XOAIItemCompilePlugin {
 		return metadata;
 	}
 
+	/**
+	 *
+	 * Build access rights of the Item on Bitstream level
+	 *
+	 * @param context
+	 * @param item
+	 * @return
+	 * @throws SQLException
+	 */
 	private String buildPermission(Context context, Item item) throws SQLException {
 
-		String values = "metadata only access";
+		String value = ItemUtils.METADATA_ONLY_ACCESS;
 		Bundle[] bnds;
 		try {
 			bnds = item.getBundles(Constants.DEFAULT_BUNDLE_NAME);
@@ -72,11 +85,11 @@ public class PermissionElementAdditional implements XOAIItemCompilePlugin {
 			}
 
 			if (bitstream == null) {
-				return "metadata only access";
+				return value;
 			}
-			values = ItemUtils.getDRM(AuthorizeManager.getPoliciesActionFilter(context, bitstream, Constants.READ));
+			value = ItemUtils.getAccessRightsValue(AuthorizeManager.getPoliciesActionFilter(context, bitstream, Constants.READ));
 		}
-		return values;
+		return value;
 	}
 
 }

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/PermissionElementAdditional.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/PermissionElementAdditional.java
@@ -87,7 +87,7 @@ public class PermissionElementAdditional implements XOAIItemCompilePlugin {
 			if (bitstream == null) {
 				return value;
 			}
-			value = ItemUtils.getAccessRightsValue(AuthorizeManager.getPoliciesActionFilter(context, bitstream, Constants.READ));
+			value = ItemUtils.getAccessRightsValue(context, AuthorizeManager.getPoliciesActionFilter(context, bitstream, Constants.READ));
 		}
 		return value;
 	}

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/PermissionElementAdditional.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/PermissionElementAdditional.java
@@ -1,0 +1,82 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xoai.app;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.dspace.authorize.AuthorizeManager;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Item;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.xoai.util.ItemUtils;
+
+import com.lyncode.xoai.dataprovider.xml.xoai.Element;
+import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
+
+public class PermissionElementAdditional implements XOAIItemCompilePlugin {
+
+	private static Logger log = LogManager.getLogger(PermissionElementAdditional.class);
+
+	@Override
+	public Metadata additionalMetadata(Context context, Metadata metadata, Item item) {
+		
+		Element other;
+		List<Element> elements = metadata.getElement();
+		if (ItemUtils.getElement(elements, "others") != null) {
+			other = ItemUtils.getElement(elements, "others");
+		} else {
+			other = ItemUtils.create("others");
+		}
+
+		String drm = null;
+
+		try {
+			drm = buildPermission(context, item);
+		} catch (SQLException e) {
+			log.error(e.getMessage(), e);
+		}
+
+		other.getField().add(ItemUtils.createValue("drm", drm));
+
+		return metadata;
+	}
+
+	private String buildPermission(Context context, Item item) throws SQLException {
+
+		String values = "metadata only access";
+		Bundle[] bnds;
+		try {
+			bnds = item.getBundles(Constants.DEFAULT_BUNDLE_NAME);
+		} catch (SQLException e) {
+			throw new RuntimeException(e.getMessage(), e);
+		}
+
+		for (Bundle bnd : bnds) {
+
+			Bitstream bitstream = Bitstream.find(context, bnd.getPrimaryBitstreamID());
+			if (bitstream == null) {
+				for (Bitstream b : bnd.getBitstreams()) {
+					bitstream = b;
+					break;
+				}
+			}
+
+			if (bitstream == null) {
+				return "metadata only access";
+			}
+			values = ItemUtils.getDRM(AuthorizeManager.getPoliciesActionFilter(context, bitstream, Constants.READ));
+		}
+		return values;
+	}
+
+}

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -288,7 +288,7 @@ public class XOAI {
         XmlOutputContext xmlContext = XmlOutputContext.emptyContext(out, Second);
         Metadata metadata = retrieveMetadata(context, item);
         
-        //Do any additional metadata element, depends on the plugins
+        //Do any additional content on "item.compile" field, depends on the plugins
         List<XOAIItemCompilePlugin> xOAIItemCompilePlugins = new DSpace().getServiceManager().getServicesByType(XOAIItemCompilePlugin.class);
         for (XOAIItemCompilePlugin xOAIItemCompilePlugin : xOAIItemCompilePlugins)
         {

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAIItemCompilePlugin.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAIItemCompilePlugin.java
@@ -1,0 +1,25 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xoai.app;
+
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+
+import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
+
+/**
+ * Used to enrich item.compile field description
+ *
+ */
+public interface XOAIItemCompilePlugin
+{
+
+    public Metadata additionalMetadata(Context context, Metadata metadata,
+            Item item);
+
+}

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/resources/DSpaceResourceResolver.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/resources/DSpaceResourceResolver.java
@@ -25,7 +25,7 @@ import com.lyncode.xoai.dataprovider.services.api.ResourceResolver;
 public class DSpaceResourceResolver implements ResourceResolver
 {
     private static final TransformerFactory transformerFactory = TransformerFactory
-            .newInstance();
+            .newInstance("net.sf.saxon.TransformerFactoryImpl", null);
 
     private final String basePath = ConfigurationManager.getProperty("oai",
             "config.dir");

--- a/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
@@ -232,7 +232,7 @@ public class ItemUtils
                     String oname = bit.getSource();
                     String name = bit.getName();
                     String description = bit.getDescription();
-                    String drm = ItemUtils.getAccessRightsValue(AuthorizeManager.getPoliciesActionFilter(context, bit,  Constants.READ));
+                    String drm = ItemUtils.getAccessRightsValue(context, AuthorizeManager.getPoliciesActionFilter(context, bit,  Constants.READ));
                         
                     if (name != null)
                         bitstream.getField().add(
@@ -346,7 +346,8 @@ public class ItemUtils
 	 * @param rps
 	 * @return
 	 */
-	public static String getAccessRightsValue(List<ResourcePolicy> rps) {
+	public static String getAccessRightsValue(Context context, List<ResourcePolicy> rps)
+			throws SQLException {
 		Date now = new Date();
 		Date embargoEndDate = null;
 		boolean openAccess = false;
@@ -370,6 +371,7 @@ public class ItemUtils
 						embargoEndDate = rp.getStartDate();
 					}
 				}
+				context.removeCached(rp, rp.getID());
 			}
 		}
 		String value = METADATA_ONLY_ACCESS;

--- a/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
@@ -44,7 +44,14 @@ import com.lyncode.xoai.util.Base64Utils;
 @SuppressWarnings("deprecation")
 public class ItemUtils
 {
-    
+    public static final String RESTRICTED_ACCESS = "restricted access";
+
+    public static final String EMBARGOED_ACCESS = "embargoed access";
+
+    public static final String OPEN_ACCESS = "open access";
+
+    public static final String METADATA_ONLY_ACCESS = "metadata only access";
+
     private static Logger log = LogManager
             .getLogger(ItemUtils.class);
 
@@ -225,7 +232,7 @@ public class ItemUtils
                     String oname = bit.getSource();
                     String name = bit.getName();
                     String description = bit.getDescription();
-                    String drm = ItemUtils.getDRM(AuthorizeManager.getPoliciesActionFilter(context, bit,  Constants.READ));
+                    String drm = ItemUtils.getAccessRightsValue(AuthorizeManager.getPoliciesActionFilter(context, bit,  Constants.READ));
                         
                     if (name != null)
                         bitstream.getField().add(
@@ -330,7 +337,16 @@ public class ItemUtils
         return metadata;
     }
     
-	public static String getDRM(List<ResourcePolicy> rps) {
+	/**
+	 * Method to return a default value text to identify access rights:
+	 * 'open access','embargoed access','restricted access','metadata only access'
+	 *
+	 * NOTE: embargoed access contains also embargo end date in the form "embargoed access|||yyyy-MM-dd"
+	 *
+	 * @param rps
+	 * @return
+	 */
+	public static String getAccessRightsValue(List<ResourcePolicy> rps) {
 		Date now = new Date();
 		Date embargoEndDate = null;
 		boolean openAccess = false;
@@ -356,19 +372,19 @@ public class ItemUtils
 				}
 			}
 		}
-		String values = "metadata only access";
+		String value = METADATA_ONLY_ACCESS;
 		// if there are fulltext build the values
 		if (openAccess) {
 			// open access
-			values = "open access";
+			value = OPEN_ACCESS;
 		} else if (withEmbargo) {
 			// all embargoed
-			values = "embargoed access" + "|||" + sdf.format(embargoEndDate);
+			value = EMBARGOED_ACCESS + "|||" + sdf.format(embargoEndDate);
 		} else if (groupRestricted) {
 			// all restricted
-			values = "restricted access";
+			value = RESTRICTED_ACCESS;
 		}
-		return values;
+		return value;
 	}
 
  }

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/stylesheets/AbstractXSLTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/stylesheets/AbstractXSLTest.java
@@ -19,7 +19,8 @@ import java.io.File;
 import java.io.InputStream;
 
 public abstract class AbstractXSLTest {
-    private static final TransformerFactory factory = TransformerFactory.newInstance();
+    private static final TransformerFactory factory = TransformerFactory
+            .newInstance("net.sf.saxon.TransformerFactoryImpl", null);
 
     protected TransformBuilder apply (String xslLocation) throws Exception {
         return new TransformBuilder(xslLocation);

--- a/dspace/config/crosswalks/oai/metadataFormats/mets.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/mets.xsl
@@ -12,10 +12,7 @@
 	
 	>  http://www.loc.gov/standards/mets/mets.xsd
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-	xmlns:doc="http://www.lyncode.com/xoai" 
-    xmlns:date="http://exslt.org/dates-and-times" 
-    extension-element-prefixes="date" version="1.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:doc="http://www.lyncode.com/xoai" version="2.0">
     
 	<xsl:output omit-xml-declaration="yes" method="xml" indent="yes" />
 
@@ -32,7 +29,7 @@
 			</xsl:attribute>
 			<metsHdr>
 				<xsl:attribute name="CREATEDATE">
-					<xsl:value-of select="concat(date:format-date(date:date(), 'yyyy-MM-dd'), 'T' , date:format-date(date:time(), 'HH:mm:ss'), 'Z')"/>
+					<xsl:value-of select="concat(format-date(current-date(), 'yyyy-MM-dd'), 'T' , format-time(current-time(), 'HH:mm:ss'), 'Z')"/>
 				</xsl:attribute>
 				<agent ROLE="CUSTODIAN" TYPE="ORGANIZATION">
 					<name><xsl:value-of select="doc:metadata/doc:element[@name='repository']/doc:field[@name='name']/text()" /></name>

--- a/dspace/config/crosswalks/oai/metadataFormats/mets.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/mets.xsl
@@ -29,7 +29,7 @@
 			</xsl:attribute>
 			<metsHdr>
 				<xsl:attribute name="CREATEDATE">
-					<xsl:value-of select="concat(format-date(current-date(), 'yyyy-MM-dd'), 'T' , format-time(current-time(), 'HH:mm:ss'), 'Z')"/>
+					<xsl:value-of select="concat(format-date(current-date(), '[Y0001]-[M02]-[D02]'), 'T' , format-time(current-time(), '[H01]:[m01]:[s01]'), 'Z')"/>
 				</xsl:attribute>
 				<agent ROLE="CUSTODIAN" TYPE="ORGANIZATION">
 					<name><xsl:value-of select="doc:metadata/doc:element[@name='repository']/doc:field[@name='name']/text()" /></name>

--- a/dspace/config/modules/spring.cfg
+++ b/dspace/config/modules/spring.cfg
@@ -8,4 +8,5 @@
 # These classes contain the paths to where to spring files are loaded
 springloader.modules=org.dspace.app.configuration.APISpringLoader,\
   org.dspace.app.xmlui.configuration.XMLUISpringLoader,\
-  org.dspace.app.webui.configuration.JSPUISpringLoader
+  org.dspace.app.webui.configuration.JSPUISpringLoader,\
+  org.dspace.xoai.app.OAISpringLoader

--- a/dspace/config/spring/oai/oai.xml
+++ b/dspace/config/spring/oai/oai.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                  http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+                  http://www.springframework.org/schema/context
+                  http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+
+    <context:annotation-config /> <!-- allows us to use spring annotations in beans -->
+
+	<!-- Additional item.compile plugin to enrich field with information about orcid metadata: to use it activate ORCID based authority control on dspace.cfg-->
+<!--  	<bean id="orcidVirtualElementAdditional"
+		class="org.dspace.xoai.app.OrcidVirtualElementAdditional">
+		<property name="metadata" value="dc.contributor.author"/>
+		<property name="authorityService" ref="org.dspace.authority.AuthoritySearchService"/>
+	</bean> -->
+	
+	<!-- Additional item.compile plugin to enrich field with information about DRM metadata -->
+	<bean id="PermissionElementAdditional"
+	class="org.dspace.xoai.app.PermissionElementAdditional"/>
+
+	<!-- Additional item.compile plugin to enrich field with information about Creative Commons License metadata -->
+	<bean id="CCElementAdditional"
+	class="org.dspace.xoai.app.CCElementAdditional"/>
+</beans>

--- a/dspace/config/spring/oai/oai.xml
+++ b/dspace/config/spring/oai/oai.xml
@@ -30,6 +30,8 @@
 	class="org.dspace.xoai.app.PermissionElementAdditional"/>
 
 	<!-- Additional item.compile plugin to enrich field with information about Creative Commons License metadata -->
-	<bean id="CCElementAdditional"
-	class="org.dspace.xoai.app.CCElementAdditional"/>
+	<!-- For large repository the strategy used to retrieve Creative Commons information could be degraded the indexing performance.
+		Tested it on a repository of 163K items and the full reindex process takes 2 hours more - the full reindex process without this takes 1 hour. -->
+	<!-- <bean id="CCElementAdditional"
+	class="org.dspace.xoai.app.CCElementAdditional"/> -->
 </beans>


### PR DESCRIPTION
As agreed on https://github.com/DSpace/DSpace/pull/2709#issuecomment-653817186 this PR is a simplify version of https://github.com/DSpace/DSpace/pull/2703 that contains only the core infrastructure to address the insert of additional metadata into item.compile via spring beans