### PR TITLE
Bump Handle to version 9.3.0 final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1238,13 +1238,13 @@
             <dependency>
                 <groupId>net.handle</groupId>
                 <artifactId>handle</artifactId>
-                <version>9.3.0-SNAPSHOT</version>
+                <version>9.3.0</version>
             </dependency>
             <!-- Required to run Handle Server -->
             <dependency>
                 <groupId>net.cnri</groupId>
                 <artifactId>cnri-servlet-container</artifactId>
-                <version>3.0.0-SNAPSHOT</version>
+                <version>3.0.0</version>
             </dependency>
             <!-- Jetty is needed to run Handle Server (and tests in some modules) -->
             <dependency>


### PR DESCRIPTION
## References
* [JIRA ticket](https://jira.lyrasis.org/browse/DS-4205)

## Description
Bump Handle software and CNRI dependencies from snapshot to final versions. There were no major changes between the last snapshot and final, so this should still work fine.

## Instructions for Reviewers
Try configuring and running a Handle server using the included scripts and note that it works. 

List of changes in this PR:
* net.handle:handle dependency bumped to 9.3.0
* net.cnri:cnri-servlet-container bumped to 3.0.0.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- ~~My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide)~~.
- ~~My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.~~
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- ~~If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.~~
- ~~If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.~~
