### PR TITLE
The /authz/authorizations/search/object endpoint sometimes ignores the feature param

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationRestRepositoryIT.java
@@ -988,7 +988,7 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
         // verify that it works for administrators - with eperson parameter
         getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", comUri)
-                .param("projection", "full")
+                .param("projection", "level")
                 .param("embedLevelDepth", "1")
                 .param("feature", alwaysTrue.getName())
                 .param("eperson", admin.getID().toString()))
@@ -1007,7 +1007,7 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
         // verify that it works for administrators - without eperson parameter
         getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", comUri)
-                .param("projection", "full")
+                .param("projection", "level")
                 .param("embedLevelDepth", "1")
                 .param("feature", alwaysTrue.getName()))
             .andExpect(status().isOk())
@@ -1030,7 +1030,7 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
         // verify that it works for normal loggedin users - with eperson parameter
         getClient(epersonToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", comUri)
-                .param("projection", "full")
+                .param("projection", "level")
                 .param("embedLevelDepth", "1")
                 .param("feature", alwaysTrue.getName())
                 .param("eperson", eperson.getID().toString()))
@@ -1052,7 +1052,7 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
         // verify that it works for normal loggedin users - without eperson parameter
         getClient(epersonToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", comUri)
-                .param("projection", "full")
+                .param("projection", "level")
                 .param("embedLevelDepth", "1")
                 .param("feature", alwaysTrue.getName()))
                 .andExpect(status().isOk())
@@ -1073,7 +1073,7 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
         // verify that it works for administators inspecting other users - by using the eperson parameter
         getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", comUri)
-                .param("projection", "full")
+                .param("projection", "level")
                 .param("embedLevelDepth", "1")
                 .param("feature", alwaysTrue.getName())
                 .param("eperson", eperson.getID().toString()))
@@ -1095,7 +1095,7 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
         // verify that it works for administators inspecting other users - by assuming login
         getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", comUri)
-                .param("projection", "full")
+                .param("projection", "level")
                 .param("embedLevelDepth", "1")
                 .param("feature", alwaysTrue.getName())
                 .header("X-On-Behalf-Of", eperson.getID()))
@@ -1117,7 +1117,7 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
         // verify that it works for anonymous users
         getClient().perform(get("/api/authz/authorizations/search/object")
                 .param("uri", comUri)
-                .param("projection", "full")
+                .param("projection", "level")
                 .param("embedLevelDepth", "1")
                 .param("feature", alwaysTrue.getName()))
                 .andExpect(status().isOk())

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationRestRepositoryIT.java
@@ -7,8 +7,12 @@
  */
 package org.dspace.app.rest;
 
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -982,94 +986,153 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
         String adminToken = getAuthToken(admin.getEmail(), password);
 
         // verify that it works for administrators - with eperson parameter
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", comUri)
-                .param("projection", "level")
+                .param("projection", "full")
                 .param("embedLevelDepth", "1")
                 .param("feature", alwaysTrue.getName())
                 .param("eperson", admin.getID().toString()))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.type", is("authorization")))
-            .andExpect(jsonPath("$._embedded.feature.id", is(alwaysTrue.getName())))
-            .andExpect(jsonPath("$.id", Matchers.is(admin.getID().toString() + "_" + alwaysTrue.getName() + "_"
-                    + comRest.getUniqueType() + "_" + comRest.getId())));
+            .andExpect(jsonPath("$.page.totalElements", is(1)))
+            .andExpect(jsonPath("$._embedded.authorizations", contains(
+                    allOf(
+                            hasJsonPath("$.id", is(admin.getID().toString() + "_" + alwaysTrue.getName() + "_"
+                                    + comRest.getUniqueType() + "_" + comRest.getId())),
+                            hasJsonPath("$.type", is("authorization")),
+                            hasJsonPath("$._embedded.feature.id", is(alwaysTrue.getName())),
+                            hasJsonPath("$._embedded.eperson.id", is(admin.getID().toString()))
+                    )
+            )));
 
         // verify that it works for administrators - without eperson parameter
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", comUri)
-                .param("projection", "level")
+                .param("projection", "full")
                 .param("embedLevelDepth", "1")
                 .param("feature", alwaysTrue.getName()))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.type", is("authorization")))
-            .andExpect(jsonPath("$._embedded.feature.id", is(alwaysTrue.getName())))
-            .andExpect(jsonPath("$.id", Matchers.is(admin.getID().toString() + "_" + alwaysTrue.getName() + "_"
-                    + comRest.getUniqueType() + "_" + comRest.getId())));
+            .andExpect(jsonPath("$.page.totalElements", is(1)))
+            .andExpect(jsonPath("$._embedded.authorizations", contains(
+                allOf(
+                    hasJsonPath("$.id", is(
+                            admin.getID().toString() + "_"
+                                    + alwaysTrue.getName() + "_"
+                                    + comRest.getUniqueType() + "_" + comRest.getId()
+                    )),
+                    hasJsonPath("$.type", is("authorization")),
+                    hasJsonPath("$._embedded.feature.id", is(alwaysTrue.getName())),
+                    hasJsonPath("$._embedded.eperson.id", is(admin.getID().toString()))
+                )
+            )));
 
         String epersonToken = getAuthToken(eperson.getEmail(), password);
 
         // verify that it works for normal loggedin users - with eperson parameter
