### PR TITLE
Cookie preferences & End User Agreement per account - initial registries update

### DIFF
--- a/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
@@ -81,18 +81,27 @@ public class EPersonTest extends AbstractUnitTest {
     @Test
     public void testPreferences() throws Exception {
 
-        ePersonService.addMetadata(context, eperson, "dspace", "agreements", "end-user", null, "test");
-        ePersonService.addMetadata(context, eperson, "dspace", "agreements", "cookies", null,
-                                   "Dspace cookies agreement metadata");
+        String cookies =
+            "{" +
+                "\"token_item\":true," +
+                "\"impersonation\":true," +
+                "\"redirect\":true," +
+                "\"language\":true," +
+                "\"klaro\":true," +
+                "\"google-analytics\":false" +
+                "}";
+
+        ePersonService.addMetadata(context, eperson, "dspace", "agreements", "cookies", null, cookies);
+        ePersonService.addMetadata(context, eperson, "dspace", "agreements", "end-user", null, "true");
         context.commit();
 
         assertEquals(
-                "test",
-                ePersonService.getMetadataFirstValue(eperson, "dspace", "agreements", "end-user", null)
+            cookies,
+            ePersonService.getMetadataFirstValue(eperson, "dspace", "agreements", "cookies", null)
         );
         assertEquals(
-                "Dspace cookies agreement metadata",
-                ePersonService.getMetadataFirstValue(eperson, "dspace", "agreements", "cookies", null)
+            "true",
+                ePersonService.getMetadataFirstValue(eperson, "dspace", "agreements", "end-user", null)
         );
     }
 

--- a/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
@@ -82,11 +82,16 @@ public class EPersonTest extends AbstractUnitTest {
     public void testPreferences() throws Exception {
 
         ePersonService.addMetadata(context, eperson, "dspace", "agreements", "end-user", null, "test");
+        ePersonService.addMetadata(context, eperson, "dspace", "agreements", "cookies", null, "Dspace cookies agreement metadata");
         context.commit();
 
         assertEquals(
                 "test",
                 ePersonService.getMetadataFirstValue(eperson, "dspace", "agreements", "end-user", null)
+        );
+        assertEquals(
+                "Dspace cookies agreement metadata",
+                ePersonService.getMetadataFirstValue(eperson, "dspace", "agreements", "cookies", null)
         );
     }
 

--- a/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
@@ -81,17 +81,12 @@ public class EPersonTest extends AbstractUnitTest {
     @Test
     public void testPreferences() throws Exception {
 
-        ePersonService.addMetadata(context, eperson, "dspace", "cookies", "functional", null, "true");
-        ePersonService.addMetadata(context, eperson, "dspace", "cookies", "statistics", null, "false");
+        ePersonService.addMetadata(context, eperson, "dspace", "agreements", "end-user", null, "test");
         context.commit();
 
         assertEquals(
-                "true",
-                ePersonService.getMetadataFirstValue(eperson, "dspace", "cookies", "functional", null)
-        );
-        assertEquals(
-                "false",
-                ePersonService.getMetadataFirstValue(eperson, "dspace", "cookies", "statistics", null)
+                "test",
+                ePersonService.getMetadataFirstValue(eperson, "dspace", "agreements", "end-user", null)
         );
     }
 

--- a/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
@@ -82,7 +82,8 @@ public class EPersonTest extends AbstractUnitTest {
     public void testPreferences() throws Exception {
 
         ePersonService.addMetadata(context, eperson, "dspace", "agreements", "end-user", null, "test");
-        ePersonService.addMetadata(context, eperson, "dspace", "agreements", "cookies", null, "Dspace cookies agreement metadata");
+        ePersonService.addMetadata(context, eperson, "dspace", "agreements", "cookies", null,
+                                   "Dspace cookies agreement metadata");
         context.commit();
 
         assertEquals(

--- a/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
@@ -78,6 +78,22 @@ public class EPersonTest extends AbstractUnitTest {
         super.destroy();
     }
 
+    @Test
+    public void testPreferences() throws Exception {
+
+        ePersonService.addMetadata(context, eperson, "dspace", "cookies", "functional", null, "true");
+        ePersonService.addMetadata(context, eperson, "dspace", "cookies", "statistics", null, "false");
+        context.commit();
+
+        assertEquals(
+                "true",
+                ePersonService.getMetadataFirstValue(eperson, "dspace", "cookies", "functional", null)
+        );
+        assertEquals(
+                "false",
+                ePersonService.getMetadataFirstValue(eperson, "dspace", "cookies", "statistics", null)
+        );
+    }
 
     /**
      * Test of equals method, of class EPerson.

--- a/dspace/config/registries/dspace-types.xml
+++ b/dspace/config/registries/dspace-types.xml
@@ -16,5 +16,19 @@
         <scope_note></scope_note>
     </dc-type>
 
+    <dc-type>
+        <schema>dspace</schema>
+        <element>cookies</element>
+        <qualifier>functional</qualifier>
+        <scope_note></scope_note>
+    </dc-type>
+
+    <dc-type>
+        <schema>dspace</schema>
+        <element>cookies</element>
+        <qualifier>statistics</qualifier>
+        <scope_note></scope_note>
+    </dc-type>
+
 
 </dspace-dc-types>

--- a/dspace/config/registries/dspace-types.xml
+++ b/dspace/config/registries/dspace-types.xml
@@ -18,17 +18,9 @@
 
     <dc-type>
         <schema>dspace</schema>
-        <element>cookies</element>
-        <qualifier>functional</qualifier>
+        <element>agreements</element>
+        <qualifier>end-user</qualifier>
         <scope_note></scope_note>
     </dc-type>
-
-    <dc-type>
-        <schema>dspace</schema>
-        <element>cookies</element>
-        <qualifier>statistics</qualifier>
-        <scope_note></scope_note>
-    </dc-type>
-
 
 </dspace-dc-types>

--- a/dspace/config/registries/dspace-types.xml
+++ b/dspace/config/registries/dspace-types.xml
@@ -23,4 +23,11 @@
         <scope_note></scope_note>
     </dc-type>
 
+    <dc-type>
+        <schema>dspace</schema>
+        <element>agreements</element>
+        <qualifier>cookies</qualifier>
+        <scope_note></scope_note>
+    </dc-type>
+
 </dspace-dc-types>

--- a/dspace/config/registries/dspace-types.xml
+++ b/dspace/config/registries/dspace-types.xml
@@ -20,14 +20,14 @@
         <schema>dspace</schema>
         <element>agreements</element>
         <qualifier>end-user</qualifier>
-        <scope_note></scope_note>
+        <scope_note>Stores whether the End User Agreement has been accepted by an EPerson. Valid values; true, false</scope_note>
     </dc-type>
 
     <dc-type>
         <schema>dspace</schema>
         <element>agreements</element>
         <qualifier>cookies</qualifier>
-        <scope_note></scope_note>
+        <scope_note>Stores the cookie preferences of an EPerson, as selected in last session. Value will be an array of cookieName/boolean pairs, specifying which cookies are allowed or not allowed.</scope_note>
     </dc-type>
 
 </dspace-dc-types>


### PR DESCRIPTION
## References
* Fixes [GitHub issue](https://github.com/DSpace/DSpace/issues/2807)

## Description
This adds in the initial metadatafields for the cookie preference related work.
The current fields have been provided by @artlowel as he is handling the Angular version implementation of this.

## Instructions for Reviewers
This basically only adds in some metadatafields, and adds in a check to make sure that these metadatas exist and can be filled in on an eperson level.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
