### PR TITLE
Improve indexing performance (uncache relationship metadata entities)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/RelationshipMetadataServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/RelationshipMetadataServiceImpl.java
@@ -51,6 +51,12 @@ public class RelationshipMetadataServiceImpl implements RelationshipMetadataServ
                     fullMetadataValueList
                         .addAll(findRelationshipMetadataValueForItemRelationship(context, item, entityType,
                                 relationship, enableVirtualMetadata));
+                    if (item.getID().equals(relationship.getLeftItem().getID())) {
+                        context.uncacheEntity(relationship.getRightItem());
+                    } else {
+                        context.uncacheEntity(relationship.getLeftItem());
+                    }
+                    context.uncacheEntity(relationship);
                 }
 
             }


### PR DESCRIPTION
## References
* [JIRA DS-4425](https://jira.lyrasis.org/browse/DS-4425): Indexing Performance is very slow since refactor. ITs take twice as long

## Description
Indexing in DSpace 7 (particularly in repositories with large numbers of relationships) has gotten increasingly slow. In addition, processing becomes increasingly slower as indexing continues.

After investigating the cause of this, it was discovered that, for every item, all of its relationships _and_ related entities were kept in the hibernate cache for the rest of the job. To fix this issue, relationship entities and the related entity (but not the invoked entity) are uncached after the respective `RelationshipMetadataValue` has been created.

Note: This should also improve performance for any repeated calls to `itemService.getMetadata()`.

## Instructions for Reviewers
1. Test repo with adequate number of items/relationships
2. Test indexing performance
3. Apply patch
3. Repeat indexing test performance

List of changes in this PR:
* Relationship entities and related DSO entities are properly uncached after use in `getRelationshipMetadata()`

## Checklist

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [N/A] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [N/A] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [N/A] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
