### PR TITLE
More fixes based on LGTM.com feedback

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -1506,60 +1506,53 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
                     log.error("Unable to create contents directory: " + zipDir + entry.getName());
                 }
             } else {
-                System.out.println("Extracting file: " + entry.getName());
-                log.info("Extracting file: " + entry.getName());
-
-                int index = entry.getName().lastIndexOf('/');
-                if (index == -1) {
-                    // Was it created on Windows instead?
-                    index = entry.getName().lastIndexOf('\\');
-                }
-                if (index > 0) {
-                    File dir = new File(zipDir + entry.getName().substring(0, index));
-                    if (!dir.exists() && !dir.mkdirs()) {
-                        log.error("Unable to create directory: " + dir.getAbsolutePath());
-                    }
-                    // Verify that the directory the entry is using is a subpath of zipDir (and not somewhere else!)
-                    if (!dir.toPath().normalize().startsWith(zipDir)) {
-                        throw new IOException("Bad zip entry: '" + entry.getName()
-                                                  + "' in file '" + zipfile.getAbsolutePath() + "'!"
-                                                  + " Cannot process this file.");
-                    }
-
-                    //Entries could have too many directories, and we need to adjust the sourcedir
-                    // file1.zip (SimpleArchiveFormat / item1 / contents|dublin_core|...
-                    //            SimpleArchiveFormat / item2 / contents|dublin_core|...
-                    // or
-                    // file2.zip (item1 / contents|dublin_core|...
-                    //            item2 / contents|dublin_core|...
-
-                    //regex supports either windows or *nix file paths
-                    String[] entryChunks = entry.getName().split("/|\\\\");
-                    if (entryChunks.length > 2) {
-                        if (StringUtils.equals(sourceDirForZip, sourcedir)) {
-                            sourceDirForZip = sourcedir + "/" + entryChunks[0];
-                        }
-                    }
-
-
-                }
-                byte[] buffer = new byte[1024];
-                int len;
                 File outFile = new File(zipDir + entry.getName());
-                // Verify that this file will be created in our zipDir (and not somewhere else!)
+                // Verify that this file will be extracted into our zipDir (and not somewhere else!)
                 if (!outFile.toPath().normalize().startsWith(zipDir)) {
                     throw new IOException("Bad zip entry: '" + entry.getName()
                                               + "' in file '" + zipfile.getAbsolutePath() + "'!"
                                               + " Cannot process this file.");
+                } else {
+                    System.out.println("Extracting file: " + entry.getName());
+                    log.info("Extracting file: " + entry.getName());
+
+                    int index = entry.getName().lastIndexOf('/');
+                    if (index == -1) {
+                        // Was it created on Windows instead?
+                        index = entry.getName().lastIndexOf('\\');
+                    }
+                    if (index > 0) {
+                        File dir = new File(zipDir + entry.getName().substring(0, index));
+                        if (!dir.exists() && !dir.mkdirs()) {
+                            log.error("Unable to create directory: " + dir.getAbsolutePath());
+                        }
+
+                        //Entries could have too many directories, and we need to adjust the sourcedir
+                        // file1.zip (SimpleArchiveFormat / item1 / contents|dublin_core|...
+                        //            SimpleArchiveFormat / item2 / contents|dublin_core|...
+                        // or
+                        // file2.zip (item1 / contents|dublin_core|...
+                        //            item2 / contents|dublin_core|...
+
+                        //regex supports either windows or *nix file paths
+                        String[] entryChunks = entry.getName().split("/|\\\\");
+                        if (entryChunks.length > 2) {
+                            if (StringUtils.equals(sourceDirForZip, sourcedir)) {
+                                sourceDirForZip = sourcedir + "/" + entryChunks[0];
+                            }
+                        }
+                    }
+                    byte[] buffer = new byte[1024];
+                    int len;
+                    InputStream in = zf.getInputStream(entry);
+                    BufferedOutputStream out = new BufferedOutputStream(
+                        new FileOutputStream(outFile));
+                    while ((len = in.read(buffer)) >= 0) {
+                        out.write(buffer, 0, len);
+                    }
+                    in.close();
+                    out.close();
                 }
-                InputStream in = zf.getInputStream(entry);
-                BufferedOutputStream out = new BufferedOutputStream(
-                    new FileOutputStream(outFile));
-                while ((len = in.read(buffer)) >= 0) {
-                    out.write(buffer, 0, len);
-                }
-                in.close();
-                out.close();
             }
         }
 

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -1506,23 +1506,24 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
                     log.error("Unable to create contents directory: " + zipDir + entry.getName());
                 }
             } else {
-                File outFile = new File(zipDir + entry.getName());
+                String entryName = entry.getName();
+                File outFile = new File(zipDir + entryName);
                 // Verify that this file will be extracted into our zipDir (and not somewhere else!)
                 if (!outFile.toPath().normalize().startsWith(zipDir)) {
-                    throw new IOException("Bad zip entry: '" + entry.getName()
+                    throw new IOException("Bad zip entry: '" + entryName
                                               + "' in file '" + zipfile.getAbsolutePath() + "'!"
                                               + " Cannot process this file.");
                 } else {
-                    System.out.println("Extracting file: " + entry.getName());
-                    log.info("Extracting file: " + entry.getName());
+                    System.out.println("Extracting file: " + entryName);
+                    log.info("Extracting file: " + entryName);
 
-                    int index = entry.getName().lastIndexOf('/');
+                    int index = entryName.lastIndexOf('/');
                     if (index == -1) {
                         // Was it created on Windows instead?
-                        index = entry.getName().lastIndexOf('\\');
+                        index = entryName.lastIndexOf('\\');
                     }
                     if (index > 0) {
-                        File dir = new File(zipDir + entry.getName().substring(0, index));
+                        File dir = new File(zipDir + entryName.substring(0, index));
                         if (!dir.exists() && !dir.mkdirs()) {
                             log.error("Unable to create directory: " + dir.getAbsolutePath());
                         }
@@ -1535,7 +1536,7 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
                         //            item2 / contents|dublin_core|...
 
                         //regex supports either windows or *nix file paths
-                        String[] entryChunks = entry.getName().split("/|\\\\");
+                        String[] entryChunks = entryName.split("/|\\\\");
                         if (entryChunks.length > 2) {
                             if (StringUtils.equals(sourceDirForZip, sourcedir)) {
                                 sourceDirForZip = sourcedir + "/" + entryChunks[0];

--- a/dspace-api/src/main/java/org/dspace/content/RelationshipMetadataValue.java
+++ b/dspace-api/src/main/java/org/dspace/content/RelationshipMetadataValue.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.content;
 
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.dspace.core.Constants;
 
 /**
@@ -58,6 +59,11 @@ public class RelationshipMetadataValue extends MetadataValue {
             return false;
         }
         return super.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(getID()).append(isUseForPlace()).toHashCode();
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/packager/METSManifest.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/METSManifest.java
@@ -245,7 +245,7 @@ public class METSManifest {
     protected METSManifest(SAXBuilder builder, Element mets, String configName) {
         super();
         this.mets = mets;
-        parser = builder;
+        this.parser = builder;
         this.configName = configName;
     }
 
@@ -623,7 +623,7 @@ public class METSManifest {
      * @throws SQLException                if database error
      * @throws AuthorizeException          if authorization error
      */
-    public List<Element> getMdContentAsXml(Element mdSec, Mdref callback)
+    private List<Element> getMdContentAsXml(Element mdSec, Mdref callback)
         throws MetadataValidationException, PackageValidationException,
         IOException, SQLException, AuthorizeException {
         try {
@@ -677,7 +677,9 @@ public class METSManifest {
                 if (mdRef != null) {
                     String mimeType = mdRef.getAttributeValue("MIMETYPE");
                     if (mimeType != null && mimeType.equalsIgnoreCase("text/xml")) {
-                        Document mdd = parser.build(callback.getInputStream(mdRef));
+                        // This next line triggers a false-positive XXE warning from LGTM, even though we disallow DTD
+                        // parsing during initialization of parser in create()
+                        Document mdd = parser.build(callback.getInputStream(mdRef)); // lgtm [java/xxe]
                         List<Element> result = new ArrayList<Element>(1);
                         result.add(mdd.getRootElement());
                         return result;

--- a/dspace-api/src/main/java/org/dspace/ctask/general/MetadataWebService.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/MetadataWebService.java
@@ -268,7 +268,9 @@ public class MetadataWebService extends AbstractCurationTask implements Namespac
                 // boiler-plate handling taken from Apache 4.1 javadoc
                 InputStream instream = entity.getContent();
                 try {
-                    Document doc = docBuilder.parse(instream);
+                    // This next line triggers a false-positive XXE warning from LGTM, even though we disallow DTD
+                    // parsing during initialization of docBuilder in init()
+                    Document doc = docBuilder.parse(instream);  // lgtm [java/xxe]
                     status = processResponse(doc, item, resultSb);
                 } catch (SAXException saxE) {
                     log.error("caught exception: " + saxE);

--- a/dspace-api/src/main/java/org/dspace/harvest/HarvestScheduler.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/HarvestScheduler.java
@@ -95,7 +95,7 @@ public class HarvestScheduler implements Runnable {
         interruptValue = newInterruptValue;
     }
 
-    public static int getInterrupt() {
+    public static synchronized int getInterrupt() {
         return interrupt;
     }
 

--- a/dspace-api/src/main/java/org/dspace/identifier/doi/DOIOrganiser.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/DOIOrganiser.java
@@ -704,8 +704,8 @@ public class DOIOrganiser {
                           + ex.codeToString(ex.getCode()), ex);
 
             if (!quiet) {
-                System.err.println("It wasn't possible to detect this identifier: "
-                                       + DOI.SCHEME + doiRow.getDoi());
+                System.err.println("It wasn't possible to detect this DOI identifier: "
+                                       + identifier);
             }
         }
 

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -1221,7 +1221,7 @@ public class DatabaseUtils {
      * Discovery/Solr needs reindexing.
      * @return whether reindexing should happen.
      */
-    public static boolean getReindexDiscovery() {
+    public static synchronized boolean getReindexDiscovery() {
         boolean autoReindex = DSpaceServicesFactory.getInstance()
             .getConfigurationService()
             .getBooleanProperty("discovery.autoReindex", true);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/AuthenticationRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/AuthenticationRestController.java
@@ -118,8 +118,7 @@ public class AuthenticationRestController implements InitializingBean {
 
         //If we don't have an EPerson here, this means authentication failed and we should return an error message.
         return getLoginResponse(request,
-                                "Authentication failed for user " + user + ": The credentials you provided are not " +
-                                    "valid.");
+                                "Authentication failed. The credentials you provided are not valid.");
     }
 
     /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/StatelessLoginFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/StatelessLoginFilter.java
@@ -14,6 +14,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -27,6 +29,7 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
  * @author Tom Desair (tom dot desair at atmire dot com)
  */
 public class StatelessLoginFilter extends AbstractAuthenticationProcessingFilter {
+    private static final Logger log = LoggerFactory.getLogger(StatelessLoginFilter.class);
 
     protected AuthenticationManager authenticationManager;
 
@@ -74,7 +77,9 @@ public class StatelessLoginFilter extends AbstractAuthenticationProcessingFilter
         String authenticateHeaderValue = restAuthenticationService.getWwwAuthenticateHeaderValue(request, response);
 
         response.setHeader("WWW-Authenticate", authenticateHeaderValue);
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, failed.getMessage());
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Authentication failed!");
+        log.error("Authentication failed (status:{})",
+                  HttpServletResponse.SC_UNAUTHORIZED, failed);
     }
 
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthenticationRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthenticationRestControllerIT.java
@@ -403,7 +403,7 @@ public class AuthenticationRestControllerIT extends AbstractControllerIntegratio
     public void testLoginEmptyRequest() throws Exception {
         getClient().perform(post("/api/authn/login"))
                    .andExpect(status().isUnauthorized())
-                   .andExpect(status().reason(containsString("Login failed")));
+                   .andExpect(status().reason(containsString("Authentication failed")));
     }
 
     @Test

--- a/dspace-sword/src/main/java/org/purl/sword/base/SWORDEntry.java
+++ b/dspace-sword/src/main/java/org/purl/sword/base/SWORDEntry.java
@@ -380,7 +380,7 @@ public class SWORDEntry extends Entry {
                                                                      SwordValidationInfoType.WARNING));
             }
         } else if (swordUserAgent != null && validateAll) {
-            info.addValidationInfo(swordUserAgent.validate(validationContext));
+            swordEntry.addValidationInfo(swordUserAgent.validate(validationContext));
         }
 
         // additional rules for sword elements
@@ -393,7 +393,7 @@ public class SWORDEntry extends Entry {
                                                                      "dereferences to such a description.",
                                                                  SwordValidationInfoType.ERROR));
         } else if (swordTreatment != null && validateAll) {
-            info.addValidationInfo(swordTreatment.validate(validationContext));
+            swordEntry.addValidationInfo(swordTreatment.validate(validationContext));
         }
 
         // additional rules for sword elements
@@ -409,7 +409,7 @@ public class SWORDEntry extends Entry {
                                                                      SwordValidationInfoType.WARNING));
             }
         } else if (swordVerboseDescription != null && validateAll) {
-            info.addValidationInfo(swordVerboseDescription.validate(validationContext));
+            swordEntry.addValidationInfo(swordVerboseDescription.validate(validationContext));
         }
 
         if (swordNoOp == null) {
@@ -428,7 +428,7 @@ public class SWORDEntry extends Entry {
                                                                      SwordValidationInfoType.WARNING));
             }
         } else if (swordNoOp != null && validateAll) {
-            info.addValidationInfo(swordNoOp.validate(validationContext));
+            swordEntry.addValidationInfo(swordNoOp.validate(validationContext));
         }
 
         if (swordPackaging == null) {
@@ -440,7 +440,7 @@ public class SWORDEntry extends Entry {
                                                                      "it SHOULD take a value from [SWORD-TYPES].",
                                                                  SwordValidationInfoType.INFO));
         } else if (swordPackaging != null && validateAll) {
-            info.addValidationInfo(swordPackaging.validate(validationContext));
+            swordEntry.addValidationInfo(swordPackaging.validate(validationContext));
         }
 
         return swordEntry;


### PR DESCRIPTION
## References
Follow-up to #2904 

## Description
Minor code fixes/refactors to fix several LGTM.com reported issues. 

Fixes the following:
* Potential [Zip Slip](https://lgtm.com/rules/1506728586782/) in `ItemImportServiceImpl`.  Was only partially resolved in previous PR.  This PR refactors the method further to allow for checking Zip paths once.
* Fix information exposure through stacktrace in login failed error message (see StatelessLoginFilter)
* Fix inconsistency issues where getter was not synchronized while corresponding setter *was*.
* Add a missing hashCode() method when equals() was used.
* Fix a few "variable is always null" issues
* Tell LGTM to ignore a few false-positive XXE warnings...both were fixed in #2904, but LGTM still warns about them.
* Fix minor possible XSS issue if invalid user param passed into authentication.

## Instructions for Reviewers
* Review the code changes
* Verify that LGTM reports back that issues are fixed (and a few now ignored)
* Verify the tests succeed
