### PR TITLE
Default Anonymous READ rights for the site object

### DIFF
--- a/dspace-api/src/test/java/org/dspace/content/SiteTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/SiteTest.java
@@ -14,13 +14,16 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.sql.SQLException;
+import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.dspace.AbstractUnitTest;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.SiteService;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Constants;
+import org.dspace.eperson.Group;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -141,6 +144,19 @@ public class SiteTest extends AbstractUnitTest {
     @Test
     public void testGetURL() {
         assertThat("testGetURL 0", s.getURL(), equalTo(ConfigurationManager.getProperty("dspace.ui.url")));
+    }
+
+    @Test
+    public void testAnonymousReadRights() throws Exception {
+        List<Group> groupList = authorizeService.getAuthorizedGroups(context, s, Constants.READ);
+        boolean foundAnonInList = false;
+        for (Group group : groupList) {
+            if (StringUtils.equalsIgnoreCase(group.getName(), "Anonymous")) {
+                foundAnonInList = true;
+            }
+        }
+        assertTrue(foundAnonInList);
+
     }
 
 }


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes [GitHub issue](https://github.com/DSpace/DSpace/issues/2923)
* Related to [PR](https://github.com/DSpace/DSpace/pull/2782) where this was first noticed

## Description
This PR adds in a general Anonymous read rights resource policy for the Site object. 
This is required for the different Authorization calls that can be done through the REST api.
Since REST uses an explicit check through the PreAuthorize for example, if a site does not have this resource policy, it would be considered NOT to be authorized for the current user.
 
## Instructions for Reviewers

The rights weren't able to be added in flyway as the Site object and Group objects get created after the migrations have ran. 
This means that it’s impossible to add resourcePolicies for those in flyway because no objects are present to create this object on.
To handle this, we updated the [SiteServiceInitializer](https://github.com/atmire/DSpace/blob/w2p-72503_default-anonymous-access-site-object/dspace-api/src/main/java/org/dspace/storage/rdbms/SiteServiceInitializer.java#L56) that is also responsible for the actual site object creation. Similar to the site creation, this is also done only once.

Additional tests were created to make sure that the Site object has anonymous read rights as well
## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