-        getClient(epersonToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(epersonToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", comUri)
-                .param("projection", "level")
+                .param("projection", "full")
                 .param("embedLevelDepth", "1")
                 .param("feature", alwaysTrue.getName())
                 .param("eperson", eperson.getID().toString()))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.type", is("authorization")))
-            .andExpect(jsonPath("$._embedded.feature.id", is(alwaysTrue.getName())))
-            .andExpect(jsonPath("$.id", Matchers.is(eperson.getID().toString() + "_" + alwaysTrue.getName() + "_"
-                    + comRest.getUniqueType() + "_" + comRest.getId())));
+                .andExpect(jsonPath("$.page.totalElements", is(1)))
+                .andExpect(jsonPath("$._embedded.authorizations", contains(
+                        allOf(
+                                hasJsonPath("$.id", is(
+                                        eperson.getID().toString() + "_"
+                                                + alwaysTrue.getName() + "_"
+                                                + comRest.getUniqueType() + "_" + comRest.getId()
+                                )),
+                                hasJsonPath("$.type", is("authorization")),
+                                hasJsonPath("$._embedded.feature.id", is(alwaysTrue.getName())),
+                                hasJsonPath("$._embedded.eperson.id", is(eperson.getID().toString()))
+                        )
+                )));
 
         // verify that it works for normal loggedin users - without eperson parameter
-        getClient(epersonToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(epersonToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", comUri)
-                .param("projection", "level")
+                .param("projection", "full")
                 .param("embedLevelDepth", "1")
                 .param("feature", alwaysTrue.getName()))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.type", is("authorization")))
-            .andExpect(jsonPath("$._embedded.feature.id", is(alwaysTrue.getName())))
-            .andExpect(jsonPath("$.id", Matchers.is(eperson.getID().toString() + "_" + alwaysTrue.getName() + "_"
-                    + comRest.getUniqueType() + "_" + comRest.getId())));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements", is(1)))
+                .andExpect(jsonPath("$._embedded.authorizations", contains(
+                        allOf(
+                                hasJsonPath("$.id", is(
+                                        eperson.getID().toString() + "_"
+                                                + alwaysTrue.getName() + "_"
+                                                + comRest.getUniqueType() + "_" + comRest.getId()
+                                )),
+                                hasJsonPath("$.type", is("authorization")),
+                                hasJsonPath("$._embedded.feature.id", is(alwaysTrue.getName())),
+                                hasJsonPath("$._embedded.eperson.id", is(eperson.getID().toString()))
+                        )
+                )));
 
         // verify that it works for administators inspecting other users - by using the eperson parameter
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", comUri)
-                .param("projection", "level")
+                .param("projection", "full")
                 .param("embedLevelDepth", "1")
                 .param("feature", alwaysTrue.getName())
                 .param("eperson", eperson.getID().toString()))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.type", is("authorization")))
-            .andExpect(jsonPath("$._embedded.feature.id", is(alwaysTrue.getName())))
-            .andExpect(jsonPath("$.id", Matchers.is(eperson.getID().toString() + "_" + alwaysTrue.getName() + "_"
-                    + comRest.getUniqueType() + "_" + comRest.getId())));
+                .andExpect(jsonPath("$.page.totalElements", is(1)))
+                .andExpect(jsonPath("$._embedded.authorizations", contains(
+                        allOf(
+                                hasJsonPath("$.id", is(
+                                        eperson.getID().toString() + "_"
+                                                + alwaysTrue.getName() + "_"
+                                                + comRest.getUniqueType() + "_" + comRest.getId()
+                                )),
+                                hasJsonPath("$.type", is("authorization")),
+                                hasJsonPath("$._embedded.feature.id", is(alwaysTrue.getName())),
+                                hasJsonPath("$._embedded.eperson.id", is(eperson.getID().toString()))
+                        )
+                )));
 
         // verify that it works for administators inspecting other users - by assuming login
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", comUri)
-                .param("projection", "level")
+                .param("projection", "full")
                 .param("embedLevelDepth", "1")
                 .param("feature", alwaysTrue.getName())
                 .header("X-On-Behalf-Of", eperson.getID()))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.type", is("authorization")))
-            .andExpect(jsonPath("$._embedded.feature.id", is(alwaysTrue.getName())))
-            .andExpect(jsonPath("$.id", Matchers.is(eperson.getID().toString() + "_" + alwaysTrue.getName() + "_"
-                    + comRest.getUniqueType() + "_" + comRest.getId())));
+                .andExpect(jsonPath("$.page.totalElements", is(1)))
+                .andExpect(jsonPath("$._embedded.authorizations", contains(
+                        allOf(
+                                hasJsonPath("$.id", is(
+                                        eperson.getID().toString() + "_"
+                                                + alwaysTrue.getName() + "_"
+                                                + comRest.getUniqueType() + "_" + comRest.getId()
+                                )),
+                                hasJsonPath("$.type", is("authorization")),
+                                hasJsonPath("$._embedded.feature.id", is(alwaysTrue.getName())),
+                                hasJsonPath("$._embedded.eperson.id", is(eperson.getID().toString()))
+                        )
+                )));
 
         // verify that it works for anonymous users
-        getClient().perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient().perform(get("/api/authz/authorizations/search/object")
                 .param("uri", comUri)
-                .param("projection", "level")
+                .param("projection", "full")
                 .param("embedLevelDepth", "1")
                 .param("feature", alwaysTrue.getName()))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.type", is("authorization")))
-            .andExpect(jsonPath("$._embedded.feature.id", is(alwaysTrue.getName())))
-            .andExpect(jsonPath("$.id",Matchers.is(alwaysTrue.getName() + "_"
-                    + comRest.getUniqueType() + "_" + comRest.getId())));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements", is(1)))
+                .andExpect(jsonPath("$._embedded.authorizations", contains(
+                        allOf(
+                                hasJsonPath("$.id", is(
+                                        alwaysTrue.getName() + "_"
+                                                + comRest.getUniqueType() + "_" + comRest.getId()
+                                )),
+                                hasJsonPath("$.type", is("authorization")),
+                                hasJsonPath("$._embedded.feature.id", is(alwaysTrue.getName())),
+                                hasJsonPath("$._embedded.eperson", nullValue())
+                        )
+                )));
     }
 
     @Test
