### PR TITLE
ROOT endpoint (/server) returns the version of DSpace

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/RootConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/RootConverter.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.app.rest.converter;
 
+import static org.dspace.app.util.Util.getSourceVersion;
+
 import org.dspace.app.rest.model.RootRest;
 import org.dspace.services.ConfigurationService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +28,7 @@ public class RootConverter {
         rootRest.setDspaceName(configurationService.getProperty("dspace.name"));
         rootRest.setDspaceUI(configurationService.getProperty("dspace.ui.url"));
         rootRest.setDspaceServer(configurationService.getProperty("dspace.server.url"));
+        rootRest.setDspaceVersion(getSourceVersion());
         return rootRest;
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/RootRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/RootRest.java
@@ -20,6 +20,7 @@ public class RootRest extends RestAddressableModel {
     private String dspaceUI;
     private String dspaceName;
     private String dspaceServer;
+    private String dspaceVersion;
 
     public String getCategory() {
         return CATEGORY;
@@ -56,6 +57,14 @@ public class RootRest extends RestAddressableModel {
 
     public void setDspaceServer(String dspaceServerURL) {
         this.dspaceServer = dspaceServerURL;
+    }
+
+    public String getDspaceVersion() {
+        return dspaceVersion;
+    }
+
+    public void setDspaceVersion(String dspaceVersion) {
+        this.dspaceVersion = dspaceVersion;
     }
 
     @Override

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/converter/RootConverterTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/converter/RootConverterTest.java
@@ -51,6 +51,7 @@ public class RootConverterTest {
         assertEquals("dspaceurl", rootRest.getDspaceUI());
         assertEquals("dspacename", rootRest.getDspaceName());
         assertEquals(restUrl, rootRest.getDspaceServer());
+        assertNotNull(rootRest.getDspaceVersion());
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/converter/RootConverterTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/converter/RootConverterTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 
 import org.dspace.app.rest.model.RootRest;
+import org.dspace.app.util.Util;
 import org.dspace.services.ConfigurationService;
 import org.junit.Before;
 import org.junit.Test;
@@ -51,7 +52,7 @@ public class RootConverterTest {
         assertEquals("dspaceurl", rootRest.getDspaceUI());
         assertEquals("dspacename", rootRest.getDspaceName());
         assertEquals(restUrl, rootRest.getDspaceServer());
-        assertNotNull(rootRest.getDspaceVersion());
+        assertEquals(Util.getSourceVersion(), rootRest.getDspaceVersion());
     }
 
     @Test


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/2819

## Description
This PR ensures that the DSpace version is included in the ROOT endpoint for the DSpace 7 REST API

## Instructions for Reviewers


List of changes in this PR:
* The ROOT endpoint now contains the version of DSpace

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
