### PR TITLE
Scripts and processes - Script output

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/dao/ProcessLogDAO.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/ProcessLogDAO.java
@@ -15,7 +15,17 @@ import org.dspace.core.GenericDAO;
 import org.dspace.scripts.Process;
 import org.dspace.scripts.ProcessLog;
 
+/**
+ * This is a DAO class that deals with DB calls for the {@link ProcessLog} entity
+ */
 public interface ProcessLogDAO extends GenericDAO<ProcessLog> {
 
+    /**
+     * This method will return a list of {@link ProcessLog} objects for the given {@link Process}
+     * @param context   The relevant DSpace context
+     * @param process   The {@link Process} from which we'll retrieve the {@link ProcessLog} objects
+     * @return          The list of {@link ProcessLog} objects
+     * @throws SQLException If something goes wrong
+     */
     public List<ProcessLog> findByProcess(Context context, Process process) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/content/dao/ProcessLogDAO.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/ProcessLogDAO.java
@@ -1,0 +1,21 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.dao;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.dspace.core.Context;
+import org.dspace.core.GenericDAO;
+import org.dspace.scripts.Process;
+import org.dspace.scripts.ProcessLog;
+
+public interface ProcessLogDAO extends GenericDAO<ProcessLog> {
+
+    public List<ProcessLog> findByProcess(Context context, Process process) throws SQLException;
+}

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/ProcessLogDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/ProcessLogDAOImpl.java
@@ -20,8 +20,12 @@ import org.dspace.scripts.Process;
 import org.dspace.scripts.ProcessLog;
 import org.dspace.scripts.ProcessLog_;
 
+/**
+ * This is the implementing class for the {@link ProcessLogDAO}
+ */
 public class ProcessLogDAOImpl extends AbstractHibernateDAO<ProcessLog> implements ProcessLogDAO {
 
+    @Override
     public List<ProcessLog> findByProcess(Context context, Process process) throws SQLException {
         CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
         CriteriaQuery criteriaQuery = getCriteriaQuery(criteriaBuilder, ProcessLog.class);

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/ProcessLogDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/ProcessLogDAOImpl.java
@@ -1,0 +1,34 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.dao.impl;
+
+import java.sql.SQLException;
+import java.util.List;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+
+import org.dspace.content.dao.ProcessLogDAO;
+import org.dspace.core.AbstractHibernateDAO;
+import org.dspace.core.Context;
+import org.dspace.scripts.Process;
+import org.dspace.scripts.ProcessLog;
+import org.dspace.scripts.ProcessLog_;
+
+public class ProcessLogDAOImpl extends AbstractHibernateDAO<ProcessLog> implements ProcessLogDAO {
+
+    public List<ProcessLog> findByProcess(Context context, Process process) throws SQLException {
+        CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
+        CriteriaQuery criteriaQuery = getCriteriaQuery(criteriaBuilder, ProcessLog.class);
+        Root<ProcessLog> processLogRoot = criteriaQuery.from(ProcessLog.class);
+        criteriaQuery.select(processLogRoot);
+        criteriaQuery.where(criteriaBuilder.equal(processLogRoot.get(ProcessLog_.process), process));
+
+        return list(context, criteriaQuery, false, ProcessLog.class, -1, -1);
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
@@ -64,8 +64,19 @@ public abstract class HibernateDBConnection implements DBConnection<Session> {
     private boolean batchModeEnabled = false;
     private boolean readOnlyEnabled = false;
 
+    /**
+     * Retrieves the current Session from Hibernate (per our settings, Hibernate is configured to create one Session
+     * per thread). If Session doesn't yet exist, it is created. A Transaction is also initialized (or reinintialized)
+     * in the Session if one doesn't exist, or was previously closed (e.g. if commit() was previously called)
+     * @return Hibernate current Session object
+     * @throws SQLException
+     */
     public abstract Session getSession() throws SQLException;
 
+    /**
+     * Retrieves the current Session from Hibernate
+     * @return  The current Session
+     */
     public abstract Session getCurrentSession();
 
 

--- a/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
@@ -55,7 +55,7 @@ import org.springframework.orm.hibernate5.SessionFactoryUtils;
  *
  * @author kevinvandevelde at atmire.com
  */
-public class HibernateDBConnection implements DBConnection<Session> {
+public abstract class HibernateDBConnection implements DBConnection<Session> {
 
     @Autowired(required = true)
     @Qualifier("sessionFactory")
@@ -64,24 +64,10 @@ public class HibernateDBConnection implements DBConnection<Session> {
     private boolean batchModeEnabled = false;
     private boolean readOnlyEnabled = false;
 
-    /**
-     * Retrieves the current Session from Hibernate (per our settings, Hibernate is configured to create one Session
-     * per thread). If Session doesn't yet exist, it is created. A Transaction is also initialized (or reinintialized)
-     * in the Session if one doesn't exist, or was previously closed (e.g. if commit() was previously called)
-     * @return Hibernate current Session object
-     * @throws SQLException
-     */
-    @Override
-    public Session getSession() throws SQLException {
-        // If we don't yet have a live transaction, start a new one
-        // NOTE: a Session cannot be used until a Transaction is started.
-        if (!isTransActionAlive()) {
-            sessionFactory.getCurrentSession().beginTransaction();
-            configureDatabaseMode();
-        }
-        // Return the current Hibernate Session object (Hibernate will create one if it doesn't yet exist)
-        return sessionFactory.getCurrentSession();
-    }
+    public abstract Session getSession() throws SQLException;
+
+    public abstract Session getCurrentSession();
+
 
     /**
      * Check if the connection has a currently active Transaction. A Transaction is active if it has not yet been
@@ -232,7 +218,7 @@ public class HibernateDBConnection implements DBConnection<Session> {
         return batchModeEnabled;
     }
 
-    private void configureDatabaseMode() throws SQLException {
+    protected void configureDatabaseMode() throws SQLException {
         if (batchModeEnabled) {
             getSession().setHibernateFlushMode(FlushMode.ALWAYS);
         } else if (readOnlyEnabled) {

--- a/dspace-api/src/main/java/org/dspace/core/ManagedHibernateDBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/ManagedHibernateDBConnection.java
@@ -1,0 +1,58 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.core;
+
+import java.sql.SQLException;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+public class ManagedHibernateDBConnection extends HibernateDBConnection {
+
+    @Autowired(required = true)
+    @Qualifier("managedSessionFactory")
+    private SessionFactory sessionFactory;
+
+    private Session session;
+    private Transaction transaction;
+
+    public SessionFactory getSessionFactory() {
+        return sessionFactory;
+    }
+
+    @Override
+    public Session getSession() {
+        if (session == null) {
+            this.session = getSessionFactory().openSession();
+        }
+
+        return session;
+    }
+
+    @Override
+    public Session getCurrentSession() {
+        return getSession();
+    }
+
+    @Override
+    public Transaction getTransaction() {
+        if (transaction == null) {
+            this.transaction = getSession().beginTransaction();
+        }
+        return this.transaction;
+    }
+
+    @Override
+    public void commit() throws SQLException {
+        super.commit();
+        transaction = null;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/core/ManagedHibernateDBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/ManagedHibernateDBConnection.java
@@ -15,6 +15,9 @@ import org.hibernate.Transaction;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
+/**
+ * Implementing class for the MANAGED Context state for {@link HibernateDBConnection}
+ */
 public class ManagedHibernateDBConnection extends HibernateDBConnection {
 
     @Autowired(required = true)

--- a/dspace-api/src/main/java/org/dspace/core/ThreadBoundHibernateDBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/ThreadBoundHibernateDBConnection.java
@@ -15,6 +15,9 @@ import org.hibernate.Transaction;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
+/**
+ * Implementing class for the regular Context states for {@link HibernateDBConnection}
+ */
 public class ThreadBoundHibernateDBConnection extends HibernateDBConnection {
 
     @Autowired(required = true)

--- a/dspace-api/src/main/java/org/dspace/core/ThreadBoundHibernateDBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/ThreadBoundHibernateDBConnection.java
@@ -1,0 +1,47 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.core;
+
+import java.sql.SQLException;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+public class ThreadBoundHibernateDBConnection extends HibernateDBConnection {
+
+    @Autowired(required = true)
+    @Qualifier("sessionFactory")
+    private SessionFactory sessionFactory;
+
+    public SessionFactory getSessionFactory() {
+        return sessionFactory;
+    }
+
+    @Override
+    public Session getSession() throws SQLException {
+        if (!isTransActionAlive()) {
+            getSessionFactory().getCurrentSession().beginTransaction();
+            configureDatabaseMode();
+        }
+        return getSessionFactory().getCurrentSession();
+    }
+
+    @Override
+    public Session getCurrentSession() {
+        return getSessionFactory().getCurrentSession();
+    }
+
+    @Override
+    protected Transaction getTransaction() {
+        return getCurrentSession().getTransaction();
+    }
+
+}

--- a/dspace-api/src/main/java/org/dspace/scripts/ProcessLog.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/ProcessLog.java
@@ -1,0 +1,122 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.scripts;
+
+import java.util.Date;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+@Entity
+@Table(name = "process_log")
+public class ProcessLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "process_log_id_seq")
+    @SequenceGenerator(name = "process_log_id_seq", sequenceName = "process_log_id_seq", allocationSize = 1)
+    @Column(name = "process_log_id", unique = true, nullable = false)
+    private Integer processLogId;
+
+    @ManyToOne
+    @JoinColumn(name = "process_id", nullable = false)
+    private Process process;
+
+    @Column(name = "output", nullable = false)
+    private String output;
+
+    @Column(name = "time", nullable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date time;
+
+    @Column(name = "log_level", nullable = false)
+    private ProcessLogLevel processLogLevel;
+
+    protected ProcessLog() {
+    }
+
+    public Integer getProcessLogId() {
+        return processLogId;
+    }
+
+    public void setProcessLogId(Integer processLogId) {
+        this.processLogId = processLogId;
+    }
+
+    public Process getProcess() {
+        return process;
+    }
+
+    public void setProcess(Process process) {
+        this.process = process;
+    }
+
+    public String getOutput() {
+        return output;
+    }
+
+    public void setOutput(String output) {
+        this.output = output;
+    }
+
+    public Date getTime() {
+        return time;
+    }
+
+    public void setTime(Date time) {
+        this.time = time;
+    }
+
+    public ProcessLogLevel getProcessLogLevel() {
+        return processLogLevel;
+    }
+
+    public void setProcessLogLevel(ProcessLogLevel processLogLevel) {
+        this.processLogLevel = processLogLevel;
+    }
+
+    /**
+     * Return <code>true</code> if <code>other</code> is the same Bitstream
+     * as this object, <code>false</code> otherwise
+     *
+     * @param other object to compare to
+     * @return <code>true</code> if object passed in represents the same
+     * collection as this object
+     */
+    @Override
+    public boolean equals(Object other) {
+        return (other instanceof ProcessLog &&
+            new EqualsBuilder().append(this.getProcessLogId(), ((ProcessLog) other).getProcessLogId())
+                               .append(this.getProcess(), ((ProcessLog) other).getProcess())
+                               .append(this.getOutput(), ((ProcessLog) other).getOutput())
+                               .append(this.getTime(), ((ProcessLog) other).getTime())
+                               .append(this.getProcessLogLevel(), ((ProcessLog) other).getProcessLogLevel())
+                               .isEquals());
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+            .append(this.getProcessLogId())
+            .append(this.getProcess())
+            .append(this.getOutput())
+            .append(this.getTime())
+            .append(this.getProcessLogLevel())
+            .toHashCode();
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/scripts/ProcessLog.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/ProcessLog.java
@@ -23,6 +23,9 @@ import javax.persistence.TemporalType;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+/**
+ * This class is the representation of the ProcessLog entity stored in the process_log table in the DB
+ */
 @Entity
 @Table(name = "process_log")
 public class ProcessLog {

--- a/dspace-api/src/main/java/org/dspace/scripts/ProcessLogLevel.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/ProcessLogLevel.java
@@ -1,0 +1,14 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.scripts;
+
+public enum ProcessLogLevel {
+    INFO,
+    WARNING,
+    ERROR
+}

--- a/dspace-api/src/main/java/org/dspace/scripts/ProcessLogLevel.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/ProcessLogLevel.java
@@ -7,6 +7,9 @@
  */
 package org.dspace.scripts;
 
+/**
+ * This Enum defines all the possible Log levels that a {@link ProcessLog} can hold in the DB
+ */
 public enum ProcessLogLevel {
     INFO,
     WARNING,

--- a/dspace-api/src/main/java/org/dspace/scripts/service/ProcessService.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/service/ProcessService.java
@@ -18,6 +18,8 @@ import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.dspace.scripts.DSpaceCommandLineParameter;
 import org.dspace.scripts.Process;
+import org.dspace.scripts.ProcessLog;
+import org.dspace.scripts.ProcessLogLevel;
 
 /**
  * An interface for the ProcessService with methods regarding the Process workload
@@ -82,6 +84,16 @@ public interface ProcessService {
     public List<Process> findAllSortByStartTime(Context context) throws SQLException;
 
     /**
+     * This method will append the Process with a {@link ProcessLog} of log level as defined by the given
+     * {@link ProcessLogLevel}
+     * @param context   The relevant DSpace context
+     * @param process   The Process for which a log will be created
+     * @param output    The output to be written in the log
+     * @param processLogLevel   The level of the log
+     */
+    public void appendLog(Context context, Process process, String output, ProcessLogLevel processLogLevel);
+
+    /**
      * This method will perform the logic needed to update the Process object in the database to represent a
      * started state. A started state refers to {@link org.dspace.content.ProcessStatus#RUNNING}
      * @param context   The relevant DSpace context
@@ -140,6 +152,15 @@ public interface ProcessService {
     public void update(Context context, Process process) throws SQLException;
 
     /**
+     * This method fetches the List of {@link ProcessLog} objects for a given {@link Process}
+     * @param context   The relevant DSpace context
+     * @param process   The Process that we need to get the logs for
+     * @return The list of {@link ProcessLog} objects
+     * @throws SQLException If something goes wrong
+     */
+    public List<ProcessLog> getProcessLogsFromProcess(Context context, Process process) throws SQLException;
+
+    /**
      * This method will retrieve the list of parameters from the Process in its String format and it will parse
      * these parameters to a list of {@link DSpaceCommandLineParameter} objects for better usability throughout DSpace
      * @param process   The Process object for which we'll return the parameters
@@ -152,7 +173,7 @@ public interface ProcessService {
      * @param context           The relevant DSpace context
      * @param process           The process that should hold the requested Bitstream
      * @param bitstreamName     The name of the requested Bitstream
-     * @return                  The Bitstream from the given Process that matches the given bitstream name
+     * @return The Bitstream from the given Process that matches the given bitstream name
      */
     public Bitstream getBitstreamByName(Context context, Process process, String bitstreamName);
 
@@ -161,7 +182,7 @@ public interface ProcessService {
      * @param context   The relevant DSpace context
      * @param process   The process that holds the Bitstreams to be searched in
      * @param type      The type that the Bitstream must have
-     * @return          The Bitstream of the given type for the given Process
+     * @return The Bitstream of the given type for the given Process
      */
     public Bitstream getBitstream(Context context, Process process, String type);
 
@@ -169,14 +190,14 @@ public interface ProcessService {
      * This method will return all the Bitstreams for a given process
      * @param context   The relevant DSpace context
      * @param process   The process that holds the Bitstreams to be searched in
-     * @return          The list of Bitstreams
+     * @return The list of Bitstreams
      */
     public List<Bitstream> getBitstreams(Context context, Process process);
 
     /**
      * Returns the total amount of Process objects in the dataase
      * @param context   The relevant DSpace context
-     * @return          An integer that describes the amount of Process objects in the database
+     * @return An integer that describes the amount of Process objects in the database
      * @throws SQLException If something goes wrong
      */
     int countTotal(Context context) throws SQLException;
@@ -185,7 +206,7 @@ public interface ProcessService {
      * This will return a list of Strings where each String represents the type of a Bitstream in the Process given
      * @param context   The DSpace context
      * @param process   The Process object that we'll use to find the bitstreams
-     * @return          A list of Strings where each String represents a fileType that is in the Process
+     * @return A list of Strings where each String represents a fileType that is in the Process
      */
     public List<String> getFileTypesForProcessBitstreams(Context context, Process process);
 

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.0_2019_06_14__scripts-and-process.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.0_2019_06_14__scripts-and-process.sql
@@ -14,6 +14,7 @@
 -- http://flywaydb.org/
 -- ===============================================================
 CREATE SEQUENCE process_id_seq;
+CREATE SEQUENCE process_log_id_seq;
 
 CREATE TABLE process
 (
@@ -24,17 +25,28 @@ CREATE TABLE process
     creation_time           TIMESTAMP NOT NULL,
     script                  VARCHAR(256) NOT NULL,
     status                  VARCHAR(32),
-    parameters              VARCHAR(512)
+    parameters              VARCHAR (512)
+);
+
+CREATE TABLE process_log
+(
+    process_log_id          INTEGER NOT NULL PRIMARY KEY,
+    process_id              INTEGER NOT NULL REFERENCES process(process_id),
+    output                  VARCHAR NOT NULL,
+    time                    TIMESTAMP NOT NULL,
+    log_level               INTEGER NOT NULL
 );
 
 CREATE TABLE process2bitstream
 (
-  process_id   INTEGER REFERENCES process(process_id),
-  bitstream_id UUID REFERENCES bitstream(uuid),
-  CONSTRAINT PK_process2bitstream PRIMARY KEY (process_id, bitstream_id)
+    process_id   INTEGER REFERENCES process(process_id),
+    bitstream_id UUID REFERENCES bitstream(uuid),
+    CONSTRAINT PK_process2bitstream PRIMARY KEY (process_id, bitstream_id)
+
 );
 
 CREATE INDEX process_user_id_idx ON process(user_id);
 CREATE INDEX process_status_idx ON process(status);
+CREATE INDEX process_log_process_id_idx ON process_log(process_id);
 CREATE INDEX process_name_idx on process(script);
 CREATE INDEX process_start_time_idx on process(start_time);

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V7.0_2019_06_14__scripts-and-process.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V7.0_2019_06_14__scripts-and-process.sql
@@ -14,6 +14,7 @@
 -- http://flywaydb.org/
 -- ===============================================================
 CREATE SEQUENCE process_id_seq;
+CREATE SEQUENCE process_log_id_seq;
 
 CREATE TABLE process
 (
@@ -24,17 +25,28 @@ CREATE TABLE process
     creation_time           TIMESTAMP NOT NULL,
     script                  VARCHAR(256) NOT NULL,
     status                  VARCHAR(32),
-    parameters              VARCHAR(512)
+    parameters              VARCHAR (512)
+);
+
+CREATE TABLE process_log
+(
+    process_log_id          INTEGER NOT NULL PRIMARY KEY,
+    process_id              INTEGER NOT NULL REFERENCES process(process_id),
+    output                  CLOB NOT NULL,
+    time                    TIMESTAMP NOT NULL,
+    log_level               INTEGER NOT NULL
 );
 
 CREATE TABLE process2bitstream
 (
-  process_id   INTEGER REFERENCES process(process_id),
-  bitstream_id RAW(16) REFERENCES bitstream(uuid),
-  CONSTRAINT PK_process2bitstream PRIMARY KEY (process_id, bitstream_id)
+    process_id   INTEGER REFERENCES process(process_id),
+    bitstream_id RAW(16) REFERENCES bitstream(uuid),
+    CONSTRAINT PK_process2bitstream PRIMARY KEY (process_id, bitstream_id)
+
 );
 
 CREATE INDEX process_user_id_idx ON process(user_id);
 CREATE INDEX process_status_idx ON process(status);
+CREATE INDEX process_log_process_id_idx ON process_log(process_id);
 CREATE INDEX process_name_idx on process(script);
 CREATE INDEX process_start_time_idx on process(start_time);

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.0_2019_06_14__scripts-and-process.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.0_2019_06_14__scripts-and-process.sql
@@ -14,6 +14,7 @@
 -- http://flywaydb.org/
 -- ===============================================================
 CREATE SEQUENCE process_id_seq;
+CREATE SEQUENCE process_log_id_seq;
 
 CREATE TABLE process
 (
@@ -24,7 +25,16 @@ CREATE TABLE process
     creation_time           TIMESTAMP NOT NULL,
     script                  VARCHAR(256) NOT NULL,
     status                  VARCHAR(32),
-    parameters              VARCHAR(512)
+    parameters              VARCHAR (512)
+);
+
+CREATE TABLE process_log
+(
+    process_log_id          INTEGER NOT NULL PRIMARY KEY,
+    process_id              INTEGER NOT NULL REFERENCES process(process_id),
+    output                  TEXT NOT NULL,
+    time                    TIMESTAMP NOT NULL,
+    log_level               INTEGER NOT NULL
 );
 
 CREATE TABLE process2bitstream
@@ -36,5 +46,6 @@ CREATE TABLE process2bitstream
 
 CREATE INDEX process_user_id_idx ON process(user_id);
 CREATE INDEX process_status_idx ON process(status);
+CREATE INDEX process_log_process_id_idx ON process_log(process_id);
 CREATE INDEX process_name_idx on process(script);
 CREATE INDEX process_start_time_idx on process(start_time);

--- a/dspace-api/src/main/resources/spring/spring-dspace-core-services.xml
+++ b/dspace-api/src/main/resources/spring/spring-dspace-core-services.xml
@@ -45,4 +45,9 @@
     <bean class="org.dspace.storage.rdbms.PostgreSQLCryptoChecker"/>
     <bean class="org.dspace.storage.rdbms.SiteServiceInitializer"/>
 
+
+    <bean name="threadBoundHibernateDBConnection" class="org.dspace.core.ThreadBoundHibernateDBConnection" lazy-init="true"/>
+    <bean name="managedHibernateDBConnection" class="org.dspace.core.ManagedHibernateDBConnection" lazy-init="true" scope="prototype"/>
+
+
 </beans>

--- a/dspace-api/src/test/java/org/dspace/core/HibernateDBConnectionTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/HibernateDBConnectionTest.java
@@ -44,7 +44,7 @@ public class HibernateDBConnectionTest extends AbstractUnitTest {
         super.init();
         // Get a DB connection to test with
         connection = new DSpace().getServiceManager()
-                                 .getServiceByName(null, HibernateDBConnection.class);
+                                 .getServiceByName(null, ThreadBoundHibernateDBConnection.class);
     }
 
     /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ProcessOutputRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ProcessOutputRest.java
@@ -9,6 +9,10 @@ package org.dspace.app.rest.model;
 
 import java.util.List;
 
+/**
+ * This class acts as a REST representation for the {@link org.dspace.scripts.ProcessLog} objects that a given
+ * {@link org.dspace.scripts.Process} may hold
+ */
 public class ProcessOutputRest implements RestModel {
     public static final String NAME = "processOutput";
     private List<String> logs = null;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ProcessOutputRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ProcessOutputRest.java
@@ -1,0 +1,27 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import java.util.List;
+
+public class ProcessOutputRest implements RestModel {
+    public static final String NAME = "processOutput";
+    private List<String> logs = null;
+
+    public String getType() {
+        return NAME;
+    }
+
+    public void setLogs(List<String> logs) {
+        this.logs = logs;
+    }
+
+    public List<String> getLogs() {
+        return logs;
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ProcessRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ProcessRest.java
@@ -28,6 +28,10 @@ import org.dspace.scripts.Process;
     @LinkRest(
         name = ProcessRest.FILE_TYPES,
         method = "getFileTypesFromProcess"
+    ),
+    @LinkRest(
+        name = ProcessRest.OUTPUT,
+        method = "getOutputFromProcess"
     )
 })
 public class ProcessRest extends BaseObjectRest<Integer> {
@@ -37,6 +41,8 @@ public class ProcessRest extends BaseObjectRest<Integer> {
 
     public static final String FILES = "files";
     public static final String FILE_TYPES = "filetypes";
+    public static final String OUTPUT = "output";
+
     public String getCategory() {
         return CATEGORY;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/ProcessOutputResource.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/ProcessOutputResource.java
@@ -10,6 +10,9 @@ package org.dspace.app.rest.model.hateoas;
 import org.dspace.app.rest.model.ProcessOutputRest;
 import org.dspace.app.rest.model.hateoas.annotations.RelNameDSpaceResource;
 
+/**
+ * This is the Resource class for the {@link ProcessOutputRest}
+ */
 @RelNameDSpaceResource(ProcessOutputRest.NAME)
 public class ProcessOutputResource extends HALResource<ProcessOutputRest> {
     public ProcessOutputResource(ProcessOutputRest content) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/ProcessOutputResource.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/ProcessOutputResource.java
@@ -1,0 +1,18 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model.hateoas;
+
+import org.dspace.app.rest.model.ProcessOutputRest;
+import org.dspace.app.rest.model.hateoas.annotations.RelNameDSpaceResource;
+
+@RelNameDSpaceResource(ProcessOutputRest.NAME)
+public class ProcessOutputResource extends HALResource<ProcessOutputRest> {
+    public ProcessOutputResource(ProcessOutputRest content) {
+        super(content);
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ProcessOutputLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ProcessOutputLinkRepository.java
@@ -1,0 +1,58 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.repository;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
+
+import org.dspace.app.rest.model.ProcessOutputRest;
+import org.dspace.app.rest.model.ProcessRest;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.core.Context;
+import org.dspace.scripts.Process;
+import org.dspace.scripts.ProcessLog;
+import org.dspace.scripts.service.ProcessService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Component;
+
+@Component(ProcessRest.CATEGORY + "." + ProcessRest.NAME + "." + ProcessRest.OUTPUT)
+public class ProcessOutputLinkRepository extends AbstractDSpaceRestRepository implements LinkRestRepository {
+
+    @Autowired
+    private ProcessService processService;
+
+    @Autowired
+    private AuthorizeService authorizeService;
+
+    @PreAuthorize("hasAuthority('ADMIN')")
+    public ProcessOutputRest getOutputFromProcess(@Nullable HttpServletRequest request,
+                                                      Integer processId,
+                                                      @Nullable Pageable optionalPageable,
+                                                      Projection projection) throws SQLException, AuthorizeException {
+
+        Context context = obtainContext();
+        Process process = processService.find(context, processId);
+        if ((context.getCurrentUser() == null) || (!context.getCurrentUser().equals(process.getEPerson())
+            && !authorizeService.isAdmin(context))) {
+            throw new AuthorizeException("The current user is not eligible to view the process with id: " + processId);
+        }
+        ProcessOutputRest output = new ProcessOutputRest();
+        List<ProcessLog> processLogs = processService.getProcessLogsFromProcess(context, process);
+
+        output.setLogs(processLogs.stream().map(processLog -> processLog.getOutput()).collect(Collectors.toList()));
+
+        return output;
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ProcessOutputLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ProcessOutputLinkRepository.java
@@ -27,6 +27,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Component;
 
+/**
+ * This is the LinkRepository that deals with GET calls for the {@link ProcessLog} list from a given {@link Process}
+ */
 @Component(ProcessRest.CATEGORY + "." + ProcessRest.NAME + "." + ProcessRest.OUTPUT)
 public class ProcessOutputLinkRepository extends AbstractDSpaceRestRepository implements LinkRestRepository {
 
@@ -36,6 +39,18 @@ public class ProcessOutputLinkRepository extends AbstractDSpaceRestRepository im
     @Autowired
     private AuthorizeService authorizeService;
 
+    /**
+     * This method will retrieve the list of {@link ProcessLog} objects from the {@link Process} as defined through the
+     * given ID in the rest call and it'll wrap this in a {@link ProcessOutputRest} object to return these
+     * @param request           The current request
+     * @param processId         The given processId for the {@link Process}
+     * @param optionalPageable  Pageable if applicable
+     * @param projection        The current projection
+     * @return                  The {@link ProcessOutputRest} containing the list of all {@link ProcessLog} for the
+     *                          given {@link Process}
+     * @throws SQLException         If something goes wrong
+     * @throws AuthorizeException   If something goes wrong
+     */
     @PreAuthorize("hasAuthority('ADMIN')")
     public ProcessOutputRest getOutputFromProcess(@Nullable HttpServletRequest request,
                                                       Integer processId,

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/scripts/handler/impl/RestDSpaceRunnableHandler.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/scripts/handler/impl/RestDSpaceRunnableHandler.java
@@ -175,11 +175,19 @@ public class RestDSpaceRunnableHandler implements DSpaceRunnableHandler {
     }
 
 
-    private void appendLogToProcess(String message, ProcessLogLevel error) {
+    /**
+     * This method will ensure that the current {@link Process} has the given {@link org.dspace.scripts.ProcessLog}
+     * objects made and attached to it in the DB when a log is called.
+     * It'll use a separate Context for this and close this one immediately afterwards so that it's updated in
+     * real-time
+     * @param message   The message to be used in the log
+     * @param processLogLevel   The log level to be used in the log
+     */
+    private void appendLogToProcess(String message, ProcessLogLevel processLogLevel) {
         Context context = new Context(Context.Mode.MANAGED);
         try {
             Process process = processService.find(context, processId);
-            processService.appendLog(context, process, message, error);
+            processService.appendLog(context, process, message, processLogLevel);
             context.complete();
         } catch (SQLException e) {
             log.error("RestDSpaceRunnableHandler with process: " + processId + " could not write log to process", e);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/Utils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/Utils.java
@@ -268,6 +268,9 @@ public class Utils {
         if (StringUtils.equals(modelPlural, "properties")) {
             return PropertyRest.NAME;
         }
+        if (StringUtils.equals((modelPlural), "process")) {
+            return ProcessRest.NAME;
+        }
         return modelPlural.replaceAll("s$", "");
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProcessRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProcessRestRepositoryIT.java
@@ -31,6 +31,7 @@ import org.dspace.content.Bitstream;
 import org.dspace.content.ProcessStatus;
 import org.dspace.scripts.DSpaceCommandLineParameter;
 import org.dspace.scripts.Process;
+import org.dspace.scripts.ProcessLogLevel;
 import org.dspace.scripts.service.ProcessService;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -318,6 +319,25 @@ public class ProcessRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         getClient(token).perform(get("/api/system/processes/" + new Random() + "/filetypes"))
                         .andExpect(status().isNotFound());
+
+
+    }
+
+    @Test
+    public void getProcessOutput() throws Exception {
+        try (InputStream is = IOUtils.toInputStream("Test File For Process", CharEncoding.UTF_8)) {
+            processService.appendLog(context, process, "testlog", ProcessLogLevel.INFO);
+        }
+
+        List<String> fileTypesToCheck = new LinkedList<>();
+        fileTypesToCheck.add("inputfile");
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/system/processes/" + process.getID() + "/output"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.logs", containsInAnyOrder("testlog")))
+                        .andExpect(jsonPath("$.type", is("processOutput")));
 
 
     }

--- a/dspace/config/hibernate-managed-ehcache-config.xml
+++ b/dspace/config/hibernate-managed-ehcache-config.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+-->
+<ehcache xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="ehcache.xsd"
+    updateCheck='false'
+    name='org.dspace.hibernate.managed'>
+
+    <diskStore path="java.io.tmpdir"/>
+
+    <!--
+    Mandatory Default Cache configuration. These settings will be applied to caches
+    created programmtically using CacheManager.add(String cacheName).
+
+    The defaultCache has an implicit name "default" which is a reserved cache name.
+    -->
+    <defaultCache
+        maxElementsInMemory="3000"
+        eternal="false"
+        timeToIdleSeconds="1"
+        timeToLiveSeconds="1200"
+        overflowToDisk="true"
+        diskSpoolBufferSizeMB="30"
+        maxElementsOnDisk="10000"
+        diskPersistent="false"
+        diskExpiryThreadIntervalSeconds="120"
+        memoryStoreEvictionPolicy="LRU">
+    </defaultCache>
+
+    <!-- this cache tracks the timestamps of the most recent updates to particular tables.
+      It is important that the cache timeout of the underlying cache implementation be set to a
+      higher value than the timeouts of any of the query caches. In fact, it is recommended that
+      the the underlying cache not be configured for expiry at all. -->
+    <cache name="org.hibernate.cache.spi.UpdateTimestampsCache"
+        maxElementsInMemory="6000" eternal="true" overflowToDisk="false" />
+
+    <!-- this cache stores the actual objects pulled out of the DB by hibernate -->
+    <cache name="org.hibernate.cache.internal.StandardQueryCache"
+        maxElementsInMemory="2000" eternal="false" timeToIdleSeconds="1800"
+        timeToLiveSeconds="600" overflowToDisk="false" diskExpiryThreadIntervalSeconds="60"
+        memoryStoreEvictionPolicy="LRU"/>
+
+    <!-- DSpace classes in the second level cache -->
+
+    <!-- We only have 1 site object, so it is best to cache it -->
+    <cache name="org.dspace.content.Site"
+        maxElementsInMemory="1" eternal="false" timeToIdleSeconds="86400"
+        timeToLiveSeconds="86400" overflowToDisk="false"
+        memoryStoreEvictionPolicy="LRU"/>
+
+    <!-- The number of metadata schemas is limited and not updated frequently, so if we cache them
+         the likelihood of a cache hit is very high -->
+    <cache name="org.dspace.content.MetadataSchema"
+        maxElementsInMemory="100" eternal="false" timeToIdleSeconds="3600"
+        timeToLiveSeconds="3600" overflowToDisk="true" diskExpiryThreadIntervalSeconds="60"
+        memoryStoreEvictionPolicy="LRU"/>
+
+    <!-- The number of metadata fields is limited and not updated frequently, so if we cache them
+         the likelihood of a cache hit is very high -->
+    <cache name="org.dspace.content.MetadataField"
+        maxElementsInMemory="2000" eternal="false"  timeToIdleSeconds="3600"
+        timeToLiveSeconds="3600" overflowToDisk="true" diskExpiryThreadIntervalSeconds="60"
+        memoryStoreEvictionPolicy="LRU"/>
+
+    <!-- It is not a good idea to cache Item records. Most repositories have a large number of items
+         so the cache would have to be updated frequently. In addition there are many processes that
+         touch a lot of different items (discovery search, filter media, curation tasks...) which also makes
+         the cache less efficient. The probably of having a cache hit is thus very low and that is why Items
+         should not be cached. The same reasoning applies to Metadata values, Bundles, Bitstreams and Handles. -->
+
+    <!-- The number of groups in a repository can be very big, but only a small percentage of them is used
+         very frequently. So it makes sense to cache Group records because the cache hit rate is likely to be high -->
+    <cache name="org.dspace.eperson.Group"
+        maxElementsInMemory="5000" eternal="false" timeToIdleSeconds="1800"
+        timeToLiveSeconds="3600" overflowToDisk="false"
+        memoryStoreEvictionPolicy="LRU"/>
+
+    <!-- Like items, there are too many different Resource policy records for the cache to work efficiently.
+         In addition, resource policies are the core security mechanism in DSpace so want need to be 100% we
+         do not receive a stale policy when querying them. -->
+
+    <!-- The total number of epersons in DSpace can be very large, but the number of concurrent authenticated users is mostly
+         limited. Therefor having the authenticated users data cached will increase performance as the cache hit rate will
+         be high. -->
+    <cache name="org.dspace.eperson.EPerson"
+        maxElementsInMemory="1000" eternal="false" timeToIdleSeconds="1800"
+        timeToLiveSeconds="1800" overflowToDisk="false"
+        memoryStoreEvictionPolicy="LRU"/>
+
+    <!-- The number of collections is mostly a fixed set in a repository which is not updated frequently. This means that
+         most queries for a collection will be able to use the cached version. So adding caching here makes sense. -->
+    <cache name="org.dspace.content.Collection"
+        maxElementsInMemory="4000" eternal="false" timeToIdleSeconds="1800"
+        timeToLiveSeconds="1800" overflowToDisk="true" diskExpiryThreadIntervalSeconds="60"
+        memoryStoreEvictionPolicy="LRU"/>
+
+    <!-- Like collections, the same applies to communities. So we also setup a cache for communities. -->
+    <cache name="org.dspace.content.Community"
+        maxElementsInMemory="2000" eternal="false" timeToIdleSeconds="1800"
+        timeToLiveSeconds="1800" overflowToDisk="true" diskExpiryThreadIntervalSeconds="60"
+        memoryStoreEvictionPolicy="LRU"/>
+
+</ehcache>

--- a/dspace/config/hibernate.cfg.xml
+++ b/dspace/config/hibernate.cfg.xml
@@ -49,6 +49,7 @@
         <mapping class="org.dspace.content.EntityType"/>
 
         <mapping class="org.dspace.scripts.Process"/>
+        <mapping class="org.dspace.scripts.ProcessLog"/>
 
         <mapping class="org.dspace.content.MetadataField"/>
         <mapping class="org.dspace.content.MetadataSchema"/>

--- a/dspace/config/spring/api/core-dao-services.xml
+++ b/dspace/config/spring/api/core-dao-services.xml
@@ -33,6 +33,7 @@
     <bean class="org.dspace.content.dao.impl.RelationshipTypeDAOImpl"/>
 
     <bean class="org.dspace.content.dao.impl.ProcessDAOImpl"/>
+    <bean class="org.dspace.content.dao.impl.ProcessLogDAOImpl"/>
 
     <bean class="org.dspace.eperson.dao.impl.EPersonDAOImpl"/>
     <bean class="org.dspace.eperson.dao.impl.Group2GroupCacheDAOImpl"/>

--- a/dspace/config/spring/api/core-hibernate.xml
+++ b/dspace/config/spring/api/core-hibernate.xml
@@ -16,9 +16,32 @@
         <property name="hibernateProperties">
             <props>
                 <prop key="hibernate.dialect">${db.dialect}</prop>
+                <prop key="hibernate.current_session_context_class">org.hibernate.context.internal.ThreadLocalSessionContext</prop>
                 <prop key="hibernate.default_schema">${db.schema}</prop>
                 <prop key='net.sf.ehcache.configurationResourceName'>
                     file:${dspace.dir}/config/hibernate-ehcache-config.xml
+                </prop>
+            </props>
+        </property>
+    </bean>
+
+    <!-- Hibernate 4 Configuration -->
+    <bean id="managedSessionFactory" class="org.springframework.orm.hibernate5.LocalSessionFactoryBean" lazy-init="true">
+        <!-- Load most Hibernate settings from hibernate.cfg.xml -->
+        <property name="configLocation" value="file:${dspace.dir}/config/hibernate.cfg.xml"/>
+        <!-- Use the dataSource defined in the bean below. This is necessary so that Flyway can initialize
+             our database using the dataSource *prior* to Hibernate taking over -->
+        <property name="dataSource" ref="dataSource" />
+        <!-- Specify some additional Hibernate settings via dynamic properties. As noted below,
+        these values will be dynamically loaded from DSpace's ConfigurationService. -->
+        <!-- All other Hibernate settings are specified via the hibernate.cfg.xml referenced above. -->
+        <property name="hibernateProperties">
+            <props>
+                <prop key="hibernate.dialect">${db.dialect}</prop>
+                <prop key="hibernate.current_session_context_class">org.hibernate.context.internal.ManagedSessionContext</prop>
+                <prop key="hibernate.default_schema">${db.schema}</prop>
+                <prop key='net.sf.ehcache.configurationResourceName'>
+                    file:${dspace.dir}/config/hibernate-managed-ehcache-config.xml
                 </prop>
             </props>
         </property>


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Related to [REST Contract](https://github.com/DSpace/Rest7Contract/blob/main/scripts-endpoint.md) -> Pertaining to the "output" link -> "/api/system/processes/5/output"
* Fixes [GitHub issue](https://github.com/DSpace/DSpace/pull/2820#discussion_r459276967), the output of the script can afterwards be used for additional testing etc

## Description
For both the Angular team, as well as for the writing of certain REST tests, we want to be able to see the output of a script that has been started from the scripts and processes.

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* ProcessLog is a new db table that is used to keep the script output in the db.
    * This has been updated through the scripts and processes Flyway file
    * This also keeps the log level separately in the table for more specific information 
* The scripts that are handled through the [RestDSpaceRunnableHandler are logged to the db](https://github.com/atmire/DSpace/blob/w2p-72040_export-script-output/dspace-server-webapp/src/main/java/org/dspace/app/rest/scripts/handler/impl/RestDSpaceRunnableHandler.java#L156)
* A new mode '[MANAGED](https://github.com/atmire/DSpace/blob/w2p-72040_export-script-output/dspace-api/src/main/java/org/dspace/core/Context.java#L130)' for the Context has been created
    * When this mode is used, spring retrieves a '[managedHibernateDBConnection](https://github.com/atmire/DSpace/blob/w2p-72040_export-script-output/dspace-api/src/main/java/org/dspace/core/Context.java#L173)'
    * This allows for more finegrained usage of the commits, since we need to be able to commit immediately after wanting to write to the logs since, if the process fails, and the log hasn't been comitted to the db, the information on WHY the script failed is lost
        * This context is separate from the thread and doesn't interfere with the script. For example, if we want to print to the logs that x items have been processed, but we do not want to actually commit it until all items are ready, we can commit this context, and make sure that the actual item changes are not committed.
        * This 'managed' context can basically be considered the DSpace5 context where you are completely responsible of the state of the context.
        * The 'normal' context for DSpace 6 and 7 is connected to the thread
* ProcessOutputRest and ProcessOutputResource are added to support the retrieval through REST
* ProcessRest added to support the link through the LinkRest framework
* ProcessOutputLinkRepository added to support the retrieval call
* Added required logic to xml files:
    * DAO in core-dao-services.xml
    * hibernate managed vs normal threadbound xml in core-hibernate.xml and hibernate-managed-ehcache-config.xml
    * Model object in hibernate.cfg.xml



## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
