### PR TITLE
Features endpoint: Community / collection creation

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CreateCollectionFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CreateCollectionFeature.java
@@ -53,7 +53,7 @@ public class CreateCollectionFeature implements AuthorizationFeature {
     @Override
     public String[] getSupportedTypes() {
         return new String[]{
-                CommunityRest.CATEGORY + "." + CommunityRest.NAME
+            CommunityRest.CATEGORY + "." + CommunityRest.NAME
         };
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CreateCollectionFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CreateCollectionFeature.java
@@ -1,0 +1,59 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization.impl;
+
+import java.sql.SQLException;
+
+import org.dspace.app.rest.authorization.AuthorizationFeature;
+import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.model.CommunityRest;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.Community;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * The canCreateCollections feature.
+ * It can be used to verify if a user has access to create a new collection within a specific community.
+ */
+@Component
+@AuthorizationFeatureDocumentation(name = CreateCollectionFeature.NAME,
+        description = "It can be used to verify if a user has access to create a new collection within a specific "
+                + "community")
+public class CreateCollectionFeature implements AuthorizationFeature {
+
+    public static final String NAME = "canCreateCollections";
+
+    @Autowired
+    AuthorizeService authService;
+
+    @Autowired
+    Utils utils;
+
+    @Override
+    public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException {
+        if (object != null) {
+            if (object instanceof CommunityRest) {
+                Community community = (Community) utils.getDSpaceAPIObjectFromRest(context, object);
+                return authService.authorizeActionBoolean(context, community, Constants.ADD);
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[]{
+                CommunityRest.CATEGORY + "." + CommunityRest.NAME
+        };
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CreateCommunityFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CreateCommunityFeature.java
@@ -59,8 +59,8 @@ public class CreateCommunityFeature implements AuthorizationFeature {
     @Override
     public String[] getSupportedTypes() {
         return new String[]{
-                SiteRest.CATEGORY + "." + SiteRest.NAME,
-                CommunityRest.CATEGORY + "." + CommunityRest.NAME
+            SiteRest.CATEGORY + "." + SiteRest.NAME,
+            CommunityRest.CATEGORY + "." + CommunityRest.NAME
         };
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CreateCommunityFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CreateCommunityFeature.java
@@ -1,0 +1,66 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization.impl;
+
+import java.sql.SQLException;
+
+import org.dspace.app.rest.authorization.AuthorizationFeature;
+import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.model.CommunityRest;
+import org.dspace.app.rest.model.SiteRest;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.Community;
+import org.dspace.content.Site;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * The canCreateCommunities feature.
+ * It can be used to verify if a user has access to create a new community within a specific parent community or site.
+ */
+@Component
+@AuthorizationFeatureDocumentation(name = CreateCommunityFeature.NAME,
+        description = "It can be used to verify if a user has access to create a new community within a specific parent"
+                + " community or site")
+public class CreateCommunityFeature implements AuthorizationFeature {
+
+    public static final String NAME = "canCreateCommunities";
+
+    @Autowired
+    AuthorizeService authService;
+
+    @Autowired
+    Utils utils;
+
+    @Override
+    public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException {
+        if (object != null) {
+            if (object instanceof CommunityRest) {
+                Community community = (Community) utils.getDSpaceAPIObjectFromRest(context, object);
+                return authService.authorizeActionBoolean(context, community, Constants.ADD);
+            }
+            if (object instanceof SiteRest) {
+                Site site = (Site) utils.getDSpaceAPIObjectFromRest(context, object);
+                return authService.authorizeActionBoolean(context, site, Constants.ADD);
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[]{
+                SiteRest.CATEGORY + "." + SiteRest.NAME,
+                CommunityRest.CATEGORY + "." + CommunityRest.NAME
+        };
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/CanCreateCollectionsIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/CanCreateCollectionsIT.java
@@ -1,0 +1,269 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.dspace.app.rest.authorization.impl.CreateCollectionFeature;
+import org.dspace.app.rest.converter.CollectionConverter;
+import org.dspace.app.rest.converter.CommunityConverter;
+import org.dspace.app.rest.converter.SiteConverter;
+import org.dspace.app.rest.model.CollectionRest;
+import org.dspace.app.rest.model.CommunityRest;
+import org.dspace.app.rest.model.SiteRest;
+import org.dspace.app.rest.projection.DefaultProjection;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Site;
+import org.dspace.content.service.SiteService;
+import org.dspace.core.Constants;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class CanCreateCollectionsIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private SiteService siteService;
+
+    @Autowired
+    private AuthorizationFeatureService authorizationFeatureService;
+
+    @Autowired
+    private CommunityConverter communityConverter;
+
+    @Autowired
+    private SiteConverter siteConverter;
+
+    @Autowired
+    private CollectionConverter collectionConverter;
+
+    @Autowired
+    private AuthorizeService authorizeService;
+
+    @Autowired
+    private Utils utils;
+
+    private Community communityA;
+    private Community communityB;
+    private Community communityC;
+    private Collection collectionA;
+
+    private AuthorizationFeature canCreateCollectionsFeature;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        context.turnOffAuthorisationSystem();
+        communityA = CommunityBuilder.createCommunity(context).withName("Community A").build();
+        collectionA = CollectionBuilder.createCollection(context, communityA).withName("Collection A").build();
+        communityB = CommunityBuilder.createCommunity(context).withName("Community B").build();
+        communityC = CommunityBuilder.createSubCommunity(context, communityB).withName("Community C").build();
+        context.restoreAuthSystemState();
+
+        canCreateCollectionsFeature = authorizationFeatureService.find(CreateCollectionFeature.NAME);
+    }
+
+    @Test
+    public void canCreateCollectionsOnCommunityAsAdminTest() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+        CommunityRest comRest = communityConverter.convert(communityA, DefaultProjection.DEFAULT);
+        String comUri = utils.linkToSingleResource(comRest, "self").getHref();
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                .param("uri", comUri)
+                .param("feature", canCreateCollectionsFeature.getName())
+                .param("embed", "feature"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded").exists())
+                .andExpect(jsonPath("$.page.totalElements", greaterThan(0)));
+    }
+
+    @Test
+    public void canCreateCollectionsOnSiteAsAdminTest() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+        Site site = siteService.findSite(context);
+        SiteRest siteRest = siteConverter.convert(site, DefaultProjection.DEFAULT);
+        String siteUri = utils.linkToSingleResource(siteRest, "self").getHref();
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                .param("uri", siteUri)
+                .param("feature", canCreateCollectionsFeature.getName())
+                .param("embed", "feature"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded").doesNotExist())
+                .andExpect(jsonPath("$.page.totalElements", is(0)));
+    }
+
+    @Test
+    public void canCreateCollectionsOnCollectionAsAdminTest() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+        CollectionRest collectionRest = collectionConverter.convert(collectionA, DefaultProjection.DEFAULT);
+        String collectionUri = utils.linkToSingleResource(collectionRest, "self").getHref();
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                .param("uri", collectionUri)
+                .param("feature", canCreateCollectionsFeature.getName())
+                .param("embed", "feature"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded").doesNotExist())
+                .andExpect(jsonPath("$.page.totalElements", is(0)));
+    }
+
+    @Test
+    public void canCreateCollectionsOnCommunityAsAnonymousTest() throws Exception {
+        CommunityRest comRest = communityConverter.convert(communityA, DefaultProjection.DEFAULT);
+        String comUri = utils.linkToSingleResource(comRest, "self").getHref();
+
+        getClient().perform(get("/api/authz/authorizations/search/object")
+                .param("uri", comUri)
+                .param("feature", canCreateCollectionsFeature.getName())
+                .param("embed", "feature"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded").doesNotExist())
+                .andExpect(jsonPath("$.page.totalElements", is(0)));
+    }
+
+    @Test
+    public void canCreateCollectionsOnSiteAsAnonymousTest() throws Exception {
+        Site site = siteService.findSite(context);
+        SiteRest siteRest = siteConverter.convert(site, DefaultProjection.DEFAULT);
+        String siteUri = utils.linkToSingleResource(siteRest, "self").getHref();
+
+        getClient().perform(get("/api/authz/authorizations/search/object")
+                .param("uri", siteUri)
+                .param("feature", canCreateCollectionsFeature.getName())
+                .param("embed", "feature"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded").doesNotExist())
+                .andExpect(jsonPath("$.page.totalElements", is(0)));
+    }
+
+    @Test
+    public void canCreateCollectionsOnCollectionAsAnonymousTest() throws Exception {
+        CollectionRest collectionRest = collectionConverter.convert(collectionA, DefaultProjection.DEFAULT);
+        String collectionUri = utils.linkToSingleResource(collectionRest, "self").getHref();
+
+        getClient().perform(get("/api/authz/authorizations/search/object")
+                .param("uri", collectionUri)
+                .param("feature", canCreateCollectionsFeature.getName())
+                .param("embed", "feature"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded").doesNotExist())
+                .andExpect(jsonPath("$.page.totalElements", is(0)));
+    }
+
+    @Test
+    public void canCreateCollectionsOnCommunityAsEPersonWithoutRightsTest() throws Exception {
+        authorizeService.addPolicy(context, communityB, Constants.ADMIN, eperson);
+        String token = getAuthToken(eperson.getEmail(), password);
+        CommunityRest comRest = communityConverter.convert(communityA, DefaultProjection.DEFAULT);
+        String comUri = utils.linkToSingleResource(comRest, "self").getHref();
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                .param("uri", comUri)
+                .param("feature", canCreateCollectionsFeature.getName())
+                .param("embed", "feature"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded").doesNotExist())
+                .andExpect(jsonPath("$.page.totalElements", is(0)));
+    }
+
+    @Test
+    public void canCreateCollectionsOnSiteAsEPersonWithoutRightsTest() throws Exception {
+        authorizeService.addPolicy(context, communityB, Constants.ADMIN, eperson);
+        String token = getAuthToken(eperson.getEmail(), password);
+        Site site = siteService.findSite(context);
+        SiteRest siteRest = siteConverter.convert(site, DefaultProjection.DEFAULT);
+        String siteUri = utils.linkToSingleResource(siteRest, "self").getHref();
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                .param("uri", siteUri)
+                .param("feature", canCreateCollectionsFeature.getName())
+                .param("embed", "feature"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded").doesNotExist())
+                .andExpect(jsonPath("$.page.totalElements", is(0)));
+    }
+
+    @Test
+    public void canCreateCollectionsOnCollectionAsEPersonWithoutRightsTest() throws Exception {
+        authorizeService.addPolicy(context, communityB, Constants.ADMIN, eperson);
+        String token = getAuthToken(eperson.getEmail(), password);
+        CollectionRest collectionRest = collectionConverter.convert(collectionA, DefaultProjection.DEFAULT);
+        String collectionUri = utils.linkToSingleResource(collectionRest, "self").getHref();
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                .param("uri", collectionUri)
+                .param("feature", canCreateCollectionsFeature.getName())
+                .param("embed", "feature"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded").doesNotExist())
+                .andExpect(jsonPath("$.page.totalElements", is(0)));
+    }
+
+    @Test
+    public void canCreateCollectionsOnCommunityAsEPersonWithRightsTest() throws Exception {
+        authorizeService.addPolicy(context, communityB, Constants.ADMIN, eperson);
+        String token = getAuthToken(eperson.getEmail(), password);
+        CommunityRest comRest = communityConverter.convert(communityB, DefaultProjection.DEFAULT);
+        String comUri = utils.linkToSingleResource(comRest, "self").getHref();
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                .param("uri", comUri)
+                .param("feature", canCreateCollectionsFeature.getName())
+                .param("embed", "feature"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded").exists())
+                .andExpect(jsonPath("$.page.totalElements", greaterThan(0)));
+    }
+
+    @Test
+    public void canCreateCollectionsOnSubCommunityAsEPersonWithRightsOnParentCommunityTest() throws Exception {
+        authorizeService.addPolicy(context, communityB, Constants.ADMIN, eperson);
+        String token = getAuthToken(eperson.getEmail(), password);
+        CommunityRest comRest = communityConverter.convert(communityC, DefaultProjection.DEFAULT);
+        String comUri = utils.linkToSingleResource(comRest, "self").getHref();
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                .param("uri", comUri)
+                .param("feature", canCreateCollectionsFeature.getName())
+                .param("embed", "feature"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded").exists())
+                .andExpect(jsonPath("$.page.totalElements", greaterThan(0)));
+    }
+
+    @Test
+    public void canCreateCollectionsOnSubCommunityAsEPersonWithoutRightsOnParentCommunityTest() throws Exception {
+        authorizeService.addPolicy(context, communityA, Constants.ADMIN, eperson);
+        String token = getAuthToken(eperson.getEmail(), password);
+        CommunityRest comRest = communityConverter.convert(communityC, DefaultProjection.DEFAULT);
+        String comUri = utils.linkToSingleResource(comRest, "self").getHref();
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                .param("uri", comUri)
+                .param("feature", canCreateCollectionsFeature.getName())
+                .param("embed", "feature"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded").doesNotExist())
+                .andExpect(jsonPath("$.page.totalElements", is(0)));
+    }
+
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/CanCreateCollectionsIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/CanCreateCollectionsIT.java
@@ -35,6 +35,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+/**
+ * This test deals with testing the feature {@link CreateCollectionFeature}
+ */
 public class CanCreateCollectionsIT extends AbstractControllerIntegrationTest {
 
     @Autowired

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/CanCreateCommunitiesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/CanCreateCommunitiesIT.java
@@ -1,0 +1,235 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.dspace.app.rest.authorization.impl.CreateCommunityFeature;
+import org.dspace.app.rest.converter.CollectionConverter;
+import org.dspace.app.rest.converter.CommunityConverter;
+import org.dspace.app.rest.converter.SiteConverter;
+import org.dspace.app.rest.model.CollectionRest;
+import org.dspace.app.rest.model.CommunityRest;
+import org.dspace.app.rest.model.SiteRest;
+import org.dspace.app.rest.projection.DefaultProjection;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Site;
+import org.dspace.content.service.SiteService;
+import org.dspace.core.Constants;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class CanCreateCommunitiesIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private SiteService siteService;
+
+    @Autowired
+    private AuthorizationFeatureService authorizationFeatureService;
+
+    @Autowired
+    private CommunityConverter communityConverter;
+
+    @Autowired
+    private SiteConverter siteConverter;
+
+    @Autowired
+    private CollectionConverter collectionConverter;
+
+    @Autowired
+    private AuthorizeService authorizeService;
+
+    @Autowired
+    private Utils utils;
+
+    private Community communityA;
+    private Community communityB;
+    private Collection collectionA;
+
+    private AuthorizationFeature canCreateCommunitiesFeature;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        context.turnOffAuthorisationSystem();
+        communityA = CommunityBuilder.createCommunity(context).withName("Community A").build();
+        communityB = CommunityBuilder.createSubCommunity(context, communityA).withName("Community B").build();
+        collectionA = CollectionBuilder.createCollection(context, communityB).withName("Collection A").build();
+        context.restoreAuthSystemState();
+
+        canCreateCommunitiesFeature = authorizationFeatureService.find(CreateCommunityFeature.NAME);
+    }
+
+    @Test
+    public void canCreateCommunitiesOnCommunityAsAdminTest() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+        CommunityRest comRest = communityConverter.convert(communityA, DefaultProjection.DEFAULT);
+        String comUri = utils.linkToSingleResource(comRest, "self").getHref();
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                .param("uri", comUri)
+                .param("feature", canCreateCommunitiesFeature.getName())
+                .param("embed", "feature"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded").exists())
+                .andExpect(jsonPath("$.page.totalElements", greaterThan(0)));
+    }
+
+    @Test
+    public void canCreateCommunitiesOnSiteAsAdminTest() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+        Site site = siteService.findSite(context);
+        SiteRest siteRest = siteConverter.convert(site, DefaultProjection.DEFAULT);
+        String siteUri = utils.linkToSingleResource(siteRest, "self").getHref();
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                .param("uri", siteUri)
+                .param("feature", canCreateCommunitiesFeature.getName())
+                .param("embed", "feature"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded").exists())
+                .andExpect(jsonPath("$.page.totalElements", greaterThan(0)));
+    }
+
+    @Test
+    public void canCreateCommunitiesOnCollectionAsAdminTest() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+        CollectionRest collectionRest = collectionConverter.convert(collectionA, DefaultProjection.DEFAULT);
+        String collectionUri = utils.linkToSingleResource(collectionRest, "self").getHref();
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                .param("uri", collectionUri)
+                .param("feature", canCreateCommunitiesFeature.getName())
+                .param("embed", "feature"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded").doesNotExist())
+                .andExpect(jsonPath("$.page.totalElements", is(0)));
+    }
+
+    @Test
+    public void canCreateCommunitiesOnCommunityAsAnonymousTest() throws Exception {
+        CommunityRest comRest = communityConverter.convert(communityA, DefaultProjection.DEFAULT);
+        String comUri = utils.linkToSingleResource(comRest, "self").getHref();
+
+        getClient().perform(get("/api/authz/authorizations/search/object")
+                .param("uri", comUri)
+                .param("feature", canCreateCommunitiesFeature.getName())
+                .param("embed", "feature"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded").doesNotExist())
+                .andExpect(jsonPath("$.page.totalElements", is(0)));
+    }
+
+    @Test
+    public void canCreateCommunitiesOnSiteAsAnonymousTest() throws Exception {
+        Site site = siteService.findSite(context);
+        SiteRest siteRest = siteConverter.convert(site, DefaultProjection.DEFAULT);
+        String siteUri = utils.linkToSingleResource(siteRest, "self").getHref();
+
+        getClient().perform(get("/api/authz/authorizations/search/object")
+                .param("uri", siteUri)
+                .param("feature", canCreateCommunitiesFeature.getName())
+                .param("embed", "feature"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded").doesNotExist())
+                .andExpect(jsonPath("$.page.totalElements", is(0)));
+    }
+
+    @Test
+    public void canCreateCommunitiesOnCollectionAsAnonymousTest() throws Exception {
+        CollectionRest collectionRest = collectionConverter.convert(collectionA, DefaultProjection.DEFAULT);
+        String collectionUri = utils.linkToSingleResource(collectionRest, "self").getHref();
+
+        getClient().perform(get("/api/authz/authorizations/search/object")
+                .param("uri", collectionUri)
+                .param("feature", canCreateCommunitiesFeature.getName())
+                .param("embed", "feature"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded").doesNotExist())
+                .andExpect(jsonPath("$.page.totalElements", is(0)));
+    }
+
+    @Test
+    public void canCreateCommunitiesOnCommunityAsEPersonWithoutRightsTest() throws Exception {
+        authorizeService.addPolicy(context, communityB, Constants.ADMIN, eperson);
+        String token = getAuthToken(eperson.getEmail(), password);
+        CommunityRest comRest = communityConverter.convert(communityA, DefaultProjection.DEFAULT);
+        String comUri = utils.linkToSingleResource(comRest, "self").getHref();
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                .param("uri", comUri)
+                .param("feature", canCreateCommunitiesFeature.getName())
+                .param("embed", "feature"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded").doesNotExist())
+                .andExpect(jsonPath("$.page.totalElements", is(0)));
+    }
+
+    @Test
+    public void canCreateCommunitiesOnSiteAsEPersonWithoutRightsTest() throws Exception {
+        authorizeService.addPolicy(context, communityB, Constants.ADMIN, eperson);
+        String token = getAuthToken(eperson.getEmail(), password);
+        Site site = siteService.findSite(context);
+        SiteRest siteRest = siteConverter.convert(site, DefaultProjection.DEFAULT);
+        String siteUri = utils.linkToSingleResource(siteRest, "self").getHref();
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                .param("uri", siteUri)
+                .param("feature", canCreateCommunitiesFeature.getName())
+                .param("embed", "feature"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded").doesNotExist())
+                .andExpect(jsonPath("$.page.totalElements", is(0)));
+    }
+
+    @Test
+    public void canCreateCommunitiesOnCollectionAsEPersonWithoutRightsTest() throws Exception {
+        authorizeService.addPolicy(context, communityB, Constants.ADMIN, eperson);
+        String token = getAuthToken(eperson.getEmail(), password);
+        CollectionRest collectionRest = collectionConverter.convert(collectionA, DefaultProjection.DEFAULT);
+        String collectionUri = utils.linkToSingleResource(collectionRest, "self").getHref();
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                .param("uri", collectionUri)
+                .param("feature", canCreateCommunitiesFeature.getName())
+                .param("embed", "feature"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded").doesNotExist())
+                .andExpect(jsonPath("$.page.totalElements", is(0)));
+    }
+
+    @Test
+    public void canCreateCommunitiesOnCommunityAsEPersonWithRightsTest() throws Exception {
+        authorizeService.addPolicy(context, communityB, Constants.ADMIN, eperson);
+        String token = getAuthToken(eperson.getEmail(), password);
+        CommunityRest comRest = communityConverter.convert(communityB, DefaultProjection.DEFAULT);
+        String comUri = utils.linkToSingleResource(comRest, "self").getHref();
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                .param("uri", comUri)
+                .param("feature", canCreateCommunitiesFeature.getName())
+                .param("embed", "feature"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded").exists())
+                .andExpect(jsonPath("$.page.totalElements", greaterThan(0)));
+    }
+
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/CanCreateCommunitiesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/CanCreateCommunitiesIT.java
@@ -35,6 +35,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+/**
+ * This test deals with testing the feature {@link CreateCommunityFeature}
+ */
 public class CanCreateCommunitiesIT extends AbstractControllerIntegrationTest {
 
     @Autowired


### PR DESCRIPTION
## References
Fixes #2945 

## Description
We've added REST Authorization Features that will determine whether the given Community can be edited by the current user in the context. We've added the canCreateCollections and the canCreateCommunities features

## Instructions for Reviewers

List of changes in this PR:
* Added the CanCreateCollections and CanCreateCommunities features for the Community object
* Provided tests for these new features

To test this PR:
* Navigate to the {dspace.url}/server/api/authz/authorizations/search/object?uri={dspace.url}/server/api/core/communities/{communityID}6&embed=feature whilst being logged in as admin
* Verify that you can see the two new features

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
