### PR TITLE
Re-enable automated CSRF Protection in Spring Security for Server Webapp

### DIFF
--- a/dspace-api/src/test/java/org/dspace/builder/util/AbstractBuilderCleanupUtil.java
+++ b/dspace-api/src/test/java/org/dspace/builder/util/AbstractBuilderCleanupUtil.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import org.dspace.builder.AbstractBuilder;
 import org.dspace.builder.BitstreamBuilder;
 import org.dspace.builder.BitstreamFormatBuilder;
+import org.dspace.builder.BundleBuilder;
 import org.dspace.builder.ClaimedTaskBuilder;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
@@ -28,6 +29,7 @@ import org.dspace.builder.PoolTaskBuilder;
 import org.dspace.builder.ProcessBuilder;
 import org.dspace.builder.RelationshipBuilder;
 import org.dspace.builder.RelationshipTypeBuilder;
+import org.dspace.builder.ResourcePolicyBuilder;
 import org.dspace.builder.SiteBuilder;
 import org.dspace.builder.WorkflowItemBuilder;
 import org.dspace.builder.WorkspaceItemBuilder;
@@ -43,9 +45,13 @@ public class AbstractBuilderCleanupUtil {
             = new LinkedHashMap<>();
 
     /**
-     * Constructor that will initialize the Map with a predefined order for deletion
+     * Constructor that will initialize the Map with a predefined order for deletion.
+     * <P>
+     * Objects are deleted top-to-bottom in this Map. Objects that need to be removed *first*
+     * should appear at the top. Objects that may be deleted later, appear at the bottom.
      */
     public AbstractBuilderCleanupUtil() {
+        map.put(ResourcePolicyBuilder.class.getName(), new LinkedList<>());
         map.put(RelationshipBuilder.class.getName(), new LinkedList<>());
         map.put(RelationshipTypeBuilder.class.getName(), new LinkedList<>());
         map.put(EntityTypeBuilder.class.getName(), new LinkedList<>());
@@ -59,6 +65,7 @@ public class AbstractBuilderCleanupUtil {
         map.put(CommunityBuilder.class.getName(), new LinkedList<>());
         map.put(EPersonBuilder.class.getName(), new LinkedList<>());
         map.put(GroupBuilder.class.getName(), new LinkedList<>());
+        map.put(BundleBuilder.class.getName(), new LinkedList<>());
         map.put(ItemBuilder.class.getName(), new LinkedList<>());
         map.put(MetadataFieldBuilder.class.getName(), new LinkedList<>());
         map.put(MetadataSchemaBuilder.class.getName(), new LinkedList<>());

--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -407,8 +407,7 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
-            <!-- Must be kept in sync with version of Spring Security used by Spring Boot -->
-            <version>5.2.2.RELEASE</version>
+            <version>${spring-security.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -405,6 +405,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <!-- Must be kept in sync with version of Spring Security used by Spring Boot -->
+            <version>5.2.2.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
             <version>${json-path.version}</version>

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/Application.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/Application.java
@@ -154,7 +154,7 @@ public class Application extends SpringBootServletInitializer {
                             // Allow list of request preflight headers allowed to be sent to us from the client
                             .allowedHeaders("Authorization", "Content-Type", "X-Requested-With", "accept", "Origin",
                                             "Access-Control-Request-Method", "Access-Control-Request-Headers",
-                                            "X-On-Behalf-Of")
+                                            "X-On-Behalf-Of", "X-XSRF-TOKEN")
                             // Allow list of response headers allowed to be sent by us (the server)
                             .exposedHeaders("Access-Control-Allow-Origin", "Access-Control-Allow-Credentials",
                                             "Authorization");

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/CrossSiteCookieCsrfTokenRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/CrossSiteCookieCsrfTokenRepository.java
@@ -1,0 +1,216 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.security;
+
+import java.util.UUID;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.HttpHeaders;
+
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.CsrfTokenRepository;
+import org.springframework.security.web.csrf.DefaultCsrfToken;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.WebUtils;
+
+/**
+ * This is a Spring Security CookieCsrfTokenRepository which supports
+ * cross-site cookies (i.e. SameSite=None).
+ * <P>
+ * This code was mostly borrowed from Spring Security's CookieCsrfTokenRepository
+ * https://github.com/spring-projects/spring-security/blob/5.2.x/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
+ * <P>
+ * Corresponding tests were also copied to CrossSiteCookieCsrfTokenRepositoryTest.
+ * <P>
+ * The only modification were to the saveToken() method below. See that method's JavaDocs.
+ * <P>
+ * NOTE: This class is TEMPORARY and should be REMOVED as soon as the "SameSite" attribute is supported by
+ * Spring Security's CookieCsrfTokenRepository. As soon as the below ticket is resolved & we upgrade Spring Security,
+ * then this custom class can be removed:
+ * https://github.com/spring-projects/spring-security/issues/7537
+ */
+public class CrossSiteCookieCsrfTokenRepository implements CsrfTokenRepository {
+    static final String DEFAULT_CSRF_COOKIE_NAME = "XSRF-TOKEN";
+
+    static final String DEFAULT_CSRF_PARAMETER_NAME = "_csrf";
+
+    static final String DEFAULT_CSRF_HEADER_NAME = "X-XSRF-TOKEN";
+
+    private String parameterName = DEFAULT_CSRF_PARAMETER_NAME;
+
+    private String headerName = DEFAULT_CSRF_HEADER_NAME;
+
+    private String cookieName = DEFAULT_CSRF_COOKIE_NAME;
+
+    private boolean cookieHttpOnly = true;
+
+    private String cookiePath;
+
+    private String cookieDomain;
+
+    public CrossSiteCookieCsrfTokenRepository() {
+    }
+
+    @Override
+    public CsrfToken generateToken(HttpServletRequest request) {
+        return new DefaultCsrfToken(this.headerName, this.parameterName,
+                                    createNewToken());
+    }
+
+    /**
+     * This is the only method modified for DSpace.  We changed this method to use ResponseCookie to build the
+     * cookie, so that we could hardcode the "SameSite" attribute to a value of "None". This allows for cross site
+     * XSRF-TOKEN cookies.
+     * @param token
+     * @param request
+     * @param response
+     */
+    @Override
+    public void saveToken(CsrfToken token, HttpServletRequest request,
+                          HttpServletResponse response) {
+        String tokenValue = token == null ? "" : token.getToken();
+        Cookie cookie = new Cookie(this.cookieName, tokenValue);
+        cookie.setSecure(request.isSecure());
+        if (this.cookiePath != null && !this.cookiePath.isEmpty()) {
+            cookie.setPath(this.cookiePath);
+        } else {
+            cookie.setPath(this.getRequestContext(request));
+        }
+        if (token == null) {
+            cookie.setMaxAge(0);
+        } else {
+            cookie.setMaxAge(-1);
+        }
+        cookie.setHttpOnly(cookieHttpOnly);
+        if (this.cookieDomain != null && !this.cookieDomain.isEmpty()) {
+            cookie.setDomain(this.cookieDomain);
+        }
+
+        // Custom: Turn the above Cookie into a ResponseCookie so that we can set "SameSite"
+        // & hardcode "SameSite=None" to allow this cookie to be used cross site.
+        ResponseCookie responseCookie = ResponseCookie.from(cookie.getName(), cookie.getValue())
+                                              .path(cookie.getPath()).maxAge(cookie.getMaxAge())
+                                              .domain(cookie.getDomain()).httpOnly(cookie.isHttpOnly())
+                                              .secure(cookie.getSecure()).sameSite("None").build();
+        // Write the ResponseCookie to the Set-Cookie header
+        response.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());
+    }
+
+    @Override
+    public CsrfToken loadToken(HttpServletRequest request) {
+        Cookie cookie = WebUtils.getCookie(request, this.cookieName);
+        if (cookie == null) {
+            return null;
+        }
+        String token = cookie.getValue();
+        if (!StringUtils.hasLength(token)) {
+            return null;
+        }
+        return new DefaultCsrfToken(this.headerName, this.parameterName, token);
+    }
+
+
+    /**
+     * Sets the name of the HTTP request parameter that should be used to provide a token.
+     *
+     * @param parameterName the name of the HTTP request parameter that should be used to
+     * provide a token
+     */
+    public void setParameterName(String parameterName) {
+        Assert.notNull(parameterName, "parameterName is not null");
+        this.parameterName = parameterName;
+    }
+
+    /**
+     * Sets the name of the HTTP header that should be used to provide the token.
+     *
+     * @param headerName the name of the HTTP header that should be used to provide the
+     * token
+     */
+    public void setHeaderName(String headerName) {
+        Assert.notNull(headerName, "headerName is not null");
+        this.headerName = headerName;
+    }
+
+    /**
+     * Sets the name of the cookie that the expected CSRF token is saved to and read from.
+     *
+     * @param cookieName the name of the cookie that the expected CSRF token is saved to
+     * and read from
+     */
+    public void setCookieName(String cookieName) {
+        Assert.notNull(cookieName, "cookieName is not null");
+        this.cookieName = cookieName;
+    }
+
+    /**
+     * Sets the HttpOnly attribute on the cookie containing the CSRF token.
+     * Defaults to <code>true</code>.
+     *
+     * @param cookieHttpOnly <code>true</code> sets the HttpOnly attribute, <code>false</code> does not set it
+     */
+    public void setCookieHttpOnly(boolean cookieHttpOnly) {
+        this.cookieHttpOnly = cookieHttpOnly;
+    }
+
+    private String getRequestContext(HttpServletRequest request) {
+        String contextPath = request.getContextPath();
+        return contextPath.length() > 0 ? contextPath : "/";
+    }
+
+    /**
+     * Factory method to conveniently create an instance that has
+     * {@link #setCookieHttpOnly(boolean)} set to false.
+     *
+     * @return an instance of CookieCsrfTokenRepository with
+     * {@link #setCookieHttpOnly(boolean)} set to false
+     */
+    public static CrossSiteCookieCsrfTokenRepository withHttpOnlyFalse() {
+        CrossSiteCookieCsrfTokenRepository result = new CrossSiteCookieCsrfTokenRepository();
+        result.setCookieHttpOnly(false);
+        return result;
+    }
+
+    private String createNewToken() {
+        return UUID.randomUUID().toString();
+    }
+
+    /**
+     * Set the path that the Cookie will be created with. This will override the default functionality which uses the
+     * request context as the path.
+     *
+     * @param path the path to use
+     */
+    public void setCookiePath(String path) {
+        this.cookiePath = path;
+    }
+
+    /**
+     * Get the path that the CSRF cookie will be set to.
+     *
+     * @return the path to be used.
+     */
+    public String getCookiePath() {
+        return this.cookiePath;
+    }
+
+    /**
+     * Sets the domain of the cookie that the expected CSRF token is saved to and read from.
+     *
+     * @since 5.2
+     * @param cookieDomain the domain of the cookie that the expected CSRF token is saved to
+     * and read from
+     */
+    public void setCookieDomain(String cookieDomain) {
+        this.cookieDomain = cookieDomain;
+    }
+
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/CrossSiteCookieCsrfTokenRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/CrossSiteCookieCsrfTokenRepository.java
@@ -94,12 +94,17 @@ public class CrossSiteCookieCsrfTokenRepository implements CsrfTokenRepository {
             cookie.setDomain(this.cookieDomain);
         }
 
-        // Custom: Turn the above Cookie into a ResponseCookie so that we can set "SameSite"
-        // & hardcode "SameSite=None" to allow this cookie to be used cross site.
+        // Custom: Turn the above Cookie into a ResponseCookie so that we can set "SameSite" attribute
+        // NOTE: ONLY set "SameSite=None" if cookie is also secure. Most modern browsers will block it otherwise.
+        // This means that DSpace MUST USE HTTPS if the UI is on a different domain then backend.
+        String sameSite = "";
+        if (cookie.getSecure()) {
+            sameSite = "None";
+        }
         ResponseCookie responseCookie = ResponseCookie.from(cookie.getName(), cookie.getValue())
                                               .path(cookie.getPath()).maxAge(cookie.getMaxAge())
                                               .domain(cookie.getDomain()).httpOnly(cookie.isHttpOnly())
-                                              .secure(cookie.getSecure()).sameSite("None").build();
+                                              .secure(cookie.getSecure()).sameSite(sameSite).build();
         // Write the ResponseCookie to the Set-Cookie header
         response.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.authentication.logout.HttpStatusReturningLogoutSuccessHandler;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 /**
@@ -78,9 +79,9 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
             .anonymous().authorities(ANONYMOUS_GRANT).and()
             //Wire up the HttpServletRequest with the current SecurityContext values
             .servletApi().and().cors().and()
-            //Disable CSRF as our API can be used by clients on an other domain, we are also protected against this,
-            // since we pass the token in a header
-            .csrf().disable()
+            //Enable CSRF protection with the CookieCsrfTokenRepository designed for Angular apps
+            // See https://docs.spring.io/spring-security/site/docs/current/reference/html5/#servlet-csrf
+            .csrf(csrf -> csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()))
             //Return 401 on authorization failures with a correct WWWW-Authenticate header
             .exceptionHandling().authenticationEntryPoint(
                     new DSpace401AuthenticationEntryPoint(restAuthenticationService))

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
@@ -24,7 +24,6 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.authentication.logout.HttpStatusReturningLogoutSuccessHandler;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
-import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfTokenRepository;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
@@ -152,7 +151,11 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
      * @return CookieCsrfTokenRepository with cookie path="/"
      */
     private CsrfTokenRepository getCsrfTokenRepository() {
-        CookieCsrfTokenRepository tokenRepository = CookieCsrfTokenRepository.withHttpOnlyFalse();
+        // We are using a *custom* CrossSiteCookieCsrfTokenRepository in which sets
+        // "SameSite=None" to allow this XSRF-TOKEN cookie to be used in cross site requests.
+        // This custom class should be REMOVED when this Spring Security ticket is resolved:
+        // https://github.com/spring-projects/spring-security/issues/7537
+        CrossSiteCookieCsrfTokenRepository tokenRepository = CrossSiteCookieCsrfTokenRepository.withHttpOnlyFalse();
         tokenRepository.setCookiePath("/");
         return tokenRepository;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
@@ -25,10 +25,11 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.authentication.logout.HttpStatusReturningLogoutSuccessHandler;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRepository;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 /**
- * Spring Security configuration for DSpace Spring Rest
+ * Spring Security configuration for DSpace Server Webapp
  *
  * @author Frederic Van Reet (frederic dot vanreet at atmire dot com)
  * @author Tom Desair (tom dot desair at atmire dot com)
@@ -78,10 +79,9 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
             //Anonymous requests should have the "ANONYMOUS" security grant
             .anonymous().authorities(ANONYMOUS_GRANT).and()
             //Wire up the HttpServletRequest with the current SecurityContext values
-            .servletApi().and().cors().and()
-            //Enable CSRF protection with the CookieCsrfTokenRepository designed for Angular apps
-            // See https://docs.spring.io/spring-security/site/docs/current/reference/html5/#servlet-csrf
-            .csrf(csrf -> csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()))
+            .servletApi().and()
+            //Enable CORS for Spring Security (see CORS settings in Application and ApplicationConfig)
+            .cors().and()
             //Return 401 on authorization failures with a correct WWWW-Authenticate header
             .exceptionHandling().authenticationEntryPoint(
                     new DSpace401AuthenticationEntryPoint(restAuthenticationService))
@@ -99,9 +99,17 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .permitAll()
             .and()
 
+            //Enable CSRF protection (only on /api/ URLs) with the CookieCsrfTokenRepository designed for Angular apps
+            // See https://docs.spring.io/spring-security/site/docs/current/reference/html5/#servlet-csrf
+            // While we primarily use JWT in headers, enabled CSRF protection because we also support JWT via Cookies
+            .antMatcher("/api/**")
+                .csrf().csrfTokenRepository(this.getCsrfTokenRepository())
+            .and()
+
             //Configure the URL patterns with their authentication requirements
             //Enable Spring Security authorization on /api/ URLs only
-            .antMatcher("/api/**").authorizeRequests()
+            .antMatcher("/api/**")
+                .authorizeRequests()
                 //Allow POST by anyone on the login endpoint
                 .antMatchers(HttpMethod.POST,"/api/authn/login").permitAll()
                 //TRACE, CONNECT, OPTIONS, HEAD
@@ -131,6 +139,22 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(AuthenticationManagerBuilder auth) throws Exception {
         auth.authenticationProvider(ePersonRestAuthenticationProvider);
+    }
+
+    /**
+     * Override the defaults of CookieCsrfTokenRepository to always set the Path to "/"
+     * <P>
+     * We use the CookieCsrfTokenRepository designed for Angular apps
+     * See https://docs.spring.io/spring-security/site/docs/current/reference/html5/#servlet-csrf
+     * <P>
+     * However, Angular *requires* the CSR cookie path to always be "/" or it will ignore it.
+     * See: https://stackoverflow.com/a/50511663
+     * @return CookieCsrfTokenRepository with cookie path="/"
+     */
+    private CsrfTokenRepository getCsrfTokenRepository() {
+        CookieCsrfTokenRepository tokenRepository = CookieCsrfTokenRepository.withHttpOnlyFalse();
+        tokenRepository.setCookiePath("/");
+        return tokenRepository;
     }
 
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/jwt/JWTTokenRestAuthenticationServiceImpl.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/jwt/JWTTokenRestAuthenticationServiceImpl.java
@@ -15,6 +15,7 @@ import java.util.List;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.HttpHeaders;
 
 import com.nimbusds.jose.JOSEException;
 import org.apache.commons.lang3.StringUtils;
@@ -32,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 /**
@@ -151,11 +153,12 @@ public class JWTTokenRestAuthenticationServiceImpl implements RestAuthentication
 
     @Override
     public void invalidateAuthenticationCookie(HttpServletResponse response) {
-        Cookie cookie = new Cookie(AUTHORIZATION_COOKIE, "");
-        cookie.setHttpOnly(true);
-        cookie.setMaxAge(0);
-        cookie.setSecure(true);
-        response.addCookie(cookie);
+        // Re-send the same cookie (as addTokenToResponse()) with no value and a Max-Age of 0 seconds
+        ResponseCookie cookie = ResponseCookie.from(AUTHORIZATION_COOKIE, "")
+                                              .maxAge(0).httpOnly(true).secure(true).sameSite("None").build();
+
+        // Write the cookie to the Set-Cookie header in order to send it
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 
     @Override
@@ -190,14 +193,28 @@ public class JWTTokenRestAuthenticationServiceImpl implements RestAuthentication
         return wwwAuthenticate.toString();
     }
 
-    private void addTokenToResponse(final HttpServletResponse response, final String token, final Boolean addCookie)
-            throws IOException {
+    /**
+     * Adds the Authentication token (JWT) to the response either in a header (default) or in a cookie.
+     * <P>
+     * If 'addCookie' is true, then the JWT is also added to a response cookie. This is primarily for support of auth
+     * plugins which _require_ cookie-based auth (e.g. Shibboleth). Note that this cookie can be used cross-site
+     * (i.e. SameSite=None), but cannot be used by Javascript (HttpOnly) including the Angular UI. It also will only be
+     * sent via HTTPS (Secure).
+     * <P>
+     * If 'addCookie' is false, then the JWT is only added in the Authorization header. This is recommended behavior
+     * as it is the most secure. For the UI (or any JS clients) the JWT must be sent in the Authorization header.
+     * @param response current response
+     * @param token the authentication token
+     * @param addCookie whether to send token in a cookie (true) or header (false)
+     */
+    private void addTokenToResponse(final HttpServletResponse response, final String token, final Boolean addCookie) {
         // we need authentication cookies because Shibboleth can't use the authentication headers due to the redirects
         if (addCookie) {
-            Cookie cookie = new Cookie(AUTHORIZATION_COOKIE, token);
-            cookie.setHttpOnly(true);
-            cookie.setSecure(true);
-            response.addCookie(cookie);
+            ResponseCookie cookie = ResponseCookie.from(AUTHORIZATION_COOKIE, token)
+                                                  .httpOnly(true).secure(true).sameSite("None").build();
+
+            // Write the cookie to the Set-Cookie header in order to send it
+            response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
         }
         response.setHeader(AUTHORIZATION_HEADER, String.format("%s %s", AUTHORIZATION_TYPE, token));
     }

--- a/dspace-server-webapp/src/main/webapp/index.html
+++ b/dspace-server-webapp/src/main/webapp/index.html
@@ -180,10 +180,10 @@
         <h3>Make a non-GET request</h3>
     </div>
 
-    <form class="non-safe" action="<%= href %>">
+    <form class="non-safe" action="<%= _.escape(href) %>">
         <div class="modal-body">
             <p>Target URI</p>
-            <input name="url" type="text" class="url" value="<%= href %>" />
+            <input name="url" type="text" class="url" value="<%= _.escape(href) %>" />
             <p>Method:</p>
             <input name="method" type="text" class="method" value="POST" />
             <p>Headers:</p>

--- a/dspace-server-webapp/src/main/webapp/js/hal/http/client.js
+++ b/dspace-server-webapp/src/main/webapp/js/hal/http/client.js
@@ -12,10 +12,30 @@ HAL.Http.Client = function(opts) {
     this.defaultHeaders = {'Accept': 'application/hal+json, application/json, */*; q=0.01'};
     var authorizationHeader = getAuthorizationHeader();
     authorizationHeader ? this.defaultHeaders.Authorization = authorizationHeader : '';
+    // If we find a CSRF header (in a cookie), send it back in X-XSRF-Token header
+    var csrfToken = getCSRFToken();
+    csrfToken ? this.defaultHeaders['X-XSRF-Token'] = csrfToken : '';
+    // Write all headers to console (for easy debugging)
     console.log(this.defaultHeaders);
     this.headers = this.defaultHeaders;
 };
 
+/**
+ * Get CSRF Token by parsing it out of the XSRF-TOKEN cookie sent by our DSpace server webapp
+ **/
+function getCSRFToken() {
+    var cookie = document.cookie.match('(^|;)\\s*' + 'XSRF-TOKEN' + '\\s*=\\s*([^;]+)');
+    if(cookie != undefined) {
+        return cookie.pop();
+    } else {
+        return undefined;
+    }
+}
+
+/**
+ * Get Authorization Header by parsing it out of the "MyHalBrowserToken" cookie.
+ * This cookie is set in login.html after a successful login occurs.
+ **/
 function getAuthorizationHeader() {
     var cookie = document.cookie.match('(^|;)\\s*' + 'MyHalBrowserToken' + '\\s*=\\s*([^;]+)');
     if(cookie != undefined) {

--- a/dspace-server-webapp/src/main/webapp/login.html
+++ b/dspace-server-webapp/src/main/webapp/login.html
@@ -98,6 +98,11 @@
         $.ajax({
           url : window.location.href.replace("login.html", "") + 'api/authn/login',
           type : 'POST',
+          beforeSend: function (xhr, settings) {
+               // If CSRF token found in cookie, send it back as X-XSRF-Token header
+               var csrfToken = getCSRFToken();
+               xhr.setRequestHeader('X-XSRF-Token', csrfToken ? csrfToken : '');
+          },
           success : successHandler,
           error : function(result, status, xhr) {
               if (result.status === 401) {
@@ -108,12 +113,11 @@
                       if (realms.length == 1){
                           var loc = /location="([^,]*)"/.exec(authenticate);
                           if (loc !== null && loc.length === 2) {
-                          document.location = loc[1];
+                              document.location = loc[1];
                           }
                       } else if (realms.length > 1){
                           for (var i = 0; i < realms.length; i++){
                               addLocationButton(realms[i], element);
-
                           }
                       }
                   }
@@ -134,6 +138,18 @@
             return string.charAt(0).toUpperCase() + string.slice(1);
         }
 
+       /**
+        * Get CSRF Token by parsing it out of the XSRF-TOKEN cookie sent by our DSpace server webapp
+        **/
+        function getCSRFToken() {
+            var cookie = document.cookie.match('(^|;)\\s*' + 'XSRF-TOKEN' + '\\s*=\\s*([^;]+)');
+            if(cookie != undefined) {
+                return cookie.pop();
+            } else {
+                return undefined;
+            }
+        }
+
         $("#login-form").submit(function(event) {
             event.preventDefault();
             $.ajax({
@@ -144,6 +160,11 @@
                 data: {
                     user: $("#username").val(),
                     password: $("#password").val()
+                },
+                beforeSend: function (xhr, settings) {
+                    // If CSRF token found in cookie, send it back as X-XSRF-Token header
+                    var csrfToken = getCSRFToken();
+                    xhr.setRequestHeader('X-XSRF-Token', csrfToken ? csrfToken : '');
                 },
                 success : successHandler,
                 error : function() {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/CrossSiteCookieCsrfTokenRepositoryTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/CrossSiteCookieCsrfTokenRepositoryTest.java
@@ -27,7 +27,7 @@ import org.springframework.security.web.csrf.CsrfToken;
  *
  * The only modifications are:
  *   - Updating these tests to use our custom CrossSiteCookieCsrfTokenRepository
- *   - Updating the saveToken() test, where we check for our custom SameSite attribute.
+ *   - Updating the saveTokenSecure() test, where we check for our custom SameSite attribute.
  */
 @RunWith(MockitoJUnitRunner.class)
 public class CrossSiteCookieCsrfTokenRepositoryTest {
@@ -85,12 +85,6 @@ public class CrossSiteCookieCsrfTokenRepositoryTest {
         assertThat(tokenCookie.getSecure()).isEqualTo(this.request.isSecure());
         assertThat(tokenCookie.getValue()).isEqualTo(token.getToken());
         assertThat(tokenCookie.isHttpOnly()).isEqualTo(true);
-        // DSpace Custom assert to verify SameSite attribute is set
-        // The Cookie class doesn't yet support SameSite, so we have to re-read
-        // the cookie from our headers, and check it.
-        List<String> headers = this.response.getHeaders(HttpHeaders.SET_COOKIE);
-        assertThat(headers.size()).isEqualTo(1);
-        assertThat(headers.get(0)).containsIgnoringCase("SameSite=None");
     }
 
     @Test
@@ -103,6 +97,12 @@ public class CrossSiteCookieCsrfTokenRepositoryTest {
             .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
 
         assertThat(tokenCookie.getSecure()).isTrue();
+        // DSpace Custom assert to verify SameSite attribute is set
+        // The Cookie class doesn't yet support SameSite, so we have to re-read
+        // the cookie from our headers, and check it.
+        List<String> headers = this.response.getHeaders(HttpHeaders.SET_COOKIE);
+        assertThat(headers.size()).isEqualTo(1);
+        assertThat(headers.get(0)).containsIgnoringCase("SameSite=None");
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/CrossSiteCookieCsrfTokenRepositoryTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/CrossSiteCookieCsrfTokenRepositoryTest.java
@@ -1,0 +1,287 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import javax.servlet.http.Cookie;
+import javax.ws.rs.core.HttpHeaders;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.web.csrf.CsrfToken;
+
+/**
+ * This is almost an exact copy of Spring Security's CookieCsrfTokenRepositoryTests
+ * https://github.com/spring-projects/spring-security/blob/5.2.x/web/src/test/java/org/springframework/security/web/csrf/CookieCsrfTokenRepositoryTests.java
+ *
+ * The only modifications are:
+ *   - Updating these tests to use our custom CrossSiteCookieCsrfTokenRepository
+ *   - Updating the saveToken() test, where we check for our custom SameSite attribute.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CrossSiteCookieCsrfTokenRepositoryTest {
+    CrossSiteCookieCsrfTokenRepository repository;
+    MockHttpServletResponse response;
+    MockHttpServletRequest request;
+
+    @Before
+    public void setup() {
+        this.repository = new CrossSiteCookieCsrfTokenRepository();
+        this.request = new MockHttpServletRequest();
+        this.response = new MockHttpServletResponse();
+        this.request.setContextPath("/context");
+    }
+
+    @Test
+    public void generateToken() {
+        CsrfToken generateToken = this.repository.generateToken(this.request);
+
+        assertThat(generateToken).isNotNull();
+        assertThat(generateToken.getHeaderName())
+            .isEqualTo(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_HEADER_NAME);
+        assertThat(generateToken.getParameterName())
+            .isEqualTo(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_PARAMETER_NAME);
+        assertThat(generateToken.getToken()).isNotEmpty();
+    }
+
+    @Test
+    public void generateTokenCustom() {
+        String headerName = "headerName";
+        String parameterName = "paramName";
+        this.repository.setHeaderName(headerName);
+        this.repository.setParameterName(parameterName);
+
+        CsrfToken generateToken = this.repository.generateToken(this.request);
+
+        assertThat(generateToken).isNotNull();
+        assertThat(generateToken.getHeaderName()).isEqualTo(headerName);
+        assertThat(generateToken.getParameterName()).isEqualTo(parameterName);
+        assertThat(generateToken.getToken()).isNotEmpty();
+    }
+
+    @Test
+    public void saveToken() {
+        CsrfToken token = this.repository.generateToken(this.request);
+        this.repository.saveToken(token, this.request, this.response);
+
+        Cookie tokenCookie = this.response
+            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+
+        assertThat(tokenCookie.getMaxAge()).isEqualTo(-1);
+        assertThat(tokenCookie.getName())
+            .isEqualTo(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+        assertThat(tokenCookie.getPath()).isEqualTo(this.request.getContextPath());
+        assertThat(tokenCookie.getSecure()).isEqualTo(this.request.isSecure());
+        assertThat(tokenCookie.getValue()).isEqualTo(token.getToken());
+        assertThat(tokenCookie.isHttpOnly()).isEqualTo(true);
+        // DSpace Custom assert to verify SameSite attribute is set
+        // The Cookie class doesn't yet support SameSite, so we have to re-read
+        // the cookie from our headers, and check it.
+        List<String> headers = this.response.getHeaders(HttpHeaders.SET_COOKIE);
+        assertThat(headers.size()).isEqualTo(1);
+        assertThat(headers.get(0)).containsIgnoringCase("SameSite=None");
+    }
+
+    @Test
+    public void saveTokenSecure() {
+        this.request.setSecure(true);
+        CsrfToken token = this.repository.generateToken(this.request);
+        this.repository.saveToken(token, this.request, this.response);
+
+        Cookie tokenCookie = this.response
+            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+
+        assertThat(tokenCookie.getSecure()).isTrue();
+    }
+
+    @Test
+    public void saveTokenNull() {
+        this.request.setSecure(true);
+        this.repository.saveToken(null, this.request, this.response);
+
+        Cookie tokenCookie = this.response
+            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+
+        assertThat(tokenCookie.getMaxAge()).isZero();
+        assertThat(tokenCookie.getName())
+            .isEqualTo(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+        assertThat(tokenCookie.getPath()).isEqualTo(this.request.getContextPath());
+        assertThat(tokenCookie.getSecure()).isEqualTo(this.request.isSecure());
+        assertThat(tokenCookie.getValue()).isEmpty();
+    }
+
+    @Test
+    public void saveTokenHttpOnlyTrue() {
+        this.repository.setCookieHttpOnly(true);
+        CsrfToken token = this.repository.generateToken(this.request);
+        this.repository.saveToken(token, this.request, this.response);
+
+        Cookie tokenCookie = this.response
+            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+
+        assertThat(tokenCookie.isHttpOnly()).isTrue();
+    }
+
+    @Test
+    public void saveTokenHttpOnlyFalse() {
+        this.repository.setCookieHttpOnly(false);
+        CsrfToken token = this.repository.generateToken(this.request);
+        this.repository.saveToken(token, this.request, this.response);
+
+        Cookie tokenCookie = this.response
+            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+
+        assertThat(tokenCookie.isHttpOnly()).isFalse();
+    }
+
+    @Test
+    public void saveTokenWithHttpOnlyFalse() {
+        this.repository = CrossSiteCookieCsrfTokenRepository.withHttpOnlyFalse();
+        CsrfToken token = this.repository.generateToken(this.request);
+        this.repository.saveToken(token, this.request, this.response);
+
+        Cookie tokenCookie = this.response
+            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+
+        assertThat(tokenCookie.isHttpOnly()).isFalse();
+    }
+
+    @Test
+    public void saveTokenCustomPath() {
+        String customPath = "/custompath";
+        this.repository.setCookiePath(customPath);
+        CsrfToken token = this.repository.generateToken(this.request);
+        this.repository.saveToken(token, this.request, this.response);
+
+        Cookie tokenCookie = this.response
+            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+
+        assertThat(tokenCookie.getPath()).isEqualTo(this.repository.getCookiePath());
+    }
+
+    @Test
+    public void saveTokenEmptyCustomPath() {
+        String customPath = "";
+        this.repository.setCookiePath(customPath);
+        CsrfToken token = this.repository.generateToken(this.request);
+        this.repository.saveToken(token, this.request, this.response);
+
+        Cookie tokenCookie = this.response
+            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+
+        assertThat(tokenCookie.getPath()).isEqualTo(this.request.getContextPath());
+    }
+
+    @Test
+    public void saveTokenNullCustomPath() {
+        String customPath = null;
+        this.repository.setCookiePath(customPath);
+        CsrfToken token = this.repository.generateToken(this.request);
+        this.repository.saveToken(token, this.request, this.response);
+
+        Cookie tokenCookie = this.response
+            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+
+        assertThat(tokenCookie.getPath()).isEqualTo(this.request.getContextPath());
+    }
+
+    @Test
+    public void saveTokenWithCookieDomain() {
+        String domainName = "example.com";
+        this.repository.setCookieDomain(domainName);
+
+        CsrfToken token = this.repository.generateToken(this.request);
+        this.repository.saveToken(token, this.request, this.response);
+
+        Cookie tokenCookie = this.response
+            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+
+        assertThat(tokenCookie.getDomain()).isEqualTo(domainName);
+    }
+
+    @Test
+    public void loadTokenNoCookiesNull() {
+        assertThat(this.repository.loadToken(this.request)).isNull();
+    }
+
+    @Test
+    public void loadTokenCookieIncorrectNameNull() {
+        this.request.setCookies(new Cookie("other", "name"));
+
+        assertThat(this.repository.loadToken(this.request)).isNull();
+    }
+
+    @Test
+    public void loadTokenCookieValueEmptyString() {
+        this.request.setCookies(
+            new Cookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME, ""));
+
+        assertThat(this.repository.loadToken(this.request)).isNull();
+    }
+
+    @Test
+    public void loadToken() {
+        CsrfToken generateToken = this.repository.generateToken(this.request);
+
+        this.request
+            .setCookies(new Cookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME,
+                                   generateToken.getToken()));
+
+        CsrfToken loadToken = this.repository.loadToken(this.request);
+
+        assertThat(loadToken).isNotNull();
+        assertThat(loadToken.getHeaderName()).isEqualTo(generateToken.getHeaderName());
+        assertThat(loadToken.getParameterName())
+            .isEqualTo(generateToken.getParameterName());
+        assertThat(loadToken.getToken()).isNotEmpty();
+    }
+
+    @Test
+    public void loadTokenCustom() {
+        String cookieName = "cookieName";
+        String value = "value";
+        String headerName = "headerName";
+        String parameterName = "paramName";
+        this.repository.setHeaderName(headerName);
+        this.repository.setParameterName(parameterName);
+        this.repository.setCookieName(cookieName);
+
+        this.request.setCookies(new Cookie(cookieName, value));
+
+        CsrfToken loadToken = this.repository.loadToken(this.request);
+
+        assertThat(loadToken).isNotNull();
+        assertThat(loadToken.getHeaderName()).isEqualTo(headerName);
+        assertThat(loadToken.getParameterName()).isEqualTo(parameterName);
+        assertThat(loadToken.getToken()).isEqualTo(value);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setCookieNameNullIllegalArgumentException() {
+        this.repository.setCookieName(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setParameterNameNullIllegalArgumentException() {
+        this.repository.setParameterName(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setHeaderNameNullIllegalArgumentException() {
+        this.repository.setHeaderName(null);
+    }
+
+
+
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/test/AbstractControllerIntegrationTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/test/AbstractControllerIntegrationTest.java
@@ -124,13 +124,13 @@ public class AbstractControllerIntegrationTest extends AbstractIntegrationTestWi
             // Enable/Integrate Spring Security with MockMVC
             .apply(springSecurity());
 
-        // Make sure all MockMvc requests (in all tests) include a valid CSRF token by default
+        // Make sure all MockMvc requests (in all tests) include a valid CSRF token (in header) by default.
         // If an authToken was passed in, also make sure request sends the authToken in the "Authorization" header
         if (StringUtils.isNotBlank(authToken)) {
             mockMvcBuilder.defaultRequest(
-                get("/").with(csrf()).header(AUTHORIZATION_HEADER, AUTHORIZATION_TYPE + authToken));
+                get("/").with(csrf().asHeader()).header(AUTHORIZATION_HEADER, AUTHORIZATION_TYPE + authToken));
         } else {
-            mockMvcBuilder.defaultRequest(get("/").with(csrf()));
+            mockMvcBuilder.defaultRequest(get("/").with(csrf().asHeader()));
         }
 
         return mockMvcBuilder
@@ -138,7 +138,7 @@ public class AbstractControllerIntegrationTest extends AbstractIntegrationTestWi
     }
 
     public MockHttpServletResponse getAuthResponse(String user, String password) throws Exception {
-        return getClient().perform(post("/api/authn/login").with(csrf())
+        return getClient().perform(post("/api/authn/login")
                                        .param("user", user)
                                        .param("password", password))
                           .andReturn().getResponse();
@@ -146,7 +146,7 @@ public class AbstractControllerIntegrationTest extends AbstractIntegrationTestWi
 
     public MockHttpServletResponse getAuthResponseWithXForwardedForHeader(String user, String password,
                                                                           String xForwardedFor) throws Exception {
-        return getClient().perform(post("/api/authn/login").with(csrf())
+        return getClient().perform(post("/api/authn/login")
                                        .param("user", user)
                                        .param("password", password)
                                        .header("X-Forwarded-For", xForwardedFor))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/test/AbstractControllerIntegrationTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/test/AbstractControllerIntegrationTest.java
@@ -41,7 +41,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder;

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -350,6 +350,16 @@ useProxies = true
 # This is necessary because Angular Universal will also behave as a proxy server.
 proxies.trusted.ipranges = 127.0.0.1
 
+# Spring Boot proxy configuration (can be set in local.cfg or in application.properties).
+# By default, Spring Boot does not automatically use X-Forwarded-* Headers when generating links (and similar) in the
+# REST API. When using a proxy in front of the REST API, you may need to modify this setting:
+#   * NATIVE = allows your web server to natively support standard Forwarded headers
+#   * FRAMEWORK = enables Spring Framework's built in filter to manage these headers in Spring Boot
+#   * NONE = default value. Forwarded headers are ignored
+# For more information see
+# https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto-use-behind-a-proxy-server
+#server.forward-headers-strategy=FRAMEWORK
+
 #### Media Filter / Format Filter plugins (through PluginService) ####
 # Media/Format Filters help to full-text index content or
 # perform automated format conversions

--- a/dspace/modules/server/pom.xml
+++ b/dspace/modules/server/pom.xml
@@ -298,6 +298,12 @@ just adding new jar in the classloader</description>
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <version>${spring-security.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path-assert</artifactId>
             <version>${json-path.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <java.version>11</java.version>
         <spring.version>5.2.5.RELEASE</spring.version>
         <spring-boot.version>2.2.6.RELEASE</spring-boot.version>
+        <spring-security.version>5.2.2.RELEASE</spring-security.version> <!-- sync with version used by spring-boot-->
         <hibernate.version>5.4.10.Final</hibernate.version>
         <hibernate-validator.version>6.0.18.Final</hibernate-validator.version>
         <postgresql.driver.version>42.2.9</postgresql.driver.version>


### PR DESCRIPTION
## References
* This issue was discovered by LGTM, as (currently) our `WebSecurityConfiguration` includes `csrf().disabled()`.  See LGTM Rule: https://lgtm.com/rules/1511220334423/
* **MUST BE MERGED WITH ANGULAR PR:** https://github.com/DSpace/dspace-angular/pull/833  (If this PR is merged prior to the Angular PR, then authentication/authorization will no longer work in the Angular UI as every auth request will return a `403 Forbidden`)


## Description
As noted in that [LGTM rule](https://lgtm.com/rules/1511220334423/), Spring Security enables this CSRF protection by default and recommends it "for any request that could be processed by a browser client by normal users".

**Simply put, this PR reenables CSRF protection in Spring Security, and configures it based on [Angular best practices](https://angular.io/guide/http#security-xsrf-protection).**

Previously, we had chosen to *disable* this default CSRF protection because (as originally designed) we planned to make _all authentication checks_ via the `Authorization: Bearer...` Header.  If Authentication checks only occur via Headers, then CSRF protection is unnecessary (as [CSRF only applies to Cookies](https://security.stackexchange.com/questions/62080/is-csrf-possible-if-i-dont-even-use-cookies)).

However, we changed this behavior recently when implementing Shibboleth Authentication in PR #2651.  Shibboleth implementation required us to also support Cookie-based authentication checks.

On current `main`, while we _primarily_ still do authentication checks via that `Authorization` Header, we **now do support authentication checks via Cookie**.  See this newly added IT `testStatusPasswordAuthenticatedWithCookie()` which verifies that: https://github.com/DSpace/DSpace/commit/2d489ad70a1795551b20222ab8b4833607b14ac4

Because of this newly added behavior (and the fact that we plan to store additional session/user info in Cookies, see #2807), we really should have CSRF protection enabled.

**NOTE: After this is accepted, we will need to make minor updates to the REST Contract.**  I promise to make these changes once this has been accepted. 
1. All modification requests (e.g. POST, PUT, PATCH, DELETE) will require CSRF verification (X-XSRF-TOKEN header) to succeed. Otherwise a 403 Forbidden error will be returned.  Read only requests (GET, OPTIONS) do NOT require CSRF verification.
2. Our CSRF verification process aligns with the recommendations of Spring Security + Angular
    * The REST API sends a `XSRF-TOKEN` Cookie in each request.
    * When making a modification request, the Client **must** include a `X-XSRF-TOKEN` Header in the request, with the value of the `XSRF-TOKEN` Cookie in that Header.

## Instructions for Reviewers
Reviewers should:
1. Verify code & tests look good
2. Verify HAL Browser still works (it needed minor updates to support CSRF protection), especially authentication & access restricted endpoints.
3. (Optionally) test it with Shibboleth authentication as well. (However, I don't believe it should be affected.)

List of changes in this PR:
* Re-enabled CSRF protection in `WebSecurityConfiguration`
    * Took the opportunity to restructure `WebSecurityConfiguration` & add more inline comments, as it had gotten confusing.
* Allowed the `X-XSRF-TOKEN` header in `Application` settings
* Added CSRF protection support to all ITs.  See changes to `AbstractControllerIntegrationTest`. Required adding `spring-security-test` as a dependency
* Updated HAL Browser to support XSRF-TOKEN Cookie & X-XSRF-TOKEN Header
    * While making these modifications, I stumbled on a minor XSS security issue in HAL Browser described in https://github.com/mikekelly/hal-browser/pull/97.  So, I applied that fix.
* Minor updates to `AbstractBuilderCleanupUtil` to add in missing Builders.  I hit some strange random test errors that were solved by adding missing Builders into the cleanup list.
* **UPDATE:** This PR has been updated to ensure both the XSRF-TOKEN Cookie **and** the DSpace auth Cookie both have `SameSite=None; Secure`.  This ensures that both cookies can be used/sent cross domain (e.g. if UI is on a different host from backend, or if Shibboleth is on a different host from backend).


## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
