### PR TITLE
Features endpoint - Edit item permissions in REST

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
@@ -629,6 +629,10 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
             case Constants.DELETE:
                 if (AuthorizeConfiguration.canCommunityAdminPerformSubelementDeletion()) {
                     adminObject = getParentObject(context, community);
+                    if (adminObject == null) {
+                        //top-level community, has to be admin of the current communitu
+                        adminObject = community;
+                    }
                 }
                 break;
             case Constants.ADD:

--- a/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
@@ -630,7 +630,7 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
                 if (AuthorizeConfiguration.canCommunityAdminPerformSubelementDeletion()) {
                     adminObject = getParentObject(context, community);
                     if (adminObject == null) {
-                        //top-level community, has to be admin of the current communitu
+                        //top-level community, has to be admin of the current community
                         adminObject = community;
                     }
                 }

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -1100,19 +1100,7 @@ prevent the generation of resource policy entry values with null dspace_object a
                 }
                 break;
             case Constants.DELETE:
-                if (item.getOwningCollection() != null) {
-                    if (AuthorizeConfiguration.canCollectionAdminPerformItemDeletion()) {
-                        adminObject = collection;
-                    } else if (AuthorizeConfiguration.canCommunityAdminPerformItemDeletion()) {
-                        adminObject = community;
-                    }
-                } else {
-                    if (AuthorizeConfiguration.canCollectionAdminManageTemplateItem()) {
-                        adminObject = collection;
-                    } else if (AuthorizeConfiguration.canCommunityAdminManageCollectionTemplateItem()) {
-                        adminObject = community;
-                    }
-                }
+                adminObject = item;
                 break;
             case Constants.WRITE:
                 // if it is a template item we need to check the

--- a/dspace-api/src/test/java/org/dspace/content/CommunityTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/CommunityTest.java
@@ -1013,7 +1013,8 @@ public class CommunityTest extends AbstractDSpaceObjectTest {
                    equalTo(c));
         assertThat("testGetAdminObject 1", (Community) communityService.getAdminObject(context, c, Constants.ADD),
                    equalTo(c));
-        assertThat("testGetAdminObject 2", communityService.getAdminObject(context, c, Constants.DELETE), nullValue());
+        assertThat("testGetAdminObject 2", (Community) communityService.getAdminObject(context, c, Constants.DELETE),
+                   equalTo(c));
         assertThat("testGetAdminObject 3", (Community) communityService.getAdminObject(context, c, Constants.ADMIN),
                    equalTo(c));
     }

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -1598,8 +1598,8 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         assertThat("testGetAdminObject 0", (Item) itemService.getAdminObject(context, it, Constants.REMOVE),
                    equalTo(it));
         assertThat("testGetAdminObject 1", (Item) itemService.getAdminObject(context, it, Constants.ADD), equalTo(it));
