### PR TITLE
Features Endpoint: Permissions to view stats, map items, see versions

### DIFF
--- a/dspace-api/src/test/data/dspaceFolder/config/local.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/local.cfg
@@ -129,3 +129,6 @@ configuration.exposed.array.value = public_value_1, public_value_2
 # Test config for the authentication ip functionality
 authentication-ip.Staff = 5.5.5.5
 authentication-ip.Student = 6.6.6.6
+
+# Test config for the usage statistics authorization
+usage-statistics.authorization.admin.usage = true

--- a/dspace-api/src/test/data/dspaceFolder/config/local.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/local.cfg
@@ -133,3 +133,4 @@ authentication-ip.Student = 6.6.6.6
 # Test config for the usage statistics authorization
 usage-statistics.authorization.admin.usage = true
 usage-statistics.authorization.admin.workflow = true
+usage-statistics.authorization.admin.search = true

--- a/dspace-api/src/test/data/dspaceFolder/config/local.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/local.cfg
@@ -132,3 +132,4 @@ authentication-ip.Student = 6.6.6.6
 
 # Test config for the usage statistics authorization
 usage-statistics.authorization.admin.usage = true
+usage-statistics.authorization.admin.workflow = true

--- a/dspace-api/src/test/data/dspaceFolder/config/local.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/local.cfg
@@ -129,11 +129,3 @@ configuration.exposed.array.value = public_value_1, public_value_2
 # Test config for the authentication ip functionality
 authentication-ip.Staff = 5.5.5.5
 authentication-ip.Student = 6.6.6.6
-
-# Test config for the usage statistics authorization
-usage-statistics.authorization.admin.usage = true
-usage-statistics.authorization.admin.workflow = true
-usage-statistics.authorization.admin.search = true
-
-# Test config for the versioning authorization
-versioning.item.history.view.admin = false

--- a/dspace-api/src/test/data/dspaceFolder/config/local.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/local.cfg
@@ -134,3 +134,6 @@ authentication-ip.Student = 6.6.6.6
 usage-statistics.authorization.admin.usage = true
 usage-statistics.authorization.admin.workflow = true
 usage-statistics.authorization.admin.search = true
