### PR TITLE
Bug fix: Bean capitalization fix

### DIFF
--- a/dspace/config/spring/api/external-services.xml
+++ b/dspace/config/spring/api/external-services.xml
@@ -32,7 +32,7 @@
     </bean>
 
     <bean id="pubmedLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
-        <property name="metadataSource" ref="PubmedImportService"/>
+        <property name="metadataSource" ref="pubmedImportService"/>
         <property name="sourceIdentifier" value="pubmed"/>
         <property name="recordIdMetadata" value="dc.identifier.other"/>
     </bean>


### PR DESCRIPTION
## Description
After merging https://github.com/DSpace/DSpace/pull/2914, I discovered that the Server Webapp would not start and was throwing this error
```
10-Sep-2020 18:36:33.249 SEVERE [localhost-startStop-1] org.apache.catalina.core.ContainerBase.addChildInternal ContainerBase.addChild: start:
org.apache.catalina.LifecycleException: Failed to start component [StandardEngine[Catalina].StandardHost[localhost].StandardContext[/server]]
...
Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'externalSourcesRestController': Unsatisfied dependency expressed through field 'externalSourceRestRepository'; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'integration.externalsource': Unsatisfied dependency expressed through field 'externalDataService'; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'org.dspace.external.service.impl.ExternalDataServiceImpl#0': Unsatisfied dependency expressed through field 'externalDataProviders'; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'pubmedLiveImportDataProvider' defined in file [/dspace/config/spring/api/external-services.xml]: Cannot resolve reference to bean 'PubmedImportService' while setting bean property 'metadataSource'; nested exception is org.springframework.beans.factory.NoSuchBeanDefinitionException: No bean named 'PubmedImportService' available
dspace 
```

The issue seems to have been that in #2914, the bean name was changed from `PubmedImportService` to `pubmedImportService`.  This tiny PR just fixes the bean reference in the `external-services.xml`, where it was still referenced by the (previous) capitalized name.

Once Travis approves this change, I'll merge immediately as this fixes the issue locally. Without this change, I cannot get the Server Webapp to startup.