### PR TITLE
Add ability to opt-out of relation metadata fields when deriving metadata from relationships.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -1334,12 +1334,18 @@ prevent the generation of resource policy entry values with null dspace_object a
     @Override
     public List<MetadataValue> getMetadata(Item item, String schema, String element, String qualifier, String lang,
                                            boolean enableVirtualMetadata) {
+        return this.getMetadata(item, schema, element, qualifier, lang, enableVirtualMetadata, false);
+    }
+
+    @Override
+    public List<MetadataValue> getMetadata(Item item, String schema, String element, String qualifier, String lang,
+                                           boolean enableVirtualMetadata, boolean allRelationFields) {
         //Fields of the relation schema are virtual metadata
         //except for relation.type which is the type of item in the model
         if (StringUtils.equals(schema, MetadataSchemaEnum.RELATION.getName()) && !StringUtils.equals(element, "type")) {
 
             List<RelationshipMetadataValue> relationMetadata = relationshipMetadataService
-                .getRelationshipMetadata(item, false);
+                .getRelationshipMetadata(item, false, allRelationFields);
             List<MetadataValue> listToReturn = new LinkedList<>();
             for (MetadataValue metadataValue : relationMetadata) {
                 if (StringUtils.equals(metadataValue.getMetadataField().getElement(), element)) {
@@ -1355,7 +1361,8 @@ prevent the generation of resource policy entry values with null dspace_object a
 
             List<MetadataValue> fullMetadataValueList = new LinkedList<>();
             if (enableVirtualMetadata) {
-                fullMetadataValueList.addAll(relationshipMetadataService.getRelationshipMetadata(item, true));
+                fullMetadataValueList.addAll(
+                        relationshipMetadataService.getRelationshipMetadata(item, true, allRelationFields));
 
             }
             fullMetadataValueList.addAll(dbMetadataValues);

--- a/dspace-api/src/main/java/org/dspace/content/RelationshipMetadataService.java
+++ b/dspace-api/src/main/java/org/dspace/content/RelationshipMetadataService.java
@@ -31,6 +31,20 @@ public interface RelationshipMetadataService {
     public List<RelationshipMetadataValue> getRelationshipMetadata(Item item, boolean enableVirtualMetadata);
 
     /**
+     * This method retrieves a list of MetadataValue objects that get constructed from processing
+     * the given Item's Relationships through the config given to the {@link VirtualMetadataPopulator}
+     * @param item  The Item that will be processed through it's Relationships
+     * @param enableVirtualMetadata This parameter will determine whether the list of Relationship metadata
+     *                              should be populated with metadata that is being generated through the
+     *                              VirtualMetadataPopulator functionality or not
+     * @param allRelationFields If true, all relation fields will be used and generation of relation metadata will not
+     *                          be impacted by ignoredRelationFields configuration
+     * @return      The list of MetadataValue objects constructed through the Relationships
+     */
+    public List<RelationshipMetadataValue> getRelationshipMetadata(Item item, boolean enableVirtualMetadata,
+                                                                   boolean allRelationFields);
+
+    /**
      * Retrieves the list of RelationshipMetadataValue objects specific to only one Relationship of the item.
      *
      * This method processes one Relationship of an Item and will return a list of RelationshipMetadataValue objects

--- a/dspace-api/src/main/java/org/dspace/content/RelationshipServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/RelationshipServiceImpl.java
@@ -11,6 +11,7 @@ import java.sql.SQLException;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -89,7 +90,7 @@ public class RelationshipServiceImpl implements RelationshipService {
                 // for a proper place allocation
                 Relationship relationshipToReturn = relationshipDAO.create(context, relationship);
                 updatePlaceInRelationship(context, relationshipToReturn);
-                update(context, relationshipToReturn);
+                relationshipDAO.save(context, relationshipToReturn);
                 return relationshipToReturn;
             } else {
                 throw new AuthorizeException(
@@ -281,6 +282,13 @@ public class RelationshipServiceImpl implements RelationshipService {
             }
         });
         return list;
+    }
+
+    @Override
+    public List<Relationship> findByItemAndRelationshipTypeIds(Context context, Item item,
+                                                               Set<Integer> relationshipTypeIds,
+                                                               Integer limit, Integer offset) throws SQLException {
+        return relationshipDAO.findByItemAndRelationshipTypeIds(context, item, relationshipTypeIds, limit, offset);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/dao/RelationshipDAO.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/RelationshipDAO.java
@@ -9,6 +9,7 @@ package org.dspace.content.dao;
 
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Set;
 
 import org.dspace.content.Item;
 import org.dspace.content.Relationship;
@@ -175,6 +176,21 @@ public interface RelationshipDAO extends GenericDAO<Relationship> {
      * @throws SQLException if database error
      */
     int countByRelationshipType(Context context, RelationshipType relationshipType) throws SQLException;
+
+    /**
+     * This method returns a list of relationships for a specific item based on a list of RelationshipType ids
+     * @param context   The relevant DSpace context
+     * @param item      The Item that has to be the left or right item for the relationship to be included in the list
+     * @param relationshipTypeIds The set of relationshipType Ids to filter by
+     * @param limit     paging limit
+     * @param offset    paging offset
+     * @return  The list of matching relationships
+     * @throws SQLException If something goes wrong
+     */
+    List<Relationship> findByItemAndRelationshipTypeIds(Context context, Item item,
+                                                        Set<Integer> relationshipTypeIds,
+                                                        Integer limit, Integer offset)
+            throws SQLException;
 
     /**
      * This method returns a count of Relationship objects that have the given Item object

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/RelationshipDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/RelationshipDAOImpl.java
@@ -9,7 +9,9 @@ package org.dspace.content.dao.impl;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
@@ -44,6 +46,26 @@ public class RelationshipDAOImpl extends AbstractHibernateDAO<Relationship> impl
             .where(criteriaBuilder.or(criteriaBuilder.equal(relationshipRoot.get(Relationship_.leftItem), item),
                                       criteriaBuilder.equal(relationshipRoot.get(Relationship_.rightItem), item)));
         return list(context, criteriaQuery, false, Relationship.class, limit, offset);
+    }
+
+    @Override
+    public List<Relationship> findByItemAndRelationshipTypeIds(Context context, Item item,
+                                                               Set<Integer> relationshipTypeIds,
+                                                               Integer limit, Integer offset)
+            throws SQLException {
+
+        CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
+        CriteriaQuery criteriaQuery = getCriteriaQuery(criteriaBuilder, Relationship.class);
+        Root<Relationship> relationshipRoot = criteriaQuery.from(Relationship.class);
+        criteriaQuery.select(relationshipRoot);
+        if (relationshipTypeIds != null && !relationshipTypeIds.isEmpty()) {
+            criteriaQuery
+                    .where(criteriaBuilder.or(criteriaBuilder.equal(relationshipRoot.get(Relationship_.leftItem), item),
+                            criteriaBuilder.equal(relationshipRoot.get(Relationship_.rightItem), item)),
+                            relationshipRoot.get(Relationship_.relationshipType).in(relationshipTypeIds));
+            return list(context, criteriaQuery, false, Relationship.class, limit, offset);
+        }
+        return new LinkedList<>();
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
@@ -726,5 +726,58 @@ public interface ItemService
     public List<MetadataValue> getMetadata(Item item, String schema, String element, String qualifier,
                                            String lang, boolean enableVirtualMetadata);
 
+    /**
+     * Get metadata for the DSpace Object in a chosen schema.
+     * See <code>MetadataSchema</code> for more information about schemas.
+     * Passing in a <code>null</code> value for <code>qualifier</code>
+     * or <code>lang</code> only matches metadata fields where that
+     * qualifier or languages is actually <code>null</code>.
+     * Passing in <code>DSpaceObject.ANY</code>
+     * retrieves all metadata fields with any value for the qualifier or
+     * language, including <code>null</code>
+     * <P>
+     * Examples:
+     * <P>
+     * Return values of the unqualified "title" field, in any language.
+     * Qualified title fields (e.g. "title.uniform") are NOT returned:
+     * <P>
+     * <code>dspaceobject.getMetadataByMetadataString("dc", "title", null, DSpaceObject.ANY );</code>
+     * <P>
+     * Return all US English values of the "title" element, with any qualifier
+     * (including unqualified):
+     * <P>
+     * <code>dspaceobject.getMetadataByMetadataString("dc, "title", DSpaceObject.ANY, "en_US" );</code>
+     * <P>
+     * The ordering of values of a particular element/qualifier/language
+     * combination is significant. When retrieving with wildcards, values of a
+     * particular element/qualifier/language combinations will be adjacent, but
+     * the overall ordering of the combinations is indeterminate.
+     *
+     * If enableVirtualMetadata is set to false, the virtual metadata will not be included
+     *
+     * @param item         Item
+     * @param schema       the schema for the metadata field. <em>Must</em> match
+     *                     the <code>name</code> of an existing metadata schema.
+     * @param element      the element name. <code>DSpaceObject.ANY</code> matches any
+     *                     element. <code>null</code> doesn't really make sense as all
+     *                     metadata must have an element.
+     * @param qualifier    the qualifier. <code>null</code> means unqualified, and
+     *                     <code>DSpaceObject.ANY</code> means any qualifier (including
+     *                     unqualified.)
+     * @param lang         the ISO639 language code, optionally followed by an underscore
+     *                     and the ISO3166 country code. <code>null</code> means only
+     *                     values with no language are returned, and
+     *                     <code>DSpaceObject.ANY</code> means values with any country code or
+     *                     no country code are returned.
+     * @param enableVirtualMetadata
+     *                     Enables virtual metadata calculation and inclusion from the
+     *                     relationships.
+     * @param allRelationFields If true, all relation fields will be used and generation of relation metadata will not
+     *                          be impacted by ignoredRelationFields configuration
+     * @return metadata fields that match the parameters
+     */
+    public List<MetadataValue> getMetadata(Item item, String schema, String element, String qualifier,
+                                           String lang, boolean enableVirtualMetadata, boolean allRelationFields);
+
 
 }

--- a/dspace-api/src/main/java/org/dspace/content/service/RelationshipService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/RelationshipService.java
@@ -9,6 +9,7 @@ package org.dspace.content.service;
 
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Set;
 
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Item;
@@ -51,6 +52,20 @@ public interface RelationshipService extends DSpaceCRUDService<Relationship> {
      * @throws SQLException If something goes wrong
      */
     public List<Relationship> findAll(Context context) throws SQLException;
+
+    /**
+     * Retrieves the a list of relationships currently in the system delimited by a list of RelationshipType ids
+     * @param context   The relevant DSpace context
+     * @param item      The Item that has to be the left or right item for the relationship to be included in the list
+     * @param relationshipTypeIds The set of relationshipType Ids to filter by
+     * @param limit     paging limit
+     * @param offset    paging offset
+     * @return  The list of all relationships currently in the system
+     * @throws SQLException If something goes wrong
+     */
+    List<Relationship> findByItemAndRelationshipTypeIds(Context context, Item item,
+                                                        Set<Integer> relationshipTypeIds,
+                                                        Integer limit, Integer offset) throws SQLException;
 
     /**
      * Retrieves the full list of relationships currently in the system

--- a/dspace-api/src/main/java/org/dspace/content/virtual/VirtualMetadataPopulator.java
+++ b/dspace-api/src/main/java/org/dspace/content/virtual/VirtualMetadataPopulator.java
@@ -9,6 +9,7 @@ package org.dspace.content.virtual;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.dspace.content.RelationshipType;
 
@@ -25,6 +26,13 @@ public class VirtualMetadataPopulator {
     private Map<String, HashMap<String, VirtualMetadataConfiguration>> map;
 
     /**
+     * The relation metadata fields that should be excluded when deriving metadata from relationships.
+     */
+    private Set<String> ignoredRelationFields;
+
+    private Map<String, Map<String, Integer>> typeIds;
+
+    /**
      * Standard setter for the map
      * @param map   The map to be used in the VirtualMetadataPopulator
      */
@@ -38,6 +46,37 @@ public class VirtualMetadataPopulator {
      */
     public Map<String, HashMap<String, VirtualMetadataConfiguration>> getMap() {
         return map;
+    }
+
+    /**
+     * Standard setter for ignoredRelationFields
+     * @param ignoredRelationFields  The relation metadata fields that should be excluded when deriving metadata
+     *                               from relationships.
+     */
+    public void setIgnoredRelationFields(Set<String> ignoredRelationFields) {
+        this.ignoredRelationFields = ignoredRelationFields;
+    }
+
+    /**
+     * Standard getter for ignoredRelationFields
+     * @return  The relation metadata fields that should be excluded when deriving metadata from relationships.
+     */
+    public Set<String> getIgnoredRelationFields() {
+        return ignoredRelationFields;
+    }
+
+    /**
+     * Standard setter for typeIds
+     */
+    public void setTypeIds(Map<String, Map<String, Integer>> typeIds) {
+        this.typeIds = typeIds;
+    }
+
+    /**
+     * Standard getter for typeIds
+     */
+    public Map<String, Map<String, Integer>> getTypeIds() {
+        return typeIds;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/ItemIndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/ItemIndexFactoryImpl.java
@@ -297,7 +297,8 @@ public class ItemIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Indexable
             }
 
             List<String> toIgnoreMetadataFields = SearchUtils.getIgnoredMetadataFields(item.getType());
-            List<MetadataValue> mydc = itemService.getMetadata(item, Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+            List<MetadataValue> mydc =
+                    itemService.getMetadata(item, Item.ANY, Item.ANY, Item.ANY, Item.ANY, true, true);
             for (MetadataValue meta : mydc) {
                 MetadataField metadataField = meta.getMetadataField();
                 MetadataSchema metadataSchema = metadataField.getMetadataSchema();

--- a/dspace/config/spring/api/virtual-metadata.xml
+++ b/dspace/config/spring/api/virtual-metadata.xml
@@ -23,6 +23,13 @@
                 <entry key="isJournalIssueOfPublication" value-ref="isJournalIssueOfPublicationMap"/>
             </map>
         </property>
+        <property name="ignoredRelationFields">
+            <set>
+                <!-- Relationsips listed here will be excluded when deriving metadata from relationships -->
+                <!-- e.g. Exclude parent-to-child relationships to improve performance -->
+                <!--<value>isPublicationOfOrgUnit</value>-->
+            </set>
+        </property>
     </bean>
 
     <bean class="org.dspace.content.virtual.EntityTypeToFilterQueryService">


### PR DESCRIPTION
## Description
In repositories that contain 100s-1000s of relationships, REST performance can become very slow due to the generation of relation metadata during most REST calls. To mitigate this problem, a solution has been developed to opt-out of any unnecessary relationships. For example, image an OrgUnit with 1000s of Publications. Generating all of the relation metadata for every `isPublicationOfOrgUnit` value can take minutes, leaving page just hanging. Instead, we can exclude `isPublicationOfOrgUnit` and performance is drastically improved.

Note: This does not impact indexing, so virtual metadata and queries which rely on bi-directional relationships still function as expected.

## Instructions for Reviewers
1. Create an item with 100s-1000s of child relationships.
2. Test performance
3. Configure `virtual-metadata.xml` to exclude the parent-to-child relationships label
4. Repeat performance test

List of changes in this PR:
* Add new `ignoredRelationFields` value to `VirtualMetadataPopulator` and config
* When generating relation metadata, don't include relationships with labels in this Set.

## Checklist
- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [N/A] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [N/A] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
