### PR TITLE
Bugfix to avoid duplicates in discovery consumer

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/AbstractIndexableObject.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/AbstractIndexableObject.java
@@ -12,6 +12,15 @@ import java.io.Serializable;
 import org.dspace.core.ReloadableEntity;
 import org.dspace.discovery.IndexableObject;
 
+/**
+ * This class exists in order to provide a default implementation for the equals and hashCode methods.
+ * Since IndexableObjects can be made multiple times for the same underlying object, we needed a more finetuned
+ * equals and hashcode methods. We're simply checking that the underlying objects are equal and generating the hashcode
+ * for the underlying object. This way, we'll always get a proper result when calling equals or hashcode on an
+ * IndexableObject because it'll depend on the underlying object
+ * @param <T>   Refers to the underlying entity that is linked to this object
+ * @param <PK>  The type of ID that this entity uses
+ */
 public abstract class AbstractIndexableObject<T extends ReloadableEntity<PK>, PK extends Serializable>
     implements IndexableObject<T,PK> {
 

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/AbstractIndexableObject.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/AbstractIndexableObject.java
@@ -1,0 +1,34 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.discovery.indexobject;
+
+import java.io.Serializable;
+
+import org.dspace.core.ReloadableEntity;
+import org.dspace.discovery.IndexableObject;
+
+public abstract class AbstractIndexableObject<T extends ReloadableEntity<PK>, PK extends Serializable>
+    implements IndexableObject<T,PK> {
+
+    @Override
+    public boolean equals(Object obj) {
+        //Two IndexableObjects of the same DSpaceObject are considered equal
+        if (!(obj instanceof AbstractIndexableObject)) {
+            return false;
+        }
+        IndexableDSpaceObject other = (IndexableDSpaceObject) obj;
+        return other.getIndexedObject().equals(getIndexedObject());
+    }
+
+    @Override
+    public int hashCode() {
+        //Two IndexableObjects of the same DSpaceObject are considered equal
+        return getIndexedObject().hashCode();
+    }
+
+}

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/IndexableClaimedTask.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/IndexableClaimedTask.java
@@ -7,7 +7,6 @@
  */
 package org.dspace.discovery.indexobject;
 
-import org.dspace.discovery.IndexableObject;
 import org.dspace.xmlworkflow.storedcomponents.ClaimedTask;
 
 /**
@@ -15,7 +14,7 @@ import org.dspace.xmlworkflow.storedcomponents.ClaimedTask;
  *
  * @author Kevin Van de Velde (kevin at atmire dot com)
  */
-public class IndexableClaimedTask implements IndexableObject<ClaimedTask, Integer> {
+public class IndexableClaimedTask extends AbstractIndexableObject<ClaimedTask, Integer> {
 
     private ClaimedTask claimedTask;
     public static final String TYPE = ClaimedTask.class.getSimpleName();

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/IndexableDSpaceObject.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/IndexableDSpaceObject.java
@@ -40,4 +40,20 @@ public abstract class IndexableDSpaceObject<T extends DSpaceObject> implements I
     public UUID getID() {
         return dso.getID();
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        //Two IndexableObjects of the same DSpaceObject are considered equal
+        if (!(obj instanceof IndexableDSpaceObject)) {
+            return false;
+        }
+        IndexableDSpaceObject other = (IndexableDSpaceObject) obj;
+        return other.getIndexedObject().equals(getIndexedObject());
+    }
+
+    @Override
+    public int hashCode() {
+        //Two IndexableObjects of the same DSpaceObject are considered equal
+        return getIndexedObject().hashCode();
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/IndexableDSpaceObject.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/IndexableDSpaceObject.java
@@ -10,7 +10,6 @@ package org.dspace.discovery.indexobject;
 import java.util.UUID;
 
 import org.dspace.content.DSpaceObject;
-import org.dspace.discovery.IndexableObject;
 
 /**
  * DSpaceObject implementation for the IndexableObject, contains methods used by all DSpaceObject methods
@@ -18,7 +17,7 @@ import org.dspace.discovery.IndexableObject;
  *
  * @author Kevin Van de Velde (kevin at atmire dot com)
  */
-public abstract class IndexableDSpaceObject<T extends DSpaceObject> implements IndexableObject<T, UUID> {
+public abstract class IndexableDSpaceObject<T extends DSpaceObject> extends AbstractIndexableObject<T, UUID> {
 
     private T dso;
 
@@ -41,19 +40,5 @@ public abstract class IndexableDSpaceObject<T extends DSpaceObject> implements I
         return dso.getID();
     }
 
-    @Override
-    public boolean equals(Object obj) {
-        //Two IndexableObjects of the same DSpaceObject are considered equal
-        if (!(obj instanceof IndexableDSpaceObject)) {
-            return false;
-        }
-        IndexableDSpaceObject other = (IndexableDSpaceObject) obj;
-        return other.getIndexedObject().equals(getIndexedObject());
-    }
 
-    @Override
-    public int hashCode() {
-        //Two IndexableObjects of the same DSpaceObject are considered equal
-        return getIndexedObject().hashCode();
-    }
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/IndexableInProgressSubmission.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/IndexableInProgressSubmission.java
@@ -8,14 +8,13 @@
 package org.dspace.discovery.indexobject;
 
 import org.dspace.content.InProgressSubmission;
-import org.dspace.discovery.IndexableObject;
 
 /**
  * InProgressSubmission implementation for the IndexableObject
  * @author Kevin Van de Velde (kevin at atmire dot com)
  */
 public abstract class IndexableInProgressSubmission<T extends InProgressSubmission>
-        implements IndexableObject<T, Integer> {
+        extends AbstractIndexableObject<T, Integer> {
 
     protected T inProgressSubmission;
 

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/IndexableMetadataField.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/IndexableMetadataField.java
@@ -15,7 +15,7 @@ import org.dspace.discovery.IndexableObject;
  *
  * @author Maria Verdonck (Atmire) on 14/07/2020
  */
-public class IndexableMetadataField implements IndexableObject<MetadataField, Integer> {
+public class IndexableMetadataField extends AbstractIndexableObject<MetadataField, Integer> {
 
     private MetadataField metadataField;
     public static final String TYPE = MetadataField.class.getSimpleName();

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/IndexablePoolTask.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/IndexablePoolTask.java
@@ -7,14 +7,13 @@
  */
 package org.dspace.discovery.indexobject;
 
-import org.dspace.discovery.IndexableObject;
 import org.dspace.xmlworkflow.storedcomponents.PoolTask;
 
 /**
  * PoolTask implementation for the IndexableObject
  * @author Kevin Van de Velde (kevin at atmire dot com)
  */
-public class IndexablePoolTask implements IndexableObject<PoolTask, Integer> {
+public class IndexablePoolTask extends AbstractIndexableObject<PoolTask, Integer> {
 
     public static final String TYPE = PoolTask.class.getSimpleName();
 


### PR DESCRIPTION
## Description
This is a really minor change. Discovery was updating an item multiple times in a single commit, once per metadata modified event. This solves the problem

## Instructions for Reviewers
You can monitor your DSpace logs, perform some edits to an item and commit it, there's a reasonable chance indexing the same item is mentioned multiple times.
This PR solves that problem. It doesn't change behavior, only performance

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
