### PR TITLE
Submission bugfix for file upload mandatory

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/validation/UploadValidation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/validation/UploadValidation.java
@@ -43,7 +43,7 @@ public class UploadValidation extends AbstractValidation {
 
         for (String key : uploadConfigurationService.getMap().keySet()) {
             if (getName().equals(key)) {
-                UploadConfiguration uploadConfig = uploadConfigurationService.getMap().get(key);
+                UploadConfiguration uploadConfig = uploadConfigurationService.getMap().get(config.getId());
                 if (uploadConfig.isRequired() && !itemService.hasUploadedFiles(obj.getItem())) {
                     addError(ERROR_VALIDATION_FILEREQUIRED,
                              "/" + WorkspaceItemRestRepository.OPERATION_PATH_SECTIONS + "/"

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/validation/UploadValidation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/validation/UploadValidation.java
@@ -41,15 +41,11 @@ public class UploadValidation extends AbstractValidation {
                                     SubmissionStepConfig config) throws DCInputsReaderException, SQLException {
         //TODO MANAGE METADATA
 
-        for (String key : uploadConfigurationService.getMap().keySet()) {
-            if (getName().equals(key)) {
-                UploadConfiguration uploadConfig = uploadConfigurationService.getMap().get(config.getId());
-                if (uploadConfig.isRequired() && !itemService.hasUploadedFiles(obj.getItem())) {
-                    addError(ERROR_VALIDATION_FILEREQUIRED,
-                             "/" + WorkspaceItemRestRepository.OPERATION_PATH_SECTIONS + "/"
-                                 + config.getId());
-                }
-            }
+        UploadConfiguration uploadConfig = uploadConfigurationService.getMap().get(config.getId());
+        if (uploadConfig.isRequired() && !itemService.hasUploadedFiles(obj.getItem())) {
+            addError(ERROR_VALIDATION_FILEREQUIRED,
+                     "/" + WorkspaceItemRestRepository.OPERATION_PATH_SECTIONS + "/"
+                         + config.getId());
         }
         return getErrors();
     }


### PR DESCRIPTION
## Description
When verifying whether the file upload is mandatory, the submission REST API always verified for the submission step with name "upload" instead of the current step

## Instructions for Reviewers
Configure a new submission step, with a different name (not upload).
Set file upload optional for this step
Verify whether REST no longer claims there are validation errors due to missing files

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
