### PR TITLE
[DS-4001] Set the primaryBitstreamID only if the bitstream has not been deleted…

### DIFF
--- a/dspace-api/src/main/java/org/dspace/submit/step/UploadStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/UploadStep.java
@@ -346,11 +346,11 @@ public class UploadStep extends AbstractProcessingStep
         if (request.getParameter("primary_bitstream_id") != null)
         {
             List<Bundle> bundles = itemService.getBundles(item, "ORIGINAL");
-            if (bundles.size() > 0)
+            Bitstream primaryBitstream = bitstreamService.find(context, Util.getUUIDParameter(request, "primary_bitstream_id"));
+            if (bundles.size() > 0 && !primaryBitstream.isDeleted())
             {
-            	bundles.get(0).setPrimaryBitstreamID(bitstreamService.find(context, Util.getUUIDParameter(request,
-                        "primary_bitstream_id")));
-            	bundleService.update(context, bundles.get(0));
+                bundles.get(0).setPrimaryBitstreamID(primaryBitstream);
+                bundleService.update(context, bundles.get(0));
             }
         }
 

--- a/dspace-api/src/main/java/org/dspace/submit/step/UploadWithEmbargoStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/UploadWithEmbargoStep.java
@@ -334,10 +334,10 @@ public class UploadWithEmbargoStep extends UploadStep
         if (request.getParameter("primary_bitstream_id") != null)
         {
             List<Bundle> bundles = itemService.getBundles(item, "ORIGINAL");
-            if (bundles.size() > 0)
+            Bitstream primaryBitstream = bitstreamService.find(context, Util.getUUIDParameter(request, "primary_bitstream_id"));
+            if (bundles.size() > 0 && !primaryBitstream.isDeleted())
             {
-                bundles.get(0).setPrimaryBitstreamID(bitstreamService.find(context, Util.getUUIDParameter(request
-                        , "primary_bitstream_id")));
+                bundles.get(0).setPrimaryBitstreamID(primaryBitstream);
                 bundleService.update(context, bundles.get(0));
             }
         }

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EditItemServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EditItemServlet.java
@@ -831,7 +831,12 @@ public class EditItemServlet extends DSpaceServlet
 
                     if (primaryBitstreamID != null)
                     {
-                        bundle.setPrimaryBitstreamID(bitstreamService.find(context, primaryBitstreamID));
+                        Bitstream primaryBitstream = bitstreamService.find(context, primaryBitstreamID);
+
+                        if(!primaryBitstream.isDeleted())
+                        {
+                            bundle.setPrimaryBitstreamID(primaryBitstream);
+                        }
                     }
 
                     if (userFormatDesc != null)

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowItemUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowItemUtils.java
@@ -669,7 +669,7 @@ public class FlowItemUtils
 		if (bundles != null && bundles.size() > 0)
 		{
 			Bundle bundle = bundles.get(0);
-			if (bundle.getPrimaryBitstream() != null && bundle.getPrimaryBitstream().toString().equals(String.valueOf(bitstreamID)))
+			if (bundle.getPrimaryBitstream() != null && bundle.getPrimaryBitstream().equals(bitstream))
 			{
 				// currently the bitstream is primary
 				if ("no".equals(primary))


### PR DESCRIPTION
…. Otherwise a deleted primary bitstream is still referenced in the bundle table which results in a deletion violates foreign key constraint error during a bitstream cleanup task.

## References
https://jira.lyrasis.org/browse/DS-4001
Fixes #7348

## Description
See comment: https://jira.lyrasis.org/browse/DS-4001?focusedCommentId=65591&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-65591


