### PR TITLE
Ensure ShibbolethRestController only redirects to trusted URLs after authentication

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ShibbolethRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ShibbolethRestController.java
@@ -49,6 +49,9 @@ public class ShibbolethRestController implements InitializingBean {
             .register(this, Arrays.asList(new Link("/api/" + AuthnRest.CATEGORY, "shibboleth")));
     }
 
+    // LGTM.com thinks this method has an unvalidated URL redirect (https://lgtm.com/rules/4840088/) in `redirectUrl`,
+    // even though we are clearly validating the hostname of `redirectUrl` and test it in ShibbolethRestControllerIT
+    @SuppressWarnings("lgtm[java/unvalidated-url-redirection]")
     @RequestMapping(method = RequestMethod.GET)
     public void shibboleth(HttpServletResponse response,
             @RequestParam(name = "redirectUrl", required = false) String redirectUrl) throws IOException {


### PR DESCRIPTION
This bug was discovered/reported by LGTM in the [ShibbolethRestController](https://lgtm.com/projects/g/DSpace/DSpace/snapshot/8276a236d2f44297651b311b0be1c76a89b5d05b/files/dspace-server-webapp/src/main/java/org/dspace/app/rest/ShibbolethRestController.java?sort=name&dir=ASC&mode=heatmap#xa5d3dfed284111b7:1)

## Description
The `ShibbolethRestController` will allow redirection to arbitrary URLs after successful authentication.  This is a security issue if individuals are fooled into clicking the below link while logged in.

This behavior can even be reproduced on the demo REST API by doing the following:
1. Login the the REST demo site: https://dspace7.4science.cloud/server/login.html
2. Then, visit this link:  https://dspace7.4science.cloud/server/api/authn/shibboleth?redirectUrl=http://google.com
3. You will be redirected to the Google homepage

In this PR, I've modified this Controller to ONLY allow redirects to URLs that have the same hostname as either `dspace.server.url` or `dspace.ui.url` configurations.  This should allow Shibboleth to work for any REST API or UI path, but not allow redirects to arbitrary locations.

## Instructions for Reviewers
* Review code & verify the new ITs which prove the functionality.  
* Optionally, retest above example on a local REST API, and verify that passing "http://google.com" now returns a `400 Bad Request` response.
* Ideally, someone with Shibboleth can test this new setup to verify that it works as expected with Shibboleth enabled for DSpace.
