### PR TITLE
Upgrade to latest commons configuration & opencsv

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -864,7 +864,7 @@
         <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
-            <version>4.5</version>
+            <version>5.2</version>
         </dependency>
 
         <!-- Email templating -->

--- a/dspace-api/src/main/java/org/dspace/statistics/util/RepairDump.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/RepairDump.java
@@ -19,6 +19,7 @@ import java.util.UUID;
 
 import com.opencsv.CSVReader;
 import com.opencsv.CSVWriter;
+import com.opencsv.exceptions.CsvValidationException;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
@@ -112,6 +113,9 @@ public class RepairDump {
         } catch (IOException ex) {
             System.err.format("Could not read the export at record %d:  ", recordCount);
             System.err.println(ex.getMessage());
+        } catch (CsvValidationException csve) {
+            System.err.format("Invalid line at record %d:  ", recordCount);
+            System.err.println(csve.getMessage());
         } finally {
             System.err.format("Repaired %d out of %d records.%n",
                     repairCount, recordCount);

--- a/pom.xml
+++ b/pom.xml
@@ -1319,7 +1319,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-configuration2</artifactId>
-                <version>2.3</version>
+                <version>2.7</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
## References
Fixes security alert: https://github.com/DSpace/DSpace/network/alert/pom.xml/org.apache.commons:commons-configuration2/open

## Description
Upgrades to latest version of Apache Commons Configuration (v2.7).  

Also upgraded to latest version of `opencsv` in order to resolve dependency conflicts.  This required a very minor code change to `RepairDump` class.

## Instructions for Reviewers
* Review code changes
* Verify tests didn't fail.  We have lots of tests that depend on Configuration, so any issues should be caught by tests. Same goes for CSV import/export tests.