### PR TITLE
Fixes to Parent POM to resolve release issues with Beta 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1005,6 +1005,7 @@
                 <artifactId>dspace-api</artifactId>
                 <type>test-jar</type>
                 <version>7.0-beta4-SNAPSHOT</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.dspace.modules</groupId>
@@ -1037,6 +1038,7 @@
                 <artifactId>dspace-server-webapp</artifactId>
                 <type>test-jar</type>
                 <version>7.0-beta4-SNAPSHOT</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.dspace</groupId>
@@ -1228,11 +1230,13 @@
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-analyzers-smartcn</artifactId>
                 <version>${solr.client.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-analyzers-stempel</artifactId>
                 <version>${solr.client.version}</version>
+                <scope>test</scope>
             </dependency>
 
             <dependency>
@@ -1858,7 +1862,7 @@
         <!-- Check Maven Central first (before other repos below) -->
         <repository>
             <id>maven-central</id>
-            <url>https://repo1.maven.org/maven2</url>
+            <url>https://repo.maven.apache.org/maven2</url>
         </repository>
         <!-- Enable access to artifacts in Sonatype's snapshot repo for Snapshots ONLY -->
         <repository>


### PR DESCRIPTION
While trying to release 7.0 beta 4, I've run into several undiscovered issues with our Parent POM which is resulting in release issues.

1. First, our POM is not defaulting to check Maven Central *first* for all content, as we do not have Maven Central linked first in our repository listing.  (This was added in a prior commit that I pushed directly, but the URL is corrected to the latest version in this PR)
2. Second, several test dependencies are accidentally "leaking" into the release build dependencies because they are missing the `<scope>test</scope>`.  These were added in #2897 and the `test` scope was accidentally left off.
     * This results in `mvn release:perform` attempting to find these test-jars in Maven Central (in order to validate build/release dependencies), and throwing an error when they cannot be found.

These changes are minor, but I'm submitting them as PR in order to ensure they don't affect our normal build/test process.  So, if Travis succeeds, then I'll merge this immediately (as they should fix the release issues I've been hitting)
