### PR TITLE
Bugfixes configurable workflow 6 x

### DIFF
--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
@@ -307,6 +307,11 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
                     nextStep = currentStep;
                     nextActionConfig.getProcessingAction().activate(c, wfi);
                     if (nextActionConfig.requiresUI() && !enteredNewStep) {
+                        //Delete existing task if one with the same c, wfi and user settings is present but has a different actionID
+                        ClaimedTask task = claimedTaskService.findByWorkflowIdAndEPerson(c, wfi, user);
+                        if (!task.getActionID().equals(nextActionConfig.getId())) {
+                            deleteClaimedTask(c, wfi, task);
+                        }
                         createOwnedTask(c, wfi, currentStep, nextActionConfig, user);
                         return nextActionConfig;
                     } else if( nextActionConfig.requiresUI() && enteredNewStep){

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/userassignment/AutoAssignAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/userassignment/AutoAssignAction.java
@@ -109,7 +109,7 @@ public class AutoAssignAction extends UserSelectionAction {
      */
     protected void createTaskForEPerson(Context c, XmlWorkflowItem wfi, Step step, WorkflowActionConfig actionConfig, EPerson user) throws SQLException, AuthorizeException, IOException {
         if(claimedTaskService.find(c, wfi, step.getId(), actionConfig.getId()) != null){
-            workflowRequirementsService.addClaimedUser(c, wfi, step, c.getCurrentUser());
+            workflowRequirementsService.addClaimedUser(c, wfi, step, user);
             XmlWorkflowServiceFactory.getInstance().getXmlWorkflowService().createOwnedTask(c, wfi, step, actionConfig, user);
         }
     }


### PR DESCRIPTION
## Description
Fixes two bugs in the configurable workflow: creating tasks for the wrong EPerson when selectrevieweraction is used and remove old task for the same EPerson if multiple <actions> are defined in one workflow step.

## Instructions for Reviewers
- Creating task for the wrong EPerson
When using the selectrevieweraction in a step of the configurable workflow, a new task for the selected EPerson is created in org.dspace.xmlworkflow.state.actions.userassignment.AutoAssignAction.createTaskForEPerson(). The task was created for the current user, not the user selected (and given to createTaskForEPerson()).
--> commit "Bugfix: Creating task for wrong EPerson."

- Removing old tasks
When using multiple <action> tags in on step of the configurable workflow, the previous task is not removed before starting the new action. This results in an exception thrown by uniqueResult(criteria) in org.dspace.xmlworkflow.storedcomponents.dao.impl.ClaimedTaskDAOImpl.findByWorkflowItemAndEPerson().
--> commit: "Bugfix: Remove old task."

- DSpace 7
The same bugs seem to be present in DSpace 7. I will open a pull request for that version after this one is completed and closed.