-        assertThat("testGetAdminObject 2", (Collection) itemService.getAdminObject(context, it, Constants.DELETE),
-                   equalTo(collection));
+        assertThat("testGetAdminObject 2", (Item) itemService.getAdminObject(context, it, Constants.DELETE),
+                   equalTo(it));
         assertThat("testGetAdminObject 3", (Item) itemService.getAdminObject(context, it, Constants.ADMIN),
                    equalTo(it));
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/AuthorizeServiceRestUtil.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/AuthorizeServiceRestUtil.java
@@ -1,0 +1,73 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization;
+
+import java.sql.SQLException;
+
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.security.DSpaceRestPermission;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.DSpaceObjectService;
+import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * This class is a wrapper around the AuthorizationService which takes Rest objects instead of dspace objects
+ */
+@Component
+public class AuthorizeServiceRestUtil {
+    @Autowired
+    private AuthorizeService authorizeService;
+    @Autowired
+    private Utils utils;
+    @Autowired
+    private ContentServiceFactory contentServiceFactory;
+
+    /**
+     * Checks that the specified eperson can perform the given action on the rest given object.
+     *
+     * @param context               DSpace context
+     * @param object                The Rest object to test the action against
+     * @param dSpaceRestPermission  The permission to check
+     * @return A boolean indicating if the action is allowed by the logged in ePerson on the given object
+     * @throws SQLException
+     */
+    public boolean authorizeActionBoolean(Context context, BaseObjectRest object,
+                                          DSpaceRestPermission dSpaceRestPermission)
+        throws SQLException {
+
+        DSpaceObject dSpaceObject = (DSpaceObject)utils.getDSpaceAPIObjectFromRest(context, object);
+        if (dSpaceObject == null) {
+            return false;
+        }
+
+        DSpaceObjectService<DSpaceObject> dSpaceObjectService =
+            contentServiceFactory.getDSpaceObjectService(dSpaceObject.getType());
+
+        EPerson ePerson = context.getCurrentUser();
+
+        if (dSpaceObjectService != null) {
+            if (dSpaceObject instanceof Item) {
+                if (!DSpaceRestPermission.READ.equals(dSpaceRestPermission)
+                    && !((Item) dSpaceObject).isArchived() && !((Item) dSpaceObject).isWithdrawn()) {
+                    return false;
+                }
+            }
+
+            return authorizeService.authorizeActionBoolean(context, ePerson, dSpaceObject,
+                dSpaceRestPermission.getDspaceApiActionId(), true);
+        }
+        return false;
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/AuthorizeServiceRestUtil.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/AuthorizeServiceRestUtil.java
@@ -57,17 +57,16 @@ public class AuthorizeServiceRestUtil {
 
         EPerson ePerson = context.getCurrentUser();
 
-        if (dSpaceObjectService != null) {
-            if (dSpaceObject instanceof Item) {
-                if (!DSpaceRestPermission.READ.equals(dSpaceRestPermission)
-                    && !((Item) dSpaceObject).isArchived() && !((Item) dSpaceObject).isWithdrawn()) {
-                    return false;
-                }
+        // If the item is still inprogress we can process here only the READ permission.
+        // Other actions need to be evaluated against the wrapper object (workspace or workflow item)
+        if (dSpaceObject instanceof Item) {
+            if (!DSpaceRestPermission.READ.equals(dSpaceRestPermission)
+                && !((Item) dSpaceObject).isArchived() && !((Item) dSpaceObject).isWithdrawn()) {
+                return false;
             }
-
-            return authorizeService.authorizeActionBoolean(context, ePerson, dSpaceObject,
-                dSpaceRestPermission.getDspaceApiActionId(), true);
         }
-        return false;
+
+        return authorizeService.authorizeActionBoolean(context, ePerson, dSpaceObject,
+            dSpaceRestPermission.getDspaceApiActionId(), true);
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CreateBitstreamFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CreateBitstreamFeature.java
@@ -29,6 +29,8 @@ import org.springframework.stereotype.Component;
 
 /**
  * The create bitstream feature. It can be used to verify if bitstreams can be created in a specific bundle.
+ *
+ * Authorization is granted if the current user has ADD & WRITE permissions on the given bundle AND the item
  */
 @Component
 @AuthorizationFeatureDocumentation(name = CreateBitstreamFeature.NAME,
@@ -61,8 +63,9 @@ public class CreateBitstreamFeature implements AuthorizationFeature {
             DSpaceObject owningObject = bundleService.getParentObject(context,
                 (Bundle)utils.getDSpaceAPIObjectFromRest(context, object));
 
+            // Safety check. In case this is ever not true, this method should be revised.
             if (!(owningObject instanceof Item)) {
-                log.error("The partent object of bundle " + object.getType() + " is not an item");
+                log.error("The parent object of bundle " + object.getType() + " is not an item");
                 return false;
             }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CreateBitstreamFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CreateBitstreamFeature.java
@@ -19,8 +19,8 @@ import org.dspace.app.rest.security.DSpaceRestPermission;
 import org.dspace.app.rest.utils.Utils;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Bundle;
-import org.dspace.content.Collection;
 import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
 import org.dspace.content.service.BundleService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
@@ -61,12 +61,12 @@ public class CreateBitstreamFeature implements AuthorizationFeature {
             DSpaceObject owningObject = bundleService.getParentObject(context,
                 (Bundle)utils.getDSpaceAPIObjectFromRest(context, object));
 
-            if (!(owningObject instanceof Collection)) {
+            if (!(owningObject instanceof Item)) {
                 log.error("The partent object of bundle " + object.getType() + " is not an item");
                 return false;
             }
 
-            if (authorizeService.authorizeActionBoolean(context, context.getCurrentUser(), owningObject,
+            if (!authorizeService.authorizeActionBoolean(context, context.getCurrentUser(), owningObject,
                 Constants.WRITE, true)) {
                 return false;
             }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CreateBitstreamFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CreateBitstreamFeature.java
@@ -1,0 +1,86 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization.impl;
+
+import java.sql.SQLException;
+
+import org.apache.log4j.Logger;
+import org.dspace.app.rest.authorization.AuthorizationFeature;
+import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
+import org.dspace.app.rest.authorization.AuthorizeServiceRestUtil;
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.model.BundleRest;
+import org.dspace.app.rest.security.DSpaceRestPermission;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.Bundle;
+import org.dspace.content.Collection;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.service.BundleService;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * The create bitstream feature. It can be used to verify if bitstreams can be created in a specific bundle.
+ */
+@Component
+@AuthorizationFeatureDocumentation(name = CreateBitstreamFeature.NAME,
+    description = "It can be used to verify if bitstreams can be created in a specific bundle")
+public class CreateBitstreamFeature implements AuthorizationFeature {
+
+    Logger log = Logger.getLogger(CreateBitstreamFeature.class);
+
+    public final static String NAME = "canCreateBitstream";
+
+    @Autowired
+    private AuthorizeServiceRestUtil authorizeServiceRestUtil;
+    @Autowired
+    private BundleService bundleService;
+    @Autowired
+    private Utils utils;
+    @Autowired
+    private AuthorizeService authorizeService;
+
+    @Override
+    public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException {
+        if (object instanceof BundleRest) {
+            if (!authorizeServiceRestUtil.authorizeActionBoolean(context, object, DSpaceRestPermission.WRITE)) {
+                return false;
+            }
+            if (!authorizeServiceRestUtil.authorizeActionBoolean(context, object, DSpaceRestPermission.ADD)) {
+                return false;
+            }
+
+            DSpaceObject owningObject = bundleService.getParentObject(context,
+                (Bundle)utils.getDSpaceAPIObjectFromRest(context, object));
+
+            if (!(owningObject instanceof Collection)) {
+                log.error("The partent object of bundle " + object.getType() + " is not an item");
+                return false;
+            }
+
+            if (authorizeService.authorizeActionBoolean(context, context.getCurrentUser(), owningObject,
+                Constants.WRITE, true)) {
+                return false;
+            }
+
+            return authorizeService.authorizeActionBoolean(context, context.getCurrentUser(), owningObject,
+                Constants.ADD, true);
+        }
+        return false;
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[]{
+            BundleRest.CATEGORY + "." + BundleRest.NAME
+        };
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CreateBundleFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CreateBundleFeature.java
@@ -21,6 +21,8 @@ import org.springframework.stereotype.Component;
 
 /**
  * The create bundle feature. It can be used to verify if bundles can be created in a specific item.
+ *
+ * Authorization is granted if the current user has ADD & WRITE permissions on the given item
  */
 @Component
 @AuthorizationFeatureDocumentation(name = CreateBundleFeature.NAME,

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CreateBundleFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CreateBundleFeature.java
@@ -1,0 +1,52 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization.impl;
+
+import java.sql.SQLException;
+
+import org.dspace.app.rest.authorization.AuthorizationFeature;
+import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
+import org.dspace.app.rest.authorization.AuthorizeServiceRestUtil;
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.model.ItemRest;
+import org.dspace.app.rest.security.DSpaceRestPermission;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * The create bundle feature. It can be used to verify if bundles can be created in a specific item.
+ */
+@Component
+@AuthorizationFeatureDocumentation(name = CreateBundleFeature.NAME,
+    description = "It can be used to verify if bundles can be created in a specific item")
+public class CreateBundleFeature implements AuthorizationFeature {
+
+    public final static String NAME = "canCreateBundle";
+
+    @Autowired
+    private AuthorizeServiceRestUtil authorizeServiceRestUtil;
+
+    @Override
+    public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException {
+        if (object instanceof ItemRest) {
+            if (!authorizeServiceRestUtil.authorizeActionBoolean(context, object, DSpaceRestPermission.WRITE)) {
+                return false;
+            }
+            return authorizeServiceRestUtil.authorizeActionBoolean(context, object, DSpaceRestPermission.ADD);
+        }
+        return false;
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[]{
+            ItemRest.CATEGORY + "." + ItemRest.NAME
+        };
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/DeleteFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/DeleteFeature.java
@@ -28,7 +28,6 @@ import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.content.factory.ContentServiceFactory;
-import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,8 +51,6 @@ public class DeleteFeature implements AuthorizationFeature {
     private AuthorizeService authorizeService;
     @Autowired
     private ContentServiceFactory contentServiceFactory;
-    @Autowired
-    private WorkspaceItemService workspaceItemService;
 
     @Override
     public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/DeleteFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/DeleteFeature.java
@@ -35,6 +35,16 @@ import org.springframework.stereotype.Component;
 
 /**
  * The delete feature. It can be used to verify if specific content can be deleted/expunged.
+ *
+ * Authorization is granted
+ * - for a bitstream if the current used has REMOVE permissions on both the Item and the Bundle
+ * - for a bundle if the current user has REMOVE permissions on the Item
+ * - for an item if the current user has REMOVE permissions on the collection AND and DELETE permissions on the item
+ * - for a collection if the current user has REMOVE permissions on the community
+ * - for a community with a parent community if the current user has REMOVE permissions on the parent community
+ * - for a community without a parent community if the current user has DELETE permissions on the current community
+ * - for other objects if the current user has REMOVE permissions on the parent object if there is one. Otherwise if the
+ *      current user has DELETE permissions on the current object
  */
 @Component
 @AuthorizationFeatureDocumentation(name = DeleteFeature.NAME,

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/DeleteFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/DeleteFeature.java
@@ -1,0 +1,131 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization.impl;
+
+import java.sql.SQLException;
+
+import org.dspace.app.rest.authorization.AuthorizationFeature;
+import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
+import org.dspace.app.rest.authorization.AuthorizeServiceRestUtil;
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.model.BitstreamRest;
+import org.dspace.app.rest.model.BundleRest;
+import org.dspace.app.rest.model.CollectionRest;
+import org.dspace.app.rest.model.CommunityRest;
+import org.dspace.app.rest.model.EPersonRest;
+import org.dspace.app.rest.model.GroupRest;
+import org.dspace.app.rest.model.ItemRest;
+import org.dspace.app.rest.model.WorkspaceItemRest;
+import org.dspace.app.rest.security.DSpaceRestPermission;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.content.WorkspaceItem;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.WorkspaceItemService;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * The delete feature. It can be used to verify if specific content can be deleted/expunged.
+ */
+@Component
+@AuthorizationFeatureDocumentation(name = DeleteFeature.NAME,
+    description = "It can be used to verify if specific content can be deleted/expunged")
+public class DeleteFeature implements AuthorizationFeature {
+
+    public final static String NAME = "canDelete";
+
+    @Autowired
+    private AuthorizeServiceRestUtil authorizeServiceRestUtil;
+    @Autowired
+    private Utils utils;
+    @Autowired
+    private AuthorizeService authorizeService;
+    @Autowired
+    private ContentServiceFactory contentServiceFactory;
+    @Autowired
+    private WorkspaceItemService workspaceItemService;
+
+    @Override
+    public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException {
+        if (object instanceof BaseObjectRest) {
+            if (object.getType().equals(WorkspaceItemRest.NAME)) {
+                object = ((WorkspaceItemRest)object).getItem();
+            }
+
+            DSpaceObject dSpaceObject = (DSpaceObject) utils.getDSpaceAPIObjectFromRest(context, object);
+            DSpaceObject parentObject = getParentObject(context, dSpaceObject);
+
+            switch (object.getType()) {
+                case BitstreamRest.NAME:
+                    return (
+                        authorizeService.authorizeActionBoolean(context, context.getCurrentUser(), parentObject,
+                            Constants.REMOVE, true)
+                        && authorizeService.authorizeActionBoolean(context, context.getCurrentUser(), dSpaceObject,
+                            Constants.REMOVE, true)
+                        );
+                case ItemRest.NAME:
+                    return (
+                        authorizeService.authorizeActionBoolean(context, context.getCurrentUser(), parentObject,
+                            Constants.REMOVE, true)
+                        && authorizeServiceRestUtil.authorizeActionBoolean(context, object,
+                            DSpaceRestPermission.DELETE)
+                        );
+                case CollectionRest.NAME:
+                case CommunityRest.NAME:
+                case BundleRest.NAME:
+                case WorkspaceItemRest.NAME:
+                case EPersonRest.NAME:
+                case GroupRest.NAME:
+                default:
+                    if (parentObject != null) {
+                        return authorizeService.authorizeActionBoolean(context, context.getCurrentUser(), parentObject,
+                            Constants.REMOVE, true);
+                    }
+
+                    return authorizeServiceRestUtil.authorizeActionBoolean(context, object,
+                        DSpaceRestPermission.DELETE);
+            }
+        }
+        return false;
+    }
+
+    private DSpaceObject getParentObject(Context context, DSpaceObject object) throws SQLException {
+        DSpaceObject parentObject
+            = contentServiceFactory.getDSpaceObjectService(object.getType()).getParentObject(context, object);
+        if (object.getType() == Constants.ITEM && parentObject == null) {
+            Item item = (Item) object;
+            parentObject = item.getOwningCollection();
+            WorkspaceItem byItem = ContentServiceFactory.getInstance()
+                                        .getWorkspaceItemService()
+                                        .findByItem(context, item);
+            if (byItem != null) {
+                parentObject = byItem.getCollection();
+            }
+        }
+        return parentObject;
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[]{
+            CommunityRest.CATEGORY + "." + CommunityRest.NAME,
+            CollectionRest.CATEGORY + "." + CollectionRest.NAME,
+            ItemRest.CATEGORY + "." + ItemRest.NAME,
+            BundleRest.CATEGORY + "." + BundleRest.NAME,
+            BitstreamRest.CATEGORY + "." + BitstreamRest.NAME,
+            WorkspaceItemRest.CATEGORY + "." + WorkspaceItemRest.NAME,
+            EPersonRest.CATEGORY + "." + EPersonRest.NAME,
+            GroupRest.CATEGORY + "." + GroupRest.NAME
+        };
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/EditMetadataFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/EditMetadataFeature.java
@@ -1,0 +1,62 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization.impl;
+
+import java.sql.SQLException;
+
+import org.dspace.app.rest.authorization.AuthorizationFeature;
+import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
+import org.dspace.app.rest.authorization.AuthorizeServiceRestUtil;
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.model.BitstreamRest;
+import org.dspace.app.rest.model.BundleRest;
+import org.dspace.app.rest.model.CollectionRest;
+import org.dspace.app.rest.model.CommunityRest;
+import org.dspace.app.rest.model.ItemRest;
+import org.dspace.app.rest.security.DSpaceRestPermission;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * The edit metadata feature. It can be used to verify if the metadata of the specified objects can be edited.
+ */
+@Component
+@AuthorizationFeatureDocumentation(name = EditMetadataFeature.NAME,
+    description = "It can be used to verify if the metadata of the specified objects can be edited")
+public class EditMetadataFeature implements AuthorizationFeature {
+
+    public final static String NAME = "canEditMetadata";
+
+    @Autowired
+    private AuthorizeServiceRestUtil authorizeServiceRestUtil;
+
+    @Override
+    public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException {
+        if (object instanceof CommunityRest
+                || object instanceof CollectionRest
+                || object instanceof ItemRest
+                || object instanceof BundleRest
+                || object instanceof BitstreamRest
+        ) {
+            return authorizeServiceRestUtil.authorizeActionBoolean(context, object, DSpaceRestPermission.WRITE);
+        }
+        return false;
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[]{
+            CommunityRest.CATEGORY + "." + CommunityRest.NAME,
+            CollectionRest.CATEGORY + "." + CollectionRest.NAME,
+            ItemRest.CATEGORY + "." + ItemRest.NAME,
+            BundleRest.CATEGORY + "." + BundleRest.NAME,
+            BitstreamRest.CATEGORY + "." + BitstreamRest.NAME
+        };
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/EditMetadataFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/EditMetadataFeature.java
@@ -18,6 +18,7 @@ import org.dspace.app.rest.model.BundleRest;
 import org.dspace.app.rest.model.CollectionRest;
 import org.dspace.app.rest.model.CommunityRest;
 import org.dspace.app.rest.model.ItemRest;
+import org.dspace.app.rest.model.SiteRest;
 import org.dspace.app.rest.security.DSpaceRestPermission;
 import org.dspace.core.Context;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,6 +44,7 @@ public class EditMetadataFeature implements AuthorizationFeature {
                 || object instanceof ItemRest
                 || object instanceof BundleRest
                 || object instanceof BitstreamRest
+                || object instanceof SiteRest
         ) {
             return authorizeServiceRestUtil.authorizeActionBoolean(context, object, DSpaceRestPermission.WRITE);
         }
@@ -56,7 +58,8 @@ public class EditMetadataFeature implements AuthorizationFeature {
             CollectionRest.CATEGORY + "." + CollectionRest.NAME,
             ItemRest.CATEGORY + "." + ItemRest.NAME,
             BundleRest.CATEGORY + "." + BundleRest.NAME,
-            BitstreamRest.CATEGORY + "." + BitstreamRest.NAME
+            BitstreamRest.CATEGORY + "." + BitstreamRest.NAME,
+            SiteRest.CATEGORY + "." + SiteRest.NAME
         };
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/EditMetadataFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/EditMetadataFeature.java
@@ -26,6 +26,8 @@ import org.springframework.stereotype.Component;
 
 /**
  * The edit metadata feature. It can be used to verify if the metadata of the specified objects can be edited.
+ *
+ * Authorization is granted if the current user has WRITE permissions on the given DSO
  */
 @Component
 @AuthorizationFeatureDocumentation(name = EditMetadataFeature.NAME,

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/MakeDiscoverableFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/MakeDiscoverableFeature.java
@@ -1,0 +1,49 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization.impl;
+
+import java.sql.SQLException;
+
+import org.dspace.app.rest.authorization.AuthorizationFeature;
+import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
+import org.dspace.app.rest.authorization.AuthorizeServiceRestUtil;
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.model.ItemRest;
+import org.dspace.app.rest.security.DSpaceRestPermission;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * The make discoverable feature. It can be used to verify if an item can be made discoverable.
+ */
+@Component
+@AuthorizationFeatureDocumentation(name = MakeDiscoverableFeature.NAME,
+    description = "It can be used to verify if an item can be made discoverable")
+public class MakeDiscoverableFeature implements AuthorizationFeature {
+
+    public final static String NAME = "canMakeDiscoverable";
+
+    @Autowired
+    private AuthorizeServiceRestUtil authorizeServiceRestUtil;
+
+    @Override
+    public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException {
+        if (object instanceof ItemRest) {
+            return authorizeServiceRestUtil.authorizeActionBoolean(context, object, DSpaceRestPermission.WRITE);
+        }
+        return false;
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[]{
+            ItemRest.CATEGORY + "." + ItemRest.NAME
+        };
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/MakeDiscoverableFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/MakeDiscoverableFeature.java
@@ -21,6 +21,8 @@ import org.springframework.stereotype.Component;
 
 /**
  * The make discoverable feature. It can be used to verify if an item can be made discoverable.
+ *
+ * Authorization is granted if the current user has WRITE permissions on the given item
  */
 @Component
 @AuthorizationFeatureDocumentation(name = MakeDiscoverableFeature.NAME,

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/MakePrivateFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/MakePrivateFeature.java
@@ -1,0 +1,49 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization.impl;
+
+import java.sql.SQLException;
+
+import org.dspace.app.rest.authorization.AuthorizationFeature;
+import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
+import org.dspace.app.rest.authorization.AuthorizeServiceRestUtil;
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.model.ItemRest;
+import org.dspace.app.rest.security.DSpaceRestPermission;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * The make private feature. It can be used to verify if an item can be made private.
+ */
+@Component
+@AuthorizationFeatureDocumentation(name = MakePrivateFeature.NAME,
+    description = "It can be used to verify if an item can be made private")
+public class MakePrivateFeature implements AuthorizationFeature {
+
+    public final static String NAME = "canMakePrivate";
+
+    @Autowired
+    private AuthorizeServiceRestUtil authorizeServiceRestUtil;
+
+    @Override
+    public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException {
+        if (object instanceof ItemRest) {
+            return authorizeServiceRestUtil.authorizeActionBoolean(context, object, DSpaceRestPermission.WRITE);
+        }
+        return false;
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[]{
+            ItemRest.CATEGORY + "." + ItemRest.NAME
+        };
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/MakePrivateFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/MakePrivateFeature.java
@@ -21,6 +21,8 @@ import org.springframework.stereotype.Component;
 
 /**
  * The make private feature. It can be used to verify if an item can be made private.
+ *
+ * Authorization is granted if the current user has WRITE permissions on the given item
  */
 @Component
 @AuthorizationFeatureDocumentation(name = MakePrivateFeature.NAME,

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/MoveFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/MoveFeature.java
@@ -64,7 +64,7 @@ public class MoveFeature implements AuthorizationFeature {
             }
 
             return authorizeService.authorizeActionBoolean(context, context.getCurrentUser(), owningObject,
-                Constants.WRITE, true);
+                Constants.REMOVE, true);
         }
         return false;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/MoveFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/MoveFeature.java
@@ -29,6 +29,9 @@ import org.springframework.stereotype.Component;
 
 /**
  * The move feature. It can be used to verify if item can be moved to a different collection.
+ *
+ * Authorization is granted if the current user has WRITE permissions on the given item and REMOVE permissions on the
+ * item’s owning collection
  */
 @Component
 @AuthorizationFeatureDocumentation(name = MoveFeature.NAME,

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/MoveFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/MoveFeature.java
@@ -1,0 +1,78 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization.impl;
+
+import java.sql.SQLException;
+
+import org.apache.log4j.Logger;
+import org.dspace.app.rest.authorization.AuthorizationFeature;
+import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
+import org.dspace.app.rest.authorization.AuthorizeServiceRestUtil;
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.model.ItemRest;
+import org.dspace.app.rest.security.DSpaceRestPermission;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.Collection;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * The move feature. It can be used to verify if item can be moved to a different collection.
+ */
+@Component
+@AuthorizationFeatureDocumentation(name = MoveFeature.NAME,
+    description = "It can be used to verify if item can be moved to a different collection")
+public class MoveFeature implements AuthorizationFeature {
+
+    Logger log = Logger.getLogger(MoveFeature.class);
+
+    public final static String NAME = "canMove";
+
+    @Autowired
+    private AuthorizeServiceRestUtil authorizeServiceRestUtil;
+    @Autowired
+    private Utils utils;
+    @Autowired
+    private ItemService itemService;
+    @Autowired
+    private AuthorizeService authorizeService;
+
+    @Override
+    public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException {
+        if (object instanceof ItemRest) {
+            if (!authorizeServiceRestUtil.authorizeActionBoolean(context, object, DSpaceRestPermission.WRITE)) {
+                return false;
+            }
+
+            DSpaceObject owningObject = itemService.getParentObject(context,
+                (Item)utils.getDSpaceAPIObjectFromRest(context, object));
+
+            if (!(owningObject instanceof Collection)) {
+                log.error("The partent object of item " + object.getType() + " is not a collection");
+                return false;
+            }
+
+            return authorizeService.authorizeActionBoolean(context, context.getCurrentUser(), owningObject,
+                Constants.WRITE, true);
+        }
+        return false;
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[]{
+            ItemRest.CATEGORY + "." + ItemRest.NAME
+        };
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/PolicyFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/PolicyFeature.java
@@ -1,0 +1,100 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization.impl;
+
+import java.sql.SQLException;
+
+import org.dspace.app.rest.authorization.AuthorizationFeature;
+import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.model.BitstreamRest;
+import org.dspace.app.rest.model.BundleRest;
+import org.dspace.app.rest.model.CollectionRest;
+import org.dspace.app.rest.model.CommunityRest;
+import org.dspace.app.rest.model.ItemRest;
+import org.dspace.app.rest.model.SiteRest;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.app.util.AuthorizeUtil;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * The policy feature. It can be used by administrators (or community/collection delegate) to manage resource policies
+ */
+@Component
+@AuthorizationFeatureDocumentation(name = PolicyFeature.NAME,
+    description = "It can be used to verify if the resourcepolicies of the specified objects can be managed")
+public class PolicyFeature implements AuthorizationFeature {
+
+    public static final String NAME = "canManagePolicies";
+
+    @Autowired
+    AuthorizeService authService;
+    @Autowired
+    private Utils utils;
+
+    @Override
+    public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException {
+        if (object != null) {
+            try {
+                if (object instanceof SiteRest) {
+                    return authService.isAdmin(context);
+                }
+                if (object instanceof CommunityRest) {
+                    AuthorizeUtil.authorizeManageCommunityPolicy(context,
+                        (Community)utils.getDSpaceAPIObjectFromRest(context, object));
+                    return true;
+                }
+                if (object instanceof CollectionRest) {
+                    AuthorizeUtil.authorizeManageCollectionPolicy(context,
+                        (Collection) utils.getDSpaceAPIObjectFromRest(context, object));
+                    return true;
+                }
+                if (object instanceof ItemRest) {
+                    AuthorizeUtil.authorizeManageItemPolicy(context,
+                        (Item)utils.getDSpaceAPIObjectFromRest(context, object));
+                    return true;
+                }
+                if (object instanceof BundleRest) {
+                    AuthorizeUtil.authorizeManageBundlePolicy(context,
+                        (Bundle)utils.getDSpaceAPIObjectFromRest(context, object));
+                    return true;
+                }
+                if (object instanceof BitstreamRest) {
+                    AuthorizeUtil.authorizeManageBitstreamPolicy(context,
+                        (Bitstream)utils.getDSpaceAPIObjectFromRest(context, object));
+                    return true;
+                }
+            } catch (AuthorizeException e) {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[]{
+            SiteRest.CATEGORY + "." + SiteRest.NAME,
+            CommunityRest.CATEGORY + "." + CommunityRest.NAME,
+            CollectionRest.CATEGORY + "." + CollectionRest.NAME,
+            ItemRest.CATEGORY + "." + ItemRest.NAME,
+            BundleRest.CATEGORY + "." + BundleRest.NAME,
+            BitstreamRest.CATEGORY + "." + BitstreamRest.NAME
+        };
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/PolicyFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/PolicyFeature.java
@@ -33,6 +33,10 @@ import org.springframework.stereotype.Component;
 
 /**
  * The policy feature. It can be used by administrators (or community/collection delegate) to manage resource policies
+ *
+ * Authorization is granted
+ * - for the site if the current user is administrator
+ * - for other objects if the current user has ADMIN permissions on the object
  */
 @Component
 @AuthorizationFeatureDocumentation(name = PolicyFeature.NAME,

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ReorderBitstreamFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ReorderBitstreamFeature.java
@@ -21,6 +21,8 @@ import org.springframework.stereotype.Component;
 
 /**
  * The reorder bitstream feature. It can be used to verify if bitstreams can be reordered in a specific bundle.
+ *
+ * Authorization is granted if the current user has WRITE permissions on the given bundle
  */
 @Component
 @AuthorizationFeatureDocumentation(name = ReorderBitstreamFeature.NAME,

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ReorderBitstreamFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ReorderBitstreamFeature.java
@@ -1,0 +1,49 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization.impl;
+
+import java.sql.SQLException;
+
+import org.dspace.app.rest.authorization.AuthorizationFeature;
+import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
+import org.dspace.app.rest.authorization.AuthorizeServiceRestUtil;
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.model.BundleRest;
+import org.dspace.app.rest.security.DSpaceRestPermission;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * The reorder bitstream feature. It can be used to verify if bitstreams can be reordered in a specific bundle.
+ */
+@Component
+@AuthorizationFeatureDocumentation(name = ReorderBitstreamFeature.NAME,
+    description = "It can be used to verify if bitstreams can be reordered in a specific bundle")
+public class ReorderBitstreamFeature implements AuthorizationFeature {
+
+    public final static String NAME = "canReorderBitstreams";
+
+    @Autowired
+    private AuthorizeServiceRestUtil authorizeServiceRestUtil;
+
+    @Override
+    public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException {
+        if (object instanceof BundleRest) {
+            return authorizeServiceRestUtil.authorizeActionBoolean(context, object, DSpaceRestPermission.WRITE);
+        }
+        return false;
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[]{
+            BundleRest.CATEGORY + "." + BundleRest.NAME
+        };
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/GenericAuthorizationFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/GenericAuthorizationFeatureIT.java
@@ -1,0 +1,873 @@
+package org.dspace.app.rest.authorization;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.InputStream;
+
+import org.apache.commons.codec.CharEncoding;
+import org.apache.commons.io.IOUtils;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.builder.BitstreamBuilder;
+import org.dspace.builder.BundleBuilder;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.EPersonBuilder;
+import org.dspace.builder.GroupBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.builder.ResourcePolicyBuilder;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.core.Constants;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
+import org.dspace.services.ConfigurationService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Test for the following authorization features:
+ *     canManagePolicies
+ *     canEditMetadata
+ *     canMove
+ *     canMakePrivate
+ *     canMakeDiscoverable
+ *     canDelete
+ *     canReorderBitstreams
+ *     canCreateBitstream
+ *     canCreateBundle
+ */
+public class GenericAuthorizationFeatureIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    ConfigurationService configurationService;
+
+    private Community communityA;
+    private Community communityAA;
+    private Community communityB;
+    private Community communityBB;
+    private Collection collectionX;
+    private Collection collectionY;
+    private Item item1;
+    private Item item2;
+    private Bundle bundle1;
+    private Bundle bundle2;
+    private Bitstream bitstream1;
+    private Bitstream bitstream2;
+
+    private Group item1AdminGroup;
+
+    private EPerson communityAAdmin;
+    private EPerson collectionXAdmin;
+    private EPerson item1Admin;
+    private EPerson communityAWriter;
+    private EPerson collectionXWriter;
+    private EPerson item1Writer;
+
+    boolean originalAlwaysThrowException;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        context.turnOffAuthorisationSystem();
+
+        communityAAdmin = EPersonBuilder.createEPerson(context)
+            .withNameInMetadata("Jhon", "Brown")
+            .withEmail("communityAAdmin@my.edu")
+            .withPassword(password)
+            .build();
+        collectionXAdmin = EPersonBuilder.createEPerson(context)
+            .withNameInMetadata("Jhon", "Brown")
+            .withEmail("collectionXAdmin@my.edu")
+            .withPassword(password)
+            .build();
+        item1Admin = EPersonBuilder.createEPerson(context)
+            .withNameInMetadata("Jhon", "Brown")
+            .withEmail("item1Admin@my.edu")
+            .withPassword(password)
+            .build();
+        communityAWriter = EPersonBuilder.createEPerson(context)
+            .withNameInMetadata("Jhon", "Brown")
+            .withEmail("communityAWriter@my.edu")
+            .withPassword(password)
+            .build();
+        collectionXWriter = EPersonBuilder.createEPerson(context)
+            .withNameInMetadata("Jhon", "Brown")
+            .withEmail("collectionXWriter@my.edu")
+            .withPassword(password)
+            .build();
+        item1Writer = EPersonBuilder.createEPerson(context)
+            .withNameInMetadata("Jhon", "Brown")
+            .withEmail("item1Writer@my.edu")
+            .withPassword(password)
+            .build();
+
+        communityA = CommunityBuilder.createCommunity(context)
+            .withName("communityA")
+            .withAdminGroup(communityAAdmin)
+            .build();
+        communityAA = CommunityBuilder.createCommunity(context)
+            .withName("communityAA")
+            .addParentCommunity(context, communityA)
+            .build();
+        collectionX = CollectionBuilder.createCollection(context, communityAA)
+            .withName("collectionX")
+            .withAdminGroup(collectionXAdmin)
+            .build();
+        item1 = ItemBuilder.createItem(context, collectionX)
+            .withTitle("item1")
+            .withIssueDate("2020-07-08")
+            .withAuthor("Smith, Donald").withAuthor("Doe, John")
+            .withSubject("item1Entry")
+            .build();
+        bundle1 = BundleBuilder.createBundle(context, item1)
+            .withName("bundle1")
+            .build();
+        try (InputStream is = IOUtils.toInputStream("randomContent", CharEncoding.UTF_8)) {
+            bitstream1 = BitstreamBuilder.createBitstream(context, bundle1, is)
+                .withName("bitstream1")
+                .withMimeType("text/plain")
+                .build();
+        }
+
+        item1AdminGroup = GroupBuilder.createGroup(context)
+            .withName("item1AdminGroup")
+            .addMember(item1Admin)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(item1)
+            .withAction(Constants.ADMIN)
+            .withGroup(item1AdminGroup)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(communityA)
+            .withAction(Constants.WRITE)
+            .withUser(communityAWriter)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(collectionX)
+            .withAction(Constants.WRITE)
+            .withUser(collectionXWriter)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(item1)
+            .withAction(Constants.WRITE)
+            .withUser(item1Writer)
+            .build();
+
+        communityB = CommunityBuilder.createCommunity(context)
+            .withName("communityB")
+            .build();
+        communityBB = CommunityBuilder.createCommunity(context)
+            .withName("communityBB")
+            .addParentCommunity(context, communityB)
+            .build();
+        collectionY = CollectionBuilder.createCollection(context, communityBB)
+            .withName("collectionY")
+            .build();
+        item2 = ItemBuilder.createItem(context, collectionY)
+            .withTitle("item2")
+            .withIssueDate("2020-07-08")
+            .withAuthor("Smith, Donald").withAuthor("Doe, John")
+            .withSubject("item2Entry")
+            .build();
+        bundle2 = BundleBuilder.createBundle(context, item2)
+            .withName("bundle2")
+            .build();
+        try (InputStream is = IOUtils.toInputStream("randomContent", CharEncoding.UTF_8)) {
+            bitstream2 = BitstreamBuilder.createBitstream(context, bundle2, is)
+                .withName("bitstream2")
+                .withMimeType("text/plain")
+                .build();
+        }
+
+        context.restoreAuthSystemState();
+
+        originalAlwaysThrowException = configurationService.getBooleanProperty(
+            "org.dspace.app.rest.authorization.AlwaysThrowExceptionFeature.turnoff", false);
+        configurationService.setProperty(
+            "org.dspace.app.rest.authorization.AlwaysThrowExceptionFeature.turnoff", "true");
+    }
+
+    @Override
+    @After
+    public void destroy() throws Exception {
+        configurationService.setProperty(
+            "org.dspace.app.rest.authorization.AlwaysThrowExceptionFeature.turnoff", originalAlwaysThrowException);
+        super.destroy();
+    }
+
+    private void testAdminsHavePermissionsAllDso(String feature) throws Exception {
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        String communityAAdminToken = getAuthToken(communityAAdmin.getEmail(), password);
+        String collectionXAdminToken = getAuthToken(collectionXAdmin.getEmail(), password);
+        String item1AdminToken = getAuthToken(item1Admin.getEmail(), password);
+        String siteId = ContentServiceFactory.getInstance().getSiteService().findSite(context).getID().toString();
+
+        // Verify the general admin has this feature on the site
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/sites/" + siteId))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify community A admin doesn’t have this feature on the site
+        getClient(communityAAdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/sites/" + siteId))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify the general admin has this feature on community A
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/communities/" + communityA.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify community A admin has this feature on community A
+        getClient(communityAAdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/communities/" + communityA.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify community A admin has this feature on community AA
+        getClient(communityAAdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/communities/" + communityAA.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify collection X admin doesn’t have this feature on community A
+        getClient(collectionXAdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/communities/" + communityA.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify community A admin doesn’t have this feature on community B
+        getClient(communityAAdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/communities/" + communityB.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify the general admin has this feature on collection X
+        getClient(adminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/collections/" + collectionX.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify community A admin has this feature on collection X
+        getClient(communityAAdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/collections/" + collectionX.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify collection X admin has this feature on collection X
+        getClient(collectionXAdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/collections/" + collectionX.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify item 1 admin doesn’t have this feature on collection X
+        getClient(item1AdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/collections/" + collectionX.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify collection X admin doesn’t have this feature on collection Y
+        getClient(collectionXAdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/collections/" + collectionY.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify the general admin has this feature on item 1
+        getClient(adminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify community A admin has this feature on item 1
+        getClient(communityAAdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify collection X admin has this feature on item 1
+        getClient(collectionXAdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify item 1 admin has this feature on item 1
+        getClient(item1AdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify item 1 admin doesn’t have this feature on item 2
+        getClient(item1AdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/items/" + item2.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify the general admin has this feature on the bundle in item 1
+        getClient(adminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify community A admin has this feature on the bundle in item 1
+        getClient(communityAAdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify collection X admin has this feature on the bundle in item 1
+        getClient(collectionXAdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify item 1 admin has this feature on the bundle in item 1
+        getClient(item1AdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify item 1 admin doesn’t have this feature on the bundle in item 2
+        getClient(item1AdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/bundles/" + bundle2.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify the general admin has this feature on the bitstream in item 1
+        getClient(adminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/bitstreams/" + bitstream1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify community A admin has this feature on the bitstream in item 1
+        getClient(communityAAdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/bitstreams/" + bitstream1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify collection X admin has this feature on the bitstream in item 1
+        getClient(collectionXAdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/bitstreams/" + bitstream1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify item 1 admin has this feature on the bitstream in item 1
+        getClient(item1AdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/bitstreams/" + bitstream1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify item 1 admin doesn’t have this feature on the bitstream in item 2
+        getClient(item1AdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/bitstreams/" + bitstream2.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+    }
+
+    private void testAdminsHavePermissionsItem(String feature) throws Exception {
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        String communityAAdminToken = getAuthToken(communityAAdmin.getEmail(), password);
+        String collectionXAdminToken = getAuthToken(collectionXAdmin.getEmail(), password);
+        String item1AdminToken = getAuthToken(item1Admin.getEmail(), password);
+
+        // Verify the general admin has this feature on item 1
+        getClient(adminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify community A admin has this feature on item 1
+        getClient(communityAAdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify collection X admin has this feature on item 1
+        getClient(collectionXAdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify item 1 admin has this feature on item 1
+        getClient(item1AdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify community A admin doesn’t have this feature on item 2
+        getClient(communityAAdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/items/" + item2.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+    }
+
+    private void testWriteUsersHavePermissionsAllDso(String feature, boolean hasDSOAccess) throws Exception {
+        String communityAWriterToken = getAuthToken(communityAWriter.getEmail(), password);
+        String collectionXWriterToken = getAuthToken(collectionXWriter.getEmail(), password);
+        String item1WriterToken = getAuthToken(item1Writer.getEmail(), password);
+
+        // Verify community A write has this feature on community A if the boolean parameter is true
+        // (or doesn’t have access otherwise)
+        if (hasDSOAccess) {
+            getClient(communityAWriterToken).perform(
+                get("/api/authz/authorizations/search/object?embed=feature&uri="
+                    + "http://localhost/api/core/communities/" + communityA.getID()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                    + feature + "')]").exists());
+        } else {
+            getClient(communityAWriterToken).perform(
+                get("/api/authz/authorizations/search/object?embed=feature&uri="
+                    + "http://localhost/api/core/communities/" + communityA.getID()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                    + feature + "')]").doesNotExist());
+        }
+
+        // Verify community A write doesn’t have this feature on community AA
+        getClient(communityAWriterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/communities/" + communityAA.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify community A write doesn’t have this feature on collection X
+        getClient(communityAWriterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/collections/" + collectionX.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify community A write doesn’t have this feature on item 1
+        getClient(communityAWriterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify community A write doesn’t have this feature on the bundle in item 1
+        getClient(communityAWriterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify community A write doesn’t have this feature on the bitstream in item 1
+        getClient(communityAWriterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify collection X write doesn’t have this feature on community A
+        getClient(collectionXWriterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/communities/" + communityA.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify collection X write doesn’t have this feature on community AA
+        getClient(collectionXWriterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/communities/" + communityAA.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify collection X write has this feature on collection X if the boolean parameter is true
+        // (or doesn’t have access otherwise)
+        if (hasDSOAccess) {
+            getClient(collectionXWriterToken).perform(
+                get("/api/authz/authorizations/search/object?embed=feature&uri="
+                    + "http://localhost/api/core/collections/" + collectionX.getID()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                    + feature + "')]").exists());
+        } else {
+            getClient(collectionXWriterToken).perform(
+                get("/api/authz/authorizations/search/object?embed=feature&uri="
+                    + "http://localhost/api/core/collections/" + collectionX.getID()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                    + feature + "')]").doesNotExist());
+        }
+
+        // Verify collection X write doesn’t have this feature on item 1
+        getClient(collectionXWriterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify collection X write doesn’t have this feature on the bundle in item 1
+        getClient(collectionXWriterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify collection X write doesn’t have this feature on the bitstream in item 1
+        getClient(collectionXWriterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/bitstreams/" + bitstream1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify item 1 write doesn’t have this feature on community A
+        getClient(item1WriterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/communities/" + communityA.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify item 1 write doesn’t have this feature on community AA
+        getClient(item1WriterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/communities/" + communityAA.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify item 1 write doesn’t have this feature on collection X
+        getClient(item1WriterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/collections/" + collectionX.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify item 1 write has this feature on item 1 if the boolean parameter is true
+        // (or doesn’t have access otherwise)
+        if (hasDSOAccess) {
+            getClient(item1WriterToken).perform(
+                get("/api/authz/authorizations/search/object?embed=feature&uri="
+                    + "http://localhost/api/core/items/" + item1.getID()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                    + feature + "')]").exists());
+        } else {
+            getClient(item1WriterToken).perform(
+                get("/api/authz/authorizations/search/object?embed=feature&uri="
+                    + "http://localhost/api/core/items/" + item1.getID()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                    + feature + "')]").doesNotExist());
+        }
+
+        // Verify item 1 write doesn’t have this feature on the bundle in item 1
+        getClient(item1WriterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify item 1 write doesn’t have this feature on the bitstream in item 1
+        getClient(item1WriterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/bitstreams/" + bitstream1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify community A write doesn’t have this feature on community B
+        getClient(communityAWriterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/communities/" + communityB.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify collection X write doesn’t have this feature on collection Y
+        getClient(collectionXWriterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/collections/" + collectionY.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify item 1 write doesn’t have this feature on item 2
+        getClient(item1WriterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/items/" + item2.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+    }
+
+    private void testWriteUsersHavePermissionsItem(String feature, boolean hasDSOAccess) throws Exception {
+        String communityAWriterToken = getAuthToken(communityAWriter.getEmail(), password);
+        String collectionXWriterToken = getAuthToken(collectionXWriter.getEmail(), password);
+        String item1WriterToken = getAuthToken(item1Writer.getEmail(), password);
+
+        // Verify community A write doesn’t have this feature on item 1
+        getClient(communityAWriterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify collection X write doesn’t have this feature on item 1
+        getClient(collectionXWriterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify item 1 write has this feature on item 1 if the boolean parameter is true
+        // (or doesn’t have access otherwise)
+        if (hasDSOAccess) {
+            getClient(item1WriterToken).perform(
+                get("/api/authz/authorizations/search/object?embed=feature&uri="
+                    + "http://localhost/api/core/items/" + item1.getID()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                    + feature + "')]").exists());
+        } else {
+            getClient(item1WriterToken).perform(
+                get("/api/authz/authorizations/search/object?embed=feature&uri="
+                    + "http://localhost/api/core/items/" + item1.getID()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                    + feature + "')]").doesNotExist());
+        }
+
+        // Verify item 1 write doesn’t have this feature on item 2
+        getClient(item1WriterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/items/" + item2.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+    }
+
+    @Test
+    public void testCanManagePoliciesAdmin() throws Exception {
+        testWriteUsersHavePermissionsAllDso("canManagePolicies", false);
+    }
+
+    @Test
+    public void testCanManagePoliciesWriter() throws Exception {
+        testWriteUsersHavePermissionsAllDso("canManagePolicies", false);
+    }
+
+
+    @Test
+    public void testCanEditMetadataAdmin() throws Exception {
+        testAdminsHavePermissionsAllDso("canEditMetadata");
+    }
+
+    @Test
+    public void testCanEditMetadataWriter() throws Exception {
+        testWriteUsersHavePermissionsAllDso("canEditMetadata", true);
+    }
+
+    @Test
+    public void testCanMoveAdmin() throws Exception {
+        String item1WriterToken = getAuthToken(item1Writer.getEmail(), password);
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        String communityAAdminToken = getAuthToken(communityAAdmin.getEmail(), password);
+        String collectionXAdminToken = getAuthToken(collectionXAdmin.getEmail(), password);
+        String item1AdminToken = getAuthToken(item1Admin.getEmail(), password);
+        String feature = "canMove";
+
+        // Verify the general admin has this feature on item 1
+        getClient(adminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify community A admin has this feature on item 1
+        getClient(communityAAdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify collection X admin has this feature on item 1
+        getClient(collectionXAdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify item 1 admin doesn’t have this feature on item 1
+        getClient(item1AdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify community A admin doesn’t have this feature on item 2
+        getClient(communityAAdminToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/items/" + item2.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+
+        // grant item 1 admin REMOVE permissions on the item’s owning collection
+        // verify item 1 admin has this feature on item 1
+        context.turnOffAuthorisationSystem();
+        ResourcePolicy removePermission = ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(collectionX)
+            .withAction(Constants.REMOVE)
+            .withUser(item1Writer)
+            .build();
+        context.restoreAuthSystemState();
+
+        // verify item 1 write has this feature on item 1
+        getClient(item1WriterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='canMove')]")
+                .exists());
+
+        context.turnOffAuthorisationSystem();
+        ResourcePolicyBuilder.delete(removePermission.getID());
+        context.restoreAuthSystemState();
+    }
+
+    @Test
+    public void testCanMoveWriter() throws Exception {
+        testWriteUsersHavePermissionsItem("canMove", false);
+
+        // grant item 1 write REMOVE permissions on the item’s owning collection
+        context.turnOffAuthorisationSystem();
+        ResourcePolicy removePermission = ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(collectionX)
+            .withAction(Constants.REMOVE)
+            .withUser(item1Writer)
+            .build();
+        context.restoreAuthSystemState();
+
+        String item1WriterToken = getAuthToken(item1Writer.getEmail(), password);
+        // verify item 1 write has this feature on item 1
+        getClient(item1WriterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+                + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='canMove')]")
+                .exists());
+
+        context.turnOffAuthorisationSystem();
+        ResourcePolicyBuilder.delete(removePermission.getID());
+        context.restoreAuthSystemState();
+    }
+
+    @Test
+    public void testCanMakePrivateAdmin() throws Exception {
+        testAdminsHavePermissionsItem("canMakePrivate");
+    }
+
+    @Test
+    public void testCanMakePrivateWriter() throws Exception {
+        testWriteUsersHavePermissionsItem("canMakePrivate", true);
+    }
+
+    @Test
+    public void testCanMakeDiscoverableAdmin() throws Exception {
+        testAdminsHavePermissionsItem("canMakeDiscoverable");
+    }
+
+    @Test
+    public void testCanMakeDiscoverableWriter() throws Exception {
+        testWriteUsersHavePermissionsItem("canMakeDiscoverable", true);
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/GenericAuthorizationFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/GenericAuthorizationFeatureIT.java
@@ -35,7 +35,6 @@ import org.dspace.core.Constants;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.services.ConfigurationService;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -78,8 +77,6 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
     private EPerson communityAWriter;
     private EPerson collectionXWriter;
     private EPerson item1Writer;
-
-    boolean originalAlwaysThrowException;
 
     @Override
     @Before
@@ -200,18 +197,8 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
 
         context.restoreAuthSystemState();
 
-        originalAlwaysThrowException = configurationService.getBooleanProperty(
-            "org.dspace.app.rest.authorization.AlwaysThrowExceptionFeature.turnoff", false);
         configurationService.setProperty(
             "org.dspace.app.rest.authorization.AlwaysThrowExceptionFeature.turnoff", "true");
-    }
-
-    @Override
-    @After
-    public void destroy() throws Exception {
-        configurationService.setProperty(
-            "org.dspace.app.rest.authorization.AlwaysThrowExceptionFeature.turnoff", originalAlwaysThrowException);
-        super.destroy();
     }
 
     private void testAdminsHavePermissionsAllDso(String feature) throws Exception {
@@ -825,10 +812,6 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
             .andExpect(status().isOk())
             .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='canMove')]")
                 .exists());
-
-        context.turnOffAuthorisationSystem();
-        ResourcePolicyBuilder.delete(removePermission.getID());
-        context.restoreAuthSystemState();
     }
 
     @Test
@@ -852,10 +835,6 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
             .andExpect(status().isOk())
             .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='canMove')]")
                 .exists());
-
-        context.turnOffAuthorisationSystem();
-        ResourcePolicyBuilder.delete(removePermission.getID());
-        context.restoreAuthSystemState();
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/GenericAuthorizationFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/GenericAuthorizationFeatureIT.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.app.rest.authorization;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -758,7 +765,7 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
         String communityAAdminToken = getAuthToken(communityAAdmin.getEmail(), password);
         String collectionXAdminToken = getAuthToken(collectionXAdmin.getEmail(), password);
         String item1AdminToken = getAuthToken(item1Admin.getEmail(), password);
-        String feature = "canMove";
+        final String feature = "canMove";
 
         // Verify the general admin has this feature on item 1
         getClient(adminToken).perform(
@@ -869,5 +876,834 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
     @Test
     public void testCanMakeDiscoverableWriter() throws Exception {
         testWriteUsersHavePermissionsItem("canMakeDiscoverable", true);
+    }
+
+    @Test
+    public void testCanDeleteAdmin() throws Exception {
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        String communityAAdminToken = getAuthToken(communityAAdmin.getEmail(), password);
+        String collectionXAdminToken = getAuthToken(collectionXAdmin.getEmail(), password);
+        String item1AdminToken = getAuthToken(item1Admin.getEmail(), password);
+        String siteId = ContentServiceFactory.getInstance().getSiteService().findSite(context).getID().toString();
+        final String feature = "canDelete";
+
+        // Verify the general admin doesn’t have this feature on the site
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/sites/" + siteId))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify the general admin has this feature on community A
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/communities/" + communityA.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify community A admin has this feature on community A
+        getClient(communityAAdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/communities/" + communityA.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify community A admin has this feature on community AA
+        getClient(communityAAdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/communities/" + communityAA.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Create a community AA admin and verify the community AA admin doesn’t have this feature on community AA
+        context.turnOffAuthorisationSystem();
+        EPerson communityAAAdmin = EPersonBuilder.createEPerson(context)
+            .withNameInMetadata("Jhon", "Brown")
+            .withEmail("communityAAAdmin@my.edu")
+            .withPassword(password)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(communityAA)
+            .withAction(Constants.ADMIN)
+            .withUser(communityAAAdmin)
+            .build();
+        context.restoreAuthSystemState();
+        String communityAAAdminToken = getAuthToken(communityAAAdmin.getEmail(), password);
+        getClient(communityAAAdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/communities/" + communityAA.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify collection X admin doesn’t have this feature on community A
+        getClient(collectionXAdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/communities/" + communityA.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify community A admin doesn’t have this feature on community B
+        getClient(communityAAdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/communities/" + communityB.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify the general admin has this feature on collection X
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/collections/" + collectionX.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify community A admin has this feature on collection X
+        getClient(communityAAdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/collections/" + collectionX.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify collection X admin doesn’t have this feature on collection X
+        getClient(collectionXAdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/collections/" + collectionX.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify item 1 admin doesn’t have this feature on collection X
+        getClient(item1AdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/collections/" + collectionX.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify collection X admin doesn’t have this feature on collection Y
+        getClient(collectionXAdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/collections/" + collectionY.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify the general admin has this feature on item 1
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify community A admin has this feature on item 1
+        getClient(communityAAdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify collection X admin has this feature on item 1
+        getClient(collectionXAdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify item 1 admin doesn’t have this feature on item 1
+        getClient(item1AdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify item 1 admin doesn’t have this feature on item 2
+        getClient(item1AdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/items/" + item2.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify the general admin has this feature on the bundle in item 1
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify community A admin has this feature on the bundle in item 1
+        getClient(communityAAdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify collection X admin has this feature on the bundle in item 1
+        getClient(collectionXAdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify item 1 admin has this feature on the bundle in item 1
+        getClient(item1AdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify item 1 admin doesn’t have this feature on the bundle in item 2
+        getClient(item1AdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bundles/" + bundle2.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify the general admin has this feature on the bitstream in item 1
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bitstreams/" + bitstream1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify community A admin has this feature on the bitstream in item 1
+        getClient(communityAAdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bitstreams/" + bitstream1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify collection X admin has this feature on the bitstream in item 1
+        getClient(collectionXAdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bitstreams/" + bitstream1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify item 1 admin has this feature on the bitstream in item 1
+        getClient(item1AdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bitstreams/" + bitstream1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify item 1 admin doesn’t have this feature on the bitstream in item 2
+        getClient(item1AdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bitstreams/" + bitstream2.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+    }
+
+    @Test
+    public void testCanDeleteAdminParent() throws Exception {
+        String collectionXAdminToken = getAuthToken(collectionXAdmin.getEmail(), password);
+        String item1AdminToken = getAuthToken(item1Admin.getEmail(), password);
+        final String feature = "canDelete";
+
+        // Create a community AA admin, grant REMOVE permissions on community A to this user
+        context.turnOffAuthorisationSystem();
+        EPerson communityAAAdmin = EPersonBuilder.createEPerson(context)
+            .withNameInMetadata("Jhon", "Brown")
+            .withEmail("communityAAAdmin@my.edu")
+            .withPassword(password)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(communityA)
+            .withAction(Constants.REMOVE)
+            .withUser(communityAAAdmin)
+            .build();
+        context.restoreAuthSystemState();
+        String communityAAAdminToken = getAuthToken(communityAAAdmin.getEmail(), password);
+        //verify the community AA admin has this feature on community AA
+        getClient(communityAAAdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/communities/" + communityAA.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Grant REMOVE permissions on community AA for collection X admin
+        context.turnOffAuthorisationSystem();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(communityAA)
+            .withAction(Constants.REMOVE)
+            .withUser(collectionXAdmin)
+            .build();
+        context.restoreAuthSystemState();
+        // verify collection X admin has this feature on collection X
+        getClient(collectionXAdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/collections/" + collectionX.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Grant REMOVE permissions on collection X for item 1 admin
+        context.turnOffAuthorisationSystem();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(collectionX)
+            .withAction(Constants.REMOVE)
+            .withUser(item1Admin)
+            .build();
+        context.restoreAuthSystemState();
+        // verify item 1 admin has this feature on item 1
+        getClient(item1AdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+    }
+
+    @Test
+    public void testCanDeleteWriter() throws Exception {
+        testWriteUsersHavePermissionsAllDso("canManagePolicies", false);
+    }
+
+    @Test
+    public void testCanDeleteMinimalPermissions() throws Exception {
+        final String feature = "canDelete";
+
+        // Create a new user, grant DELETE permissions on community A to this user
+        context.turnOffAuthorisationSystem();
+        EPerson communityADeleter = EPersonBuilder.createEPerson(context)
+            .withNameInMetadata("Jhon", "Brown")
+            .withEmail("communityADeleter@my.edu")
+            .withPassword(password)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(communityA)
+            .withAction(Constants.DELETE)
+            .withUser(communityADeleter)
+            .build();
+        context.restoreAuthSystemState();
+        String communityADeleterToken = getAuthToken(communityADeleter.getEmail(), password);
+        // Verify the user has this feature on community A
+        getClient(communityADeleterToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/communities/" + communityA.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+        // Verify this user doesn’t have this feature on community AA
+        getClient(communityADeleterToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/communities/" + communityAA.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+
+        // Create a new user, grant REMOVE permissions on community A to this user
+        context.turnOffAuthorisationSystem();
+        EPerson communityARemover = EPersonBuilder.createEPerson(context)
+            .withNameInMetadata("Jhon", "Brown")
+            .withEmail("communityARemover@my.edu")
+            .withPassword(password)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(communityA)
+            .withAction(Constants.REMOVE)
+            .withUser(communityARemover)
+            .build();
+        context.restoreAuthSystemState();
+        String communityARemoverToken = getAuthToken(communityARemover.getEmail(), password);
+        // Verify the user has this feature on community AA
+        getClient(communityARemoverToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/communities/" + communityAA.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+        // Verify this user doesn’t have this feature on community A
+        getClient(communityARemoverToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/communities/" + communityA.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+        // Verify this user doesn’t have this feature on collection X
+        getClient(communityARemoverToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/collections/" + collectionX.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Create a new user, grant REMOVE permissions on community AA to this user
+        context.turnOffAuthorisationSystem();
+        EPerson communityAARemover = EPersonBuilder.createEPerson(context)
+            .withNameInMetadata("Jhon", "Brown")
+            .withEmail("communityAARemover@my.edu")
+            .withPassword(password)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(communityAA)
+            .withAction(Constants.REMOVE)
+            .withUser(communityAARemover)
+            .build();
+        context.restoreAuthSystemState();
+        String communityAARemoverToken = getAuthToken(communityAARemover.getEmail(), password);
+        // Verify the user has this feature on collection X
+        getClient(communityAARemoverToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/collections/" + collectionX.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+        // Verify this user doesn’t have this feature on community AA
+        getClient(communityAARemoverToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/communities/" + communityAA.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+        // Verify this user doesn’t have this feature on item 1
+        getClient(communityAARemoverToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Create a new user, grant REMOVE permissions on collection X to this user
+        context.turnOffAuthorisationSystem();
+        EPerson collectionXRemover = EPersonBuilder.createEPerson(context)
+            .withNameInMetadata("Jhon", "Brown")
+            .withEmail("communityXRemover@my.edu")
+            .withPassword(password)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(collectionX)
+            .withAction(Constants.REMOVE)
+            .withUser(collectionXRemover)
+            .build();
+        context.restoreAuthSystemState();
+        String collectionXRemoverToken = getAuthToken(collectionXRemover.getEmail(), password);
+        // Verify the user doesn’t have this feature on item 1
+        getClient(collectionXRemoverToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Create a new user, grant DELETE permissions on item 1 to this user
+        context.turnOffAuthorisationSystem();
+        EPerson item1Deleter = EPersonBuilder.createEPerson(context)
+            .withNameInMetadata("Jhon", "Brown")
+            .withEmail("item1Deleter@my.edu")
+            .withPassword(password)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(item1)
+            .withAction(Constants.DELETE)
+            .withUser(item1Deleter)
+            .build();
+        context.restoreAuthSystemState();
+        String item1DeleterToken = getAuthToken(item1Deleter.getEmail(), password);
+        // Verify the user doesn’t have this feature on item 1
+        getClient(item1DeleterToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Create a new user, grant REMOVE permissions on collection X and DELETE permissions on item 1 to this user
+        context.turnOffAuthorisationSystem();
+        EPerson collectionXRemoverItem1Deleter = EPersonBuilder.createEPerson(context)
+            .withNameInMetadata("Jhon", "Brown")
+            .withEmail("collectionXDeleter@my.edu")
+            .withPassword(password)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(collectionX)
+            .withAction(Constants.REMOVE)
+            .withUser(collectionXRemoverItem1Deleter)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(item1)
+            .withAction(Constants.DELETE)
+            .withUser(collectionXRemoverItem1Deleter)
+            .build();
+        context.restoreAuthSystemState();
+        String collectionXRemoverItem1DeleterToken = getAuthToken(collectionXRemoverItem1Deleter.getEmail(), password);
+        // Verify the user has this feature on item 1
+        getClient(collectionXRemoverItem1DeleterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+        // Verify this user doesn’t have this feature on collection X
+        getClient(collectionXRemoverItem1DeleterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/collections/" + collectionX.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+        // Verify this user doesn’t have this feature on the bundle in item 1
+        getClient(collectionXRemoverItem1DeleterToken).perform(
+            get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Create a new user, grant REMOVE permissions on item 1 to this user
+        context.turnOffAuthorisationSystem();
+        EPerson item1Remover = EPersonBuilder.createEPerson(context)
+            .withNameInMetadata("Jhon", "Brown")
+            .withEmail("item1Remover@my.edu")
+            .withPassword(password)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(item1)
+            .withAction(Constants.REMOVE)
+            .withUser(item1Remover)
+            .build();
+        context.restoreAuthSystemState();
+        String item1RemoverToken = getAuthToken(item1Remover.getEmail(), password);
+        // Verify the user has this feature on the bundle in item 1
+        getClient(item1RemoverToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+        // Verify this user doesn’t have this feature on item 1
+        getClient(item1RemoverToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+        // Verify this user doesn’t have this feature on the bitstream in item 1
+        getClient(item1RemoverToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bitstreams/" + bitstream1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Create a new user, grant REMOVE permissions on the bundle in item 1 to this user
+        context.turnOffAuthorisationSystem();
+        EPerson bundle1Remover = EPersonBuilder.createEPerson(context)
+            .withNameInMetadata("Jhon", "Brown")
+            .withEmail("bundle1Remover@my.edu")
+            .withPassword(password)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(bundle1)
+            .withAction(Constants.REMOVE)
+            .withUser(bundle1Remover)
+            .build();
+        context.restoreAuthSystemState();
+        String bundle1RemoverToken = getAuthToken(bundle1Remover.getEmail(), password);
+        // Verify the user doesn’t have this feature on the bitstream in item 1
+        getClient(bundle1RemoverToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bitstreams/" + bitstream1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Create a new user, grant REMOVE permissions on the bundle in item 1
+        // and REMOVE permissions on item 1 to this user
+        context.turnOffAuthorisationSystem();
+        EPerson bundle1item1Remover = EPersonBuilder.createEPerson(context)
+            .withNameInMetadata("Jhon", "Brown")
+            .withEmail("bundle1item1Remover@my.edu")
+            .withPassword(password)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(bundle1)
+            .withAction(Constants.REMOVE)
+            .withUser(bundle1item1Remover)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(item1)
+            .withAction(Constants.REMOVE)
+            .withUser(bundle1item1Remover)
+            .build();
+        context.restoreAuthSystemState();
+        String bundle1item1RemoverToken = getAuthToken(bundle1item1Remover.getEmail(), password);
+        // Verify the user has this feature on the bitstream in item 1
+        getClient(bundle1item1RemoverToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bitstreams/" + bitstream1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+    }
+
+    @Test
+    public void testCanReorderBitstreamsAdmin() throws Exception {
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        String communityAAdminToken = getAuthToken(communityAAdmin.getEmail(), password);
+        String collectionXAdminToken = getAuthToken(collectionXAdmin.getEmail(), password);
+        String item1AdminToken = getAuthToken(item1Admin.getEmail(), password);
+        final String feature = "canReorderBitstreams";
+
+        // Verify the general admin has this feature on the bundle in item 1
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify community A admin has this feature on the bundle in item 1
+        getClient(communityAAdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify collection X admin has this feature on the bundle in item 1
+        getClient(collectionXAdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify item 1 admin has this feature on the bundle in item 1
+        getClient(item1AdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify community A admin doesn’t have this feature on the bundle in item 2
+        getClient(communityAAdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bundles/" + bundle2.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+    }
+
+    @Test
+    public void testCanReorderBitstreamsWriter() throws Exception {
+        String communityAWriterToken = getAuthToken(communityAWriter.getEmail(), password);
+        String collectionXWriterToken = getAuthToken(collectionXWriter.getEmail(), password);
+        String item1WriterToken = getAuthToken(item1Writer.getEmail(), password);
+        final String feature = "canReorderBitstreams";
+
+        // Verify community A write doesn’t have this feature on the bundle in item 1
+        getClient(communityAWriterToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+        // Verify collection X write doesn’t have this feature on the bundle in item 1
+        getClient(collectionXWriterToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+        // Verify item 1 write doesn’t have this feature on the bundle in item 1
+        getClient(item1WriterToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Create a new user, grant WRITE permissions on the bundle in item 1 to this user
+        // Verify the user has this feature on the bundle in item 1
+        getClient(communityAWriterToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+    }
+
+    @Test
+    public void testCanCreateBitstreamAdmin() throws Exception {
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        String communityAAdminToken = getAuthToken(communityAAdmin.getEmail(), password);
+        String collectionXAdminToken = getAuthToken(collectionXAdmin.getEmail(), password);
+        String item1AdminToken = getAuthToken(item1Admin.getEmail(), password);
+        final String feature = "canCreateBitstream";
+
+        // Verify the general admin has this feature on the bundle in item 1
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify community A admin has this feature on the bundle in item 1
+        getClient(communityAAdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify collection X admin has this feature on the bundle in item 1
+        getClient(collectionXAdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify item 1 admin has this feature on the bundle in item 1
+        getClient(item1AdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+
+        // Verify community A admin doesn’t have this feature on the bundle in item 2
+        getClient(communityAAdminToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bundles/" + bundle2.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+    }
+
+    @Test
+    public void testCanCreateBitstreamWriter() throws Exception {
+        String communityAWriterToken = getAuthToken(communityAWriter.getEmail(), password);
+        String collectionXWriterToken = getAuthToken(collectionXWriter.getEmail(), password);
+        String item1WriterToken = getAuthToken(item1Writer.getEmail(), password);
+        final String feature = "canCreateBitstream";
+
+        // Verify community A write doesn’t have this feature on the bundle in item 1
+        getClient(communityAWriterToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify collection X write doesn’t have this feature on the bundle in item 1
+        getClient(collectionXWriterToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify item 1 write doesn’t have this feature on the bundle in item 1
+        getClient(item1WriterToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Create a new user, grant WRITE permissions on the bundle in item 1 to this user
+        context.turnOffAuthorisationSystem();
+        EPerson bundle1Writer = EPersonBuilder.createEPerson(context)
+            .withNameInMetadata("Jhon", "Brown")
+            .withEmail("bundle1Writer@my.edu")
+            .withPassword(password)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(bundle1)
+            .withAction(Constants.WRITE)
+            .withUser(bundle1Writer)
+            .build();
+        context.restoreAuthSystemState();
+        String bundle1WriterToken = getAuthToken(bundle1Writer.getEmail(), password);
+        // Verify the user doesn’t have this feature on the bundle in item 1
+        getClient(bundle1WriterToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Create a new user, grant ADD permissions on the bundle in item 1 to this user
+        context.turnOffAuthorisationSystem();
+        EPerson bundle1Adder = EPersonBuilder.createEPerson(context)
+            .withNameInMetadata("Jhon", "Brown")
+            .withEmail("bundle1Adder@my.edu")
+            .withPassword(password)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(bundle1)
+            .withAction(Constants.ADD)
+            .withUser(bundle1Adder)
+            .build();
+        context.restoreAuthSystemState();
+        String bundle1AdderToken = getAuthToken(bundle1Adder.getEmail(), password);
+        // Verify the user doesn’t have this feature on the bundle in item 1
+        getClient(bundle1AdderToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Create a new user, grant ADD and WRITE permissions on the bundle in item 1
+        // and ADD and WRITE permission on the item to this user
+        context.turnOffAuthorisationSystem();
+        EPerson bundle1WriterAdder = EPersonBuilder.createEPerson(context)
+            .withNameInMetadata("Jhon", "Brown")
+            .withEmail("bundle1WriterAdder@my.edu")
+            .withPassword(password)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(bundle1)
+            .withAction(Constants.ADD)
+            .withUser(bundle1WriterAdder)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(bundle1)
+            .withAction(Constants.WRITE)
+            .withUser(bundle1WriterAdder)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(item1)
+            .withAction(Constants.ADD)
+            .withUser(bundle1WriterAdder)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(item1)
+            .withAction(Constants.WRITE)
+            .withUser(bundle1WriterAdder)
+            .build();
+        context.restoreAuthSystemState();
+        String bundle1WriterAdderToken = getAuthToken(bundle1WriterAdder.getEmail(), password);
+        // Verify the user has this feature on the bundle in item 1
+        getClient(bundle1WriterAdderToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/bundles/" + bundle1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
+    }
+
+    @Test
+    public void testCanCreateBundleAdmin() throws Exception {
+        testAdminsHavePermissionsItem("canCreateBundle");
+    }
+
+    @Test
+    public void testCanCreateBundleWriter() throws Exception {
+        String communityAWriterToken = getAuthToken(communityAWriter.getEmail(), password);
+        String collectionXWriterToken = getAuthToken(collectionXWriter.getEmail(), password);
+        String item1WriterToken = getAuthToken(item1Writer.getEmail(), password);
+        final String feature = "canCreateBundle";
+
+        // Verify community A write doesn’t have this feature on item 1
+        getClient(communityAWriterToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify collection X write doesn’t have this feature on item 1
+        getClient(collectionXWriterToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Verify item 1 write doesn’t have this feature on item 1
+        getClient(item1WriterToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").doesNotExist());
+
+        // Create a new user, grant ADD and WRITE permissions on item 1 to this user
+        context.turnOffAuthorisationSystem();
+        EPerson item1AdderWriter = EPersonBuilder.createEPerson(context)
+            .withNameInMetadata("Jhon", "Brown")
+            .withEmail("item1AdderWriter@my.edu")
+            .withPassword(password)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(item1)
+            .withAction(Constants.ADD)
+            .withUser(item1AdderWriter)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(item1)
+            .withAction(Constants.WRITE)
+            .withUser(item1AdderWriter)
+            .build();
+        context.restoreAuthSystemState();
+        String item1AdderWriterToken = getAuthToken(item1AdderWriter.getEmail(), password);
+        // Verify the user has this feature on item 1
+        getClient(item1AdderWriterToken).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
+            + "http://localhost/api/core/items/" + item1.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='"
+                + feature + "')]").exists());
     }
 }


### PR DESCRIPTION
## References
* Fixes [GitHub issue](https://github.com/DSpace/DSpace/issues/2921)

## Description
This PR implements the features:
* canManagePolicies
* canEditMetadata
* canMove
* canMakePrivate
* canMakeDiscoverable
* canDelete
* canReorderBitstreams
* canCreateBitstream
* canCreateBundle

The permissions have been determined based on what's verified in DSpace 6.

This also fixes an error with the difference between REMOVE and DELETE policies. REMOVE is based on the parent's permission and DELETE is based on the current DSO's permission, which in itself was implemented correctly. But the ADMIN rights were not consistent with this setup.

## Instructions for Reviewers
The code outside the ITs is limited to making the authorizations accessible and fixing some bugs in the API.

For the ITs, we created a setup with 2 communities, each with a sub-community, each with a collection, each with an item, each with a bundle, each with a bitstream, e.g. (not displaying bundle and bitstream in the sample below)
* community A
  * community AA
    * collection X
      * item 1
* community B
  * community BB
    * collection Y
      * item 2

We also created the following users in the setup:
* community A admin (in the admin group of this community)
* collection X admin (in the admin group of this collection)
* item 1 admin (in the admin group of this item)
* community A write (with write permissions on this community)
* collection X write (with write permissions on this collection)
* item 1 write (with write permissions on this item)

To ease the tests, we created a few common methods to verify whether admins have permissions for a specific feature, and to verify whether people with WRITE access have permissions for a specific feature.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