@@ -1086,52 +1149,52 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
         String adminToken = getAuthToken(admin.getEmail(), password);
 
         // verify that it works for administrators - with eperson parameter
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", alwaysFalse.getName())
                 .param("eperson", admin.getID().toString()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         // verify that it works for administrators - without eperson parameter
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", alwaysFalse.getName()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         String epersonToken = getAuthToken(eperson.getEmail(), password);
 
         // verify that it works for normal loggedin users - with eperson parameter
-        getClient(epersonToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(epersonToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", trueForAdmins.getName())
                 .param("eperson", eperson.getID().toString()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         // verify that it works for normal loggedin users - without eperson parameter
-        getClient(epersonToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(epersonToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", trueForAdmins.getName()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         // verify that it works for administators inspecting other users - by using the eperson parameter
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", trueForAdmins.getName())
                 .param("eperson", eperson.getID().toString()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         // verify that it works for administators inspecting other users - by assuming login
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", trueForAdmins.getName())
                 .header("X-On-Behalf-Of", eperson.getID()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         // verify that it works for anonymous users
-        getClient().perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient().perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", trueForLoggedUsers.getName()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 
     @Test
@@ -1153,98 +1216,99 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
         String adminToken = getAuthToken(admin.getEmail(), password);
 
         // verify that it works for administrators, no result - with eperson parameter
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", wrongSiteUri)
                 .param("feature", alwaysTrue.getName())
                 .param("eperson", admin.getID().toString()))
-            .andExpect(status().isNoContent());
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", "not-existing-feature")
                 .param("eperson", admin.getID().toString()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         // verify that it works for administrators, no result - without eperson parameter
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", wrongSiteUri)
                 .param("feature", alwaysTrue.getName()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", "not-existing-feature"))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         String epersonToken = getAuthToken(eperson.getEmail(), password);
 
         // verify that it works for normal loggedin users - with eperson parameter
-        getClient(epersonToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(epersonToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", wrongSiteUri)
                 .param("feature", alwaysTrue.getName())
                 .param("eperson", eperson.getID().toString()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
-        getClient(epersonToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(epersonToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", "not-existing-feature")
                 .param("eperson", eperson.getID().toString()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         // verify that it works for normal loggedin users - without eperson parameter
-        getClient(epersonToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(epersonToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", wrongSiteUri)
                 .param("feature", alwaysTrue.getName()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
-        getClient(epersonToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(epersonToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", "not-existing-feature"))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         // verify that it works for administators inspecting other users - by using the eperson parameter
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", wrongSiteUri)
                 .param("feature", alwaysTrue.getName())
                 .param("eperson", eperson.getID().toString()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", "not-existing-feature")
                 .param("eperson", eperson.getID().toString()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         // verify that it works for administators inspecting other users - by assuming login
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", wrongSiteUri)
                 .param("feature", alwaysTrue.getName())
                 .header("X-On-Behalf-Of", eperson.getID()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", "not-existing-feature")
                 .header("X-On-Behalf-Of", eperson.getID()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         // verify that it works for anonymous users
-        getClient().perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient().perform(get("/api/authz/authorizations/search/object")
                 .param("uri", wrongSiteUri)
                 .param("feature", alwaysTrue.getName()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
-        getClient().perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient().perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", "not-existing-feature"))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 
     @Test
     /**
      * Verify that the findByObject return the 400 Bad Request response for invalid or missing URI or feature (required
      * parameters)
-     * 
+     *
      * @throws Exception
      */
     public void findByObjectAndFeatureBadRequestTest() throws Exception {
@@ -1266,34 +1330,34 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
             log.debug("findByObjectAndFeatureBadRequestTest - Testing the URI: " + invalidUri);
 
             // verify that it works for administrators with an invalid or missing uri - with eperson parameter
-            getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+            getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                     .param("uri", invalidUri)
                     .param("feature", alwaysTrue.getName())
                     .param("eperson", admin.getID().toString()))
                 .andExpect(status().isBadRequest());
 
             // verify that it works for administrators with an invalid or missing uri - without eperson parameter
-            getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+            getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                     .param("uri", invalidUri)
                     .param("feature", alwaysTrue.getName()))
                 .andExpect(status().isBadRequest());
 
             // verify that it works for normal loggedin users with an invalid or missing uri - with eperson parameter
-            getClient(epersonToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+            getClient(epersonToken).perform(get("/api/authz/authorizations/search/object")
                     .param("uri", invalidUri)
                     .param("feature", alwaysTrue.getName())
                     .param("eperson", eperson.getID().toString()))
                 .andExpect(status().isBadRequest());
 
             // verify that it works for normal loggedin users with an invalid or missing uri - without eperson parameter
-            getClient(epersonToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+            getClient(epersonToken).perform(get("/api/authz/authorizations/search/object")
                     .param("uri", invalidUri)
                     .param("feature", alwaysTrue.getName()))
                 .andExpect(status().isBadRequest());
 
             // verify that it works for administators inspecting other users with an invalid or missing uri - by
             // using the eperson parameter
-            getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+            getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                     .param("uri", invalidUri)
                     .param("feature", alwaysTrue.getName())
                     .param("eperson", eperson.getID().toString()))
@@ -1301,51 +1365,18 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
 
             // verify that it works for administators inspecting other users with an invalid or missing uri - by
             // assuming login
-            getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+            getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                     .param("uri", invalidUri)
                     .param("feature", alwaysTrue.getName())
                     .header("X-On-Behalf-Of", eperson.getID()))
                 .andExpect(status().isBadRequest());
 
             // verify that it works for anonymous users with an invalid or missing uri
-            getClient().perform(get("/api/authz/authorizations/search/objectAndFeature")
+            getClient().perform(get("/api/authz/authorizations/search/object")
                     .param("uri", invalidUri)
                     .param("feature", alwaysTrue.getName()))
                 .andExpect(status().isBadRequest());
         }
-
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
-                .param("eperson", admin.getID().toString()))
-            .andExpect(status().isBadRequest());
-        getClient(epersonToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
-                .param("eperson", eperson.getID().toString()))
-            .andExpect(status().isBadRequest());
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
-                .param("eperson", eperson.getID().toString()))
-            .andExpect(status().isBadRequest());
-        getClient().perform(get("/api/authz/authorizations/search/objectAndFeature"))
-            .andExpect(status().isBadRequest());
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature"))
-            .andExpect(status().isBadRequest());
-
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
-                .param("uri", siteUri)
-                .param("eperson", admin.getID().toString()))
-            .andExpect(status().isBadRequest());
-        getClient(epersonToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
-                .param("uri", siteUri)
-                .param("eperson", eperson.getID().toString()))
-            .andExpect(status().isBadRequest());
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
-                .param("uri", siteUri)
-                .param("eperson", eperson.getID().toString()))
-            .andExpect(status().isBadRequest());
-        getClient().perform(get("/api/authz/authorizations/search/objectAndFeature")
-                .param("uri", siteUri))
-            .andExpect(status().isBadRequest());
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
-                .param("uri", siteUri.toString()))
-            .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -1363,28 +1394,28 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
         configurationService.setProperty("org.dspace.app.rest.authorization.AlwaysThrowExceptionFeature.turnoff", true);
 
         // verify that it works for an anonymous user inspecting an admin user - by using the eperson parameter
-        getClient().perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient().perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", alwaysTrue.getName())
                 .param("eperson", admin.getID().toString()))
             .andExpect(status().isUnauthorized());
 
         // verify that it works for an anonymous user inspecting an admin user - by assuming login
-        getClient().perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient().perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", alwaysTrue.getName())
                 .header("X-On-Behalf-Of", admin.getID()))
             .andExpect(status().isUnauthorized());
 
         // verify that it works for an anonymous user inspecting a normal user - by using the eperson parameter
-        getClient().perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient().perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", alwaysTrue.getName())
                 .param("eperson", eperson.getID().toString()))
             .andExpect(status().isUnauthorized());
 
         // verify that it works for an anonymous user inspecting a normal user - by assuming login
-        getClient().perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient().perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", alwaysTrue.getName())
                 .header("X-On-Behalf-Of", eperson.getID()))
@@ -1411,28 +1442,28 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
         String anotherToken = getAuthToken(anotherEperson.getEmail(), password);
 
         // verify that he cannot search the admin authorizations - by using the eperson parameter
-        getClient(anotherToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(anotherToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", alwaysTrue.getName())
                 .param("eperson", admin.getID().toString()))
             .andExpect(status().isForbidden());
 
         // verify that he cannot search the admin authorizations - by assuming login
-        getClient(anotherToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(anotherToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", alwaysTrue.getName())
                 .header("X-On-Behalf-Of", admin.getID()))
             .andExpect(status().isForbidden());
 
         // verify that he cannot search the authorizations of another "normal" eperson - by using the eperson parameter
-        getClient(anotherToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(anotherToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", alwaysTrue.getName())
                 .param("eperson", eperson.getID().toString()))
             .andExpect(status().isForbidden());
 
         // verify that he cannot search the authorizations of another "normal" eperson - by assuming login
-        getClient(anotherToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(anotherToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", alwaysTrue.getName())
                 .header("X-On-Behalf-Of", eperson.getID()))
@@ -1452,14 +1483,14 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
         String adminToken = getAuthToken(admin.getEmail(), password);
 
         // verify that it works for administrators - with eperson parameter
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", alwaysException.getName())
                 .param("eperson", admin.getID().toString()))
             .andExpect(status().isInternalServerError());
 
         // verify that it works for administrators - without eperson parameter
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", alwaysException.getName()))
             .andExpect(status().isInternalServerError());
@@ -1467,20 +1498,20 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
         String epersonToken = getAuthToken(eperson.getEmail(), password);
 
         // verify that it works for normal loggedin users - with eperson parameter
-        getClient(epersonToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(epersonToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", alwaysException.getName())
                 .param("eperson", eperson.getID().toString()))
             .andExpect(status().isInternalServerError());
 
         // verify that it works for normal loggedin users - without eperson parameter
-        getClient(epersonToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(epersonToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", alwaysException.getName()))
             .andExpect(status().isInternalServerError());
 
         // verify that it works for anonymous users
-        getClient().perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient().perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", alwaysException.getName()))
             .andExpect(status().isInternalServerError());
@@ -1520,31 +1551,31 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
         // check both via direct access than via a search method
         getClient(adminToken).perform(get("/api/authz/authorizations/" + authAdminSite.getID()))
             .andExpect(status().isNotFound());
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", trueForUsersInGroupTest.getName())
                 .param("eperson", admin.getID().toString()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
         // nor the normal user both directly than if checked by the admin
         getClient(adminToken).perform(get("/api/authz/authorizations/" + authNormalUserSite.getID()))
             .andExpect(status().isNotFound());
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", trueForUsersInGroupTest.getName())
                 .param("eperson", normalUser.getID().toString()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
         getClient(normalUserToken).perform(get("/api/authz/authorizations/" + authNormalUserSite.getID()))
             .andExpect(status().isNotFound());
-        getClient(normalUserToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(normalUserToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", trueForUsersInGroupTest.getName())
                 .param("eperson", normalUser.getID().toString()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         // instead the member user has
         getClient(adminToken).perform(get("/api/authz/authorizations/" + authMemberSite.getID()))
             .andExpect(status().isOk());
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", trueForUsersInGroupTest.getName())
                 .param("eperson", memberOfTestGroup.getID().toString()))
@@ -1552,7 +1583,7 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
         // so it can also check itself the permission
         getClient(memberToken).perform(get("/api/authz/authorizations/" + authMemberSite.getID()))
             .andExpect(status().isOk());
-        getClient(memberToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(memberToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", trueForUsersInGroupTest.getName())
                 .param("eperson", memberOfTestGroup.getID().toString()))
@@ -1568,7 +1599,7 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
         // our admin now should have the authorization
         getClient(adminToken).perform(get("/api/authz/authorizations/" + authAdminSite.getID()))
             .andExpect(status().isOk());
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", trueForUsersInGroupTest.getName())
                 .param("eperson", admin.getID().toString()))
@@ -1576,15 +1607,15 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
         // our normal user when checked via the admin should still not have the authorization
         getClient(adminToken).perform(get("/api/authz/authorizations/" + authNormalUserSite.getID()))
             .andExpect(status().isNotFound());
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", trueForUsersInGroupTest.getName())
                 .param("eperson", normalUser.getID().toString()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
         // but he should have the authorization if loggedin directly
         getClient(normalUserToken).perform(get("/api/authz/authorizations/" + authNormalUserSite.getID()))
             .andExpect(status().isOk());
-        getClient(normalUserToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(normalUserToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", trueForUsersInGroupTest.getName())
                 .param("eperson", normalUser.getID().toString()))
@@ -1592,14 +1623,14 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
         // for our direct member user we don't expect differences
         getClient(adminToken).perform(get("/api/authz/authorizations/" + authMemberSite.getID()))
             .andExpect(status().isOk());
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", trueForUsersInGroupTest.getName())
                 .param("eperson", memberOfTestGroup.getID().toString()))
             .andExpect(status().isOk());
         getClient(memberToken).perform(get("/api/authz/authorizations/" + authMemberSite.getID()))
             .andExpect(status().isOk());
-        getClient(memberToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(memberToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", trueForUsersInGroupTest.getName())
                 .param("eperson", memberOfTestGroup.getID().toString()))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/CCLicenseFeatureRestIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/CCLicenseFeatureRestIT.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.app.rest.authorization;
 
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -81,13 +83,14 @@ public class CCLicenseFeatureRestIT extends AbstractControllerIntegrationTest {
                     .andExpect(jsonPath("$",
                             Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminCCLicense))));
 
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", itemUri)
                 .param("eperson", admin.getID().toString())
                 .param("feature", ccLicenseFeature.getName()))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$",
-                    Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminCCLicense))));
+            .andExpect(jsonPath("$._embedded.authorizations", contains(
+                    Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminCCLicense))))
+            );
     }
 
     @Test
@@ -110,13 +113,14 @@ public class CCLicenseFeatureRestIT extends AbstractControllerIntegrationTest {
                     .andExpect(jsonPath("$",
                             Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminCCLicense))));
 
-        getClient(comAdminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(comAdminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", itemUri)
                 .param("eperson", eperson.getID().toString())
                 .param("feature", ccLicenseFeature.getName()))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$",
-                    Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminCCLicense))));
+            .andExpect(jsonPath("$._embedded.authorizations", contains(
+                    Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminCCLicense))))
+            );
 
         // verify that the property core.authorization.collection-admin.item-admin.cc-license = false is respected
         // the community admins should be still authorized
@@ -127,13 +131,14 @@ public class CCLicenseFeatureRestIT extends AbstractControllerIntegrationTest {
                 .andExpect(jsonPath("$",
                         Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminCCLicense))));
 
-        getClient(comAdminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(comAdminToken).perform(get("/api/authz/authorizations/search/object")
             .param("uri", itemUri)
             .param("eperson", eperson.getID().toString())
             .param("feature", ccLicenseFeature.getName()))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$",
-                Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminCCLicense))));
+        .andExpect(jsonPath("$._embedded.authorizations", contains(
+                Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminCCLicense))))
+        );
 
         // now verify that the property core.authorization.community-admin.item-admin.cc-license = false is respected
         // and also community admins are blocked
@@ -143,11 +148,11 @@ public class CCLicenseFeatureRestIT extends AbstractControllerIntegrationTest {
         getClient(comAdminToken).perform(get("/api/authz/authorizations/" + authAdminCCLicense.getID()))
                     .andExpect(status().isNotFound());
 
-        getClient(comAdminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(comAdminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", itemUri)
                 .param("eperson", eperson.getID().toString())
                 .param("feature", ccLicenseFeature.getName()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 
     @Test
@@ -170,24 +175,25 @@ public class CCLicenseFeatureRestIT extends AbstractControllerIntegrationTest {
                     .andExpect(jsonPath("$",
                             Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminCCLicense))));
 
-        getClient(colAdminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(colAdminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", itemUri)
                 .param("eperson", eperson.getID().toString())
                 .param("feature", ccLicenseFeature.getName()))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$",
-                    Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminCCLicense))));
+            .andExpect(jsonPath("$._embedded.authorizations", contains(
+                    Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminCCLicense))))
+            );
         // verify that the property core.authorization.collection-admin.item-admin.cc-license = false is respected
         configurationService.setProperty("core.authorization.item-admin.cc-license", false);
         configurationService.setProperty("core.authorization.collection-admin.item-admin.cc-license", false);
         getClient(colAdminToken).perform(get("/api/authz/authorizations/" + authAdminCCLicense.getID()))
                     .andExpect(status().isNotFound());
 
-        getClient(colAdminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(colAdminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", itemUri)
                 .param("eperson", eperson.getID().toString())
                 .param("feature", ccLicenseFeature.getName()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 
     @Test
@@ -211,23 +217,24 @@ public class CCLicenseFeatureRestIT extends AbstractControllerIntegrationTest {
                     .andExpect(jsonPath("$",
                             Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminCCLicense))));
 
-        getClient(itemAdminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(itemAdminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", itemUri)
                 .param("eperson", eperson.getID().toString())
                 .param("feature", ccLicenseFeature.getName()))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$",
-                    Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminCCLicense))));
+            .andExpect(jsonPath("$._embedded.authorizations", contains(
+                    Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminCCLicense))))
+            );
         // verify that the property core.authorization.item-admin.cc-license = false is respected
         configurationService.setProperty("core.authorization.item-admin.cc-license", false);
         getClient(itemAdminToken).perform(get("/api/authz/authorizations/" + authAdminCCLicense.getID()))
                     .andExpect(status().isNotFound());
 
-        getClient(itemAdminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(itemAdminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", itemUri)
                 .param("eperson", eperson.getID().toString())
                 .param("feature", ccLicenseFeature.getName()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 
     @Test
@@ -248,19 +255,19 @@ public class CCLicenseFeatureRestIT extends AbstractControllerIntegrationTest {
         getClient(epersonToken).perform(get("/api/authz/authorizations/" + authEpersonCCLicense.getID()))
                     .andExpect(status().isNotFound());
 
-        getClient(epersonToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(epersonToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", itemUri)
                 .param("eperson", eperson.getID().toString())
                 .param("feature", ccLicenseFeature.getName()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         // check the authorization for the anonymous user
         getClient().perform(get("/api/authz/authorizations/" + authAnonymousCCLicense.getID()))
                 .andExpect(status().isNotFound());
 
-        getClient().perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient().perform(get("/api/authz/authorizations/search/object")
             .param("uri", itemUri)
             .param("feature", ccLicenseFeature.getName()))
-        .andExpect(status().isNoContent());
+        .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/EPersonRegistrationFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/EPersonRegistrationFeatureIT.java
@@ -7,7 +7,10 @@
  */
 package org.dspace.app.rest.authorization;
 
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.dspace.app.rest.authorization.impl.EPersonRegistrationFeature;
@@ -63,10 +66,11 @@ public class EPersonRegistrationFeatureIT extends AbstractControllerIntegrationT
         String siteUri = utils.linkToSingleResource(SiteRest, "self").getHref();
 
 
-        getClient().perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient().perform(get("/api/authz/authorizations/search/object")
                                           .param("uri", siteUri)
                                           .param("feature", epersonRegistrationFeature.getName()))
-                             .andExpect(status().isOk());
+                             .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements", greaterThan(0)));
     }
 
     @Test
@@ -78,10 +82,11 @@ public class EPersonRegistrationFeatureIT extends AbstractControllerIntegrationT
 
         configurationService.setProperty("user.registration", false);
 
-        getClient().perform(get("/api/authz/authorizations/search/objectAndFeature")
-                                          .param("uri", siteUri)
-                                          .param("feature", epersonRegistrationFeature.getName()))
-                             .andExpect(status().isNoContent());
+        getClient().perform(get("/api/authz/authorizations/search/object")
+                .param("uri", siteUri)
+                .param("feature", epersonRegistrationFeature.getName()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements", is(0)));
 
     }
 
@@ -94,18 +99,20 @@ public class EPersonRegistrationFeatureIT extends AbstractControllerIntegrationT
         String siteUri = utils.linkToSingleResource(SiteRest, "self").getHref();
 
 
-        getClient().perform(get("/api/authz/authorizations/search/objectAndFeature")
-                                          .param("uri", siteUri)
-                                          .param("feature", epersonRegistrationFeature.getName()))
-                             .andExpect(status().isOk());
+        getClient().perform(get("/api/authz/authorizations/search/object")
+                .param("uri", siteUri)
+                .param("feature", epersonRegistrationFeature.getName()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements", greaterThan(0)));
 
         //Enable Shibboleth and password login
         configurationService.setProperty("plugin.sequence.org.dspace.authenticate.AuthenticationMethod", SHIB_ONLY);
 
-        getClient().perform(get("/api/authz/authorizations/search/objectAndFeature")
-                                          .param("uri", siteUri)
-                                          .param("feature", epersonRegistrationFeature.getName()))
-                             .andExpect(status().isNoContent());
+        getClient().perform(get("/api/authz/authorizations/search/object")
+                .param("uri", siteUri)
+                .param("feature", epersonRegistrationFeature.getName()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements", is(0)));
 
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/LoginOnBehalfOfFeatureRestIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/LoginOnBehalfOfFeatureRestIT.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.app.rest.authorization;
 
+import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -101,8 +102,7 @@ public class LoginOnBehalfOfFeatureRestIT extends AbstractControllerIntegrationT
                                      .param("eperson", String.valueOf(admin.getID()))
                                      .param("feature", loginOnBehalfOf.getName()))
                         .andExpect(status().isOk())
-                        .andExpect(jsonPath("$._embedded.authorizations", Matchers.not(Matchers.hasItem(
-                            AuthorizationMatcher.matchAuthorization(loginOnBehalfOfAuthorization)))));
+                        .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 
     @Test
@@ -122,8 +122,7 @@ public class LoginOnBehalfOfFeatureRestIT extends AbstractControllerIntegrationT
                                      .param("eperson", String.valueOf(eperson.getID()))
                                      .param("feature", loginOnBehalfOf.getName()))
                         .andExpect(status().isOk())
-                        .andExpect(jsonPath("$._embedded.authorizations", Matchers.not(
-                            Matchers.hasItem(AuthorizationMatcher.matchAuthorization(loginOnBehalfOfAuthorization)))));
+                        .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 
     @Test
@@ -143,8 +142,7 @@ public class LoginOnBehalfOfFeatureRestIT extends AbstractControllerIntegrationT
                                      .param("eperson", String.valueOf(eperson.getID()))
                                      .param("feature", loginOnBehalfOf.getName()))
                         .andExpect(status().isOk())
-                        .andExpect(jsonPath("$._embedded.authorizations", Matchers.not(
-                            Matchers.hasItem(AuthorizationMatcher.matchAuthorization(loginOnBehalfOfAuthorization)))));
+                        .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 
     @Test
@@ -164,7 +162,6 @@ public class LoginOnBehalfOfFeatureRestIT extends AbstractControllerIntegrationT
                                      .param("eperson", String.valueOf(admin.getID()))
                                      .param("feature", loginOnBehalfOf.getName()))
                         .andExpect(status().isOk())
-                        .andExpect(jsonPath("$._embedded.authorizations", Matchers.not(
-                            Matchers.hasItem(AuthorizationMatcher.matchAuthorization(loginOnBehalfOfAuthorization)))));
+                        .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ReinstateFeatureRestIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ReinstateFeatureRestIT.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.app.rest.authorization;
 
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -82,13 +84,14 @@ public class ReinstateFeatureRestIT extends AbstractControllerIntegrationTest {
                     .andExpect(jsonPath("$",
                             Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))));
 
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", itemUri)
                 .param("eperson", admin.getID().toString())
                 .param("feature", reinstateFeature.getName()))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$",
-                    Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))));
+            .andExpect(jsonPath("$._embedded.authorizations", contains(
+                    Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))))
+            );
     }
 
     @Test
