### PR TITLE
Remove unused, obscure, confusing injection of DSpace properties by bean post-processor

### DIFF
--- a/dspace-services/src/main/java/org/dspace/servicemanager/DSpaceServiceManager.java
+++ b/dspace-services/src/main/java/org/dspace/servicemanager/DSpaceServiceManager.java
@@ -28,12 +28,9 @@ import org.dspace.kernel.mixins.ServiceManagerReadyAware;
 import org.dspace.kernel.mixins.ShutdownService;
 import org.dspace.servicemanager.config.DSpaceConfigurationService;
 import org.dspace.servicemanager.spring.DSpaceBeanFactoryPostProcessor;
-import org.dspace.services.ConfigurationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.BeansException;
-import org.springframework.beans.PropertyAccessorFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
@@ -577,47 +574,6 @@ public final class DSpaceServiceManager implements ServiceManagerSystem {
     }
 
     // STATICS
-
-    /**
-     * Configures a given service (i.e. bean) based on any DSpace configuration
-     * settings which refer to it by name. .
-     * <P>
-     * NOTE: Any configurations related to a specific service MUST be prefixed
-     * with the given service's name (e.g. [serviceName].setting = value)
-     * <P>
-     * This method logs an error if it encounters configs which refer to a
-     * service by name, but is an invalid setting for that service.
-     *
-     * @param serviceName the name of the service
-     * @param service     the service object (which will be configured)
-     * @param config      the running configuration service
-     */
-    public static void configureService(String serviceName, Object service, ConfigurationService config) {
-
-        // Check if the configuration has any properties whose prefix
-        // corresponds to this service's name
-        List<String> configKeys = config.getPropertyKeys(serviceName);
-        if (configKeys != null && !configKeys.isEmpty()) {
-            BeanWrapper beanWrapper = PropertyAccessorFactory.forBeanPropertyAccess(service);
-            for (String key : configKeys) {
-                // Remove serviceName prefix from key. This is the name of the actual bean's parameter
-                // This removes the first x chars, where x is length of serviceName + 1 char
-                // Format of Key: [serviceName].[param]
-                String param = key.substring(serviceName.length() + 1);
-
-                try {
-                    // Attempt to set this configuration on the given service's bean
-                    beanWrapper.setPropertyValue(param, config.getProperty(key));
-                    log.info("Set param (" + param + ") on service bean (" + serviceName + ") to: " + config
-                        .getProperty(key));
-                } catch (RuntimeException e) {
-                    // If an error occurs, just log it
-                    log.error("Unable to set param (" + param + ") on service bean (" + serviceName + ") to: " + config
-                        .getProperty(key), e);
-                }
-            }
-        }
-    }
 
     /**
      * Initializes a service if it asks to be initialized or does nothing.

--- a/dspace-services/src/main/java/org/dspace/servicemanager/spring/DSpaceBeanPostProcessor.java
+++ b/dspace-services/src/main/java/org/dspace/servicemanager/spring/DSpaceBeanPostProcessor.java
@@ -8,43 +8,18 @@
 package org.dspace.servicemanager.spring;
 
 import org.dspace.servicemanager.DSpaceServiceManager;
-import org.dspace.servicemanager.config.DSpaceConfigurationService;
 import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.beans.factory.config.DestructionAwareBeanPostProcessor;
 
 /**
- * This processes beans as they are loaded into the system by spring.
- * Allows us to handle the init method and also push config options.
+ * This processes beans as they are loaded into the system by Spring.
+ * Allows us to handle the init method.
  *
  * @author Aaron Zeckoski (azeckoski @ gmail.com)
  */
