### PR TITLE
Features endpoint: Download/RequestACopy features

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/DownloadFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/DownloadFeature.java
@@ -48,7 +48,7 @@ public class DownloadFeature implements AuthorizationFeature {
     @Override
     public String[] getSupportedTypes() {
         return new String[]{
-                BitstreamRest.CATEGORY + "." + BitstreamRest.NAME,
+            BitstreamRest.CATEGORY + "." + BitstreamRest.NAME,
         };
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/DownloadFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/DownloadFeature.java
@@ -9,7 +9,6 @@ package org.dspace.app.rest.authorization.impl;
 
 import java.sql.SQLException;
 
-import org.apache.log4j.Logger;
 import org.dspace.app.rest.authorization.AuthorizationFeature;
 import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
 import org.dspace.app.rest.authorization.AuthorizeServiceRestUtil;
@@ -29,8 +28,6 @@ import org.springframework.stereotype.Component;
 @AuthorizationFeatureDocumentation(name = DownloadFeature.NAME,
         description = "It can be used to verify if the user can download a bitstream")
 public class DownloadFeature implements AuthorizationFeature {
-
-    Logger log = Logger.getLogger(DownloadFeature.class);
 
     public final static String NAME = "canDownload";
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/DownloadFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/DownloadFeature.java
@@ -15,18 +15,15 @@ import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
 import org.dspace.app.rest.authorization.AuthorizeServiceRestUtil;
 import org.dspace.app.rest.model.BaseObjectRest;
 import org.dspace.app.rest.model.BitstreamRest;
-import org.dspace.app.rest.model.ItemRest;
 import org.dspace.app.rest.security.DSpaceRestPermission;
-import org.dspace.authorize.service.AuthorizeService;
-import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
- * The create bitstream feature. It can be used to verify if bitstreams can be created in a specific bundle.
+ * The download bitstream feature. It can be used to verify if a bitstream can be downloaded.
  *
- * Authorization is granted if the current user has ADD & WRITE permissions on the given bundle AND the item
+ * Authorization is granted if the current user has READ permissions on the given bitstream.
  */
 @Component
 @AuthorizationFeatureDocumentation(name = DownloadFeature.NAME,

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/DownloadFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/DownloadFeature.java
@@ -1,0 +1,57 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization.impl;
+
+import java.sql.SQLException;
+
+import org.apache.log4j.Logger;
+import org.dspace.app.rest.authorization.AuthorizationFeature;
+import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
+import org.dspace.app.rest.authorization.AuthorizeServiceRestUtil;
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.model.BitstreamRest;
+import org.dspace.app.rest.model.ItemRest;
+import org.dspace.app.rest.security.DSpaceRestPermission;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * The create bitstream feature. It can be used to verify if bitstreams can be created in a specific bundle.
+ *
+ * Authorization is granted if the current user has ADD & WRITE permissions on the given bundle AND the item
+ */
+@Component
+@AuthorizationFeatureDocumentation(name = DownloadFeature.NAME,
+        description = "It can be used to verify if the user can download a bitstream")
+public class DownloadFeature implements AuthorizationFeature {
+
+    Logger log = Logger.getLogger(DownloadFeature.class);
+
+    public final static String NAME = "canDownload";
+
+    @Autowired
+    private AuthorizeServiceRestUtil authorizeServiceRestUtil;
+
+    @Override
+    public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException {
+        if (object instanceof BitstreamRest) {
+            return authorizeServiceRestUtil.authorizeActionBoolean(context, object, DSpaceRestPermission.READ);
+        }
+        return false;
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[]{
+                BitstreamRest.CATEGORY + "." + BitstreamRest.NAME,
+        };
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/RequestCopyFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/RequestCopyFeature.java
@@ -1,0 +1,84 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization.impl;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.log4j.Logger;
+import org.dspace.app.rest.authorization.AuthorizationFeature;
+import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
+import org.dspace.app.rest.authorization.AuthorizeServiceRestUtil;
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.model.BitstreamRest;
+import org.dspace.app.rest.model.ItemRest;
+import org.dspace.app.rest.security.DSpaceRestPermission;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Item;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * The create bitstream feature. It can be used to verify if bitstreams can be created in a specific bundle.
+ *
+ * Authorization is granted if the current user has ADD & WRITE permissions on the given bundle AND the item
+ */
+@Component
+@AuthorizationFeatureDocumentation(name = RequestCopyFeature.NAME,
+        description = "It can be used to verify if the user can request a copy of a bitstream")
+public class RequestCopyFeature implements AuthorizationFeature {
+
+    Logger log = Logger.getLogger(RequestCopyFeature.class);
+
+    public final static String NAME = "canRequestACopy";
+
+    @Autowired
+    private AuthorizeServiceRestUtil authorizeServiceRestUtil;
+    @Autowired
+    private AuthorizeService authorizeService;
+
+    @Autowired
+    private ItemService itemService;
+
+    @Override
+    public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException {
+        if (object instanceof ItemRest) {
+            ItemRest itemRest = (ItemRest) object;
+            String id = itemRest.getId();
+            Item item = itemService.find(context, UUID.fromString(id));
+            List<Bundle> bunds = item.getBundles();
+
+            for (Bundle bund : bunds) {
+                List<Bitstream> bitstreams = bund.getBitstreams();
+                for (Bitstream bitstream : bitstreams) {
+                    boolean authorized = authorizeService.authorizeActionBoolean(context, bitstream, Constants.READ);
+                    if (!authorized) {
+                        return true;
+                    }
+                }
+            }
+        } else if (object instanceof BitstreamRest) {
+            return !authorizeServiceRestUtil.authorizeActionBoolean(context, object, DSpaceRestPermission.READ);
+        }
+        return false;
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[]{
+                ItemRest.CATEGORY + "." + ItemRest.NAME,
+                BitstreamRest.CATEGORY + "." + BitstreamRest.NAME,
+        };
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/RequestCopyFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/RequestCopyFeature.java
@@ -92,8 +92,8 @@ public class RequestCopyFeature implements AuthorizationFeature {
     @Override
     public String[] getSupportedTypes() {
         return new String[]{
-                ItemRest.CATEGORY + "." + ItemRest.NAME,
-                BitstreamRest.CATEGORY + "." + BitstreamRest.NAME,
+            ItemRest.CATEGORY + "." + ItemRest.NAME,
+            BitstreamRest.CATEGORY + "." + BitstreamRest.NAME,
         };
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/DownloadFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/DownloadFeatureIT.java
@@ -1,0 +1,305 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.InputStream;
+
+import org.apache.commons.codec.CharEncoding;
+import org.apache.commons.io.IOUtils;
+import org.dspace.app.rest.authorization.impl.DownloadFeature;
+import org.dspace.app.rest.converter.BitstreamConverter;
+import org.dspace.app.rest.converter.CollectionConverter;
+import org.dspace.app.rest.converter.ItemConverter;
+import org.dspace.app.rest.matcher.AuthorizationMatcher;
+import org.dspace.app.rest.model.BitstreamRest;
+import org.dspace.app.rest.model.CollectionRest;
+import org.dspace.app.rest.model.ItemRest;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.authorize.service.ResourcePolicyService;
+import org.dspace.builder.BitstreamBuilder;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.core.Constants;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class DownloadFeatureIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private AuthorizationFeatureService authorizationFeatureService;
+
+    @Autowired
+    private ResourcePolicyService resourcePolicyService;
+
+    @Autowired
+    private CollectionConverter collectionConverter;
+
+    @Autowired
+    private ItemConverter itemConverter;
+
+    @Autowired
+    private BitstreamConverter bitstreamConverter;
+
+
+    @Autowired
+    private Utils utils;
+
+    private AuthorizationFeature downloadFeature;
+
+    private Collection collectionA;
+    private Item itemA;
+    private Bitstream bitstreamA;
+    private Bitstream bitstreamB;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        context.turnOffAuthorisationSystem();
+        downloadFeature = authorizationFeatureService.find(DownloadFeature.NAME);
+
+        String bitstreamContent = "Dummy content";
+
+        Community communityA = CommunityBuilder.createCommunity(context).build();
+        collectionA = CollectionBuilder.createCollection(context, communityA).withLogo("Blub").build();
+
+        itemA = ItemBuilder.createItem(context, collectionA).build();
+
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstreamA = BitstreamBuilder.createBitstream(context, itemA, is)
+                                         .withName("Bitstream")
+                                         .withDescription("Description")
+                                         .withMimeType("text/plain")
+                                         .build();
+            bitstreamB = BitstreamBuilder.createBitstream(context, itemA, is)
+                                         .withName("Bitstream2")
+                                         .withDescription("Description2")
+                                         .withMimeType("text/plain")
+                                         .build();
+        }
+        resourcePolicyService.removePolicies(context, bitstreamB, Constants.READ);
+
+
+        context.restoreAuthSystemState();
+    }
+
+
+    @Test
+    public void downloadOfCollectionAAsAdmin() throws Exception {
+        CollectionRest collectionRest = collectionConverter.convert(collectionA, Projection.DEFAULT);
+        String collectionUri = utils.linkToSingleResource(collectionRest, "self").getHref();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                                         .param("uri", collectionUri)
+                                         .param("feature", downloadFeature.getName()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.page.totalElements", is(0)))
+                        .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    @Test
+    public void downloadOfItemAAsAdmin() throws Exception {
+        ItemRest itemRest = itemConverter.convert(itemA, Projection.DEFAULT);
+        String itemUri = utils.linkToSingleResource(itemRest, "self").getHref();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                                         .param("uri", itemUri)
+                                         .param("feature", downloadFeature.getName()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.page.totalElements", is(0)))
+                        .andExpect(jsonPath("$._embedded").doesNotExist());
+
+    }
+
+    @Test
+    public void downloadOfBitstreamAAsAdmin() throws Exception {
+        BitstreamRest bitstreamRest = bitstreamConverter.convert(bitstreamA, Projection.DEFAULT);
+        String bitstreamUri = utils.linkToSingleResource(bitstreamRest, "self").getHref();
+
+        Authorization authorizationFeature = new Authorization(admin, downloadFeature, bitstreamRest);
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                                         .param("uri", bitstreamUri)
+                                         .param("feature", downloadFeature.getName()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+                        .andExpect(jsonPath("$._embedded.authorizations", contains(
+                                Matchers.is(AuthorizationMatcher.matchAuthorization(authorizationFeature)))));
+
+    }
+
+    @Test
+    public void downloadOfBitstreamBAsAdmin() throws Exception {
+        BitstreamRest bitstreamRest = bitstreamConverter.convert(bitstreamB, Projection.DEFAULT);
+        String bitstreamUri = utils.linkToSingleResource(bitstreamRest, "self").getHref();
+
+        Authorization authorizationFeature = new Authorization(admin, downloadFeature, bitstreamRest);
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                                         .param("uri", bitstreamUri)
+                                         .param("feature", downloadFeature.getName()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+                        .andExpect(jsonPath("$._embedded.authorizations", contains(
+                                Matchers.is(AuthorizationMatcher.matchAuthorization(authorizationFeature)))));
+
+    }
+
+
+    // Tests for anonymous user
+    @Test
+    public void downloadOfCollectionAAsAnonymous() throws Exception {
+        CollectionRest collectionRest = collectionConverter.convert(collectionA, Projection.DEFAULT);
+        String collectionUri = utils.linkToSingleResource(collectionRest, "self").getHref();
+
+        getClient().perform(get("/api/authz/authorizations/search/object")
+                                    .param("uri", collectionUri)
+                                    .param("feature", downloadFeature.getName()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.page.totalElements", is(0)))
+                   .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    @Test
+    public void downloadOfItemAAsAnonymous() throws Exception {
+        ItemRest itemRest = itemConverter.convert(itemA, Projection.DEFAULT);
+        String itemUri = utils.linkToSingleResource(itemRest, "self").getHref();
+
+
+        getClient().perform(get("/api/authz/authorizations/search/object")
+                                    .param("uri", itemUri)
+                                    .param("feature", downloadFeature.getName()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.page.totalElements", is(0)))
+                   .andExpect(jsonPath("$._embedded").doesNotExist());
+
+    }
+
+    @Test
+    public void downloadOfBitstreamAAsAnonymous() throws Exception {
+        BitstreamRest bitstreamRest = bitstreamConverter.convert(bitstreamA, Projection.DEFAULT);
+        String bitstreamUri = utils.linkToSingleResource(bitstreamRest, "self").getHref();
+
+        Authorization authorizationFeature = new Authorization(null, downloadFeature, bitstreamRest);
+
+        getClient().perform(get("/api/authz/authorizations/search/object")
+                                    .param("uri", bitstreamUri)
+                                    .param("feature", downloadFeature.getName()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+                   .andExpect(jsonPath("$._embedded.authorizations", contains(
+                           Matchers.is(AuthorizationMatcher.matchAuthorization(authorizationFeature)))));
+
+    }
+
+    @Test
+    public void downloadOfBitstreamBAsAnonymous() throws Exception {
+        BitstreamRest bitstreamRest = bitstreamConverter.convert(bitstreamB, Projection.DEFAULT);
+        String bitstreamUri = utils.linkToSingleResource(bitstreamRest, "self").getHref();
+
+
+        getClient().perform(get("/api/authz/authorizations/search/object")
+                                    .param("uri", bitstreamUri)
+                                    .param("feature", downloadFeature.getName()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.page.totalElements", is(0)))
+                   .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    // Test for Eperson
+    @Test
+    public void downloadOfCollectionAAsEperson() throws Exception {
+        CollectionRest collectionRest = collectionConverter.convert(collectionA, Projection.DEFAULT);
+        String collectionUri = utils.linkToSingleResource(collectionRest, "self").getHref();
+
+        String token = getAuthToken(eperson.getEmail(), password);
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                                         .param("uri", collectionUri)
+                                         .param("feature", downloadFeature.getName()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.page.totalElements", is(0)))
+                        .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    @Test
+    public void downloadOfItemAAsEperson() throws Exception {
+        ItemRest itemRest = itemConverter.convert(itemA, Projection.DEFAULT);
+        String itemUri = utils.linkToSingleResource(itemRest, "self").getHref();
+
+        String token = getAuthToken(eperson.getEmail(), password);
+
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                                         .param("uri", itemUri)
+                                         .param("feature", downloadFeature.getName()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.page.totalElements", is(0)))
+                        .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    @Test
+    public void downloadOfBitstreamAAsEperson() throws Exception {
+        BitstreamRest bitstreamRest = bitstreamConverter.convert(bitstreamA, Projection.DEFAULT);
+        String bitstreamUri = utils.linkToSingleResource(bitstreamRest, "self").getHref();
+
+        Authorization authorizationFeature = new Authorization(eperson, downloadFeature, bitstreamRest);
+
+        String token = getAuthToken(eperson.getEmail(), password);
+
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                                         .param("uri", bitstreamUri)
+                                         .param("feature", downloadFeature.getName()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+                        .andExpect(jsonPath("$._embedded.authorizations", contains(
+                                Matchers.is(AuthorizationMatcher.matchAuthorization(authorizationFeature)))));
+
+    }
+
+    @Test
+    public void downloadOfBitstreamBAsEperson() throws Exception {
+        BitstreamRest bitstreamRest = bitstreamConverter.convert(bitstreamB, Projection.DEFAULT);
+        String bitstreamUri = utils.linkToSingleResource(bitstreamRest, "self").getHref();
+
+        String token = getAuthToken(eperson.getEmail(), password);
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                                         .param("uri", bitstreamUri)
+                                         .param("feature", downloadFeature.getName()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.page.totalElements", is(0)))
+                        .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/RequestCopyFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/RequestCopyFeatureIT.java
@@ -460,7 +460,7 @@ public class RequestCopyFeatureIT extends AbstractControllerIntegrationTest {
     public void requestACopyItemTypeLoggedAsAnonymous() throws Exception {
         configurationService.setProperty("request.item.type", "logged");
 
-        BitstreamRest bitstreamRest = bitstreamConverter.convert(bitstreamFromCollection, Projection.DEFAULT);
+        BitstreamRest bitstreamRest = bitstreamConverter.convert(bitstreamB, Projection.DEFAULT);
         String bitstreamUri = utils.linkToSingleResource(bitstreamRest, "self").getHref();
 
         getClient().perform(get("/api/authz/authorizations/search/object")
@@ -473,6 +473,8 @@ public class RequestCopyFeatureIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void requestACopyItemTypeLoggedAsEperson() throws Exception {
+        configurationService.setProperty("request.item.type", "logged");
+
         BitstreamRest bitstreamRest = bitstreamConverter.convert(bitstreamB, Projection.DEFAULT);
         String bitstreamUri = utils.linkToSingleResource(bitstreamRest, "self").getHref();
         Authorization authorizationFeature = new Authorization(eperson, requestCopyFeature, bitstreamRest);
@@ -492,7 +494,7 @@ public class RequestCopyFeatureIT extends AbstractControllerIntegrationTest {
     public void requestACopyItemTypeEmptyAsAnonymous() throws Exception {
         configurationService.setProperty("request.item.type", "");
 
-        BitstreamRest bitstreamRest = bitstreamConverter.convert(bitstreamFromCollection, Projection.DEFAULT);
+        BitstreamRest bitstreamRest = bitstreamConverter.convert(bitstreamB, Projection.DEFAULT);
         String bitstreamUri = utils.linkToSingleResource(bitstreamRest, "self").getHref();
 
         getClient().perform(get("/api/authz/authorizations/search/object")
@@ -506,7 +508,7 @@ public class RequestCopyFeatureIT extends AbstractControllerIntegrationTest {
     public void requestACopyItemTypeEmptyAsEperson() throws Exception {
         configurationService.setProperty("request.item.type", "");
 
-        BitstreamRest bitstreamRest = bitstreamConverter.convert(bitstreamFromCollection, Projection.DEFAULT);
+        BitstreamRest bitstreamRest = bitstreamConverter.convert(bitstreamB, Projection.DEFAULT);
         String bitstreamUri = utils.linkToSingleResource(bitstreamRest, "self").getHref();
 
         String token = getAuthToken(eperson.getEmail(), password);
@@ -522,7 +524,7 @@ public class RequestCopyFeatureIT extends AbstractControllerIntegrationTest {
     public void requestACopyItemTypeBogusValueAsAnonymous() throws Exception {
         configurationService.setProperty("request.item.type", "invalid value");
 
-        BitstreamRest bitstreamRest = bitstreamConverter.convert(bitstreamFromCollection, Projection.DEFAULT);
+        BitstreamRest bitstreamRest = bitstreamConverter.convert(bitstreamB, Projection.DEFAULT);
         String bitstreamUri = utils.linkToSingleResource(bitstreamRest, "self").getHref();
 
         getClient().perform(get("/api/authz/authorizations/search/object")
@@ -536,7 +538,7 @@ public class RequestCopyFeatureIT extends AbstractControllerIntegrationTest {
     public void requestACopyItemTypeBogusValueAsEperson() throws Exception {
         configurationService.setProperty("request.item.type", "invalid value");
 
-        BitstreamRest bitstreamRest = bitstreamConverter.convert(bitstreamFromCollection, Projection.DEFAULT);
+        BitstreamRest bitstreamRest = bitstreamConverter.convert(bitstreamB, Projection.DEFAULT);
         String bitstreamUri = utils.linkToSingleResource(bitstreamRest, "self").getHref();
 
         String token = getAuthToken(eperson.getEmail(), password);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/RequestCopyFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/RequestCopyFeatureIT.java
@@ -1,0 +1,358 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.InputStream;
+
+import org.apache.commons.codec.CharEncoding;
+import org.apache.commons.io.IOUtils;
+import org.dspace.app.rest.authorization.impl.RequestCopyFeature;
+import org.dspace.app.rest.converter.BitstreamConverter;
+import org.dspace.app.rest.converter.ConverterService;
+import org.dspace.app.rest.converter.ItemConverter;
+import org.dspace.app.rest.converter.SiteConverter;
+import org.dspace.app.rest.model.BitstreamRest;
+import org.dspace.app.rest.model.CollectionRest;
+import org.dspace.app.rest.model.ItemRest;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.authorize.service.ResourcePolicyService;
+import org.dspace.builder.BitstreamBuilder;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.builder.WorkspaceItemBuilder;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.content.Site;
+import org.dspace.content.WorkspaceItem;
+import org.dspace.content.service.SiteService;
+import org.dspace.core.Constants;
+import org.dspace.services.ConfigurationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class RequestCopyFeatureIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private AuthorizationFeatureService authorizationFeatureService;
+
+    @Autowired
+    private ConverterService converterService;
+
+    @Autowired
+    private ConfigurationService configurationService;
+
+    @Autowired
+    private SiteService siteService;
+
+    @Autowired
+    ResourcePolicyService resourcePolicyService;
+
+    @Autowired
+    private SiteConverter siteConverter;
+
+    @Autowired
+    private ItemConverter itemConverter;
+
+    @Autowired
+    private BitstreamConverter bitstreamConverter;
+
+
+    @Autowired
+    private Utils utils;
+
+    private AuthorizationFeature requestCopyFeature;
+
+    private Collection collectionA;
+    private Item itemA;
+    private Bitstream bitstreamA;
+    private Bitstream bitstreamB;
+
+    private Item itemInWorkSpace;
+    private Bitstream bitstreamFromWorkSpaceItem;
+
+    private Bitstream bitstreamFromCollection;
+
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        context.turnOffAuthorisationSystem();
+        requestCopyFeature = authorizationFeatureService.find(RequestCopyFeature.NAME);
+
+        String bitstreamContent = "Dummy content";
+
+        Community communityA = CommunityBuilder.createCommunity(context).build();
+        collectionA = CollectionBuilder.createCollection(context, communityA).withLogo("Blub").build();
+        bitstreamFromCollection = collectionA.getLogo();
+
+        itemA = ItemBuilder.createItem(context, collectionA).build();
+
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstreamA = BitstreamBuilder.createBitstream(context, itemA, is)
+                                         .withName("Bitstream")
+                                         .withDescription("Description")
+                                         .withMimeType("text/plain")
+                                         .build();
+            bitstreamB = BitstreamBuilder.createBitstream(context, itemA, is)
+                                         .withName("Bitstream2")
+                                         .withDescription("Description2")
+                                         .withMimeType("text/plain")
+                                         .build();
+            WorkspaceItem workspaceItem = WorkspaceItemBuilder.createWorkspaceItem(context, collectionA)
+                                                              .withFulltext("Test", "source", is)
+                                                              .build();
+            itemInWorkSpace = workspaceItem.getItem();
+            bitstreamFromWorkSpaceItem = itemInWorkSpace.getBundles("ORIGINAL").get(0).getBitstreams().get(0);
+        }
+        resourcePolicyService.removePolicies(context, bitstreamB, Constants.READ);
+
+
+        context.restoreAuthSystemState();
+    }
+
+
+    @Test
+    public void requestCopyOnCollectionAAsAdmin() throws Exception {
+        CollectionRest collectionRest = converterService.toRest(collectionA, Projection.DEFAULT);
+        String collectionUri = utils.linkToSingleResource(collectionRest, "self").getHref();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                                         .param("uri", collectionUri)
+                                         .param("feature", requestCopyFeature.getName()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.page.totalElements", is(0)))
+                        .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+    @Test
+    public void requestCopyOnItemAAsAdmin() throws Exception {
+        ItemRest itemRest = itemConverter.convert(itemA, Projection.DEFAULT);
+        String itemUri = utils.linkToSingleResource(itemRest, "self").getHref();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                                         .param("uri", itemUri)
+                                         .param("feature", requestCopyFeature.getName()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.page.totalElements", is(0)))
+                        .andExpect(jsonPath("$._embedded").doesNotExist());
+
+    }
+
+    @Test
+    public void requestCopyOnItemInWorkSpaceAsAdmin() throws Exception {
+        ItemRest itemRest = itemConverter.convert(itemInWorkSpace, Projection.DEFAULT);
+        String itemUri = utils.linkToSingleResource(itemRest, "self").getHref();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                                         .param("uri", itemUri)
+                                         .param("feature", requestCopyFeature.getName()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.page.totalElements", is(0)))
+                        .andExpect(jsonPath("$._embedded").doesNotExist());
+
+    }
+
+    @Test
+    public void requestCopyOnBitstreamAAsAdmin() throws Exception {
+        BitstreamRest bitstreamRest = bitstreamConverter.convert(bitstreamA, Projection.DEFAULT);
+        String bitstreamUri = utils.linkToSingleResource(bitstreamRest, "self").getHref();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                                         .param("uri", bitstreamUri)
+                                         .param("feature", requestCopyFeature.getName()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.page.totalElements", is(0)))
+                        .andExpect(jsonPath("$._embedded").doesNotExist());
+
+    }
+
+    @Test
+    public void requestCopyOnBitstreamBAsAdmin() throws Exception {
+        BitstreamRest bitstreamRest = bitstreamConverter.convert(bitstreamB, Projection.DEFAULT);
+        String bitstreamUri = utils.linkToSingleResource(bitstreamRest, "self").getHref();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                                         .param("uri", bitstreamUri)
+                                         .param("feature", requestCopyFeature.getName()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.page.totalElements", is(0)))
+                        .andExpect(jsonPath("$._embedded").doesNotExist());
+
+    }
+
+    @Test
+    public void requestCopyOnBitstreamFromWorkSpaceItemAsAdmin() throws Exception {
+        BitstreamRest bitstreamRest = bitstreamConverter.convert(bitstreamFromWorkSpaceItem, Projection.DEFAULT);
+        String bitstreamUri = utils.linkToSingleResource(bitstreamRest, "self").getHref();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                                         .param("uri", bitstreamUri)
+                                         .param("feature", requestCopyFeature.getName()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.page.totalElements", is(0)))
+                        .andExpect(jsonPath("$._embedded").doesNotExist());
+
+    }
+
+    @Test
+    public void requestCopyOnBitstreamFromCollectionAsAdmin() throws Exception {
+        BitstreamRest bitstreamRest = bitstreamConverter.convert(bitstreamFromCollection, Projection.DEFAULT);
+        String bitstreamUri = utils.linkToSingleResource(bitstreamRest, "self").getHref();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                                         .param("uri", bitstreamUri)
+                                         .param("feature", requestCopyFeature.getName()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.page.totalElements", is(0)))
+                        .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+
+    // Tests for anonymous user
+    @Test
+    public void requestCopyOnCollectionAAsAnonymous() throws Exception {
+        CollectionRest collectionRest = converterService.toRest(collectionA, Projection.DEFAULT);
+        String collectionUri = utils.linkToSingleResource(collectionRest, "self").getHref();
+
+        getClient().perform(get("/api/authz/authorizations/search/object")
+                                         .param("uri", collectionUri)
+                                         .param("feature", requestCopyFeature.getName()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.page.totalElements", is(0)))
+                        .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+    @Test
+    public void requestCopyOnItemAAsAnonymous() throws Exception {
+        ItemRest itemRest = itemConverter.convert(itemA, Projection.DEFAULT);
+        String itemUri = utils.linkToSingleResource(itemRest, "self").getHref();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                                         .param("uri", itemUri)
+                                         .param("feature", requestCopyFeature.getName()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+                        .andExpect(jsonPath("$._embedded").doesNotExist());
+
+    }
+
+    @Test
+    public void requestCopyOnItemInWorkSpaceAsAnonymous() throws Exception {
+        ItemRest itemRest = itemConverter.convert(itemInWorkSpace, Projection.DEFAULT);
+        String itemUri = utils.linkToSingleResource(itemRest, "self").getHref();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                                         .param("uri", itemUri)
+                                         .param("feature", requestCopyFeature.getName()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.page.totalElements", is(0)))
+                        .andExpect(jsonPath("$._embedded").doesNotExist());
+
+    }
+
+    @Test
+    public void requestCopyOnBitstreamAAsAnonymous() throws Exception {
+        BitstreamRest bitstreamRest = bitstreamConverter.convert(bitstreamA, Projection.DEFAULT);
+        String bitstreamUri = utils.linkToSingleResource(bitstreamRest, "self").getHref();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                                         .param("uri", bitstreamUri)
+                                         .param("feature", requestCopyFeature.getName()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.page.totalElements", is(0)))
+                        .andExpect(jsonPath("$._embedded").doesNotExist());
+
+    }
+
+    @Test
+    public void requestCopyOnBitstreamBAsAnonymous() throws Exception {
+        BitstreamRest bitstreamRest = bitstreamConverter.convert(bitstreamB, Projection.DEFAULT);
+        String bitstreamUri = utils.linkToSingleResource(bitstreamRest, "self").getHref();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                                         .param("uri", bitstreamUri)
+                                         .param("feature", requestCopyFeature.getName()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+                        .andExpect(jsonPath("$._embedded").doesNotExist());
+
+    }
+
+    @Test
+    public void requestCopyOnBitstreamFromWorkSpaceItemAsAnonymous() throws Exception {
+        BitstreamRest bitstreamRest = bitstreamConverter.convert(bitstreamFromWorkSpaceItem, Projection.DEFAULT);
+        String bitstreamUri = utils.linkToSingleResource(bitstreamRest, "self").getHref();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                                         .param("uri", bitstreamUri)
+                                         .param("feature", requestCopyFeature.getName()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.page.totalElements", is(0)))
+                        .andExpect(jsonPath("$._embedded").doesNotExist());
+
+    }
+
+    @Test
+    public void requestCopyOnBitstreamFromCollectionAsAnonymous() throws Exception {
+        BitstreamRest bitstreamRest = bitstreamConverter.convert(bitstreamFromCollection, Projection.DEFAULT);
+        String bitstreamUri = utils.linkToSingleResource(bitstreamRest, "self").getHref();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/authz/authorizations/search/object")
+                                         .param("uri", bitstreamUri)
+                                         .param("feature", requestCopyFeature.getName()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.page.totalElements", is(0)))
+                        .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    // Test for Eperson
+
+
+
+
+
+
+
+}


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/2943

## Description
We've added REST Authorization Features: 
* canDownload: Can the current Bitstream or Bitstreams in an item be downloaded
* canRequestACopy: Can a copy of the current Bitstream be requested

## Instructions for Reviewers

List of changes in this PR:
* Added the DownloadFeature and RequestCopyFeature features for the Bitstream/Item and Bitstream objects respectively
* Provided tests for these new features

To test this PR:
* Navigate to the {dspace.url}/server/api/authz/authorizations/search/object?uri={dspace.url}/server/api/core/bitstreams/{bitstreamID}&embed=feature whilst being logged in as admin and verify that you can see the DownloadFeature
* Navigate to the {dspace.url}/server/api/authz/authorizations/search/object?uri={dspace.url}/server/api/core/bitstreams/{bitstreamID}&embed=feature with the Bitstream being a private Bitstream and whilst not being logged in. verify that you can see the RequestACopyFeature
* Navigate to the {dspace.url}/server/api/authz/authorizations/search/object?uri={dspace.url}/server/api/core/items/{itemID}&embed=feature with the Item being an Item that contains a private Bitstream and whilst not being logged in. verify that you can see the RequestACopyFeature

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
