### PR TITLE
DS-4527: Authorizations endpoint and X-On-Behalf-Of headers

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/AuthorizationRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/AuthorizationRestRepository.java
@@ -242,25 +242,27 @@ public class AuthorizationRestRepository extends DSpaceRestRepository<Authorizat
      */
     private EPerson getUserFromRequestParameter(Context context, UUID epersonUuid)
             throws AuthorizeException, SQLException {
+
         EPerson currUser = context.getCurrentUser();
-        EPerson user = currUser;
-        if (epersonUuid != null) {
+
+        if (epersonUuid == null) {
+            // no user is specified in the request parameters, check the permissions for the current user
+            return currUser;
+
+        } else {
+            // a user is specified in the request parameters
+
             if (currUser == null) {
                 throw new AuthorizeException("attempt to anonymously access the authorization of the eperson "
                         + epersonUuid);
-            } else {
-                // an user is specified in the request parameters
-                if (!authorizeService.isAdmin(context) && !epersonUuid.equals(currUser.getID())) {
-                    throw new AuthorizeException("attempt to access the authorization of the eperson " + epersonUuid
-                            + " only system administrators can see the authorization of other users");
-                }
-                user = epersonService.find(context, epersonUuid);
+
+            } else if (!authorizeService.isAdmin(context) && !epersonUuid.equals(currUser.getID())) {
+                throw new AuthorizeException("attempt to access the authorization of the eperson " + epersonUuid
+                        + " as a non-admin; only system administrators can see the authorization of other users");
             }
-        } else {
-            // the request asks to check the permission for the anonymous user
-            user = null;
+
+            return epersonService.find(context, epersonUuid);
         }
-        return user;
     }
 
     @Override


### PR DESCRIPTION
Authorizations endpoint should also recognize Authorization and X-On-Behalf-Of headers

## References
* Link to [JIRA](https://jira.lyrasis.org/browse/DS-4527) ticket
* Fixes #2810 

## Description
This fixes two problems with the Authorizations endpoint:
* The eperson parameter is no longer required, it will use the eperson from the authentication header
* If the X-On-Behalf-Of header is present, it will use the eperson from that header

## Instructions for Reviewers
Best to review this by requesting whether the user has authorization without specifying the eperson parameter.
Make sure to also verify it using the log-in-as functionality

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