-public final class DSpaceBeanPostProcessor implements BeanPostProcessor, DestructionAwareBeanPostProcessor {
-
-    private DSpaceConfigurationService configurationService;
-
-    @Autowired
-    public DSpaceBeanPostProcessor(DSpaceConfigurationService configurationService) {
-        if (configurationService == null) {
-            throw new IllegalArgumentException("configuration service cannot be null");
-        }
-        this.configurationService = configurationService;
-    }
-
-    /* (non-Javadoc)
-     * @see org.springframework.beans.factory.config.BeanPostProcessor#postProcessBeforeInitialization(java.lang
-     * .Object, java.lang.String)
-     */
-    @Override
-    public Object postProcessBeforeInitialization(Object bean, String beanName)
-        throws BeansException {
-        // Before initializing the service, first configure it based on any related settings in the configurationService
-        // NOTE: configs related to this bean MUST be prefixed with the bean's name (e.g. [beanName].setting = value)
-        DSpaceServiceManager.configureService(beanName, bean, configurationService);
-        return bean;
-    }
-
+public final class DSpaceBeanPostProcessor
+        implements BeanPostProcessor, DestructionAwareBeanPostProcessor {
     /* (non-Javadoc)
      * @see org.springframework.beans.factory.config.BeanPostProcessor#postProcessAfterInitialization(java.lang
      * .Object, java.lang.String)
@@ -65,7 +40,7 @@ public final class DSpaceBeanPostProcessor implements BeanPostProcessor, Destruc
         DSpaceServiceManager.shutdownService(bean);
     }
 
-    //    @Override
+    @Override
     public boolean requiresDestruction(Object arg0) {
         return false;
     }

--- a/dspace-services/src/test/java/org/dspace/servicemanager/DSpaceServiceManagerTest.java
+++ b/dspace-services/src/test/java/org/dspace/servicemanager/DSpaceServiceManagerTest.java
@@ -28,7 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * testing the main dspace service manager
+ * Testing the main DSpace service manager.
  *
  * @author Aaron Zeckoski (azeckoski @ gmail.com)
  */
@@ -41,10 +41,6 @@ public class DSpaceServiceManagerTest {
     @Before
     public void init() {
         configurationService = new DSpaceConfigurationService();
-
-        // Set some sample configurations relating to services/beans
-        configurationService.loadConfig(SampleAnnotationBean.class.getName() + ".sampleValue", "beckyz");
-        configurationService.loadConfig("fakeBean.fakeParam", "beckyz");
 
         dsm = new DSpaceServiceManager(configurationService, SPRING_TEST_CONFIG_FILE);
     }
@@ -166,33 +162,6 @@ public class DSpaceServiceManagerTest {
         assertNotNull(sab);
         assertEquals(null, sab.getSampleValue());
         sab = null;
-    }
-
-    @Test
-    public void testGetServiceByNameConfig() {
-        dsm.startup();
-
-        ConcreteExample concrete = dsm.getServiceByName(ConcreteExample.class.getName(), ConcreteExample.class);
-        assertNotNull(concrete);
-        assertEquals("azeckoski", concrete.getName());
-        concrete = null;
-
-        // initialize a SampleAnnotationBean
-        SampleAnnotationBean sab = dsm
-            .getServiceByName(SampleAnnotationBean.class.getName(), SampleAnnotationBean.class);
-        assertNotNull(sab);
-        // Based on the configuration for "sampleValue" in the init() method above,
-        // a value should be pre-set!
-        assertEquals("beckyz", sab.getSampleValue());
-        sab = null;
-
-        SpringAnnotationBean spr = dsm.getServiceByName(
-            SpringAnnotationBean.class.getName(), SpringAnnotationBean.class);
-        assertNotNull(spr);
-        assertEquals("azeckoski", spr.getConcreteName());
-        assertEquals("aaronz", spr.getExampleName());
-        assertEquals(null, spr.getSampleValue());
-        spr = null;
     }
 
     /**


### PR DESCRIPTION
## References
* Fixes [#2958](https://github.com/DSpace/DSpace/issues)

## Description
Remove Bean post-processing method that looks for DSpace configuration properties beginning with the bean's `id` and tries to inject them.

## Instructions for Reviewers
1. create a DSpace configuration property with a dotted name like this.that.
1. define a Bean which has the id equal to the part of the DSpace property name before the first dot (e.g. this), and which is embodied by a class which does not have a property with a name equal to the part of the DSpace property after the first dot (e.g. that). Configure it for eager instantiation. Do not give it `<property>` with that name.
1. start DSpace and you should no longer log a failure to instantiate the bean, noting a missing setter.

List of changes in this PR:
* Removed DSpaceBeanPostProcessor.postProcessBeforeInitialization (the locus of the problem).
* Removed DSpaceBeanPostProcessor's constructor, no longer needed.
* Removed test for removed method's effects.
* Removed DSpaceServiceManager.configureService, no longer referenced.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
