### PR TITLE
[Issue: 2821] Metadata export script help clarifications

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportCLIScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportCLIScriptConfiguration.java
@@ -1,0 +1,22 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.bulkedit;
+
+import org.dspace.scripts.configuration.ScriptConfiguration;
+
+/**
+ * The {@link ScriptConfiguration} for the {@link org.dspace.app.bulkedit.MetadataExport} CLI script
+ * Overwritten to provide a different file parameter description
+ */
+public class MetadataExportCLIScriptConfiguration extends MetadataExportScriptConfiguration<MetadataExport> {
+
+    @Override
+    protected String getFileParameterDescription() {
+        return "destination where you want file written";
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportScriptConfiguration.java
@@ -56,7 +56,7 @@ public class MetadataExportScriptConfiguration<T extends MetadataExport> extends
 
             options.addOption("i", "id", true, "ID or handle of thing to export (item, collection, or community)");
             options.getOption("i").setType(String.class);
-            options.addOption("f", "file", true, "destination where you want file written");
+            options.addOption("f", "file", true, getFileParameterDescription());
             options.getOption("f").setType(OutputStream.class);
             options.getOption("f").setRequired(true);
             options.addOption("a", "all", false,
@@ -69,6 +69,10 @@ public class MetadataExportScriptConfiguration<T extends MetadataExport> extends
             super.options = options;
         }
         return options;
+    }
+
+    protected String getFileParameterDescription() {
+        return "file name of the exported file";
     }
 
 }

--- a/dspace/config/spring/api/scripts.xml
+++ b/dspace/config/spring/api/scripts.xml
@@ -14,7 +14,7 @@
         <property name="dspaceRunnableClass" value="org.dspace.app.bulkedit.MetadataImportCLI"/>
     </bean>
 
-    <bean id="metadata-export" class="org.dspace.app.bulkedit.MetadataExportScriptConfiguration">
+    <bean id="metadata-export" class="org.dspace.app.bulkedit.MetadataExportCLIScriptConfiguration">
         <property name="description" value="Export metadata for batch editing"/>
         <property name="dspaceRunnableClass" value="org.dspace.app.bulkedit.MetadataExport"/>
     </bean>

--- a/dspace/config/spring/rest/scripts.xml
+++ b/dspace/config/spring/rest/scripts.xml
@@ -12,4 +12,9 @@
         <property name="description" value="Import metadata after batch editing" />
         <property name="dspaceRunnableClass" value="org.dspace.app.bulkedit.MetadataImport"/>
     </bean>
+
+    <bean id="metadata-export" class="org.dspace.app.bulkedit.MetadataExportScriptConfiguration">
+        <property name="description" value="Export metadata for batch editing"/>
+        <property name="dspaceRunnableClass" value="org.dspace.app.bulkedit.MetadataExport"/>
+    </bean>
 </beans>


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/2821

## Description
There was a bug in the help function of the metadata export scripts leading admins to believe that a server path is needed on where to store the file. But this argument is to be used as a filename for the REST call.

## Instructions for Reviewers
Retrieve the help instructions from REST & CLI, these will now properly explains what the "--file" flag does.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
