### PR TITLE
DS-4552 Update crosswalk according to new guidelines

### DIFF
--- a/dspace/config/crosswalks/DIM2DataCite.xsl
+++ b/dspace/config/crosswalks/DIM2DataCite.xsl
@@ -21,7 +21,9 @@
          Please take a look into the DSpace documentation for details on how to
          change those. -->
     <!-- DO NOT CHANGE ANYTHING BELOW THIS LINE EXCEPT YOU REALLY KNOW WHAT YOU ARE DOING! -->
-    
+
+    <!-- The base url of DataCite resolver see: https://support.datacite.org/docs/datacite-doi-display-guidelines -->
+    <xsl:variable name="baseurl" select="'https://doi.org/'" />
     <!-- We need the prefix to determine DOIs that were minted by ourself. -->
     <xsl:param name="prefix">10.5072/dspace-</xsl:param>
     <!-- The content of the following parameter will be used as element publisher. -->
@@ -32,6 +34,7 @@
     <xsl:param name="hostinginstitution"><xsl:value-of select="$publisher" /></xsl:param>
     <!-- Please take a look into the DataCite schema documentation if you want to know how to use these elements.
          http://schema.datacite.org -->
+
 
     <xsl:output method="xml" indent="yes" encoding="utf-8" />
 
@@ -65,7 +68,7 @@
                 company as well. We have to ensure to use URIs of our prefix
                 as primary identifiers only.
             -->
-            <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='identifier' and starts-with(., concat('http://dx.doi.org/', $prefix))]" />
+            <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='identifier' and starts-with(., concat($baseurl, $prefix))]" />
 
             <!--
                 DataCite (2)
@@ -230,9 +233,9 @@
                 Occ: 0-n
                 Required Attribute: alternateIdentifierType (free format)
             -->
-            <xsl:if test="//dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and not(starts-with(., concat('http://dx.doi.org/', $prefix)))]">
+            <xsl:if test="//dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and not(starts-with(., concat($baseurl, $prefix)))]">
                 <xsl:element name="alternateIdentifiers">
-                    <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and not(starts-with(., concat('http://dx.doi.org/', $prefix)))]" />
+                    <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and not(starts-with(., concat($baseurl, $prefix)))]" />
                 </xsl:element>
             </xsl:if>
 
@@ -295,7 +298,7 @@
         company as well. We have to ensure to use URIs of our prefix
         as primary identifiers only.
     -->
-    <xsl:template match="dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and starts-with(., concat('http://dx.doi.org/', $prefix))]">
+    <xsl:template match="dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and starts-with(., concat($baseurl, $prefix))]">
         <identifier identifierType="DOI">
             <xsl:value-of select="substring(., 19)"/>
         </identifier>
@@ -512,7 +515,7 @@
         resolveUrlToHandle(context, altId) until one is recognized or all have
         been tested.
     -->
-    <xsl:template match="//dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and not(starts-with(., concat('http://dx.doi.org/', $prefix)))]">
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and not(starts-with(., concat($baseurl, $prefix)))]">
         <xsl:element name="alternateIdentifier">
             <xsl:if test="@qualifier">
                 <xsl:attribute name="alternateIdentifierType"><xsl:value-of select="@qualifier" /></xsl:attribute>


### PR DESCRIPTION
## Description
The crosswalk for DOI minting currently mints using HTTP and the subdomain "dx.doi.org" whereas the official guidelines recommends HTTPS and "doi.org" https://support.datacite.org/docs/datacite-doi-display-guidelines.

This PR simply changes the value to use HTTPS and drop the subdomain. Additionally it stores this as a variable to avoid repetition but at a slight cost of readability.