### PR TITLE
Item Import handles multiple metadata schemas in  lines

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -712,7 +712,7 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
         if (inlineSchema==null || "".equals(inlineSchema)) {
             inlineSchema = getAttributeValue(n, "schema");
             if (inlineSchema==null || "".equals(inlineSchema)) {
-                inlineSchema = MetadataSchema.DC_SCHEMA;
+                inlineSchema = MetadataSchemaEnum.DC.getName();
             }
         }
         // //getElementData(n, "element");


### PR DESCRIPTION
## References
 * [Jira ticket - DS-4543](https://jira.lyrasis.org/browse/DS-4543)

## Description
ItemImport service modifications in order to allow the importer to take care of the schema string within the `dcvalue` lines.

## Instructions for Reviewers
The SAF import allows us to import different metadata schemas with the aid of multiple XML files where the root node may contain a `schema` attribute telling to DSpace which metadata namespace should be used during the import process as [this](https://wiki.lyrasis.org/display/DSDOC6x/Importing+and+Exporting+Items+via+Simple+Archive+Format#ImportingandExportingItemsviaSimpleArchiveFormat-Configuringmetadata_[prefix].xmlforaDifferentSchema) works well.
The change in this PR allows the user to add the `schema` attribute for each `dcvalue` node within the `dublin_core.xml` so there is no need to create separate XML files for each namespace, they can be used mixed within one.
The change does not modify the original flow so the user can split the metadata into different XML files where the `schema` attribute is in the root node.

List of changes in this PR:
* There is no default metadata schema in case if the root node does not contain `schema` attribute.
* Additional variable within `addDCValue()` and related changes to manage the `schema` attributes within the `dcvalue` nodes.
* Break lines longer than 120 chars - only in branch `DS-4543_dsapce-6_x`

To test the modifications import this package: 
[itemimport-test-20200824.tar.gz](https://github.com/DSpace/DSpace/files/5118128/itemimport-test-20200824.tar.gz)



## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
