### PR TITLE
Upgrade to Flyway v6.5.5. Update code based on Flyway API changes

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -739,7 +739,7 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-            <version>4.0.3</version>
+            <version>6.5.5</version>
         </dependency>
 
         <!-- Google Analytics -->

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -157,6 +157,19 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>src/test/resources/**</exclude>
+                        <exclude>src/test/data/**</exclude>
+                        <!-- Ignore license header requirements on Flyway upgrade scripts -->
+                        <exclude>src/main/resources/org/dspace/storage/rdbms/flywayupgrade/**</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -190,7 +190,15 @@ public class Context implements AutoCloseable {
         setMode(this.mode);
     }
 
-    public static boolean updateDatabase() {
+    /**
+     * Update the DSpace database, ensuring that any necessary migrations are run prior to initializing
+     * Hibernate.
+     * <P>
+     * This is synchronized as it only needs to be run successfully *once* (for the first Context initialized).
+     *
+     * @return true/false, based on whether database was successfully updated
+     */
+    public static synchronized boolean updateDatabase() {
         //If the database has not been updated yet, update it and remember that.
         if (databaseUpdated.compareAndSet(false, true)) {
 
@@ -200,7 +208,7 @@ public class Context implements AutoCloseable {
             try {
                 DatabaseUtils.updateDatabase();
             } catch (SQLException sqle) {
-                log.fatal("Cannot initialize database via Flyway!", sqle);
+                log.fatal("Cannot update or initialize database via Flyway!", sqle);
                 databaseUpdated.set(false);
             }
         }
@@ -641,9 +649,9 @@ public class Context implements AutoCloseable {
     /**
      * Temporary change the user bound to the context, empty the special groups that
      * are retained to allow subsequent restore
-     * 
+     *
      * @param newUser the EPerson to bound to the context
-     * 
+     *
      * @throws IllegalStateException if the switch was already performed without be
      *                               restored
      */
@@ -661,7 +669,7 @@ public class Context implements AutoCloseable {
 
     /**
      * Restore the user bound to the context and his special groups
-     * 
+     *
      * @throws IllegalStateException if no switch was performed before
      */
     public void restoreContextUser() {

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseRegistryUpdater.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseRegistryUpdater.java
@@ -9,7 +9,6 @@ package org.dspace.storage.rdbms;
 
 import java.io.File;
 import java.io.IOException;
-import java.sql.Connection;
 import java.sql.SQLException;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
@@ -24,8 +23,8 @@ import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.workflow.factory.WorkflowServiceFactory;
 import org.dspace.xmlworkflow.service.XmlWorkflowService;
-import org.flywaydb.core.api.MigrationInfo;
-import org.flywaydb.core.api.callback.FlywayCallback;
+import org.flywaydb.core.api.callback.Callback;
+import org.flywaydb.core.api.callback.Event;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
@@ -50,7 +49,7 @@ import org.xml.sax.SAXException;
  *
  * @author Tim Donohue
  */
-public class DatabaseRegistryUpdater implements FlywayCallback {
+public class DatabaseRegistryUpdater implements Callback {
     /**
      * logging category
      */
@@ -107,73 +106,38 @@ public class DatabaseRegistryUpdater implements FlywayCallback {
         }
     }
 
+
+    /**
+     * Events supported by this callback.
+     * @param event Flyway event
+     * @param context Flyway context
+     * @return true if AFTER_MIGRATE event
+     */
     @Override
-    public void beforeClean(Connection connection) {
-
-    }
-
-    @Override
-    public void afterClean(Connection connection) {
-
-    }
-
-    @Override
-    public void beforeMigrate(Connection connection) {
-
-    }
-
-    @Override
-    public void afterMigrate(Connection connection) {
+    public boolean supports(Event event, org.flywaydb.core.api.callback.Context context) {
         // Must run AFTER all migrations complete, since it is dependent on Hibernate
+        return event.equals(Event.AFTER_MIGRATE);
+    }
+
+    /**
+     * Whether event can be handled in a transaction or whether it must be handle outside of transaction.
+     * @param event Flyway event
+     * @param context Flyway context
+     * @return true
+     */
+    @Override
+    public boolean canHandleInTransaction(Event event, org.flywaydb.core.api.callback.Context context) {
+        // Always return true, as our handle() method is updating the database.
+        return true;
+    }
+
+    /**
+     * What to run when the callback is triggered.
+     * @param event Flyway event
+     * @param context Flyway context
+     */
+    @Override
+    public void handle(Event event, org.flywaydb.core.api.callback.Context context) {
         updateRegistries();
-    }
-
-    @Override
-    public void beforeEachMigrate(Connection connection, MigrationInfo migrationInfo) {
-
-    }
-
-    @Override
-    public void afterEachMigrate(Connection connection, MigrationInfo migrationInfo) {
-
-    }
-
-    @Override
-    public void beforeValidate(Connection connection) {
-
-    }
-
-    @Override
-    public void afterValidate(Connection connection) {
-
-    }
-
-    @Override
-    public void beforeBaseline(Connection connection) {
-
-    }
-
-    @Override
-    public void afterBaseline(Connection connection) {
-
-    }
-
-    @Override
-    public void beforeRepair(Connection connection) {
-
-    }
-
-    @Override
-    public void afterRepair(Connection connection) {
-
-    }
-
-    @Override
-    public void beforeInfo(Connection connection) {
-
-    }
-
-    @Override
-    public void afterInfo(Connection connection) {
     }
 }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -106,6 +106,10 @@ public class DatabaseUtils {
             FluentConfiguration flywayConfiguration = setupFlyway(dataSource);
             Flyway flyway = flywayConfiguration.load();
 
+            // Now, check our Flyway database table to see if it needs upgrading
+            // *before* any other Flyway commands can be run. This is a safety check.
+            FlywayUpgradeUtils.upgradeFlywayTable(flyway, dataSource.getConnection());
+
             // "test" = Test Database Connection
             if (argv[0].equalsIgnoreCase("test")) {
                 // Try to connect to the database
@@ -568,10 +572,7 @@ public class DatabaseUtils {
             // nothing to worry about...you can always trigger them to run using "database migrate ignored" from CLI
             flywayConfiguration.ignoreIgnoredMigrations(true);
 
-            // Set flyway callbacks (i.e. classes which are called post-DB migration and similar)
-            // In this situation, we have a Registry Updater that runs PRE-migration
-            // NOTE: DatabaseLegacyReindexer only indexes in Legacy Lucene & RDBMS indexes. It can be removed
-            // once those are obsolete.
+            // Set Flyway callbacks (i.e. classes which are called post-DB migration and similar)
             List<Callback> flywayCallbacks = DSpaceServicesFactory.getInstance().getServiceManager()
                                                                         .getServicesByType(Callback.class);
 

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/FlywayUpgradeUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/FlywayUpgradeUtils.java
@@ -22,7 +22,6 @@ import org.apache.commons.text.StringSubstitutor;
 import org.apache.logging.log4j.Logger;
 import org.dspace.storage.rdbms.migration.MigrationUtils;
 import org.flywaydb.core.Flyway;
-import org.springframework.core.io.ClassPathResource;
 
 /**
  * Utility class used to detect issues with the Flyway migration history table and attempt to correct/fix them.
@@ -93,8 +92,7 @@ public class FlywayUpgradeUtils {
                 log.info("Attempting to upgrade Flyway table '{}' using script at '{}'",
                          FLYWAY_TABLE, scriptPath);
                 // Load the Flyway v4.2.0 upgrade SQL script as a String
-                String flywayUpgradeSQL = MigrationUtils.resourceToString(
-                    new ClassPathResource(scriptPath, FlywayUpgradeUtils.class.getClassLoader()));
+                String flywayUpgradeSQL = MigrationUtils.getResourceAsString(scriptPath);
 
                 // As this Flyway upgrade SQL was borrowed from Flyway v4.2.0 directly, it contains some inline
                 // variables which need replacing, namely ${schema} and ${table} variables.

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/FlywayUpgradeUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/FlywayUpgradeUtils.java
@@ -1,0 +1,119 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.storage.rdbms;
+
+import static org.dspace.storage.rdbms.DatabaseUtils.FLYWAY_TABLE;
+import static org.dspace.storage.rdbms.DatabaseUtils.executeSql;
+import static org.dspace.storage.rdbms.DatabaseUtils.getCurrentFlywayState;
+import static org.dspace.storage.rdbms.DatabaseUtils.getDbType;
+import static org.dspace.storage.rdbms.DatabaseUtils.getSchemaName;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.text.StringSubstitutor;
+import org.apache.logging.log4j.Logger;
+import org.dspace.storage.rdbms.migration.MigrationUtils;
+import org.flywaydb.core.Flyway;
+import org.springframework.core.io.ClassPathResource;
+
+/**
+ * Utility class used to detect issues with the Flyway migration history table and attempt to correct/fix them.
+ * These issues can occur when attempting to upgrade your database across multiple versions/releases of Flyway.
+ * <p>
+ * As documented in this issue ticket, Flyway does not normally support skipping over any
+ * major release (for example going from v3 to v5 is unsuppored): https://github.com/flyway/flyway/issues/2126
+ * <p>
+ * This class allows us to do a migration (where needed) through multiple major versions of Flyway.
+ *
+ * @author Tim Donohue
+ */
+public class FlywayUpgradeUtils {
+    /**
+     * log4j category
+     */
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(FlywayUpgradeUtils.class);
+
+    // Resource path of all Flyway upgrade scripts
+    private static final String UPGRADE_SCRIPT_PATH = "org/dspace/storage/rdbms/flywayupgrade/";
+
+
+    /**
+     * Default constructor
+     */
+    private FlywayUpgradeUtils() { }
+
+    /**
+     * Ensures the Flyway migration history table (FLYWAY_TABLE) is upgraded to the latest version of Flyway safely.
+     * <P>
+     * Unfortunately, Flyway does not always support skipping major versions (e.g. upgrading directly from Flyway
+     * v3.x to 5.x is not possible, see https://github.com/flyway/flyway/issues/2126).
+     * <P>
+     * While sometimes it's possible to do so, other times you MUST upgrade through each major version. This method
+     * ensures we upgrade the Flyway history table through each version of Flyway where deemed necessary.
+     *
+     * @param flyway initialized/configured Flyway object
+     * @param connection current database connection
+     */
+    protected static synchronized void upgradeFlywayTable(Flyway flyway, Connection connection)
+        throws SQLException {
+        // Whether the Flyway table needs updating or not
+        boolean needsUpgrade = false;
+
+        // Determine if Flyway needs updating by running a simple info() command.
+        // This command will not run any pending migrations, but it will throw an exception
+        // if the Flyway migration history table is NOT valid for the current version of Flyway
+        try {
+            flyway.info();
+        } catch (Exception e) {
+            // ignore error, but log info statement to say we will try to upgrade to fix problem
+            log.info("Flyway table '{}' appears to be outdated. Will attempt to upgrade it automatically. " +
+                         "Flyway Exception was '{}'", FLYWAY_TABLE, e.toString());
+            needsUpgrade = true;
+        }
+
+        if (needsUpgrade) {
+            // Get the DSpace version info from the LAST migration run.
+            String lastMigration = getCurrentFlywayState(connection);
+            // If this is an older DSpace 5.x compatible database, then it used Flyway 3.x.
+            // Because we cannot upgrade directly from Flyway 3.x -> 6.x, we need to FIRST update this
+            // database to be compatible with Flyway 4.2.0 (which can be upgraded directly to Flyway 6.x)
+            if (lastMigration.startsWith("5.")) {
+                // Based on type of DB, get path to our Flyway 4.x upgrade script
+                String dbtype = getDbType(connection);
+                String scriptPath = UPGRADE_SCRIPT_PATH + dbtype + "/upgradeToFlyway4x.sql";
+
+                log.info("Attempting to upgrade Flyway table '{}' using script at '{}'",
+                         FLYWAY_TABLE, scriptPath);
+                // Load the Flyway v4.2.0 upgrade SQL script as a String
+                String flywayUpgradeSQL = MigrationUtils.resourceToString(
+                    new ClassPathResource(scriptPath, FlywayUpgradeUtils.class.getClassLoader()));
+
+                // As this Flyway upgrade SQL was borrowed from Flyway v4.2.0 directly, it contains some inline
+                // variables which need replacing, namely ${schema} and ${table} variables.
+                // We'll use the StringSubstitutor to replace those variables with their proper values.
+                Map<String, String> valuesMap = new HashMap<>();
+                valuesMap.put("schema", getSchemaName(connection));
+                valuesMap.put("table", FLYWAY_TABLE);
+                StringSubstitutor sub = new StringSubstitutor(valuesMap);
+                flywayUpgradeSQL = sub.replace(flywayUpgradeSQL);
+
+                // Run the script to update the Flyway table to be compatible with FLyway v4.x
+                executeSql(connection, flywayUpgradeSQL);
+            }
+            // NOTE: no other DSpace versions require a specialized Flyway upgrade script at this time.
+            // DSpace 4 didn't use Flyway. DSpace 6 used Flyway v4, which Flyway v6 can update automatically.
+
+            // After any Flyway table upgrade, we MUST run a Flyway repair() to cleanup migration checksums if needed
+            log.info("Repairing Flyway table '{}' after upgrade...", FLYWAY_TABLE);
+            flyway.repair();
+        }
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/GroupServiceInitializer.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/GroupServiceInitializer.java
@@ -7,13 +7,11 @@
  */
 package org.dspace.storage.rdbms;
 
-import java.sql.Connection;
-
 import org.apache.logging.log4j.Logger;
 import org.dspace.core.Context;
 import org.dspace.eperson.service.GroupService;
-import org.flywaydb.core.api.MigrationInfo;
-import org.flywaydb.core.api.callback.FlywayCallback;
+import org.flywaydb.core.api.callback.Callback;
+import org.flywaydb.core.api.callback.Event;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -22,7 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  *
  * @author kevinvandevelde at atmire.com
  */
-public class GroupServiceInitializer implements FlywayCallback {
+public class GroupServiceInitializer implements Callback {
 
     private final Logger log = org.apache.logging.log4j.LogManager.getLogger(GroupServiceInitializer.class);
 
@@ -53,73 +51,36 @@ public class GroupServiceInitializer implements FlywayCallback {
 
     }
 
+    /**
+     * Events supported by this callback.
+     * @param event Flyway event
+     * @param context Flyway context
+     * @return true if AFTER_MIGRATE event
+     */
     @Override
-    public void beforeClean(Connection connection) {
-
+    public boolean supports(Event event, org.flywaydb.core.api.callback.Context context) {
+        // Must run AFTER all migrations complete, since it is dependent on Hibernate
+        return event.equals(Event.AFTER_MIGRATE);
     }
 
+    /**
+     * Whether event can be handled in a transaction or whether it must be handle outside of transaction.
+     * @param event Flyway event
+     * @param context Flyway context
+     * @return true
+     */
     @Override
-    public void afterClean(Connection connection) {
-
+    public boolean canHandleInTransaction(Event event, org.flywaydb.core.api.callback.Context context) {
+        return true;
     }
 
+    /**
+     * What to run when the callback is triggered.
+     * @param event Flyway event
+     * @param context Flyway context
+     */
     @Override
-    public void beforeMigrate(Connection connection) {
-
-    }
-
-    @Override
-    public void afterMigrate(Connection connection) {
+    public void handle(Event event, org.flywaydb.core.api.callback.Context context) {
         initGroups();
-    }
-
-    @Override
-    public void beforeEachMigrate(Connection connection, MigrationInfo migrationInfo) {
-
-    }
-
-    @Override
-    public void afterEachMigrate(Connection connection, MigrationInfo migrationInfo) {
-
-    }
-
-    @Override
-    public void beforeValidate(Connection connection) {
-
-    }
-
-    @Override
-    public void afterValidate(Connection connection) {
-
-    }
-
-    @Override
-    public void beforeBaseline(Connection connection) {
-
-    }
-
-    @Override
-    public void afterBaseline(Connection connection) {
-
-    }
-
-    @Override
-    public void beforeRepair(Connection connection) {
-
-    }
-
-    @Override
-    public void afterRepair(Connection connection) {
-
-    }
-
-    @Override
-    public void beforeInfo(Connection connection) {
-
-    }
-
-    @Override
-    public void afterInfo(Connection connection) {
-
     }
 }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/SiteServiceInitializer.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/SiteServiceInitializer.java
@@ -7,8 +7,6 @@
  */
 package org.dspace.storage.rdbms;
 
-import java.sql.Connection;
-
 import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Site;
@@ -17,8 +15,8 @@ import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.service.GroupService;
-import org.flywaydb.core.api.MigrationInfo;
-import org.flywaydb.core.api.callback.FlywayCallback;
+import org.flywaydb.core.api.callback.Callback;
+import org.flywaydb.core.api.callback.Event;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -27,7 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  *
  * @author kevinvandevelde at atmire.com
  */
-public class SiteServiceInitializer implements FlywayCallback {
+public class SiteServiceInitializer implements Callback {
 
     private Logger log = org.apache.logging.log4j.LogManager.getLogger(SiteServiceInitializer.class);
 
@@ -46,13 +44,13 @@ public class SiteServiceInitializer implements FlywayCallback {
         try {
             context = new Context();
             context.turnOffAuthorisationSystem();
-            // While it's not really a formal "registry", we need to ensure the
-            // default, required Groups exist in the DSpace database
+            // Create Site object if it doesn't exist in database
             Site site = null;
             if (siteService.findSite(context) == null) {
                 site = siteService.createSite(context);
             }
             context.restoreAuthSystemState();
+            // Give Anonymous users READ permissions on the Site Object (if doesn't exist)
             if (!authorizeService.authorizeActionBoolean(context, site, Constants.READ)) {
                 context.turnOffAuthorisationSystem();
                 Group anonGroup = groupService.findByName(context, Group.ANONYMOUS);
@@ -64,7 +62,7 @@ public class SiteServiceInitializer implements FlywayCallback {
             // Commit changes and close context
             context.complete();
         } catch (Exception e) {
-            log.error("Error attempting to add/update default DSpace Groups", e);
+            log.error("Error attempting to add/update default Site object", e);
         } finally {
             // Clean up our context, if it still exists & it was never completed
             if (context != null && context.isValid()) {
@@ -75,73 +73,36 @@ public class SiteServiceInitializer implements FlywayCallback {
 
     }
 
+    /**
+     * Events supported by this callback.
+     * @param event Flyway event
+     * @param context Flyway context
+     * @return true if AFTER_MIGRATE event
+     */
     @Override
-    public void beforeClean(Connection connection) {
-
+    public boolean supports(Event event, org.flywaydb.core.api.callback.Context context) {
+        // Must run AFTER all migrations complete, since it is dependent on Hibernate
+        return event.equals(Event.AFTER_MIGRATE);
     }
 
+    /**
+     * Whether event can be handled in a transaction or whether it must be handle outside of transaction.
+     * @param event Flyway event
+     * @param context Flyway context
+     * @return true
+     */
     @Override
-    public void afterClean(Connection connection) {
-
+    public boolean canHandleInTransaction(Event event, org.flywaydb.core.api.callback.Context context) {
+        return true;
     }
 
+    /**
+     * What to run when the callback is triggered.
+     * @param event Flyway event
+     * @param context Flyway context
+     */
     @Override
-    public void beforeMigrate(Connection connection) {
-
-    }
-
-    @Override
-    public void afterMigrate(Connection connection) {
+    public void handle(Event event, org.flywaydb.core.api.callback.Context context) {
         initializeSiteObject();
-    }
-
-    @Override
-    public void beforeEachMigrate(Connection connection, MigrationInfo migrationInfo) {
-
-    }
-
-    @Override
-    public void afterEachMigrate(Connection connection, MigrationInfo migrationInfo) {
-
-    }
-
-    @Override
-    public void beforeValidate(Connection connection) {
-
-    }
-
-    @Override
-    public void afterValidate(Connection connection) {
-
-    }
-
-    @Override
-    public void beforeBaseline(Connection connection) {
-
-    }
-
-    @Override
-    public void afterBaseline(Connection connection) {
-
-    }
-
-    @Override
-    public void beforeRepair(Connection connection) {
-
-    }
-
-    @Override
-    public void afterRepair(Connection connection) {
-
-    }
-
-    @Override
-    public void beforeInfo(Connection connection) {
-
-    }
-
-    @Override
-    public void afterInfo(Connection connection) {
-
     }
 }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/MigrationUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/MigrationUtils.java
@@ -7,12 +7,19 @@
  */
 package org.dspace.storage.rdbms.migration;
 
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import org.apache.commons.lang3.StringUtils;
+import org.dspace.core.Constants;
+import org.springframework.core.io.Resource;
+import org.springframework.util.FileCopyUtils;
 
 /**
  * This Utility class offers utility methods which may be of use to perform
@@ -269,5 +276,20 @@ public class MigrationUtils {
         }
 
         return checksum;
+    }
+
+    /**
+     * Read a given Resource, converting to a String. This is used by several Java-based
+     * migrations to read a SQL migration into a string, so that it can be executed under
+     * specific scenarios.
+     * @param resource Resource to read
+     * @return String contents of Resource
+     */
+    public static String resourceToString(Resource resource) {
+        try (Reader reader = new InputStreamReader(resource.getInputStream(), Constants.DEFAULT_ENCODING)) {
+            return FileCopyUtils.copyToString(reader);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/MigrationUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/MigrationUtils.java
@@ -15,10 +15,10 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
 import org.dspace.core.Constants;
-import org.springframework.core.io.Resource;
 import org.springframework.util.FileCopyUtils;
 
 /**
@@ -282,14 +282,20 @@ public class MigrationUtils {
      * Read a given Resource, converting to a String. This is used by several Java-based
      * migrations to read a SQL migration into a string, so that it can be executed under
      * specific scenarios.
-     * @param resource Resource to read
+     * @param resourcePath relative path of resource to read
      * @return String contents of Resource
      */
-    public static String resourceToString(Resource resource) {
-        try (Reader reader = new InputStreamReader(resource.getInputStream(), Constants.DEFAULT_ENCODING)) {
+    public static String getResourceAsString(String resourcePath) {
+        // Read the resource, copying to a string
+        try (Reader reader =
+                 new InputStreamReader(
+                     Objects.requireNonNull(MigrationUtils.class.getClassLoader().getResourceAsStream(resourcePath)),
+                     Constants.DEFAULT_ENCODING)) {
             return FileCopyUtils.copyToString(reader);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
+        } catch (NullPointerException e) {
+            throw new IllegalStateException("Resource at " + resourcePath + " was not found", e);
         }
     }
 }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V1_3_9__Drop_constraint_for_DSpace_1_4_schema.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V1_3_9__Drop_constraint_for_DSpace_1_4_schema.java
@@ -8,11 +8,10 @@
 package org.dspace.storage.rdbms.migration;
 
 import java.io.IOException;
-import java.sql.Connection;
 import java.sql.SQLException;
 
-import org.flywaydb.core.api.migration.MigrationChecksumProvider;
-import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
 
 /**
  * This class is in support of the "V1.4__Upgrade_to_DSpace_1.4_schema.sql"
@@ -38,22 +37,22 @@ import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
  * @author Tim Donohue
  */
 public class V1_3_9__Drop_constraint_for_DSpace_1_4_schema
-    implements JdbcMigration, MigrationChecksumProvider {
+    extends BaseJavaMigration {
     /* The checksum to report for this migration (when successful) */
     private int checksum = -1;
 
     /**
      * Actually migrate the existing database
      *
-     * @param connection SQL Connection object
+     * @param context Flyway Migration Context
      * @throws IOException  A general class of exceptions produced by failed or interrupted I/O operations.
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
     @Override
-    public void migrate(Connection connection)
+    public void migrate(Context context)
         throws IOException, SQLException {
         // Drop the constraint associated with "name" column of "community"
-        checksum = MigrationUtils.dropDBConstraint(connection, "community", "name", "key");
+        checksum = MigrationUtils.dropDBConstraint(context.getConnection(), "community", "name", "key");
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V1_5_9__Drop_constraint_for_DSpace_1_6_schema.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V1_5_9__Drop_constraint_for_DSpace_1_6_schema.java
@@ -8,11 +8,10 @@
 package org.dspace.storage.rdbms.migration;
 
 import java.io.IOException;
-import java.sql.Connection;
 import java.sql.SQLException;
 
-import org.flywaydb.core.api.migration.MigrationChecksumProvider;
-import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
 
 /**
  * This class is in support of the "V1.6__Upgrade_to_DSpace_1.6_schema.sql"
@@ -38,26 +37,29 @@ import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
  * @author Tim Donohue
  */
 public class V1_5_9__Drop_constraint_for_DSpace_1_6_schema
-    implements JdbcMigration, MigrationChecksumProvider {
+    extends BaseJavaMigration {
     /* The checksum to report for this migration (when successful) */
     private int checksum = -1;
 
     /**
      * Actually migrate the existing database
      *
-     * @param connection SQL Connection object
+     * @param context Flyway Migration Context
      * @throws IOException  A general class of exceptions produced by failed or interrupted I/O operations.
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
     @Override
-    public void migrate(Connection connection)
+    public void migrate(Context context)
         throws IOException, SQLException {
         // Drop the constraint associated with "collection_id" column of "community2collection" table
-        int return1 = MigrationUtils.dropDBConstraint(connection, "community2collection", "collection_id", "pkey");
+        int return1 = MigrationUtils.dropDBConstraint(context.getConnection(), "community2collection",
+                                                      "collection_id", "pkey");
         // Drop the constraint associated with "child_comm_id" column of "community2community" table
-        int return2 = MigrationUtils.dropDBConstraint(connection, "community2community", "child_comm_id", "pkey");
+        int return2 = MigrationUtils.dropDBConstraint(context.getConnection(), "community2community",
+                                                      "child_comm_id", "pkey");
         // Drop the constraint associated with "item_id" column of "collection2item" table
-        int return3 = MigrationUtils.dropDBConstraint(connection, "collection2item", "item_id", "pkey");
+        int return3 = MigrationUtils.dropDBConstraint(context.getConnection(), "collection2item",
+                                                      "item_id", "pkey");
 
         // Checksum will just be the sum of those three return values
         checksum = return1 + return2 + return3;

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V5_0_2014_09_25__DS_1582_Metadata_For_All_Objects_drop_constraint.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V5_0_2014_09_25__DS_1582_Metadata_For_All_Objects_drop_constraint.java
@@ -8,11 +8,10 @@
 package org.dspace.storage.rdbms.migration;
 
 import java.io.IOException;
-import java.sql.Connection;
 import java.sql.SQLException;
 
-import org.flywaydb.core.api.migration.MigrationChecksumProvider;
-import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
 
 /**
  * This class is in support of the DS-1582 Metadata for All Objects feature.
@@ -39,22 +38,22 @@ import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
  * @author Tim Donohue
  */
 public class V5_0_2014_09_25__DS_1582_Metadata_For_All_Objects_drop_constraint
-    implements JdbcMigration, MigrationChecksumProvider {
+    extends BaseJavaMigration {
     /* The checksum to report for this migration (when successful) */
     private int checksum = -1;
 
     /**
      * Actually migrate the existing database
      *
-     * @param connection SQL Connection object
+     * @param context Flyway Migration Context
      * @throws IOException  A general class of exceptions produced by failed or interrupted I/O operations.
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
     @Override
-    public void migrate(Connection connection)
+    public void migrate(Context context)
         throws IOException, SQLException {
         // Drop the constraint associated with "item_id" column of "metadatavalue"
-        checksum = MigrationUtils.dropDBConstraint(connection, "metadatavalue", "item_id", "fkey");
+        checksum = MigrationUtils.dropDBConstraint(context.getConnection(), "metadatavalue", "item_id", "fkey");
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V5_7_2017_05_05__DS_3431_Add_Policies_for_BasicWorkflow.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V5_7_2017_05_05__DS_3431_Add_Policies_for_BasicWorkflow.java
@@ -10,7 +10,6 @@ package org.dspace.storage.rdbms.migration;
 import org.dspace.storage.rdbms.DatabaseUtils;
 import org.flywaydb.core.api.migration.BaseJavaMigration;
 import org.flywaydb.core.api.migration.Context;
-import org.springframework.core.io.ClassPathResource;
 
 public class V5_7_2017_05_05__DS_3431_Add_Policies_for_BasicWorkflow
     extends BaseJavaMigration {
@@ -35,9 +34,8 @@ public class V5_7_2017_05_05__DS_3431_Add_Policies_for_BasicWorkflow
         } else {
             //Migrate the basic workflow
             // Get the contents of our data migration script, based on path & DB type
-            dataMigrateSQL = MigrationUtils.resourceToString(
-                new ClassPathResource(sqlMigrationPath + "basicWorkflow" + "/V5.7_2017.05.05__DS-3431.sql",
-                                      getClass().getClassLoader()));
+            dataMigrateSQL = MigrationUtils.getResourceAsString(
+                sqlMigrationPath + "basicWorkflow/V5.7_2017.05.05__DS-3431.sql");
         }
 
         // Actually execute the Data migration SQL

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V5_7_2017_05_05__DS_3431_Add_Policies_for_BasicWorkflow.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V5_7_2017_05_05__DS_3431_Add_Policies_for_BasicWorkflow.java
@@ -7,25 +7,22 @@
  */
 package org.dspace.storage.rdbms.migration;
 
-import java.sql.Connection;
-
-import org.dspace.core.Constants;
 import org.dspace.storage.rdbms.DatabaseUtils;
-import org.flywaydb.core.api.migration.MigrationChecksumProvider;
-import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
-import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.core.io.ClassPathResource;
 
 public class V5_7_2017_05_05__DS_3431_Add_Policies_for_BasicWorkflow
-    implements JdbcMigration, MigrationChecksumProvider {
+    extends BaseJavaMigration {
 
     // Size of migration script run
     Integer migration_file_size = -1;
 
 
     @Override
-    public void migrate(Connection connection) throws Exception {
+    public void migrate(Context context) throws Exception {
         // Based on type of DB, get path to SQL migration script
-        String dbtype = DatabaseUtils.getDbType(connection);
+        String dbtype = DatabaseUtils.getDbType(context.getConnection());
 
         String dataMigrateSQL;
         String sqlMigrationPath = "org/dspace/storage/rdbms/sqlmigration/workflow/" + dbtype + "/";
@@ -33,19 +30,19 @@ public class V5_7_2017_05_05__DS_3431_Add_Policies_for_BasicWorkflow
         // If XMLWorkflow Table does NOT exist in this database, then lets do the migration!
         // If XMLWorkflow Table ALREADY exists, then this migration is a noop, we assume you manually ran the sql
         // scripts
-        if (DatabaseUtils.tableExists(connection, "cwf_workflowitem")) {
+        if (DatabaseUtils.tableExists(context.getConnection(), "cwf_workflowitem")) {
             return;
         } else {
             //Migrate the basic workflow
             // Get the contents of our data migration script, based on path & DB type
-            dataMigrateSQL = new ClassPathResource(sqlMigrationPath + "basicWorkflow" + "/V5.7_2017.05.05__DS-3431.sql",
-                                                   getClass().getClassLoader())
-                .loadAsString(Constants.DEFAULT_ENCODING);
+            dataMigrateSQL = MigrationUtils.resourceToString(
+                new ClassPathResource(sqlMigrationPath + "basicWorkflow" + "/V5.7_2017.05.05__DS-3431.sql",
+                                      getClass().getClassLoader()));
         }
 
         // Actually execute the Data migration SQL
         // This will migrate all existing traditional workflows to the new XMLWorkflow system & tables
-        DatabaseUtils.executeSql(connection, dataMigrateSQL);
+        DatabaseUtils.executeSql(context.getConnection(), dataMigrateSQL);
         migration_file_size = dataMigrateSQL.length();
 
     }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V6_0_2015_03_06__DS_2701_Dso_Uuid_Migration.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V6_0_2015_03_06__DS_2701_Dso_Uuid_Migration.java
@@ -7,30 +7,29 @@
  */
 package org.dspace.storage.rdbms.migration;
 
-import java.sql.Connection;
-
-import org.flywaydb.core.api.migration.MigrationChecksumProvider;
-import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
 
 /**
  * Migration class that will drop the public key for the dspace objects, the integer based key will be moved to a UUID
  *
  * @author kevinvandevelde at atmire.com
  */
-public class V6_0_2015_03_06__DS_2701_Dso_Uuid_Migration implements JdbcMigration, MigrationChecksumProvider {
+public class V6_0_2015_03_06__DS_2701_Dso_Uuid_Migration extends BaseJavaMigration {
 
     private int checksum = -1;
 
 
     @Override
-    public void migrate(Connection connection) throws Exception {
-        checksum += MigrationUtils.dropDBConstraint(connection, "eperson", "eperson_id", "pkey");
-        checksum += MigrationUtils.dropDBConstraint(connection, "epersongroup", "eperson_group_id", "pkey");
-        checksum += MigrationUtils.dropDBConstraint(connection, "community", "community_id", "pkey");
-        checksum += MigrationUtils.dropDBConstraint(connection, "collection", "collection_id", "pkey");
-        checksum += MigrationUtils.dropDBConstraint(connection, "item", "item_id", "pkey");
-        checksum += MigrationUtils.dropDBConstraint(connection, "bundle", "bundle_id", "pkey");
-        checksum += MigrationUtils.dropDBConstraint(connection, "bitstream", "bitstream_id", "pkey");
+    public void migrate(Context context) throws Exception {
+        checksum += MigrationUtils.dropDBConstraint(context.getConnection(), "eperson", "eperson_id", "pkey");
+        checksum += MigrationUtils.dropDBConstraint(context.getConnection(), "epersongroup",
+                                                    "eperson_group_id", "pkey");
+        checksum += MigrationUtils.dropDBConstraint(context.getConnection(), "community", "community_id", "pkey");
+        checksum += MigrationUtils.dropDBConstraint(context.getConnection(), "collection", "collection_id", "pkey");
+        checksum += MigrationUtils.dropDBConstraint(context.getConnection(), "item", "item_id", "pkey");
+        checksum += MigrationUtils.dropDBConstraint(context.getConnection(), "bundle", "bundle_id", "pkey");
+        checksum += MigrationUtils.dropDBConstraint(context.getConnection(), "bitstream", "bitstream_id", "pkey");
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V6_0_2015_08_31__DS_2701_Hibernate_Workflow_Migration.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V6_0_2015_08_31__DS_2701_Hibernate_Workflow_Migration.java
@@ -7,29 +7,26 @@
  */
 package org.dspace.storage.rdbms.migration;
 
-import java.sql.Connection;
-
-import org.dspace.core.Constants;
 import org.dspace.storage.rdbms.DatabaseUtils;
-import org.flywaydb.core.api.migration.MigrationChecksumProvider;
-import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
-import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.core.io.ClassPathResource;
 
 /**
  * User: kevin (kevin at atmire.com)
  * Date: 1/09/15
  * Time: 12:08
  */
-public class V6_0_2015_08_31__DS_2701_Hibernate_Workflow_Migration implements JdbcMigration, MigrationChecksumProvider {
+public class V6_0_2015_08_31__DS_2701_Hibernate_Workflow_Migration extends BaseJavaMigration {
 
     // Size of migration script run
     Integer migration_file_size = -1;
 
 
     @Override
-    public void migrate(Connection connection) throws Exception {
+    public void migrate(Context context) throws Exception {
         // Based on type of DB, get path to SQL migration script
-        String dbtype = DatabaseUtils.getDbType(connection);
+        String dbtype = DatabaseUtils.getDbType(context.getConnection());
 
         String dataMigrateSQL;
         String sqlMigrationPath = "org/dspace/storage/rdbms/sqlmigration/workflow/" + dbtype + "/";
@@ -37,24 +34,22 @@ public class V6_0_2015_08_31__DS_2701_Hibernate_Workflow_Migration implements Jd
         // If XMLWorkflow Table does NOT exist in this database, then lets do the migration!
         // If XMLWorkflow Table ALREADY exists, then this migration is a noop, we assume you manually ran the sql
         // scripts
-        if (DatabaseUtils.tableExists(connection, "cwf_workflowitem")) {
+        if (DatabaseUtils.tableExists(context.getConnection(), "cwf_workflowitem")) {
             // Get the contents of our data migration script, based on path & DB type
-            dataMigrateSQL = new ClassPathResource(sqlMigrationPath + "xmlworkflow" +
+            dataMigrateSQL = MigrationUtils.resourceToString(new ClassPathResource(sqlMigrationPath + "xmlworkflow" +
                                                        "/V6.0_2015.08.11__DS-2701_Xml_Workflow_Migration.sql",
-                                                   getClass().getClassLoader())
-                .loadAsString(Constants.DEFAULT_ENCODING);
+                                                   getClass().getClassLoader()));
         } else {
             //Migrate the basic workflow
             // Get the contents of our data migration script, based on path & DB type
-            dataMigrateSQL = new ClassPathResource(sqlMigrationPath + "basicWorkflow" +
+            dataMigrateSQL = MigrationUtils.resourceToString(new ClassPathResource(sqlMigrationPath + "basicWorkflow" +
                                                        "/V6.0_2015.08.11__DS-2701_Basic_Workflow_Migration.sql",
-                                                   getClass().getClassLoader())
-                .loadAsString(Constants.DEFAULT_ENCODING);
+                                                   getClass().getClassLoader()));
         }
 
         // Actually execute the Data migration SQL
         // This will migrate all existing traditional workflows to the new XMLWorkflow system & tables
-        DatabaseUtils.executeSql(connection, dataMigrateSQL);
+        DatabaseUtils.executeSql(context.getConnection(), dataMigrateSQL);
         migration_file_size = dataMigrateSQL.length();
 
     }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V6_0_2015_08_31__DS_2701_Hibernate_Workflow_Migration.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V6_0_2015_08_31__DS_2701_Hibernate_Workflow_Migration.java
@@ -10,7 +10,6 @@ package org.dspace.storage.rdbms.migration;
 import org.dspace.storage.rdbms.DatabaseUtils;
 import org.flywaydb.core.api.migration.BaseJavaMigration;
 import org.flywaydb.core.api.migration.Context;
-import org.springframework.core.io.ClassPathResource;
 
 /**
  * User: kevin (kevin at atmire.com)
@@ -36,15 +35,13 @@ public class V6_0_2015_08_31__DS_2701_Hibernate_Workflow_Migration extends BaseJ
         // scripts
         if (DatabaseUtils.tableExists(context.getConnection(), "cwf_workflowitem")) {
             // Get the contents of our data migration script, based on path & DB type
-            dataMigrateSQL = MigrationUtils.resourceToString(new ClassPathResource(sqlMigrationPath + "xmlworkflow" +
-                                                       "/V6.0_2015.08.11__DS-2701_Xml_Workflow_Migration.sql",
-                                                   getClass().getClassLoader()));
+            dataMigrateSQL = MigrationUtils.getResourceAsString(sqlMigrationPath + "xmlworkflow" +
+                                                       "/V6.0_2015.08.11__DS-2701_Xml_Workflow_Migration.sql");
         } else {
             //Migrate the basic workflow
             // Get the contents of our data migration script, based on path & DB type
-            dataMigrateSQL = MigrationUtils.resourceToString(new ClassPathResource(sqlMigrationPath + "basicWorkflow" +
-                                                       "/V6.0_2015.08.11__DS-2701_Basic_Workflow_Migration.sql",
-                                                   getClass().getClassLoader()));
+            dataMigrateSQL = MigrationUtils.getResourceAsString(sqlMigrationPath + "basicWorkflow" +
+                                                       "/V6.0_2015.08.11__DS-2701_Basic_Workflow_Migration.sql");
         }
 
         // Actually execute the Data migration SQL

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V6_0_2016_01_26__DS_2188_Remove_DBMS_Browse_Tables.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V6_0_2016_01_26__DS_2188_Remove_DBMS_Browse_Tables.java
@@ -14,8 +14,8 @@ import org.apache.logging.log4j.Logger;
 import org.dspace.browse.BrowseException;
 import org.dspace.browse.BrowseIndex;
 import org.dspace.storage.rdbms.DatabaseUtils;
-import org.flywaydb.core.api.migration.MigrationChecksumProvider;
-import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
 
 /**
  * This Flyway Java migration deletes any legacy DBMS browse tables found in
@@ -23,7 +23,7 @@ import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
  *
  * @author Tim Donohue
  */
-public class V6_0_2016_01_26__DS_2188_Remove_DBMS_Browse_Tables implements JdbcMigration, MigrationChecksumProvider {
+public class V6_0_2016_01_26__DS_2188_Remove_DBMS_Browse_Tables extends BaseJavaMigration {
     /**
      * log4j category
      */
@@ -34,8 +34,8 @@ public class V6_0_2016_01_26__DS_2188_Remove_DBMS_Browse_Tables implements JdbcM
     private int checksum = -1;
 
     @Override
-    public void migrate(Connection connection) throws Exception, SQLException {
-        removeDBMSBrowseTables(connection);
+    public void migrate(Context context) throws Exception, SQLException {
+        removeDBMSBrowseTables(context.getConnection());
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V6_1_2017_01_03__DS_3431_Add_Policies_for_BasicWorkflow.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V6_1_2017_01_03__DS_3431_Add_Policies_for_BasicWorkflow.java
@@ -10,7 +10,6 @@ package org.dspace.storage.rdbms.migration;
 import org.dspace.storage.rdbms.DatabaseUtils;
 import org.flywaydb.core.api.migration.BaseJavaMigration;
 import org.flywaydb.core.api.migration.Context;
-import org.springframework.core.io.ClassPathResource;
 
 public class V6_1_2017_01_03__DS_3431_Add_Policies_for_BasicWorkflow
     extends BaseJavaMigration {
@@ -35,9 +34,8 @@ public class V6_1_2017_01_03__DS_3431_Add_Policies_for_BasicWorkflow
         } else {
             //Migrate the basic workflow
             // Get the contents of our data migration script, based on path & DB type
-            dataMigrateSQL = MigrationUtils.resourceToString(
-                new ClassPathResource(sqlMigrationPath + "basicWorkflow" + "/V6.1_2017.01.03__DS-3431.sql",
-                                      getClass().getClassLoader()));
+            dataMigrateSQL = MigrationUtils.getResourceAsString(sqlMigrationPath + "basicWorkflow" +
+                                                                    "/V6.1_2017.01.03__DS-3431.sql");
         }
 
         // Actually execute the Data migration SQL

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V6_1_2017_01_03__DS_3431_Add_Policies_for_BasicWorkflow.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V6_1_2017_01_03__DS_3431_Add_Policies_for_BasicWorkflow.java
@@ -7,25 +7,22 @@
  */
 package org.dspace.storage.rdbms.migration;
 
-import java.sql.Connection;
-
-import org.dspace.core.Constants;
 import org.dspace.storage.rdbms.DatabaseUtils;
-import org.flywaydb.core.api.migration.MigrationChecksumProvider;
-import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
-import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.core.io.ClassPathResource;
 
 public class V6_1_2017_01_03__DS_3431_Add_Policies_for_BasicWorkflow
-    implements JdbcMigration, MigrationChecksumProvider {
+    extends BaseJavaMigration {
 
     // Size of migration script run
     Integer migration_file_size = -1;
 
 
     @Override
-    public void migrate(Connection connection) throws Exception {
+    public void migrate(Context context) throws Exception {
         // Based on type of DB, get path to SQL migration script
-        String dbtype = DatabaseUtils.getDbType(connection);
+        String dbtype = DatabaseUtils.getDbType(context.getConnection());
 
         String dataMigrateSQL;
         String sqlMigrationPath = "org/dspace/storage/rdbms/sqlmigration/workflow/" + dbtype + "/";
@@ -33,19 +30,19 @@ public class V6_1_2017_01_03__DS_3431_Add_Policies_for_BasicWorkflow
         // If XMLWorkflow Table does NOT exist in this database, then lets do the migration!
         // If XMLWorkflow Table ALREADY exists, then this migration is a noop, we assume you manually ran the sql
         // scripts
-        if (DatabaseUtils.tableExists(connection, "cwf_workflowitem")) {
+        if (DatabaseUtils.tableExists(context.getConnection(), "cwf_workflowitem")) {
             return;
         } else {
             //Migrate the basic workflow
             // Get the contents of our data migration script, based on path & DB type
-            dataMigrateSQL = new ClassPathResource(sqlMigrationPath + "basicWorkflow" + "/V6.1_2017.01.03__DS-3431.sql",
-                                                   getClass().getClassLoader())
-                .loadAsString(Constants.DEFAULT_ENCODING);
+            dataMigrateSQL = MigrationUtils.resourceToString(
+                new ClassPathResource(sqlMigrationPath + "basicWorkflow" + "/V6.1_2017.01.03__DS-3431.sql",
+                                      getClass().getClassLoader()));
         }
 
         // Actually execute the Data migration SQL
         // This will migrate all existing traditional workflows to the new XMLWorkflow system & tables
-        DatabaseUtils.executeSql(connection, dataMigrateSQL);
+        DatabaseUtils.executeSql(context.getConnection(), dataMigrateSQL);
         migration_file_size = dataMigrateSQL.length();
 
     }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V7_0_2018_04_03__Upgrade_Workflow_Policy.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V7_0_2018_04_03__Upgrade_Workflow_Policy.java
@@ -12,7 +12,6 @@ import org.dspace.workflow.factory.WorkflowServiceFactory;
 import org.dspace.xmlworkflow.service.XmlWorkflowService;
 import org.flywaydb.core.api.migration.BaseJavaMigration;
 import org.flywaydb.core.api.migration.Context;
-import org.springframework.core.io.ClassPathResource;
 
 /**
  * This class automatically adding rptype to the resource policy created with a migration into XML-based Configurable
@@ -35,10 +34,8 @@ public class V7_0_2018_04_03__Upgrade_Workflow_Policy extends BaseJavaMigration 
                 String dbtype = DatabaseUtils.getDbType(context.getConnection());
 
                 String sqlMigrationPath = "org/dspace/storage/rdbms/sqlmigration/workflow/" + dbtype + "/";
-                String dataMigrateSQL = MigrationUtils.resourceToString(
-                    new ClassPathResource(sqlMigrationPath + "xmlworkflow" +
-                                              "/V7.0_2018.04.03__upgrade_workflow_policy.sql",
-                                          getClass().getClassLoader()));
+                String dataMigrateSQL = MigrationUtils.getResourceAsString(
+                    sqlMigrationPath + "xmlworkflow/V7.0_2018.04.03__upgrade_workflow_policy.sql");
 
                 // Actually execute the Data migration SQL
                 // This will migrate all existing traditional workflows to the new XMLWorkflow system & tables

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V7_0_2018_04_03__Upgrade_Workflow_Policy.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V7_0_2018_04_03__Upgrade_Workflow_Policy.java
@@ -7,15 +7,12 @@
  */
 package org.dspace.storage.rdbms.migration;
 
-import java.sql.Connection;
-
-import org.dspace.core.Constants;
 import org.dspace.storage.rdbms.DatabaseUtils;
 import org.dspace.workflow.factory.WorkflowServiceFactory;
 import org.dspace.xmlworkflow.service.XmlWorkflowService;
-import org.flywaydb.core.api.migration.MigrationChecksumProvider;
-import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
-import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.core.io.ClassPathResource;
 
 /**
  * This class automatically adding rptype to the resource policy created with a migration into XML-based Configurable
@@ -23,30 +20,29 @@ import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
  *
  * @author Luigi Andrea Pascarelli (luigiandrea.pascarelli at 4science.it)
  */
-public class V7_0_2018_04_03__Upgrade_Workflow_Policy implements JdbcMigration, MigrationChecksumProvider {
+public class V7_0_2018_04_03__Upgrade_Workflow_Policy extends BaseJavaMigration {
     // Size of migration script run
     protected Integer migration_file_size = -1;
 
 
     @Override
-    public void migrate(Connection connection) throws Exception {
+    public void migrate(Context context) throws Exception {
         // Make sure XML Workflow is enabled, shouldn't even be needed since this class is only loaded if the service
         // is enabled.
         if (WorkflowServiceFactory.getInstance().getWorkflowService() instanceof XmlWorkflowService) {
             // Now, check if the XMLWorkflow table (cwf_workflowitem) already exists in this database
-            if (DatabaseUtils.tableExists(connection, "cwf_workflowitem")) {
-                String dbtype = DatabaseUtils.getDbType(connection);
+            if (DatabaseUtils.tableExists(context.getConnection(), "cwf_workflowitem")) {
+                String dbtype = DatabaseUtils.getDbType(context.getConnection());
 
                 String sqlMigrationPath = "org/dspace/storage/rdbms/sqlmigration/workflow/" + dbtype + "/";
-                String dataMigrateSQL = new ClassPathResource(sqlMigrationPath +
-                                                                  "xmlworkflow" +
-                                                                  "/V7.0_2018.04.03__upgrade_workflow_policy.sql",
-                                                              getClass().getClassLoader())
-                    .loadAsString(Constants.DEFAULT_ENCODING);
+                String dataMigrateSQL = MigrationUtils.resourceToString(
+                    new ClassPathResource(sqlMigrationPath + "xmlworkflow" +
+                                              "/V7.0_2018.04.03__upgrade_workflow_policy.sql",
+                                          getClass().getClassLoader()));
 
                 // Actually execute the Data migration SQL
                 // This will migrate all existing traditional workflows to the new XMLWorkflow system & tables
-                DatabaseUtils.executeSql(connection, dataMigrateSQL);
+                DatabaseUtils.executeSql(context.getConnection(), dataMigrateSQL);
 
                 // Assuming both succeeded, save the size of the scripts for getChecksum() below
                 migration_file_size = dataMigrateSQL.length();

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/xmlworkflow/V5_0_2014_11_04__Enable_XMLWorkflow_Migration.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/xmlworkflow/V5_0_2014_11_04__Enable_XMLWorkflow_Migration.java
@@ -8,18 +8,17 @@
 package org.dspace.storage.rdbms.xmlworkflow;
 
 import java.io.IOException;
-import java.sql.Connection;
 import java.sql.SQLException;
 
-import org.dspace.core.Constants;
 import org.dspace.storage.rdbms.DatabaseUtils;
+import org.dspace.storage.rdbms.migration.MigrationUtils;
 import org.dspace.workflow.factory.WorkflowServiceFactory;
 import org.dspace.xmlworkflow.service.XmlWorkflowService;
-import org.flywaydb.core.api.migration.MigrationChecksumProvider;
-import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
-import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
 
 /**
  * This class automatically migrates your DSpace Database to use the
@@ -38,7 +37,7 @@ import org.slf4j.LoggerFactory;
  * @author Tim Donohue
  */
 public class V5_0_2014_11_04__Enable_XMLWorkflow_Migration
-    implements JdbcMigration, MigrationChecksumProvider {
+    extends BaseJavaMigration {
     /**
      * logging category
      */
@@ -50,12 +49,12 @@ public class V5_0_2014_11_04__Enable_XMLWorkflow_Migration
     /**
      * Actually migrate the existing database
      *
-     * @param connection SQL Connection object
+     * @param context Flyway Migration Context
      * @throws IOException  A general class of exceptions produced by failed or interrupted I/O operations.
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
     @Override
-    public void migrate(Connection connection)
+    public void migrate(Context context)
         throws IOException, SQLException {
         // Make sure XML Workflow is enabled, shouldn't even be needed since this class is only loaded if the service
         // is enabled.
@@ -64,13 +63,13 @@ public class V5_0_2014_11_04__Enable_XMLWorkflow_Migration
             // migration, as it is incompatible
             // with a 6.x database. In that scenario the corresponding 6.x XML Workflow migration will create
             // necessary tables.
-            && DatabaseUtils.getCurrentFlywayDSpaceState(connection) < 6) {
+            && DatabaseUtils.getCurrentFlywayDSpaceState(context.getConnection()) < 6) {
             // Now, check if the XMLWorkflow table (cwf_workflowitem) already exists in this database
             // If XMLWorkflow Table does NOT exist in this database, then lets do the migration!
             // If XMLWorkflow Table ALREADY exists, then this migration is a noop, we assume you manually ran the sql
             // scripts
-            if (!DatabaseUtils.tableExists(connection, "cwf_workflowitem")) {
-                String dbtype = connection.getMetaData().getDatabaseProductName();
+            if (!DatabaseUtils.tableExists(context.getConnection(), "cwf_workflowitem")) {
+                String dbtype = context.getConnection().getMetaData().getDatabaseProductName();
                 String dbFileLocation = null;
                 if (dbtype.toLowerCase().contains("postgres")) {
                     dbFileLocation = "postgres";
@@ -88,27 +87,23 @@ public class V5_0_2014_11_04__Enable_XMLWorkflow_Migration
 
                 // Get the contents of our DB Schema migration script, based on path & DB type
                 // (e.g. /src/main/resources/[path-to-this-class]/postgres/xml_workflow_migration.sql)
-                String dbMigrateSQL = new ClassPathResource(packagePath + "/" +
-                                                                dbFileLocation +
-                                                                "/xml_workflow_migration.sql",
-                                                            getClass().getClassLoader())
-                    .loadAsString(Constants.DEFAULT_ENCODING);
+                String dbMigrateSQL = MigrationUtils.resourceToString(
+                    new ClassPathResource(packagePath + "/" + dbFileLocation + "/xml_workflow_migration.sql",
+                                          getClass().getClassLoader()));
 
                 // Actually execute the Database schema migration SQL
                 // This will create the necessary tables for the XMLWorkflow feature
-                DatabaseUtils.executeSql(connection, dbMigrateSQL);
+                DatabaseUtils.executeSql(context.getConnection(), dbMigrateSQL);
 
                 // Get the contents of our data migration script, based on path & DB type
                 // (e.g. /src/main/resources/[path-to-this-class]/postgres/data_workflow_migration.sql)
-                String dataMigrateSQL = new ClassPathResource(packagePath + "/" +
-                                                                  dbFileLocation +
-                                                                  "/data_workflow_migration.sql",
-                                                              getClass().getClassLoader())
-                    .loadAsString(Constants.DEFAULT_ENCODING);
+                String dataMigrateSQL = MigrationUtils.resourceToString(
+                    new ClassPathResource(packagePath + "/" + dbFileLocation + "/data_workflow_migration.sql",
+                                          getClass().getClassLoader()));
 
                 // Actually execute the Data migration SQL
                 // This will migrate all existing traditional workflows to the new XMLWorkflow system & tables
-                DatabaseUtils.executeSql(connection, dataMigrateSQL);
+                DatabaseUtils.executeSql(context.getConnection(), dataMigrateSQL);
 
                 // Assuming both succeeded, save the size of the scripts for getChecksum() below
                 migration_file_size = dbMigrateSQL.length() + dataMigrateSQL.length();

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/xmlworkflow/V5_0_2014_11_04__Enable_XMLWorkflow_Migration.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/xmlworkflow/V5_0_2014_11_04__Enable_XMLWorkflow_Migration.java
@@ -18,7 +18,6 @@ import org.flywaydb.core.api.migration.BaseJavaMigration;
 import org.flywaydb.core.api.migration.Context;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.io.ClassPathResource;
 
 /**
  * This class automatically migrates your DSpace Database to use the
@@ -87,9 +86,8 @@ public class V5_0_2014_11_04__Enable_XMLWorkflow_Migration
 
                 // Get the contents of our DB Schema migration script, based on path & DB type
                 // (e.g. /src/main/resources/[path-to-this-class]/postgres/xml_workflow_migration.sql)
-                String dbMigrateSQL = MigrationUtils.resourceToString(
-                    new ClassPathResource(packagePath + "/" + dbFileLocation + "/xml_workflow_migration.sql",
-                                          getClass().getClassLoader()));
+                String dbMigrateSQL = MigrationUtils.getResourceAsString(packagePath + "/" + dbFileLocation +
+                                                                             "/xml_workflow_migration.sql");
 
                 // Actually execute the Database schema migration SQL
                 // This will create the necessary tables for the XMLWorkflow feature
@@ -97,9 +95,8 @@ public class V5_0_2014_11_04__Enable_XMLWorkflow_Migration
 
                 // Get the contents of our data migration script, based on path & DB type
                 // (e.g. /src/main/resources/[path-to-this-class]/postgres/data_workflow_migration.sql)
-                String dataMigrateSQL = MigrationUtils.resourceToString(
-                    new ClassPathResource(packagePath + "/" + dbFileLocation + "/data_workflow_migration.sql",
-                                          getClass().getClassLoader()));
+                String dataMigrateSQL = MigrationUtils.getResourceAsString(packagePath + "/" + dbFileLocation +
+                                                                               "/data_workflow_migration.sql");
 
                 // Actually execute the Data migration SQL
                 // This will migrate all existing traditional workflows to the new XMLWorkflow system & tables

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/xmlworkflow/V6_0_2015_09_01__DS_2701_Enable_XMLWorkflow_Migration.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/xmlworkflow/V6_0_2015_09_01__DS_2701_Enable_XMLWorkflow_Migration.java
@@ -14,7 +14,6 @@ import org.dspace.workflow.factory.WorkflowServiceFactory;
 import org.dspace.xmlworkflow.service.XmlWorkflowService;
 import org.flywaydb.core.api.migration.BaseJavaMigration;
 import org.flywaydb.core.api.migration.Context;
-import org.springframework.core.io.ClassPathResource;
 
 /**
  * This class automatically migrates your DSpace Database to use the
@@ -66,10 +65,8 @@ public class V6_0_2015_09_01__DS_2701_Enable_XMLWorkflow_Migration extends BaseJ
 
                 // Get the contents of our DB Schema migration script, based on path & DB type
                 // (e.g. /src/main/resources/[path-to-this-class]/postgres/xml_workflow_migration.sql)
-                String dbMigrateSQL = MigrationUtils.resourceToString(
-                    new ClassPathResource(packagePath + "/" + dbFileLocation +
-                                              "/v6.0__DS-2701_xml_workflow_migration.sql",
-                                          getClass().getClassLoader()));
+                String dbMigrateSQL = MigrationUtils.getResourceAsString(packagePath + "/" + dbFileLocation +
+                                              "/v6.0__DS-2701_xml_workflow_migration.sql");
 
                 // Actually execute the Database schema migration SQL
                 // This will create the necessary tables for the XMLWorkflow feature
@@ -77,10 +74,8 @@ public class V6_0_2015_09_01__DS_2701_Enable_XMLWorkflow_Migration extends BaseJ
 
                 // Get the contents of our data migration script, based on path & DB type
                 // (e.g. /src/main/resources/[path-to-this-class]/postgres/data_workflow_migration.sql)
-                String dataMigrateSQL = MigrationUtils.resourceToString(
-                    new ClassPathResource(packagePath + "/" + dbFileLocation +
-                                              "/v6.0__DS-2701_data_workflow_migration.sql",
-                                          getClass().getClassLoader()));
+                String dataMigrateSQL = MigrationUtils.getResourceAsString(packagePath + "/" + dbFileLocation +
+                                              "/v6.0__DS-2701_data_workflow_migration.sql");
 
                 // Actually execute the Data migration SQL
                 // This will migrate all existing traditional workflows to the new XMLWorkflow system & tables

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/xmlworkflow/V6_0_2015_09_01__DS_2701_Enable_XMLWorkflow_Migration.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/xmlworkflow/V6_0_2015_09_01__DS_2701_Enable_XMLWorkflow_Migration.java
@@ -7,15 +7,14 @@
  */
 package org.dspace.storage.rdbms.xmlworkflow;
 
-import java.sql.Connection;
 
-import org.dspace.core.Constants;
 import org.dspace.storage.rdbms.DatabaseUtils;
+import org.dspace.storage.rdbms.migration.MigrationUtils;
 import org.dspace.workflow.factory.WorkflowServiceFactory;
 import org.dspace.xmlworkflow.service.XmlWorkflowService;
-import org.flywaydb.core.api.migration.MigrationChecksumProvider;
-import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
-import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.core.io.ClassPathResource;
 
 /**
  * This class automatically migrates your DSpace Database to use the
@@ -34,13 +33,13 @@ import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
  * Date: 1/09/15
  * Time: 11:34
  */
-public class V6_0_2015_09_01__DS_2701_Enable_XMLWorkflow_Migration implements JdbcMigration, MigrationChecksumProvider {
+public class V6_0_2015_09_01__DS_2701_Enable_XMLWorkflow_Migration extends BaseJavaMigration {
     // Size of migration script run
     protected Integer migration_file_size = -1;
 
 
     @Override
-    public void migrate(Connection connection) throws Exception {
+    public void migrate(Context context) throws Exception {
         // Make sure XML Workflow is enabled, shouldn't even be needed since this class is only loaded if the service
         // is enabled.
         if (WorkflowServiceFactory.getInstance().getWorkflowService() instanceof XmlWorkflowService) {
@@ -48,8 +47,8 @@ public class V6_0_2015_09_01__DS_2701_Enable_XMLWorkflow_Migration implements Jd
             // If XMLWorkflow Table does NOT exist in this database, then lets do the migration!
             // If XMLWorkflow Table ALREADY exists, then this migration is a noop, we assume you manually ran the sql
             // scripts
-            if (!DatabaseUtils.tableExists(connection, "cwf_workflowitem")) {
-                String dbtype = connection.getMetaData().getDatabaseProductName();
+            if (!DatabaseUtils.tableExists(context.getConnection(), "cwf_workflowitem")) {
+                String dbtype = context.getConnection().getMetaData().getDatabaseProductName();
                 String dbFileLocation = null;
                 if (dbtype.toLowerCase().contains("postgres")) {
                     dbFileLocation = "postgres";
@@ -67,27 +66,25 @@ public class V6_0_2015_09_01__DS_2701_Enable_XMLWorkflow_Migration implements Jd
 
                 // Get the contents of our DB Schema migration script, based on path & DB type
                 // (e.g. /src/main/resources/[path-to-this-class]/postgres/xml_workflow_migration.sql)
-                String dbMigrateSQL = new ClassPathResource(packagePath + "/" +
-                                                                dbFileLocation +
-                                                                "/v6.0__DS-2701_xml_workflow_migration.sql",
-                                                            getClass().getClassLoader())
-                    .loadAsString(Constants.DEFAULT_ENCODING);
+                String dbMigrateSQL = MigrationUtils.resourceToString(
+                    new ClassPathResource(packagePath + "/" + dbFileLocation +
+                                              "/v6.0__DS-2701_xml_workflow_migration.sql",
+                                          getClass().getClassLoader()));
 
                 // Actually execute the Database schema migration SQL
                 // This will create the necessary tables for the XMLWorkflow feature
-                DatabaseUtils.executeSql(connection, dbMigrateSQL);
+                DatabaseUtils.executeSql(context.getConnection(), dbMigrateSQL);
 
                 // Get the contents of our data migration script, based on path & DB type
                 // (e.g. /src/main/resources/[path-to-this-class]/postgres/data_workflow_migration.sql)
-                String dataMigrateSQL = new ClassPathResource(packagePath + "/" +
-                                                                  dbFileLocation +
-                                                                  "/v6.0__DS-2701_data_workflow_migration.sql",
-                                                              getClass().getClassLoader())
-                    .loadAsString(Constants.DEFAULT_ENCODING);
+                String dataMigrateSQL = MigrationUtils.resourceToString(
+                    new ClassPathResource(packagePath + "/" + dbFileLocation +
+                                              "/v6.0__DS-2701_data_workflow_migration.sql",
+                                          getClass().getClassLoader()));
 
                 // Actually execute the Data migration SQL
                 // This will migrate all existing traditional workflows to the new XMLWorkflow system & tables
-                DatabaseUtils.executeSql(connection, dataMigrateSQL);
+                DatabaseUtils.executeSql(context.getConnection(), dataMigrateSQL);
 
                 // Assuming both succeeded, save the size of the scripts for getChecksum() below
                 migration_file_size = dbMigrateSQL.length() + dataMigrateSQL.length();

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
@@ -188,7 +188,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
 
     @Override
     public List<String> getFlywayMigrationLocations() {
-        return Collections.singletonList("classpath:org.dspace.storage.rdbms.xmlworkflow");
+        return Collections.singletonList("classpath:org/dspace/storage/rdbms/xmlworkflow");
     }
 
     @Override

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/flywayupgrade/oracle/upgradeToFlyway4x.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/flywayupgrade/oracle/upgradeToFlyway4x.sql
@@ -1,0 +1,29 @@
+--
+-- Copyright 2010-2017 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-----------------
+-- This is the Oracle upgrade script from Flyway v4.2.0, copied/borrowed from:
+-- https://github.com/flyway/flyway/blob/flyway-4.2.0/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/oracle/upgradeMetaDataTable.sql
+--
+-- The variables in this script are replaced in FlywayUpgradeUtils.upgradeFlywayTable()
+------------------
+
+DROP INDEX "${schema}"."${table}_vr_idx";
+DROP INDEX "${schema}"."${table}_ir_idx";
+ALTER TABLE "${schema}"."${table}" DROP COLUMN "version_rank";
+ALTER TABLE "${schema}"."${table}" DROP PRIMARY KEY DROP INDEX;
+ALTER TABLE "${schema}"."${table}" MODIFY "version" NULL;
+ALTER TABLE "${schema}"."${table}" ADD CONSTRAINT "${table}_pk" PRIMARY KEY ("installed_rank");
+UPDATE "${schema}"."${table}" SET "type"='BASELINE' WHERE "type"='INIT';

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/flywayupgrade/postgres/upgradeToFlyway4x.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/flywayupgrade/postgres/upgradeToFlyway4x.sql
@@ -1,0 +1,29 @@
+--
+-- Copyright 2010-2017 Boxfuse GmbH
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-----------------
+-- This is the PostgreSQL upgrade script from Flyway v4.2.0, copied/borrowed from:
+-- https://github.com/flyway/flyway/blob/flyway-4.2.0/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/oracle/upgradeMetaDataTable.sql
+--
+-- The variables in this script are replaced in FlywayUpgradeUtils.upgradeFlywayTable()
+------------------
+
+DROP INDEX "${schema}"."${table}_vr_idx";
+DROP INDEX "${schema}"."${table}_ir_idx";
+ALTER TABLE "${schema}"."${table}" DROP COLUMN "version_rank";
+ALTER TABLE "${schema}"."${table}" DROP CONSTRAINT "${table}_pk";
+ALTER TABLE "${schema}"."${table}" ALTER COLUMN "version" DROP NOT NULL;
+ALTER TABLE "${schema}"."${table}" ADD CONSTRAINT "${table}_pk" PRIMARY KEY ("installed_rank");
+UPDATE "${schema}"."${table}" SET "type"='BASELINE' WHERE "type"='INIT';

--- a/dspace-api/src/test/java/org/dspace/AbstractIntegrationTestWithDatabase.java
+++ b/dspace-api/src/test/java/org/dspace/AbstractIntegrationTestWithDatabase.java
@@ -83,11 +83,6 @@ public class AbstractIntegrationTestWithDatabase extends AbstractDSpaceIntegrati
      */
     @BeforeClass
     public static void initDatabase() {
-        // Clear our old flyway object. Because this DB is in-memory, its
-        // data is lost when the last connection is closed. So, we need
-        // to (re)start Flyway from scratch for each Unit Test class.
-        DatabaseUtils.clearFlywayDBCache();
-
         try {
             // Update/Initialize the database to latest version (via Flyway)
             DatabaseUtils.updateDatabase();

--- a/dspace-api/src/test/java/org/dspace/AbstractUnitTest.java
+++ b/dspace-api/src/test/java/org/dspace/AbstractUnitTest.java
@@ -75,11 +75,6 @@ public class AbstractUnitTest extends AbstractDSpaceTest {
      */
     @BeforeClass
     public static void initDatabase() {
-        // Clear our old flyway object. Because this DB is in-memory, its
-        // data is lost when the last connection is closed. So, we need
-        // to (re)start Flyway from scratch for each Unit Test class.
-        DatabaseUtils.clearFlywayDBCache();
-
         try {
             // Update/Initialize the database to latest version (via Flyway)
             DatabaseUtils.updateDatabase();


### PR DESCRIPTION
## References
* Fixes #2948 

## Description
This PR updates us to Flyway v6.5.5 (the latest version of https://flywaydb.org/) from v4.0.3

A large amount of code refactoring was necessary, as the Flyway Java API has changed significantly between v4 and v6.  However, all code changes were in the `dspace-api` layer in the `org.dspace.storage.rdbms` package. 

A few key points:
* The `DatabaseUtils` class no longer needs to cache the `Flyway` object.  Caching was able to be removed based on the updated v6 Flyway API
* All Callback classes were simplified. They now only require 3 methods: `supports()`, `canHandleInTransaction()` and `handle()`.
* Flyway removed/hid some classes from its API which were duplicative of Spring core classes. So, in some areas, I was able to replace old Flyway versions of classes with Spring ones. 
* **NEW** A new `FlywayUpgradeUtils` class was added to help with DSpace 5.x to 7.x upgrades. This was needed because DSpace 5.x used Flyway 3.x, which cannot be upgraded directly to Flyway 6.x (cause of major database-level changes in Flyway 4.x, see https://github.com/flyway/flyway/issues/2126).  The FlywayUpgradeUtils class checks for this scenario, and runs a SQL script to update the database structure to be compatible with Flyway 4.x (which can be upgraded directly to Flyway 6.x) 
* _NOTE:_ Flyway has its own `Context` object now in their v6 API.  So, in reviewing code, be aware that most of the `Context` objects in this PR are Flyway's `Context` and not DSpace's `Context`

## Instructions for Reviewers

* Code should be relatively easy to review. It's often the same general changes over and over again in many of the `org.dspace.storage.rdbms.*` classes.
* All existing tests pass, which proves the code works...as our Unit & Integration tests both use Flyway to initialize the test database in H2.
* `FlywayUpgradeUtils` was added to solve [this previously reported issue](https://github.com/DSpace/DSpace/pull/2949#pullrequestreview-485704326).
* You can install this PR locally and verify that your local backend (on either Postgres or Oracle) also still works as expected.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
