### PR TITLE
Add error logging & fix "Information exposure through a stack trace" error reported by LGTM

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -150,8 +150,12 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
         //Make sure Spring picks up this exception
         request.setAttribute(EXCEPTION_ATTRIBUTE, ex);
 
-        //Log the full error and status code
-        log.error("{} (status:{})", message, statusCode, ex);
+        // For now, just logging server errors.
+        // We don't want to fill logs with bad/invalid REST API requests.
+        if (statusCode == HttpServletResponse.SC_INTERNAL_SERVER_ERROR) {
+            // Log the full error and status code
+            log.error("{} (status:{})", message, statusCode, ex);
+        }
 
         //Exception properties will be set by org.springframework.boot.web.support.ErrorPageFilter
         response.sendError(statusCode, message);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -61,7 +61,7 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
     @ExceptionHandler({IllegalArgumentException.class, MultipartException.class})
     protected void handleWrongRequestException(HttpServletRequest request, HttpServletResponse response,
                                                   Exception ex) throws IOException {
-        sendErrorResponse(request, response, ex, "Bad or invalid request", HttpServletResponse.SC_BAD_REQUEST);
+        sendErrorResponse(request, response, ex, "Request is invalid or incorrect", HttpServletResponse.SC_BAD_REQUEST);
     }
 
     @ExceptionHandler(SQLException.class)
@@ -82,7 +82,8 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
     @ExceptionHandler(MethodNotAllowedException.class)
     protected void methodNotAllowedException(HttpServletRequest request, HttpServletResponse response,
                                                   Exception ex) throws IOException {
-        sendErrorResponse(request, response, ex, "Method is not allowed or supported", HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+        sendErrorResponse(request, response, ex, "Method is not allowed or supported",
+                          HttpServletResponse.SC_METHOD_NOT_ALLOWED);
     }
 
     @ExceptionHandler( {UnprocessableEntityException.class})
@@ -100,7 +101,7 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
         throws IOException {
         // we want the 400 status for missing parameters, see https://jira.lyrasis.org/browse/DS-4428
         sendErrorResponse(request, response, null,
-                          "Required parameters are invalid",
+                          "A required parameter is invalid",
                           HttpStatus.BAD_REQUEST.value());
     }
 
@@ -109,7 +110,7 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
         throws IOException {
         // we want the 400 status for missing parameters, see https://jira.lyrasis.org/browse/DS-4428
         sendErrorResponse(request, response, null,
-                          "Required parameters are missing",
+                          "A required parameter is missing",
                           HttpStatus.BAD_REQUEST.value());
     }
 
@@ -139,7 +140,7 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
         } else {
             returnCode = HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
         }
-        sendErrorResponse(request, response, ex, "An Exception has occurred", returnCode);
+        sendErrorResponse(request, response, ex, "An exception has occurred", returnCode);
 
     }
 
@@ -150,7 +151,7 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
         request.setAttribute(EXCEPTION_ATTRIBUTE, ex);
 
         //Log the full error and status code
-        log.error(message + " (status={})", statusCode, ex);
+        log.error("{} (status:{})", message, statusCode, ex);
 
         //Exception properties will be set by org.springframework.boot.web.support.ErrorPageFilter
         response.sendError(statusCode, message);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpace401AuthenticationEntryPoint.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpace401AuthenticationEntryPoint.java
@@ -35,7 +35,6 @@ public class DSpace401AuthenticationEntryPoint implements AuthenticationEntryPoi
         response.setHeader("WWW-Authenticate",
                 restAuthenticationService.getWwwAuthenticateHeaderValue(request, response));
 
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED,
-                authException.getMessage());
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Authentication is required");
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowDefinitionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowDefinitionRestRepositoryIT.java
@@ -240,7 +240,7 @@ public class WorkflowDefinitionRestRepositoryIT extends AbstractControllerIntegr
         getClient(token).perform(get(WORKFLOW_DEFINITIONS_ENDPOINT + "/search/findByCollection?uuid=" + nonValidUUID))
             //We expect a 400 Illegal Argument Exception (Bad Request) cannot convert UUID
             .andExpect(status().isBadRequest())
-            .andExpect(status().reason(containsString("Failed to convert " + nonValidUUID)));
+            .andExpect(status().reason(containsString("A required parameter is invalid")));
     }
 
     @Test

--- a/dspace-sword/src/main/java/org/purl/sword/server/ServiceDocumentServlet.java
+++ b/dspace-sword/src/main/java/org/purl/sword/server/ServiceDocumentServlet.java
@@ -164,7 +164,8 @@ public class ServiceDocumentServlet extends HttpServlet {
         } catch (SWORDException se) {
             log.error("Internal error", se);
             // Throw a HTTP 500
-            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, se.getMessage());
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                               "Internal error (check logs for more information)");
         }
     }
 


### PR DESCRIPTION
Fixes 4 "information exposure through a stack trace" security errors reported via LGTM:
* https://lgtm.com/projects/g/DSpace/DSpace/snapshot/621ff0b34f595fee414898708936a7599844f35e/files/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java?sort=name&dir=ASC&mode=heatmap#x8cf9f13e9b0c67c6:1
* https://lgtm.com/projects/g/DSpace/DSpace/snapshot/621ff0b34f595fee414898708936a7599844f35e/files/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/StatelessAuthenticationFilter.java#xcb020f5149e7b68e:1
* https://lgtm.com/projects/g/DSpace/DSpace/snapshot/621ff0b34f595fee414898708936a7599844f35e/files/dspace-sword/src/main/java/org/purl/sword/server/ServiceDocumentServlet.java#xa48e2d0ea0e92d78:1
* https://lgtm.com/projects/g/DSpace/DSpace/snapshot/621ff0b34f595fee414898708936a7599844f35e/files/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpace401AuthenticationEntryPoint.java#xa31493f1b1a6da3c:1

Description of this error from LGTM: https://lgtm.com/rules/6780073/

This PR does the following:
1. Fixes the above LGTM bugs by no longer returning the error stacktrace as part of REST API (or SWORD) responses. 
2. Add REST API error logging for Internal Server Errors (500 response) **only**.  We can choose to update this at a later time to include additional error logging, but I was hesitant to log Bad Request errors (and similar) as that'd quickly fill up log files.
3. Minor cleanup of `StatelessAuthenticationFilter`, to provide better error messages (and to no longer log unauthenticated errors).

Flagged this PR for one approval as it also will be verified by LGTM.