### PR TITLE
Fix shibboleth redirect to work with all allowed origins

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ShibbolethRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ShibbolethRestController.java
@@ -8,6 +8,7 @@
 package org.dspace.app.rest;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import javax.servlet.http.HttpServletResponse;
 
@@ -62,8 +63,14 @@ public class ShibbolethRestController implements InitializingBean {
         // Validate that the redirectURL matches either the server or UI hostname. It *cannot* be an arbitrary URL.
         String redirectHostName = Utils.getHostName(redirectUrl);
         String serverHostName = Utils.getHostName(configurationService.getProperty("dspace.server.url"));
-        String clientHostName = Utils.getHostName(configurationService.getProperty("dspace.ui.url"));
-        if (StringUtils.equalsAnyIgnoreCase(redirectHostName, serverHostName, clientHostName)) {
+        ArrayList<String> allowedHostNames = new ArrayList<String>();
+        allowedHostNames.add(serverHostName);
+        String[] allowedUrls = configurationService.getArrayProperty("rest.cors.allowed-origins");
+        for (String url : allowedUrls) {
+            allowedHostNames.add(Utils.getHostName(url));
+        }
+
+        if (StringUtils.equalsAnyIgnoreCase(redirectHostName, allowedHostNames.toArray(new String[0]))) {
             log.debug("Shibboleth redirecting to " + redirectUrl);
             response.sendRedirect(redirectUrl);
         } else {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ShibbolethRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ShibbolethRestControllerIT.java
@@ -12,7 +12,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.services.ConfigurationService;
+import org.junit.Before;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Integration test that cover ShibbolethRestController
@@ -20,6 +23,17 @@ import org.junit.Test;
  * @author Giuseppe Digilio (giuseppe dot digilio at 4science dot it)
  */
 public class ShibbolethRestControllerIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    ConfigurationService configurationService;
+
+
+    @Before
+    public void setup() throws Exception {
+        super.setUp();
+        configurationService.setProperty("rest.cors.allowed-origins",
+                "${dspace.ui.url}, http://anotherdspacehost:4000");
+    }
 
     @Test
     public void testRedirectToDefaultDspaceUrl() throws Exception {
@@ -32,12 +46,23 @@ public class ShibbolethRestControllerIT extends AbstractControllerIntegrationTes
 
     @Test
     public void testRedirectToGivenTrustedUrl() throws Exception {
+
         String token = getAuthToken(eperson.getEmail(), password);
 
         getClient(token).perform(get("/api/authn/shibboleth")
                 .param("redirectUrl", "http://localhost:8080/server/api/authn/status"))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("http://localhost:8080/server/api/authn/status"));
+    }
+
+    @Test
+    public void testRedirectToAnotherGivenTrustedUrl() throws Exception {
+        String token = getAuthToken(eperson.getEmail(), password);
+
+        getClient(token).perform(get("/api/authn/shibboleth")
+                .param("redirectUrl", "http://anotherdspacehost:4000/home"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("http://anotherdspacehost:4000/home"));
     }
 
     @Test


### PR DESCRIPTION
## Description
This PR change the behaviour of `ShibbolethRestController` in the way it can redirect, after authentication, to all urls present in the `rest.cors.allowed-origins` property


- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
