### PR TITLE
DS-4551 Close FileInputStreams

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SubmissionController.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SubmissionController.java
@@ -1757,21 +1757,23 @@ public class SubmissionController extends DSpaceServlet
                     // throw IOException to handle it in the calling method
                     throw e;
                 }
+                finally {
+                    try
+                    {
+                        if (is != null)
+                        {
+                            is.close();
+                        }
+                    }
+                    catch (IOException ex)
+                    {
+                        // nothing to do here
+                    }
+                }
             }
         } 
         finally 
         {
-            try 
-            {
-                if (is != null) 
-                {
-                    is.close();
-                }
-            } 
-            catch (IOException ex) 
-            {
-                // nothing to do here
-            }
             try 
             {
                 if (os != null) 


### PR DESCRIPTION
## References
* Fixes [DS-4551](https://jira.lyrasis.org/browse/DS-4551)

## Description
Closes `FileInputStream`s immediately after they are no longer in use, to avoid an excessive number of open files when processing a large upload. In the original code, only the last `FileInputStream` was closed, because `is.close()` was called outside of the loop that opens the streams instead of within the loop. I just moved the `is.close()` to the appropriate place.

To verify the problem and the result _from outside_ you can profile open files for the process. Description of how to do so can be found in [DS-4551](https://jira.lyrasis.org/browse/DS-4551).