@@ -111,13 +114,14 @@ public class ReinstateFeatureRestIT extends AbstractControllerIntegrationTest {
                     .andExpect(jsonPath("$",
                             Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))));
 
-        getClient(comAdminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(comAdminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", itemUri)
                 .param("eperson", eperson.getID().toString())
                 .param("feature", reinstateFeature.getName()))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$",
-                    Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))));
+            .andExpect(jsonPath("$._embedded.authorizations", contains(
+                    Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))))
+            );
 
         // verify that the property core.authorization.collection-admin.item.reinstatiate = false is respected
         // the community admins should be still authorized
@@ -127,13 +131,14 @@ public class ReinstateFeatureRestIT extends AbstractControllerIntegrationTest {
                 .andExpect(jsonPath("$",
                         Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))));
 
-        getClient(comAdminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(comAdminToken).perform(get("/api/authz/authorizations/search/object")
             .param("uri", itemUri)
             .param("eperson", eperson.getID().toString())
             .param("feature", reinstateFeature.getName()))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$",
-                Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))));
+        .andExpect(jsonPath("$._embedded.authorizations", contains(
+                Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))))
+        );
 
         // now verify that the property core.authorization.community-admin.item.reinstatiate = false is respected
         // and also community admins are blocked
@@ -143,11 +148,11 @@ public class ReinstateFeatureRestIT extends AbstractControllerIntegrationTest {
         getClient(comAdminToken).perform(get("/api/authz/authorizations/" + authAdminWithdraw.getID()))
                     .andExpect(status().isNotFound());
 
-        getClient(comAdminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(comAdminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", itemUri)
                 .param("eperson", eperson.getID().toString())
                 .param("feature", reinstateFeature.getName()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 
     @Test
@@ -170,23 +175,24 @@ public class ReinstateFeatureRestIT extends AbstractControllerIntegrationTest {
                     .andExpect(jsonPath("$",
                             Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))));
 
-        getClient(colAdminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(colAdminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", itemUri)
                 .param("eperson", eperson.getID().toString())
                 .param("feature", reinstateFeature.getName()))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$",
-                    Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))));
+            .andExpect(jsonPath("$._embedded.authorizations", contains(
+                    Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))))
+            );
         // verify that the property core.authorization.collection-admin.item.reinstatiate = false is respected
         configurationService.setProperty("core.authorization.collection-admin.item.reinstatiate", false);
         getClient(colAdminToken).perform(get("/api/authz/authorizations/" + authAdminWithdraw.getID()))
                     .andExpect(status().isNotFound());
 