+
+# Test config for the versioning authorization
+versioning.item.history.view.admin = false

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ManageMappedItemsFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ManageMappedItemsFeature.java
@@ -1,0 +1,61 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization.impl;
+
+import java.sql.SQLException;
+
+import org.dspace.app.rest.authorization.AuthorizationFeature;
+import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.model.CollectionRest;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.Collection;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * The manage mapped items feature. It can be used to verify if mapped items can be listed, searched, added and removed.
+ *
+ * Authorization is granted if the current user has ADD and WRITE permissions on the given Collection.
+ */
+@Component
+@AuthorizationFeatureDocumentation(name = ManageMappedItemsFeature.NAME,
+    description = "It can be used to verify if mapped items can be listed, searched, added and removed")
+public class ManageMappedItemsFeature implements AuthorizationFeature {
+
+    public final static String NAME = "canManageMappedItems";
+
+    @Autowired
+    private AuthorizeService authorizeService;
+
+    @Autowired
+    private Utils utils;
+
+    @Override
+    public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException {
+        if (object instanceof CollectionRest) {
+            Collection collection = (Collection)utils.getDSpaceAPIObjectFromRest(context, object);
+
+            if (authorizeService.authorizeActionBoolean(context, collection, Constants.WRITE)
+                && authorizeService.authorizeActionBoolean(context, collection, Constants.ADD)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[]{
+            CollectionRest.CATEGORY + "." + CollectionRest.NAME
+        };
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ViewSearchStatisticsFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ViewSearchStatisticsFeature.java
@@ -1,0 +1,66 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization.impl;
+
+import java.sql.SQLException;
+
+import org.dspace.app.rest.authorization.AuthorizationFeature;
+import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.model.SiteRest;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.DSpaceObject;
+import org.dspace.core.Context;
+import org.dspace.services.ConfigurationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * The view search statistics feature. It can be used to verify if search statistics can be viewed.
+ *
+ * In case DSpace is configured to only show search statistics to administrators, authorization is granted if the
+ * current user is the site admin. Otherwise, authorization is granted if the current user can view the site.
+ */
+@Component
+@AuthorizationFeatureDocumentation(name = ViewSearchStatisticsFeature.NAME,
+    description = "It can be used to verify if the search statistics can be viewed")
+public class ViewSearchStatisticsFeature implements AuthorizationFeature {
+
+    public final static String NAME = "canViewSearchStatistics";
+
+    @Autowired
+    private ConfigurationService configurationService;
+
+    @Autowired
+    private AuthorizeService authorizeService;
+
+    @Autowired
+    private Utils utils;
+
+    @Override
+    public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException {
+        if (object instanceof SiteRest) {
+            if (configurationService.getBooleanProperty("usage-statistics.authorization.admin.search", true)) {
+                return authorizeService.isAdmin(context,
+                    (DSpaceObject)utils.getDSpaceAPIObjectFromRest(context, object));
+            } else {
+                return authorizeService.authorizeActionBoolean(context,
+                    (DSpaceObject)utils.getDSpaceAPIObjectFromRest(context, object), org.dspace.core.Constants.READ);
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[]{
+            SiteRest.CATEGORY + "." + SiteRest.NAME
+        };
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ViewUsageStatisticsFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ViewUsageStatisticsFeature.java
@@ -1,0 +1,76 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization.impl;
+
+import java.sql.SQLException;
+
+import org.dspace.app.rest.authorization.AuthorizationFeature;
+import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.model.CollectionRest;
+import org.dspace.app.rest.model.CommunityRest;
+import org.dspace.app.rest.model.ItemRest;
+import org.dspace.app.rest.model.SiteRest;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.DSpaceObject;
+import org.dspace.core.Context;
+import org.dspace.services.ConfigurationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * The view statistics feature. It can be used to verify if statistics can be viewed.
+ *
+ * In case DSpace is configured to only show statistics to administrators, authorization is granted if the current user
+ * is the object's admin. Otherwise, authorization is granted if the current user can view the object.
+ */
+@Component
+@AuthorizationFeatureDocumentation(name = ViewUsageStatisticsFeature.NAME,
+    description = "It can be used to verify if statistics can be viewed")
+public class ViewUsageStatisticsFeature implements AuthorizationFeature {
+
+    public final static String NAME = "canViewUsageStatistics";
+
+    @Autowired
+    private ConfigurationService configurationService;
+
+    @Autowired
+    private AuthorizeService authorizeService;
+
+    @Autowired
+    private Utils utils;
+
+    @Override
+    public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException {
+        if (object instanceof SiteRest
+            || object instanceof CommunityRest
+            || object instanceof CollectionRest
+            || object instanceof ItemRest) {
+
+            if (configurationService.getBooleanProperty("usage-statistics.authorization.admin.usage", true)) {
+                return authorizeService.isAdmin(context,
+                    (DSpaceObject)utils.getDSpaceAPIObjectFromRest(context, object));
+            } else {
+                return authorizeService.authorizeActionBoolean(context,
+                    (DSpaceObject)utils.getDSpaceAPIObjectFromRest(context, object), org.dspace.core.Constants.READ);
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[]{
+            SiteRest.CATEGORY + "." + SiteRest.NAME,
+            CommunityRest.CATEGORY + "." + CommunityRest.NAME,
+            CollectionRest.CATEGORY + "." + CollectionRest.NAME,
+            ItemRest.CATEGORY + "." + ItemRest.NAME
+        };
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ViewVersionsFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ViewVersionsFeature.java
@@ -1,0 +1,62 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization.impl;
+
+import java.sql.SQLException;
+
+import org.dspace.app.rest.authorization.AuthorizationFeature;
+import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
+import org.dspace.app.rest.authorization.AuthorizeServiceRestUtil;
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.model.ItemRest;
+import org.dspace.app.rest.security.DSpaceRestPermission;
+import org.dspace.core.Context;
+import org.dspace.services.ConfigurationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * The view versions feature. It can be used to verify if the user can view the versions of an Item.
+ *
+ * In case DSpace is configured to only show versions to administrators, authorization is granted if the
+ * current user is the object's admin. Otherwise, authorization is granted if the current user can view the object.
+ */
+@Component
+@AuthorizationFeatureDocumentation(name = ViewVersionsFeature.NAME,
+    description = "It can be used to verify if the user can view the versions of an Item")
+public class ViewVersionsFeature implements AuthorizationFeature {
+
+    public final static String NAME = "canViewVersions";
+
+    @Autowired
+    private ConfigurationService configurationService;
+
+    @Autowired
+    private AuthorizeServiceRestUtil authorizeServiceRestUtil;
+
+    @Override
+    public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException {
+        if (object instanceof ItemRest) {
+            if (configurationService.getBooleanProperty("versioning.item.history.view.admin",
+                false)) {
+                return authorizeServiceRestUtil.authorizeActionBoolean(context, object, DSpaceRestPermission.ADMIN);
+            } else {
+                return authorizeServiceRestUtil.authorizeActionBoolean(context, object, DSpaceRestPermission.READ);
+            }
+
+        }
+        return false;
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[]{
+            ItemRest.CATEGORY + "." + ItemRest.NAME
+        };
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ViewWorkflowStatisticsFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ViewWorkflowStatisticsFeature.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.app.rest.authorization.impl;
 
 import java.sql.SQLException;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ViewWorkflowStatisticsFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ViewWorkflowStatisticsFeature.java
@@ -1,0 +1,66 @@
+package org.dspace.app.rest.authorization.impl;
+
+import java.sql.SQLException;
+
+import org.dspace.app.rest.authorization.AuthorizationFeature;
+import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.model.CollectionRest;
+import org.dspace.app.rest.model.CommunityRest;
+import org.dspace.app.rest.model.SiteRest;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.DSpaceObject;
+import org.dspace.core.Context;
+import org.dspace.services.ConfigurationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * The view workflow statistics feature. It can be used to verify if statistics can be viewed.
+ *
+ * In case DSpace is configured to only show workflow statistics to administrators, authorization is granted if the
+ * current user is the object's admin. Otherwise, authorization is granted if the current user can view the object.
+ */
+@Component
+@AuthorizationFeatureDocumentation(name = ViewWorkflowStatisticsFeature.NAME,
+    description = "It can be used to verify if the workflow statistics can be viewed")
+public class ViewWorkflowStatisticsFeature implements AuthorizationFeature {
+
+    public final static String NAME = "canViewWorkflowStatistics";
+
+    @Autowired
+    private ConfigurationService configurationService;
+
+    @Autowired
+    private AuthorizeService authorizeService;
+
+    @Autowired
+    private Utils utils;
+
+    @Override
+    public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException {
+        if (object instanceof SiteRest
+            || object instanceof CommunityRest
+            || object instanceof CollectionRest) {
+
+            if (configurationService.getBooleanProperty("usage-statistics.authorization.admin.workflow", true)) {
+                return authorizeService.isAdmin(context,
+                    (DSpaceObject)utils.getDSpaceAPIObjectFromRest(context, object));
+            } else {
+                return authorizeService.authorizeActionBoolean(context,
+                    (DSpaceObject)utils.getDSpaceAPIObjectFromRest(context, object), org.dspace.core.Constants.READ);
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[]{
+            SiteRest.CATEGORY + "." + SiteRest.NAME,
+            CommunityRest.CATEGORY + "." + CommunityRest.NAME,
+            CollectionRest.CATEGORY + "." + CollectionRest.NAME
+        };
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ManageMappedItemsFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ManageMappedItemsFeatureIT.java
@@ -1,0 +1,191 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.InputStream;
+
+import org.apache.commons.codec.CharEncoding;
+import org.apache.commons.io.IOUtils;
+import org.dspace.app.rest.converter.BitstreamConverter;
+import org.dspace.app.rest.converter.CollectionConverter;
+import org.dspace.app.rest.model.BitstreamRest;
+import org.dspace.app.rest.model.CollectionRest;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.builder.BitstreamBuilder;
+import org.dspace.builder.BundleBuilder;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.builder.ResourcePolicyBuilder;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.core.Constants;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Test for the canManageMappedItems authorization feature
+ */
+public class ManageMappedItemsFeatureIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private Utils utils;
+
+    @Autowired
+    private CollectionConverter collectionConverter;
+
+    @Autowired
+    private BitstreamConverter bitstreamConverter;
+
+    private Community communityA;
+    private Collection collectionA;
+    private CollectionRest collectionARest;
+    private Item itemA;
+    private Bitstream bitstreamA;
+    private BitstreamRest bitstreamARest;
+    private Bundle bundleA;
+
+    final String feature = "canManageMappedItems";
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        context.turnOffAuthorisationSystem();
+
+        communityA = CommunityBuilder.createCommunity(context)
+            .withName("communityA")
+            .build();
+        collectionA = CollectionBuilder.createCollection(context, communityA)
+            .withName("collectionA")
+            .build();
+        itemA = ItemBuilder.createItem(context, collectionA)
+            .withTitle("itemA")
+            .build();
+        bundleA = BundleBuilder.createBundle(context, itemA)
+            .withName("ORIGINAL")
+            .build();
+        String bitstreamContent = "Dummy content";
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstreamA = BitstreamBuilder.createBitstream(context, bundleA, is)
+                .withName("bistreamA")
+                .build();
+        }
+
+        context.restoreAuthSystemState();
+
+        collectionARest = collectionConverter.convert(collectionA, Projection.DEFAULT);
+        bitstreamARest = bitstreamConverter.convert(bitstreamA, Projection.DEFAULT);
+    }
+
+    @Test
+    public void adminCollectionAdminSuccess() throws Exception {
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        getClient(adminToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(collectionARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+            .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void epersonCollectionNotFound() throws Exception {
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+        getClient(epersonToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(collectionARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    @Test
+    public void addWriteEpersonCollectionSuccess() throws Exception {
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(collectionA)
+            .withAction(Constants.ADD)
+            .withUser(eperson)
+            .build();
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(collectionA)
+            .withAction(Constants.WRITE)
+            .withUser(eperson)
+            .build();
+
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+        getClient(epersonToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(collectionARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+            .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void adminEpersonCollectionSuccess() throws Exception {
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withDspaceObject(collectionA)
+            .withAction(Constants.ADMIN)
+            .withUser(eperson)
+            .build();
+
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+        getClient(epersonToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(collectionARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+            .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void anonymousCollectionNotFound() throws Exception {
+        getClient().perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(collectionARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    @Test
+    public void adminBitstreamNotFound() throws Exception {
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        getClient(adminToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(bitstreamARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ViewSearchStatisticsFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ViewSearchStatisticsFeatureIT.java
@@ -52,7 +52,6 @@ public class ViewSearchStatisticsFeatureIT extends AbstractControllerIntegration
 
     private Site site;
     private SiteRest siteRest;
-    ;
     private Community communityA;
     private CommunityRest communityARest;
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ViewSearchStatisticsFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ViewSearchStatisticsFeatureIT.java
@@ -1,0 +1,99 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.dspace.app.rest.converter.SiteConverter;
+import org.dspace.app.rest.model.SiteRest;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.content.Site;
+import org.dspace.content.service.SiteService;
+import org.dspace.services.ConfigurationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Test for the canViewSearchStatistics authorization feature
+ */
+public class ViewSearchStatisticsFeatureIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private Utils utils;
+
+    @Autowired
+    private ConfigurationService configurationService;
+
+    @Autowired
+    private SiteConverter siteConverter;
+
+    @Autowired
+    SiteService siteService;
+
+    private Site site;
+    private SiteRest siteRest;
+
+    final String feature = "canViewSearchStatistics";
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        site = siteService.findSite(context);
+        siteRest = siteConverter.convert(site, Projection.DEFAULT);
+    }
+
+    @Test
+    public void adminSiteAdminRequiredSuccess() throws Exception {
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        getClient(adminToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(siteRest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+            .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void ePersonSiteAdminRequiredNotFound() throws Exception {
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+        getClient(epersonToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(siteRest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    @Test
+    public void ePersonSiteAdminNotRequiredSuccess() throws Exception {
+        configurationService.setProperty("usage-statistics.authorization.admin.search", false);
+
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+        getClient(epersonToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(siteRest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+            .andExpect(jsonPath("$._embedded").exists());
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ViewUsageStatisticsFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ViewUsageStatisticsFeatureIT.java
@@ -321,4 +321,60 @@ public class ViewUsageStatisticsFeatureIT extends AbstractControllerIntegrationT
             .andExpect(jsonPath("$.page.totalElements", is(0)))
             .andExpect(jsonPath("$._embedded").doesNotExist());
     }
+
+    @Test
+    public void anonymousItemAdminNotRequiredSuccess() throws Exception {
+        configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
+
+        getClient().perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(itemARest, "self").getHref()))
+                               .andExpect(status().isOk())
+                               .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+                               .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void anonymousCollectionAdminNotRequiredSuccess() throws Exception {
+        configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
+
+        getClient().perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(collectionARest, "self").getHref()))
+                               .andExpect(status().isOk())
+                               .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+                               .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void anonymousCommunityAdminNotRequiredSuccess() throws Exception {
+        configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
+
+        getClient().perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(communityARest, "self").getHref()))
+                               .andExpect(status().isOk())
+                               .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+                               .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void anonymousSiteAdminNotRequiredSuccess() throws Exception {
+        configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
+
+        getClient().perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(siteRest, "self").getHref()))
+                               .andExpect(status().isOk())
+                               .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+                               .andExpect(jsonPath("$._embedded").exists());
+    }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ViewUsageStatisticsFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ViewUsageStatisticsFeatureIT.java
@@ -1,0 +1,315 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.InputStream;
+
+import org.apache.commons.codec.CharEncoding;
+import org.apache.commons.io.IOUtils;
+import org.dspace.app.rest.converter.BitstreamConverter;
+import org.dspace.app.rest.converter.CollectionConverter;
+import org.dspace.app.rest.converter.CommunityConverter;
+import org.dspace.app.rest.converter.ItemConverter;
+import org.dspace.app.rest.converter.SiteConverter;
+import org.dspace.app.rest.model.BitstreamRest;
+import org.dspace.app.rest.model.CollectionRest;
+import org.dspace.app.rest.model.CommunityRest;
+import org.dspace.app.rest.model.ItemRest;
+import org.dspace.app.rest.model.SiteRest;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.builder.BitstreamBuilder;
+import org.dspace.builder.BundleBuilder;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.content.Site;
+import org.dspace.content.service.SiteService;
+import org.dspace.services.ConfigurationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Test for the canViewUsageStatistics authorization feature
+ */
+public class ViewUsageStatisticsFeatureIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private Utils utils;
+
+    @Autowired
+    private ConfigurationService configurationService;
+
+    @Autowired
+    private AuthorizeService authorizeService;
+
+    @Autowired
+    private SiteConverter siteConverter;
+
+    @Autowired
+    private CommunityConverter communityConverter;
+
+    @Autowired
+    private CollectionConverter collectionConverter;
+
+    @Autowired
+    private ItemConverter itemConverter;
+
+    @Autowired
+    private BitstreamConverter bitstreamConverter;
+
+    @Autowired
+    SiteService siteService;
+
+    private Site site;
+    private SiteRest siteRest;
+    private Community communityA;
+    private CommunityRest communityARest;
+    private Collection collectionA;
+    private CollectionRest collectionARest;
+    private Item itemA;
+    private ItemRest itemARest;
+    private Bitstream bitstreamA;
+    private BitstreamRest bitstreamARest;
+    private Bundle bundleA;
+    private String adminToken;
+    private String epersonToken;
+
+    final String feature = "canViewUsageStatistics";
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        context.turnOffAuthorisationSystem();
+
+        site = siteService.findSite(context);
+        communityA = CommunityBuilder.createCommunity(context)
+            .withName("communityA")
+            .build();
+        collectionA = CollectionBuilder.createCollection(context, communityA)
+            .withName("collectionA")
+            .build();
+        itemA = ItemBuilder.createItem(context, collectionA)
+            .withTitle("itemA")
+            .build();
+        bundleA = BundleBuilder.createBundle(context, itemA)
+            .withName("ORIGINAL")
+            .build();
+        String bitstreamContent = "Dummy content";
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstreamA = BitstreamBuilder.createBitstream(context, bundleA, is)
+                .withName("bistreamA")
+                .build();
+        }
+
+        context.restoreAuthSystemState();
+
+        siteRest = siteConverter.convert(site, Projection.DEFAULT);
+        communityARest = communityConverter.convert(communityA, Projection.DEFAULT);
+        collectionARest = collectionConverter.convert(collectionA, Projection.DEFAULT);
+        itemARest = itemConverter.convert(itemA, Projection.DEFAULT);
+        bitstreamARest = bitstreamConverter.convert(bitstreamA, Projection.DEFAULT);
+
+        adminToken = getAuthToken(admin.getEmail(), password);
+        epersonToken = getAuthToken(eperson.getEmail(), password);
+    }
+
+    @Test
+    public void adminBitstreamTestNotFound() throws Exception {
+        getClient(adminToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(bitstreamARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    @Test
+    public void adminItemAdminRequiredSuccess() throws Exception {
+        getClient(adminToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(itemARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+            .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void adminCollectionAdminRequiredSuccess() throws Exception {
+        getClient(adminToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(collectionARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+            .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void adminCommunityAdminRequiredSuccess() throws Exception {
+        getClient(adminToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(communityARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+            .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void adminSiteAdminRequiredSuccess() throws Exception {
+        getClient(adminToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(siteRest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+            .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void ePersonItemAdminRequiredNotFound() throws Exception {
+        getClient(epersonToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(itemARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    @Test
+    public void ePersonCollectionAdminRequiredNotFound() throws Exception {
+        getClient(epersonToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(collectionARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    @Test
+    public void ePersonCommunityAdminRequiredNotFound() throws Exception {
+        getClient(epersonToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(communityARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    @Test
+    public void ePersonSiteAdminRequiredNotFound() throws Exception {
+        getClient(epersonToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(siteRest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    @Test
+    public void ePersonItemAdminNotRequiredSuccess() throws Exception {
+        configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
+
+        getClient(epersonToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(itemARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+            .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void ePersonCollectionAdminNotRequiredSuccess() throws Exception {
+        configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
+
+        getClient(epersonToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(collectionARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+            .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void ePersonCommunityAdminNotRequiredSuccess() throws Exception {
+        configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
+
+        getClient(epersonToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(communityARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+            .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void ePersonSiteAdminNotRequiredSuccess() throws Exception {
+        configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
+
+        getClient(epersonToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(siteRest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+            .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void ePersonPrivateItemAdminNotRequiredNotFound() throws Exception {
+        configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
+        authorizeService.removeAllPolicies(context, itemA);
+
+        getClient(epersonToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(itemARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ViewUsageStatisticsFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ViewUsageStatisticsFeatureIT.java
@@ -78,7 +78,7 @@ public class ViewUsageStatisticsFeatureIT extends AbstractControllerIntegrationT
     private BitstreamConverter bitstreamConverter;
 
     @Autowired
-    SiteService siteService;
+    private SiteService siteService;
 
     private Site site;
     private SiteRest siteRest;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ViewUsageStatisticsFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ViewUsageStatisticsFeatureIT.java
@@ -91,8 +91,6 @@ public class ViewUsageStatisticsFeatureIT extends AbstractControllerIntegrationT
     private Bitstream bitstreamA;
     private BitstreamRest bitstreamARest;
     private Bundle bundleA;
-    private String adminToken;
-    private String epersonToken;
 
     final String feature = "canViewUsageStatistics";
 
@@ -129,13 +127,11 @@ public class ViewUsageStatisticsFeatureIT extends AbstractControllerIntegrationT
         collectionARest = collectionConverter.convert(collectionA, Projection.DEFAULT);
         itemARest = itemConverter.convert(itemA, Projection.DEFAULT);
         bitstreamARest = bitstreamConverter.convert(bitstreamA, Projection.DEFAULT);
-
-        adminToken = getAuthToken(admin.getEmail(), password);
-        epersonToken = getAuthToken(eperson.getEmail(), password);
     }
 
     @Test
     public void adminBitstreamTestNotFound() throws Exception {
+        String adminToken = getAuthToken(admin.getEmail(), password);
         getClient(adminToken).perform(
             get("/api/authz/authorizations/search/object")
                 .param("embed", "feature")
@@ -148,6 +144,7 @@ public class ViewUsageStatisticsFeatureIT extends AbstractControllerIntegrationT
 
     @Test
     public void adminItemAdminRequiredSuccess() throws Exception {
+        String adminToken = getAuthToken(admin.getEmail(), password);
         getClient(adminToken).perform(
             get("/api/authz/authorizations/search/object")
                 .param("embed", "feature")
@@ -160,6 +157,7 @@ public class ViewUsageStatisticsFeatureIT extends AbstractControllerIntegrationT
 
     @Test
     public void adminCollectionAdminRequiredSuccess() throws Exception {
+        String adminToken = getAuthToken(admin.getEmail(), password);
         getClient(adminToken).perform(
             get("/api/authz/authorizations/search/object")
                 .param("embed", "feature")
@@ -172,6 +170,7 @@ public class ViewUsageStatisticsFeatureIT extends AbstractControllerIntegrationT
 
     @Test
     public void adminCommunityAdminRequiredSuccess() throws Exception {
+        String adminToken = getAuthToken(admin.getEmail(), password);
         getClient(adminToken).perform(
             get("/api/authz/authorizations/search/object")
                 .param("embed", "feature")
@@ -184,6 +183,7 @@ public class ViewUsageStatisticsFeatureIT extends AbstractControllerIntegrationT
 
     @Test
     public void adminSiteAdminRequiredSuccess() throws Exception {
+        String adminToken = getAuthToken(admin.getEmail(), password);
         getClient(adminToken).perform(
             get("/api/authz/authorizations/search/object")
                 .param("embed", "feature")
@@ -196,6 +196,7 @@ public class ViewUsageStatisticsFeatureIT extends AbstractControllerIntegrationT
 
     @Test
     public void ePersonItemAdminRequiredNotFound() throws Exception {
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
         getClient(epersonToken).perform(
             get("/api/authz/authorizations/search/object")
                 .param("embed", "feature")
@@ -208,6 +209,7 @@ public class ViewUsageStatisticsFeatureIT extends AbstractControllerIntegrationT
 
     @Test
     public void ePersonCollectionAdminRequiredNotFound() throws Exception {
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
         getClient(epersonToken).perform(
             get("/api/authz/authorizations/search/object")
                 .param("embed", "feature")
@@ -220,6 +222,7 @@ public class ViewUsageStatisticsFeatureIT extends AbstractControllerIntegrationT
 
     @Test
     public void ePersonCommunityAdminRequiredNotFound() throws Exception {
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
         getClient(epersonToken).perform(
             get("/api/authz/authorizations/search/object")
                 .param("embed", "feature")
@@ -232,6 +235,7 @@ public class ViewUsageStatisticsFeatureIT extends AbstractControllerIntegrationT
 
     @Test
     public void ePersonSiteAdminRequiredNotFound() throws Exception {
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
         getClient(epersonToken).perform(
             get("/api/authz/authorizations/search/object")
                 .param("embed", "feature")
@@ -246,6 +250,7 @@ public class ViewUsageStatisticsFeatureIT extends AbstractControllerIntegrationT
     public void ePersonItemAdminNotRequiredSuccess() throws Exception {
         configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
 
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
         getClient(epersonToken).perform(
             get("/api/authz/authorizations/search/object")
                 .param("embed", "feature")
@@ -260,6 +265,7 @@ public class ViewUsageStatisticsFeatureIT extends AbstractControllerIntegrationT
     public void ePersonCollectionAdminNotRequiredSuccess() throws Exception {
         configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
 
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
         getClient(epersonToken).perform(
             get("/api/authz/authorizations/search/object")
                 .param("embed", "feature")
@@ -274,6 +280,7 @@ public class ViewUsageStatisticsFeatureIT extends AbstractControllerIntegrationT
     public void ePersonCommunityAdminNotRequiredSuccess() throws Exception {
         configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
 
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
         getClient(epersonToken).perform(
             get("/api/authz/authorizations/search/object")
                 .param("embed", "feature")
@@ -288,6 +295,7 @@ public class ViewUsageStatisticsFeatureIT extends AbstractControllerIntegrationT
     public void ePersonSiteAdminNotRequiredSuccess() throws Exception {
         configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
 
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
         getClient(epersonToken).perform(
             get("/api/authz/authorizations/search/object")
                 .param("embed", "feature")
@@ -303,6 +311,7 @@ public class ViewUsageStatisticsFeatureIT extends AbstractControllerIntegrationT
         configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
         authorizeService.removeAllPolicies(context, itemA);
 
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
         getClient(epersonToken).perform(
             get("/api/authz/authorizations/search/object")
                 .param("embed", "feature")

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ViewVersionsFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ViewVersionsFeatureIT.java
@@ -1,0 +1,280 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.InputStream;
+
+import org.apache.commons.codec.CharEncoding;
+import org.apache.commons.io.IOUtils;
+import org.dspace.app.rest.converter.BitstreamConverter;
+import org.dspace.app.rest.converter.ItemConverter;
+import org.dspace.app.rest.model.BitstreamRest;
+import org.dspace.app.rest.model.ItemRest;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.builder.BitstreamBuilder;
+import org.dspace.builder.BundleBuilder;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.services.ConfigurationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Test for the canViewVersions authorization feature
+ */
+public class ViewVersionsFeatureIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private Utils utils;
+
+    @Autowired
+    private ConfigurationService configurationService;
+
+    @Autowired
+    private AuthorizeService authorizeService;
+
+    @Autowired
+    private ItemConverter itemConverter;
+
+    @Autowired
+    private BitstreamConverter bitstreamConverter;
+
+    private Community communityA;
+    private Collection collectionA;
+    private Item itemA;
+    private ItemRest itemARest;
+    private Bitstream bitstreamA;
+    private BitstreamRest bitstreamARest;
+    private Bundle bundleA;
+
+    final String feature = "canViewVersions";
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        context.turnOffAuthorisationSystem();
+
+        communityA = CommunityBuilder.createCommunity(context)
+            .withName("communityA")
+            .build();
+        collectionA = CollectionBuilder.createCollection(context, communityA)
+            .withName("collectionA")
+            .build();
+        itemA = ItemBuilder.createItem(context, collectionA)
+            .withTitle("itemA")
+            .build();
+        bundleA = BundleBuilder.createBundle(context, itemA)
+            .withName("ORIGINAL")
+            .build();
+        String bitstreamContent = "Dummy content";
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstreamA = BitstreamBuilder.createBitstream(context, bundleA, is)
+                .withName("bistreamA")
+                .build();
+        }
+
+        context.restoreAuthSystemState();
+
+        itemARest = itemConverter.convert(itemA, Projection.DEFAULT);
+        bitstreamARest = bitstreamConverter.convert(bitstreamA, Projection.DEFAULT);
+    }
+
+    @Test
+    public void anonymousItemSuccess() throws Exception {
+        getClient().perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(itemARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+            .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void epersonItemSuccess() throws Exception {
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+        getClient(epersonToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(itemARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+            .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void adminItemSuccess() throws Exception {
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        getClient(adminToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(itemARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+            .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void anonymousPrivateItemNotFound() throws Exception {
+        authorizeService.removeAllPolicies(context, itemA);
+        getClient().perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(itemARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    @Test
+    public void epersonPrivateItemNotFound() throws Exception {
+        authorizeService.removeAllPolicies(context, itemA);
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+        getClient(epersonToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(itemARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    @Test
+    public void adminPrivateItemSuccess() throws Exception {
+        authorizeService.removeAllPolicies(context, itemA);
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        getClient(adminToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(itemARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+            .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void anonymousItemAdminRequiredNotFound() throws Exception {
+        configurationService.setProperty("versioning.item.history.view.admin", true);
+        getClient().perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(itemARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    @Test
+    public void epersonItemAdminRequiredNotFound() throws Exception {
+        configurationService.setProperty("versioning.item.history.view.admin", true);
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+        getClient(epersonToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(itemARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    @Test
+    public void adminItemAdminRequiredSuccess() throws Exception {
+        configurationService.setProperty("versioning.item.history.view.admin", true);
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        getClient(adminToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(itemARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+            .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void anonymousPrivateItemAdminRequiredNotFound() throws Exception {
+        authorizeService.removeAllPolicies(context, itemA);
+        configurationService.setProperty("versioning.item.history.view.admin", true);
+        getClient().perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(itemARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    @Test
+    public void epersonPrivateItemAdminRequiredNotFound() throws Exception {
+        authorizeService.removeAllPolicies(context, itemA);
+        configurationService.setProperty("versioning.item.history.view.admin", true);
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+        getClient(epersonToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(itemARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    @Test
+    public void adminPrivateItemAdminRequiredSuccess() throws Exception {
+        authorizeService.removeAllPolicies(context, itemA);
+        configurationService.setProperty("versioning.item.history.view.admin", true);
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        getClient(adminToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(itemARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+            .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void adminBitstreamNotFound() throws Exception {
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        getClient(adminToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(bitstreamARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ViewWorkflowStatisticsFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ViewWorkflowStatisticsFeatureIT.java
@@ -253,4 +253,46 @@ public class ViewWorkflowStatisticsFeatureIT extends AbstractControllerIntegrati
             .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
             .andExpect(jsonPath("$._embedded").exists());
     }
+
+    @Test
+    public void anonymousCollectionAdminNotRequiredSuccess() throws Exception {
+        configurationService.setProperty("usage-statistics.authorization.admin.workflow", false);
+
+        getClient().perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(collectionARest, "self").getHref()))
+                               .andExpect(status().isOk())
+                               .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+                               .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void anonymousCommunityAdminNotRequiredSuccess() throws Exception {
+        configurationService.setProperty("usage-statistics.authorization.admin.workflow", false);
+
+        getClient().perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(communityARest, "self").getHref()))
+                               .andExpect(status().isOk())
+                               .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+                               .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void anonymousSiteAdminNotRequiredSuccess() throws Exception {
+        configurationService.setProperty("usage-statistics.authorization.admin.workflow", false);
+
+        getClient().perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(siteRest, "self").getHref()))
+                               .andExpect(status().isOk())
+                               .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+                               .andExpect(jsonPath("$._embedded").exists());
+    }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ViewWorkflowStatisticsFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ViewWorkflowStatisticsFeatureIT.java
@@ -1,0 +1,256 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.InputStream;
+
+import org.apache.commons.codec.CharEncoding;
+import org.apache.commons.io.IOUtils;
+import org.dspace.app.rest.converter.BitstreamConverter;
+import org.dspace.app.rest.converter.CollectionConverter;
+import org.dspace.app.rest.converter.CommunityConverter;
+import org.dspace.app.rest.converter.SiteConverter;
+import org.dspace.app.rest.model.BitstreamRest;
+import org.dspace.app.rest.model.CollectionRest;
+import org.dspace.app.rest.model.CommunityRest;
+import org.dspace.app.rest.model.SiteRest;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.builder.BitstreamBuilder;
+import org.dspace.builder.BundleBuilder;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.content.Site;
+import org.dspace.content.service.SiteService;
+import org.dspace.services.ConfigurationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Test for the canViewWorkflowStatistics authorization feature
+ */
+public class ViewWorkflowStatisticsFeatureIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private Utils utils;
+
+    @Autowired
+    private ConfigurationService configurationService;
+
+    @Autowired
+    private SiteConverter siteConverter;
+
+    @Autowired
+    private CommunityConverter communityConverter;
+
+    @Autowired
+    private CollectionConverter collectionConverter;
+
+    @Autowired
+    private BitstreamConverter bitstreamConverter;
+
+    @Autowired
+    SiteService siteService;
+
+    private Site site;
+    private SiteRest siteRest;
+    private Community communityA;
+    private CommunityRest communityARest;
+    private Collection collectionA;
+    private CollectionRest collectionARest;
+    private Item itemA;
+    private Bitstream bitstreamA;
+    private BitstreamRest bitstreamARest;
+    private Bundle bundleA;
+
+    final String feature = "canViewWorkflowStatistics";
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        context.turnOffAuthorisationSystem();
+
+        site = siteService.findSite(context);
+        communityA = CommunityBuilder.createCommunity(context)
+            .withName("communityA")
+            .build();
+        collectionA = CollectionBuilder.createCollection(context, communityA)
+            .withName("collectionA")
+            .build();
+        itemA = ItemBuilder.createItem(context, collectionA)
+            .withTitle("itemA")
+            .build();
+        bundleA = BundleBuilder.createBundle(context, itemA)
+            .withName("ORIGINAL")
+            .build();
+        String bitstreamContent = "Dummy content";
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstreamA = BitstreamBuilder.createBitstream(context, bundleA, is)
+                .withName("bistreamA")
+                .build();
+        }
+
+        context.restoreAuthSystemState();
+
+        siteRest = siteConverter.convert(site, Projection.DEFAULT);
+        communityARest = communityConverter.convert(communityA, Projection.DEFAULT);
+        collectionARest = collectionConverter.convert(collectionA, Projection.DEFAULT);
+        bitstreamARest = bitstreamConverter.convert(bitstreamA, Projection.DEFAULT);
+    }
+
+    @Test
+    public void adminBitstreamTestNotFound() throws Exception {
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        getClient(adminToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(bitstreamARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    @Test
+    public void adminCollectionAdminRequiredSuccess() throws Exception {
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        getClient(adminToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(collectionARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+            .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void adminCommunityAdminRequiredSuccess() throws Exception {
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        getClient(adminToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(communityARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+            .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void adminSiteAdminRequiredSuccess() throws Exception {
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        getClient(adminToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(siteRest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+            .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void ePersonCollectionAdminRequiredNotFound() throws Exception {
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+        getClient(epersonToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(collectionARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    @Test
+    public void ePersonCommunityAdminRequiredNotFound() throws Exception {
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+        getClient(epersonToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(communityARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    @Test
+    public void ePersonSiteAdminRequiredNotFound() throws Exception {
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+        getClient(epersonToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(siteRest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    @Test
+    public void ePersonCollectionAdminNotRequiredSuccess() throws Exception {
+        configurationService.setProperty("usage-statistics.authorization.admin.workflow", false);
+
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+        getClient(epersonToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(collectionARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+            .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void ePersonCommunityAdminNotRequiredSuccess() throws Exception {
+        configurationService.setProperty("usage-statistics.authorization.admin.workflow", false);
+
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+        getClient(epersonToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(communityARest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+            .andExpect(jsonPath("$._embedded").exists());
+    }
+
+    @Test
+    public void ePersonSiteAdminNotRequiredSuccess() throws Exception {
+        configurationService.setProperty("usage-statistics.authorization.admin.workflow", false);
+
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+        getClient(epersonToken).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("embed", "feature")
+                .param("feature", feature)
+                .param("uri", utils.linkToSingleResource(siteRest, "self").getHref()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+            .andExpect(jsonPath("$._embedded").exists());
+    }
+}


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/2969

## Description
This PR introduces new REST Authorization features
- canManageMappedItems
- canViewSearchStatistics
- canViewUsageStatistics
- canViewVersions
- canViewWorkflowStatistics

## Instructions for Reviewers

List of changes in this PR:
* Added the five above mentioned features for various DSpaceObjects
* Provided tests for these new features

How to test this PR:
- Retrieve the features for the Item, Collection, Community and Site objects as an admin and verify that their respective new features are present. The tests will deal with all cases that can happen for each feature individually.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
