### PR TITLE
Support multiple dsoType values in discovery

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/DiscoverQuery.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/DiscoverQuery.java
@@ -7,6 +7,9 @@
  */
 package org.dspace.discovery;
 
+import static java.util.Collections.singletonList;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -31,7 +34,7 @@ public class DiscoverQuery {
      **/
     private String query;
     private List<String> filterQueries;
-    private String DSpaceObjectFilter = null;
+    private List<String> dspaceObjectFilters = new ArrayList<>();
     private List<String> fieldPresentQueries;
     private boolean spellCheck;
 
@@ -118,20 +121,33 @@ public class DiscoverQuery {
      * Sets the DSpace object filter, must be an DSpace Object type integer
      * can be used to only return objects from a certain DSpace Object type
      *
-     * @param DSpaceObjectFilter the DSpace object filer
+     * @param dspaceObjectFilter the DSpace object filter
      */
-    public void setDSpaceObjectFilter(String DSpaceObjectFilter) {
-        this.DSpaceObjectFilter = DSpaceObjectFilter;
+    public void setDSpaceObjectFilter(String dspaceObjectFilter) {
+        this.dspaceObjectFilters = singletonList(dspaceObjectFilter);
     }
 
     /**
-     * Gets the DSpace object filter
-     * can be used to only return objects from a certain DSpace Object type
+     * Adds a DSpace object filter, must be an DSpace Object type integer.
+     * Can be used to also return objects from a certain DSpace Object type.
      *
-     * @return the DSpace object filer
+     * @param dspaceObjectFilter the DSpace object filer
      */
-    public String getDSpaceObjectFilter() {
-        return DSpaceObjectFilter;
+    public void addDSpaceObjectFilter(String dspaceObjectFilter) {
+
+        if (isNotBlank(dspaceObjectFilter)) {
+            this.dspaceObjectFilters.add(dspaceObjectFilter);
+        }
+    }
+
+    /**
+     * Gets the DSpace object filters
+     * can be used to only return objects from certain DSpace Object types
+     *
+     * @return the DSpace object filters
+     */
+    public List<String> getDSpaceObjectFilters() {
+        return dspaceObjectFilters;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.discovery;
 
+import static java.util.stream.Collectors.joining;
+
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -751,8 +753,13 @@ public class SolrServiceImpl implements SearchService, IndexingService {
             String filterQuery = discoveryQuery.getFilterQueries().get(i);
             solrQuery.addFilterQuery(filterQuery);
         }
-        if (discoveryQuery.getDSpaceObjectFilter() != null) {
-            solrQuery.addFilterQuery(SearchUtils.RESOURCE_TYPE_FIELD + ":" + discoveryQuery.getDSpaceObjectFilter());
+        if (discoveryQuery.getDSpaceObjectFilters() != null) {
+            solrQuery.addFilterQuery(
+                    discoveryQuery.getDSpaceObjectFilters()
+                            .stream()
+                            .map(filter -> SearchUtils.RESOURCE_TYPE_FIELD + ":" + filter)
+                            .collect(joining(" OR "))
+            );
         }
 
         for (int i = 0; i < discoveryQuery.getFieldPresentQueries().size(); i++) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.app.rest;
 
+import static org.apache.commons.collections4.ListUtils.emptyIfNull;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -100,51 +102,55 @@ public class DiscoveryRestController implements InitializingBean {
 
     @RequestMapping(method = RequestMethod.GET, value = "/search/facets")
     public FacetsResource getFacets(@RequestParam(name = "query", required = false) String query,
-                                    @RequestParam(name = "dsoType", required = false) String dsoType,
+                                    @RequestParam(name = "dsoType", required = false) List<String> dsoTypes,
                                     @RequestParam(name = "scope", required = false) String dsoScope,
                                     @RequestParam(name = "configuration", required = false) String configuration,
                                     List<SearchFilter> searchFilters,
                                     Pageable page) throws Exception {
 
+        dsoTypes = emptyIfNull(dsoTypes);
+
         if (log.isTraceEnabled()) {
             log.trace("Searching with scope: " + StringUtils.trimToEmpty(dsoScope)
-                          + ", configuration name: " + StringUtils.trimToEmpty(configuration)
-                          + ", dsoType: " + StringUtils.trimToEmpty(dsoType)
-                          + ", query: " + StringUtils.trimToEmpty(query)
-                          + ", filters: " + Objects.toString(searchFilters));
+                    + ", configuration name: " + StringUtils.trimToEmpty(configuration)
+                    + ", dsoTypes: " + String.join(", ", dsoTypes)
+                    + ", query: " + StringUtils.trimToEmpty(query)
+                    + ", filters: " + Objects.toString(searchFilters));
         }
 
         SearchResultsRest searchResultsRest = discoveryRestRepository
-            .getAllFacets(query, dsoType, dsoScope, configuration, searchFilters);
+            .getAllFacets(query, dsoTypes, dsoScope, configuration, searchFilters);
 
         FacetsResource facetsResource = new FacetsResource(searchResultsRest, page);
         halLinkService.addLinks(facetsResource, page);
 
         return facetsResource;
-
-
     }
 
     @RequestMapping(method = RequestMethod.GET, value = "/search/objects")
     public SearchResultsResource getSearchObjects(@RequestParam(name = "query", required = false) String query,
-                                                  @RequestParam(name = "dsoType", required = false) String dsoType,
+                                                  @RequestParam(name = "dsoType", required = false)
+                                                          List<String> dsoTypes,
                                                   @RequestParam(name = "scope", required = false) String dsoScope,
                                                   @RequestParam(name = "configuration", required = false) String
                                                       configuration,
                                                   List<SearchFilter> searchFilters,
                                                   Pageable page) throws Exception {
+
+        dsoTypes = emptyIfNull(dsoTypes);
+
         if (log.isTraceEnabled()) {
             log.trace("Searching with scope: " + StringUtils.trimToEmpty(dsoScope)
-                          + ", configuration name: " + StringUtils.trimToEmpty(configuration)
-                          + ", dsoType: " + StringUtils.trimToEmpty(dsoType)
-                          + ", query: " + StringUtils.trimToEmpty(query)
-                          + ", filters: " + Objects.toString(searchFilters)
-                          + ", page: " + Objects.toString(page));
+                    + ", configuration name: " + StringUtils.trimToEmpty(configuration)
+                    + ", dsoTypes: " + String.join(", ", dsoTypes)
+                    + ", query: " + StringUtils.trimToEmpty(query)
+                    + ", filters: " + Objects.toString(searchFilters)
+                    + ", page: " + Objects.toString(page));
         }
 
         //Get the Search results in JSON format
         SearchResultsRest searchResultsRest = discoveryRestRepository
-            .getSearchObjects(query, dsoType, dsoScope, configuration, searchFilters, page, utils.obtainProjection());
+            .getSearchObjects(query, dsoTypes, dsoScope, configuration, searchFilters, page, utils.obtainProjection());
 
         //Convert the Search JSON results to paginated HAL resources
         SearchResultsResource searchResultsResource = new SearchResultsResource(searchResultsRest, utils, page);
@@ -174,15 +180,18 @@ public class DiscoveryRestController implements InitializingBean {
     public RepresentationModel getFacetValues(@PathVariable("name") String facetName,
                                               @RequestParam(name = "prefix", required = false) String prefix,
                                               @RequestParam(name = "query", required = false) String query,
-                                              @RequestParam(name = "dsoType", required = false) String dsoType,
+                                              @RequestParam(name = "dsoType", required = false) List<String> dsoTypes,
                                               @RequestParam(name = "scope", required = false) String dsoScope,
                                               @RequestParam(name = "configuration", required = false) String
                                                       configuration,
                                               List<SearchFilter> searchFilters,
                                               Pageable page) throws Exception {
+
+        dsoTypes = emptyIfNull(dsoTypes);
+
         if (log.isTraceEnabled()) {
             log.trace("Facetting on facet " + facetName + " with scope: " + StringUtils.trimToEmpty(dsoScope)
-                          + ", dsoType: " + StringUtils.trimToEmpty(dsoType)
+                          + ", dsoTypes: " + String.join(", ", dsoTypes)
                           + ", prefix: " + StringUtils.trimToEmpty(prefix)
                           + ", query: " + StringUtils.trimToEmpty(query)
                           + ", filters: " + Objects.toString(searchFilters)
@@ -190,7 +199,7 @@ public class DiscoveryRestController implements InitializingBean {
         }
 
         FacetResultsRest facetResultsRest = discoveryRestRepository
-            .getFacetObjects(facetName, prefix, query, dsoType, dsoScope, configuration, searchFilters, page);
+            .getFacetObjects(facetName, prefix, query, dsoTypes, dsoScope, configuration, searchFilters, page);
 
         FacetResultsResource facetResultsResource = converter.toResource(facetResultsRest);
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverFacetResultsConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverFacetResultsConverter.java
@@ -35,13 +35,14 @@ public class DiscoverFacetResultsConverter {
     @Autowired
     private SearchFilterToAppliedFilterConverter searchFilterToAppliedFilterConverter;
 
-    public FacetResultsRest convert(Context context, String facetName, String prefix, String query, String dsoType,
-                                    String dsoScope, List<SearchFilter> searchFilters, DiscoverResult searchResult,
-                                    DiscoveryConfiguration configuration, Pageable page, Projection projection) {
+    public FacetResultsRest convert(Context context, String facetName, String prefix, String query,
+                                    List<String> dsoTypes, String dsoScope, List<SearchFilter> searchFilters,
+                                    DiscoverResult searchResult, DiscoveryConfiguration configuration, Pageable page,
+                                    Projection projection) {
         FacetResultsRest facetResultsRest = new FacetResultsRest();
         facetResultsRest.setProjection(projection);
 
-        setRequestInformation(context, facetName, prefix, query, dsoType, dsoScope, searchFilters, searchResult,
+        setRequestInformation(context, facetName, prefix, query, dsoTypes, dsoScope, searchFilters, searchResult,
                 configuration, facetResultsRest, page, projection);
 
         addToFacetResultList(facetName, searchResult, facetResultsRest, configuration, page, projection);
@@ -72,14 +73,14 @@ public class DiscoverFacetResultsConverter {
         return facetValueConverter.convert(value, projection);
     }
 
-    private void setRequestInformation(Context context, String facetName, String prefix, String query, String dsoType,
-                                       String dsoScope, List<SearchFilter> searchFilters, DiscoverResult searchResult,
-                                       DiscoveryConfiguration configuration, FacetResultsRest facetResultsRest,
-                                       Pageable page, Projection projection) {
+    private void setRequestInformation(Context context, String facetName, String prefix, String query,
+                                       List<String> dsoTypes, String dsoScope, List<SearchFilter> searchFilters,
+                                       DiscoverResult searchResult, DiscoveryConfiguration configuration,
+                                       FacetResultsRest facetResultsRest, Pageable page, Projection projection) {
         facetResultsRest.setQuery(query);
         facetResultsRest.setPrefix(prefix);
         facetResultsRest.setScope(dsoScope);
-        facetResultsRest.setDsoType(dsoType);
+        facetResultsRest.setDsoTypes(dsoTypes);
 
         facetResultsRest.setFacetEntry(convertFacetEntry(facetName, searchResult, configuration, page, projection));
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverFacetsConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverFacetsConverter.java
@@ -38,7 +38,7 @@ public class DiscoverFacetsConverter {
     @Autowired
     private SearchService searchService;
 
-    public SearchResultsRest convert(Context context, String query, String dsoType, String configurationName,
+    public SearchResultsRest convert(Context context, String query, List<String> dsoTypes, String configurationName,
                                      String dsoScope, List<SearchFilter> searchFilters, final Pageable page,
                                      DiscoveryConfiguration configuration, DiscoverResult searchResult,
                                      Projection projection) {
@@ -46,7 +46,7 @@ public class DiscoverFacetsConverter {
         SearchResultsRest searchResultsRest = new SearchResultsRest();
         searchResultsRest.setProjection(projection);
 
-        setRequestInformation(context, query, dsoType, configurationName, dsoScope, searchFilters, page,
+        setRequestInformation(context, query, dsoTypes, configurationName, dsoScope, searchFilters, page,
                               searchResultsRest);
         addFacetValues(context, searchResult, searchResultsRest, configuration, projection);
 
@@ -129,13 +129,13 @@ public class DiscoverFacetsConverter {
         }
     }
 
-    private void setRequestInformation(final Context context, final String query, final String dsoType,
+    private void setRequestInformation(final Context context, final String query, final List<String> dsoTypes,
                                        final String configurationName, final String scope,
                                        final List<SearchFilter> searchFilters, final Pageable page,
                                        final SearchResultsRest resultsRest) {
         resultsRest.setQuery(query);
         resultsRest.setConfiguration(configurationName);
-        resultsRest.setDsoType(dsoType);
+        resultsRest.setDsoTypes(dsoTypes);
         resultsRest.setSort(SearchResultsRest.Sorting.fromPage(page));
 
         resultsRest.setScope(scope);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverResultConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverResultConverter.java
@@ -43,7 +43,7 @@ public class DiscoverResultConverter {
     @Autowired
     private SearchFilterToAppliedFilterConverter searchFilterToAppliedFilterConverter;
 
-    public SearchResultsRest convert(final Context context, final String query, final String dsoType,
+    public SearchResultsRest convert(final Context context, final String query, final List<String> dsoTypes,
                                      final String configurationName, final String scope,
                                      final List<SearchFilter> searchFilters, final Pageable page,
                                      final DiscoverResult searchResult, final DiscoveryConfiguration configuration,
@@ -52,7 +52,7 @@ public class DiscoverResultConverter {
         SearchResultsRest resultsRest = new SearchResultsRest();
         resultsRest.setProjection(projection);
 
-        setRequestInformation(context, query, dsoType, configurationName, scope, searchFilters, page, resultsRest);
+        setRequestInformation(context, query, dsoTypes, configurationName, scope, searchFilters, page, resultsRest);
 
         addSearchResults(searchResult, resultsRest, projection);
 
@@ -101,13 +101,13 @@ public class DiscoverResultConverter {
         return null;
     }
 
-    private void setRequestInformation(final Context context, final String query, final String dsoType,
+    private void setRequestInformation(final Context context, final String query, final List<String> dsoTypes,
                                        final String configurationName, final String scope,
                                        final List<SearchFilter> searchFilters, final Pageable page,
                                        final SearchResultsRest resultsRest) {
         resultsRest.setQuery(query);
         resultsRest.setConfiguration(configurationName);
-        resultsRest.setDsoType(dsoType);
+        resultsRest.setDsoTypes(dsoTypes);
 
         resultsRest.setScope(scope);
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/link/search/DiscoveryRestHalLinkFactory.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/link/search/DiscoveryRestHalLinkFactory.java
@@ -28,7 +28,7 @@ public abstract class DiscoveryRestHalLinkFactory<T> extends HalLinkFactory<T, D
     public UriComponentsBuilder buildSearchBaseLink(final DiscoveryResultsRest data) {
         try {
             UriComponentsBuilder uriBuilder = uriBuilder(getMethodOn()
-                    .getSearchObjects(data.getQuery(), data.getDsoType(),
+                    .getSearchObjects(data.getQuery(), data.getDsoTypes(),
                             data.getScope(), data.getConfiguration(),
                             null, null));
 
@@ -43,7 +43,7 @@ public abstract class DiscoveryRestHalLinkFactory<T> extends HalLinkFactory<T, D
         try {
             UriComponentsBuilder uriBuilder = uriBuilder(
                     getMethodOn().getFacetValues(data.getFacetEntry().getName(), data.getPrefix(), data.getQuery(),
-                            data.getDsoType(), data.getScope(), data.getConfiguration(), null, null));
+                            data.getDsoTypes(), data.getScope(), data.getConfiguration(), null, null));
 
             return addFilterParams(uriBuilder, data);
         } catch (Exception ex) {
@@ -54,7 +54,7 @@ public abstract class DiscoveryRestHalLinkFactory<T> extends HalLinkFactory<T, D
 
     protected UriComponentsBuilder buildSearchFacetsBaseLink(final SearchResultsRest data) {
         try {
-            UriComponentsBuilder uriBuilder = uriBuilder(getMethodOn().getFacets(data.getQuery(), data.getDsoType(),
+            UriComponentsBuilder uriBuilder = uriBuilder(getMethodOn().getFacets(data.getQuery(), data.getDsoTypes(),
                     data.getScope(), data.getConfiguration(), null, null));
 
             uriBuilder = addSortingParms(uriBuilder, data);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/link/search/SearchFacetEntryHalLinkFactory.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/link/search/SearchFacetEntryHalLinkFactory.java
@@ -8,6 +8,7 @@
 package org.dspace.app.rest.link.search;
 
 import java.util.LinkedList;
+import java.util.List;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.BooleanUtils;
@@ -39,7 +40,7 @@ public class SearchFacetEntryHalLinkFactory extends DiscoveryRestHalLinkFactory<
         DiscoveryResultsRest searchData = halResource.getSearchData();
 
         String query = searchData == null ? null : searchData.getQuery();
-        String dsoType = searchData == null ? null : searchData.getDsoType();
+        List<String> dsoType = searchData == null ? null : searchData.getDsoTypes();
         String scope = searchData == null ? null : searchData.getScope();
         String configuration = searchData == null ? null : searchData.getConfiguration();
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/DiscoveryResultsRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/DiscoveryResultsRest.java
@@ -27,7 +27,7 @@ public abstract class DiscoveryResultsRest extends BaseObjectRest<String> {
     private List<SearchResultsRest.AppliedFilter> appliedFilters;
     private SearchResultsRest.Sorting sort;
     @JsonIgnore
-    private String dsoType;
+    private List<String> dsoTypes;
     @JsonIgnore
     private List<SearchFilter> searchFilters;
     private String configuration;
@@ -52,12 +52,12 @@ public abstract class DiscoveryResultsRest extends BaseObjectRest<String> {
         this.query = query;
     }
 
-    public String getDsoType() {
-        return dsoType;
+    public List<String> getDsoTypes() {
+        return dsoTypes;
     }
 
-    public void setDsoType(final String dsoType) {
-        this.dsoType = dsoType;
+    public void setDsoTypes(final List<String> dsoTypes) {
+        this.dsoTypes = dsoTypes;
     }
 
     public String getScope() {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
@@ -89,7 +89,7 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
         return discoverConfigurationConverter.convert(discoveryConfiguration, utils.obtainProjection());
     }
 
-    public SearchResultsRest getSearchObjects(final String query, final String dsoType, final String dsoScope,
+    public SearchResultsRest getSearchObjects(final String query, final List<String> dsoTypes, final String dsoScope,
                                               final String configuration,
                                               final List<SearchFilter> searchFilters, final Pageable page,
                                               final Projection projection) {
@@ -103,7 +103,7 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
 
         try {
             discoverQuery = queryBuilder
-                .buildQuery(context, scopeObject, discoveryConfiguration, query, searchFilters, dsoType, page);
+                .buildQuery(context, scopeObject, discoveryConfiguration, query, searchFilters, dsoTypes, page);
             searchResult = searchService.search(context, scopeObject, discoverQuery);
 
         } catch (SearchServiceException e) {
@@ -112,7 +112,7 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
         }
 
         return discoverResultConverter
-            .convert(context, query, dsoType, configuration, dsoScope, searchFilters, page, searchResult,
+            .convert(context, query, dsoTypes, configuration, dsoScope, searchFilters, page, searchResult,
                      discoveryConfiguration, projection);
     }
 
@@ -130,7 +130,7 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
         return discoverSearchSupportConverter.convert();
     }
 
-    public FacetResultsRest getFacetObjects(String facetName, String prefix, String query, String dsoType,
+    public FacetResultsRest getFacetObjects(String facetName, String prefix, String query, List<String> dsoTypes,
             String dsoScope, final String configuration, List<SearchFilter> searchFilters, Pageable page) {
 
         Context context = obtainContext();
@@ -143,7 +143,7 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
         DiscoverQuery discoverQuery = null;
         try {
             discoverQuery = queryBuilder.buildFacetQuery(context, scopeObject, discoveryConfiguration, prefix, query,
-                    searchFilters, dsoType, page, facetName);
+                    searchFilters, dsoTypes, page, facetName);
             searchResult = searchService.search(context, scopeObject, discoverQuery);
 
         } catch (SearchServiceException e) {
@@ -152,12 +152,12 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
         }
 
         FacetResultsRest facetResultsRest = discoverFacetResultsConverter.convert(context, facetName, prefix, query,
-                dsoType, dsoScope, searchFilters, searchResult, discoveryConfiguration, page,
+                dsoTypes, dsoScope, searchFilters, searchResult, discoveryConfiguration, page,
                 utils.obtainProjection());
         return facetResultsRest;
     }
 
-    public SearchResultsRest getAllFacets(String query, String dsoType, String dsoScope, String configuration,
+    public SearchResultsRest getAllFacets(String query, List<String> dsoTypes, String dsoScope, String configuration,
                                           List<SearchFilter> searchFilters) {
 
         Context context = obtainContext();
@@ -171,14 +171,14 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
 
         try {
             discoverQuery = queryBuilder
-                .buildQuery(context, scopeObject, discoveryConfiguration, query, searchFilters, dsoType, page);
+                .buildQuery(context, scopeObject, discoveryConfiguration, query, searchFilters, dsoTypes, page);
             searchResult = searchService.search(context, scopeObject, discoverQuery);
 
         } catch (SearchServiceException e) {
             log.error("Error while searching with Discovery", e);
         }
 
-        SearchResultsRest searchResultsRest = discoverFacetsConverter.convert(context, query, dsoType,
+        SearchResultsRest searchResultsRest = discoverFacetsConverter.convert(context, query, dsoTypes,
                 configuration, dsoScope, searchFilters, page, discoveryConfiguration, searchResult,
                 utils.obtainProjection());
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/DiscoverQueryBuilder.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/DiscoverQueryBuilder.java
@@ -69,6 +69,17 @@ public class DiscoverQueryBuilder implements InitializingBean {
         pageSizeLimit = configurationService.getIntProperty("rest.search.max.results", 100);
     }
 
+    /**
+     * Build a discovery query
+     *
+     * @param context                   the DSpace context
+     * @param scope                     the scope for this discovery query
+     * @param discoveryConfiguration    the discovery configuration for this discovery query
+     * @param query                     the query string for this discovery query
+     * @param searchFilters             the search filters for this discovery query
+     * @param dsoType                   only include search results with this type
+     * @param page                      the pageable for this discovery query
+     */
     public DiscoverQuery buildQuery(Context context, IndexableObject scope,
                                     DiscoveryConfiguration discoveryConfiguration,
                                     String query, List<SearchFilter> searchFilters,
@@ -80,6 +91,17 @@ public class DiscoverQueryBuilder implements InitializingBean {
         return buildQuery(context, scope, discoveryConfiguration, query, searchFilters, dsoTypes, page);
     }
 
+    /**
+     * Build a discovery query
+     *
+     * @param context                   the DSpace context
+     * @param scope                     the scope for this discovery query
+     * @param discoveryConfiguration    the discovery configuration for this discovery query
+     * @param query                     the query string for this discovery query
+     * @param searchFilters             the search filters for this discovery query
+     * @param dsoTypes                  only include search results with one of these types
+     * @param page                      the pageable for this discovery query
+     */
     public DiscoverQuery buildQuery(Context context, IndexableObject scope,
                                     DiscoveryConfiguration discoveryConfiguration,
                                     String query, List<SearchFilter> searchFilters,
@@ -113,6 +135,19 @@ public class DiscoverQueryBuilder implements InitializingBean {
         }
     }
 
+    /**
+     * Create a discovery facet query.
+     *
+     * @param context                   the DSpace context
+     * @param scope                     the scope for this discovery query
+     * @param discoveryConfiguration    the discovery configuration for this discovery query
+     * @param prefix                    limit the facets results to those starting with the given prefix.
+     * @param query                     the query string for this discovery query
+     * @param searchFilters             the search filters for this discovery query
+     * @param dsoType                   only include search results with this type
+     * @param page                      the pageable for this discovery query
+     * @param facetName                 the facet field
+     */
     public DiscoverQuery buildFacetQuery(Context context, IndexableObject scope,
                                          DiscoveryConfiguration discoveryConfiguration,
                                          String prefix, String query, List<SearchFilter> searchFilters,
@@ -125,6 +160,19 @@ public class DiscoverQueryBuilder implements InitializingBean {
                 context, scope, discoveryConfiguration, prefix, query, searchFilters, dsoTypes, page, facetName);
     }
 
+    /**
+     * Create a discovery facet query.
+     *
+     * @param context                   the DSpace context
+     * @param scope                     the scope for this discovery query
+     * @param discoveryConfiguration    the discovery configuration for this discovery query
+     * @param prefix                    limit the facets results to those starting with the given prefix.
+     * @param query                     the query string for this discovery query
+     * @param searchFilters             the search filters for this discovery query
+     * @param dsoTypes                  only include search results with one of these types
+     * @param page                      the pageable for this discovery query
+     * @param facetName                 the facet field
+     */
     public DiscoverQuery buildFacetQuery(Context context, IndexableObject scope,
                                          DiscoveryConfiguration discoveryConfiguration,
                                          String prefix, String query, List<SearchFilter> searchFilters,

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -1351,9 +1351,10 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
 
         context.restoreAuthSystemState();
 
-        //** WHEN **
-        //An anonymous user browses this endpoint to find the the objects in the system
-        //With a dsoType 'item'
+        // ** WHEN **
+        // An anonymous user browses this endpoint to find the the objects in the system
+
+        // With dsoType 'item'
         getClient().perform(get("/api/discover/search/objects")
                 .param("dsoType", "Item"))
 
@@ -1384,8 +1385,118 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link available
-                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
-        ;
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")));
+
+        // With dsoTypes 'community' and 'collection'
+        getClient().perform(get("/api/discover/search/objects")
+                .param("dsoType", "Community")
+                .param("dsoType", "Collection"))
+
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                // The page element needs to look like this and only have four totalElements because we only want
+                // the communities and the collections (dsoType) and we only created two of both types
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 4)
+                )))
+                // Only the two communities and the two collections can be present in the embedded.objects section
+                // as that's what we specified in the dsoType parameter
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                        SearchResultMatcher.match("core", "community", "communities"),
+                        SearchResultMatcher.match("core", "community", "communities"),
+                        SearchResultMatcher.match("core", "collection", "collections"),
+                        SearchResultMatcher.match("core", "collection", "collections")
+                )))
+                //These facets have to show up in the embedded.facets section as well with the given hasMore
+                // property because we don't exceed their default limit for a hasMore true (the default is 10)
+                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                        FacetEntryMatcher.authorFacet(false),
+                        FacetEntryMatcher.entityTypeFacet(false),
+                        FacetEntryMatcher.subjectFacet(false),
+                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                )))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")));
+
+        // With dsoTypes 'collection' and 'item'
+        getClient().perform(get("/api/discover/search/objects")
+                .param("dsoType", "Collection")
+                .param("dsoType", "Item"))
+
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                // The page element needs to look like this and only have five totalElements because we only want
+                // the collections and the items (dsoType) and we only created two collections and three items
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 5)
+                )))
+                // Only the two collections and the three items can be present in the embedded.objects section
+                // as that's what we specified in the dsoType parameter
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                        SearchResultMatcher.match("core", "collection", "collections"),
+                        SearchResultMatcher.match("core", "collection", "collections"),
+                        SearchResultMatcher.match("core", "item", "items"),
+                        SearchResultMatcher.match("core", "item", "items"),
+                        SearchResultMatcher.match("core", "item", "items")
+                )))
+                //These facets have to show up in the embedded.facets section as well with the given hasMore
+                // property because we don't exceed their default limit for a hasMore true (the default is 10)
+                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                        FacetEntryMatcher.authorFacet(false),
+                        FacetEntryMatcher.entityTypeFacet(false),
+                        FacetEntryMatcher.subjectFacet(false),
+                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                )))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")));
+
+        // With dsoTypes 'community', 'collection' and 'item'
+        getClient().perform(get("/api/discover/search/objects")
+                .param("dsoType", "Community")
+                .param("dsoType", "Collection")
+                .param("dsoType", "Item"))
+
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //The type has to be 'discover'
+                .andExpect(jsonPath("$.type", is("discover")))
+                // The page element needs to look like this and have seven totalElements because we want
+                // the communities, the collections and the items (dsoType) and we created two communities,
+                // two collections and three items
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 7)
+                )))
+                // The two communities, the two collections and the three items can be present in the embedded.objects
+                // section as that's what we specified in the dsoType parameter
+                .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                        SearchResultMatcher.match("core", "community", "communities"),
+                        SearchResultMatcher.match("core", "community", "communities"),
+                        SearchResultMatcher.match("core", "collection", "collections"),
+                        SearchResultMatcher.match("core", "collection", "collections"),
+                        SearchResultMatcher.match("core", "item", "items"),
+                        SearchResultMatcher.match("core", "item", "items"),
+                        SearchResultMatcher.match("core", "item", "items")
+                )))
+                //These facets have to show up in the embedded.facets section as well with the given hasMore
+                // property because we don't exceed their default limit for a hasMore true (the default is 10)
+                .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                        FacetEntryMatcher.authorFacet(false),
+                        FacetEntryMatcher.entityTypeFacet(false),
+                        FacetEntryMatcher.subjectFacet(false),
+                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                )))
+                //There always needs to be a self link available
+                .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")));
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/utils/DiscoverQueryBuilderTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/utils/DiscoverQueryBuilderTest.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.app.rest.utils;
 
+import static java.util.Collections.emptyList;
 import static org.dspace.discovery.configuration.DiscoveryConfigurationParameters.SORT.COUNT;
 import static org.dspace.discovery.configuration.DiscoveryConfigurationParameters.SORT.VALUE;
 import static org.dspace.discovery.configuration.DiscoveryConfigurationParameters.TYPE_HIERARCHICAL;
@@ -14,10 +15,11 @@ import static org.dspace.discovery.configuration.DiscoveryConfigurationParameter
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -181,7 +183,7 @@ public class DiscoverQueryBuilderTest {
 
         assertThat(discoverQuery.getFilterQueries(), containsInAnyOrder("archived:true", "subject:\"Java\""));
         assertThat(discoverQuery.getQuery(), is(query));
-        assertThat(discoverQuery.getDSpaceObjectFilter(), is(IndexableItem.TYPE));
+        assertThat(discoverQuery.getDSpaceObjectFilters(), contains(IndexableItem.TYPE));
         assertThat(discoverQuery.getSortField(), is("dc.title_sort"));
         assertThat(discoverQuery.getSortOrder(), is(DiscoverQuery.SORT_ORDER.asc));
         assertThat(discoverQuery.getMaxResults(), is(10));
@@ -203,11 +205,11 @@ public class DiscoverQueryBuilderTest {
     @Test
     public void testBuildQueryDefaults() throws Exception {
         DiscoverQuery discoverQuery =
-            queryBuilder.buildQuery(context, null, discoveryConfiguration, null, null, null, null);
+            queryBuilder.buildQuery(context, null, discoveryConfiguration, null, null, emptyList(), null);
 
         assertThat(discoverQuery.getFilterQueries(), containsInAnyOrder("archived:true"));
-        assertThat(discoverQuery.getQuery(), isEmptyOrNullString());
-        assertThat(discoverQuery.getDSpaceObjectFilter(), isEmptyOrNullString());
+        assertThat(discoverQuery.getQuery(), is(emptyOrNullString()));
+        assertThat(discoverQuery.getDSpaceObjectFilters(), is(empty()));
         //Note this should actually be "dc.date.accessioned_dt"  but remember that our searchService is just a stupid
         // mock
         assertThat(discoverQuery.getSortField(), is("dc.date.accessioned_sort"));
@@ -233,11 +235,11 @@ public class DiscoverQueryBuilderTest {
         page = PageRequest.of(2, 10, Sort.Direction.ASC, "SCORE");
 
         DiscoverQuery discoverQuery =
-            queryBuilder.buildQuery(context, null, discoveryConfiguration, null, null, null, page);
+            queryBuilder.buildQuery(context, null, discoveryConfiguration, null, null, emptyList(), page);
 
         assertThat(discoverQuery.getFilterQueries(), containsInAnyOrder("archived:true"));
-        assertThat(discoverQuery.getQuery(), isEmptyOrNullString());
-        assertThat(discoverQuery.getDSpaceObjectFilter(), is(isEmptyOrNullString()));
+        assertThat(discoverQuery.getQuery(), is(emptyOrNullString()));
+        assertThat(discoverQuery.getDSpaceObjectFilters(), is(empty()));
         //Note this should actually be "dc.date.accessioned_dt"  but remember that our searchService is just a stupid
         // mock
         assertThat(discoverQuery.getSortField(), is("score_sort"));
@@ -297,8 +299,8 @@ public class DiscoverQueryBuilderTest {
 
         assertThat(discoverQuery.getFilterQueries(), containsInAnyOrder("archived:true", "subject:\"Java\""));
         assertThat(discoverQuery.getQuery(), is(query));
-        assertThat(discoverQuery.getDSpaceObjectFilter(), is(IndexableItem.TYPE));
-        assertThat(discoverQuery.getSortField(), isEmptyOrNullString());
+        assertThat(discoverQuery.getDSpaceObjectFilters(), contains(IndexableItem.TYPE));
+        assertThat(discoverQuery.getSortField(), is(emptyOrNullString()));
         assertThat(discoverQuery.getMaxResults(), is(0));
         assertThat(discoverQuery.getStart(), is(0));
         assertThat(discoverQuery.getFacetMinCount(), is(1));


### PR DESCRIPTION
## References
* Related to [REST Contract](https://github.com/DSpace/Rest7Contract/pull/146)

## Description
This is a minor change to support e.g. /server/api/discover/search/objects?dsoType=Collection&dsoType=Community to return communities and collections

We discovered this was relevant to create the Angular UI to import or export a CSV, where a collection or community should be selected (and both should be selectable)

## Instructions for Reviewers
There's no need to reindex data. You can test it using:
* no dsoType parameter
* /server/api/discover/search/objects?dsoType=Collection&dsoType=Community
* /server/api/discover/search/objects?dsoType=Item
* /server/api/discover/search/objects?dsoType=Item&dsoType=Collection
* …

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
