### PR TITLE
Cleaning up the cache of Builders after each test

### DIFF
--- a/dspace-api/src/test/java/org/dspace/AbstractIntegrationTestWithDatabase.java
+++ b/dspace-api/src/test/java/org/dspace/AbstractIntegrationTestWithDatabase.java
@@ -192,6 +192,8 @@ public class AbstractIntegrationTestWithDatabase extends AbstractDSpaceIntegrati
             // Reload our ConfigurationService (to reset configs to defaults again)
             DSpaceServicesFactory.getInstance().getConfigurationService().reloadConfig();
 
+            AbstractBuilder.cleanupBuilderCache();
+
             // NOTE: we explicitly do NOT destroy our default eperson & admin as they
             // are cached and reused for all tests. This speeds up all tests.
         } catch (Exception e) {

--- a/dspace-api/src/test/java/org/dspace/builder/AbstractBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/AbstractBuilder.java
@@ -195,6 +195,9 @@ public abstract class AbstractBuilder<T, S> {
         }
     }
 
+    /**
+     * This method will cleanup the map of builders
+     */
     public static void cleanupBuilderCache() {
         abstractBuilderCleanupUtil.cleanupMap();
     }

--- a/dspace-api/src/test/java/org/dspace/builder/AbstractBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/AbstractBuilder.java
@@ -195,6 +195,10 @@ public abstract class AbstractBuilder<T, S> {
         }
     }
 
+    public static void cleanupBuilderCache() {
+        abstractBuilderCleanupUtil.cleanupMap();
+    }
+
     /**
      * This method will ensure that the DSpaceObject contained within the Builder will be cleaned up properly
      * @throws Exception    If something goes wrong

--- a/dspace-api/src/test/java/org/dspace/builder/util/AbstractBuilderCleanupUtil.java
+++ b/dspace-api/src/test/java/org/dspace/builder/util/AbstractBuilderCleanupUtil.java
@@ -46,6 +46,11 @@ public class AbstractBuilderCleanupUtil {
      * Constructor that will initialize the Map with a predefined order for deletion
      */
     public AbstractBuilderCleanupUtil() {
+        initMap();
+
+    }
+
+    private void initMap() {
         map.put(RelationshipBuilder.class.getName(), new LinkedList<>());
         map.put(RelationshipTypeBuilder.class.getName(), new LinkedList<>());
         map.put(EntityTypeBuilder.class.getName(), new LinkedList<>());
@@ -64,7 +69,6 @@ public class AbstractBuilderCleanupUtil {
         map.put(MetadataSchemaBuilder.class.getName(), new LinkedList<>());
         map.put(SiteBuilder.class.getName(), new LinkedList<>());
         map.put(ProcessBuilder.class.getName(), new LinkedList<>());
-
     }
 
     /**
@@ -89,5 +93,10 @@ public class AbstractBuilderCleanupUtil {
                 abstractBuilder.cleanup();
             }
         }
+    }
+
+    public void cleanupMap() {
+        this.map.clear();
+        initMap();
     }
 }

--- a/dspace-api/src/test/java/org/dspace/builder/util/AbstractBuilderCleanupUtil.java
+++ b/dspace-api/src/test/java/org/dspace/builder/util/AbstractBuilderCleanupUtil.java
@@ -95,6 +95,9 @@ public class AbstractBuilderCleanupUtil {
         }
     }
 
+    /**
+     * Clears and re-initialises the map of builders
+     */
     public void cleanupMap() {
         this.map.clear();
         initMap();


### PR DESCRIPTION
## Description
Currently the map of builders is not cleaned after every test run. This caused the issue of the delete being called on a builder for which there was no object anymore since the previous test had deleted it.
Since this delete was being called, we're creating a Context with the try-with-resources. Since there's no object anymore, the context.complete() will not be called. But because we're using a try-with-resources, the context will be closed and therefor aborted. Since contexts are shared on the same thread, this causes the general context to be aborted and not committed. If this happened in the first Builder after a test, any manual cleanup through services in that test would be lost as the context would never be committed. This caused for data inconsistencies.

## Instructions for Reviewers

List of changes in this PR:
* Added a cleanup to the map of Builders after each test run so that 'dead' builders aren't kept and ran when they don't contain a valid Object anyway.

### How to test this PR

* Boot up the code without this PR and create a test in which you create a RegistrationData object. Then delete the RegistrationData object afterwards in that very same test
* Create a test in which you create an EPerson through a Builder.
* Create a third test in which you check that the list of RegistrationData fetched through a findall at the beginning of the test is empty.

Execution of the tests in order for this problem to occur has to be:
1. The test that creates the EPerson through the builder
2. The test that manually creates and deletes the RegistrationData object (Creation through a REST call, deletion through a service.delete)
3. The test that checks that the list of RegistrationData from a findAll is empty


## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