-        getClient(colAdminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(colAdminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", itemUri)
                 .param("eperson", eperson.getID().toString())
                 .param("feature", reinstateFeature.getName()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 
     @Test
@@ -207,20 +213,20 @@ public class ReinstateFeatureRestIT extends AbstractControllerIntegrationTest {
         getClient(epersonToken).perform(get("/api/authz/authorizations/" + authEpersonWithdraw.getID()))
                     .andExpect(status().isNotFound());
 
-        getClient(epersonToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(epersonToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", itemUri)
                 .param("eperson", eperson.getID().toString())
                 .param("feature", reinstateFeature.getName()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         // check the authorization for the anonymous user
         getClient().perform(get("/api/authz/authorizations/" + authAnonymousWithdraw.getID()))
                 .andExpect(status().isNotFound());
 
-        getClient().perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient().perform(get("/api/authz/authorizations/search/object")
             .param("uri", itemUri)
             .param("feature", reinstateFeature.getName()))
-        .andExpect(status().isNoContent());
+        .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 
     @Test
@@ -251,28 +257,28 @@ public class ReinstateFeatureRestIT extends AbstractControllerIntegrationTest {
         getClient(adminToken).perform(get("/api/authz/authorizations/" + authWithdrawnItem.getID()))
                     .andExpect(status().isNotFound());
 
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", archivedItemUri)
                 .param("eperson", eperson.getID().toString())
                 .param("feature", reinstateFeature.getName()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         getClient(adminToken).perform(get("/api/authz/authorizations/" + authWsItem.getID()))
             .andExpect(status().isNotFound());
 
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", wsItemUri)
                 .param("eperson", eperson.getID().toString())
                 .param("feature", reinstateFeature.getName()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         getClient(adminToken).perform(get("/api/authz/authorizations/" + authWFItem.getID()))
             .andExpect(status().isNotFound());
 
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", wfItemUri)
                 .param("eperson", eperson.getID().toString())
                 .param("feature", reinstateFeature.getName()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/WithdrawFeatureRestIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/WithdrawFeatureRestIT.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.app.rest.authorization;
 
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -82,13 +84,14 @@ public class WithdrawFeatureRestIT extends AbstractControllerIntegrationTest {
                     .andExpect(jsonPath("$",
                             Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))));
 
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", itemUri)
                 .param("eperson", admin.getID().toString())
                 .param("feature", withdrawFeature.getName()))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$",
-                    Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))));
+            .andExpect(jsonPath("$._embedded.authorizations", contains(
+                    Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))))
+            );
     }
 
     @Test
@@ -111,13 +114,14 @@ public class WithdrawFeatureRestIT extends AbstractControllerIntegrationTest {
                     .andExpect(jsonPath("$",
                             Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))));
 
-        getClient(comAdminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(comAdminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", itemUri)
                 .param("eperson", eperson.getID().toString())
                 .param("feature", withdrawFeature.getName()))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$",
-                    Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))));
+            .andExpect(jsonPath("$._embedded.authorizations", contains(
+                    Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))))
+            );
 
         // verify that the property core.authorization.collection-admin.item.withdraw = false is respected
         // the community admins should be still authorized
