### PR TITLE
Minor Test fix: Ensure prior data is cleaned. Fix ordering of params in assert

### DIFF
--- a/dspace-api/src/test/java/org/dspace/curate/CuratorTest.java
+++ b/dspace-api/src/test/java/org/dspace/curate/CuratorTest.java
@@ -54,7 +54,7 @@ public class CuratorTest extends AbstractUnitTest {
      */
     @Test
     public void testCurate_DSpaceObject() throws Exception {
-        System.out.println("curate");
+        CoreServiceFactory.getInstance().getPluginService().clearNamedPluginClasses();
 
         final String TASK_NAME = "dummyTask";
 
@@ -114,6 +114,6 @@ public class CuratorTest extends AbstractUnitTest {
         curator.curate(context, item);
 
         assertEquals(Curator.CURATE_SUCCESS, curator.getStatus(TASK_NAME));
-        assertEquals(reporterOutput.toString(), "No operation performed on testHandle");
+        assertEquals("No operation performed on testHandle", reporterOutput.toString());
     }
 }


### PR DESCRIPTION
## Description
Very minor fix to `CuratatorTest.testCurate_DSpaceObject()` test to ensure it starts with all Plugin classes cleaned out.

While this test seems to succeed in Travis CI, it *fails* for me locally (on Windows 10) as my testing environment runs these tests in a different order than Travis CI.

This setting was copied from the other test in that same file: https://github.com/DSpace/DSpace/blob/main/dspace-api/src/test/java/org/dspace/curate/CuratorTest.java#L95

I also updated the ordering of params in an `assertEquals` in the same file, as they were passed in the wrong order.  The expected value should be the first param and not the last.

**Assuming this succeeds in Travis CI** it can be merged immediately.  It's a minor fix to allow this test to work on Windows 10 (at least my system) and it should not affect Travis CI behavior.