### PR TITLE
[DS-4552] Revert PR#2985 "DS-4552 Update crosswalk according to new guidelines"

### DIFF
--- a/dspace/config/crosswalks/DIM2DataCite.xsl
+++ b/dspace/config/crosswalks/DIM2DataCite.xsl
@@ -21,9 +21,7 @@
          Please take a look into the DSpace documentation for details on how to
          change those. -->
     <!-- DO NOT CHANGE ANYTHING BELOW THIS LINE EXCEPT YOU REALLY KNOW WHAT YOU ARE DOING! -->
-
-    <!-- The base url of DataCite resolver see: https://support.datacite.org/docs/datacite-doi-display-guidelines -->
-    <xsl:variable name="baseurl" select="'https://doi.org/'" />
+    
     <!-- We need the prefix to determine DOIs that were minted by ourself. -->
     <xsl:param name="prefix">10.5072/dspace-</xsl:param>
     <!-- The content of the following parameter will be used as element publisher. -->
@@ -34,7 +32,6 @@
     <xsl:param name="hostinginstitution"><xsl:value-of select="$publisher" /></xsl:param>
     <!-- Please take a look into the DataCite schema documentation if you want to know how to use these elements.
          http://schema.datacite.org -->
-
 
     <xsl:output method="xml" indent="yes" encoding="utf-8" />
 
@@ -68,7 +65,7 @@
                 company as well. We have to ensure to use URIs of our prefix
                 as primary identifiers only.
             -->
-            <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='identifier' and starts-with(., concat($baseurl, $prefix))]" />
+            <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='identifier' and starts-with(., concat('http://dx.doi.org/', $prefix))]" />
 
             <!--
                 DataCite (2)
@@ -233,9 +230,9 @@
                 Occ: 0-n
                 Required Attribute: alternateIdentifierType (free format)
             -->
-            <xsl:if test="//dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and not(starts-with(., concat($baseurl, $prefix)))]">
+            <xsl:if test="//dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and not(starts-with(., concat('http://dx.doi.org/', $prefix)))]">
                 <xsl:element name="alternateIdentifiers">
-                    <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and not(starts-with(., concat($baseurl, $prefix)))]" />
+                    <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and not(starts-with(., concat('http://dx.doi.org/', $prefix)))]" />
                 </xsl:element>
             </xsl:if>
 
@@ -298,7 +295,7 @@
         company as well. We have to ensure to use URIs of our prefix
         as primary identifiers only.
     -->
-    <xsl:template match="dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and starts-with(., concat($baseurl, $prefix))]">
+    <xsl:template match="dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and starts-with(., concat('http://dx.doi.org/', $prefix))]">
         <identifier identifierType="DOI">
             <xsl:value-of select="substring(., 19)"/>
         </identifier>
@@ -515,7 +512,7 @@
         resolveUrlToHandle(context, altId) until one is recognized or all have
         been tested.
     -->
-    <xsl:template match="//dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and not(starts-with(., concat($baseurl, $prefix)))]">
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and not(starts-with(., concat('http://dx.doi.org/', $prefix)))]">
         <xsl:element name="alternateIdentifier">
             <xsl:if test="@qualifier">
                 <xsl:attribute name="alternateIdentifierType"><xsl:value-of select="@qualifier" /></xsl:attribute>


### PR DESCRIPTION
JIRA: https://jira.lyrasis.org/browse/DS-4552

Reverts DSpace/DSpace#2985 - as per notes on issue, it may well be too risky to try and update these prefixes in a minor 6.x release
Many sites will have existing items with dc.identifier.uri values using the deprecated prefix, other crosswalk mapping and transformation rules for the deprecated prefix. Given this risk and the fact that the dx.doi.org is deprecated but not removed (and it is highly unlikely that a URI prefix for a persistent URI service will stop working even in the long-term), I've spoken to other devs and Hrafn and think we should revert the previous quick change in the Datacite crosswalk