@@ -127,13 +131,14 @@ public class WithdrawFeatureRestIT extends AbstractControllerIntegrationTest {
                 .andExpect(jsonPath("$",
                         Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))));
 
-        getClient(comAdminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(comAdminToken).perform(get("/api/authz/authorizations/search/object")
             .param("uri", itemUri)
             .param("eperson", eperson.getID().toString())
             .param("feature", withdrawFeature.getName()))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$",
-                Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))));
+        .andExpect(jsonPath("$._embedded.authorizations", contains(
+                Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))))
+        );
 
         // now verify that the property core.authorization.community-admin.item.withdraw = false is respected
         // and also community admins are blocked
@@ -143,11 +148,11 @@ public class WithdrawFeatureRestIT extends AbstractControllerIntegrationTest {
         getClient(comAdminToken).perform(get("/api/authz/authorizations/" + authAdminWithdraw.getID()))
                     .andExpect(status().isNotFound());
 
-        getClient(comAdminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(comAdminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", itemUri)
                 .param("eperson", eperson.getID().toString())
                 .param("feature", withdrawFeature.getName()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 
     @Test
@@ -170,23 +175,24 @@ public class WithdrawFeatureRestIT extends AbstractControllerIntegrationTest {
                     .andExpect(jsonPath("$",
                             Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))));
 
-        getClient(colAdminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(colAdminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", itemUri)
                 .param("eperson", eperson.getID().toString())
                 .param("feature", withdrawFeature.getName()))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$",
-                    Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))));
+            .andExpect(jsonPath("$._embedded.authorizations", contains(
+                    Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))))
+            );
         // verify that the property core.authorization.collection-admin.item.withdraw = false is respected
         configurationService.setProperty("core.authorization.collection-admin.item.withdraw", false);
         getClient(colAdminToken).perform(get("/api/authz/authorizations/" + authAdminWithdraw.getID()))
                     .andExpect(status().isNotFound());
 
