### PR TITLE
DS-4542 - The list of collection returned by collectionService.findAuthorizedOptimized of version 6x and 7x differs from 5x version 

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -213,32 +213,28 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
 
     @Override
     public List<Collection> findDirectMapped(Context context, int actionID) throws SQLException {
-        return collectionDAO.findAuthorized(context, context.getCurrentUser(), Arrays.asList(Constants.ADD,Constants.ADMIN));
+        return collectionDAO.findAuthorized(context, context.getCurrentUser(), Arrays.asList(actionID,Constants.ADMIN));
     }
 
     @Override
     public List<Collection> findGroup2CommunityMapped(Context context) throws SQLException {
-        List<Community> communities = communityService.findAuthorizedGroupMapped(context, Arrays.asList(Constants.ADD, Constants.ADMIN));
+        List<Community> communities = communityService.findAuthorizedGroupMapped(context, Collections
+            .singletonList(Constants.ADMIN));
         List<Collection> collections = new ArrayList<>();
         for (Community community : communities) {
-            collections.addAll(community.getCollections());
+            collections.addAll(community.getAllCollections());
         }
         return collections;
     }
 
     @Override
     public List<Collection> findGroup2GroupMapped(Context context, int actionID) throws SQLException {
-        return collectionDAO.findAuthorizedByGroup(context, context.getCurrentUser(), Collections.singletonList(actionID));
+        return collectionDAO.findAuthorizedByGroup2Group(context, context.getCurrentUser(), Arrays.asList(actionID, Constants.ADMIN));
     }
 
     @Override
     public List<Collection> findGroupMapped(Context context, int actionID) throws SQLException {
-        List<Community> communities = communityService.findAuthorized(context, Arrays.asList(Constants.ADD, Constants.ADMIN));
-        List<Collection> collections = new ArrayList<>();
-        for (Community community : communities) {
-            collections.addAll(community.getCollections());
-        }
-        return collections;
+        return collectionDAO.findAuthorizedByGroup(context, context.getCurrentUser(), Arrays.asList(actionID, Constants.ADMIN));
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/Community.java
+++ b/dspace-api/src/main/java/org/dspace/content/Community.java
@@ -207,6 +207,37 @@ public class Community extends DSpaceObject implements DSpaceObjectLegacySupport
     }
 
     /**
+     * Return an array of collections of this community and its subcommunities
+     *
+     * @return array of Collection objects
+     */
+    public List<Collection> getAllCollections()
+    {
+        List<Collection> collectionList = new ArrayList<>();
+        for (Community subcommunity : getSubcommunities())
+        {
+            addCollectionList(subcommunity, collectionList);
+        }
+
+        collectionList.addAll(getCollections());
+
+        return collectionList;
+    }
+
+    /**
+     * Internal method to process subcommunities recursively
+     */
+    private void addCollectionList(Community community, List<Collection> collectionList)
+    {
+        for (Community subcommunity : community.getSubcommunities())
+        {
+            addCollectionList(subcommunity, collectionList);
+        }
+
+        collectionList.addAll(community.getCollections());
+    }
+
+    /**
      * Return <code>true</code> if <code>other</code> is the same Community
      * as this object, <code>false</code> otherwise
      * 

--- a/dspace-api/src/main/java/org/dspace/content/dao/CollectionDAO.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/CollectionDAO.java
@@ -39,6 +39,8 @@ public interface CollectionDAO extends DSpaceObjectLegacySupportDAO<Collection> 
 
     List<Collection> findAuthorizedByGroup(Context context, EPerson ePerson, List<Integer> actions) throws SQLException;
 
+    List<Collection> findAuthorizedByGroup2Group(Context context, EPerson ePerson, List<Integer> actions) throws SQLException;
+
     List<Collection> findCollectionsWithSubscribers(Context context) throws SQLException;
 
     int countRows(Context context) throws SQLException;

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/CommunityDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/CommunityDAOImpl.java
@@ -155,14 +155,16 @@ public class CommunityDAOImpl extends AbstractHibernateDSODAO<Community> impleme
 //                "  resourcepolicy.resource_type_id = 4 AND eperson.eperson_id = ?", context.getCurrentUser().getID());
         StringBuilder query = new StringBuilder();
         query.append("select c from Community c join c.resourcePolicies rp join rp.epersonGroup rpGroup WHERE ");
+        query.append(" ( ");
         for (int i = 0; i < actions.size(); i++) {
             Integer action = actions.get(i);
             if(i != 0)
             {
-                query.append(" AND ");
+                query.append(" OR ");
             }
             query.append("rp.actionId=").append(action);
         }
+        query.append(" ) ");
         query.append(" AND rp.resourceTypeId=").append(Constants.COMMUNITY);
         query.append(" AND rp.epersonGroup.id IN (select g.id from Group g where (from EPerson e where e.id = :eperson_id) in elements(epeople))");
         Query hibernateQuery = createQuery(context, query.toString());


### PR DESCRIPTION
JIRA ticket: https://jira.lyrasis.org/browse/DS-4542
Fixes https://github.com/DSpace/DSpace/issues/7875

This PR corrects the list of collections returned by collectionService.findAuthorizedOptimized where an user can submit when the configuration key org.dspace.content.Collection.findAuthorizedPerformanceOptimize is set to true:

To test it configure:

`org.dspace.content.Collection.findAuthorizedPerformanceOptimize = true`

The list of collection where a user can submit should include:

- Collections of subcommunities of a community where the user is part of the community admin group.
- Collections where the user is part of collection admin group.
- Collections where the user is part of a group inside another group authorized to add into or administer the collection.

It can be also tested running this Script:

`dspace dsrun org.dspace.app.util.OptimizeSelectCollection <email>`