### PR TITLE
Update start-handle-server

### DIFF
--- a/dspace/bin/start-handle-server
+++ b/dspace/bin/start-handle-server
@@ -37,7 +37,7 @@ if [ "$JAVA_OPTS" = "" ]; then
 fi
 
 # Remove lock file, in case the old Handle server did not shut down properly
-rm -f $handledir/txns/lock
+rm -f $HANDLEDIR/txns/lock
 
 # Start the Handle server, with a special log4j properties file.
 # We cannot simply write to the same logs, since log4j


### PR DESCRIPTION
start-handle-server will not start if handle-server terminated abnormally (including system restart). Case error in the line to remove stale lock file.

## Description
start-handle-server has a typographical error that neutralizes the line to remove lock file if the handle server terminated abnormally, including as the result of a system reset. The intention of the code was to remove the lock file when start-handle-server was run.

## Instructions for Reviewers

### To verify the bug

1. Kill the running handle server with kill -9.  Lockfile in [dspace]/handle-server/txns/lock will remain.
2. Attempt to restart the handle server using [dspace]/bin/start-handle-server
3. handle server does not start

Error message in [dspace]/log/handle-server.log:

 "2020/08/14 06:21:09 EDT" 25 Rotating log files
Error: Queue files are locked
       (see the error log for details.)

Shutting down...

Error message in [dspace]/handle-server/error.log-$datestamp:

"2020/08/14 06:21:10 EDT" 25 Started new run.
Saving global values to: /var/lib/tomcat8/.handle/root_info
Error: lock file (/dspace01/dspace/handle-server/txns/lock) exists.  If you are sure that another server is not running, remove this file and restart the server
java.lang.Exception: Queue files are locked
        at net.handle.server.TransactionQueue.getLock(TransactionQueue.java:230)
        at net.handle.server.TransactionQueue.<init>(TransactionQueue.java:110)
        at net.handle.server.HandleServer.<init>(HandleServer.java:493)
        at net.handle.server.AbstractServer.getInstance(AbstractServer.java:72)
        at net.handle.server.Main.initialize(Main.java:152)
        at net.handle.server.Main.main(Main.java:75)
Shutting down...

After applying the patch the handle server will remove the lock file before restarting.

## Checklist

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [NA] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [NA] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [NA] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [NA] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