-        getClient(colAdminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(colAdminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", itemUri)
                 .param("eperson", eperson.getID().toString())
                 .param("feature", withdrawFeature.getName()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 
     @Test
@@ -207,20 +213,20 @@ public class WithdrawFeatureRestIT extends AbstractControllerIntegrationTest {
         getClient(epersonToken).perform(get("/api/authz/authorizations/" + authEpersonWithdraw.getID()))
                     .andExpect(status().isNotFound());
 
-        getClient(epersonToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(epersonToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", itemUri)
                 .param("eperson", eperson.getID().toString())
                 .param("feature", withdrawFeature.getName()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         // check the authorization for the anonymous user
         getClient().perform(get("/api/authz/authorizations/" + authAnonymousWithdraw.getID()))
                 .andExpect(status().isNotFound());
 
-        getClient().perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient().perform(get("/api/authz/authorizations/search/object")
             .param("uri", itemUri)
             .param("feature", withdrawFeature.getName()))
-        .andExpect(status().isNoContent());
+        .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 
     @Test
@@ -252,28 +258,28 @@ public class WithdrawFeatureRestIT extends AbstractControllerIntegrationTest {
         getClient(adminToken).perform(get("/api/authz/authorizations/" + authWithdrawnItem.getID()))
                     .andExpect(status().isNotFound());
 
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", withdrawnItemUri)
                 .param("eperson", eperson.getID().toString())
                 .param("feature", withdrawFeature.getName()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         getClient(adminToken).perform(get("/api/authz/authorizations/" + authWsItem.getID()))
             .andExpect(status().isNotFound());
 
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", wsItemUri)
                 .param("eperson", eperson.getID().toString())
                 .param("feature", withdrawFeature.getName()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         getClient(adminToken).perform(get("/api/authz/authorizations/" + authWFItem.getID()))
             .andExpect(status().isNotFound());
 
-        getClient(adminToken).perform(get("/api/authz/authorizations/search/objectAndFeature")
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", wfItemUri)
                 .param("eperson", eperson.getID().toString())
                 .param("feature", withdrawFeature.getName()))
-            .andExpect(status().isNoContent());
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 }


### PR DESCRIPTION
## References
* Fixes [GitHub issue](https://github.com/DSpace/DSpace/issues/2829)

## Description
This PR ensures the feature parameter is always read and https://github.com/DSpace/Rest7Contract/blob/main/authorizations.md#object is implemented correctly

## Instructions for Reviewers
This can be verified by testing https://github.com/DSpace/Rest7Contract/blob/main/authorizations.md#object with and without the feature parameter

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
